### PR TITLE
docs: Fix deprecated API references across documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Start with the curated experiments in `examples/`—each scenario ships with a README plus ready-to-run commands (including the required `export` statements) so you can iterate locally without guessing the setup.
 
-> ⚠️ The hosted Playground UI is temporarily offline. Use the examples directory for end-to-end flows until we relaunch the playground.
+> 💡 **Local Playground**: Run the interactive Streamlit control center locally with `streamlit run playground/traigent_control_center.py`. Also explore the `examples/` directory for end-to-end flows.
 
 > **Note**: Research papers and experimental code have been moved to a separate repository:
 > [Traigent-Experiments](https://github.com/Traigent/Traigent-Experiments)
@@ -305,18 +305,12 @@ uv pip install -e ".[all]"  # Or install everything
 
 ## 🎮 Interactive UI - Get Started in Minutes
 
-> ⚠️ **Playground maintenance**: The interactive UI is temporarily offline. Use the CLI and examples until the next release.
+> 💡 **Local Playground**: Launch the interactive Streamlit control center locally:
+> ```bash
+> streamlit run playground/traigent_control_center.py
+> ```
 
-<!--
-Once the Playground is back online, launch with:
-```bash
-python scripts/examples/launch_control_center.py
-# Or use the shell script:
-./scripts/examples/launch_control_center.sh
-```
--->
-
-Once the service is back online, the TraiGent Playground will provide a user-friendly interface to:
+The TraiGent Control Center provides a user-friendly interface to:
 
 - Define problems using natural language
 - Test and compare different AI agents
@@ -665,15 +659,11 @@ print(f"Best configuration cost per call: ${results.best_config_cost:.6f}")
 
 ### 🎮 Using the Interactive UI
 
-> ⚠️ The Playground is temporarily offline. See [Interactive UI section](#-interactive-ui---get-started-in-minutes) for status.
-
-<!--
-1. **Launch the Playground:**
+1. **Launch the Control Center:**
 
    ```bash
-   python scripts/examples/launch_control_center.py
+   streamlit run playground/traigent_control_center.py
    ```
--->
 
 2. **Define Your Problem:**
 
@@ -934,7 +924,7 @@ python function.py
 
 ## 📚 Documentation
 
-- **[Quick Start Guide](docs/guides/quickstart.md)**: Get started in 5 minutes
+- **[Quick Start Guide](docs/getting-started/GETTING_STARTED.md)**: Get started in 5 minutes
 - **[Playground UI Guide](playground/README.md)**: Interactive Playground
 - **[API Reference](docs/api-reference/)**: Complete API documentation
 - **[Architecture Guide](docs/architecture/ARCHITECTURE.md)**: Technical design details
@@ -1155,4 +1145,4 @@ load_dotenv()
 
 ---
 
-**[Get Started](docs/guides/quickstart.md)** | **[Examples](examples/)** | **[API Docs](docs/api-reference/)** | **[Contributing](docs/guides/CONTRIBUTING.md)**
+**[Get Started](docs/getting-started/GETTING_STARTED.md)** | **[Examples](examples/)** | **[API Docs](docs/api-reference/)** | **[Contributing](docs/guides/CONTRIBUTING.md)**

--- a/docs/features/seamless_injection.md
+++ b/docs/features/seamless_injection.md
@@ -144,7 +144,7 @@ File: `tests/functional/test_seamless_runtime_shim.py`
 
 ### 6.3 Parallelism / Concurrency
 
-- Integration test with `parallel_trials=3` and `max_trials=6`. Use deterministic mock to detect misapplied configs.
+- Integration test with `parallel_config={"trial_concurrency": 3}` and `max_trials=6`. Use deterministic mock to detect misapplied configs.
 
 ### 6.4 Telemetry
 

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -409,11 +409,10 @@ Best accuracy: 0.00
 
 **Solutions:**
 
-1. **Reduce Batch Size**
+1. **Use a Smaller Dataset Subset**
    ```python
    @traigent.optimize(
-       batch_size=10,  # Process 10 examples at a time
-       eval_dataset="large_dataset.jsonl"
+       eval_dataset="large_dataset_subset.jsonl"  # Use a representative subset
    )
    ```
 

--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -118,8 +118,8 @@ async with client:
         max_trials=30,
         optimization_strategy={
             "exploration_ratio": 0.3,
-            "parallel_trials": 5
-        }
+        },
+        parallel_config={"trial_concurrency": 5}
     )
 
     optimization_id = response.optimization_id
@@ -424,12 +424,14 @@ optimization_strategy = {
 
     # Resource management
     "max_cost_budget": 10.0,  # Maximum $10 for optimization
-    "parallel_trials": 3,      # Run 3 trials concurrently
 
     # Smart features
     "adaptive_sample_size": True,  # Increase sample size for promising configs
     "use_prior_knowledge": True    # Use meta-learning from similar tasks
 }
+
+# Parallel execution is configured separately:
+# parallel_config={"trial_concurrency": 3}  # Run 3 trials concurrently
 ```
 
 ### 4. Error Handling

--- a/docs/user-guide/choosing_optimization_model.md
+++ b/docs/user-guide/choosing_optimization_model.md
@@ -280,7 +280,7 @@ Use both models in sequence:
 
 ### Model 2 Performance:
 
-- Choose appropriate `parallel_trials` setting
+- Choose appropriate `parallel_config` settings (e.g., `parallel_config={"trial_concurrency": 4}`)
 - Use early stopping to save costs
 - Start with smaller datasets
 - Enable smart subset selection

--- a/examples/advanced/execution-modes/ex04-hybrid-privacy/hybrid_privacy.py
+++ b/examples/advanced/execution-modes/ex04-hybrid-privacy/hybrid_privacy.py
@@ -102,7 +102,7 @@ def _style_accuracy(
     max_trials=10,
 )
 def proprietary_assistant(query: str) -> str:
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
 
     llm = ChatOpenAI(
         model=config.get("model", "gpt-3.5-turbo"),

--- a/examples/advanced/metric-registry/run.py
+++ b/examples/advanced/metric-registry/run.py
@@ -68,7 +68,7 @@ _RESPONSES: dict[str, dict[str, str]] = {
 )
 def answer_prompt(prompt: str) -> str:
     """Simple rule-based function whose behaviour depends on the strategy."""
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     strategy = str(cfg.get("strategy", "baseline"))
     lookup = _RESPONSES.get(strategy, _RESPONSES["baseline"])
     return lookup.get(prompt.lower(), "i do not know")

--- a/examples/advanced/ragas/basics/run.py
+++ b/examples/advanced/ragas/basics/run.py
@@ -59,7 +59,7 @@ _GENERIC_RESPONSES = {
     execution_mode="edge_analytics",
 )
 def answer_question(question: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     strategy = cfg.get("strategy", "grounded_lookup")
     tone = cfg.get("tone", "direct")
 

--- a/examples/advanced/ragas/column_map/run.py
+++ b/examples/advanced/ragas/column_map/run.py
@@ -39,7 +39,7 @@ _RESPONSES = {
     execution_mode="edge_analytics",
 )
 def answer(prompt: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     strategy = cfg.get("strategy", "lookup")
     tone = cfg.get("tone", "concise")
 

--- a/examples/advanced/ragas/with_llm/run.py
+++ b/examples/advanced/ragas/with_llm/run.py
@@ -100,7 +100,7 @@ _HEDGED_RESPONSES = {
     metric_functions=_METRIC_FUNCTIONS,
 )
 def answer_question(question: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     policy = cfg.get("evidence_policy", "cite_context")
     style = cfg.get("answer_style", "succinct")
 

--- a/examples/core/chunking-long-context/run.py
+++ b/examples/core/chunking-long-context/run.py
@@ -282,7 +282,7 @@ def rag_qa(question: str) -> str:
         # fallback based on doc-like timeline mention
         return "timeline"
     assert os.getenv("ANTHROPIC_API_KEY"), "Missing ANTHROPIC_API_KEY"
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     retriever = _build_retriever(
         int(cfg.get("chunk_size", 512)), int(cfg.get("overlap", 16))
     )

--- a/examples/core/prompt-ab-test/run.py
+++ b/examples/core/prompt-ab-test/run.py
@@ -250,7 +250,7 @@ def qa_with_variant(question: str) -> str:
             return "Uses data and algorithms"
         return "Artificial Intelligence"
     assert os.getenv("ANTHROPIC_API_KEY"), "Missing ANTHROPIC_API_KEY"
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     variant = cfg.get("prompt_variant", "a")
     prompt = f"Question: {question}\n\n{_prompt(variant)}"
     response = ChatAnthropic(

--- a/examples/core/prompt-style-optimization/README.md
+++ b/examples/core/prompt-style-optimization/README.md
@@ -47,7 +47,7 @@ def style_accuracy_metric(output, expected, _llm_metrics):
 ## Key Concepts
 
 - **Bayesian optimization**: Efficient parameter search
-- **Seamless injection**: Auto-applied via `traigent.get_current_config()`
+- **Seamless injection**: Auto-applied via `traigent.get_trial_config()`
 - **Style validation**: Rule-based output checking
 
 ## Next Steps

--- a/examples/core/prompt-style-optimization/run.py
+++ b/examples/core/prompt-style-optimization/run.py
@@ -184,7 +184,7 @@ def style_accuracy_metric(
 )
 def draft_email(brief: str) -> str:
     if MOCK:
-        cfg = traigent.get_current_config()
+        cfg = traigent.get_trial_config()
         style = cfg.get("style", "paragraph")
         tone = cfg.get("tone", "formal")
         header = "Dear team," if tone == "formal" else "Hi team,"
@@ -194,7 +194,7 @@ def draft_email(brief: str) -> str:
             body = "\nThank you for your work and we confirm next steps. We'll follow up soon."
         return f"{header}{body}"
     assert os.getenv("ANTHROPIC_API_KEY"), "Missing ANTHROPIC_API_KEY"
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     style = cfg.get("style", "paragraph")
     tone = cfg.get("tone", "formal")
     temperature = float(cfg.get("temperature", 0.0))

--- a/examples/core/safety-guardrails/run.py
+++ b/examples/core/safety-guardrails/run.py
@@ -184,7 +184,7 @@ def respond_safely(prompt_input: str) -> str:
             return "I cannot help with that."
         return "Here are some helpful tips to stay safe and compliant."
     assert os.getenv("ANTHROPIC_API_KEY"), "Missing ANTHROPIC_API_KEY"
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     strength = cfg.get("safety_strength", "medium")
     style = cfg.get("refusal_style", "brief")
     policy = f"Safety level: {strength}. " + (

--- a/examples/core/simple-prompt/README.md
+++ b/examples/core/simple-prompt/README.md
@@ -6,7 +6,7 @@ This is the "Hello World" of TraiGent. It demonstrates the most basic usage: opt
 
 - How to use the `@traigent.optimize` decorator.
 - How to define a `configuration_space` (parameters to tune).
-- How to access injected parameters using `traigent.get_current_config()`.
+- How to access injected parameters using `traigent.get_trial_config()`.
 - How to run an optimization loop.
 
 ## The Task

--- a/examples/core/simple-prompt/index.html
+++ b/examples/core/simple-prompt/index.html
@@ -62,7 +62,7 @@
             <ul>
                 <li>How to use the <code>@traigent.optimize</code> decorator</li>
                 <li>How to define a <code>configuration_space</code> (parameters to tune)</li>
-                <li>How to access injected parameters using <code>traigent.get_current_config()</code></li>
+                <li>How to access injected parameters using <code>traigent.get_trial_config()</code></li>
                 <li>How to run an optimization loop</li>
             </ul>
         </section>

--- a/examples/core/simple-prompt/run.py
+++ b/examples/core/simple-prompt/run.py
@@ -74,7 +74,7 @@ if MOCK:
         "temperature": [0.0, 0.7],
         "prompt_style": ["concise", "detailed"],
     },
-    # 4. How parameters are injected (seamless = auto-injected into traigent.get_current_config())
+    # 4. How parameters are injected (seamless = auto-injected into traigent.get_trial_config())
     injection_mode="seamless",
     # 5. Execution mode (edge_analytics = local execution + analytics)
     execution_mode="edge_analytics",
@@ -89,7 +89,7 @@ def summarize_text(text: str) -> str:
         A summary of the input text.
     """
     # Get the current configuration chosen by the optimizer
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
 
     model = str(config.get("model", "claude-3-haiku-20240307"))
     temperature = float(config.get("temperature", 0.0))

--- a/examples/core/token-budget-summarization/run.py
+++ b/examples/core/token-budget-summarization/run.py
@@ -254,7 +254,7 @@ def summarize_keyword(text: str) -> str:
             return "timeline"
         return "decision"
     assert os.getenv("ANTHROPIC_API_KEY"), "Missing ANTHROPIC_API_KEY"
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     style = cfg.get("style", "paragraph")
     max_tokens = int(cfg.get("max_tokens", 96))
     temperature = float(cfg.get("temperature", 0.0))

--- a/examples/docs/EXAMPLES_GUIDE.md
+++ b/examples/docs/EXAMPLES_GUIDE.md
@@ -80,7 +80,7 @@ import traigent
     injection_mode="seamless",
 )
 def summarize(text: str) -> str:
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
     return f"Summary for: {text} | model={config['model']}"
 ```
 

--- a/examples/docs/QUICK_REFERENCE.md
+++ b/examples/docs/QUICK_REFERENCE.md
@@ -27,7 +27,7 @@ import traigent
     objectives=["accuracy"],
 )
 def summarize(text: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     return f"Summary | model={cfg['model']}"  # call your LLM here
 ```
 

--- a/examples/docs/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/docs/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -99,7 +99,7 @@ def classify_support_intent(message: str) -> str:
         Intent category: billing, account, technical, general, or cancellation
     """
     # Get optimized configuration
-    current = traigent.get_current_config()
+    current = traigent.get_trial_config()
     config = current if isinstance(current, dict) else {}
 
     # Build prompt based on style

--- a/examples/docs/page-inline/common-tasks/p0-context-engineering/context_engineering.py
+++ b/examples/docs/page-inline/common-tasks/p0-context-engineering/context_engineering.py
@@ -121,7 +121,7 @@ def _contains_accuracy(
     max_trials=10,
 )
 def answer_with_context(context: str, question: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )

--- a/examples/docs/page-inline/common-tasks/p0-few-shot-selection/few_shot_selection.py
+++ b/examples/docs/page-inline/common-tasks/p0-few-shot-selection/few_shot_selection.py
@@ -102,7 +102,7 @@ def _exact_match(output: str | None, expected: str | None, llm_metrics=None) -> 
     max_trials=10,
 )
 def classify_sentiment(text: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     examples = []
     if cfg.get("shots", 0) >= 1:
         examples.append("Example: 'I love it' -> positive")

--- a/examples/docs/page-inline/common-tasks/p0-structured-output/structured_output.py
+++ b/examples/docs/page-inline/common-tasks/p0-structured-output/structured_output.py
@@ -112,7 +112,7 @@ def _json_accuracy(
     max_trials=10,
 )
 def extract_json(text: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     hint = cfg.get("format_hint", "json")
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)

--- a/examples/docs/page-inline/configuration-management/applying-configurations/apply-save.py
+++ b/examples/docs/page-inline/configuration-management/applying-configurations/apply-save.py
@@ -82,7 +82,7 @@ def apply_saved_config(path: Path) -> Callable[[F], F]:
 )
 def customer_support_agent(query: str) -> str:
     """Handle a support query using parameters injected by Traigent."""
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     model = (
         cfg.get("model", "gpt-3.5-turbo") if isinstance(cfg, dict) else "gpt-3.5-turbo"
     )
@@ -102,7 +102,7 @@ def customer_support_agent(query: str) -> str:
 @apply_saved_config(CONFIG_PATH)
 def production_support_agent(query: str) -> str:
     """Use the saved optimal configuration without re-running optimization."""
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     model = (
         cfg.get("model", "gpt-3.5-turbo") if isinstance(cfg, dict) else "gpt-3.5-turbo"
     )

--- a/examples/docs/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
+++ b/examples/docs/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
@@ -82,7 +82,7 @@ def _summary_f1(output: str | None, expected: str | None, llm_metrics=None) -> f
 def adaptive_chat_bot(user_message: str) -> str:
     """Adaptive chatbot using custom parameters optimized by TraiGent."""
     # Get optimized parameters from TraiGent
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
     if not isinstance(config, dict):
         config = {}
 

--- a/examples/docs/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
+++ b/examples/docs/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
@@ -84,7 +84,7 @@ def _summary_f1(output: str | None, expected: str | None, llm_metrics=None) -> f
 def content_generator(topic: str, context: str = "") -> str:
     """Content generator using mixed parameter optimization approach."""
     # Get optimized parameters from TraiGent
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
     if not isinstance(config, dict):
         config = {}
 

--- a/examples/docs/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
+++ b/examples/docs/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
@@ -48,7 +48,7 @@ def my_function():
     # 3. Overrides your parameters with optimal ones
     # 4. Creates LLM instance with optimal parameters
 
-    optimal_config = traigent.get_current_config()
+    optimal_config = traigent.get_trial_config()
     if not isinstance(optimal_config, dict):
         optimal_config = {"model": "gpt-4o-mini", "temperature": 0.3}
 

--- a/examples/docs/page-inline/configuration-management/parameter-injection/param-custom.py
+++ b/examples/docs/page-inline/configuration-management/parameter-injection/param-custom.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover - support IDE execution paths
 )
 def adaptive_chat_bot(user_message: str) -> str:
     # Get optimized parameters from TraiGent
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
     if not isinstance(config, dict):
         config = {}
 

--- a/examples/docs/page-inline/configuration-management/parameter-injection/param-mixed.py
+++ b/examples/docs/page-inline/configuration-management/parameter-injection/param-mixed.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover - support IDE execution paths
     }
 )
 def smart_document_processor(document: str) -> str:
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
     if not isinstance(config, dict):
         config = {}
 

--- a/examples/docs/page-inline/cookbook-agents/support/advanced.py
+++ b/examples/docs/page-inline/cookbook-agents/support/advanced.py
@@ -52,7 +52,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "support_eval.jsonl")
     max_trials=10,
 )
 def support_intent(message: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
 
     guidance = {
         "direct": "Classify customer support intent.",

--- a/examples/docs/page-inline/cookbook-content/headlines/advanced.py
+++ b/examples/docs/page-inline/cookbook-content/headlines/advanced.py
@@ -50,7 +50,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")
     max_trials=10,
 )
 def generate_headline(topic: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     style_hint = {
         "neutral": "neutral journalistic tone",
         "punchy": "bold, energetic wording",

--- a/examples/docs/page-inline/cookbook-data/extraction/advanced.py
+++ b/examples/docs/page-inline/cookbook-data/extraction/advanced.py
@@ -72,7 +72,7 @@ def _json_accuracy(
     max_trials=10,
 )
 def extract_fields(text: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     guidance = {
         "direct": "Extract fields precisely.",
         "reasoned": "Identify key fields, then extract them precisely.",

--- a/examples/docs/page-inline/cookbook-nlp/sentiment/advanced.py
+++ b/examples/docs/page-inline/cookbook-nlp/sentiment/advanced.py
@@ -54,7 +54,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")
     max_trials=10,
 )
 def sentiment_analysis(text: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
 
     guidance = {
         "direct": "Classify sentiment. Be concise.",

--- a/examples/docs/page-inline/cookbook-nlp/sentiment/basic.py
+++ b/examples/docs/page-inline/cookbook-nlp/sentiment/basic.py
@@ -55,7 +55,7 @@ def sentiment_analysis(text: str) -> str:
 
     Returns one of: positive | negative | neutral
     """
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
 
     instructions = "Classify the sentiment of the following text."
     guard = (

--- a/examples/docs/page-inline/cookbook-nlp/summarization/context.py
+++ b/examples/docs/page-inline/cookbook-nlp/summarization/context.py
@@ -48,7 +48,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")
     max_trials=10,
 )
 def summarize(document: str) -> str:
-    cfg = traigent.get_current_config()
+    cfg = traigent.get_trial_config()
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=cfg.get("temperature", 0.0))
 
     def _sum(text: str) -> str:

--- a/examples/docs/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
+++ b/examples/docs/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
@@ -111,7 +111,7 @@ def intelligent_assistant(query: str) -> str:
     """An intelligent assistant that answers queries with optimal parameters."""
 
     # Get the current configuration from TraiGent
-    current = traigent.get_current_config()
+    current = traigent.get_trial_config()
     config = current if isinstance(current, dict) else {}
 
     # Map response style to system prompt

--- a/examples/docs/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
+++ b/examples/docs/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
@@ -172,7 +172,7 @@ def cost_optimized_bot(query: str) -> str:
 )
 def balanced_support_bot(query: str) -> str:
     """Bot balancing cost, quality, and response time."""
-    current = traigent.get_current_config()
+    current = traigent.get_trial_config()
     config = current if isinstance(current, dict) else {}
 
     llm = ChatOpenAI(
@@ -205,7 +205,7 @@ def balanced_support_bot(query: str) -> str:
 )
 def quality_constrained_bot(query: str) -> str:
     """Bot with quality constraints and custom metrics."""
-    current = traigent.get_current_config()
+    current = traigent.get_trial_config()
     config = current if isinstance(current, dict) else {}
 
     format_instructions = {

--- a/examples/docs/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
+++ b/examples/docs/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
@@ -142,7 +142,7 @@ def create_python_dataset() -> Dataset:
 )
 def classifier_with_python_list(text: str) -> str:
     """Classifier using Python list dataset."""
-    current = traigent.get_current_config()
+    current = traigent.get_trial_config()
     config: dict[str, Any] = current if isinstance(current, dict) else {}
 
     prompt_styles = {
@@ -235,7 +235,7 @@ class DynamicDatasetGenerator:
 )
 def math_solver(problem: str) -> str:
     """Math problem solver with dynamic dataset."""
-    current = traigent.get_current_config()
+    current = traigent.get_trial_config()
     config: dict[str, Any] = current if isinstance(current, dict) else {}
 
     if config.get("reasoning_steps", False):

--- a/walkthrough/README.md
+++ b/walkthrough/README.md
@@ -238,7 +238,7 @@ from langchain_chroma import Chroma
 )
 def customer_support(query: str, knowledge_base: list) -> str:
     # Get optimized configuration
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
 
     # Use optimized parameters
     llm = ChatOpenAI(
@@ -300,8 +300,7 @@ Speed up optimization with parallelization:
 
 ```python
 await my_agent.optimize(
-    batch_size=8,       # Process 8 examples in parallel
-    parallel_trials=4   # Test 4 configurations simultaneously
+    parallel_config={"trial_concurrency": 4}  # Test 4 configurations simultaneously
 )
 ```
 
@@ -371,7 +370,7 @@ def production_agent(
     """Production-ready agent with full optimization."""
 
     # Get optimized configuration
-    config = traigent.get_current_config()
+    config = traigent.get_trial_config()
 
     # Log configuration for monitoring
     logger.info(f"Using config: {config}")
@@ -434,8 +433,7 @@ async def deploy_optimized_agent():
     results = await production_agent.optimize(
         algorithm="bayesian",
         max_trials=100,
-        parallel_trials=4,
-        batch_size=8
+        parallel_config={"trial_concurrency": 4},
     )
 
     # Apply best configuration

--- a/walkthrough/hotpotQA/run_demo.py
+++ b/walkthrough/hotpotQA/run_demo.py
@@ -139,7 +139,7 @@ def hotpot_agent(question: str, context: list[str] | None = None) -> str:
     """Simulated HotpotQA agent; context is captured via TraiGent instrumentation."""
 
     context = context or []
-    config: dict[str, Any] = traigent.get_current_config()
+    config: dict[str, Any] = traigent.get_trial_config()
     if USE_MOCK:
         return generate_case_study_answer(question, config)
     return generate_real_answer(question, context, config)
@@ -149,7 +149,7 @@ async def main() -> None:
     result = await hotpot_agent.optimize(
         algorithm="optuna_nsga2",
         max_trials=12,
-        parallel_trials=4,
+        parallel_config={"trial_concurrency": 4},
     )
 
     print("Best configuration:")


### PR DESCRIPTION
## Summary

- **42 files updated** to fix deprecated API references identified in documentation audit
- **Phase 1 (CRITICAL)**: Fixed `parallel_trials` → `parallel_config`, removed invalid `batch_size` decorator param, fixed broken quickstart links
- **Phase 2 (HIGH)**: Replaced `get_current_config()` → `get_trial_config()` in 36 example files
- **Phase 3 (MEDIUM)**: Updated playground notices to point to local Streamlit control center

## Test plan

- [ ] Verify grep checks pass: `grep -r "get_current_config" examples/` returns no results
- [ ] Verify grep checks pass: `grep -r "parallel_trials" docs/ walkthrough/` returns no results
- [ ] Run example: `TRAIGENT_MOCK_MODE=true python examples/core/simple-prompt/run.py`
- [ ] Confirm README links work (quickstart guide, playground references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)