### PR TITLE
fix(ux): Suppress backend warnings when no API key configured

### DIFF
--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -451,6 +451,175 @@ class TestBackendSessionManagerWarningSuppression:
         with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "false"}):
             assert manager._should_suppress_backend_warnings() is False
 
+    def test_suppress_warnings_no_backend_client(
+        self, traigent_config, objective_schema, mock_optimizer
+    ):
+        """Test warnings suppression when backend_client is None."""
+        import os
+        from unittest.mock import patch
+
+        manager = BackendSessionManager(
+            backend_client=None,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        # With no backend client and mock mode off, should return False
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "false"}):
+            assert manager._should_suppress_backend_warnings() is False
+
+    def test_suppress_warnings_client_without_auth_attr(
+        self, traigent_config, objective_schema, mock_optimizer
+    ):
+        """Test warnings suppression when client has no auth attribute."""
+        import os
+        from unittest.mock import patch
+
+        # Client without auth attribute
+        client = Mock(spec=[])  # Empty spec = no attributes
+
+        manager = BackendSessionManager(
+            backend_client=client,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        # No auth attribute means no API key, should suppress
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "false"}):
+            assert manager._should_suppress_backend_warnings() is True
+
+    @pytest.mark.asyncio
+    async def test_weighted_score_update_failure_with_suppressed_warning(
+        self, traigent_config, mock_optimizer
+    ):
+        """Test weighted score update logs debug (not warning) when suppressed."""
+        import os
+        from unittest.mock import patch
+
+        from traigent.core.objectives import create_default_objectives
+
+        # Client with no API key (warnings suppressed)
+        client = Mock()
+        client.auth = Mock()
+        client.auth.has_api_key = Mock(return_value=False)
+        client.update_trial_weighted_scores = AsyncMock(return_value=False)
+        client.weighted_update_concurrency = 8
+
+        objective_schema = create_default_objectives(
+            objective_names=["accuracy", "cost"],
+            orientations={"accuracy": "maximize", "cost": "minimize"},
+            weights={"accuracy": 0.7, "cost": 0.3},
+        )
+
+        manager = BackendSessionManager(
+            backend_client=client,
+            traigent_config=traigent_config,
+            objectives=["accuracy", "cost"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        # Create mock trial and result
+        mock_trial = Mock(spec=TrialResult)
+        mock_trial.trial_id = "trial-fail-test"
+        mock_trial.config = {"param": 1}
+        mock_trial.metrics = {"accuracy": 0.9, "cost": 0.5}
+        mock_trial.is_successful = True
+
+        result = Mock(spec=OptimizationResult)
+        result.trials = [mock_trial]
+        result.successful_trials = [mock_trial]
+        result.calculate_weighted_scores = Mock(
+            return_value={
+                "weighted_scores": [(mock_trial, 0.85)],
+                "normalization_ranges": {},
+                "best_weighted_config": {"param": 1},
+                "best_weighted_score": 0.85,
+            }
+        )
+        result.metadata = {}
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "false"}):
+            update_count = await manager.update_weighted_scores(
+                result=result, session_id="test-session"
+            )
+
+        # Update failed but warning was suppressed (logged as debug)
+        assert update_count == 0
+        client.update_trial_weighted_scores.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_weighted_score_update_exception_with_suppressed_warning(
+        self, traigent_config, mock_optimizer
+    ):
+        """Test weighted score exception logs debug when warnings suppressed."""
+        import os
+        from unittest.mock import patch
+
+        from traigent.core.objectives import create_default_objectives
+
+        # Client with no API key (warnings suppressed) that raises exception
+        client = Mock()
+        client.auth = Mock()
+        client.auth.has_api_key = Mock(return_value=False)
+        client.update_trial_weighted_scores = AsyncMock(
+            side_effect=Exception("Connection failed")
+        )
+        client.weighted_update_concurrency = 8
+
+        objective_schema = create_default_objectives(
+            objective_names=["accuracy", "cost"],
+            orientations={"accuracy": "maximize", "cost": "minimize"},
+            weights={"accuracy": 0.7, "cost": 0.3},
+        )
+
+        manager = BackendSessionManager(
+            backend_client=client,
+            traigent_config=traigent_config,
+            objectives=["accuracy", "cost"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        mock_trial = Mock(spec=TrialResult)
+        mock_trial.trial_id = "trial-exc-test"
+        mock_trial.config = {"param": 1}
+        mock_trial.metrics = {"accuracy": 0.9, "cost": 0.5}
+        mock_trial.is_successful = True
+
+        result = Mock(spec=OptimizationResult)
+        result.trials = [mock_trial]
+        result.successful_trials = [mock_trial]
+        result.calculate_weighted_scores = Mock(
+            return_value={
+                "weighted_scores": [(mock_trial, 0.85)],
+                "normalization_ranges": {},
+                "best_weighted_config": {"param": 1},
+                "best_weighted_score": 0.85,
+            }
+        )
+        result.metadata = {}
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "false"}):
+            update_count = await manager.update_weighted_scores(
+                result=result, session_id="test-session"
+            )
+
+        # Exception occurred but warning was suppressed
+        assert update_count == 0
+
 
 class TestBackendSessionManagerMetadata:
     """Test metadata attachment."""

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -381,6 +381,77 @@ class TestBackendSessionManagerFinalization:
         assert summary is None
 
 
+class TestBackendSessionManagerWarningSupression:
+    """Test warning suppression logic."""
+
+    def test_suppress_warnings_in_mock_mode(
+        self, mock_backend_client, traigent_config, objective_schema, mock_optimizer
+    ):
+        """Test warnings are suppressed when TRAIGENT_MOCK_MODE is set."""
+        import os
+        from unittest.mock import patch
+
+        manager = BackendSessionManager(
+            backend_client=mock_backend_client,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "true"}):
+            assert manager._should_suppress_backend_warnings() is True
+
+    def test_suppress_warnings_without_api_key(
+        self, traigent_config, objective_schema, mock_optimizer
+    ):
+        """Test warnings are suppressed when no API key is configured."""
+        # Create client with auth manager that has no API key
+        client = Mock()
+        auth_manager = Mock()
+        auth_manager.has_api_key = Mock(return_value=False)
+        client.auth = auth_manager
+
+        manager = BackendSessionManager(
+            backend_client=client,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        assert manager._should_suppress_backend_warnings() is True
+
+    def test_no_suppress_warnings_with_api_key(
+        self, mock_backend_client, traigent_config, objective_schema, mock_optimizer
+    ):
+        """Test warnings are NOT suppressed when API key is configured."""
+        import os
+        from unittest.mock import patch
+
+        # Mock auth with has_api_key returning True
+        mock_backend_client.auth = Mock()
+        mock_backend_client.auth.has_api_key = Mock(return_value=True)
+
+        manager = BackendSessionManager(
+            backend_client=mock_backend_client,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        # Ensure mock mode is off
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_MODE": "false"}):
+            assert manager._should_suppress_backend_warnings() is False
+
+
 class TestBackendSessionManagerMetadata:
     """Test metadata attachment."""
 

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -381,7 +381,7 @@ class TestBackendSessionManagerFinalization:
         assert summary is None
 
 
-class TestBackendSessionManagerWarningSupression:
+class TestBackendSessionManagerWarningSuppression:
     """Test warning suppression logic."""
 
     def test_suppress_warnings_in_mock_mode(

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -64,6 +64,32 @@ class BackendSessionManager:
         self._optimization_id = optimization_id
         self._optimization_status = optimization_status
 
+    def _should_suppress_backend_warnings(self) -> bool:
+        """Check if backend-related warnings should be suppressed.
+
+        Returns True if:
+        - Mock mode is enabled, OR
+        - No API key is configured (user hasn't set up backend access)
+
+        This prevents noisy warnings for users evaluating the SDK without
+        backend access or running in local-only mode.
+        """
+        if is_mock_mode():
+            return True
+
+        # Check if backend client has API key configured
+        if self._backend_client:
+            auth_manager = getattr(self._backend_client, "auth", None)
+            has_api_key = bool(
+                auth_manager
+                and hasattr(auth_manager, "has_api_key")
+                and auth_manager.has_api_key()
+            )
+            if not has_api_key:
+                return True
+
+        return False
+
     def create_session(
         self,
         func: Callable[..., Any],
@@ -490,11 +516,18 @@ class BackendSessionManager:
                             objective_weights=objective_weights,
                         )
                     except Exception as exc:  # pragma: no cover - defensive
-                        logger.warning(
-                            "Exception while updating weighted score for trial %s: %s",
-                            trial_identifier,
-                            exc,
-                        )
+                        if self._should_suppress_backend_warnings():
+                            logger.debug(
+                                "Exception while updating weighted score for trial %s: %s (backend unavailable)",
+                                trial_identifier,
+                                exc,
+                            )
+                        else:
+                            logger.warning(
+                                "Exception while updating weighted score for trial %s: %s",
+                                trial_identifier,
+                                exc,
+                            )
                         return False
 
                     if success:
@@ -505,15 +538,16 @@ class BackendSessionManager:
                         )
                         return True
 
-                    # Only warn in non-mock mode to reduce noise
-                    if not is_mock_mode():
-                        logger.warning(
-                            "Failed to update weighted score for trial %s",
+                    # Suppress warnings in mock mode or when no API key configured
+                    # This prevents noisy output for users evaluating SDK without backend
+                    if self._should_suppress_backend_warnings():
+                        logger.debug(
+                            "Failed to update weighted score for trial %s (backend unavailable or mock mode)",
                             trial_identifier,
                         )
                     else:
-                        logger.debug(
-                            "Failed to update weighted score for trial %s (mock mode)",
+                        logger.warning(
+                            "Failed to update weighted score for trial %s",
                             trial_identifier,
                         )
                     return False


### PR DESCRIPTION
## Summary

- Fix noisy "Failed to update weighted score" warnings for users without backend access
- Add `_should_suppress_backend_warnings()` helper method to BackendSessionManager
- Warnings now downgrade to DEBUG level when:
  - Mock mode is enabled (`TRAIGENT_MOCK_MODE=true`), OR
  - No API key is configured

## Problem

Users evaluating the SDK without backend access (e.g., potential customers, local testing) were seeing confusing warnings:
```
Failed to update weighted score for trial trial_43d6eb4d988f
Failed to update weighted score for trial trial_28c516826a09
...
```

This created a poor first impression and confusion about whether the SDK was working correctly.

## Solution

The warning logic now checks both mock mode AND API key configuration. Users without backend access will see these messages at DEBUG level only, not as warnings.

## Test Plan

- [x] Added 3 new tests for `_should_suppress_backend_warnings()` helper
- [x] All 15 BackendSessionManager tests pass
- [x] All existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)