### PR TITLE
refactor: Consolidate injection modes - remove ATTRIBUTE, add TRAIGENT_DISABLED

### DIFF
--- a/tests/integration/backend/test_integration_summary.py
+++ b/tests/integration/backend/test_integration_summary.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Summary of Traigent SDK Backend Integration with DTOs."""
 
-
 from traigent.cloud.dtos import (
     create_local_configuration_run,
     create_local_experiment,

--- a/tests/optimizer_validation/chatbot/cli.py
+++ b/tests/optimizer_validation/chatbot/cli.py
@@ -228,8 +228,7 @@ def single_query(query: str, model: str = "claude-sonnet-4-20250514") -> None:
 
 def print_help() -> None:
     """Print usage help."""
-    print(
-        """
+    print("""
 Traigent Test Suite Chatbot - Help
 ==================================
 
@@ -252,8 +251,7 @@ Tips:
   - Be specific about what you're looking for
   - Use dimension names (InjectionMode, Algorithm, etc.) for precise queries
   - Ask about coverage gaps to find missing test scenarios
-"""
-    )
+""")
 
 
 def main() -> None:

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -161,8 +161,7 @@ class TestOptimizeDecorator:
     def test_decorator_wires_evaluation_set_dataset(self, tmp_path):
         """TVL 0.9 evaluation_set.dataset populates eval_dataset when omitted."""
         spec_path = tmp_path / "evalset.tvl.yml"
-        spec_path.write_text(
-            """tvl:
+        spec_path.write_text("""tvl:
   module: test.evalset
 tvl_version: "0.9"
 evaluation_set:
@@ -174,8 +173,7 @@ tvars:
 objectives:
   - name: accuracy
     direction: maximize
-"""
-        )
+""")
 
         @optimize(tvl_spec=spec_path)
         def tvl_wrapped(question: str) -> str:
@@ -187,8 +185,7 @@ objectives:
     def test_decorator_does_not_override_explicit_eval_dataset(self, tmp_path):
         """Explicit eval_dataset beats evaluation_set in a TVL spec."""
         spec_path = tmp_path / "evalset_override.tvl.yml"
-        spec_path.write_text(
-            """tvl:
+        spec_path.write_text("""tvl:
   module: test.evalset.override
 tvl_version: "0.9"
 evaluation_set:
@@ -200,8 +197,7 @@ tvars:
 objectives:
   - name: accuracy
     direction: maximize
-"""
-        )
+""")
 
         @optimize(tvl_spec=spec_path, eval_dataset="user.jsonl")
         def tvl_wrapped(question: str) -> str:

--- a/tests/unit/cli/test_main_cli_sample_limit.py
+++ b/tests/unit/cli/test_main_cli_sample_limit.py
@@ -16,8 +16,7 @@ def _write_temp_module(root: Path) -> Path:
     module_dir.mkdir(exist_ok=True)
     module_path = module_dir / f"module_{uuid4().hex}.py"
 
-    module_path.write_text(
-        """
+    module_path.write_text("""
 last_kwargs = {}
 
 
@@ -41,8 +40,7 @@ def fake_optimized_function():
 
 
 fake_optimized_function.optimize = _optimize_stub
-"""
-    )
+""")
 
     return module_path
 

--- a/tests/unit/cli/test_validation_system.py
+++ b/tests/unit/cli/test_validation_system.py
@@ -366,8 +366,7 @@ class TestCLIIntegration:
     def test_check_command_dry_run(self, cli_runner):
         """Test check command dry run mode."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 import traigent
 
 @traigent.optimize(
@@ -377,8 +376,7 @@ import traigent
 )
 def test_func():
     return "test"
-"""
-            )
+""")
             temp_file = f.name
 
         try:

--- a/tests/unit/config/test_providers.py
+++ b/tests/unit/config/test_providers.py
@@ -4,7 +4,6 @@ import pytest
 
 from traigent.config.context import ConfigurationContext, get_config
 from traigent.config.providers import (
-    AttributeBasedProvider,
     ContextBasedProvider,
     ParameterBasedProvider,
     get_provider,
@@ -182,83 +181,6 @@ class TestParameterBasedProvider:
         assert provider.extract_config(test_func) is None
 
 
-class TestAttributeBasedProvider:
-    """Test suite for AttributeBasedProvider."""
-
-    def test_inject_config_sync_function(self):
-        """Test decorator injection with sync function."""
-        provider = AttributeBasedProvider()
-        config = {"model": "GPT-4o", "temperature": 0.7}
-
-        wrapped_func = provider.inject_config(lambda query: None, config)
-
-        # Test that config is accessible on wrapper
-        assert hasattr(wrapped_func, "current_config")
-        assert wrapped_func.current_config == config
-
-        # Test the actual functionality in a more realistic way
-        def test_func(query: str) -> str:
-            return f"Using {query}"
-
-        wrapped = provider.inject_config(test_func, config)
-        result = wrapped("GPT-4o")
-        assert result == "Using GPT-4o"
-        assert wrapped.current_config == config
-
-    @pytest.mark.asyncio
-    async def test_inject_config_async_function(self):
-        """Test decorator injection with async function."""
-        provider = AttributeBasedProvider()
-        config = {"model": "GPT-4o", "temperature": 0.7}
-
-        async def test_func(query: str) -> str:
-            current_config = test_func.current_config
-            return f"Using {current_config['model']}"
-
-        # Rebind test_func to the wrapper so the closure sees the wrapper
-        test_func = provider.inject_config(test_func, config)
-        result = await test_func("test query")
-
-        assert result == "Using GPT-4o"
-
-    def test_inject_config_custom_attribute_name(self):
-        """Test decorator injection with custom attribute name."""
-        provider = AttributeBasedProvider(attribute_name="my_config")
-        config = {"model": "GPT-4o"}
-
-        def test_func() -> str:
-            return "test"
-
-        wrapped_func = provider.inject_config(test_func, config)
-        result = wrapped_func()
-
-        assert result == "test"
-        assert hasattr(wrapped_func, "my_config")
-        assert wrapped_func.my_config == config
-
-    def test_extract_config(self):
-        """Test extracting config from function attribute."""
-        provider = AttributeBasedProvider()
-        config = {"model": "GPT-4o"}
-
-        def test_func():
-            pass
-
-        wrapped_func = provider.inject_config(test_func, config)
-        extracted = provider.extract_config(wrapped_func)
-
-        assert extracted == config
-
-    def test_supports_function(self):
-        """Test that decorator provider supports any function."""
-        provider = AttributeBasedProvider()
-
-        def test_func():
-            pass
-
-        assert provider.supports_function(test_func) is True
-
-
 class TestGetProvider:
     """Test suite for get_provider function."""
 
@@ -279,25 +201,27 @@ class TestGetProvider:
         assert isinstance(provider, ParameterBasedProvider)
         assert provider.default_param_name == "my_config"
 
-    def test_get_decorator_provider(self):
-        """Test getting decorator provider."""
-        provider = get_provider("attribute")
-        assert isinstance(provider, AttributeBasedProvider)
-        assert provider.attribute_name == "current_config"
-
-    def test_get_decorator_provider_with_custom_attribute(self):
-        """Test getting decorator provider with custom attribute name."""
-        provider = get_provider("attribute", attribute_name="my_config")
-        assert isinstance(provider, AttributeBasedProvider)
-        assert provider.attribute_name == "my_config"
-
     def test_get_unknown_provider(self):
         """Test error for unknown provider."""
         with pytest.raises(ConfigurationError, match="Unknown injection mode: unknown"):
             get_provider("unknown")
 
-    def test_decorator_backward_compatibility(self):
-        """Test that 'decorator' mode still works for backward compatibility."""
-        # Should not raise an error
-        provider = get_provider("decorator")
-        assert isinstance(provider, AttributeBasedProvider)
+    def test_attribute_mode_raises_configuration_error(self):
+        """Test that attribute mode raises ConfigurationError with migration guide."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            get_provider("attribute")
+
+        error_message = str(exc_info.value)
+        assert "attribute" in error_message
+        assert "removed" in error_message.lower()
+        assert "context" in error_message  # Migration suggestion
+        assert "seamless" in error_message  # Alternative
+
+    def test_decorator_mode_raises_configuration_error(self):
+        """Test that decorator mode (legacy alias) raises ConfigurationError."""
+        with pytest.raises(ConfigurationError) as exc_info:
+            get_provider("decorator")
+
+        error_message = str(exc_info.value)
+        assert "decorator" in error_message
+        assert "removed" in error_message.lower()

--- a/tests/unit/core/test_attribute_parallel_safety.py
+++ b/tests/unit/core/test_attribute_parallel_safety.py
@@ -1,254 +1,190 @@
-"""Tests for attribute injection mode + parallel execution safety guards.
+"""Tests for removed attribute injection mode and TRAIGENT_DISABLED functionality.
 
-This module tests that:
-1. ValueError is raised when injection_mode='attribute' with trial_concurrency > 1
-2. Warning is logged when allow_parallel_attribute=True is used
-3. No error/warning for attribute mode with sequential execution
-4. No error/warning for other injection modes with parallel execution
+This module verifies that:
+1. Using injection_mode='attribute' raises ConfigurationError with migration guidance
+2. Using injection_mode='decorator' raises ConfigurationError with migration guidance
+3. TRAIGENT_DISABLED=1 makes @optimize a no-op pass-through
 """
-
-import logging
 
 import pytest
 
 import traigent
+from traigent.utils.exceptions import ConfigurationError
 
 # Use an existing dataset from the workspace
 EVAL_DATASET = "examples/datasets/hello-world/evaluation_set.jsonl"
 
 
-def _require(condition: bool, message: str) -> None:
-    """Fail the test with a clear message when a condition is not met."""
-    if not condition:
-        pytest.fail(message)
+class TestAttributeModeRemoval:
+    """Tests verifying attribute mode has been removed with helpful migration."""
 
+    def test_attribute_mode_raises_configuration_error(self, monkeypatch):
+        """Using injection_mode='attribute' should raise ConfigurationError."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
 
-@pytest.fixture
-def mock_mode_env(monkeypatch):
-    """Enable mock mode for all tests."""
-    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        with pytest.raises(ConfigurationError) as exc_info:
 
-
-class TestAttributeParallelSafetyGuard:
-    """Tests for the attribute mode + parallel trials safety guard."""
-
-    @pytest.mark.asyncio
-    async def test_attribute_mode_parallel_raises_by_default(self, mock_mode_env):
-        """Attribute mode with parallel trials should raise ValueError by default."""
-
-        @traigent.optimize(
-            objectives=["accuracy"],
-            configuration_space={"model": ["a", "b", "c"]},
-            eval_dataset=EVAL_DATASET,
-            injection_mode="attribute",
-            parallel_config={"trial_concurrency": 2, "mode": "parallel"},
-        )
-        def my_func(question: str) -> str:
-            return "answer"
-
-        with pytest.raises(ValueError) as exc_info:
-            await my_func.optimize(max_trials=2)
+            @traigent.optimize(
+                objectives=["accuracy"],
+                configuration_space={"model": ["a", "b"]},
+                eval_dataset=EVAL_DATASET,
+                injection_mode="attribute",
+            )
+            def my_func(question: str) -> str:
+                return "answer"
 
         error_message = str(exc_info.value)
-        _require(
-            "injection_mode='attribute'" in error_message,
-            "Expected injection_mode='attribute' to be mentioned in the error message.",
-        )
-        _require(
-            "unsafe with parallel trials" in error_message,
-            "Expected safety warning about parallel trials in the error message.",
-        )
-        _require(
-            "allow_parallel_attribute" in error_message,
-            "Expected allow_parallel_attribute guidance in the error message.",
-        )
+        assert "attribute" in error_message
+        assert "removed" in error_message.lower()
+        assert "context" in error_message  # Migration suggestion
+        assert "seamless" in error_message  # Alternative suggestion
 
-    @pytest.mark.asyncio
-    async def test_attribute_mode_parallel_with_opt_in_warns(
-        self, mock_mode_env, caplog
-    ):
-        """Attribute mode with parallel trials and opt-in should warn but not raise."""
+    def test_decorator_mode_raises_configuration_error(self, monkeypatch):
+        """Using injection_mode='decorator' (legacy alias) should raise ConfigurationError."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
 
-        @traigent.optimize(
-            objectives=["accuracy"],
-            configuration_space={"model": ["a", "b"]},
-            eval_dataset=EVAL_DATASET,
-            injection={"injection_mode": "attribute", "allow_parallel_attribute": True},
-            parallel_config={"trial_concurrency": 2, "mode": "parallel"},
-        )
-        def my_func(question: str) -> str:
-            return "answer"
+        with pytest.raises(ConfigurationError) as exc_info:
 
-        # Should not raise, but should log warning
-        with caplog.at_level(logging.WARNING):
-            await my_func.optimize(max_trials=2)
+            @traigent.optimize(
+                objectives=["accuracy"],
+                configuration_space={"model": ["a", "b"]},
+                eval_dataset=EVAL_DATASET,
+                injection_mode="decorator",
+            )
+            def my_func(question: str) -> str:
+                return "answer"
 
-        # Check warning was logged
-        warning_found = any(
-            "injection_mode='attribute' with parallel trials" in record.message
-            and "not safe" in record.message
-            for record in caplog.records
-        )
-        _require(
-            warning_found,
-            "Expected warning about attribute mode parallel safety, got: "
-            f"{[r.message for r in caplog.records]}",
-        )
+        error_message = str(exc_info.value)
+        assert "decorator" in error_message
+        assert "removed" in error_message.lower()
 
-    @pytest.mark.asyncio
-    async def test_attribute_mode_parallel_with_top_level_opt_in_warns(
-        self, mock_mode_env, caplog
-    ):
-        """Top-level allow_parallel_attribute should behave like the injection bundle."""
-
-        @traigent.optimize(
-            objectives=["accuracy"],
-            configuration_space={"model": ["a", "b"]},
-            eval_dataset=EVAL_DATASET,
-            injection_mode="attribute",
-            allow_parallel_attribute=True,
-            parallel_config={"trial_concurrency": 2, "mode": "parallel"},
-        )
-        def my_func(question: str) -> str:
-            return "answer"
-
-        # Should not raise, but should log warning
-        with caplog.at_level(logging.WARNING):
-            await my_func.optimize(max_trials=2)
-
-        # Check warning was logged
-        warning_found = any(
-            "injection_mode='attribute' with parallel trials" in record.message
-            and "not safe" in record.message
-            for record in caplog.records
-        )
-        _require(
-            warning_found,
-            "Expected warning about attribute mode parallel safety, got: "
-            f"{[r.message for r in caplog.records]}",
-        )
-
-    @pytest.mark.asyncio
-    async def test_attribute_mode_sequential_no_error(self, mock_mode_env):
-        """Attribute mode with sequential execution should work without error."""
-
-        @traigent.optimize(
-            objectives=["accuracy"],
-            configuration_space={"model": ["a", "b"]},
-            eval_dataset=EVAL_DATASET,
-            injection_mode="attribute",
-            parallel_config={"trial_concurrency": 1, "mode": "sequential"},
-        )
-        def my_func(question: str) -> str:
-            return "answer"
-
-        # Should not raise
-        result = await my_func.optimize(max_trials=2)
-        _require(result is not None, "Expected an optimization result, got None.")
-        _require(len(result.trials) > 0, "Expected at least one trial result.")
-
-    @pytest.mark.asyncio
-    async def test_attribute_mode_trial_concurrency_one_auto_no_error(
-        self, mock_mode_env
-    ):
-        """Attribute mode with trial_concurrency=1 (auto mode) should work."""
+    def test_context_mode_still_works(self, monkeypatch):
+        """Context mode should still work correctly."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
 
         @traigent.optimize(
             objectives=["accuracy"],
             configuration_space={"model": ["a"]},
-            eval_dataset=EVAL_DATASET,
-            injection_mode="attribute",
-            parallel_config={"trial_concurrency": 1},
-        )
-        def my_func(question: str) -> str:
-            return "answer"
-
-        result = await my_func.optimize(max_trials=1)
-        _require(result is not None, "Expected an optimization result, got None.")
-        _require(len(result.trials) == 1, "Expected exactly one trial result.")
-
-    @pytest.mark.asyncio
-    async def test_context_mode_parallel_no_error(self, mock_mode_env):
-        """Context mode with parallel execution should work without error."""
-
-        @traigent.optimize(
-            objectives=["accuracy"],
-            configuration_space={"model": ["a", "b"]},
             eval_dataset=EVAL_DATASET,
             injection_mode="context",
-            parallel_config={"trial_concurrency": 2, "mode": "parallel"},
         )
         def my_func(question: str) -> str:
             return "answer"
 
         # Should not raise
-        result = await my_func.optimize(max_trials=2)
-        _require(result is not None, "Expected an optimization result, got None.")
+        assert my_func is not None
+        assert hasattr(my_func, "optimize")
 
-    @pytest.mark.asyncio
-    async def test_parameter_mode_parallel_no_error(self, mock_mode_env):
-        """Parameter mode with parallel execution should work without error."""
-
-        @traigent.optimize(
-            objectives=["accuracy"],
-            configuration_space={"model": ["a", "b"]},
-            eval_dataset=EVAL_DATASET,
-            injection_mode="parameter",
-            config_param="config",
-            parallel_config={"trial_concurrency": 2, "mode": "parallel"},
-        )
-        def my_func(question: str, config: dict) -> str:
-            return "answer"
-
-        # Should not raise
-        result = await my_func.optimize(max_trials=2)
-        _require(result is not None, "Expected an optimization result, got None.")
-
-
-class TestAttributeParallelSafetyUnitLevel:
-    """Unit-level tests for the validation logic."""
-
-    def test_injection_options_has_allow_parallel_attribute_field(self):
-        """InjectionOptions should have allow_parallel_attribute field."""
-        from traigent.api.decorators import InjectionOptions
-
-        options = InjectionOptions()
-        _require(
-            hasattr(options, "allow_parallel_attribute"),
-            "Expected InjectionOptions to have allow_parallel_attribute.",
-        )
-        _require(
-            options.allow_parallel_attribute is False,
-            "Expected allow_parallel_attribute to default to False.",
-        )
-
-    def test_injection_options_allow_parallel_attribute_true(self):
-        """InjectionOptions should accept allow_parallel_attribute=True."""
-        from traigent.api.decorators import InjectionOptions
-
-        options = InjectionOptions(allow_parallel_attribute=True)
-        _require(
-            options.allow_parallel_attribute is True,
-            "Expected allow_parallel_attribute to be True when set.",
-        )
-
-    def test_optimized_function_stores_allow_parallel_attribute(self, mock_mode_env):
-        """OptimizedFunction should store allow_parallel_attribute."""
+    def test_seamless_mode_still_works(self, monkeypatch):
+        """Seamless mode should still work correctly."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
 
         @traigent.optimize(
             objectives=["accuracy"],
             configuration_space={"model": ["a"]},
             eval_dataset=EVAL_DATASET,
-            injection={"injection_mode": "attribute", "allow_parallel_attribute": True},
+            injection_mode="seamless",
         )
+        def my_func(question: str) -> str:
+            model = "default"
+            return f"answer from {model}"
+
+        # Should not raise
+        assert my_func is not None
+        assert hasattr(my_func, "optimize")
+
+
+class TestTraigentDisabled:
+    """Tests for TRAIGENT_DISABLED environment variable."""
+
+    def test_traigent_disabled_makes_decorator_passthrough(self, monkeypatch):
+        """When TRAIGENT_DISABLED=1, @optimize should return the original function."""
+        monkeypatch.setenv("TRAIGENT_DISABLED", "1")
+
+        # Need to reimport to pick up the env var change
+        from importlib import reload
+
+        import traigent.api.decorators
+
+        reload(traigent.api.decorators)
+        from traigent.api.decorators import optimize
+
+        def my_func(question: str) -> str:
+            return f"answer to {question}"
+
+        decorated = optimize(
+            objectives=["accuracy"],
+            configuration_space={"model": ["a", "b"]},
+            eval_dataset=EVAL_DATASET,
+        )(my_func)
+
+        # Should be the original function, not an OptimizedFunction
+        assert decorated is my_func
+        assert decorated("test") == "answer to test"
+
+    def test_traigent_disabled_true_works(self, monkeypatch):
+        """TRAIGENT_DISABLED=true should also disable Traigent."""
+        monkeypatch.setenv("TRAIGENT_DISABLED", "true")
+
+        from importlib import reload
+
+        import traigent.api.decorators
+
+        reload(traigent.api.decorators)
+        from traigent.api.decorators import optimize
+
         def my_func(question: str) -> str:
             return "answer"
 
-        _require(
-            hasattr(my_func, "allow_parallel_attribute"),
-            "Expected optimized function to expose allow_parallel_attribute.",
-        )
-        _require(
-            my_func.allow_parallel_attribute is True,
-            "Expected allow_parallel_attribute to be True on optimized function.",
-        )
+        decorated = optimize(
+            objectives=["accuracy"],
+            configuration_space={"model": ["a"]},
+        )(my_func)
+
+        assert decorated is my_func
+
+    def test_traigent_disabled_yes_works(self, monkeypatch):
+        """TRAIGENT_DISABLED=yes should also disable Traigent."""
+        monkeypatch.setenv("TRAIGENT_DISABLED", "yes")
+
+        from importlib import reload
+
+        import traigent.api.decorators
+
+        reload(traigent.api.decorators)
+        from traigent.api.decorators import optimize
+
+        def my_func(question: str) -> str:
+            return "answer"
+
+        decorated = optimize(
+            objectives=["accuracy"],
+            configuration_space={"model": ["a"]},
+        )(my_func)
+
+        assert decorated is my_func
+
+    def test_traigent_not_disabled_by_default(self, monkeypatch):
+        """Without TRAIGENT_DISABLED, @optimize should work normally."""
+        monkeypatch.delenv("TRAIGENT_DISABLED", raising=False)
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+        from importlib import reload
+
+        import traigent.api.decorators
+
+        reload(traigent.api.decorators)
+        from traigent.api.decorators import optimize
+
+        def my_func(question: str) -> str:
+            return "answer"
+
+        decorated = optimize(
+            objectives=["accuracy"],
+            configuration_space={"model": ["a"]},
+            eval_dataset=EVAL_DATASET,
+        )(my_func)
+
+        # Should be an OptimizedFunction, not the original
+        assert decorated is not my_func
+        assert hasattr(decorated, "optimize")

--- a/tests/unit/scripts/test_migrate_optuna.py
+++ b/tests/unit/scripts/test_migrate_optuna.py
@@ -22,14 +22,12 @@ def test_migration_applies_to_sqlite(tmp_path):
     migrations_dir = tmp_path / "migrations"
     migrations_dir.mkdir()
     migration = migrations_dir / "0001.sql"
-    migration.write_text(
-        """
+    migration.write_text("""
         CREATE TABLE IF NOT EXISTS optuna_demo (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             created TIMESTAMPTZ DEFAULT NOW()
         );
-        """
-    )
+        """)
 
     apply_migrations(db_url, migrations_dir, dry_run=False)
 

--- a/tests/unit/test_enhanced_framework_override.py
+++ b/tests/unit/test_enhanced_framework_override.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for enhanced framework override system with streaming and tool support."""
 
-
 import pytest
 
 from traigent.config.context import set_config

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -222,8 +222,7 @@ class TestPluginRegistry:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a mock plugin file
             plugin_file = Path(temp_dir) / "test_plugin.py"
-            plugin_file.write_text(
-                """
+            plugin_file.write_text("""
 from traigent.plugins.registry import OptimizerPlugin
 
 class TestOptimizer(OptimizerPlugin):
@@ -244,8 +243,7 @@ class TestOptimizer(OptimizerPlugin):
 
     def create_optimizer(self, **kwargs):
         return None
-"""
-            )
+""")
 
             # Mock Path.exists() to return True for plugin directories
             mock_path = Mock()

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -43,7 +43,6 @@ Examples:
 from __future__ import annotations
 
 import inspect
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -67,7 +66,12 @@ from traigent.config.parallel import (
     coerce_parallel_config,
     merge_parallel_configs,
 )
-from traigent.config.types import ExecutionMode, InjectionMode, resolve_execution_mode
+from traigent.config.types import (
+    ExecutionMode,
+    InjectionMode,
+    is_traigent_disabled,
+    resolve_execution_mode,
+)
 from traigent.core.objectives import (
     ObjectiveSchema,
     create_default_objectives,
@@ -98,14 +102,17 @@ class InjectionOptions(BaseModel):
     """Configuration bundle controlling how optimized configs are injected.
 
     Attributes:
-        injection_mode: How to inject config ("context", "parameter", "attribute", "seamless").
+        injection_mode: How to inject config ("context", "parameter", "seamless").
+            - "context" (default): Thread-safe contextvars, access via get_config()
+            - "parameter": Explicit config param in function signature
+            - "seamless": Zero code change, AST transformation
         config_param: Parameter name for injection_mode="parameter".
         auto_override_frameworks: Whether to auto-override framework calls.
         framework_targets: List of framework names to target.
-        allow_parallel_attribute: Opt-in to allow attribute mode with parallel trials.
-            Attribute mode is unsafe for parallel trials (race condition on shared
-            function attribute). Set to True only if you understand the risk and
-            are using context-based access inside the function body.
+
+    Note:
+        ATTRIBUTE mode was removed in v2.x due to thread-safety issues.
+        Use "context" (recommended) or "seamless" instead.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
@@ -116,7 +123,6 @@ class InjectionOptions(BaseModel):
     # Set to True explicitly when using framework integrations
     auto_override_frameworks: bool = False
     framework_targets: list[str] | None = None
-    allow_parallel_attribute: bool = False
 
 
 class ExecutionOptions(BaseModel):
@@ -290,7 +296,6 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "config_param": None,
     "auto_override_frameworks": False,  # Requires traigent-integrations plugin
     "framework_targets": None,
-    "allow_parallel_attribute": False,
     "execution_mode": "edge_analytics",
     "local_storage_path": None,
     "minimal_logging": True,
@@ -661,9 +666,8 @@ def _resolve_injection_bundle_options(
     config_param: Any,
     auto_override_frameworks: Any,
     framework_targets: Any,
-    allow_parallel_attribute: Any,
     defaults: dict[str, Any],
-) -> tuple[Any, Any, Any, Any, Any]:
+) -> tuple[Any, Any, Any, Any]:
     """Resolve injection options from bundle."""
     if injection_bundle is None:
         return (
@@ -671,7 +675,6 @@ def _resolve_injection_bundle_options(
             config_param,
             auto_override_frameworks,
             framework_targets,
-            allow_parallel_attribute,
         )
 
     return (
@@ -691,12 +694,6 @@ def _resolve_injection_bundle_options(
             "framework_targets",
             framework_targets,
             injection_bundle.framework_targets,
-            defaults,
-        ),
-        _resolve_option(
-            "allow_parallel_attribute",
-            allow_parallel_attribute,
-            injection_bundle.allow_parallel_attribute,
             defaults,
         ),
     )
@@ -824,17 +821,23 @@ def _resolve_execution_bundle_options(
 def _resolve_injection_mode_enum(
     injection_mode: str | InjectionMode,
 ) -> str | InjectionMode:
-    """Convert string injection mode to enum, handling deprecations."""
+    """Convert string injection mode to enum, handling removed modes."""
     if not isinstance(injection_mode, str):
         return injection_mode
 
-    if injection_mode == "decorator":
-        warnings.warn(
-            "injection_mode='decorator' is deprecated. Use 'attribute' instead.",
-            DeprecationWarning,
-            stacklevel=4,
+    # Handle removed injection modes with helpful migration message
+    if injection_mode in ("attribute", "decorator"):
+        from traigent.utils.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            f"injection_mode='{injection_mode}' has been removed in v2.x.\n\n"
+            "Migration guide:\n"
+            '  Before: @traigent.optimize(injection_mode="attribute")\n'
+            "          config = my_func.current_config\n\n"
+            '  After:  @traigent.optimize(injection_mode="context")\n'
+            "          config = traigent.get_config()\n\n"
+            'For zero code changes, use injection_mode="seamless" instead.'
         )
-        return InjectionMode.ATTRIBUTE
 
     try:
         return InjectionMode(injection_mode)
@@ -846,7 +849,6 @@ def _resolve_injection_mode_enum(
 _JS_INCOMPATIBLE_INJECTION_MODES = frozenset(
     {
         InjectionMode.CONTEXT,  # Uses Python's contextvars
-        InjectionMode.ATTRIBUTE,  # Stores on Python function attribute
         InjectionMode.SEAMLESS,  # Modifies Python source code
     }
 )
@@ -1227,13 +1229,13 @@ def optimize(
             injection: Grouped injection settings (InjectionOptions or dict) covering
                 how optimized parameters are applied.
             injection_mode: Selector for the injection mechanism (context, parameter,
-                attribute, seamless). Available via the bundle or legacy support.
+                seamless). "context" (default) uses thread-safe contextvars,
+                "parameter" adds explicit config param, "seamless" uses AST
+                transformation for zero code changes.
             config_param: Parameter name used when ``injection_mode="parameter"``.
             auto_override_frameworks: Toggle to auto-detect supported frameworks
                 (LangChain, OpenAI, Anthropic, etc.) and override their parameters.
             framework_targets: Explicit list of framework classes to override.
-            allow_parallel_attribute: Opt-in to allow attribute mode with parallel
-                trials (unsafe by default due to shared function attributes).
 
         Execution options:
             execution: Grouped execution settings (ExecutionOptions or dict) spanning
@@ -1337,7 +1339,20 @@ def optimize(
         ... def medical_assistant(patient_query: str) -> str:  # doctest: +SKIP
         ...     # Data never leaves your infrastructure
         ...     return process_medical_query(patient_query)
+
+    Note:
+        Set TRAIGENT_DISABLED=1 environment variable to disable all optimization.
+        The decorator becomes a pass-through that returns the original function.
     """
+    # Check if Traigent is disabled via environment variable
+    # When disabled, @optimize becomes a no-op that returns the original function
+    if is_traigent_disabled():
+        logger.debug("Traigent disabled via TRAIGENT_DISABLED env var, returning no-op")
+
+        def passthrough_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return func
+
+        return passthrough_decorator
 
     legacy_args = _parse_legacy_args(legacy)
 
@@ -1412,7 +1427,6 @@ def optimize(
     config_param = combined_settings["config_param"]
     auto_override_frameworks = combined_settings["auto_override_frameworks"]
     framework_targets = combined_settings["framework_targets"]
-    allow_parallel_attribute = combined_settings["allow_parallel_attribute"]
     execution_mode = combined_settings["execution_mode"]
     local_storage_path = combined_settings["local_storage_path"]
     minimal_logging = combined_settings["minimal_logging"]
@@ -1470,14 +1484,12 @@ def optimize(
         config_param,
         auto_override_frameworks,
         framework_targets,
-        allow_parallel_attribute,
     ) = _resolve_injection_bundle_options(
         injection_bundle,
         injection_mode,
         config_param,
         auto_override_frameworks,
         framework_targets,
-        allow_parallel_attribute,
         defaults,
     )
 
@@ -1596,7 +1608,6 @@ def optimize(
             config_param=config_param,
             auto_override_frameworks=auto_override_frameworks,
             framework_targets=framework_targets,
-            allow_parallel_attribute=allow_parallel_attribute,
             execution_mode=execution_mode_enum,
             local_storage_path=local_storage_path,
             minimal_logging=minimal_logging,

--- a/traigent/api/parameter_validator.py
+++ b/traigent/api/parameter_validator.py
@@ -45,7 +45,6 @@ class ParameterValidator:
     VALID_INJECTION_MODES = {
         InjectionMode.CONTEXT,
         InjectionMode.PARAMETER,
-        InjectionMode.ATTRIBUTE,
         InjectionMode.SEAMLESS,
     }
 

--- a/traigent/config/__init__.py
+++ b/traigent/config/__init__.py
@@ -15,7 +15,6 @@ from traigent.config.context import (
     set_config,
 )
 from traigent.config.providers import (
-    AttributeBasedProvider,
     ConfigurationProvider,
     ContextBasedProvider,
     ParameterBasedProvider,
@@ -35,7 +34,6 @@ __all__ = [
     "ConfigurationProvider",
     "ContextBasedProvider",
     "ParameterBasedProvider",
-    "AttributeBasedProvider",
     "SeamlessParameterProvider",
     "get_provider",
     # Types

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -279,105 +279,6 @@ class ParameterBasedProvider(ConfigurationProvider):
         return self.default_param_name in sig.parameters
 
 
-class AttributeBasedProvider(ConfigurationProvider):
-    """Provider that stores configuration as function attribute.
-
-    This provider attaches configuration to the function object,
-    allowing access through function attributes. Configuration is set
-    on both the wrapper and original function to support accessing
-    config from inside the function body.
-
-    Example::
-
-        @traigent.optimize(injection_mode="attribute")
-        def my_function(query: str) -> str:
-            config = my_function.current_config
-            return f"Using model: {config['model']}"
-    """
-
-    def __init__(self, attribute_name: str = "current_config") -> None:
-        """Initialize attribute-based provider.
-
-        Args:
-            attribute_name: Attribute name for storing configuration.
-                Defaults to "current_config" for backward compatibility.
-        """
-        self.attribute_name = attribute_name
-        # Track wrappers and originals for cleanup
-        self._wrappers: list[Callable[..., Any]] = []
-        self._originals: list[Callable[..., Any]] = []
-
-    def inject_config(
-        self,
-        func: Callable[..., Any],
-        config: dict[str, Any],
-        config_param: str | None = None,
-    ) -> Callable[..., Any]:
-        """Inject configuration as function attribute.
-
-        Configuration is set on the wrapper only, not the original function.
-        This avoids polluting the original function with unexpected attributes.
-
-        To access config inside your function, use traigent.get_config() which
-        works both during optimization trials and after apply_best_config().
-        For post-optimization access, you can also use func.current_config.
-        """
-
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Store current config on wrapper only (not original)
-            setattr(wrapper, self.attribute_name, config)
-            with ConfigurationContext(config):
-                return func(*args, **kwargs)
-
-        # For async functions
-        if inspect.iscoroutinefunction(func):
-
-            @wraps(func)
-            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                # Set config on wrapper only (not original)
-                setattr(async_wrapper, self.attribute_name, config)
-                with ConfigurationContext(config):
-                    return await func(*args, **kwargs)
-
-            # Set initial config on wrapper for immediate visibility after inject_config()
-            # The inner setattr ensures config stays up-to-date on each call
-            setattr(async_wrapper, self.attribute_name, config)
-            self._wrappers.append(async_wrapper)
-            self._originals.append(func)
-            return async_wrapper
-
-        # Set initial config on wrapper for immediate visibility after inject_config()
-        # The inner setattr ensures config stays up-to-date on each call
-        setattr(wrapper, self.attribute_name, config)
-        self._wrappers.append(wrapper)
-        self._originals.append(func)
-        return wrapper
-
-    def extract_config(self, func: Callable[..., Any]) -> dict[str, Any] | None:
-        """Extract configuration from function attribute."""
-        return getattr(func, self.attribute_name, None)
-
-    def supports_function(self, func: Callable[..., Any]) -> bool:
-        """Attribute injection works with any function."""
-        return True
-
-    def cleanup(self) -> None:
-        """Clean up configuration attributes from tracked wrappers.
-
-        Note: We only clean wrappers, not originals, since we no longer
-        set attributes on original functions (to avoid pollution).
-        """
-        for wrapper in self._wrappers:
-            if hasattr(wrapper, self.attribute_name):
-                try:
-                    delattr(wrapper, self.attribute_name)
-                except AttributeError:
-                    pass  # Already removed
-        self._wrappers.clear()
-        self._originals.clear()
-
-
 class SeamlessParameterProvider(ConfigurationProvider):
     """Safe provider that seamlessly injects parameters using AST transformation.
 
@@ -981,7 +882,6 @@ class SeamlessParameterProvider(ConfigurationProvider):
 _PROVIDERS: dict[str, type[ConfigurationProvider]] = {
     "context": ContextBasedProvider,
     "parameter": ParameterBasedProvider,
-    "attribute": AttributeBasedProvider,
 }
 
 # Seamless provider is included in base for now, but will move to traigent-seamless plugin
@@ -998,8 +898,7 @@ def get_provider(injection_mode: str, **kwargs: Any) -> ConfigurationProvider:
     """Get configuration provider by injection mode.
 
     Args:
-        injection_mode: One of "context", "parameter", "attribute", "seamless"
-                       ("decorator" is deprecated but still supported)
+        injection_mode: One of "context", "parameter", "seamless"
         **kwargs: Additional arguments for provider initialization
 
     Returns:
@@ -1009,9 +908,17 @@ def get_provider(injection_mode: str, **kwargs: Any) -> ConfigurationProvider:
         ConfigurationError: If injection mode is not supported
         FeatureNotAvailableError: If seamless mode requested but plugin not installed
     """
-    # Handle backward compatibility
-    if injection_mode == "decorator":
-        injection_mode = "attribute"
+    # Handle removed injection modes with helpful migration message
+    if injection_mode in ("attribute", "decorator"):
+        raise ConfigurationError(
+            f"injection_mode='{injection_mode}' has been removed in v2.x.\n\n"
+            "Migration guide:\n"
+            '  Before: @traigent.optimize(injection_mode="attribute")\n'
+            "          config = my_func.current_config\n\n"
+            '  After:  @traigent.optimize(injection_mode="context")\n'
+            "          config = traigent.get_config()\n\n"
+            'For zero code changes, use injection_mode="seamless" instead.'
+        )
 
     if injection_mode not in _PROVIDERS:
         # Provide helpful error for seamless mode when plugin not installed
@@ -1036,10 +943,5 @@ def get_provider(injection_mode: str, **kwargs: Any) -> ConfigurationProvider:
             kwargs.get("config_param") or "config"
         )  # Default to "config" if None or missing
         return ParameterBasedProvider(default_param_name=config_param)
-    elif injection_mode == "attribute":
-        attribute_name = kwargs.get(
-            "attribute_name", "current_config"
-        )  # Default attribute name
-        return AttributeBasedProvider(attribute_name=attribute_name)
     else:
         return provider_class()

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -64,16 +64,40 @@ class InjectionMode(str, Enum):
 
     Each mode provides a different way to inject configuration into optimized functions:
 
-    - CONTEXT: Uses Python's contextvars for thread-safe configuration
+    - CONTEXT: Uses Python's contextvars for thread-safe configuration (default)
     - PARAMETER: Adds explicit configuration parameter to function signature
-    - ATTRIBUTE: Stores configuration as function attribute
-    - SEAMLESS: Modifies variable assignments in function source code
+    - SEAMLESS: Modifies variable assignments in function source code (zero code change)
+
+    Note:
+        ATTRIBUTE mode was removed in v2.x due to thread-safety issues with parallel
+        trials. Use CONTEXT (recommended) or SEAMLESS instead.
     """
 
     CONTEXT = "context"
     PARAMETER = "parameter"
-    ATTRIBUTE = "attribute"
     SEAMLESS = "seamless"
+
+
+def is_traigent_disabled() -> bool:
+    """Check if Traigent is disabled via environment variable.
+
+    When TRAIGENT_DISABLED=1 (or 'true'/'yes'), the @traigent.optimize decorator
+    becomes a pass-through that returns the original function unchanged.
+
+    This allows production deployments to disable Traigent without code changes.
+
+    Returns:
+        True if Traigent is disabled, False otherwise.
+
+    Example:
+        # In production, set TRAIGENT_DISABLED=1 to disable all optimization
+        >>> import os
+        >>> os.environ["TRAIGENT_DISABLED"] = "1"
+        >>> is_traigent_disabled()
+        True
+    """
+    val = os.getenv("TRAIGENT_DISABLED", "").lower()
+    return val in ("1", "true", "yes")
 
 
 @dataclass

--- a/traigent/core/config_builder.py
+++ b/traigent/core/config_builder.py
@@ -172,7 +172,7 @@ class OptimizedFunctionConfig:
         warnings = []
 
         # Validate injection mode
-        valid_injection_modes = ["context", "parameter", "decorator"]
+        valid_injection_modes = ["context", "parameter", "seamless"]
         if self.injection_mode not in valid_injection_modes:
             errors.append(
                 f"Invalid injection_mode: {self.injection_mode}. Must be one of {valid_injection_modes}"

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -328,7 +328,6 @@ class OptimizedFunction:
         config_param: str | None = None,
         auto_override_frameworks: bool = False,
         framework_targets: list[str] | None = None,
-        allow_parallel_attribute: bool = False,
         execution_mode: str = "cloud",
         local_storage_path: str | None = None,
         minimal_logging: bool = True,
@@ -363,8 +362,6 @@ class OptimizedFunction:
         # Config persistence parameters
         self._auto_load_best = kwargs.pop("auto_load_best", False)
         self._load_from = kwargs.pop("load_from", None)
-        # Store allow_parallel_attribute early for validation in _resolve_effective_parallel_config
-        self.allow_parallel_attribute = allow_parallel_attribute
         # Store core parameters
         self._store_core_parameters(
             func,
@@ -1359,36 +1356,6 @@ class OptimizedFunction:
 
         for warning in resolved_parallel.warnings:
             logger.warning(warning)
-
-        # Check for unsafe attribute mode + parallel trials combination
-        injection_mode_str = (
-            self.injection_mode.value
-            if hasattr(self.injection_mode, "value")
-            else self.injection_mode
-        )
-        if (
-            injection_mode_str == "attribute"
-            and resolved_parallel.trial_concurrency > 1
-        ):
-            if not getattr(self, "allow_parallel_attribute", False):
-                raise ValueError(
-                    "injection_mode='attribute' is unsafe with parallel trials "
-                    "(trial_concurrency > 1). The function attribute is shared across "
-                    "concurrent trials and can cause race conditions. "
-                    "Options:\n"
-                    "  1. Use injection_mode='context' or 'parameter' (recommended)\n"
-                    "  2. Use sequential trials: parallel_config={'trial_concurrency': 1}\n"
-                    "  3. Opt in explicitly: injection={'injection_mode': 'attribute', "
-                    "'allow_parallel_attribute': True} and access config via "
-                    "traigent.get_config() inside your function"
-                )
-            logger.warning(
-                "injection_mode='attribute' with parallel trials (trial_concurrency=%d) "
-                "is not safe. The function attribute is shared across concurrent trials "
-                "and may contain config from a different trial. Use traigent.get_config() "
-                "inside your function for correct per-trial config access.",
-                resolved_parallel.trial_concurrency,
-            )
 
         logger.info(
             "Resolved parallel configuration: mode=%s, trial_concurrency=%s, example_concurrency=%s, thread_workers=%s",


### PR DESCRIPTION
## Summary
- Remove ATTRIBUTE injection mode (unsafe for parallel trials, no unique benefit)
- Add `TRAIGENT_DISABLED` environment variable for production no-op mode
- Consolidate from 4 injection modes to 3: CONTEXT, SEAMLESS, PARAMETER

## Motivation
Based on analysis and Codex (GPT-5.2) review:
- ATTRIBUTE mode was unsafe for parallel trials due to race condition on shared function attribute
- Required opt-in `allow_parallel_attribute=True` which users could misuse
- Provided no benefit over CONTEXT mode (both required code changes to access config)

## Changes
| File | Change |
|------|--------|
| `traigent/config/types.py` | Remove `ATTRIBUTE` from `InjectionMode` enum, add `is_traigent_disabled()` |
| `traigent/config/providers.py` | Remove `AttributeBasedProvider` class, add migration error |
| `traigent/api/decorators.py` | Add `TRAIGENT_DISABLED` passthrough, remove `allow_parallel_attribute` |
| `traigent/api/parameter_validator.py` | Remove `ATTRIBUTE` from valid modes |
| `traigent/core/optimized_function.py` | Remove `allow_parallel_attribute` param and safety check |
| Tests | Updated to test removal + new `TRAIGENT_DISABLED` feature |

## Migration Guide
Users currently using `injection_mode="attribute"`:
```python
# Before
@traigent.optimize(injection_mode="attribute")
def my_func():
    config = my_func.current_config

# After (recommended)
@traigent.optimize(injection_mode="context")
def my_func():
    config = traigent.get_config()

# Or for zero code changes
@traigent.optimize(injection_mode="seamless")
def my_func():
    model = "gpt-3.5"  # Will be auto-replaced with config value
```

## New Feature: TRAIGENT_DISABLED
Set `TRAIGENT_DISABLED=1` (or `true`/`yes`) to disable all optimization:
```bash
TRAIGENT_DISABLED=1 python app.py
```
- `@traigent.optimize` becomes a pass-through (returns original function)
- Zero overhead in production
- No code changes needed to strip Traigent

## Test plan
- [x] All new tests pass (26 tests)
- [x] `make format` passes
- [x] `make lint` passes
- [ ] Full test suite on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)