### PR TITLE
ci: Remove Python 3.14 from test matrix

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -17,11 +17,9 @@ on:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
-    # Python 3.14 may fail due to missing dependency wheels - don't block PRs
-    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -30,7 +28,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: ${{ matrix.python-version == '3.14' }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -22,14 +22,12 @@ jobs:
   test-examples:
     name: Test Examples - Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest  # Only use ubuntu-latest (free for public repos)
-    # Python 3.14 may fail due to missing dependency wheels - don't block PRs
-    continue-on-error: ${{ matrix.python-version == '3.14' }}
 
     strategy:
       fail-fast: true  # Stop on first failure to save minutes
       matrix:
         # Test on supported Python versions (>=3.11 per pyproject.toml)
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -38,7 +36,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: ${{ matrix.python-version == '3.14' }}
 
     - name: Cache pip packages
       uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,12 +10,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Python 3.14 may fail due to missing dependency wheels - don't block PRs
-    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -40,7 +38,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: ${{ matrix.python-version == '3.14' }}
 
     - name: Cache pip dependencies
       uses: actions/cache@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
 
   # Secret detection
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -66,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -107,6 +122,7024 @@
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
-  "results": {},
-  "generated_at": "2024-01-01T00:00:00Z"
+  "results": {
+    ".github/workflows/examples-smoke.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/examples-smoke.yml",
+        "hashed_secret": "a0f3f533c2cbe8188b01248377461ead061020ca",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/examples-smoke.yml",
+        "hashed_secret": "15ebd6ee61f7981c21651ad806abe90f14fe44bf",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 570
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 910
+      }
+    ],
+    "configs/env-templates/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "configs/env-templates/README.md",
+        "hashed_secret": "33f220dd67f717cc949db63e21c90e130a6137da",
+        "is_verified": false,
+        "line_number": 65
+      }
+    ],
+    "docs/architecture/plugin_architecture.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/architecture/plugin_architecture.md",
+        "hashed_secret": "f4aae9866cf436c5fb567f0d599bc6ec872e83f6",
+        "is_verified": false,
+        "line_number": 138
+      }
+    ],
+    "docs/contributing/ADDING_NEW_INTEGRATIONS.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/contributing/ADDING_NEW_INTEGRATIONS.md",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "docs/contributing/SECURITY.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/contributing/SECURITY.md",
+        "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
+        "is_verified": false,
+        "line_number": 99
+      }
+    ],
+    "docs/features/authentication.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/features/authentication.md",
+        "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
+        "is_verified": false,
+        "line_number": 373
+      }
+    ],
+    "docs/tvl/tvl-website/pnpm-lock.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "121a3385c5e28b32a26d3cad7c90a29496d9747f",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "69ae37e0133456d2c3fbfd903c273bf1372267e0",
+        "is_verified": false,
+        "line_number": 244
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "24bcacef3fb203d046d58405e8207a5342669fe2",
+        "is_verified": false,
+        "line_number": 247
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d4eac0bf704336f38e69fd6832e6f021ded39602",
+        "is_verified": false,
+        "line_number": 250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dc4d28f9890d4fa2dfd62af6dad92301d743197b",
+        "is_verified": false,
+        "line_number": 254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5d38e92aeafa91e0b0d9dca469391b9cdfe9dcfd",
+        "is_verified": false,
+        "line_number": 258
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4a9ae62604ff3094a86888165571aedf55bb29b1",
+        "is_verified": false,
+        "line_number": 262
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "91ef8efb1f1a9f7b957debc2f9382278a11e9e91",
+        "is_verified": false,
+        "line_number": 266
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5cb278a68156ae376bea48fb0f872cbc5dfd0a63",
+        "is_verified": false,
+        "line_number": 270
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1ebe57ea46fba7d746cb222ee21b5cd413c80ff1",
+        "is_verified": false,
+        "line_number": 274
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1fc27c75818896b4e84d7e8ca98e0e8c00118bb7",
+        "is_verified": false,
+        "line_number": 278
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e844f3c78344b978e74bc22b6c2736d4b0c393e1",
+        "is_verified": false,
+        "line_number": 284
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8319864fae2ce720a9588f890930b4dd3f736a4f",
+        "is_verified": false,
+        "line_number": 288
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e2a4d1a24c1c4aac8dc6ee6056c8a135c8db64a",
+        "is_verified": false,
+        "line_number": 292
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6302a9750ba626bf9d98ea2b93c8044c2c13dd03",
+        "is_verified": false,
+        "line_number": 296
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "aab5f636e7355b605c94009444540cb86f20a48d",
+        "is_verified": false,
+        "line_number": 300
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8570cc5660ba5cb0957e273be0100cce91506931",
+        "is_verified": false,
+        "line_number": 304
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "210797f986e8839f4aa71c2e7fa465944644b42f",
+        "is_verified": false,
+        "line_number": 309
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "07c2a515b8ce991183b3b5cbfc018668baa54ac6",
+        "is_verified": false,
+        "line_number": 315
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "adc1d52f38ba77308117df559dea25e43eb9f263",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "67428c90207cc195acaf62942754b6a6861c8b90",
+        "is_verified": false,
+        "line_number": 325
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "de045e2ed3223c2ab40b541eb6a518fd1a3ad0f2",
+        "is_verified": false,
+        "line_number": 329
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "73b60e42d9313eca080440873f8fa1fcb5310f29",
+        "is_verified": false,
+        "line_number": 333
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3942b0ee3200c0c70746db896347c9f1c86795ee",
+        "is_verified": false,
+        "line_number": 337
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2765cac86159f5017e7511a57adb410bf0540193",
+        "is_verified": false,
+        "line_number": 340
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e7272e163bbc139a72d39a9cd8d521c3daef962d",
+        "is_verified": false,
+        "line_number": 343
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f14ba07acf972f2b7095f1814fc1596e605878a4",
+        "is_verified": false,
+        "line_number": 348
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4d2a9fe8166ba36c28dbe2172304f097713f9f4b",
+        "is_verified": false,
+        "line_number": 351
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f97e027840e6148350273c88efef7e8b5d1cf5bc",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "69a078d0c8d430cbbb7fc4c42f598e5e98ee5c5d",
+        "is_verified": false,
+        "line_number": 357
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "854ad107863bc6fe3bfc0508180a26191b1c0a2d",
+        "is_verified": false,
+        "line_number": 360
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a8e4627e40f4bf3903759a298bc646332f041250",
+        "is_verified": false,
+        "line_number": 363
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ba92041b8b57e5f3f7cfda01eca4eb5f863d8230",
+        "is_verified": false,
+        "line_number": 366
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ec1989ae36181cb6d116871a04bd886e8aa7680a",
+        "is_verified": false,
+        "line_number": 372
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7543ee65aa0a02783414e8a1dbd3d18c0c3123cc",
+        "is_verified": false,
+        "line_number": 378
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d8fa482cdfbba9269e34d191ace0e402c5cb45c3",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5cab2cbf14962ddc1d6ed2bfe25898fe4c36dec1",
+        "is_verified": false,
+        "line_number": 390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9d1eaaf504742620f3f5b102a4f02d28d4f919ce",
+        "is_verified": false,
+        "line_number": 396
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b3ffc344491402f73ea16b1b8718e18833050114",
+        "is_verified": false,
+        "line_number": 402
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e427dd2b428dd4241dd1b8355c3b92fd85839376",
+        "is_verified": false,
+        "line_number": 408
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "06c952d11f13461da10c7bba057d78cc5fa5e6fb",
+        "is_verified": false,
+        "line_number": 414
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "771db604fdb79532e77b7128227a745a3ec9ec0a",
+        "is_verified": false,
+        "line_number": 420
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c2ea7b0b8f40b08e1b89209f677ff5d6a719b60a",
+        "is_verified": false,
+        "line_number": 426
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2b63c304518691010aeed935b51f86afcc24ede1",
+        "is_verified": false,
+        "line_number": 432
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8816a15bd9ad8879b3f1823b94fb7c46dd643f17",
+        "is_verified": false,
+        "line_number": 438
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e1c65275ad0b487c12c5a2f2ca5541ad0ebe811",
+        "is_verified": false,
+        "line_number": 444
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9836b23edc498bf0925d3e560f0684f6ec75bb9a",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "19506ba5fec5de7d878352659f9a362ada89bb75",
+        "is_verified": false,
+        "line_number": 456
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f42b2f70ce99e343a262e45315a2c4d27daba270",
+        "is_verified": false,
+        "line_number": 462
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "de04d845fc3903d04f8604ae162d8a4cb95f86ba",
+        "is_verified": false,
+        "line_number": 468
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e9fc60c601cab29ea7878a0c9688fb6ee925cf9",
+        "is_verified": false,
+        "line_number": 474
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6c8a21c9366b66bd16b8848cd8ef2f10233ad5ef",
+        "is_verified": false,
+        "line_number": 480
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6b1f54e31a53e3667a97cf3af18a66d1cedec7b8",
+        "is_verified": false,
+        "line_number": 486
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "05a957e570c3e4e61ba9f99a19db326dcd2417c2",
+        "is_verified": false,
+        "line_number": 492
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "efbe56870cd191d53ef1e6ac6d40ed5eb4cd01c0",
+        "is_verified": false,
+        "line_number": 498
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "24594f4581212d856fe125c6864f7fed1b8a4b65",
+        "is_verified": false,
+        "line_number": 504
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fefbbc2958b5d0546d6507d1aad9bead9ef7e9eb",
+        "is_verified": false,
+        "line_number": 510
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5020d98c493f4c60e4e9faa360aee83831e8b060",
+        "is_verified": false,
+        "line_number": 516
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "489f7d6ea770d41978c763f306e573aa9c086e3b",
+        "is_verified": false,
+        "line_number": 522
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3bcaf9ab39f602b74d65d903898d40b60bc49e8d",
+        "is_verified": false,
+        "line_number": 528
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "84e33cad738a516642e9e4e00c9910ada2755eb8",
+        "is_verified": false,
+        "line_number": 534
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0c232b00899ac5c6c72c50d675fba58be657bb51",
+        "is_verified": false,
+        "line_number": 540
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0329358e1442ae9c1dd0cfa7884c4cc51c123c7d",
+        "is_verified": false,
+        "line_number": 546
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "45d7376b39d308f58d92366f89fd5897f34937df",
+        "is_verified": false,
+        "line_number": 552
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5520077e071061b96b1bd30a351f2bb3a52cac50",
+        "is_verified": false,
+        "line_number": 558
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a28c69b673bfe25255ddea617830f4a227450bed",
+        "is_verified": false,
+        "line_number": 564
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "87b1f5328d5448d368f3d6f42f966bf553d4bf3c",
+        "is_verified": false,
+        "line_number": 570
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5fd94d7bc55b700838f7232aa04cd14ce8883702",
+        "is_verified": false,
+        "line_number": 576
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "01860ebaf2a9445d78d11a9db89fecb64710265a",
+        "is_verified": false,
+        "line_number": 582
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c3d73f1f8439f4e9e5ad0a8febe880d627dddabc",
+        "is_verified": false,
+        "line_number": 588
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8c94dfd0dbadd0e968f0e9e175bf5bb4fd2594c0",
+        "is_verified": false,
+        "line_number": 594
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cbe73cdb542e52cf85fdae96db4078baf3f81b92",
+        "is_verified": false,
+        "line_number": 600
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ed301ff805587fb9a77f80f5d0fdda6c08a58b87",
+        "is_verified": false,
+        "line_number": 606
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "38e7a2d417fe20d4760873aa7ad041fa74821645",
+        "is_verified": false,
+        "line_number": 612
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "467ae1b8eba0bb5ed7382100073d14fbb509e77d",
+        "is_verified": false,
+        "line_number": 618
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2a46cf814514d8cf3a189ce88b22d30c24baf70a",
+        "is_verified": false,
+        "line_number": 624
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "59d87dd0fe7239a69d11c22fbefefe60c35d99fb",
+        "is_verified": false,
+        "line_number": 630
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f13e357a26f9e2972019db90dd8ceb867b494f9c",
+        "is_verified": false,
+        "line_number": 636
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f218898e24af5e5ed6a427f4ab4a68014281779f",
+        "is_verified": false,
+        "line_number": 642
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "35ecb49473bd3c2a84f86fcae2c69e255bdcd843",
+        "is_verified": false,
+        "line_number": 648
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "669e09509d438d5cd9e616a3c27c19d501a6a931",
+        "is_verified": false,
+        "line_number": 654
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5a933a1d9e284cd13a250c28ac430627f1764b3a",
+        "is_verified": false,
+        "line_number": 660
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5db841f4dee4c0a298106f6d56f32851515d99b2",
+        "is_verified": false,
+        "line_number": 663
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b013f3dad4ce2fde647e14586ce596cca9a8c39f",
+        "is_verified": false,
+        "line_number": 666
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dd1db68c43067371d00db59c7f10d0d3ad598841",
+        "is_verified": false,
+        "line_number": 672
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e0d5107e832ed2eed26116dafb2f5c5f977e1341",
+        "is_verified": false,
+        "line_number": 675
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "85caec8d352770d092317299afa348764d129ed5",
+        "is_verified": false,
+        "line_number": 678
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "12de1cdad03b08d04f2c666eb0cb5f1234b496e5",
+        "is_verified": false,
+        "line_number": 681
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
+        "is_verified": false,
+        "line_number": 685
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e3522c83d724aa4133ee6bb6d627e4390be31a5",
+        "is_verified": false,
+        "line_number": 688
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
+        "is_verified": false,
+        "line_number": 691
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
+        "is_verified": false,
+        "line_number": 695
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
+        "is_verified": false,
+        "line_number": 698
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b02f181ddfb118185d3fc0be3cac545e7bec4ce5",
+        "is_verified": false,
+        "line_number": 701
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8936283936d833d3fcbc796b612c493f0fc5a2a4",
+        "is_verified": false,
+        "line_number": 704
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5bace6024c7051eb7a1cb1e37f7b9985e533a42e",
+        "is_verified": false,
+        "line_number": 707
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
+        "is_verified": false,
+        "line_number": 710
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9966b38a797edc23680e66fcde5a3aa022979a2a",
+        "is_verified": false,
+        "line_number": 713
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6ff531666abb24912d9fae3b91bcd05a49330c9f",
+        "is_verified": false,
+        "line_number": 726
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
+        "is_verified": false,
+        "line_number": 739
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bf694b5dac75776f7b55aa5663e0d0cef3fb1812",
+        "is_verified": false,
+        "line_number": 752
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8d4a8977dae9d6867dfcdbeb6417d6ab8461534a",
+        "is_verified": false,
+        "line_number": 765
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "eea334ce67d119e127ca2448c8fd8cb9328a5664",
+        "is_verified": false,
+        "line_number": 778
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "693ab2239e3a31d3b1052c6976a8429dd406e7ea",
+        "is_verified": false,
+        "line_number": 791
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "09b6aade4800e313c2bbed96548c4f2dce507168",
+        "is_verified": false,
+        "line_number": 804
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e9d53eedf607b11c3ef44b8c6ff18958ad146340",
+        "is_verified": false,
+        "line_number": 817
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d918d00bcbccaae92cf19b1396e6a7513de61bed",
+        "is_verified": false,
+        "line_number": 826
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "32322bcf00299724296af3309bc033b969f83bf6",
+        "is_verified": false,
+        "line_number": 839
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "76bb59906af53dcb878b807d5817d5edb7ae390f",
+        "is_verified": false,
+        "line_number": 848
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ebfd0dc170295e67df4d796db25987963ca97e61",
+        "is_verified": false,
+        "line_number": 861
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d146f31752027f19751d396a49a62010d97f6b80",
+        "is_verified": false,
+        "line_number": 870
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cfe0bd31a00a41920823c76d517fe7d062e5337c",
+        "is_verified": false,
+        "line_number": 883
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b16b457c3af8581fda0aad82df8a4d25d56b72f5",
+        "is_verified": false,
+        "line_number": 896
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "28f0a338a11c78c8b77f06940e97fd7242579d23",
+        "is_verified": false,
+        "line_number": 905
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c33800ed8ec5106a1d053238f1a22ffad0f7efb9",
+        "is_verified": false,
+        "line_number": 918
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bfb1d8f7fcfdc3951f2a407606332dd0561ea889",
+        "is_verified": false,
+        "line_number": 931
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "34ad22b7134e6220790e6f8cb7f7325b72b0ac78",
+        "is_verified": false,
+        "line_number": 940
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "380016634dca8718e45627a3e887a33cfdbf9583",
+        "is_verified": false,
+        "line_number": 953
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e12e619cf0949f9f48db809f6ba8abe6d9c49b47",
+        "is_verified": false,
+        "line_number": 966
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "afb54bbdc2c452025423e4b999636e1168c9e9c8",
+        "is_verified": false,
+        "line_number": 979
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d5af9fbde70bf119125bc5280e31def9cfc5d2e4",
+        "is_verified": false,
+        "line_number": 992
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c93cfee749f39a6731bd90e3b8bfc1c2f39dd0bb",
+        "is_verified": false,
+        "line_number": 1005
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "384119563704c0a0c154cfa3a7fb2f1b6e403e4d",
+        "is_verified": false,
+        "line_number": 1018
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a9799e49f2382f864dab19d97df038fbcc760f79",
+        "is_verified": false,
+        "line_number": 1031
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "237858a86350af1517b45ec07878dc64d875b973",
+        "is_verified": false,
+        "line_number": 1044
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8016aea1098ddd8ebc4bfdebfe91e36d1f038306",
+        "is_verified": false,
+        "line_number": 1057
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ebafd7b99e26904ea5a3ba20abd17c2d7b913663",
+        "is_verified": false,
+        "line_number": 1070
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "938a7b1d49a0c2692666797b3a00b607ba1912d4",
+        "is_verified": false,
+        "line_number": 1083
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5cdcee5a29292be13235b5cbddc6aa392d2b23f1",
+        "is_verified": false,
+        "line_number": 1096
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d157cd2020faa83a1b672bfd2233a417b17e42d8",
+        "is_verified": false,
+        "line_number": 1109
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7de62fb92f302a3b6974835f839eb53033647499",
+        "is_verified": false,
+        "line_number": 1122
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "929a3372bee6ce841a9f65cc9edebf68210e5fd7",
+        "is_verified": false,
+        "line_number": 1135
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c8400bcab54bbc669cbe44b013fd300ec181ae04",
+        "is_verified": false,
+        "line_number": 1148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4ca19d51441ee1c7bae4a9ed5f5d5e5befcbbb2e",
+        "is_verified": false,
+        "line_number": 1157
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "249cc7d6ea282d76f5efff9fb4ed6ed5d3058d08",
+        "is_verified": false,
+        "line_number": 1170
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "324131826dfbc742fce8c6746a676f16efc315cd",
+        "is_verified": false,
+        "line_number": 1183
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2b0f34d995e245b329cd153a0eeee34dfc4266c7",
+        "is_verified": false,
+        "line_number": 1196
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "446546bba84a6355c159d0562c57c670fea13d34",
+        "is_verified": false,
+        "line_number": 1209
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7d3f1b8d6e4eca6f79dbaf3cdfbca069ab37a6e8",
+        "is_verified": false,
+        "line_number": 1222
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1cfc669b4a91926a20a0c195e64a33fddfc28636",
+        "is_verified": false,
+        "line_number": 1231
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "089409fd943a2fb3a5a50b4725a4c96a16bc5d19",
+        "is_verified": false,
+        "line_number": 1240
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ccf9afc9b093a34274214374a841c68216c23105",
+        "is_verified": false,
+        "line_number": 1249
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "29094c26e288b5cebbc5262a1996e29057328f1f",
+        "is_verified": false,
+        "line_number": 1258
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "95362ad9b076707c159a81577f1695dea0ed2eb3",
+        "is_verified": false,
+        "line_number": 1267
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8cd02e410a9ff591baae8fb0b142f31b91ef9ec0",
+        "is_verified": false,
+        "line_number": 1276
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9dfea0993e072e2f30d0a2cac0b7bda5f6e7f980",
+        "is_verified": false,
+        "line_number": 1285
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "15432d91ade7f228054c5d23ceac8d48711a5853",
+        "is_verified": false,
+        "line_number": 1294
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "69ae791ca6d7814550c0af06cc57217e4e1388ea",
+        "is_verified": false,
+        "line_number": 1303
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "647690124fbe1ff7811211b1ec8ec14c9800de35",
+        "is_verified": false,
+        "line_number": 1316
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "74e24729da4c61e671c60aba5212f1641cba2b44",
+        "is_verified": false,
+        "line_number": 1319
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c27db3e7ad28966571d6aaab4221024adc120e28",
+        "is_verified": false,
+        "line_number": 1322
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cb81edbb9a250cdf42587eda7d50adffe56a7716",
+        "is_verified": false,
+        "line_number": 1327
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f9f4f9a8a71949a267f7074f07957384044256e0",
+        "is_verified": false,
+        "line_number": 1332
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a0ac680a8a2a9c7fcd76e3eeec5a56dab25d4a75",
+        "is_verified": false,
+        "line_number": 1337
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2d95d1eb2675da08784f1d264e8062451750e573",
+        "is_verified": false,
+        "line_number": 1342
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cbcf851cc0fc469cc6cff29b7bda4823770c2b24",
+        "is_verified": false,
+        "line_number": 1347
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2d76c5b618e06f5060b1251c229bd66068993d79",
+        "is_verified": false,
+        "line_number": 1352
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "082cca8a1791200f5bd827df1a5af92478fff517",
+        "is_verified": false,
+        "line_number": 1357
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b6d5ddb597b029ec693970060b7472ba0087d057",
+        "is_verified": false,
+        "line_number": 1362
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "873d6e91bd90150ae8600b7982720e47b7f7726d",
+        "is_verified": false,
+        "line_number": 1367
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6f1d9b493a63d420310b699d2006de1511097c5f",
+        "is_verified": false,
+        "line_number": 1372
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "600319d21b284b959a238f481057f93ad9ace156",
+        "is_verified": false,
+        "line_number": 1377
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "78de47b110ddd28c06f356dd9fe919eea04f695c",
+        "is_verified": false,
+        "line_number": 1382
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "641123fc06f217d65b231317ec413f3d82eb2c82",
+        "is_verified": false,
+        "line_number": 1387
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0e5b7b2230b86973ef30c42ca73f8c2f1866c66f",
+        "is_verified": false,
+        "line_number": 1392
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7b234ae165a5fb9ee72ebe505cb033dd78cb1427",
+        "is_verified": false,
+        "line_number": 1397
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e15d714dc0e3fadc34fa31dd2f93530b7527c224",
+        "is_verified": false,
+        "line_number": 1402
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ef4ebf89aac434354ef0e549b6562a590b38c1ef",
+        "is_verified": false,
+        "line_number": 1407
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "847a90be5433925b78d97121266c6f28d10cad46",
+        "is_verified": false,
+        "line_number": 1412
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "efd91b12240e7d0966f7683a6632b899efb02060",
+        "is_verified": false,
+        "line_number": 1417
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "eabb7b1469793615d2e481374e7fa0bf1b797331",
+        "is_verified": false,
+        "line_number": 1422
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "98e39cf276637483701c7f4ad34f04b82b23db00",
+        "is_verified": false,
+        "line_number": 1427
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6d8b4508131713ab295b7a5d54bf9f650ea7de3a",
+        "is_verified": false,
+        "line_number": 1432
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "94a6793bad904a80d0d830ad166c5e110ef0e0ce",
+        "is_verified": false,
+        "line_number": 1435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3d1f976e7e48c3331bf146ef86537fa84641cfc9",
+        "is_verified": false,
+        "line_number": 1438
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0fa45a368d9cb3af91d18980d7bf1359cf6906ec",
+        "is_verified": false,
+        "line_number": 1441
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6ef4e98430a48ebe9da892571cc9116aa215d65a",
+        "is_verified": false,
+        "line_number": 1444
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d6f51dd81a5a11e1838c695ca672e145b4b574a3",
+        "is_verified": false,
+        "line_number": 1447
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "883ffddc90f7adb0b2e567704e0e2e7c9ce772e7",
+        "is_verified": false,
+        "line_number": 1450
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d2f4b057fca06c6c685b9e0d0d347ae4b62d81d0",
+        "is_verified": false,
+        "line_number": 1453
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6ddcd40970d7a4c79ad7d97ba287276315fbecf8",
+        "is_verified": false,
+        "line_number": 1456
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8189f85216ce53283b06100728bfbdb6ba39349b",
+        "is_verified": false,
+        "line_number": 1462
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a9ee872ba47547763ea96bf68935b1ca511b1eea",
+        "is_verified": false,
+        "line_number": 1468
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3c54a53db895c2d2db105419004c4ca9c0669b9b",
+        "is_verified": false,
+        "line_number": 1474
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "73eabe01b3849af9f5b7d09fd682e29988078e03",
+        "is_verified": false,
+        "line_number": 1480
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ed4a714216e6fb3df582608436c971c64d16eb21",
+        "is_verified": false,
+        "line_number": 1486
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e32262f842014867b6d05de1e8b54be38c774f41",
+        "is_verified": false,
+        "line_number": 1492
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "07938cb535ebe7164be475b659157d8722bf6cd8",
+        "is_verified": false,
+        "line_number": 1498
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ed8125bef66b019626fce657625f4dc098ce2d5b",
+        "is_verified": false,
+        "line_number": 1504
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "efc4995969632bacd704a7dcaaae920f586c0ebd",
+        "is_verified": false,
+        "line_number": 1510
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "91280ce4aa21694239d39cbf79a7ec38c75b6241",
+        "is_verified": false,
+        "line_number": 1522
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "108599ae85386bc9ebd90603fc1fa7332c44ab2a",
+        "is_verified": false,
+        "line_number": 1528
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e92548ca579280bcf908b3e719e347cad2f3b34e",
+        "is_verified": false,
+        "line_number": 1534
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9c93b5a77413b84c8aab30d61269c5d5af893e84",
+        "is_verified": false,
+        "line_number": 1538
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0e6b9c5945acf85ec45d0577171ab4adaf465f3c",
+        "is_verified": false,
+        "line_number": 1543
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4e6b6006b2f7a6f7794756349cd40cce5e779432",
+        "is_verified": false,
+        "line_number": 1548
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "be64cf9169891b8b4bef36e06bd7defef6a1ec7a",
+        "is_verified": false,
+        "line_number": 1551
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "50a0bc6ed4bd15cd54a9ef3e744d9e367b1ee0b2",
+        "is_verified": false,
+        "line_number": 1563
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f161e2b04f8faa8a514998b846300c0e52e3dde4",
+        "is_verified": false,
+        "line_number": 1566
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "21a255bacab0430cf0dd455985ab2ac363136cdb",
+        "is_verified": false,
+        "line_number": 1569
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "146791ae0b950340d17de1ffbda27158f3e8be1c",
+        "is_verified": false,
+        "line_number": 1572
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f0223109c42a9c75ee9a859c7897c6ab5c6eec49",
+        "is_verified": false,
+        "line_number": 1575
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7fa226273d5a0d1b9abf45e18909943d7007d1b2",
+        "is_verified": false,
+        "line_number": 1578
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a4fa4a2da187e1f35991b7e3c5bb8c58b148ca09",
+        "is_verified": false,
+        "line_number": 1581
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9ed4ec5e13d0127aa4390ca0ea6bb0c58955813c",
+        "is_verified": false,
+        "line_number": 1584
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "11c08054a654f517144d206c95a7ef3d1d1d8a10",
+        "is_verified": false,
+        "line_number": 1587
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "202814e7e7561774522a76c66bc453965f59e0be",
+        "is_verified": false,
+        "line_number": 1590
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "82e45680d983d798b7eb9ff070d2f4a2ed1a6aca",
+        "is_verified": false,
+        "line_number": 1593
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b5e25bc274fcd2e0765d9719b5778385a09cd417",
+        "is_verified": false,
+        "line_number": 1596
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8da85cbce59e3d1311b8d83fca1c8e3d0e67fa36",
+        "is_verified": false,
+        "line_number": 1599
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "681fe2f819d566ee80576d71374fbe2ea25e9856",
+        "is_verified": false,
+        "line_number": 1602
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8e2775553add62306a4a60d9730357d20cc8eca4",
+        "is_verified": false,
+        "line_number": 1605
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "13451c46d267093367a4021d60ecfd01b589453b",
+        "is_verified": false,
+        "line_number": 1608
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f10d8e7fd0a2d47dd1c517aee23443ac47c8d8f1",
+        "is_verified": false,
+        "line_number": 1611
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7ad8f7855e91cd8b06becd442f47ac889e45b05c",
+        "is_verified": false,
+        "line_number": 1614
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "709ec0fb00ecef1e145c61d0227084baf41695ee",
+        "is_verified": false,
+        "line_number": 1617
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "679c86b8b8102c4f59f082861f7153bbff1c302f",
+        "is_verified": false,
+        "line_number": 1620
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4edd46fe0024d509c40f64891b8de2c1b8648486",
+        "is_verified": false,
+        "line_number": 1623
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fdaf5cc2f4c70e89a63da173c9094c23a2bdb447",
+        "is_verified": false,
+        "line_number": 1626
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "085598568dc4c356ab7aa2d37615bf3e5ac9a276",
+        "is_verified": false,
+        "line_number": 1629
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "accccbc920e9b8894c9e249476a9d23a102dc51d",
+        "is_verified": false,
+        "line_number": 1632
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7863f0eb9ee850d4cf1b3ba4790af627e46e8bf5",
+        "is_verified": false,
+        "line_number": 1635
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "19026bc85cda2b7c02ab2100543274cdfc87e235",
+        "is_verified": false,
+        "line_number": 1638
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ba993e097570d247c652bcc7a4a09a1433017c7f",
+        "is_verified": false,
+        "line_number": 1641
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7cfe93f5ecad2c99e18b38dc4eac2dd238115509",
+        "is_verified": false,
+        "line_number": 1644
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8f7078b941b0c422ed7d2b71a8eeec584b26c85d",
+        "is_verified": false,
+        "line_number": 1647
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b70e5de9bb948e7b610f4630c08929d8c6de5a7c",
+        "is_verified": false,
+        "line_number": 1650
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0e06cd30bd4605847a6bd20556de8927f1aca0e9",
+        "is_verified": false,
+        "line_number": 1653
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8736366f5f93c2407716a62c93c8cd885c50f08d",
+        "is_verified": false,
+        "line_number": 1656
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ee467c04a4f38d68d8a5a5fc367c934838e079da",
+        "is_verified": false,
+        "line_number": 1659
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8e1c627ad3f1025cf9f784e000700389c751dc4b",
+        "is_verified": false,
+        "line_number": 1662
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9cae8ddf51d712b423a6341beaac3b89acffbaa5",
+        "is_verified": false,
+        "line_number": 1665
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1c5d9085d8ef508b7ecd2db78f089e94de0c9d02",
+        "is_verified": false,
+        "line_number": 1668
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "04c5e75f80231932968bcbf67513faeb9e5b9420",
+        "is_verified": false,
+        "line_number": 1671
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6b919cede0677aa776671ba3483c972767adbe2c",
+        "is_verified": false,
+        "line_number": 1674
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "20bd9f1e82cc3f128d819fa043e4d8be985394dc",
+        "is_verified": false,
+        "line_number": 1677
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
+        "is_verified": false,
+        "line_number": 1680
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "690f1d4ee2519d4f62cc3a3f62d6fef48b892c39",
+        "is_verified": false,
+        "line_number": 1683
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4b612bba8446c6122505b596782ba4ce168218fb",
+        "is_verified": false,
+        "line_number": 1686
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d4df5977f20f1c07ccc57574a509a2adc7ec8088",
+        "is_verified": false,
+        "line_number": 1689
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0c6d336e7fe34021c50d0363181bd912cbcd9078",
+        "is_verified": false,
+        "line_number": 1692
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c554198dff4b9d03e4fed41f9f60ab0f15c68690",
+        "is_verified": false,
+        "line_number": 1695
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7820059c8d2e0898ad244e8da132f1db709cf138",
+        "is_verified": false,
+        "line_number": 1698
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fc6d3459aaf555ec080d434621b4841e09a28e49",
+        "is_verified": false,
+        "line_number": 1701
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7a734bb2b865c8090c992da81fb88b47856d04e3",
+        "is_verified": false,
+        "line_number": 1704
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "63b336193044808bbd0e235fac5f6aeadb612a52",
+        "is_verified": false,
+        "line_number": 1707
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7101ee1815ba5a49e02c80e26cd1a18095cf9e33",
+        "is_verified": false,
+        "line_number": 1710
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d1939c5f12b77cb2d3825f0a77efbaf342eda9f1",
+        "is_verified": false,
+        "line_number": 1713
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6fe0c1d94e5bf7af28db976667694b068fbbcfa9",
+        "is_verified": false,
+        "line_number": 1716
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "edad7a64109ca056f9c0c36e70e45ff24f5942b9",
+        "is_verified": false,
+        "line_number": 1719
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5fbe6af214ff086a2f24d714dc93bbd14cfaf2c6",
+        "is_verified": false,
+        "line_number": 1722
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1c61cb6e4dfe89ea9932b7b0c795158b3609ea90",
+        "is_verified": false,
+        "line_number": 1727
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2dba792b1970249e25fea7bd4bef1339031bb5c9",
+        "is_verified": false,
+        "line_number": 1730
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9474365f899688921c3d377f365fcbbc1c136978",
+        "is_verified": false,
+        "line_number": 1733
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "33cf77c3b3f57d57c513ec1e83df5d7af1f35099",
+        "is_verified": false,
+        "line_number": 1736
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5f411c7e6073b67aca1c9043e3e952322dc21d46",
+        "is_verified": false,
+        "line_number": 1739
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "82e9b248cdbed101133fcd9229632ccd3e00d416",
+        "is_verified": false,
+        "line_number": 1742
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3b3fdad4fa80ae8473e0304fe52e0cd272ef2a11",
+        "is_verified": false,
+        "line_number": 1745
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d9ea4a68b988aca799b7049c045c05d7f5eb839a",
+        "is_verified": false,
+        "line_number": 1748
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2ed50d4e930408285a9712d6c970fd7e8c46fb69",
+        "is_verified": false,
+        "line_number": 1751
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "91e7edf530f3d2c573744a030a47764481de24a7",
+        "is_verified": false,
+        "line_number": 1757
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9ca427b833d97f9025e7605a3a2dd0d081aaa0ee",
+        "is_verified": false,
+        "line_number": 1760
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "75d6aaa3b4dd6c53985c9f5ffabf6cfdb6a426dc",
+        "is_verified": false,
+        "line_number": 1771
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d71cf22228db367a0643e25b4aaf35bda34fa9bb",
+        "is_verified": false,
+        "line_number": 1774
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e82ef1986dfaf305bd0539f0c8413683c0b20ff1",
+        "is_verified": false,
+        "line_number": 1777
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0414462c3828bc4fc16caaed47eeda948fe9cee7",
+        "is_verified": false,
+        "line_number": 1780
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "538f066bf5a6b310644be407205a05e28a8dc8fd",
+        "is_verified": false,
+        "line_number": 1783
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "89c31fa0d6838019bc29341b448d189aa712045b",
+        "is_verified": false,
+        "line_number": 1786
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "30dff6e111c0a18b53cc71da853bac87f73a816c",
+        "is_verified": false,
+        "line_number": 1790
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2b3802837ce1f8f46c325534f20f111ce94b7862",
+        "is_verified": false,
+        "line_number": 1795
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f3b53a220b75e239a29648a2022162f032abbc8d",
+        "is_verified": false,
+        "line_number": 1798
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "93aa782c4df17b6541e0e372240cf197066bab69",
+        "is_verified": false,
+        "line_number": 1802
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
+        "is_verified": false,
+        "line_number": 1805
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "599395997c127ee79a03df8cbc9c57d9c5c4b39b",
+        "is_verified": false,
+        "line_number": 1809
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4f9ca841aeb6fd5f8e147135c04c7351eda0145e",
+        "is_verified": false,
+        "line_number": 1812
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "08123a72eda5582ac678d0f7a9c55d7ab9ed22fd",
+        "is_verified": false,
+        "line_number": 1819
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ce4084b9c766db59d8efac9df450a2ec42ca3639",
+        "is_verified": false,
+        "line_number": 1822
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "eb1c10c194ba834a6b271d11ed0e87417a434c06",
+        "is_verified": false,
+        "line_number": 1825
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3165aeec45a531bca4274a9a152b2091b99bf960",
+        "is_verified": false,
+        "line_number": 1829
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e0c6298d33fd17530dfd7b996b7f0c0f67bc7f08",
+        "is_verified": false,
+        "line_number": 1833
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c61921cb03b0d17c9d180fa6d2d765269458f5e9",
+        "is_verified": false,
+        "line_number": 1838
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c56c76bc828483f5553df346fb2eaa6e3e6c4bba",
+        "is_verified": false,
+        "line_number": 1842
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "09ce1f68022d542bd4b111b2e648b4261e7ea537",
+        "is_verified": false,
+        "line_number": 1846
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f4713ff6d6ebe4c91eabb4abaa4fff79252287e2",
+        "is_verified": false,
+        "line_number": 1850
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bb4753386dbead02652a11ec39d51f531400f795",
+        "is_verified": false,
+        "line_number": 1854
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "76ee5d005d74b14bfcf949a0b24859a1ad611560",
+        "is_verified": false,
+        "line_number": 1857
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5620b727309eb0585715c051b3f1ad6560879967",
+        "is_verified": false,
+        "line_number": 1860
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "838860fad35a9938ad0c45978737609b9acf2e86",
+        "is_verified": false,
+        "line_number": 1864
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a3c954fbcfcb5b1c2087ff1e1a592601ebd0d7f0",
+        "is_verified": false,
+        "line_number": 1867
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "40b0aef4115b2c0ecffb2e2c74e6e67d01b84997",
+        "is_verified": false,
+        "line_number": 1870
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ed1668ceb8dc6aaabcb871317d585a5edf44c0bf",
+        "is_verified": false,
+        "line_number": 1873
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "198c12bf7d9e91116c7bf79acfb5d26023bddca6",
+        "is_verified": false,
+        "line_number": 1876
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c6132446174fb42fadfe75a8183f305a65574678",
+        "is_verified": false,
+        "line_number": 1880
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2e168b2e58d3797e1b488abbf415e9b90b3149b9",
+        "is_verified": false,
+        "line_number": 1885
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d2e1dec5724740f83adc172b07e15342b3eac984",
+        "is_verified": false,
+        "line_number": 1888
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ed8dee19a6f2946f9f7ee7c5f7d9652daa9064bb",
+        "is_verified": false,
+        "line_number": 1892
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5974b42acc3c558a08c734a45a10785534b5d382",
+        "is_verified": false,
+        "line_number": 1895
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "91384b25fae910b4fb3847c70b40b3f56f68346d",
+        "is_verified": false,
+        "line_number": 1899
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "83307cb75a4a44ba528f4a0aefcec2a8018dc6d8",
+        "is_verified": false,
+        "line_number": 1905
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "67df7123f1b2c84bf066bc3e6fb4834aa022e20b",
+        "is_verified": false,
+        "line_number": 1909
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9e4bcb8df7a5f802322234f792347caa3c9240fa",
+        "is_verified": false,
+        "line_number": 1912
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4e737227d8a4ff0c87704616f4c0c457fa6bf550",
+        "is_verified": false,
+        "line_number": 1916
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f4c8d4909804be929ee867133fe4b0810002c8a4",
+        "is_verified": false,
+        "line_number": 1920
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "272e5b30f1b718ab85c40a90f9022aea7f6a506f",
+        "is_verified": false,
+        "line_number": 1923
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f52956fa7c317746fde250d0f4e54d6115252cd4",
+        "is_verified": false,
+        "line_number": 1926
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7f104c1c37e525afe159a7b26fe2782992e9c896",
+        "is_verified": false,
+        "line_number": 1930
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
+        "is_verified": false,
+        "line_number": 1934
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0126e1c37886a7ddcb7c64bbaeba26fbc7350779",
+        "is_verified": false,
+        "line_number": 1937
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5c41822f05c632ab0ea5a83c2153196107e7e48a",
+        "is_verified": false,
+        "line_number": 1940
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a31efbdaf429353b1a681cdf75f1c3b091709994",
+        "is_verified": false,
+        "line_number": 1944
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e42422d60a4e1b1bb29b9f097fa9e00cca9e310d",
+        "is_verified": false,
+        "line_number": 1947
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "99cb01a94916f4b1a4cd94d7c866029a9e3734ee",
+        "is_verified": false,
+        "line_number": 1950
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8b6e3d167f9d34dcb4fb60d814fdfd4b8f850b7b",
+        "is_verified": false,
+        "line_number": 1955
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "031e74c3988d3aa3530d827ec994228035f76b24",
+        "is_verified": false,
+        "line_number": 1958
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "79380c4284060f6d92599b5075ab5dff98980365",
+        "is_verified": false,
+        "line_number": 1963
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c3882e02b815ece615eb89b61d2d0f1f1fb1a13f",
+        "is_verified": false,
+        "line_number": 1968
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "33717c29c8aea5e30d94507cde08e926103815fd",
+        "is_verified": false,
+        "line_number": 1972
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cb160c0fa67ad1904f0157c03f6acdc648e14c29",
+        "is_verified": false,
+        "line_number": 1975
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0ec2f9ddae6f2c51a32b569bfa0990b62144a32f",
+        "is_verified": false,
+        "line_number": 1979
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "63031c941f273d524122c445b6cc52855ba4d80a",
+        "is_verified": false,
+        "line_number": 1983
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8ffcdf73a059a511bd1a984ff94a6ec26a450da6",
+        "is_verified": false,
+        "line_number": 1987
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d7df03c04920f03f01f8b40c877fc25a56a9ee19",
+        "is_verified": false,
+        "line_number": 1991
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "475f81349c63a4a4aa6ee2b034a6670b65d2605d",
+        "is_verified": false,
+        "line_number": 1995
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e5ccf3a7d5ed1538ce0524b55a6faf09287516d",
+        "is_verified": false,
+        "line_number": 1999
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "981618e70764ccff965f43b2608479f4b38c4b6b",
+        "is_verified": false,
+        "line_number": 2003
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "79fe65c8553fd143f3323cfe6925f719b6ef230a",
+        "is_verified": false,
+        "line_number": 2007
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1258c27ec2d20bcd3b0691e4a621c6167bf14166",
+        "is_verified": false,
+        "line_number": 2011
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fb3a4cac7ed22b602c677b19d442df41415484d9",
+        "is_verified": false,
+        "line_number": 2016
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7584292a0d73867cf2a975ae71b7a6b4b7a18fd3",
+        "is_verified": false,
+        "line_number": 2020
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bfee3969cf314fd46a4a98c127c6e88dbe47a7d7",
+        "is_verified": false,
+        "line_number": 2024
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0648eae8d4fb533908b8beb9eace610b07c305e3",
+        "is_verified": false,
+        "line_number": 2028
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a810ae8365e0609794326708e32a66311accf6d9",
+        "is_verified": false,
+        "line_number": 2032
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "84dc5f27bdddf193db7112ded0e6e62aae32c563",
+        "is_verified": false,
+        "line_number": 2036
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "91f1d14f5c42035f88d9326dba1ab34a390de763",
+        "is_verified": false,
+        "line_number": 2040
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9b88197199e0708719546e337507aa489f482035",
+        "is_verified": false,
+        "line_number": 2044
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e646475e64142c1d1d386b89728a88e637d76ffd",
+        "is_verified": false,
+        "line_number": 2047
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e4a8eca0bfd89c5c73b1d9b70d7fdc1d63a742c3",
+        "is_verified": false,
+        "line_number": 2051
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9c2024aeeebab8de7dbec46172c80d3c0977b9fd",
+        "is_verified": false,
+        "line_number": 2055
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d3110b2f096c13b4a05286099f37adb93dc0d98b",
+        "is_verified": false,
+        "line_number": 2059
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "26abf1dd2ca59fe7be9eaa38dca3da206ea420ac",
+        "is_verified": false,
+        "line_number": 2063
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "20691e3175c231d4ed0a46b007016f11088622ce",
+        "is_verified": false,
+        "line_number": 2066
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bf1d6785d64c573898e6f002e2118df315a3fe8c",
+        "is_verified": false,
+        "line_number": 2070
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "615111c758dde1f8cbc15fe1e655610e0da5a417",
+        "is_verified": false,
+        "line_number": 2074
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b839d6cce2e9faca3fe3db9e2571dabe23cf4987",
+        "is_verified": false,
+        "line_number": 2078
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4f6023e8bc49fa69a236a0745192387ee698473f",
+        "is_verified": false,
+        "line_number": 2081
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "20a2abce8debc1b0a34db8be8bdec759c03470a5",
+        "is_verified": false,
+        "line_number": 2085
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "64a1e3b17b6fe4e477f67655772adfb9a8f0685b",
+        "is_verified": false,
+        "line_number": 2089
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5d5ad5db83b23a384f6c1d4cd98ff642d93831a2",
+        "is_verified": false,
+        "line_number": 2093
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2cc8a665f17064b10ab9135e29345f537879c7e0",
+        "is_verified": false,
+        "line_number": 2097
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "080264b10431d7bffd7d0bf2c2e0d27edc640ff4",
+        "is_verified": false,
+        "line_number": 2103
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "131593dcab4a460dbebcff8d0a12d821b3edd402",
+        "is_verified": false,
+        "line_number": 2107
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d961319d454caee7b7f6e7790a39f87e1719f043",
+        "is_verified": false,
+        "line_number": 2111
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7f3dc3eeca35d4b8f640fea69abdb9249637616d",
+        "is_verified": false,
+        "line_number": 2114
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f5f75498bedb2fb320a0c96529ed808e8032ab29",
+        "is_verified": false,
+        "line_number": 2117
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b579cc9cf455d76457ba6922c763d7fcc554f34f",
+        "is_verified": false,
+        "line_number": 2120
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
+        "is_verified": false,
+        "line_number": 2123
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
+        "is_verified": false,
+        "line_number": 2131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "62823fccad763959e8805be597bbafe575f4809e",
+        "is_verified": false,
+        "line_number": 2140
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4907d411dbbc15d87a3134352a52127406248740",
+        "is_verified": false,
+        "line_number": 2143
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b4a9257558064dbd957e726d9d25d81b97837009",
+        "is_verified": false,
+        "line_number": 2146
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "30032b6b21b6761f545cb3a442477208db30131f",
+        "is_verified": false,
+        "line_number": 2150
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6263b491d8e05bc0d6bc8b232c3a06044db2232c",
+        "is_verified": false,
+        "line_number": 2153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c5deff9c59d0e0419952da44431546620804d70e",
+        "is_verified": false,
+        "line_number": 2157
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
+        "is_verified": false,
+        "line_number": 2161
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "572b5e5253ab86ef535e76d891766cc1a17ee6a5",
+        "is_verified": false,
+        "line_number": 2165
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
+        "is_verified": false,
+        "line_number": 2169
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6cfffbcd76530450de1b86aa6a25cf6232ba9dc8",
+        "is_verified": false,
+        "line_number": 2173
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dbaf8941e1df2a6cc0af186ab8c288162c591d75",
+        "is_verified": false,
+        "line_number": 2176
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4f8baa628528be69e02276f95e83eed38d79feaa",
+        "is_verified": false,
+        "line_number": 2179
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4283f0269f12ac2e491ed22c9d47171a9d48fd48",
+        "is_verified": false,
+        "line_number": 2182
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "79119667cecad09809c34832b1f2b650b5ccded7",
+        "is_verified": false,
+        "line_number": 2185
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4d50b55900617c8d08097c03af9667c135c1fc24",
+        "is_verified": false,
+        "line_number": 2189
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7e0a63b607dc49438c5ff4a0db3931dbc0285dbc",
+        "is_verified": false,
+        "line_number": 2192
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2d3b72d498880ee7aac85ecfde3d52435c5ab00b",
+        "is_verified": false,
+        "line_number": 2195
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1f1fa592047caa0501169ce68034b590a04e268c",
+        "is_verified": false,
+        "line_number": 2200
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "140d86931cb07f9ba23e4b7ef112f5304e16aab1",
+        "is_verified": false,
+        "line_number": 2205
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "21194e556cc6a23d3903b12189b0b9cd1050f2e5",
+        "is_verified": false,
+        "line_number": 2208
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2a0c5c01be780688ae4faf4a3e1cb6e48c50dc23",
+        "is_verified": false,
+        "line_number": 2212
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ff8047908af26a3f03fd3ac26aaa2f5d7ae75e5a",
+        "is_verified": false,
+        "line_number": 2216
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b32dc7581438839b3baa8cbb9dafcc80017588ea",
+        "is_verified": false,
+        "line_number": 2220
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6d1db030d72c8b03fd95eaeb0266255402f70df5",
+        "is_verified": false,
+        "line_number": 2224
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cf75ddffbc923b32123e91e069fbcb97ac39c4d9",
+        "is_verified": false,
+        "line_number": 2228
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d076e5a9f2245bcedf234f70abb7fa41d4d9f0dc",
+        "is_verified": false,
+        "line_number": 2232
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "417a00b911e0b72a50a597cb7c4c70885c55516e",
+        "is_verified": false,
+        "line_number": 2235
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e28508e3ee2cfadee43ef9cfb9bb3b5d5d8ef5af",
+        "is_verified": false,
+        "line_number": 2239
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "508e13818451655db815826a00fe15a68b7481b7",
+        "is_verified": false,
+        "line_number": 2243
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0a78ed1531f1e89e2dde49c07aee4199c0837078",
+        "is_verified": false,
+        "line_number": 2248
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3cb8e7a708267691af8530db673cae1ad0578392",
+        "is_verified": false,
+        "line_number": 2253
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cc0394ae9ff7278ac1f8ba8305e06627798ae34b",
+        "is_verified": false,
+        "line_number": 2257
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9282693a1a1e5f8fadcc1617db1f7a097db8429b",
+        "is_verified": false,
+        "line_number": 2260
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "aabf9f3ccb818057fe7b956cb56b9c011e002839",
+        "is_verified": false,
+        "line_number": 2264
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8ab0d03e8d34c76769e2494c72290c441ebcc749",
+        "is_verified": false,
+        "line_number": 2267
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
+        "is_verified": false,
+        "line_number": 2270
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3b9b4f0e0dc452a1ab51ff9a7e649171b0b54a70",
+        "is_verified": false,
+        "line_number": 2273
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "03d6fb388dd1b185129b14221f7127715822ece6",
+        "is_verified": false,
+        "line_number": 2277
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "72e5393170ee8c03f5ebad63e044422989818b95",
+        "is_verified": false,
+        "line_number": 2280
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "030fd33a7a056f197ef34c37cfcb73f470df0612",
+        "is_verified": false,
+        "line_number": 2284
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "12ecf39948e93968cea583a27ce0f918a02e3878",
+        "is_verified": false,
+        "line_number": 2288
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
+        "is_verified": false,
+        "line_number": 2291
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4a0c4d36aaf8c5cea9b9087156ac34f7da104dc4",
+        "is_verified": false,
+        "line_number": 2294
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
+        "is_verified": false,
+        "line_number": 2298
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "608a2b22745aedb3dff3a03315104b03db3bc18a",
+        "is_verified": false,
+        "line_number": 2307
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "40e7076fc8fd248af67cfc317346eafeafa8f7a9",
+        "is_verified": false,
+        "line_number": 2311
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8880036dd8f74c6cd85075c896ff8851627a0919",
+        "is_verified": false,
+        "line_number": 2320
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dc9a2ba629796d6ef3323496eb952461f964e115",
+        "is_verified": false,
+        "line_number": 2324
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c53a12e9d025e4a06da4523b43f6538eedd9d04f",
+        "is_verified": false,
+        "line_number": 2328
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "154f11f3be7925e9dfc95d61ccd19f9d367bd090",
+        "is_verified": false,
+        "line_number": 2331
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "67e1630eef767c17f165bed8793abff78d5d53ac",
+        "is_verified": false,
+        "line_number": 2345
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
+        "is_verified": false,
+        "line_number": 2349
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e7f54899a1654525fbfb1d8c3ac44d632f655af1",
+        "is_verified": false,
+        "line_number": 2354
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
+        "is_verified": false,
+        "line_number": 2357
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "70239f714086644424a812bb19cd8af853b4fe93",
+        "is_verified": false,
+        "line_number": 2361
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4cd3a1b109eb67acf1557141e83880899d18eaea",
+        "is_verified": false,
+        "line_number": 2365
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
+        "is_verified": false,
+        "line_number": 2369
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5a4d96497ba98531c9c36ced1d043fbd8c535eff",
+        "is_verified": false,
+        "line_number": 2373
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ae324c1d6b29cddd2062229ca65d08baecc7789a",
+        "is_verified": false,
+        "line_number": 2377
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4d0e714a0f6a740c6b6b047cf9b513bf8ff4c898",
+        "is_verified": false,
+        "line_number": 2380
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "979e2a14e4576c62a9748d7466bfa7f4f3a0620d",
+        "is_verified": false,
+        "line_number": 2384
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
+        "is_verified": false,
+        "line_number": 2388
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4bc048ef798be5bb613b48cf7e4602803fb1b709",
+        "is_verified": false,
+        "line_number": 2391
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0d97c7fe1c124e07eb8bba42a86419c083ba0591",
+        "is_verified": false,
+        "line_number": 2394
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e07f2c68e0fe6abfac19da4e9dd0c81669de7078",
+        "is_verified": false,
+        "line_number": 2398
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f52c08f63289414b8da2ea1271f68c9e1d6338ea",
+        "is_verified": false,
+        "line_number": 2402
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9ac633e9766159806b447d7be2d84067548764f4",
+        "is_verified": false,
+        "line_number": 2406
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fffff370595b6f4803e610b7519dbb1bb9923c8a",
+        "is_verified": false,
+        "line_number": 2409
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3300960d885e191e93efbb20d444a625bddcfe90",
+        "is_verified": false,
+        "line_number": 2412
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a0540a26c42e0189fb536e1a42e879429302f9a8",
+        "is_verified": false,
+        "line_number": 2415
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
+        "is_verified": false,
+        "line_number": 2418
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c73d5fe546a436b30bdec90b571803faa29161c0",
+        "is_verified": false,
+        "line_number": 2421
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ecf82334d7607ee319ed50d5c868b73e18e07f8c",
+        "is_verified": false,
+        "line_number": 2424
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6b480f88105d1d6f58deb5c93ce778e95daab763",
+        "is_verified": false,
+        "line_number": 2427
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
+        "is_verified": false,
+        "line_number": 2430
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "886470e65dd1f05934c64b6cefaf846f674a70e9",
+        "is_verified": false,
+        "line_number": 2433
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
+        "is_verified": false,
+        "line_number": 2436
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
+        "is_verified": false,
+        "line_number": 2439
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4032d4dd08dc516a97cd96b4d161fd0dccb8b592",
+        "is_verified": false,
+        "line_number": 2442
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d3063fb8878cd870d06706fb7de1fbf791b78dd8",
+        "is_verified": false,
+        "line_number": 2446
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
+        "is_verified": false,
+        "line_number": 2449
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "395c2fd7dd96691ca2f110afa91b51ffc6f26d97",
+        "is_verified": false,
+        "line_number": 2452
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ebf396301cd5f2bffdd5e7e25066a15ea189798d",
+        "is_verified": false,
+        "line_number": 2455
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e6c18abd5b90c63da0bd8b4c0d3a142e3d5a83d",
+        "is_verified": false,
+        "line_number": 2459
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9cfd1c9ff642dd3f9093c2e68fda7b9daba943ca",
+        "is_verified": false,
+        "line_number": 2463
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
+        "is_verified": false,
+        "line_number": 2467
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6c0b4cfc433a0c4567ffa56f081ab35a7e8b0bb5",
+        "is_verified": false,
+        "line_number": 2470
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b339256107c4edc00f4a15bc9e8524893981ede2",
+        "is_verified": false,
+        "line_number": 2473
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a0b8be6c9c901fe0b497f749b90ea1a7228d5621",
+        "is_verified": false,
+        "line_number": 2479
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
+        "is_verified": false,
+        "line_number": 2482
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "89b283ab50bf537dfbd64a59830fb7dda89eb546",
+        "is_verified": false,
+        "line_number": 2486
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
+        "is_verified": false,
+        "line_number": 2490
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
+        "is_verified": false,
+        "line_number": 2493
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
+        "is_verified": false,
+        "line_number": 2496
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
+        "is_verified": false,
+        "line_number": 2499
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
+        "is_verified": false,
+        "line_number": 2502
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
+        "is_verified": false,
+        "line_number": 2506
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
+        "is_verified": false,
+        "line_number": 2510
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
+        "is_verified": false,
+        "line_number": 2513
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
+        "is_verified": false,
+        "line_number": 2518
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8de81592addca35790ac4952804d8bf7e97825a2",
+        "is_verified": false,
+        "line_number": 2523
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ea988cbd3d8b5e867a1b9205a31c22a0e677cc07",
+        "is_verified": false,
+        "line_number": 2527
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8271215bc0f8f3c777e34a26e08ac6f4b0643b46",
+        "is_verified": false,
+        "line_number": 2530
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e3aa848f78699e8fd784dde75cb72e3d31d89d0b",
+        "is_verified": false,
+        "line_number": 2533
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "424c32eeac514fcbcd69f564d4633bf29df3584c",
+        "is_verified": false,
+        "line_number": 2537
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "55e984b8442729280aba3a65202556f31aa7ee2b",
+        "is_verified": false,
+        "line_number": 2540
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "234449837ea82897a022123e9cef8c60b5700beb",
+        "is_verified": false,
+        "line_number": 2543
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "64cdfb16d3cf2dee4aec7722977bbcfd7f125dd1",
+        "is_verified": false,
+        "line_number": 2549
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "24652ad480f103f15bb57964ecd71d5bb6e3cdc0",
+        "is_verified": false,
+        "line_number": 2555
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8f62546695ef43015b84686167d3cb5a959c5d56",
+        "is_verified": false,
+        "line_number": 2561
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d961d5c083c668941a0fc005f4f494117c275692",
+        "is_verified": false,
+        "line_number": 2567
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1d3b7b58e55dda6205d88c114f2c7bd54c3a88b5",
+        "is_verified": false,
+        "line_number": 2573
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e49ff6eff7e9fef5776e75b90b4fe817511e3e21",
+        "is_verified": false,
+        "line_number": 2579
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "06252eb36883aef1fa36bf426225f6b836e660da",
+        "is_verified": false,
+        "line_number": 2585
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ced599fa36c18f07d6cd42c35691b91b1fbe428e",
+        "is_verified": false,
+        "line_number": 2591
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f3f7ebf5b129836f221b766a549bd87000295f12",
+        "is_verified": false,
+        "line_number": 2597
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "25190a22b603f9ec8147fb0841a1388bf16a2f10",
+        "is_verified": false,
+        "line_number": 2603
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8fd18f737f7036fe9e4886ce31dcacf15ffbb58d",
+        "is_verified": false,
+        "line_number": 2607
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5cc20a5b047f98c3bdfc84b87d743bfb60f2947a",
+        "is_verified": false,
+        "line_number": 2611
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e9fdc3025cd10bd8aa4508611e6b7b7a9d650a2c",
+        "is_verified": false,
+        "line_number": 2614
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
+        "is_verified": false,
+        "line_number": 2617
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
+        "is_verified": false,
+        "line_number": 2620
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "73bc28172456bad6166fd9a576eb52082dc4dd3c",
+        "is_verified": false,
+        "line_number": 2624
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
+        "is_verified": false,
+        "line_number": 2627
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "13e23943c1cb3acb333b79f031e253eba14e19b0",
+        "is_verified": false,
+        "line_number": 2630
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "93d26aba3b02b6b4cfc7f49abe2ae9c07fef0566",
+        "is_verified": false,
+        "line_number": 2635
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cb5bf77fc0e159831c9d3ff288109c30f9a0f5e6",
+        "is_verified": false,
+        "line_number": 2640
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
+        "is_verified": false,
+        "line_number": 2643
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "89ef487bec97886dd937d3802746b4a6a7b18ebf",
+        "is_verified": false,
+        "line_number": 2646
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "87ae5db459dbd9fe4157473b016ae5ff5ef0f4ed",
+        "is_verified": false,
+        "line_number": 2651
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
+        "is_verified": false,
+        "line_number": 2655
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bd6b0d8b6b1f3c582851ca1e5596cbb670883e54",
+        "is_verified": false,
+        "line_number": 2658
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
+        "is_verified": false,
+        "line_number": 2661
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
+        "is_verified": false,
+        "line_number": 2664
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
+        "is_verified": false,
+        "line_number": 2667
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
+        "is_verified": false,
+        "line_number": 2670
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
+        "is_verified": false,
+        "line_number": 2673
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
+        "is_verified": false,
+        "line_number": 2676
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3b13d0031f0062532c2653885b097a9721c95a86",
+        "is_verified": false,
+        "line_number": 2679
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
+        "is_verified": false,
+        "line_number": 2682
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
+        "is_verified": false,
+        "line_number": 2685
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
+        "is_verified": false,
+        "line_number": 2688
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
+        "is_verified": false,
+        "line_number": 2691
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b9381a68b32516410cee735432800123389658cd",
+        "is_verified": false,
+        "line_number": 2694
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
+        "is_verified": false,
+        "line_number": 2697
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
+        "is_verified": false,
+        "line_number": 2700
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d7c39664c403d1fecb3d1e330ad65a00bab67629",
+        "is_verified": false,
+        "line_number": 2703
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "33424d6062b147852810a1b4e7d5cd675caa3231",
+        "is_verified": false,
+        "line_number": 2707
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0661a6284527e94d3ac8b52324e219703276485b",
+        "is_verified": false,
+        "line_number": 2710
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "22f475d09df2c53aa6332a6d7aa6ac7e2cc09481",
+        "is_verified": false,
+        "line_number": 2713
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
+        "is_verified": false,
+        "line_number": 2717
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c42c0f2b427e93ec72f707573c0fcb5e4e191af4",
+        "is_verified": false,
+        "line_number": 2720
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2883c8b2e73c93ec9c28c8a8e3077279894a3bcd",
+        "is_verified": false,
+        "line_number": 2730
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2f6768b77ca0db905e677336b7ed115432d94d69",
+        "is_verified": false,
+        "line_number": 2739
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
+        "is_verified": false,
+        "line_number": 2749
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
+        "is_verified": false,
+        "line_number": 2752
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
+        "is_verified": false,
+        "line_number": 2755
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
+        "is_verified": false,
+        "line_number": 2758
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
+        "is_verified": false,
+        "line_number": 2761
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
+        "is_verified": false,
+        "line_number": 2764
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
+        "is_verified": false,
+        "line_number": 2767
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e3b8bd39c0d74b5489473733b30f2ff0c21beb55",
+        "is_verified": false,
+        "line_number": 2770
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
+        "is_verified": false,
+        "line_number": 2773
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
+        "is_verified": false,
+        "line_number": 2776
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
+        "is_verified": false,
+        "line_number": 2779
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
+        "is_verified": false,
+        "line_number": 2782
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
+        "is_verified": false,
+        "line_number": 2785
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
+        "is_verified": false,
+        "line_number": 2788
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
+        "is_verified": false,
+        "line_number": 2791
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
+        "is_verified": false,
+        "line_number": 2794
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
+        "is_verified": false,
+        "line_number": 2797
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
+        "is_verified": false,
+        "line_number": 2800
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
+        "is_verified": false,
+        "line_number": 2803
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
+        "is_verified": false,
+        "line_number": 2806
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
+        "is_verified": false,
+        "line_number": 2809
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
+        "is_verified": false,
+        "line_number": 2812
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
+        "is_verified": false,
+        "line_number": 2815
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
+        "is_verified": false,
+        "line_number": 2818
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
+        "is_verified": false,
+        "line_number": 2821
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
+        "is_verified": false,
+        "line_number": 2824
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
+        "is_verified": false,
+        "line_number": 2827
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
+        "is_verified": false,
+        "line_number": 2830
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "838abb1331a160bdd441c25a2a2d44332ee8694b",
+        "is_verified": false,
+        "line_number": 2833
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e6525dbd438fc8858b0d56c59d164f403792ba1e",
+        "is_verified": false,
+        "line_number": 2837
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5c270f653b2fcd5b7c700b53f8543df4147a4aba",
+        "is_verified": false,
+        "line_number": 2841
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0430ef838f88b8c253f36d7c2c5e9da6b30310b7",
+        "is_verified": false,
+        "line_number": 2846
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1560a9e5a2cb0315745d4a4936af7518beb680e7",
+        "is_verified": false,
+        "line_number": 2850
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "143743528e3b9b96aaf60f7aec6c318be5e54a99",
+        "is_verified": false,
+        "line_number": 2854
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "90de41bb645eb912a3dcfbf357a4d329707ba620",
+        "is_verified": false,
+        "line_number": 2857
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2718c296599ffc1e7d35452180a0ca84429f3565",
+        "is_verified": false,
+        "line_number": 2860
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d1538c9c6f5e959070b379c89558393edcf64c0d",
+        "is_verified": false,
+        "line_number": 2863
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a2e9779fa026f10b01762c6db4beb39bbf28531",
+        "is_verified": false,
+        "line_number": 2866
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "612b70ad4343adbb09a9cacc2fd28d7a2eae9313",
+        "is_verified": false,
+        "line_number": 2869
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
+        "is_verified": false,
+        "line_number": 2872
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
+        "is_verified": false,
+        "line_number": 2875
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f58d2ed9acfa2afd285ebd603ede04ea158f9767",
+        "is_verified": false,
+        "line_number": 2880
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4882a3f560bc1bf6d57e2e0d1bf68d2568e76dae",
+        "is_verified": false,
+        "line_number": 2885
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "57850ae994dc8800eef664d4c7e35bbc69515b6e",
+        "is_verified": false,
+        "line_number": 2889
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "75e87bd654e00a58569f2f4964d6ac76c962f0b8",
+        "is_verified": false,
+        "line_number": 2895
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7de59f662d7b267325ed23d6f2e9237530304d27",
+        "is_verified": false,
+        "line_number": 2898
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
+        "is_verified": false,
+        "line_number": 2902
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0817713c3585298fbb156482ffc6787018397167",
+        "is_verified": false,
+        "line_number": 2906
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1fd960f79ff7ccd39310bfdf81fba2b2663b71d0",
+        "is_verified": false,
+        "line_number": 2910
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "872f644ca44ce177f63803aa24fcb778566ecf1f",
+        "is_verified": false,
+        "line_number": 2914
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2962f0a9f971f12844f66fddcaec41e8f889ad1c",
+        "is_verified": false,
+        "line_number": 2917
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bd243db4547725d4f90f654639e2fc2cea47e9ca",
+        "is_verified": false,
+        "line_number": 2920
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
+        "is_verified": false,
+        "line_number": 2923
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d25f38e564eeda6402f558b3ad020bd05220df32",
+        "is_verified": false,
+        "line_number": 2926
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ae745d719f97b3ddb9791348b1f29ff8208c0c5c",
+        "is_verified": false,
+        "line_number": 2929
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cdb8646d4a7ff41822fd7db480ce191ce8d0adcb",
+        "is_verified": false,
+        "line_number": 2933
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "78cac34debb068504165d4e64975947b641f5da8",
+        "is_verified": false,
+        "line_number": 2936
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "976e08d754318ea78969397d0d99157a6e8813a3",
+        "is_verified": false,
+        "line_number": 2939
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
+        "is_verified": false,
+        "line_number": 2942
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "406d7e234572008768bde7f31b176a7a0f8da4f0",
+        "is_verified": false,
+        "line_number": 2945
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
+        "is_verified": false,
+        "line_number": 2949
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "06477f13a769300ebac81ebe76739fb78432f564",
+        "is_verified": false,
+        "line_number": 2952
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "18320432c7c3515f682ce9a5def8785bf11de5fd",
+        "is_verified": false,
+        "line_number": 2956
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2aaf078a06eded23d8751c4e0aad33ec11c447fd",
+        "is_verified": false,
+        "line_number": 2959
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e2d1a2a5929d1167344a4844e1292d456c714bec",
+        "is_verified": false,
+        "line_number": 2962
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8d24ba248862a0cdc267a56eaa97c4667069409d",
+        "is_verified": false,
+        "line_number": 2967
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "295c5d969535881e04800821e0a1bc48bd5761f2",
+        "is_verified": false,
+        "line_number": 2970
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
+        "is_verified": false,
+        "line_number": 2973
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "157e5b0c4ac544ad1a995d6414e4dd539af39aa3",
+        "is_verified": false,
+        "line_number": 2977
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e4d0457c3771bd19a2db30ce4295cc025189392e",
+        "is_verified": false,
+        "line_number": 2980
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e5b68dc212c35983909130bf6b5106e3a462ecbc",
+        "is_verified": false,
+        "line_number": 2984
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
+        "is_verified": false,
+        "line_number": 2989
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9f48be0a09794d087d8615cbce47e062b9984fd6",
+        "is_verified": false,
+        "line_number": 2992
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
+        "is_verified": false,
+        "line_number": 2995
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2a416cdbfc3b4651a6d04d447938ace3ff9c7b6a",
+        "is_verified": false,
+        "line_number": 2998
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "60edf9357ab126e077a488706704a2f658e19087",
+        "is_verified": false,
+        "line_number": 3002
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9366bc8779ea1bd895e15b0f9f3257a488db6397",
+        "is_verified": false,
+        "line_number": 3005
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f4184df080a8edb44024dca429a59f60a1d5308d",
+        "is_verified": false,
+        "line_number": 3009
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8287678ab8009ae16b02930c9e260d1f28578fbe",
+        "is_verified": false,
+        "line_number": 3012
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1233ad875b4ae7f0bab0b28dbae2127a4f9f738a",
+        "is_verified": false,
+        "line_number": 3016
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d270708a32c532655e0c3b6fd4bbc7475c182e50",
+        "is_verified": false,
+        "line_number": 3020
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "62066f5078abd3f1c707b12b69fcb8d5c45f69ff",
+        "is_verified": false,
+        "line_number": 3026
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "175f769aab57cbd6962a4b89661ca9b22cd9a0eb",
+        "is_verified": false,
+        "line_number": 3031
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dbc1ca0fc1f62c784dd9e4abae5b29195843b7fc",
+        "is_verified": false,
+        "line_number": 3036
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
+        "is_verified": false,
+        "line_number": 3042
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5a233e343e439f5c0b7dad5b0bb3aac587600408",
+        "is_verified": false,
+        "line_number": 3045
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fdc540c809ae88d0d77093f757f4a36ce9bdb89b",
+        "is_verified": false,
+        "line_number": 3048
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
+        "is_verified": false,
+        "line_number": 3052
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c9e32f7e9605822ec5eecb8e000538cd32106217",
+        "is_verified": false,
+        "line_number": 3062
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e48b8a44b97dad18efd583c058b08a57ae0b81b4",
+        "is_verified": false,
+        "line_number": 3072
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6b0e00a52b430695aac66bffdeca87b13dce5782",
+        "is_verified": false,
+        "line_number": 3078
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
+        "is_verified": false,
+        "line_number": 3084
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1b44c0e3cc4aa423d96cf80ea9a08cf21225dc4e",
+        "is_verified": false,
+        "line_number": 3094
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4f171d08ea6de5b94bad0eff32e65a96a10ac15a",
+        "is_verified": false,
+        "line_number": 3100
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c4dd7584b90374c3719d5069681d2c7cd05f06da",
+        "is_verified": false,
+        "line_number": 3104
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dbe8cad574fbb7dbb938da01c0c4aff2dffdd029",
+        "is_verified": false,
+        "line_number": 3108
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0f8e84e87aa0422f0c3445b79cbbe528d508dce3",
+        "is_verified": false,
+        "line_number": 3111
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8fd098a872474859bcce3e25efacdaf7d273a6e0",
+        "is_verified": false,
+        "line_number": 3118
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4e416a02c571be91e08682290d440c7879f08dc5",
+        "is_verified": false,
+        "line_number": 3121
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3843fe8bfabd5162ea792aad489b0bc2e774535e",
+        "is_verified": false,
+        "line_number": 3124
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "68aeb7ec9fab680d80cbce2a624ccf642f3339cd",
+        "is_verified": false,
+        "line_number": 3127
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "10313a72df8760e8ec47c3e5a516858781be83cc",
+        "is_verified": false,
+        "line_number": 3131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d253be4a7c019ad20bcb9cf5a4073ef85ce70854",
+        "is_verified": false,
+        "line_number": 3134
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f6cd0a74446935fab1bca4e983a1b0b98eeabc53",
+        "is_verified": false,
+        "line_number": 3137
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b2a129c0faee8294286099a63244e8811707a015",
+        "is_verified": false,
+        "line_number": 3140
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "69f812c17419570caedae0a2606890b87f7fa599",
+        "is_verified": false,
+        "line_number": 3150
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
+        "is_verified": false,
+        "line_number": 3160
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1a39ece38101be692eca60b18570d82d9b78a26e",
+        "is_verified": false,
+        "line_number": 3163
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
+        "is_verified": false,
+        "line_number": 3166
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
+        "is_verified": false,
+        "line_number": 3169
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
+        "is_verified": false,
+        "line_number": 3172
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5a333bc370c115c8b9d2fa6689eaa1dc37b696ad",
+        "is_verified": false,
+        "line_number": 3175
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "17df0cf1bffb39d85a2aea45c887f1998ffc48a8",
+        "is_verified": false,
+        "line_number": 3178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "47e9d02523f2192439c8ebc19f11d491f61874f6",
+        "is_verified": false,
+        "line_number": 3181
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a0dfdcc6623d8d2996e396f5e08840914c241a0",
+        "is_verified": false,
+        "line_number": 3184
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "12c75bf14fc9e7d25cb8b6d66ea81decab2f32aa",
+        "is_verified": false,
+        "line_number": 3189
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4ec2ff08ee70f4f3ed104cf914130dc8b4af02db",
+        "is_verified": false,
+        "line_number": 3192
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
+        "is_verified": false,
+        "line_number": 3195
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
+        "is_verified": false,
+        "line_number": 3198
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2e9e26d0fd5a69fc56b781ec5b24890dfb4976fe",
+        "is_verified": false,
+        "line_number": 3201
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
+        "is_verified": false,
+        "line_number": 3204
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
+        "is_verified": false,
+        "line_number": 3207
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "edb81778ed5fee48cae4e8a8b8d1793b9e9e7663",
+        "is_verified": false,
+        "line_number": 3211
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ca9671a0948519aefcd2ec2428e9a187e79113e3",
+        "is_verified": false,
+        "line_number": 3215
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bae67d3ce231086fba18abc7365c94878f900c14",
+        "is_verified": false,
+        "line_number": 3219
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a53482ec2c9de9f382f9c30f308986d167d2d86",
+        "is_verified": false,
+        "line_number": 3222
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a1785e76071823a09f23d2c2b64db80b223c5411",
+        "is_verified": false,
+        "line_number": 3225
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7cdaa4e52326d9a81d36d211cd26c2d7a9fc69e1",
+        "is_verified": false,
+        "line_number": 3229
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6a66a6ffc1f1c2f31ec1c5c694938bedbae39c02",
+        "is_verified": false,
+        "line_number": 3233
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "05b9deaec8f504ac476e1af49d6dd6c7c79f6b36",
+        "is_verified": false,
+        "line_number": 3237
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
+        "is_verified": false,
+        "line_number": 3241
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a3e455e610a2599c21af6806a2d0bcfa38dd3e0e",
+        "is_verified": false,
+        "line_number": 3244
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
+        "is_verified": false,
+        "line_number": 3250
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
+        "is_verified": false,
+        "line_number": 3254
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
+        "is_verified": false,
+        "line_number": 3257
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6057a244d926cc3fac60c38cc276e3a75c45e178",
+        "is_verified": false,
+        "line_number": 3260
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "859f0bf5b150aedf3fe7c8ed5719bb865f543231",
+        "is_verified": false,
+        "line_number": 3264
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "06ea5a63927e269d49312b5c9e8bea03616f842e",
+        "is_verified": false,
+        "line_number": 3267
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
+        "is_verified": false,
+        "line_number": 3272
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d4e08224926a563394787a12a3b195c3d73d224e",
+        "is_verified": false,
+        "line_number": 3275
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e7dd0f768f7d4107192416f4ceec8e68f6e019c7",
+        "is_verified": false,
+        "line_number": 3278
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7821aab8b32fe85984d087e74a64d274074fd5ff",
+        "is_verified": false,
+        "line_number": 3281
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e828f62944b52bb12d3005ea71fc3a8af14ebb31",
+        "is_verified": false,
+        "line_number": 3284
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f5cde8151f6ac3de1ce731aa99fec04b98fca09f",
+        "is_verified": false,
+        "line_number": 3287
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a48b8ac8fd33d3bfc89ac437ee1c3274e7006629",
+        "is_verified": false,
+        "line_number": 3292
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c349366fbe16160ca9910d83a1de29924246c04d",
+        "is_verified": false,
+        "line_number": 3295
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "533c0ebb91e72493384d8beda7994d2fb902cce2",
+        "is_verified": false,
+        "line_number": 3299
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "315bcdd30c6b9c9705234a5dbc10279315e7611b",
+        "is_verified": false,
+        "line_number": 3303
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
+        "is_verified": false,
+        "line_number": 3306
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a664083cd7ea977f953eb398c15a7391521e8c88",
+        "is_verified": false,
+        "line_number": 3309
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e11dc6504f1442c6e5b78658db9c245708c24690",
+        "is_verified": false,
+        "line_number": 3312
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3bea92b9f6fb799774c52db9b38668949e60a65f",
+        "is_verified": false,
+        "line_number": 3315
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "66022833f4701f45cff007311050911fe571487c",
+        "is_verified": false,
+        "line_number": 3319
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "295370934921eb088b38a5591b27ef4c3feeabda",
+        "is_verified": false,
+        "line_number": 3323
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "48ab61adf0ee0771b3002628be653baccb9af277",
+        "is_verified": false,
+        "line_number": 3327
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a6d813aa7164341218d80a2b625ff1b254fa10c3",
+        "is_verified": false,
+        "line_number": 3331
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
+        "is_verified": false,
+        "line_number": 3335
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
+        "is_verified": false,
+        "line_number": 3338
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1e68acc8ad653691b250fb20aefebd10afacfb1c",
+        "is_verified": false,
+        "line_number": 3341
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
+        "is_verified": false,
+        "line_number": 3345
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1f97ba54d48d51a2ed9bef23e8100e44b5863113",
+        "is_verified": false,
+        "line_number": 3348
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "760287f140e56c5274845b0b4c48fb3f1c6f5cbf",
+        "is_verified": false,
+        "line_number": 3353
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "955d2d24c472b4eb0b4488f935a0f65e38001df8",
+        "is_verified": false,
+        "line_number": 3356
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "60bbb117f59dfb9ea6273375f335852852518f21",
+        "is_verified": false,
+        "line_number": 3360
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b0cc5db4f99fc0fb773b7006064bd925ae04e9b5",
+        "is_verified": false,
+        "line_number": 3365
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3643f874367db545d17373925c62a1ef98b4e8eb",
+        "is_verified": false,
+        "line_number": 3368
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
+        "is_verified": false,
+        "line_number": 3371
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
+        "is_verified": false,
+        "line_number": 3374
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
+        "is_verified": false,
+        "line_number": 3377
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
+        "is_verified": false,
+        "line_number": 3380
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "96274955a46e3f4a4cf02b179edba026678799c5",
+        "is_verified": false,
+        "line_number": 3383
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
+        "is_verified": false,
+        "line_number": 3386
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
+        "is_verified": false,
+        "line_number": 3389
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "235983a96e805984ce05975bd175dfaaae62ec0a",
+        "is_verified": false,
+        "line_number": 3392
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "292b56ccb1313ea50f4d1bf0efc7f2b04670fe73",
+        "is_verified": false,
+        "line_number": 3395
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9eaf006db1f782b8da68c3ae97eae05f36c62973",
+        "is_verified": false,
+        "line_number": 3399
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
+        "is_verified": false,
+        "line_number": 3405
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
+        "is_verified": false,
+        "line_number": 3415
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
+        "is_verified": false,
+        "line_number": 3425
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
+        "is_verified": false,
+        "line_number": 3430
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4885a73ae27294938a483e855613b49825a795e8",
+        "is_verified": false,
+        "line_number": 3433
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e9929bd50a5523f3ee0cf35a8fd80c06bc43cc50",
+        "is_verified": false,
+        "line_number": 3437
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f436e5e80e3407aed61c6a5d0463a46e0da536d8",
+        "is_verified": false,
+        "line_number": 3441
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "44e465ae72a1040308940ab81352dfbacbe7e364",
+        "is_verified": false,
+        "line_number": 3445
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8dde1ebef344011f9e6ac282be903ab5cc8cdcdf",
+        "is_verified": false,
+        "line_number": 3451
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
+        "is_verified": false,
+        "line_number": 3454
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
+        "is_verified": false,
+        "line_number": 3457
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "aee6e2f94569251fe1d62eafb1e922c0c9da7310",
+        "is_verified": false,
+        "line_number": 3460
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d4993485565eb1018819491e8a7ee52a1594e101",
+        "is_verified": false,
+        "line_number": 3463
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "db1d5fe158aaf084a72a2dfa5555e5d63cc4236c",
+        "is_verified": false,
+        "line_number": 3468
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7e30ca914cc2ed38e1a330be94a26824867b5934",
+        "is_verified": false,
+        "line_number": 3471
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3885943ec38bd72b75dd793c8064f5b82b7986df",
+        "is_verified": false,
+        "line_number": 3502
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "09eef298f78df698d8ecb1d9a58fa11e5d9f4e99",
+        "is_verified": false,
+        "line_number": 3542
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c85b08c4b0d082d8ef795d3feb33248d653a86dd",
+        "is_verified": false,
+        "line_number": 3567
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "646545163be60fa7b4864dabc97dc921b6217a3f",
+        "is_verified": false,
+        "line_number": 3571
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7c0f26e555ee262ed308b5e9a40f3ed4fdaacaa9",
+        "is_verified": false,
+        "line_number": 3574
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fbab298b8cf4892db7d5b25fa56f64db70c02191",
+        "is_verified": false,
+        "line_number": 3577
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c404e90db76532488af93bd2a7001a73ec20db70",
+        "is_verified": false,
+        "line_number": 3580
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a7f758ccbe3c1a33e64125ee88909ceb0f2b9ad",
+        "is_verified": false,
+        "line_number": 3584
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ee4887dad945f60487dbcadc8e688259e0f670ae",
+        "is_verified": false,
+        "line_number": 3587
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
+        "is_verified": false,
+        "line_number": 3590
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c34d43e9581b3e233d1d2cdc667a3ce110c60491",
+        "is_verified": false,
+        "line_number": 3595
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
+        "is_verified": false,
+        "line_number": 3600
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6961f61ab86a0461464a49ee3080e16851cf964e",
+        "is_verified": false,
+        "line_number": 3603
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "543c98d315431cc1616876ddf1cdc5fd13349a9b",
+        "is_verified": false,
+        "line_number": 3607
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3c2d8491c2232a61643d57a3622f9e4c284b24f2",
+        "is_verified": false,
+        "line_number": 3610
+      }
+    ],
+    "docs/user-guide/agent_optimization.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/user-guide/agent_optimization.md",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "docs/user-guide/interactive_optimization.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/user-guide/interactive_optimization.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 359
+      }
+    ],
+    "docs/user-guide/optuna_integration.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/user-guide/optuna_integration.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 129
+      }
+    ],
+    "examples/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/README.md",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 164
+      }
+    ],
+    "examples/advanced/ragas/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/advanced/ragas/README.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "examples/docs/EXAMPLES_GUIDE.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/docs/EXAMPLES_GUIDE.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
+    "examples/docs/QUICK_REFERENCE.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/docs/QUICK_REFERENCE.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "examples/docs/START_HERE.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/docs/START_HERE.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "examples/docs/TROUBLESHOOTING.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/docs/TROUBLESHOOTING.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/docs/TROUBLESHOOTING.md",
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "examples/quickstart/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/quickstart/README.md",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 48
+      }
+    ],
+    "examples/templates/run_template.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/templates/run_template.py",
+        "hashed_secret": "a8bee6dd2bbf5bf8303b391c191e2cf38515f4a8",
+        "is_verified": false,
+        "line_number": 342
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/templates/run_template.py",
+        "hashed_secret": "19e662368a1065e8e98fdb0d0ec341e3382132cc",
+        "is_verified": false,
+        "line_number": 350
+      }
+    ],
+    "metrics/2026-01-02/aggregate_report.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "metrics/2026-01-02/aggregate_report.json",
+        "hashed_secret": "e4405b8ccb0da2f1abd2c99793542100fe917f14",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "metrics/2026-01-02/docs_examples.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "metrics/2026-01-02/docs_examples.json",
+        "hashed_secret": "e4405b8ccb0da2f1abd2c99793542100fe917f14",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "metrics/2026-01-02/security_audit.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "metrics/2026-01-02/security_audit.json",
+        "hashed_secret": "e4405b8ccb0da2f1abd2c99793542100fe917f14",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "metrics/2026-01-02/source_quality.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "metrics/2026-01-02/source_quality.json",
+        "hashed_secret": "e4405b8ccb0da2f1abd2c99793542100fe917f14",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "metrics/2026-01-02/test_quality.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "metrics/2026-01-02/test_quality.json",
+        "hashed_secret": "e4405b8ccb0da2f1abd2c99793542100fe917f14",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "plugins/traigent-ui/traigent_ui/STREAMLIT_README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "plugins/traigent-ui/traigent_ui/STREAMLIT_README.md",
+        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "scripts/smoke/smoke_real_api_measures.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/smoke/smoke_real_api_measures.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/smoke/smoke_real_api_measures.py",
+        "hashed_secret": "cbeffbb256c892acf6c43b4c72caa89534f398eb",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
+    "scripts/sonarqube-local/docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/sonarqube-local/docker-compose.yml",
+        "hashed_secret": "345e9ea7c857e75dedd9edb24c232e1cab297c19",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "scripts/utilities/check_measures.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/utilities/check_measures.py",
+        "hashed_secret": "cbeffbb256c892acf6c43b4c72caa89534f398eb",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "tests/TESTING_GUIDELINES.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/TESTING_GUIDELINES.md",
+        "hashed_secret": "425697fa9692ea5035739863d2481dbfcddfa31f",
+        "is_verified": false,
+        "line_number": 221
+      }
+    ],
+    "tests/auto_tune/test_security_utils.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/auto_tune/test_security_utils.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 93
+      }
+    ],
+    "tests/cloud/test_sync_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/cloud/test_sync_manager.py",
+        "hashed_secret": "dc1abc7f0c453564fa2538999dde8c8513fa1006",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "tests/config/plugins/anthropic.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/config/plugins/anthropic.yaml",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "tests/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/conftest.py",
+        "hashed_secret": "dfab2e513122494cf5b02fe39b8ea2a31fce02a5",
+        "is_verified": false,
+        "line_number": 636
+      }
+    ],
+    "tests/e2e/test_example_scoring_e2e.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/e2e/test_example_scoring_e2e.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 201
+      }
+    ],
+    "tests/e2e/test_privacy_decorator.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/e2e/test_privacy_decorator.py",
+        "hashed_secret": "d03a7a9634cd7ccfd21598d15a59f87f31c425a2",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
+    "tests/examples/test_readme_examples.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/examples/test_readme_examples.py",
+        "hashed_secret": "4788c228e39a7537be5cc7d159588cd4f0ce0700",
+        "is_verified": false,
+        "line_number": 159
+      }
+    ],
+    "tests/integration/backend/test_backend_integration_mock.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/backend/test_backend_integration_mock.py",
+        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "tests/integration/langfuse/test_langfuse_bridge.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/langfuse/test_langfuse_bridge.py",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 264
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/langfuse/test_langfuse_bridge.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 277
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/langfuse/test_langfuse_bridge.py",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 301
+      }
+    ],
+    "tests/integration/test_auth_flow_end_to_end.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_auth_flow_end_to_end.py",
+        "hashed_secret": "8f496788bffe8b052feeb2c64bbf8e38bdaec69b",
+        "is_verified": false,
+        "line_number": 41
+      }
+    ],
+    "tests/integration/test_custom_evaluator_fix.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/integration/test_custom_evaluator_fix.py",
+        "hashed_secret": "cbeffbb256c892acf6c43b4c72caa89534f398eb",
+        "is_verified": false,
+        "line_number": 106
+      }
+    ],
+    "tests/integration/test_execution_modes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_execution_modes.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 166
+      }
+    ],
+    "tests/integration/test_mock_mode_metrics.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_mock_mode_metrics.py",
+        "hashed_secret": "f5ef767f75e3447133504f094ac9a57a6bf9a5c6",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "tests/integration/test_privacy_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_privacy_integration.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "tests/integration/test_summary_stats_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_summary_stats_integration.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 144
+      }
+    ],
+    "tests/integration/test_traigent_decorator_cloud_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_traigent_decorator_cloud_integration.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 532
+      }
+    ],
+    "tests/optimizer_validation/test_tracking.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/optimizer_validation/test_tracking.json",
+        "hashed_secret": "eb7fdf2bc15b3790d07e011b9a1bf15588b555e6",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "tests/security/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/conftest.py",
+        "hashed_secret": "48b25a04bbb2c5e09927c90960a4114de81cbd13",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/conftest.py",
+        "hashed_secret": "651ec3ba958a2d7ca42a805fbe6a9cbd167af24c",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/conftest.py",
+        "hashed_secret": "08684e3d9b02d094d31e369da4ca94fde132c71b",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/security/conftest.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 127
+      }
+    ],
+    "tests/security/test_all_modes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_all_modes.py",
+        "hashed_secret": "8ca68e07419728079897da01028fbc2b470cf411",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_all_modes.py",
+        "hashed_secret": "651ec3ba958a2d7ca42a805fbe6a9cbd167af24c",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_all_modes.py",
+        "hashed_secret": "08684e3d9b02d094d31e369da4ca94fde132c71b",
+        "is_verified": false,
+        "line_number": 80
+      }
+    ],
+    "tests/security/test_credentials_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "372bacdec8f936edc9dedda87434dd659c5fd4b9",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "391d2ef27c79f6ba6eb55cde51d7361b6f110db3",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "36a74288c7b0ff8ccbe1a586d3830fe81f0a46db",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "1f0e468308b9284c5f17a689f1012e617abc68b8",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "02cb028d06780f9cce4f1f0499551673bd711320",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "e914bd6185ae58590f915c9b43576b2cbc2efe87",
+        "is_verified": false,
+        "line_number": 327
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "f710bdc72c1673d195fcc3969487132f7a53d392",
+        "is_verified": false,
+        "line_number": 337
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "05b23151c90608ab4de9717af2cf3787ee9cf691",
+        "is_verified": false,
+        "line_number": 468
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_credentials_integration.py",
+        "hashed_secret": "bf84a2cf551133cdab8024a1ccd1b21c52c977b8",
+        "is_verified": false,
+        "line_number": 503
+      }
+    ],
+    "tests/security/test_jwt_validator_secure.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_jwt_validator_secure.py",
+        "hashed_secret": "480a1219604c04f21f81009faf76f08a6d40c482",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "tests/security/test_seamless_security.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/security/test_seamless_security.py",
+        "hashed_secret": "b968ea5d2cc44f84fa600dc6cd6d7fe9c81d8011",
+        "is_verified": false,
+        "line_number": 390
+      }
+    ],
+    "tests/test_backend_config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "4d14ba766272bbddb6b266568a69065fcc814343",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "8b732765707d3674444ce74fef1c501deec421b6",
+        "is_verified": false,
+        "line_number": 122
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "899028db1bebde3303021f76c6f4249fb48020bb",
+        "is_verified": false,
+        "line_number": 123
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "7371fa5711fa8d4588f4eb436d4786c8bfaa413c",
+        "is_verified": false,
+        "line_number": 126
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "47c488769f38a3e9986343899cc0b8d84f3b3227",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_backend_config.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 178
+      }
+    ],
+    "tests/test_cli_auth_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_cli_auth_integration.py",
+        "hashed_secret": "34ad4531592cb8f09eb6fdd15229ed5140ee45c0",
+        "is_verified": false,
+        "line_number": 91
+      }
+    ],
+    "tests/unit/adapters/test_execution_adapter.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/adapters/test_execution_adapter.py",
+        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
+        "is_verified": false,
+        "line_number": 187
+      }
+    ],
+    "tests/unit/agents/test_platforms.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/agents/test_platforms.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 628
+      }
+    ],
+    "tests/unit/analytics/test_example_insights.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/analytics/test_example_insights.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/analytics/test_example_insights.py",
+        "hashed_secret": "7bac3a781f4b9606796e1a61bc27b0966b884cdc",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/analytics/test_example_insights.py",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/analytics/test_example_insights.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 86
+      }
+    ],
+    "tests/unit/api/test_functions.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/api/test_functions.py",
+        "hashed_secret": "1779181920c9463a9107c1bb5fbad80c4614e962",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "tests/unit/cloud/test_agent_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_agent_client.py",
+        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/cloud/test_agent_client.py",
+        "hashed_secret": "c44b91d6672bb1d7c51e050ababb0146efa84380",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/cloud/test_agent_client.py",
+        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_agent_client.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 181
+      }
+    ],
+    "tests/unit/cloud/test_api_key_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "1aa787fe0cfb373575fc2c0f6f826e7c6dc9fd41",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "9cea46b39bd44a1ef9f3e71bfe9e45c24d3300f6",
+        "is_verified": false,
+        "line_number": 162
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "df517a2cc5cb5deb5fa5aa1289ebcffecd51c2a4",
+        "is_verified": false,
+        "line_number": 183
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "fc1a45292e952648ac2db150cbdc15842b3e7581",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "2bd8e9c9c868efe968cc583d2d49f67380967d94",
+        "is_verified": false,
+        "line_number": 370
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_api_key_manager.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 435
+      }
+    ],
+    "tests/unit/cloud/test_auth_data_classes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_auth_data_classes.py",
+        "hashed_secret": "f19bdef79ff0fef5be90260fe42ad36e1394243c",
+        "is_verified": false,
+        "line_number": 286
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_auth_data_classes.py",
+        "hashed_secret": "ea45a4958bbb18451e1d48aa90745cb35a508b29",
+        "is_verified": false,
+        "line_number": 367
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_auth_data_classes.py",
+        "hashed_secret": "ad6ed643d097938d8f82b0945077efdc93928614",
+        "is_verified": false,
+        "line_number": 380
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_auth_data_classes.py",
+        "hashed_secret": "5c12943ccb00b478e844eef0121c4635fc58ce39",
+        "is_verified": false,
+        "line_number": 392
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_auth_data_classes.py",
+        "hashed_secret": "fa3b7f644207897470b4be0a5df8a6104e927627",
+        "is_verified": false,
+        "line_number": 422
+      }
+    ],
+    "tests/unit/cloud/test_authentication_concurrency.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_concurrency.py",
+        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_concurrency.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 370
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_concurrency.py",
+        "hashed_secret": "c4a8c3e29851d9ce1a8d7cd05edba07f5abc885e",
+        "is_verified": false,
+        "line_number": 419
+      }
+    ],
+    "tests/unit/cloud/test_authentication_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "a4a5d636c192de1771ecb77f5e6d6616f2048f61",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "0a806d4c41dcc539dc702489dd8131cd20f25b72",
+        "is_verified": false,
+        "line_number": 197
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "4899f9b37583a05052df43ed44db481876d06ab8",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "d9ae64509845794bad5ccbe331e4082d46911e83",
+        "is_verified": false,
+        "line_number": 902
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "f0cb94ca73e3f705d01377b89be9bee358186e16",
+        "is_verified": false,
+        "line_number": 903
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "60848657c4284b96f67dd1b78986c7b7d4d20a93",
+        "is_verified": false,
+        "line_number": 904
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "a15cc8c985741ed65cef49273853fe5d7b450a1a",
+        "is_verified": false,
+        "line_number": 1016
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_integration.py",
+        "hashed_secret": "a4f9a4d788b9ddef1a06e9afd05840aad767ed25",
+        "is_verified": false,
+        "line_number": 1017
+      }
+    ],
+    "tests/unit/cloud/test_authentication_lifecycle.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_lifecycle.py",
+        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_lifecycle.py",
+        "hashed_secret": "7ddcd00c1670e9cfd185b1f3598685e1054b9cca",
+        "is_verified": false,
+        "line_number": 605
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_lifecycle.py",
+        "hashed_secret": "9e52503a0984e613e6ed5f6f9a3cf0b93b2d826b",
+        "is_verified": false,
+        "line_number": 719
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_lifecycle.py",
+        "hashed_secret": "a90dff8ba6472d733cb0a37734fe28a8078f8444",
+        "is_verified": false,
+        "line_number": 725
+      }
+    ],
+    "tests/unit/cloud/test_authentication_security.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_security.py",
+        "hashed_secret": "25b5a7e454ccbe4974ee239749935c9e32b887e1",
+        "is_verified": false,
+        "line_number": 301
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_security.py",
+        "hashed_secret": "b3215fe1d22a64a131c0f9c09718c5b8860911ad",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_security.py",
+        "hashed_secret": "495289ab973afae18fc84235f33dadc07a9608c4",
+        "is_verified": false,
+        "line_number": 365
+      }
+    ],
+    "tests/unit/cloud/test_authentication_stress.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_stress.py",
+        "hashed_secret": "cafcea282a1104ecc395ba08b982bcce1d873da1",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_stress.py",
+        "hashed_secret": "4bb4f3c99fc956741d0b9142b07099863a6006cf",
+        "is_verified": false,
+        "line_number": 145
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_stress.py",
+        "hashed_secret": "ceef36714a7d2d193de1e0567763a203458edfdf",
+        "is_verified": false,
+        "line_number": 260
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_stress.py",
+        "hashed_secret": "1b2d5054f229016d0c3a42eaa6915c461117132b",
+        "is_verified": false,
+        "line_number": 388
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_stress.py",
+        "hashed_secret": "b345d697385f89e5f59359e63b42d301e8d520cd",
+        "is_verified": false,
+        "line_number": 506
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_authentication_stress.py",
+        "hashed_secret": "9331b9d090d37e5f3137696d4ae49de9a0caa765",
+        "is_verified": false,
+        "line_number": 746
+      }
+    ],
+    "tests/unit/cloud/test_backend_bridges_security.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_backend_bridges_security.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_backend_bridges_security.py",
+        "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
+    "tests/unit/cloud/test_backend_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_backend_client.py",
+        "hashed_secret": "fed8a020c5916e74d6858a577d400597e6dc4263",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_backend_client.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
+    "tests/unit/cloud/test_client_stateful.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_client_stateful.py",
+        "hashed_secret": "01ed6711e130bef8a0eef3572cc2f0325c4664b9",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_client_stateful.py",
+        "hashed_secret": "1cd842a8f4885c5dafb3f60f405051f7d60b5cad",
+        "is_verified": false,
+        "line_number": 492
+      }
+    ],
+    "tests/unit/cloud/test_cloud_authentication.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
+        "is_verified": false,
+        "line_number": 237
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "44c08d71fbe20d2cf9c5842af590dda096bee6f9",
+        "is_verified": false,
+        "line_number": 251
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "801f9bf378fc57a61f95a66e2465a02ed3092d7e",
+        "is_verified": false,
+        "line_number": 252
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "c6e454d960df4845f9d69eb11377c8b23882715b",
+        "is_verified": false,
+        "line_number": 273
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
+        "is_verified": false,
+        "line_number": 484
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_verified": false,
+        "line_number": 514
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "827ba56f5549ed55e91dc9fb84327b0148c01a5e",
+        "is_verified": false,
+        "line_number": 575
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 681
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
+        "is_verified": false,
+        "line_number": 1008
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "ad6ed643d097938d8f82b0945077efdc93928614",
+        "is_verified": false,
+        "line_number": 1017
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
+        "is_verified": false,
+        "line_number": 1119
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_authentication.py",
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_verified": false,
+        "line_number": 1189
+      }
+    ],
+    "tests/unit/cloud/test_cloud_client_validation.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_cloud_client_validation.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "tests/unit/cloud/test_credential_resolver.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_credential_resolver.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_credential_resolver.py",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 276
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_credential_resolver.py",
+        "hashed_secret": "3e3a880564d6961104d8ca9e82190ef682b3d11a",
+        "is_verified": false,
+        "line_number": 294
+      }
+    ],
+    "tests/unit/cloud/test_dataset_converter_validation.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "tests/unit/cloud/test_dataset_converter_validation.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "tests/unit/cloud/test_session_finalization.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_session_finalization.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/unit/cloud/test_session_ownership_enforcement.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_session_ownership_enforcement.py",
+        "hashed_secret": "d244bdec6e3b588fa5a9d63a735bc527d57ae878",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "tests/unit/cloud/test_sync_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_sync_manager.py",
+        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
+        "is_verified": false,
+        "line_number": 106
+      }
+    ],
+    "tests/unit/cloud/test_token_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_token_manager.py",
+        "hashed_secret": "b968ea5d2cc44f84fa600dc6cd6d7fe9c81d8011",
+        "is_verified": false,
+        "line_number": 377
+      }
+    ],
+    "tests/unit/cloud/test_traigent_cloud_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_traigent_cloud_client.py",
+        "hashed_secret": "fed8a020c5916e74d6858a577d400597e6dc4263",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_traigent_cloud_client.py",
+        "hashed_secret": "1365fdd044ed56597fc69f9ad30ef5eccaf4a4ab",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "tests/unit/cloud/test_trial_operations.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_trial_operations.py",
+        "hashed_secret": "159920628cb789601a3ef7859918baa2e9ea7d15",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/cloud/test_trial_operations.py",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
+    "tests/unit/config/test_api_keys.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/config/test_api_keys.py",
+        "hashed_secret": "bea2f7b64fab8d1d414d0449530b1e088d36d5b1",
+        "is_verified": false,
+        "line_number": 49
+      }
+    ],
+    "tests/unit/integrations/langfuse/test_langfuse_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/langfuse/test_langfuse_client.py",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "is_verified": false,
+        "line_number": 221
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/langfuse/test_langfuse_client.py",
+        "hashed_secret": "404bd906aa687b0616c881ddbd92ffee4cfba91a",
+        "is_verified": false,
+        "line_number": 236
+      }
+    ],
+    "tests/unit/integrations/langfuse/test_langfuse_tracker.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/langfuse/test_langfuse_tracker.py",
+        "hashed_secret": "5efd9c78161dbdc37aecdfecbe469d2d9975d9db",
+        "is_verified": false,
+        "line_number": 133
+      }
+    ],
+    "tests/unit/integrations/test_framework_override.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/test_framework_override.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 228
+      }
+    ],
+    "tests/unit/integrations/test_framework_override_extended.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/test_framework_override_extended.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 1109
+      }
+    ],
+    "tests/unit/integrations/test_mistral_plugin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/test_mistral_plugin.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 188
+      }
+    ],
+    "tests/unit/integrations/test_model_discovery.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/integrations/test_model_discovery.py",
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_verified": false,
+        "line_number": 684
+      }
+    ],
+    "tests/unit/optimizers/test_cloud_optimizer.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/optimizers/test_cloud_optimizer.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 234
+      }
+    ],
+    "tests/unit/optimizers/test_remote_services.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/optimizers/test_remote_services.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 597
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/optimizers/test_remote_services.py",
+        "hashed_secret": "b9615cef6cff3572af1365ff44c8b92ea9266f3e",
+        "is_verified": false,
+        "line_number": 1068
+      }
+    ],
+    "tests/unit/security/auth/test_oidc.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/auth/test_oidc.py",
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_verified": false,
+        "line_number": 43
+      }
+    ],
+    "tests/unit/security/auth/test_sms.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/security/auth/test_sms.py",
+        "hashed_secret": "63a0349ac776de22d5b1c0b149d7e4abbf3b3b46",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "tests/unit/security/auth/test_totp.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/unit/security/auth/test_totp.py",
+        "hashed_secret": "365822579a8709344e1840a8b3e3cad51ec62a85",
+        "is_verified": false,
+        "line_number": 102
+      }
+    ],
+    "tests/unit/security/test_audit.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_audit.py",
+        "hashed_secret": "4e6a5700698aa6f299f112948996c75b688f8d58",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "tests/unit/security/test_codex_security_fixes_regression.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_codex_security_fixes_regression.py",
+        "hashed_secret": "b968ea5d2cc44f84fa600dc6cd6d7fe9c81d8011",
+        "is_verified": false,
+        "line_number": 150
+      }
+    ],
+    "tests/unit/security/test_credentials.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_credentials.py",
+        "hashed_secret": "abb024ce40e5b84dce8710ae9610c31e3bef35af",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_credentials.py",
+        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_credentials.py",
+        "hashed_secret": "bc58608dc1ce7310e5555fe44c4b319f383d3763",
+        "is_verified": false,
+        "line_number": 346
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_credentials.py",
+        "hashed_secret": "6f1991ff4238307f653a5fc5fcc31266fdf59ff5",
+        "is_verified": false,
+        "line_number": 350
+      }
+    ],
+    "tests/unit/security/test_crypto_utils.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "02d77d6a56e52e535eb9bb8868fbbfcd8292f826",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "f0578f1e7174b1a41c4ea8c6e17f7a8a3b88c92a",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "8be52126a6fde450a7162a3651d589bb51e9579d",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "6243247eed22701b7e63f2a75ec1fe2e513a8b33",
+        "is_verified": false,
+        "line_number": 215
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_crypto_utils.py",
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_verified": false,
+        "line_number": 226
+      }
+    ],
+    "tests/unit/security/test_rate_limiter.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_rate_limiter.py",
+        "hashed_secret": "f638f7a6d6f8b1c1797912b91421c44afcc5b0d6",
+        "is_verified": false,
+        "line_number": 489
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_rate_limiter.py",
+        "hashed_secret": "96a17ac21a4074004557d56a39452d2bebd57e19",
+        "is_verified": false,
+        "line_number": 1298
+      }
+    ],
+    "tests/unit/security/test_security_authentication.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_security_authentication.py",
+        "hashed_secret": "bea2f7b64fab8d1d414d0449530b1e088d36d5b1",
+        "is_verified": false,
+        "line_number": 142
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/security/test_security_authentication.py",
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_verified": false,
+        "line_number": 219
+      }
+    ],
+    "tests/unit/test_jwt_validator.py": [
+      {
+        "type": "JSON Web Token",
+        "filename": "tests/unit/test_jwt_validator.py",
+        "hashed_secret": "34c659f4df06118f5bc39edc355b4542851ad3f6",
+        "is_verified": false,
+        "line_number": 763
+      }
+    ],
+    "tests/unit/test_privacy_mode.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_privacy_mode.py",
+        "hashed_secret": "a17c9aaa61e80a1bf71d0d850af4e5baa9800bbd",
+        "is_verified": false,
+        "line_number": 274
+      }
+    ],
+    "tests/unit/test_safeguards.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_safeguards.py",
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_verified": false,
+        "line_number": 624
+      }
+    ],
+    "tests/unit/test_secure_auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_secure_auth.py",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_secure_auth.py",
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_secure_auth.py",
+        "hashed_secret": "f6db7cd15318dc08ba07364547a31b169ee8f8f2",
+        "is_verified": false,
+        "line_number": 119
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_secure_auth.py",
+        "hashed_secret": "9ed0f816c7c969ece9f5f7d314f75ff54b95ae28",
+        "is_verified": false,
+        "line_number": 203
+      }
+    ],
+    "tests/unit/test_traigent_client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_traigent_client.py",
+        "hashed_secret": "d5bc5015ba84dfab1587b306a027052c3d44e2e0",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/test_traigent_client.py",
+        "hashed_secret": "b02010a0b32b6300b7f77710c9a9ce6be24942b5",
+        "is_verified": false,
+        "line_number": 52
+      }
+    ],
+    "tests/unit/utils/test_env_config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/utils/test_env_config.py",
+        "hashed_secret": "03a991c4d5b6de48b42c0727bd601108dfb09942",
+        "is_verified": false,
+        "line_number": 87
+      }
+    ],
+    "tests/unit/utils/test_example_id.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/utils/test_example_id.py",
+        "hashed_secret": "91746fe1ec2e340a70b46131c4974a477a807da5",
+        "is_verified": false,
+        "line_number": 43
+      }
+    ],
+    "tests/unit/utils/test_local_analytics.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/utils/test_local_analytics.py",
+        "hashed_secret": "035bf17d591b5967aafe1700f7e7d0bf0f7d6bf3",
+        "is_verified": false,
+        "line_number": 457
+      }
+    ],
+    "tests/unit/utils/test_reproducibility.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/unit/utils/test_reproducibility.py",
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_verified": false,
+        "line_number": 166
+      }
+    ],
+    "tests/utils/test_local_analytics.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/utils/test_local_analytics.py",
+        "hashed_secret": "1b945d9513b485440f93d5bc4387ee784ceedb79",
+        "is_verified": false,
+        "line_number": 584
+      }
+    ],
+    "tmp/langgraph_demo_fix_summary.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tmp/langgraph_demo_fix_summary.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 116
+      }
+    ],
+    "tools/code_review/docs/getting-started.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tools/code_review/docs/getting-started.md",
+        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tools/code_review/docs/getting-started.md",
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_verified": false,
+        "line_number": 178
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tools/code_review/docs/getting-started.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 245
+      }
+    ],
+    "tools/flow_generation_utils/codesync_flow_library.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tools/flow_generation_utils/codesync_flow_library.py",
+        "hashed_secret": "b13ad0df30154120d2385c9120207339e67d72e8",
+        "is_verified": false,
+        "line_number": 229
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tools/flow_generation_utils/codesync_flow_library.py",
+        "hashed_secret": "b13ad0df30154120d2385c9120207339e67d72e8",
+        "is_verified": false,
+        "line_number": 229
+      }
+    ],
+    "traigent/api/functions.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/api/functions.py",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 202
+      }
+    ],
+    "traigent/cloud/api_key_manager.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "traigent/cloud/api_key_manager.py",
+        "hashed_secret": "1d88dcdeae967e05e6e9a4463fbaa3bbff343d6e",
+        "is_verified": false,
+        "line_number": 320
+      }
+    ],
+    "traigent/cloud/auth.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/cloud/auth.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 66
+      }
+    ],
+    "traigent/cloud/credential_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/cloud/credential_manager.py",
+        "hashed_secret": "020accf7751ee352c63fe6f98bc23247c907e67a",
+        "is_verified": false,
+        "line_number": 103
+      }
+    ],
+    "traigent/cloud/password_auth_handler.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "traigent/cloud/password_auth_handler.py",
+        "hashed_secret": "e3984cf8d3e5e87a07a61c4a181596742ad43a17",
+        "is_verified": false,
+        "line_number": 306
+      }
+    ],
+    "traigent/integrations/langfuse/__init__.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/langfuse/__init__.py",
+        "hashed_secret": "bfc5221616fd29387d7413aeb41401391dceefa8",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "traigent/integrations/langfuse/client.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/langfuse/client.py",
+        "hashed_secret": "ec417f567082612f8fd6afafe1abcab831fca840",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "traigent/integrations/langfuse/tracker.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/langfuse/tracker.py",
+        "hashed_secret": "3de1412d782e175bafb188a225e9339bf1d5645e",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
+    "traigent/integrations/llms/anthropic_plugin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/anthropic_plugin.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "traigent/integrations/llms/langchain_plugin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/langchain_plugin.py",
+        "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/langchain_plugin.py",
+        "hashed_secret": "0f5649c9ee9b12e2dac7ee4cc9becb72a0d068ba",
+        "is_verified": false,
+        "line_number": 101
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/langchain_plugin.py",
+        "hashed_secret": "3f2df46921dd8e2c36e2ce85238705ac0774c74a",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/langchain_plugin.py",
+        "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
+        "is_verified": false,
+        "line_number": 104
+      }
+    ],
+    "traigent/integrations/llms/llamaindex_plugin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/llamaindex_plugin.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 218
+      }
+    ],
+    "traigent/integrations/llms/mistral_plugin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/mistral_plugin.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 60
+      }
+    ],
+    "traigent/security/credentials.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/security/credentials.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/security/credentials.py",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/security/credentials.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/security/credentials.py",
+        "hashed_secret": "26eae588d0859648be8edcf9cd2cf19bbdfacd43",
+        "is_verified": false,
+        "line_number": 66
+      }
+    ],
+    "traigent/security/encryption.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/security/encryption.py",
+        "hashed_secret": "f019571b10be8cf5c4cf3a8f31ccbeed5fb13701",
+        "is_verified": false,
+        "line_number": 63
+      }
+    ],
+    "traigent/utils/example_id.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "traigent/utils/example_id.py",
+        "hashed_secret": "91746fe1ec2e340a70b46131c4974a477a807da5",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "use-cases/gpt-4.1-study/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "use-cases/gpt-4.1-study/README.md",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
+    "walkthrough/examples/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/README.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "walkthrough/examples/real/01_simple.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/01_simple.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "walkthrough/examples/real/02_zero_code_change.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/02_zero_code_change.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "walkthrough/examples/real/03_parameter_mode.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/03_parameter_mode.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "walkthrough/examples/real/04_multi_objective.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/04_multi_objective.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "walkthrough/examples/real/05_rag.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/05_rag.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "walkthrough/examples/real/06_custom_evaluator.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/06_custom_evaluator.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "walkthrough/examples/real/07_privacy_modes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/07_privacy_modes.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
+      }
+    ],
+    "walkthrough/examples/real/advanced/01_tuned_variables.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/advanced/01_tuned_variables.py",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "walkthrough/examples/real/advanced/02_prompt_optimization.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/advanced/02_prompt_optimization.py",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "walkthrough/examples/real/advanced/03_multi_agent.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/real/advanced/03_multi_agent.py",
+        "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "walkthrough/examples/utils/check_environment.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/utils/check_environment.py",
+        "hashed_secret": "a19ee5a9fdc191092796cd9bfa97c55fe5631695",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/utils/check_environment.py",
+        "hashed_secret": "b780a23b530ef6bb5c3b722a0c9c5e3abf222e8b",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/utils/check_environment.py",
+        "hashed_secret": "993a5656293e1c4a708a5ba0d47d9bb2516cb48b",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/examples/utils/check_environment.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "walkthrough/hotpotQA/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/hotpotQA/README.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "walkthrough/hotpotQA/README.md",
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_verified": false,
+        "line_number": 61
+      }
+    ]
+  },
+  "generated_at": "2026-01-28T21:00:17Z"
 }


### PR DESCRIPTION
## Summary
- Remove Python 3.14 from CI test matrix
- Update detect-secrets baseline

## Motivation
Python 3.14 is still in development and causes flaky CI failures due to missing dependency wheels.

## Changes
- Remove 3.14 from matrix in:
  - examples-smoke.yml
  - test-examples.yml  
  - tests.yml
- Update detect-secrets to v1.5.0
- Regenerate secrets baseline

Supported versions: 3.11, 3.12, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)