### PR TITLE
fix: Pass max_trials to all optimizers, not just random

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,14 +49,13 @@ repos:
         pass_filenames: false
         exclude: ^tests/
 
-  # Type checking
+  # Type checking - uses pyproject.toml [tool.mypy] configuration
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:
       - id: mypy
         args:
-          - --ignore-missing-imports
-          - traigent/
+          - --config-file=pyproject.toml
         pass_filenames: false
 
   # TVL specification validation (G-2)

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1856,7 +1856,7 @@ class OptimizedFunction:
 
         # Phase 6: Create optimizer
         optimizer_kwargs = algorithm_kwargs.copy()
-        if max_trials and algorithm == "random":
+        if max_trials:
             optimizer_kwargs["max_trials"] = max_trials
 
         # Apply mock config overrides if present


### PR DESCRIPTION
## Summary
Fix bug where `max_trials` from the decorator was only passed to the random optimizer.

## Problem
Previously, Optuna and other optimizers used their internal defaults (100 trials) instead of the user-specified `max_trials` value.

## Solution
Remove the unnecessary `algorithm == "random"` condition check when passing `max_trials` to optimizer kwargs.

## Changes
- `traigent/core/optimized_function.py`: Remove algorithm check for max_trials
- `.pre-commit-config.yaml`: Fix mypy config to use pyproject.toml settings

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)