### PR TITLE
fix: Constraint-rejected configs no longer consume trial slots

### DIFF
--- a/tests/unit/core/test_constraints_enforced.py
+++ b/tests/unit/core/test_constraints_enforced.py
@@ -35,6 +35,12 @@ class _FailIfCalledEvaluator(BaseEvaluator):
 
 @pytest.mark.asyncio
 async def test_pre_constraints_prevent_evaluation() -> None:
+    """Test that pre-constraints prevent evaluation without consuming trial slots.
+
+    After fix for issue #27, constraint-rejected configs do NOT consume trial slots,
+    meaning they don't create trial records. The evaluator should never be called,
+    and the result should have no trials (since all configs were rejected).
+    """
     dataset = Dataset(
         examples=[EvaluationExample(input_data={"text": "hi"}, expected_output="hi")],
         name="t",
@@ -57,5 +63,8 @@ async def test_pre_constraints_prevent_evaluation() -> None:
         return "hi"
 
     result = await orchestrator.optimize(func=func, dataset=dataset)
-    assert result.trials
-    assert result.trials[0].status.value in {"failed", "pruned", "cancelled"}
+    # With fix for issue #27: constraint failures don't consume trial slots,
+    # so no trials are recorded (evaluator is never called)
+    assert result.trials == []
+    # Verify the optimization completed (optimizer's should_stop was respected)
+    assert result.status.value == "completed"

--- a/tests/unit/core/test_trial_lifecycle.py
+++ b/tests/unit/core/test_trial_lifecycle.py
@@ -898,3 +898,45 @@ class TestRunSequentialTrial:
 
         assert action == "continue"
         assert trial_count == 0  # Not incremented because skipped
+
+    @pytest.mark.asyncio
+    async def test_constraint_failure_does_not_consume_trial_slot(self):
+        """Test that constraint-rejected configs don't consume trial slots (issue #27)."""
+
+        orchestrator = MockOrchestrator()
+        orchestrator.max_trials = 10
+
+        # Add a pre-constraint that always fails
+        def failing_constraint(config, metrics=None):
+            return False
+
+        failing_constraint.__tvl_constraint__ = {
+            "id": "test",
+            "message": "Always fails",
+        }
+        orchestrator._constraints_pre_eval = [failing_constraint]
+        orchestrator._abandon_optuna_trial = MagicMock()  # Mock the abandon method
+
+        lifecycle = TrialLifecycle(orchestrator)
+        dataset = create_mock_dataset()
+
+        async def mock_func(input_data):
+            return "result"
+
+        trial_count, action = await lifecycle.run_sequential_trial(
+            func=mock_func,
+            dataset=dataset,
+            session_id=None,
+            function_name="test_func",
+            trial_count=5,
+        )
+
+        # Key assertions: constraint failure should NOT consume a trial slot
+        assert action == "continue"
+        assert trial_count == 5  # NOT incremented - this is the bug fix for issue #27
+
+        # Verify Optuna trial was abandoned with appropriate reason
+        orchestrator._abandon_optuna_trial.assert_called_once()
+        call_kwargs = orchestrator._abandon_optuna_trial.call_args[1]
+        assert "trial_rejected_by_constraint" in call_kwargs.get("reason", "")
+        assert call_kwargs.get("status") == TrialStatus.PRUNED

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -159,26 +159,21 @@ class TrialLifecycle:
                 stage="pre",
             )
         except TVLConstraintError as e:
-            # Constraint failed - create a failed trial without running evaluation
-            logger.info("Pre-constraint failed for config %s: %s", config_for_run, e)
-            failed_trial = TrialResult(
-                trial_id=str(trial_count),
-                config=config_for_run,
-                metrics={},
-                status=TrialStatus.FAILED,
-                duration=0.0,
-                timestamp=datetime.now(tz=UTC),
-                error_message=str(e),
-                metadata={"constraint_failure": True},
+            # Constraint failed - skip this config without consuming a trial slot
+            # (Fix for issue #27: constraint-rejected configs should not reduce actual evaluations)
+            logger.info(
+                "Pre-constraint failed for config %s: %s (not counting toward max_trials)",
+                config_for_run,
+                e,
             )
-            trial_count = await orchestrator._handle_trial_result(
-                trial_result=failed_trial,
-                optimizer_config=config,
-                current_trial_index=trial_count,
-                session_id=session_id,
-                optuna_trial_id=optuna_trial_id,
-                log_on_success=False,
-            )
+            if hasattr(orchestrator, "_abandon_optuna_trial"):
+                orchestrator._abandon_optuna_trial(  # type: ignore[attr-defined]
+                    optuna_trial_id,
+                    reason=f"trial_rejected_by_constraint:{e}",
+                    config=config_for_run,
+                    status=TrialStatus.PRUNED,
+                    pruned_step=0,
+                )
             return trial_count, "continue"
 
         # Phase 2.1: Acquire cost permit before sequential trial execution


### PR DESCRIPTION
## Summary
- Fixes #27: When pre-evaluation constraints reject a config, the trial count is no longer incremented
- This ensures users get the full number of actual evaluations they requested via `max_trials`
- Constraint failures are now handled like cache policy filtering: skip without consuming a trial slot

## Test plan
- [x] Added `test_constraint_failure_does_not_consume_trial_slot` to explicitly test new behavior
- [x] Updated `test_pre_constraints_prevent_evaluation` to expect empty trials when all configs rejected
- [x] All 1383 core unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)