### PR TITLE
fix: Add samples_exhaustive flag to check_constraints_conflict

### DIFF
--- a/tests/unit/api/test_constraints.py
+++ b/tests/unit/api/test_constraints.py
@@ -1195,6 +1195,53 @@ class TestCheckConstraintsConflict:
         result = check_constraints_conflict([c1], sample_configs=None)
         assert result is None
 
+    def test_conflict_with_exhaustive_samples(self) -> None:
+        """Test that exhaustive samples report conflict for mutually exclusive constraints."""
+        temp = Range(0.0, 2.0, name="temperature")
+        c1 = require(temp.lte(0.5))
+        c2 = require(temp.gte(0.8))
+
+        # These constraints are mutually exclusive
+        result = check_constraints_conflict(
+            [c1, c2],
+            sample_configs=[{"temperature": 0.3}, {"temperature": 0.9}],
+            samples_exhaustive=True,
+        )
+        assert result is not None
+        assert isinstance(result, ConstraintConflict)
+        assert len(result.constraints) == 2
+
+    def test_no_conflict_with_sparse_samples_default(self) -> None:
+        """Test that sparse samples don't report conflict by default (issue #38)."""
+        temp = Range(0.0, 2.0, name="temperature")
+        c1 = require(temp.lte(0.5))
+        c2 = require(temp.gte(0.8))
+
+        # Same mutually exclusive constraints, but samples_exhaustive=False (default)
+        # should return None to avoid false positives
+        result = check_constraints_conflict(
+            [c1, c2],
+            sample_configs=[{"temperature": 0.3}, {"temperature": 0.9}],
+            # samples_exhaustive defaults to False
+        )
+        assert result is None
+
+    def test_no_conflict_sparse_samples_explicit(self) -> None:
+        """Test explicit samples_exhaustive=False returns None even with all failures."""
+        temp = Range(0.0, 2.0, name="temperature")
+        c1 = require(temp.gte(0.3))
+        c2 = require(temp.lte(0.7))
+
+        # Samples outside valid range [0.3, 0.7]
+        result = check_constraints_conflict(
+            [c1, c2],
+            sample_configs=[{"temperature": 0.2}, {"temperature": 0.8}],
+            samples_exhaustive=False,
+        )
+        # Should return None since samples are not exhaustive
+        # (valid configs like 0.5 exist but weren't sampled)
+        assert result is None
+
 
 class TestExplainConstraintViolation:
     """Tests for explain_constraint_violation() function."""

--- a/traigent/api/constraints.py
+++ b/traigent/api/constraints.py
@@ -1041,6 +1041,8 @@ def check_constraints_conflict(
     constraints: list[Constraint],
     sample_configs: list[dict[str, Any]] | None = None,
     var_names: dict[int, str] | None = None,
+    *,
+    samples_exhaustive: bool = False,
 ) -> ConstraintConflict | None:
     """Check if constraints conflict with each other.
 
@@ -1051,8 +1053,7 @@ def check_constraints_conflict(
     Warning:
         This function can produce **false positives** when sample_configs is
         sparse. A conflict is reported if no sample satisfies all constraints,
-        but valid configurations may exist outside the samples. Ensure samples
-        adequately cover the parameter space, or treat results as advisory.
+        but valid configurations may exist outside the samples.
 
     Args:
         constraints: List of Constraint objects to check.
@@ -1061,23 +1062,37 @@ def check_constraints_conflict(
             For reliable conflict detection, provide samples that span
             the full domain of each constrained variable.
         var_names: Optional mapping from ParameterRange id() to config key.
+        samples_exhaustive: If True, report a conflict when no sample satisfies
+            all constraints. If False (default), return None in this case to
+            avoid false positives from sparse sampling. Set to True only when
+            sample_configs exhaustively covers the parameter space.
 
     Returns:
-        ConstraintConflict if a conflict is detected, None otherwise.
-        Note: None means no conflict was found in the samples, not that
-        no conflict exists.
+        ConstraintConflict if a definite conflict is detected, None otherwise.
+        When samples_exhaustive=False, returns None even if all samples fail,
+        since valid configurations may exist outside the samples.
 
     Example:
         >>> temp = Range(0.0, 2.0, name="temperature")
         >>> c1 = require(temp.lte(0.5))
         >>> c2 = require(temp.gte(0.8))
-        >>> # These cannot both be satisfied
+        >>> # These cannot both be satisfied - use exhaustive for definite conflicts
         >>> conflict = check_constraints_conflict(
         ...     [c1, c2],
-        ...     sample_configs=[{"temperature": 0.3}, {"temperature": 0.9}]
+        ...     sample_configs=[{"temperature": 0.3}, {"temperature": 0.9}],
+        ...     samples_exhaustive=True,  # samples cover full domain
         ... )
         >>> if conflict:
         ...     print(conflict)
+
+        >>> # With sparse samples, avoid false positives
+        >>> result = check_constraints_conflict(
+        ...     [c1, c2],
+        ...     sample_configs=[{"temperature": 0.2}],  # sparse, missing 0.3-0.5
+        ...     samples_exhaustive=False,  # default, safe for sparse samples
+        ... )
+        >>> result is None  # No conflict reported (could be false negative)
+        True
     """
     if not constraints or not sample_configs:
         return None
@@ -1107,7 +1122,13 @@ def check_constraints_conflict(
 
         all_violations.append((config, violations))
 
-    # No config satisfied all constraints - this indicates a conflict
+    # No config satisfied all constraints - this may indicate a conflict
+    # But only report if samples_exhaustive=True to avoid false positives
+    if not samples_exhaustive:
+        # Sparse samples: don't report conflict as valid configs may exist
+        # outside the sample set (fix for issue #38)
+        return None
+
     # Report the config with the most violations for best diagnostics
     # (for mutually exclusive constraints, each config violates different ones)
     if all_violations and len(constraints) > 1:


### PR DESCRIPTION
## Summary
Fixes #38: Adds `samples_exhaustive` parameter to `check_constraints_conflict()` to prevent false positives when using sparse sample configurations.

## Problem
The function would report a conflict if no sample satisfied all constraints, even when valid configurations might exist outside the sparse sample set.

## Solution
Added `samples_exhaustive: bool = False` parameter:
- **False (default)**: Returns `None` when all samples fail, avoiding false positives
- **True**: Reports conflict when no sample satisfies all constraints

## Breaking Change
This changes the default behavior - the function now returns `None` in cases where it previously returned a `ConstraintConflict`. Callers who relied on conflict detection should explicitly set `samples_exhaustive=True`.

## Test plan
- [x] Added 3 new tests for the `samples_exhaustive` parameter
- [x] All 6 constraint conflict tests pass
- [x] All 864 API unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)