### PR TITLE
fix: Compute built-in metrics even when scoring_function is provided

### DIFF
--- a/tests/unit/evaluators/test_local_evaluator_builtin_metrics.py
+++ b/tests/unit/evaluators/test_local_evaluator_builtin_metrics.py
@@ -47,9 +47,9 @@ class TestBuiltinMetricsWithMetricFunctions:
     async def test_metric_functions_with_builtin_metrics_computes_both(self):
         """When metric_functions overrides 'accuracy' but metrics includes
         built-in 'latency' and 'cost', those built-ins should still be
-        computed via compute_metrics with only ['latency', 'cost'].
+        computed via compute_metrics with metrics_override=['latency', 'cost'].
 
-        Covers lines 1180-1206 (the if-branch with base_metric_names populated).
+        Covers the if-branch with base_metric_names populated.
         """
 
         def custom_accuracy(actual, expected, **kwargs):
@@ -63,27 +63,24 @@ class TestBuiltinMetricsWithMetricFunctions:
         )
         dataset = _make_dataset()
 
-        # Capture what self.metrics is set to during the compute_metrics call.
-        captured_metrics: list[list[str]] = []
-
-        def spy_compute_metrics(*args, **kwargs):
-            captured_metrics.append(list(evaluator.metrics))
-            return {"latency": 0.5, "success_rate": 0.9}
-
-        mock_compute = MagicMock(side_effect=spy_compute_metrics)
+        mock_compute = MagicMock(return_value={"latency": 0.5, "success_rate": 0.9})
         with patch.object(evaluator, "compute_metrics", mock_compute):
             result = await evaluator.evaluate(_simple_func, {}, dataset)
 
         # compute_metrics should have been called exactly once
         mock_compute.assert_called_once()
 
-        # During the call, self.metrics should have been temporarily set to
-        # only the built-in metrics (latency, success_rate) -- not accuracy
-        # (which is overridden by metric_functions).
-        assert len(captured_metrics) == 1
-        assert "accuracy" not in captured_metrics[0]
-        assert "latency" in captured_metrics[0]
-        assert "success_rate" in captured_metrics[0]
+        # Verify metrics_override was passed with only the built-in metrics
+        # (not 'accuracy', which is overridden by metric_functions)
+        call_kwargs = mock_compute.call_args[1]
+        assert "metrics_override" in call_kwargs
+        override = call_kwargs["metrics_override"]
+        assert "accuracy" not in override
+        assert "latency" in override
+        assert "success_rate" in override
+
+        # self.metrics should NOT have been mutated (thread-safe)
+        assert evaluator.metrics == ["accuracy", "latency", "success_rate"]
 
         # The mocked built-in values should appear in aggregated_metrics
         assert result.aggregated_metrics.get("latency") == 0.5
@@ -94,7 +91,7 @@ class TestBuiltinMetricsWithMetricFunctions:
         (none in _metric_registry or _ragas_metric_names),
         aggregated_metrics should be {} from the else branch.
 
-        Covers lines 1207-1208 (the else branch: aggregated_metrics = {}).
+        Covers the else branch: aggregated_metrics = {}.
         """
 
         def custom_my_score(actual, expected, **kwargs):
@@ -119,11 +116,11 @@ class TestBuiltinMetricsWithMetricFunctions:
         mock_compute.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_metric_functions_restores_metrics_after_compute(self):
-        """After evaluate completes, self.metrics should be restored to its
-        original value even though it was temporarily overwritten.
+    async def test_self_metrics_not_mutated_during_compute(self):
+        """self.metrics should never be mutated during evaluate(),
+        ensuring thread-safety for concurrent evaluations.
 
-        Covers lines 1194-1206 (the try/finally block).
+        Verifies that metrics_override is used instead of self.metrics mutation.
         """
 
         def custom_accuracy(actual, expected, **kwargs):
@@ -138,19 +135,25 @@ class TestBuiltinMetricsWithMetricFunctions:
         )
         dataset = _make_dataset()
 
-        mock_compute = MagicMock(return_value={"latency": 0.1, "cost": 0.001})
+        # Track self.metrics during compute_metrics call
+        captured_metrics: list[list[str]] = []
+
+        def spy_compute_metrics(*args, **kwargs):
+            captured_metrics.append(list(evaluator.metrics))
+            return {"latency": 0.1, "cost": 0.001}
+
+        mock_compute = MagicMock(side_effect=spy_compute_metrics)
         with patch.object(evaluator, "compute_metrics", mock_compute):
             await evaluator.evaluate(_simple_func, {}, dataset)
 
-        # self.metrics must be restored to the original list
+        # self.metrics should be unchanged even during the call
+        assert len(captured_metrics) == 1
+        assert captured_metrics[0] == original_metrics
         assert evaluator.metrics == original_metrics
 
     @pytest.mark.asyncio
-    async def test_metric_functions_restores_metrics_on_exception(self):
-        """self.metrics should be restored even if compute_metrics raises.
-
-        Covers the finally block at lines 1205-1206.
-        """
+    async def test_self_metrics_unchanged_on_exception(self):
+        """self.metrics should remain unchanged even if compute_metrics raises."""
 
         def custom_accuracy(actual, expected, **kwargs):
             return 0.5
@@ -169,15 +172,15 @@ class TestBuiltinMetricsWithMetricFunctions:
             with pytest.raises(RuntimeError, match="boom"):
                 await evaluator.evaluate(_simple_func, {}, dataset)
 
-        # Even after an exception, self.metrics must be restored
+        # self.metrics should be unchanged (no mutation to restore)
         assert evaluator.metrics == original_metrics
 
     @pytest.mark.asyncio
     async def test_no_metric_functions_uses_compute_metrics_directly(self):
-        """When metric_functions is empty, the else branch at line 1209-1217
-        is taken and compute_metrics is called normally with full self.metrics.
+        """When metric_functions is empty, the else branch is taken and
+        compute_metrics is called normally without metrics_override.
 
-        Covers lines 1209-1217 (else branch: no metric_functions).
+        Covers else branch: no metric_functions.
         """
         evaluator = LocalEvaluator(
             metrics=["accuracy", "latency"],
@@ -193,5 +196,10 @@ class TestBuiltinMetricsWithMetricFunctions:
 
         # compute_metrics should be called once (the else branch)
         mock_compute.assert_called_once()
+
+        # No metrics_override should be passed in the else branch
+        call_kwargs = mock_compute.call_args[1]
+        assert "metrics_override" not in call_kwargs
+
         # The result should include the mocked values
         assert result.aggregated_metrics.get("latency") == 0.2

--- a/tests/unit/evaluators/test_local_evaluator_builtin_metrics.py
+++ b/tests/unit/evaluators/test_local_evaluator_builtin_metrics.py
@@ -1,0 +1,197 @@
+"""Tests for LocalEvaluator built-in metrics computation with metric_functions.
+
+Covers lines 1179-1208 in traigent/evaluators/local.py: the branching logic
+that computes built-in metrics even when custom metric_functions are provided.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
+
+
+def _make_dataset() -> Dataset:
+    """Create a minimal dataset for testing."""
+    return Dataset(
+        examples=[
+            EvaluationExample(
+                input_data={"text": "hello world"},
+                expected_output="positive",
+            ),
+            EvaluationExample(
+                input_data={"text": "goodbye world"},
+                expected_output="negative",
+            ),
+        ],
+        name="test_builtin_metrics",
+    )
+
+
+async def _simple_func(text: str) -> str:
+    return "positive"
+
+
+class TestBuiltinMetricsWithMetricFunctions:
+    """Test the branching logic at lines 1179-1208 of local.py.
+
+    When metric_functions is set (from scoring_function), the evaluator should
+    still compute built-in metrics (from _metric_registry) that are not
+    overridden by custom metric_functions.
+    """
+
+    @pytest.mark.asyncio
+    async def test_metric_functions_with_builtin_metrics_computes_both(self):
+        """When metric_functions overrides 'accuracy' but metrics includes
+        built-in 'latency' and 'cost', those built-ins should still be
+        computed via compute_metrics with only ['latency', 'cost'].
+
+        Covers lines 1180-1206 (the if-branch with base_metric_names populated).
+        """
+
+        def custom_accuracy(actual, expected, **kwargs):
+            return 0.99
+
+        evaluator = LocalEvaluator(
+            metrics=["accuracy", "latency", "success_rate"],
+            metric_functions={"accuracy": custom_accuracy},
+            detailed=True,
+            execution_mode="edge_analytics",
+        )
+        dataset = _make_dataset()
+
+        # Capture what self.metrics is set to during the compute_metrics call.
+        captured_metrics: list[list[str]] = []
+
+        def spy_compute_metrics(*args, **kwargs):
+            captured_metrics.append(list(evaluator.metrics))
+            return {"latency": 0.5, "success_rate": 0.9}
+
+        mock_compute = MagicMock(side_effect=spy_compute_metrics)
+        with patch.object(evaluator, "compute_metrics", mock_compute):
+            result = await evaluator.evaluate(_simple_func, {}, dataset)
+
+        # compute_metrics should have been called exactly once
+        mock_compute.assert_called_once()
+
+        # During the call, self.metrics should have been temporarily set to
+        # only the built-in metrics (latency, success_rate) -- not accuracy
+        # (which is overridden by metric_functions).
+        assert len(captured_metrics) == 1
+        assert "accuracy" not in captured_metrics[0]
+        assert "latency" in captured_metrics[0]
+        assert "success_rate" in captured_metrics[0]
+
+        # The mocked built-in values should appear in aggregated_metrics
+        assert result.aggregated_metrics.get("latency") == 0.5
+
+    @pytest.mark.asyncio
+    async def test_metric_functions_all_custom_no_builtins(self):
+        """When all metrics in self.metrics are only in metric_functions
+        (none in _metric_registry or _ragas_metric_names),
+        aggregated_metrics should be {} from the else branch.
+
+        Covers lines 1207-1208 (the else branch: aggregated_metrics = {}).
+        """
+
+        def custom_my_score(actual, expected, **kwargs):
+            return 0.88
+
+        # 'my_score' is NOT in _metric_registry or _ragas_metric_names
+        evaluator = LocalEvaluator(
+            metrics=["my_score"],
+            metric_functions={"my_score": custom_my_score},
+            detailed=True,
+            execution_mode="edge_analytics",
+        )
+        dataset = _make_dataset()
+
+        # Mock compute_metrics -- it should NOT be called in this branch
+        mock_compute = MagicMock(return_value={})
+        with patch.object(evaluator, "compute_metrics", mock_compute):
+            result = await evaluator.evaluate(_simple_func, {}, dataset)
+
+        # compute_metrics should NOT have been called since there are
+        # no built-in metrics to compute (all are custom-only).
+        mock_compute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_metric_functions_restores_metrics_after_compute(self):
+        """After evaluate completes, self.metrics should be restored to its
+        original value even though it was temporarily overwritten.
+
+        Covers lines 1194-1206 (the try/finally block).
+        """
+
+        def custom_accuracy(actual, expected, **kwargs):
+            return 0.77
+
+        original_metrics = ["accuracy", "latency", "cost"]
+        evaluator = LocalEvaluator(
+            metrics=original_metrics.copy(),
+            metric_functions={"accuracy": custom_accuracy},
+            detailed=True,
+            execution_mode="edge_analytics",
+        )
+        dataset = _make_dataset()
+
+        mock_compute = MagicMock(return_value={"latency": 0.1, "cost": 0.001})
+        with patch.object(evaluator, "compute_metrics", mock_compute):
+            await evaluator.evaluate(_simple_func, {}, dataset)
+
+        # self.metrics must be restored to the original list
+        assert evaluator.metrics == original_metrics
+
+    @pytest.mark.asyncio
+    async def test_metric_functions_restores_metrics_on_exception(self):
+        """self.metrics should be restored even if compute_metrics raises.
+
+        Covers the finally block at lines 1205-1206.
+        """
+
+        def custom_accuracy(actual, expected, **kwargs):
+            return 0.5
+
+        original_metrics = ["accuracy", "latency"]
+        evaluator = LocalEvaluator(
+            metrics=original_metrics.copy(),
+            metric_functions={"accuracy": custom_accuracy},
+            detailed=True,
+            execution_mode="edge_analytics",
+        )
+        dataset = _make_dataset()
+
+        mock_compute = MagicMock(side_effect=RuntimeError("boom"))
+        with patch.object(evaluator, "compute_metrics", mock_compute):
+            with pytest.raises(RuntimeError, match="boom"):
+                await evaluator.evaluate(_simple_func, {}, dataset)
+
+        # Even after an exception, self.metrics must be restored
+        assert evaluator.metrics == original_metrics
+
+    @pytest.mark.asyncio
+    async def test_no_metric_functions_uses_compute_metrics_directly(self):
+        """When metric_functions is empty, the else branch at line 1209-1217
+        is taken and compute_metrics is called normally with full self.metrics.
+
+        Covers lines 1209-1217 (else branch: no metric_functions).
+        """
+        evaluator = LocalEvaluator(
+            metrics=["accuracy", "latency"],
+            metric_functions=None,  # No custom metric functions
+            detailed=True,
+            execution_mode="edge_analytics",
+        )
+        dataset = _make_dataset()
+
+        mock_compute = MagicMock(return_value={"accuracy": 0.9, "latency": 0.2})
+        with patch.object(evaluator, "compute_metrics", mock_compute):
+            result = await evaluator.evaluate(_simple_func, {}, dataset)
+
+        # compute_metrics should be called once (the else branch)
+        mock_compute.assert_called_once()
+        # The result should include the mocked values
+        assert result.aggregated_metrics.get("latency") == 0.2

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -696,15 +696,19 @@ class BaseEvaluator(ABC):
             outputs: Actual outputs from function
             expected_outputs: Expected outputs
             errors: Error messages (None for successful evaluations)
-            **context: Additional context for metric computation
+            **context: Additional context for metric computation.
+                metrics_override: Optional list of metric names to compute
+                    instead of self.metrics. Avoids mutating shared state
+                    for thread-safety.
 
         Returns:
             Dictionary of metric name to value
         """
         metrics: dict[str, float] = {}
+        metric_names = context.pop("metrics_override", None) or self.metrics
 
         ragas_metric_names = [
-            name for name in self.metrics if name in self._ragas_metric_names
+            name for name in metric_names if name in self._ragas_metric_names
         ]
         ragas_results: dict[str, float] = {}
 
@@ -732,7 +736,7 @@ class BaseEvaluator(ABC):
                 logger.warning("Failed to compute ragas metrics: %s", exc)
                 ragas_results = dict.fromkeys(ragas_metric_names, 0.0)
 
-        for metric_name in self.metrics:
+        for metric_name in metric_names:
             if metric_name in ragas_results:
                 metrics[metric_name] = ragas_results[metric_name]
                 continue

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -1206,19 +1206,15 @@ class LocalEvaluator(BaseEvaluator):
                 and name not in custom_metric_keys
             ]
             if base_metric_names:
-                original_metrics = self.metrics
-                try:
-                    self.metrics = base_metric_names
-                    aggregated_metrics = self.compute_metrics(
-                        outputs,
-                        expected_outputs,
-                        errors,
-                        dataset=dataset,
-                        example_results=example_results,
-                        example_metrics=metrics_tracker.example_metrics,
-                    )
-                finally:
-                    self.metrics = original_metrics
+                aggregated_metrics = self.compute_metrics(
+                    outputs,
+                    expected_outputs,
+                    errors,
+                    dataset=dataset,
+                    example_results=example_results,
+                    example_metrics=metrics_tracker.example_metrics,
+                    metrics_override=base_metric_names,
+                )
             else:
                 aggregated_metrics = {}
         else:

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -1191,9 +1191,36 @@ class LocalEvaluator(BaseEvaluator):
             )
             metrics_tracker.add_example_metrics(example_metric)
 
-        # Compute aggregated metrics
+        # Compute aggregated metrics (include built-ins even with custom functions)
         if self.metric_functions:
-            aggregated_metrics: dict[str, float] = {}
+            # Filter to registry/RAGAS metrics, but exclude those already provided
+            # by custom metric_functions (e.g., skip built-in accuracy if
+            # scoring_function provides it - avoids redundant computation).
+            # Note: scoring_function maps to "accuracy" key only; cost/latency
+            # built-ins remain unless explicitly overridden via metric_functions.
+            custom_metric_keys = set(self.metric_functions.keys())
+            base_metric_names = [
+                name
+                for name in self.metrics
+                if (name in self._metric_registry or name in self._ragas_metric_names)
+                and name not in custom_metric_keys
+            ]
+            if base_metric_names:
+                original_metrics = self.metrics
+                try:
+                    self.metrics = base_metric_names
+                    aggregated_metrics = self.compute_metrics(
+                        outputs,
+                        expected_outputs,
+                        errors,
+                        dataset=dataset,
+                        example_results=example_results,
+                        example_metrics=metrics_tracker.example_metrics,
+                    )
+                finally:
+                    self.metrics = original_metrics
+            else:
+                aggregated_metrics = {}
         else:
             aggregated_metrics = self.compute_metrics(
                 outputs,


### PR DESCRIPTION
## Summary
- When a `scoring_function` was provided via `@traigent.optimize()`, the `LocalEvaluator` skipped `compute_metrics()` entirely, causing built-in metrics like latency and cost to not be computed
- Fix filters `self.metrics` to registry/RAGAS metrics (excluding those already provided by custom `metric_functions`), then calls `compute_metrics()` to get built-in metrics alongside custom ones

## Files changed
| File | Change |
|------|--------|
| `traigent/evaluators/local.py` | Filter and call `compute_metrics()` for built-in metrics even when `metric_functions` is set |

## Test plan
- [ ] Existing evaluator tests pass
- [ ] SonarCloud quality gate passes
- [ ] Built-in metrics (latency, cost) computed when `scoring_function` is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)