### PR TITLE
fix: Update enum str test for StrEnum change

### DIFF
--- a/tests/unit/api/test_api_types.py
+++ b/tests/unit/api/test_api_types.py
@@ -53,9 +53,9 @@ class TestEnums:
         assert OptimizationStatus.RUNNING != OptimizationStatus.COMPLETED
 
     def test_enum_string_representation(self):
-        """Test enum string representation."""
-        assert str(OptimizationStatus.RUNNING) == "OptimizationStatus.RUNNING"
-        assert str(TrialStatus.CANCELLED) == "TrialStatus.CANCELLED"
+        """Test enum string representation (StrEnum returns value directly)."""
+        assert str(OptimizationStatus.RUNNING) == "running"
+        assert str(TrialStatus.CANCELLED) == "cancelled"
         # Test the actual values
         assert OptimizationStatus.RUNNING.value == "running"
         assert TrialStatus.CANCELLED.value == "cancelled"


### PR DESCRIPTION
## Summary
- `OptimizationStatus` and `TrialStatus` were changed to `StrEnum` in the Israel merge, so `str()` now returns the value directly (`"running"`) instead of `"OptimizationStatus.RUNNING"`
- Updates test assertion to match the new behavior

## Test plan
- [x] `test_enum_string_representation` passes locally


🤖 Generated with [Claude Code](https://claude.com/claude-code)