### PR TITLE
fix: Add _estimate_optimization_cost delegation stub

### DIFF
--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2092,6 +2092,10 @@ class OptimizationOrchestrator:
             self._logger_facade.attach(self._logger)
         self._logger_facade.log_trial_result(trial_result)
 
+    def _estimate_optimization_cost(self, dataset: Dataset) -> float:
+        """Estimate optimization cost. Delegates to CostEstimator."""
+        return self._cost_estimator.estimate_optimization_cost(dataset)
+
     def _extract_trial_cost(self, trial_result: TrialResult) -> float | None:
         """Extract cost from trial result. Delegates to CostEstimator."""
         return CostEstimator.extract_trial_cost(trial_result)


### PR DESCRIPTION
## Summary
- Adds missing `_estimate_optimization_cost` delegation stub to `OptimizationOrchestrator`, which delegates to `CostEstimator.estimate_optimization_cost()`
- Fixes `test_orchestrator.py::TestCostEstimation` test failures introduced by the Phase 3 god-object decomposition (#96)

## Test plan
- [x] `tests/unit/core/` — 1,562 tests pass
- [x] Fixes `TestCostEstimation::test_cost_estimate_uses_budget_not_dataset_size`
- [x] Fixes `TestCostEstimation::test_cost_estimate_without_budget_uses_dataset_size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)