### PR TITLE
feat(hybrid-api): declarative optimization parity + OpenAPI contract hardening

### DIFF
--- a/docs/hybrid-mode-api-contract.md
+++ b/docs/hybrid-mode-api-contract.md
@@ -371,6 +371,8 @@ Execute the agent with a specific configuration on a batch of inputs.
 | `output_id` | string | No | Output identifier (for privacy-preserving mode) |
 | `cost_usd` | number | No | Cost for this input |
 | `latency_ms` | number | No | Latency for this input |
+| `metrics` | object | No | Per-input quality metrics (combined execute+evaluate mode) |
+| `error` | string | No | Error message for this input when execution partially fails |
 
 **Operational Metrics** (recommended):
 | Field | Type | Description |
@@ -432,7 +434,7 @@ Evaluate outputs against expected targets to measure quality.
 | `request_id` | string | No | Idempotency key (UUID) |
 | `capability_id` | string | Yes | Identifier for the evaluation capability |
 | `execution_id` | string | No | Reference to previous execute (for caching) |
-| `evaluations` | array | Yes | List of output+target pairs |
+| `evaluations` | array | No | List of output+target pairs (optional when using execution_id-only workflows) |
 | `config` | object | No | Optional config for evaluation parameters |
 | `session_id` | string | No | Session ID for stateful agents |
 
@@ -489,12 +491,14 @@ Evaluate outputs against expected targets to measure quality.
 | `status` | string | Yes | `"completed"`, `"partial"`, or `"failed"` |
 | `results` | array | Yes | Per-example evaluation results |
 | `aggregate_metrics` | object | Yes | Aggregated statistics per metric |
+| `error` | object | No | Error details for partial/failed evaluations (`code`, `message`, `failed_inputs`) |
 
 **Result Item**:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `input_id` | string | Yes | Matching input identifier |
 | `metrics` | object | Yes | Quality metrics for this example |
+| `error` | string | No | Error message for this example when evaluation partially fails |
 
 **Aggregate Metric**:
 | Field | Type | Description |

--- a/docs/hybrid-mode-api-contract.md
+++ b/docs/hybrid-mode-api-contract.md
@@ -171,7 +171,7 @@ Returns tunable variable definitions. Traigent uses these to understand what par
       "default": true
     }
   ],
-  "constraints": {}
+  "constraints": {},
   "objectives": [
     {"name": "accuracy", "direction": "maximize", "weight": 2.0},
     {"name": "cost", "direction": "minimize", "weight": 1.0}

--- a/docs/hybrid-mode-api-contract.md
+++ b/docs/hybrid-mode-api-contract.md
@@ -172,6 +172,21 @@ Returns tunable variable definitions. Traigent uses these to understand what par
     }
   ],
   "constraints": {}
+  "objectives": [
+    {"name": "accuracy", "direction": "maximize", "weight": 2.0},
+    {"name": "cost", "direction": "minimize", "weight": 1.0}
+  ],
+  "exploration": {
+    "strategy": "nsga2",
+    "budgets": {"max_trials": 50, "max_spend_usd": 10.0}
+  },
+  "promotion_policy": {
+    "dominance": "epsilon_pareto",
+    "alpha": 0.05,
+    "min_effect": {"accuracy": 0.02}
+  },
+  "defaults": {"model": "gpt-4o"},
+  "measures": ["accuracy", "cost", "latency"]
 }
 ```
 
@@ -181,6 +196,11 @@ Returns tunable variable definitions. Traigent uses these to understand what par
 | `capability_id` | string | Yes | Unique identifier for this capability |
 | `tunables` | array | Yes | List of tunable variable definitions |
 | `constraints` | object | No | Structural and behavioral constraints |
+| `objectives` | array | No | Optional objective definitions (TVL 0.9 JSON format) |
+| `exploration` | object | No | Optional exploration strategy, budgets, and convergence |
+| `promotion_policy` | object | No | Optional promotion policy (epsilon-Pareto) |
+| `defaults` | object | No | Optional default configuration values |
+| `measures` | array[string] | No | Optional declared metric names produced by service |
 
 #### Tunable Definition
 

--- a/docs/hybrid-mode-client-guide.md
+++ b/docs/hybrid-mode-client-guide.md
@@ -510,28 +510,27 @@ import traigent
     execution_mode="hybrid_api",
     hybrid_api_endpoint="http://your-service:8080",
     capability_id="my_agent",
+    eval_dataset=my_dataset,
 
-    # Auto-discover tunables from API
-    configuration_space=None,
-
-    # Or override specific tunables
-    # configuration_space={
-    #     "model": ["fast", "accurate"],  # Subset of available
-    #     "temperature": {"low": 0.0, "high": 1.0},
-    # },
+    # Provide tunables/configuration space for optimizer search
+    configuration_space={
+        "model": ["fast", "accurate", "balanced"],
+        "temperature": (0.0, 1.0),
+    },
 
     # Optimization settings
     max_trials=50,
     cost_limit=10.0,
-    batch_size=10,
+    hybrid_api_batch_size=10,
+    hybrid_api_batch_parallelism=2,
 
     # Objectives (use your custom metric names)
-    objectives=["accuracy", "total_cost_usd", "latency_ms"],
+    objectives=["accuracy", "cost", "latency"],
 )
-def my_agent():
-    pass  # Not used in hybrid mode
+def my_agent(_query: str):
+    return ""  # Execution is delegated to the external hybrid API
 
-result = traigent.run(my_agent, dataset=my_dataset)
+result = my_agent.optimize()
 print(f"Best config: {result.best_config}")
 print(f"Best metrics: {result.best_metrics}")
 ```

--- a/docs/hybrid-mode-openapi.yaml
+++ b/docs/hybrid-mode-openapi.yaml
@@ -511,6 +511,14 @@ components:
           type: number
           description: Latency for this input in milliseconds
           format: double
+        metrics:
+          type: object
+          description: Optional per-input quality metrics (combined execute+evaluate mode)
+          additionalProperties:
+            type: number
+        error:
+          type: string
+          description: Error message for this input when execution partially fails
 
     OperationalMetrics:
       type: object
@@ -656,6 +664,8 @@ components:
           description: Aggregated statistics per metric
           additionalProperties:
             $ref: "#/components/schemas/AggregateMetricStats"
+        error:
+          $ref: "#/components/schemas/ExecutionError"
 
     EvaluationResult:
       type: object
@@ -676,6 +686,9 @@ components:
             accuracy: 0.92
             relevance: 0.88
             fluency: 0.95
+        error:
+          type: string
+          description: Optional error message for this example when evaluation partially fails
 
     AggregateMetricStats:
       type: object

--- a/docs/hybrid-mode-openapi.yaml
+++ b/docs/hybrid-mode-openapi.yaml
@@ -287,12 +287,36 @@ components:
           items:
             $ref: "#/components/schemas/TunableDefinition"
         constraints:
+          description: Structural and behavioral constraints (legacy textual or typed TVL 0.9)
+          oneOf:
+            - type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+            - $ref: "#/components/schemas/TypedConstraints"
+            - type: array
+              items:
+                type: object
+                additionalProperties: true
+        objectives:
+          type: array
+          description: Optional objective definitions (TVL 0.9 compatible JSON)
+          items:
+            $ref: "#/components/schemas/ObjectiveDefinition"
+        exploration:
+          $ref: "#/components/schemas/ExplorationConfig"
+        promotion_policy:
+          $ref: "#/components/schemas/PromotionPolicy"
+        defaults:
           type: object
-          description: Structural and behavioral constraints
-          additionalProperties:
-            type: array
-            items:
-              type: string
+          description: Optional default configuration values
+          additionalProperties: true
+        measures:
+          type: array
+          description: Optional list of metric names produced by the service
+          items:
+            type: string
 
     TunableDefinition:
       type: object
@@ -350,6 +374,174 @@ components:
           type: number
           description: Step size for float types
           example: 0.1
+
+    ObjectiveDefinition:
+      type: object
+      description: Objective definition compatible with TVL 0.9 objectives section
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Objective name
+          pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
+        direction:
+          type: string
+          description: Objective orientation
+          enum: [maximize, minimize, band]
+        weight:
+          type: number
+          description: Objective weight
+          default: 1.0
+        unit:
+          type: string
+          description: Optional objective unit
+        band:
+          $ref: "#/components/schemas/BandTarget"
+
+    BandTarget:
+      type: object
+      description: Banded objective target definition
+      required:
+        - target
+      properties:
+        target:
+          type: array
+          description: Lower/upper target band
+          items:
+            type: number
+          minItems: 2
+          maxItems: 2
+        test:
+          type: string
+          description: Statistical band test
+          enum: [TOST]
+          default: TOST
+        alpha:
+          type: number
+          description: Significance level for band test
+          minimum: 0
+          maximum: 1
+          default: 0.05
+
+    ExplorationConfig:
+      type: object
+      description: Exploration strategy and budget controls (TVL 0.9 exploration section)
+      properties:
+        strategy:
+          description: Exploration strategy
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                type:
+                  type: string
+              additionalProperties: true
+        budgets:
+          $ref: "#/components/schemas/ExplorationBudgets"
+        convergence:
+          $ref: "#/components/schemas/ConvergenceCriteria"
+        parallelism:
+          type: object
+          properties:
+            max_parallel_trials:
+              type: integer
+              minimum: 1
+          additionalProperties: true
+
+    ExplorationBudgets:
+      type: object
+      description: Exploration budget limits
+      properties:
+        max_trials:
+          type: integer
+          minimum: 1
+        max_spend_usd:
+          type: number
+          minimum: 0
+        max_wallclock_s:
+          type: number
+          minimum: 0
+
+    ConvergenceCriteria:
+      type: object
+      description: Convergence stop criteria
+      required:
+        - metric
+        - window
+        - threshold
+      properties:
+        metric:
+          type: string
+        window:
+          type: integer
+          minimum: 1
+        threshold:
+          type: number
+          minimum: 0
+
+    TypedConstraints:
+      type: object
+      description: Typed TVL 0.9 constraints section
+      properties:
+        structural:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        derived:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: false
+
+    PromotionPolicy:
+      type: object
+      description: Promotion policy for epsilon-Pareto selection
+      properties:
+        dominance:
+          type: string
+          enum: [epsilon_pareto]
+          default: epsilon_pareto
+        alpha:
+          type: number
+          minimum: 0
+          maximum: 1
+          default: 0.05
+        min_effect:
+          type: object
+          additionalProperties:
+            type: number
+        adjust:
+          type: string
+          enum: [none, BH]
+          default: none
+        chance_constraints:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChanceConstraint"
+        tie_breakers:
+          type: object
+          additionalProperties:
+            type: string
+            enum: [min_abs_deviation, custom]
+
+    ChanceConstraint:
+      type: object
+      required:
+        - name
+        - threshold
+        - confidence
+      properties:
+        name:
+          type: string
+        threshold:
+          type: number
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
 
     ExecuteRequest:
       type: object

--- a/docs/hybrid-mode-schemas.json
+++ b/docs/hybrid-mode-schemas.json
@@ -265,6 +265,17 @@
         "latency_ms": {
           "type": "number",
           "description": "Latency for this input in milliseconds"
+        },
+        "metrics": {
+          "type": "object",
+          "description": "Optional per-input quality metrics (combined execute+evaluate mode)",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "error": {
+          "type": "string",
+          "description": "Error message for this input when execution partially fails"
         }
       },
       "additionalProperties": false
@@ -484,6 +495,10 @@
           "additionalProperties": {
             "type": "number"
           }
+        },
+        "error": {
+          "type": "string",
+          "description": "Optional error message for this example when evaluation partially fails"
         }
       },
       "additionalProperties": false
@@ -516,6 +531,9 @@
           "additionalProperties": {
             "$ref": "#/definitions/AggregateMetricStats"
           }
+        },
+        "error": {
+          "$ref": "#/definitions/ExecutionError"
         }
       },
       "additionalProperties": false
@@ -543,6 +561,71 @@
           "type": "object",
           "description": "Additional health details",
           "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "KeepAliveRequest": {
+      "type": "object",
+      "title": "KeepAliveRequest",
+      "description": "Request body for session heartbeat",
+      "required": ["session_id"],
+      "properties": {
+        "session_id": {
+          "type": "string",
+          "description": "Session identifier"
+        }
+      },
+      "additionalProperties": false
+    },
+    "KeepAliveResponse": {
+      "type": "object",
+      "title": "KeepAliveResponse",
+      "description": "Response body for successful session heartbeat",
+      "required": ["status", "session_id"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["alive"],
+          "description": "Session heartbeat status"
+        },
+        "session_id": {
+          "type": "string",
+          "description": "Session identifier"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorDetails": {
+      "type": "object",
+      "title": "ErrorDetails",
+      "description": "Structured error details",
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message"
+        },
+        "details": {
+          "type": "object",
+          "description": "Additional error details",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "title": "ErrorResponse",
+      "description": "Error response wrapper",
+      "required": ["error"],
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDetails"
         }
       },
       "additionalProperties": false

--- a/docs/hybrid-mode-schemas.json
+++ b/docs/hybrid-mode-schemas.json
@@ -140,14 +140,280 @@
           }
         },
         "constraints": {
-          "type": "object",
-          "description": "Structural and behavioral constraints",
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "description": "Structural and behavioral constraints (legacy textual or typed TVL 0.9)",
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "$ref": "#/definitions/TypedConstraints"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
             }
+          ]
+        },
+        "objectives": {
+          "type": "array",
+          "description": "Optional objective definitions (TVL 0.9 compatible JSON)",
+          "items": {
+            "$ref": "#/definitions/ObjectiveDefinition"
           }
+        },
+        "exploration": {
+          "$ref": "#/definitions/ExplorationConfig"
+        },
+        "promotion_policy": {
+          "$ref": "#/definitions/PromotionPolicy"
+        },
+        "defaults": {
+          "type": "object",
+          "description": "Optional default configuration values",
+          "additionalProperties": true
+        },
+        "measures": {
+          "type": "array",
+          "description": "Optional list of metric names produced by the service",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ObjectiveDefinition": {
+      "type": "object",
+      "title": "ObjectiveDefinition",
+      "description": "Objective definition compatible with TVL 0.9 objectives section",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Objective name",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+        },
+        "direction": {
+          "type": "string",
+          "description": "Objective orientation",
+          "enum": ["maximize", "minimize", "band"]
+        },
+        "weight": {
+          "type": "number",
+          "description": "Objective weight",
+          "default": 1.0
+        },
+        "unit": {
+          "type": "string",
+          "description": "Optional objective unit"
+        },
+        "band": {
+          "$ref": "#/definitions/BandTarget"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BandTarget": {
+      "type": "object",
+      "title": "BandTarget",
+      "description": "Banded objective target definition",
+      "required": ["target"],
+      "properties": {
+        "target": {
+          "type": "array",
+          "description": "Lower/upper target band",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "test": {
+          "type": "string",
+          "description": "Statistical band test",
+          "enum": ["TOST"],
+          "default": "TOST"
+        },
+        "alpha": {
+          "type": "number",
+          "description": "Significance level for band test",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.05
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExplorationConfig": {
+      "type": "object",
+      "title": "ExplorationConfig",
+      "description": "Exploration strategy and budget controls (TVL 0.9 exploration section)",
+      "properties": {
+        "strategy": {
+          "description": "Exploration strategy",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": true
+            }
+          ]
+        },
+        "budgets": {
+          "$ref": "#/definitions/ExplorationBudgets"
+        },
+        "convergence": {
+          "$ref": "#/definitions/ConvergenceCriteria"
+        },
+        "parallelism": {
+          "type": "object",
+          "properties": {
+            "max_parallel_trials": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExplorationBudgets": {
+      "type": "object",
+      "title": "ExplorationBudgets",
+      "description": "Exploration budget limits",
+      "properties": {
+        "max_trials": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_spend_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_wallclock_s": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConvergenceCriteria": {
+      "type": "object",
+      "title": "ConvergenceCriteria",
+      "description": "Convergence stop criteria",
+      "required": ["metric", "window", "threshold"],
+      "properties": {
+        "metric": {
+          "type": "string"
+        },
+        "window": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "threshold": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "TypedConstraints": {
+      "type": "object",
+      "title": "TypedConstraints",
+      "description": "Typed TVL 0.9 constraints section",
+      "properties": {
+        "structural": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "derived": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "PromotionPolicy": {
+      "type": "object",
+      "title": "PromotionPolicy",
+      "description": "Promotion policy for epsilon-Pareto selection",
+      "properties": {
+        "dominance": {
+          "type": "string",
+          "enum": ["epsilon_pareto"],
+          "default": "epsilon_pareto"
+        },
+        "alpha": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.05
+        },
+        "min_effect": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "adjust": {
+          "type": "string",
+          "enum": ["none", "BH"],
+          "default": "none"
+        },
+        "chance_constraints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ChanceConstraint"
+          }
+        },
+        "tie_breakers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["min_abs_deviation", "custom"]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ChanceConstraint": {
+      "type": "object",
+      "title": "ChanceConstraint",
+      "required": ["name", "threshold", "confidence"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "number"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
         }
       },
       "additionalProperties": false

--- a/tests/integration/hybrid/mock_hybrid_server.py
+++ b/tests/integration/hybrid/mock_hybrid_server.py
@@ -100,39 +100,42 @@ class MockHybridServer:
             "supports_keep_alive": self.config.supports_keep_alive,
             "supports_streaming": False,
             "max_batch_size": self.config.max_batch_size,
+            "max_payload_bytes": None,
         }
 
     def get_config_space(self) -> dict[str, Any]:
         """Return TVAR definitions for the mock agent."""
+        tunables = [
+            {
+                "name": "model",
+                "type": "enum",
+                "domain": {"values": ["fast", "accurate", "balanced"]},
+                "default": "balanced",
+            },
+            {
+                "name": "temperature",
+                "type": "float",
+                "domain": {"range": [0.0, 1.0], "resolution": 0.1},
+                "default": 0.5,
+            },
+            {
+                "name": "max_retries",
+                "type": "int",
+                "domain": {"range": [0, 5]},
+                "default": 2,
+            },
+            {
+                "name": "use_cache",
+                "type": "bool",
+                "domain": {},
+                "default": True,
+            },
+        ]
         return {
             "schema_version": "0.9",
             "capability_id": "mock_test_agent",
-            "tvars": [
-                {
-                    "name": "model",
-                    "type": "enum",
-                    "domain": {"values": ["fast", "accurate", "balanced"]},
-                    "default": "balanced",
-                },
-                {
-                    "name": "temperature",
-                    "type": "float",
-                    "domain": {"range": [0.0, 1.0], "resolution": 0.1},
-                    "default": 0.5,
-                },
-                {
-                    "name": "max_retries",
-                    "type": "int",
-                    "domain": {"range": [0, 5]},
-                    "default": 2,
-                },
-                {
-                    "name": "use_cache",
-                    "type": "bool",
-                    "domain": {},
-                    "default": True,
-                },
-            ],
+            "tunables": tunables,
+            "tvars": tunables,
         }
 
     def execute(self, request: dict[str, Any]) -> dict[str, Any]:
@@ -386,12 +389,16 @@ class MockHybridServer:
         self.keep_alive_call_count += 1
 
         if not self.config.supports_keep_alive:
-            return {"alive": False, "error": "Keep-alive not supported"}
+            return {
+                "status": "unsupported",
+                "alive": False,
+                "error": "Keep-alive not supported",
+            }
 
         if session_id in self.active_sessions:
-            return {"alive": True, "session_id": session_id}
+            return {"status": "alive", "alive": True, "session_id": session_id}
         else:
-            return {"alive": False, "reason": "Session not found"}
+            return {"status": "expired", "alive": False, "reason": "Session not found"}
 
     def health_check(self) -> dict[str, Any]:
         """Return health status."""

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -53,6 +53,41 @@ class TestOptimizeDecorator:
 
         assert isinstance(training_function, OptimizedFunction)
 
+    def test_execution_bundle_passes_hybrid_api_transport(self):
+        """Execution bundle should preserve preconfigured transport objects."""
+        from traigent.api.decorators import ExecutionOptions
+
+        transport = Mock(name="hybrid_transport")
+
+        @optimize(
+            configuration_space={"x": [1, 2]},
+            execution=ExecutionOptions(
+                execution_mode="hybrid_api",
+                hybrid_api_transport=transport,
+            ),
+        )
+        def sample_function(x: int) -> int:
+            return x
+
+        assert isinstance(sample_function, OptimizedFunction)
+        assert sample_function.execution_mode == "hybrid_api"
+        assert sample_function.hybrid_api_transport is transport
+
+    def test_direct_hybrid_api_transport_runtime_option_is_supported(self):
+        """Direct runtime options should accept hybrid_api_transport."""
+        transport = Mock(name="hybrid_transport_direct")
+
+        @optimize(
+            configuration_space={"x": [1, 2]},
+            execution_mode="hybrid_api",
+            hybrid_api_transport=transport,
+        )
+        def sample_function(x: int) -> int:
+            return x
+
+        assert isinstance(sample_function, OptimizedFunction)
+        assert sample_function.hybrid_api_transport is transport
+
     def test_decorated_function_execution(self):
         """Test that decorated function can still be called normally."""
 

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -1,6 +1,7 @@
 """Tests for trial_operations.py - particularly new code paths."""
 
-from unittest.mock import Mock
+import logging
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -20,7 +21,7 @@ class TestRedactSensitiveFields:
 
     def test_redact_string_api_key(self):
         """Test that string API keys are redacted."""
-        data = {"api_key": "sk-1234567890abcdef"}  # noqa: S105 - test credential
+        data = {"api_key": "sk-1234567890abcdef"}  # noqa: S105  # pragma: allowlist secret
         result = TrialOperations._redact_sensitive_fields(data)
         assert "[REDACTED:" in result["api_key"]
         assert "chars]" in result["api_key"]
@@ -67,7 +68,7 @@ class TestRedactSensitiveFields:
         """Test that nested structures are processed."""
         data = {
             "config": {
-                "api_key": "secret123",
+                "api_key": "secret123",  # pragma: allowlist secret
                 "name": "test",
             }
         }
@@ -100,3 +101,76 @@ class TestCreateLocalhostConnector:
         ops = TrialOperations(mock_client)
         connector = ops._create_localhost_connector()
         assert connector is None
+
+
+class TestMeasuresDictValidationInSubmission:
+    """Test MeasuresDict validation warning path in submit_trial_result_via_session."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_metric_key_logs_warning_and_submits_unvalidated(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Invalid metric keys trigger MeasuresDict warning but submission continues."""
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://api.example.com"  # pragma: allowlist secret
+        mock_client.backend_config.api_base_url = "https://api.example.com"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="completed")
+        mock_client._normalize_execution_mode = Mock(return_value="edge_analytics")
+        mock_client._sanitize_error_message = Mock(return_value="")
+
+        ops = TrialOperations(mock_client)
+        ops._handle_trial_success_response = AsyncMock(return_value=True)
+
+        # Use a metric key with a hyphen — MeasuresDict rejects non-identifier keys
+        invalid_metrics = {"invalid-key": 0.95}
+
+        # Build nested async context manager mocks for aiohttp
+        mock_response = Mock()
+        mock_response.status = 200
+
+        # post() returns an async context manager yielding mock_response
+        mock_post_ctx = AsyncMock()
+        mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_post_ctx)
+
+        # ClientSession() returns an async context manager yielding mock_session
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch(
+                "traigent.cloud.trial_operations.AIOHTTP_AVAILABLE",
+                True,
+            ),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+
+            with caplog.at_level(logging.WARNING, logger="traigent.cloud.trial_operations"):
+                result = await ops.submit_trial_result_via_session(
+                    session_id="test-session",
+                    trial_id="test-trial",
+                    config={"model": "gpt-4"},
+                    metrics=invalid_metrics,
+                    status="completed",
+                )
+
+            # The warning should have been logged
+            assert any("Metrics validation warning" in msg for msg in caplog.messages)
+            # Submission should still proceed (True = success)
+            assert result is True

--- a/tests/unit/config/test_types.py
+++ b/tests/unit/config/test_types.py
@@ -1,9 +1,9 @@
-"""Tests for TraigentConfig type."""
+"""Tests for TraigentConfig type and execution mode helpers."""
 
 import pytest
 
-from traigent.config.types import TraigentConfig
-from traigent.utils.exceptions import ValidationError
+from traigent.config.types import TraigentConfig, validate_execution_mode
+from traigent.utils.exceptions import ConfigurationError, ValidationError
 
 
 class TestTraigentConfig:
@@ -162,3 +162,12 @@ class TestTraigentConfig:
         assert result["custom_setting"] is True
         assert result["api_version"] == "2023-07-01"
         assert result["model"] == "GPT-4o"
+
+
+class TestValidateExecutionMode:
+    """Tests for validate_execution_mode function."""
+
+    def test_invalid_mode_string_raises_configuration_error(self) -> None:
+        """Invalid mode string should raise ConfigurationError, not ValueError."""
+        with pytest.raises(ConfigurationError, match="No such mode 'nonexistent_mode'"):
+            validate_execution_mode("nonexistent_mode")

--- a/tests/unit/core/optimized_function_tests/test_initialization.py
+++ b/tests/unit/core/optimized_function_tests/test_initialization.py
@@ -128,6 +128,21 @@ class TestOptimizedFunctionInitialization:
                 objectives=sample_objectives,
             )
 
+    def test_empty_configuration_space_allowed_with_hybrid_discovery(
+        self, simple_function, sample_objectives
+    ):
+        """Hybrid API auto-discovery can bootstrap the config space at runtime."""
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space={},
+            objectives=sample_objectives,
+            execution_mode="hybrid_api",
+            hybrid_api_endpoint="http://localhost:8080",
+            hybrid_api_auto_discover_tvars=True,
+        )
+
+        assert opt_func.configuration_space == {}
+
     def test_invalid_objectives_type(self, simple_function, sample_config_space):
         """Test error with invalid objectives type."""
         # Now raises ValidationError from validation module

--- a/tests/unit/core/optimized_function_tests/test_optimization.py
+++ b/tests/unit/core/optimized_function_tests/test_optimization.py
@@ -419,6 +419,203 @@ class TestOptimization:
         require(mock_evaluator.metrics == ["accuracy"])
 
     @pytest.mark.asyncio
+    async def test_hybrid_discovery_empty_config_space_raises(
+        self, simple_function, sample_dataset
+    ):
+        """Empty discovery result should raise ValueError."""
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space={},
+            objectives=["accuracy"],
+            eval_dataset=sample_dataset,
+            execution_mode="hybrid_api",
+            hybrid_api_endpoint="http://localhost:8080",
+            hybrid_api_auto_discover_tvars=True,
+        )
+
+        mock_evaluator = Mock()
+        mock_evaluator.discover_config_space = AsyncMock(return_value={})
+        mock_evaluator.close = AsyncMock()
+
+        with (
+            patch(
+                "traigent.core.optimized_function.create_effective_evaluator",
+                return_value=(mock_evaluator, None),
+            ),
+            pytest.raises(ValueError, match="config-space discovery returned no"),
+        ):
+            await opt_func.optimize()
+
+        mock_evaluator.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_discovery_failure_cleans_up_evaluator(
+        self, simple_function, sample_dataset
+    ):
+        """If discovery raises, the bootstrap evaluator should be closed."""
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space={},
+            objectives=["accuracy"],
+            eval_dataset=sample_dataset,
+            execution_mode="hybrid_api",
+            hybrid_api_endpoint="http://localhost:8080",
+            hybrid_api_auto_discover_tvars=True,
+        )
+
+        mock_evaluator = Mock()
+        mock_evaluator.discover_config_space = AsyncMock(
+            side_effect=ConnectionError("connection refused")
+        )
+        mock_evaluator.close = AsyncMock()
+
+        with (
+            patch(
+                "traigent.core.optimized_function.create_effective_evaluator",
+                return_value=(mock_evaluator, None),
+            ),
+            pytest.raises(ConnectionError, match="connection refused"),
+        ):
+            await opt_func.optimize()
+
+        mock_evaluator.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_discovery_promotion_gate_applied_and_restored(
+        self, simple_function, sample_dataset
+    ):
+        """Discovered promotion policy is applied during optimize and restored after."""
+        from traigent.tvl.models import PromotionPolicy
+
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space={},
+            objectives=["accuracy"],
+            eval_dataset=sample_dataset,
+            execution_mode="hybrid_api",
+            hybrid_api_endpoint="http://localhost:8080",
+            hybrid_api_auto_discover_tvars=True,
+        )
+
+        original_gate = getattr(opt_func, "promotion_gate", None)
+        from datetime import datetime
+
+        mock_result = OptimizationResult(
+            trials=[],
+            best_config={"temperature": 0.5},
+            best_score=0.95,
+            optimization_id="hybrid-promo",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime.now(),
+            metadata={},
+        )
+
+        mock_evaluator = Mock()
+        mock_evaluator.discover_config_space = AsyncMock(
+            return_value={"temperature": [0.1, 0.5, 1.0]}
+        )
+        mock_evaluator.optimization_spec = {
+            "objective_schema": create_default_objectives(["accuracy"]),
+            "constraints": [],
+            "default_config": {},
+            "runtime_overrides": {},
+            "promotion_policy": PromotionPolicy(alpha=0.05),
+            "measures": [],
+        }
+        mock_evaluator.metrics = ["accuracy"]
+
+        with (
+            patch(
+                "traigent.core.optimized_function.create_effective_evaluator",
+                return_value=(mock_evaluator, None),
+            ),
+            patch(
+                "traigent.core.optimized_function.get_optimizer",
+                return_value=Mock(),
+            ),
+            patch(
+                "traigent.core.optimized_function.OptimizationOrchestrator"
+            ) as MockOrchestrator,
+        ):
+            mock_orchestrator = MockOrchestrator.return_value
+            mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
+
+            result = await opt_func.optimize()
+            require(result.best_score == pytest.approx(0.95))
+
+            _, orch_kwargs = MockOrchestrator.call_args
+            require(
+                orch_kwargs.get("promotion_gate") is not None,
+                "Promotion gate should have been set from discovery",
+            )
+
+        require(
+            getattr(opt_func, "promotion_gate", None) is original_gate,
+            "Promotion gate should be restored after optimize",
+        )
+
+    @pytest.mark.asyncio
+    async def test_hybrid_discovery_non_dict_spec_ignored(
+        self, simple_function, sample_dataset
+    ):
+        """Non-dict optimization_spec should be silently ignored."""
+        from datetime import datetime
+
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space={},
+            objectives=["accuracy"],
+            eval_dataset=sample_dataset,
+            execution_mode="hybrid_api",
+            hybrid_api_endpoint="http://localhost:8080",
+            hybrid_api_auto_discover_tvars=True,
+        )
+
+        mock_result = OptimizationResult(
+            trials=[],
+            best_config={"temperature": 0.5},
+            best_score=0.8,
+            optimization_id="hybrid-nondict",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime.now(),
+            metadata={},
+        )
+
+        mock_evaluator = Mock()
+        mock_evaluator.discover_config_space = AsyncMock(
+            return_value={"temperature": [0.1, 0.5, 1.0]}
+        )
+        mock_evaluator.optimization_spec = "not_a_dict"
+        mock_evaluator.metrics = ["accuracy"]
+
+        with (
+            patch(
+                "traigent.core.optimized_function.create_effective_evaluator",
+                return_value=(mock_evaluator, None),
+            ),
+            patch(
+                "traigent.core.optimized_function.get_optimizer",
+                return_value=Mock(),
+            ),
+            patch(
+                "traigent.core.optimized_function.OptimizationOrchestrator"
+            ) as MockOrchestrator,
+        ):
+            mock_orchestrator = MockOrchestrator.return_value
+            mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
+
+            result = await opt_func.optimize()
+            require(result.best_score == pytest.approx(0.8))
+
+    @pytest.mark.asyncio
     async def test_decorator_runtime_defaults_propagate_to_optimize(
         self, simple_function, sample_config_space, sample_objectives, sample_dataset
     ):

--- a/tests/unit/core/optimized_function_tests/test_optimization.py
+++ b/tests/unit/core/optimized_function_tests/test_optimization.py
@@ -21,9 +21,7 @@ from traigent.core.optimized_function import OptimizedFunction
 from traigent.tvl.spec_loader import TVLBudget, TVLSpecArtifact
 from traigent.utils.exceptions import OptimizationError
 
-from .test_fixtures import (
-    create_simple_evaluator,
-)
+from .test_fixtures import create_simple_evaluator
 
 
 def require(condition: bool, message: str = "Assertion failed") -> None:
@@ -328,6 +326,97 @@ class TestOptimization:
             mock_loader.assert_called_once()
             _, orchestrator_kwargs = MockOrchestrator.call_args
             require(orchestrator_kwargs["max_trials"] == 5)
+
+    @pytest.mark.asyncio
+    async def test_hybrid_discovery_spec_applies_before_optimizer_construction(
+        self, simple_function, sample_dataset
+    ):
+        """Hybrid config-space discovery can supply objectives, budgets, and defaults."""
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space={},
+            objectives=["accuracy"],
+            eval_dataset=sample_dataset,
+            execution_mode="hybrid_api",
+            hybrid_api_endpoint="http://localhost:8080",
+            hybrid_api_auto_discover_tvars=True,
+        )
+
+        from datetime import datetime
+
+        mock_result = OptimizationResult(
+            trials=[],
+            best_config={"temperature": 0.5},
+            best_score=0.91,
+            optimization_id="hybrid-discovery",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["quality", "cost"],
+            algorithm="random",
+            timestamp=datetime.now(),
+            metadata={},
+        )
+
+        mock_evaluator = Mock()
+        mock_evaluator.discover_config_space = AsyncMock(
+            return_value={"temperature": [0.1, 0.5, 1.0], "model": ["a", "b"]}
+        )
+        mock_evaluator.optimization_spec = {
+            "objective_schema": create_default_objectives(["quality", "cost"]),
+            "constraints": [lambda _config, _metrics: True],
+            "default_config": {"temperature": 0.1},
+            "runtime_overrides": {
+                "max_trials": 7,
+                "parallel_config": {"trial_concurrency": 3},
+            },
+            "promotion_policy": None,
+            "measures": ["quality", "cost", "latency"],
+        }
+        mock_evaluator.metrics = ["accuracy"]
+
+        with (
+            patch(
+                "traigent.core.optimized_function.create_effective_evaluator",
+                return_value=(mock_evaluator, None),
+            ) as mock_create_eval,
+            patch(
+                "traigent.core.optimized_function.get_optimizer",
+                return_value=Mock(),
+            ) as mock_get_optimizer,
+            patch(
+                "traigent.core.optimized_function.OptimizationOrchestrator"
+            ) as MockOrchestrator,
+        ):
+            mock_orchestrator = MockOrchestrator.return_value
+            mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
+
+            result = await opt_func.optimize()
+
+            require(result.best_score == pytest.approx(0.91))
+            mock_create_eval.assert_called_once()
+            mock_evaluator.discover_config_space.assert_awaited_once()
+
+            optimizer_call = mock_get_optimizer.call_args
+            require(
+                optimizer_call.args[1]
+                == {"temperature": [0.1, 0.5, 1.0], "model": ["a", "b"]}
+            )
+            require(optimizer_call.args[2] == ["quality", "cost"])
+            require(optimizer_call.kwargs["max_trials"] == 7)
+
+            _, orchestrator_kwargs = MockOrchestrator.call_args
+            require(orchestrator_kwargs["max_trials"] == 7)
+            require(orchestrator_kwargs["parallel_trials"] == 3)
+            require(orchestrator_kwargs["default_config"] == {"temperature": 0.1})
+            require(
+                len(orchestrator_kwargs.get("constraints", [])) == 1,
+                "Expected discovered constraint to be forwarded",
+            )
+
+        require(opt_func.objectives == ["accuracy"])
+        require(opt_func.default_config == {})
+        require(mock_evaluator.metrics == ["accuracy"])
 
     @pytest.mark.asyncio
     async def test_decorator_runtime_defaults_propagate_to_optimize(

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -3,6 +3,7 @@
 Tests the extracted backend session lifecycle manager with stub backend client.
 """
 
+import re
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -266,6 +267,38 @@ class TestBackendSessionManagerTrialSubmission:
         mock_backend_client._submit_trial_result_via_session.assert_called_once()
         call_kwargs = mock_backend_client._submit_trial_result_via_session.call_args
         assert call_kwargs.kwargs["status"] == "PRUNED"
+
+    @pytest.mark.asyncio
+    async def test_submit_trial_metrics_keys_are_measuresdict_compatible(
+        self, backend_session_manager, mock_backend_client
+    ):
+        """Submitted metric keys follow MeasuresDict identifier requirements."""
+        from traigent.api.types import TrialStatus
+
+        trial = Mock(spec=TrialResult)
+        trial.trial_id = "trial-hybrid-metrics"
+        trial.config = {"param1": 1}
+        trial.metrics = {"cost": 0.05, "success_rate": 1.0, "latency": 120.0}
+        trial.is_successful = True
+        trial.status = TrialStatus.COMPLETED
+        trial.duration = 1.0
+        trial.error_message = None
+        trial.metadata = {}
+        trial.get_metric = Mock(
+            side_effect=lambda key, default=None: trial.metrics.get(key, default)
+        )
+
+        await backend_session_manager.submit_trial(
+            trial_result=trial,
+            session_id="test-session-id",
+        )
+
+        call_kwargs = (
+            mock_backend_client._submit_trial_result_via_session.call_args.kwargs
+        )
+        metrics_payload = call_kwargs["metrics"]
+        pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+        assert all(pattern.match(k) for k in metrics_payload.keys())
 
 
 class TestBackendSessionManagerWeightedScores:

--- a/tests/unit/core/test_optimization_pipeline_hybrid_api.py
+++ b/tests/unit/core/test_optimization_pipeline_hybrid_api.py
@@ -1,0 +1,66 @@
+"""Tests for hybrid_api evaluator wiring in optimization_pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.core.optimization_pipeline import (
+    create_effective_evaluator,
+    create_traigent_config,
+)
+from traigent.evaluators.hybrid_api import HybridAPIEvaluator
+
+
+def _make_common_kwargs() -> dict[str, object]:
+    return {
+        "timeout": None,
+        "custom_evaluator": None,
+        "effective_batch_size": None,
+        "effective_thread_workers": None,
+        "effective_privacy_enabled": False,
+        "objectives": ["accuracy"],
+        "js_runtime_config": None,
+        "mock_mode_config": None,
+        "metric_functions": None,
+        "scoring_function": None,
+        "decorator_custom_evaluator": None,
+    }
+
+
+def test_create_traigent_config_accepts_hybrid_api_mode() -> None:
+    """create_traigent_config supports execution_mode='hybrid_api'."""
+    cfg = create_traigent_config(
+        execution_mode="hybrid_api",
+        local_storage_path=None,
+        minimal_logging=True,
+        privacy_enabled=False,
+    )
+    assert cfg.execution_mode == "hybrid_api"
+
+
+def test_create_effective_evaluator_uses_hybrid_api_evaluator() -> None:
+    """Hybrid mode wiring returns HybridAPIEvaluator when requested."""
+    evaluator, js_pool = create_effective_evaluator(
+        **_make_common_kwargs(),
+        execution_mode="hybrid_api",
+        hybrid_api_endpoint="http://localhost:8080",
+        hybrid_api_capability_id="cap-1",
+        hybrid_api_batch_size=8,
+        hybrid_api_batch_parallelism=2,
+    )
+
+    assert isinstance(evaluator, HybridAPIEvaluator)
+    assert evaluator._api_endpoint == "http://localhost:8080"
+    assert evaluator._capability_id == "cap-1"
+    assert evaluator._batch_size == 8
+    assert evaluator._batch_parallelism == 2
+    assert js_pool is None
+
+
+def test_create_effective_evaluator_hybrid_api_requires_endpoint_or_transport() -> None:
+    """Missing hybrid endpoint/transport raises a clear error."""
+    with pytest.raises(ValueError, match="hybrid_api execution mode requires"):
+        create_effective_evaluator(
+            **_make_common_kwargs(),
+            execution_mode="hybrid_api",
+        )

--- a/tests/unit/core/test_refactoring_utils.py
+++ b/tests/unit/core/test_refactoring_utils.py
@@ -120,8 +120,8 @@ class TestRefactoringValidator:
         validator.baseline_metrics = {"import_time": 0.1}
 
         with patch("traigent.core.refactoring_utils.time.time") as mock_time:
-            # Calls: start_time=time.time(), current=time.time()-start_time.
-            # Provide enough values to survive any extra logging calls too.
+            # start_time=100.0, current=time.time()-start_time=100.2-100.0=0.2
+            # regression_ratio = 0.2 / 0.1 = 2.0 > 1.05 → regression detected
             mock_time.side_effect = [100.0, 100.2] + [100.2] * 20
 
             result = validator.validate_performance_regression(threshold=0.05)
@@ -405,16 +405,17 @@ class TestEdgeCases:
         validator.baseline_metrics = {"import_time": 0.1}
 
         # Test high threshold - should not detect regression
+        # start=100.0, current=100.15-100.0=0.15 → ratio 1.5 < 1.6
         with patch("traigent.core.refactoring_utils.time.time") as mock_time:
-            mock_time.side_effect = [100.0, 100.15]  # 0.15s import time (1.5x baseline)
+            mock_time.side_effect = [100.0, 100.15] + [100.15] * 10
 
             result = validator.validate_performance_regression(threshold=0.6)
             assert result["regression_detected"] is False
 
         # Test low threshold - should detect regression
+        # start=100.0, current=100.15-100.0=0.15 → ratio 1.5 > 1.3
         with patch("traigent.core.refactoring_utils.time.time") as mock_time:
-            # Provide extra values for logger.warning() which internally uses time.time()
-            mock_time.side_effect = [100.0, 100.15, 100.15, 100.15, 100.15]
+            mock_time.side_effect = [100.0, 100.15] + [100.15] * 10
 
             result = validator.validate_performance_regression(threshold=0.3)
             assert result["regression_detected"] is True

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -458,7 +458,6 @@ class TestEnsureLifecycleManager:
         )
 
         mock_lm = MagicMock()
-        mock_lm.create_session = MagicMock(return_value="session-abc")
         mock_lm.register = AsyncMock()
 
         ev = HybridAPIEvaluator(
@@ -474,8 +473,8 @@ class TestEnsureLifecycleManager:
             await ev._ensure_lifecycle_manager()
 
         assert ev._lifecycle_manager is mock_lm
-        assert ev._session_id == "session-abc"
-        mock_lm.register.assert_awaited_once_with("session-abc")
+        assert ev._session_id is None
+        mock_lm.register.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_idempotent(self, mock_transport: MagicMock) -> None:
@@ -484,7 +483,6 @@ class TestEnsureLifecycleManager:
             return_value=_default_capabilities(supports_keep_alive=True)
         )
         mock_lm = MagicMock()
-        mock_lm.create_session = MagicMock(return_value="s1")
         mock_lm.register = AsyncMock()
 
         ev = HybridAPIEvaluator(transport=mock_transport, keep_alive=True)
@@ -496,6 +494,27 @@ class TestEnsureLifecycleManager:
             await ev._ensure_lifecycle_manager()
             await ev._ensure_lifecycle_manager()
             mock_cls.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_registers_existing_session_id(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """Registers keep-alive only after a real session_id is known."""
+        mock_transport.capabilities = AsyncMock(
+            return_value=_default_capabilities(supports_keep_alive=True)
+        )
+        mock_lm = MagicMock()
+        mock_lm.register = AsyncMock()
+        ev = HybridAPIEvaluator(transport=mock_transport, keep_alive=True)
+        ev._session_id = "session-abc"
+
+        with patch(
+            "traigent.evaluators.hybrid_api.AgentLifecycleManager",
+            return_value=mock_lm,
+        ):
+            await ev._ensure_lifecycle_manager()
+
+        mock_lm.register.assert_awaited_once_with("session-abc")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -351,6 +351,9 @@ class TestDiscoverConfigSpace:
             }
         )
         mock_discovery.get_capability_id = MagicMock(return_value="discovered_cap")
+        mock_discovery.build_optimization_spec = AsyncMock(
+            return_value={"runtime_overrides": {"max_trials": 50}}
+        )
 
         with patch(
             "traigent.evaluators.hybrid_api.ConfigSpaceDiscovery",
@@ -362,6 +365,7 @@ class TestDiscoverConfigSpace:
             "model": ["gpt-4", "claude-3"],
             "temperature": {"low": 0, "high": 1},
         }
+        assert evaluator.optimization_spec == {"runtime_overrides": {"max_trials": 50}}
 
     @pytest.mark.asyncio
     async def test_discover_updates_capability_id_when_none(
@@ -376,6 +380,7 @@ class TestDiscoverConfigSpace:
         mock_discovery = MagicMock()
         mock_discovery.fetch_and_normalize = AsyncMock(return_value={})
         mock_discovery.get_capability_id = MagicMock(return_value="auto_cap")
+        mock_discovery.build_optimization_spec = AsyncMock(return_value={})
 
         with patch(
             "traigent.evaluators.hybrid_api.ConfigSpaceDiscovery",
@@ -393,6 +398,7 @@ class TestDiscoverConfigSpace:
         mock_discovery = MagicMock()
         mock_discovery.fetch_and_normalize = AsyncMock(return_value={})
         mock_discovery.get_capability_id = MagicMock(return_value="other")
+        mock_discovery.build_optimization_spec = AsyncMock(return_value={})
 
         with patch(
             "traigent.evaluators.hybrid_api.ConfigSpaceDiscovery",
@@ -410,6 +416,7 @@ class TestDiscoverConfigSpace:
         mock_discovery = MagicMock()
         mock_discovery.fetch_and_normalize = AsyncMock(return_value={})
         mock_discovery.get_capability_id = MagicMock(return_value="cap")
+        mock_discovery.build_optimization_spec = AsyncMock(return_value={})
 
         with patch(
             "traigent.evaluators.hybrid_api.ConfigSpaceDiscovery",

--- a/tests/unit/hybrid/test_discovery.py
+++ b/tests/unit/hybrid/test_discovery.py
@@ -36,6 +36,34 @@ class TestConfigSpaceDiscovery:
                         domain={"range": [0.0, 2.0], "resolution": 0.1},
                     ),
                 ],
+                constraints={
+                    "structural": [
+                        {
+                            "id": "temp_bound",
+                            "expr": "params.temperature >= 0.0",
+                        }
+                    ]
+                },
+                objectives=[
+                    {"name": "accuracy", "direction": "maximize", "weight": 2.0},
+                    {"name": "cost", "direction": "minimize", "weight": 1.0},
+                ],
+                exploration={
+                    "strategy": "nsga2",
+                    "budgets": {"max_trials": 25, "max_spend_usd": 5.0},
+                    "convergence": {
+                        "metric": "hypervolume_improvement",
+                        "window": 5,
+                        "threshold": 0.01,
+                    },
+                },
+                promotion_policy={
+                    "dominance": "epsilon_pareto",
+                    "alpha": 0.05,
+                    "min_effect": {"accuracy": 0.02},
+                },
+                defaults={"model": "gpt-4", "temperature": 0.4},
+                measures=["accuracy", "cost"],
             )
         )
         return transport
@@ -97,6 +125,45 @@ class TestConfigSpaceDiscovery:
         assert len(tvars) == 2
 
     @pytest.mark.asyncio
+    async def test_get_optional_optimization_sections(
+        self, discovery: ConfigSpaceDiscovery
+    ) -> None:
+        """Optional optimization metadata is available after discovery."""
+        await discovery.fetch()
+        assert discovery.get_objectives() is not None
+        assert discovery.get_exploration() is not None
+        assert discovery.get_promotion_policy() is not None
+        assert discovery.get_defaults() == {"model": "gpt-4", "temperature": 0.4}
+        assert discovery.get_measures() == ["accuracy", "cost"]
+
+    @pytest.mark.asyncio
+    async def test_build_optimization_spec(
+        self, discovery: ConfigSpaceDiscovery
+    ) -> None:
+        """Build optimizer-compatible spec from config-space metadata."""
+        spec = await discovery.build_optimization_spec()
+        assert spec["configuration_space"]["model"] == ["gpt-4", "claude-3"]
+        assert spec["default_config"] == {"model": "gpt-4", "temperature": 0.4}
+        assert spec["objective_schema"] is not None
+        assert spec["promotion_policy"] is not None
+        assert spec["runtime_overrides"]["algorithm"] == "nsga2"
+        assert spec["runtime_overrides"]["max_trials"] == 25
+        assert spec["runtime_overrides"]["cost_limit"] == 5.0
+        assert (
+            spec["runtime_overrides"]["convergence_metric"] == "hypervolume_improvement"
+        )
+        assert len(spec["constraints"]) >= 1
+        assert spec["measures"] == ["accuracy", "cost"]
+
+    @pytest.mark.asyncio
+    async def test_build_tvl_artifact_alias(
+        self, discovery: ConfigSpaceDiscovery
+    ) -> None:
+        """Legacy alias delegates to build_optimization_spec()."""
+        spec = await discovery.build_tvl_artifact()
+        assert "configuration_space" in spec
+
+    @pytest.mark.asyncio
     async def test_clear_cache(
         self, discovery: ConfigSpaceDiscovery, mock_transport: MagicMock
     ) -> None:
@@ -107,6 +174,28 @@ class TestConfigSpaceDiscovery:
         # Should fetch again after cache clear
         await discovery.fetch()
         assert mock_transport.discover_config_space.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_build_optimization_spec_with_legacy_text_constraints(self) -> None:
+        """Legacy textual constraint maps are normalized for parsing."""
+        transport = MagicMock()
+        transport.discover_config_space = AsyncMock(
+            return_value=ConfigSpaceResponse(
+                schema_version="0.9",
+                capability_id="legacy_agent",
+                tvars=[
+                    TVARDefinition(
+                        name="temperature",
+                        type="float",
+                        domain={"range": [0.0, 1.0]},
+                    )
+                ],
+                constraints={"hard": ["params.temperature <= 1.0"]},
+            )
+        )
+        discovery = ConfigSpaceDiscovery(transport)
+        spec = await discovery.build_optimization_spec()
+        assert len(spec["constraints"]) == 1
 
 
 class TestConfigSpaceDiscoveryWithTools:

--- a/tests/unit/hybrid/test_discovery.py
+++ b/tests/unit/hybrid/test_discovery.py
@@ -445,3 +445,110 @@ class TestValidateConfigAgainstTvars:
         errors = validate_config_against_tvars(config, tvars)
 
         assert any("temperature" in e and "expected float" in e for e in errors)
+
+
+class TestNormalizeConstraintsForParsing:
+    """Tests for _normalize_constraints_for_parsing static method."""
+
+    def test_none_returns_none(self) -> None:
+        """None constraints pass through."""
+        result = ConfigSpaceDiscovery._normalize_constraints_for_parsing(None)
+        assert result is None
+
+    def test_list_returns_list(self) -> None:
+        """List constraints pass through unchanged."""
+        constraints = [{"id": "c1", "type": "expression", "rule": "x > 0"}]
+        result = ConfigSpaceDiscovery._normalize_constraints_for_parsing(constraints)
+        assert result is constraints
+
+    def test_non_dict_non_list_returns_none(self) -> None:
+        """Non-dict, non-list input returns None."""
+        result = ConfigSpaceDiscovery._normalize_constraints_for_parsing(42)  # type: ignore[arg-type]
+        assert result is None
+
+    def test_typed_constraints_pass_through(self) -> None:
+        """TVL 0.9 typed constraints with 'structural'/'derived' keys pass through."""
+        constraints = {"structural": [{"expr": "x > 0"}], "derived": []}
+        result = ConfigSpaceDiscovery._normalize_constraints_for_parsing(constraints)
+        assert result is constraints
+
+    def test_legacy_text_constraints_with_non_list_entries_skipped(self) -> None:
+        """Legacy constraints where group value is not a list are skipped."""
+        constraints = {"hard": "not_a_list", "soft": ["x > 0"]}
+        result = ConfigSpaceDiscovery._normalize_constraints_for_parsing(constraints)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["rule"] == "x > 0"
+
+    def test_legacy_dict_entries_appended(self) -> None:
+        """Legacy constraint entries that are already dicts are passed through."""
+        entry = {"id": "c1", "type": "expression", "rule": "x > 0"}
+        constraints = {"hard": [entry]}
+        result = ConfigSpaceDiscovery._normalize_constraints_for_parsing(constraints)
+        assert isinstance(result, list)
+        assert result[0] is entry
+
+
+class TestDiscoveryGettersBeforeFetch:
+    """Test discovery getters return None/empty before fetch."""
+
+    def test_get_promotion_policy_before_fetch(self) -> None:
+        """get_promotion_policy returns None when not yet fetched."""
+        transport = MagicMock()
+        discovery = ConfigSpaceDiscovery(transport)
+        assert discovery.get_promotion_policy() is None
+
+    def test_get_objectives_before_fetch(self) -> None:
+        """get_objectives returns None before fetch."""
+        transport = MagicMock()
+        discovery = ConfigSpaceDiscovery(transport)
+        assert discovery.get_objectives() is None
+
+    def test_get_exploration_before_fetch(self) -> None:
+        """get_exploration returns None before fetch."""
+        transport = MagicMock()
+        discovery = ConfigSpaceDiscovery(transport)
+        assert discovery.get_exploration() is None
+
+    def test_get_defaults_before_fetch(self) -> None:
+        """get_defaults returns None before fetch."""
+        transport = MagicMock()
+        discovery = ConfigSpaceDiscovery(transport)
+        assert discovery.get_defaults() is None
+
+    def test_get_measures_before_fetch(self) -> None:
+        """get_measures returns None before fetch."""
+        transport = MagicMock()
+        discovery = ConfigSpaceDiscovery(transport)
+        assert discovery.get_measures() is None
+
+
+class TestBuildOptimizationSpecDerivedConstraints:
+    """Test build_optimization_spec with derived constraints."""
+
+    @pytest.mark.asyncio
+    async def test_derived_constraints_compiled(self) -> None:
+        """Derived constraints from response are compiled into wrappers."""
+        transport = MagicMock()
+        transport.discover_config_space = AsyncMock(
+            return_value=ConfigSpaceResponse(
+                schema_version="0.9",
+                capability_id="derived_agent",
+                tvars=[
+                    TVARDefinition(
+                        name="temperature",
+                        type="float",
+                        domain={"range": [0.0, 1.0]},
+                    )
+                ],
+                constraints={
+                    "derived": [
+                        {"require": "params.temperature <= 0.9", "when": "True"}
+                    ]
+                },
+            )
+        )
+        discovery = ConfigSpaceDiscovery(transport)
+        spec = await discovery.build_optimization_spec()
+        assert len(spec["constraints"]) >= 1
+        assert spec["derived_constraints"] is not None

--- a/tests/unit/hybrid/test_http_transport.py
+++ b/tests/unit/hybrid/test_http_transport.py
@@ -284,7 +284,7 @@ class TestHTTPTransportMethods:
     async def test_keep_alive(self, transport: HTTPTransport) -> None:
         """Test keep-alive method."""
         mock_caps = ServiceCapabilities(version="1.0", supports_keep_alive=True)
-        mock_response = {"alive": True, "session_id": "session-123"}
+        mock_response = {"status": "alive", "session_id": "session-123"}
 
         with (
             patch.object(
@@ -308,7 +308,7 @@ class TestHTTPTransportMethods:
     async def test_keep_alive_expired(self, transport: HTTPTransport) -> None:
         """Test keep-alive with expired session."""
         mock_caps = ServiceCapabilities(version="1.0", supports_keep_alive=True)
-        mock_response = {"alive": False, "reason": "expired"}
+        mock_response = {"status": "expired", "reason": "expired"}
 
         with (
             patch.object(
@@ -327,6 +327,32 @@ class TestHTTPTransportMethods:
             alive = await transport.keep_alive("session-123")
 
         assert alive is False
+
+    @pytest.mark.asyncio
+    async def test_keep_alive_backward_compatible_alive_field(
+        self, transport: HTTPTransport
+    ) -> None:
+        """Legacy wrappers returning {'alive': bool} are still supported."""
+        mock_caps = ServiceCapabilities(version="1.0", supports_keep_alive=True)
+        mock_response = {"alive": True, "session_id": "session-123"}
+
+        with (
+            patch.object(
+                transport,
+                "capabilities",
+                new_callable=AsyncMock,
+                return_value=mock_caps,
+            ),
+            patch.object(
+                transport,
+                "_request",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+        ):
+            alive = await transport.keep_alive("session-123")
+
+        assert alive is True
 
     @pytest.mark.asyncio
     async def test_keep_alive_not_supported(self, transport: HTTPTransport) -> None:

--- a/tests/unit/hybrid/test_http_transport.py
+++ b/tests/unit/hybrid/test_http_transport.py
@@ -366,6 +366,32 @@ class TestHTTPTransportMethods:
                 await transport.keep_alive("session-123")
 
     @pytest.mark.asyncio
+    async def test_keep_alive_no_status_or_alive_returns_false(
+        self, transport: HTTPTransport
+    ) -> None:
+        """Keep-alive with response missing both 'status' and 'alive' returns False."""
+        mock_caps = ServiceCapabilities(version="1.0", supports_keep_alive=True)
+        mock_response = {"session_id": "session-123", "info": "no relevant key"}
+
+        with (
+            patch.object(
+                transport,
+                "capabilities",
+                new_callable=AsyncMock,
+                return_value=mock_caps,
+            ),
+            patch.object(
+                transport,
+                "_request",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+        ):
+            alive = await transport.keep_alive("session-123")
+
+        assert alive is False
+
+    @pytest.mark.asyncio
     async def test_close(self, transport: HTTPTransport) -> None:
         """Test closing transport."""
         # Initialize client

--- a/tests/unit/hybrid/test_mcp_transport.py
+++ b/tests/unit/hybrid/test_mcp_transport.py
@@ -6,20 +6,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from traigent.hybrid.mcp_transport import (
-    CONFIG_SPACE_URI,
-    HEALTH_URI,
-    MCPTransport,
-)
+from traigent.hybrid.mcp_transport import CONFIG_SPACE_URI, HEALTH_URI, MCPTransport
 from traigent.hybrid.protocol import (
     HybridEvaluateRequest,
     HybridExecuteRequest,
     ServiceCapabilities,
 )
-from traigent.hybrid.transport import (
-    TransportConnectionError,
-    TransportError,
-)
+from traigent.hybrid.transport import TransportConnectionError, TransportError
 
 
 @dataclass
@@ -596,6 +589,27 @@ class TestMCPTransportKeepAlive:
         alive = await transport.keep_alive("session-123")
 
         assert alive is False
+
+    @pytest.mark.asyncio
+    async def test_keep_alive_with_status_alive(self, transport: MCPTransport) -> None:
+        """Keep-alive with status='alive' returns True (not backward-compat path)."""
+        caps_data = {"version": "1.0", "supports_keep_alive": True}
+        caps_response = MockMCPResponse(
+            success=True,
+            data={"content": json.dumps(caps_data)},
+        )
+
+        keep_alive_response = MockMCPResponse(
+            success=True,
+            data={"status": "alive", "session_id": "session-123"},
+        )
+
+        transport._client.read_resource = AsyncMock(return_value=caps_response)
+        transport._client.call_tool = AsyncMock(return_value=keep_alive_response)
+
+        alive = await transport.keep_alive("session-123")
+
+        assert alive is True
 
 
 class TestMCPTransportClose:

--- a/tests/unit/hybrid/test_protocol.py
+++ b/tests/unit/hybrid/test_protocol.py
@@ -319,12 +319,64 @@ class TestConfigSpaceResponse:
                 {"name": "model", "type": "enum", "domain": {"values": ["gpt-4"]}},
                 {"name": "temp", "type": "float", "domain": {"range": [0.0, 1.0]}},
             ],
+            "objectives": [
+                {"name": "accuracy", "direction": "maximize", "weight": 2.0},
+                {"name": "cost", "direction": "minimize", "weight": 1.0},
+            ],
+            "exploration": {
+                "strategy": "nsga2",
+                "budgets": {"max_trials": 50, "max_spend_usd": 10.0},
+            },
+            "promotion_policy": {
+                "dominance": "epsilon_pareto",
+                "alpha": 0.05,
+                "min_effect": {"accuracy": 0.02},
+            },
+            "defaults": {"model": "gpt-4"},
+            "measures": ["accuracy", "cost"],
         }
 
         response = ConfigSpaceResponse.from_dict(data)
         assert response.schema_version == "0.9"
         assert response.capability_id == "test_agent"
         assert len(response.tvars) == 2
+        assert response.objectives == data["objectives"]
+        assert response.exploration == data["exploration"]
+        assert response.promotion_policy == data["promotion_policy"]
+        assert response.defaults == data["defaults"]
+        assert response.measures == data["measures"]
+
+    def test_to_dict_includes_optional_optimization_sections(self) -> None:
+        """Optional optimization sections round-trip via to_dict."""
+        response = ConfigSpaceResponse(
+            schema_version="0.9",
+            capability_id="test",
+            tvars=[
+                TVARDefinition(
+                    name="model",
+                    type="enum",
+                    domain={"values": ["gpt-4"]},
+                )
+            ],
+            constraints={
+                "structural": [{"id": "c1", "expr": "params.model == 'gpt-4'"}]
+            },
+            objectives=[{"name": "accuracy", "direction": "maximize"}],
+            exploration={"strategy": "nsga2"},
+            promotion_policy={"dominance": "epsilon_pareto"},
+            defaults={"model": "gpt-4"},
+            measures=["accuracy"],
+        )
+
+        serialized = response.to_dict()
+        assert serialized["objectives"] == [
+            {"name": "accuracy", "direction": "maximize"}
+        ]
+        assert serialized["exploration"] == {"strategy": "nsga2"}
+        assert serialized["promotion_policy"] == {"dominance": "epsilon_pareto"}
+        assert serialized["defaults"] == {"model": "gpt-4"}
+        assert serialized["measures"] == ["accuracy"]
+        assert serialized["constraints"] == response.constraints
 
     def test_to_traigent_config_space(self) -> None:
         """Test converting to Traigent config space format."""

--- a/tests/unit/hybrid/test_protocol.py
+++ b/tests/unit/hybrid/test_protocol.py
@@ -166,18 +166,26 @@ class TestHybridEvaluateResponse:
         """Test creating response from dictionary."""
         data = {
             "request_id": "req_123",
-            "status": "completed",
+            "status": "partial",
             "results": [{"input_id": "1", "metrics": {"accuracy": 0.95}}],
             "aggregate_metrics": {"accuracy": {"mean": 0.95, "std": 0.02, "n": 10}},
+            "error": {
+                "code": "EVALUATION_PARTIAL_FAILURE",
+                "message": "One or more items failed during evaluation",
+                "failed_inputs": ["2"],
+            },
         }
 
         response = HybridEvaluateResponse.from_dict(data)
 
         assert response.request_id == "req_123"
-        assert response.status == "completed"
+        assert response.status == "partial"
         assert len(response.results) == 1
         assert response.results[0]["metrics"]["accuracy"] == 0.95
         assert response.aggregate_metrics["accuracy"]["mean"] == 0.95
+        assert response.aggregate_metrics["accuracy"]["n"] == 10
+        assert response.error is not None
+        assert response.error["code"] == "EVALUATION_PARTIAL_FAILURE"
 
 
 class TestServiceCapabilities:
@@ -275,6 +283,28 @@ class TestTVARDefinition:
         assert tvar.name == "test_var"
         assert tvar.is_tool is True
         assert len(tvar.constraints) == 1
+
+    def test_from_dict_accepts_top_level_values(self) -> None:
+        """Top-level values are normalized into domain.values."""
+        data = {
+            "name": "model",
+            "type": "enum",
+            "values": ["gpt-4", "claude-3"],
+        }
+        tvar = TVARDefinition.from_dict(data)
+        assert tvar.domain["values"] == ["gpt-4", "claude-3"]
+
+    def test_from_dict_accepts_top_level_range(self) -> None:
+        """Top-level range/resolution are normalized into domain."""
+        data = {
+            "name": "temperature",
+            "type": "float",
+            "range": [0.0, 1.0],
+            "resolution": 0.1,
+        }
+        tvar = TVARDefinition.from_dict(data)
+        assert tvar.domain["range"] == [0.0, 1.0]
+        assert tvar.domain["resolution"] == 0.1
 
 
 class TestConfigSpaceResponse:

--- a/tests/unit/tvl/test_promotion_gate.py
+++ b/tests/unit/tvl/test_promotion_gate.py
@@ -412,6 +412,28 @@ class TestBandedObjectivesEdgeCases:
 class TestFromSpecArtifact:
     """Tests for PromotionGate.from_spec_artifact using mocked ObjectiveSchema."""
 
+    def test_from_policy_returns_none_without_policy(self) -> None:
+        """from_policy returns None when policy is missing."""
+        gate = PromotionGate.from_policy(promotion_policy=None, objective_schema=None)
+        assert gate is None
+
+    def test_from_policy_with_objective_schema(self) -> None:
+        """from_policy builds objective specs without artifact duck typing."""
+        from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
+
+        schema = ObjectiveSchema.from_objectives(
+            [ObjectiveDefinition(name="accuracy", orientation="maximize", weight=1.0)]
+        )
+
+        gate = PromotionGate.from_policy(
+            promotion_policy=PromotionPolicy(alpha=0.05),
+            objective_schema=schema,
+        )
+
+        assert gate is not None
+        assert "accuracy" in gate.objectives
+        assert gate.objectives["accuracy"].direction == "maximize"
+
     def test_no_promotion_policy_returns_none(self) -> None:
         """Returns None when artifact has no promotion policy."""
         from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema

--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -520,3 +520,54 @@ class TestRunServer:
         app = MagicMock()
         with pytest.raises(ValueError, match="Unknown server"):
             run_server(app, server="gunicorn")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _make_error_response tests
+# ---------------------------------------------------------------------------
+class TestMakeErrorResponse:
+    """Tests for _make_error_response helper."""
+
+    def test_without_details(self) -> None:
+        """Test error response without details."""
+        from traigent.wrapper.server import _make_error_response
+
+        result = _make_error_response("ERR_CODE", "Something went wrong")
+        assert result == {"error": {"code": "ERR_CODE", "message": "Something went wrong"}}
+
+    def test_with_details(self) -> None:
+        """Test error response with details included."""
+        from traigent.wrapper.server import _make_error_response
+
+        result = _make_error_response(
+            "VALIDATION_ERROR",
+            "Bad input",
+            details={"field": "temperature", "reason": "out of range"},
+        )
+        assert result["error"]["code"] == "VALIDATION_ERROR"
+        assert result["error"]["details"]["field"] == "temperature"
+
+
+# ---------------------------------------------------------------------------
+# Keep-alive 404 path test
+# ---------------------------------------------------------------------------
+class TestKeepAlive404:
+    """Test keep-alive returns 404 when session is not found."""
+
+    @pytest.mark.asyncio
+    async def test_keep_alive_returns_404_when_session_not_found(self) -> None:
+        """Keep-alive for unknown session with keep_alive disabled returns 404."""
+        svc = TraigentService(
+            capability_id="test_svc",
+            supports_keep_alive=False,
+        )
+        app = create_app(svc)
+        request_body = json.dumps({"session_id": "nonexistent"}).encode()
+        send = _SendCollector()
+        await app(
+            _make_scope("POST", KEEP_ALIVE_PATH),
+            _make_receive(request_body),
+            send,
+        )
+        assert send.status == 404
+        assert send.body_json["error"]["code"] == "SESSION_NOT_FOUND"

--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -187,7 +187,11 @@ class TestCreateAppRoutes:
     @pytest.fixture
     def service(self) -> TraigentService:
         """Create a TraigentService with handlers registered."""
-        svc = TraigentService(capability_id="test_svc", version="1.0")
+        svc = TraigentService(
+            capability_id="test_svc",
+            version="1.0",
+            supports_keep_alive=True,
+        )
 
         @svc.tvars
         def cfg():
@@ -305,7 +309,8 @@ class TestCreateAppRoutes:
             send,
         )
         assert send.status == 200
-        assert send.body_json["alive"] is True
+        assert send.body_json["status"] == "alive"
+        assert send.body_json["session_id"] == sid
 
     @pytest.mark.asyncio
     async def test_keep_alive_missing_session(self, app, service) -> None:
@@ -317,8 +322,10 @@ class TestCreateAppRoutes:
             _make_receive(request_body),
             send,
         )
-        assert send.status == 404
-        assert send.body_json["alive"] is False
+        # Wrapper now auto-creates keep-alive sessions for stateful integrations.
+        assert send.status == 200
+        assert send.body_json["status"] == "alive"
+        assert send.body_json["session_id"] == "nonexistent"
 
     # --- 404 for unknown routes ---
     @pytest.mark.asyncio
@@ -331,7 +338,8 @@ class TestCreateAppRoutes:
             send,
         )
         assert send.status == 404
-        assert "Not found" in send.body_json["error"]
+        assert send.body_json["error"]["code"] == "NOT_FOUND"
+        assert "Not found" in send.body_json["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_wrong_method_returns_404(self, app) -> None:
@@ -380,7 +388,8 @@ class TestCreateAppErrorHandling:
             send,
         )
         assert send.status == 400
-        assert "Invalid JSON" in send.body_json["error"]
+        assert send.body_json["error"]["code"] == "INVALID_JSON"
+        assert "Invalid JSON" in send.body_json["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_value_error_returns_400(self) -> None:
@@ -396,7 +405,8 @@ class TestCreateAppErrorHandling:
             send,
         )
         assert send.status == 400
-        assert "No execute handler" in send.body_json["error"]
+        assert send.body_json["error"]["code"] == "INVALID_REQUEST"
+        assert "No execute handler" in send.body_json["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_generic_exception_returns_500(self) -> None:
@@ -412,7 +422,8 @@ class TestCreateAppErrorHandling:
             send,
         )
         assert send.status == 500
-        assert "unexpected" in send.body_json["error"]
+        assert send.body_json["error"]["code"] == "INTERNAL_ERROR"
+        assert "unexpected" in send.body_json["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_empty_body_treated_as_empty_dict(self) -> None:
@@ -430,8 +441,8 @@ class TestCreateAppErrorHandling:
             _make_receive(b""),
             send,
         )
-        # Should succeed with empty inputs
-        assert send.status == 200
+        assert send.status == 400
+        assert send.body_json["error"]["code"] == "INVALID_REQUEST"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -30,6 +30,12 @@ class TestServiceConfig:
         assert cfg.supports_streaming is False
         assert cfg.max_batch_size == 100
         assert cfg.schema_version == "0.9"
+        assert cfg.constraints is None
+        assert cfg.objectives is None
+        assert cfg.exploration is None
+        assert cfg.promotion_policy is None
+        assert cfg.defaults is None
+        assert cfg.measures is None
 
     def test_custom_values(self) -> None:
         """Test ServiceConfig with custom values."""
@@ -40,6 +46,12 @@ class TestServiceConfig:
             supports_streaming=True,
             max_batch_size=50,
             schema_version="1.0",
+            constraints={"structural": [{"expr": "params.temperature <= 1.0"}]},
+            objectives=[{"name": "accuracy", "direction": "maximize"}],
+            exploration={"strategy": "nsga2"},
+            promotion_policy={"dominance": "epsilon_pareto"},
+            defaults={"model": "gpt-4"},
+            measures=["accuracy"],
         )
         assert cfg.capability_id == "qa_agent"
         assert cfg.version == "2.5"
@@ -47,6 +59,12 @@ class TestServiceConfig:
         assert cfg.supports_streaming is True
         assert cfg.max_batch_size == 50
         assert cfg.schema_version == "1.0"
+        assert cfg.constraints is not None
+        assert cfg.objectives is not None
+        assert cfg.exploration is not None
+        assert cfg.promotion_policy is not None
+        assert cfg.defaults == {"model": "gpt-4"}
+        assert cfg.measures == ["accuracy"]
 
 
 # ---------------------------------------------------------------------------
@@ -106,12 +124,22 @@ class TestTraigentServiceInit:
             supports_keep_alive=True,
             supports_streaming=True,
             max_batch_size=25,
+            objectives=[{"name": "accuracy", "direction": "maximize"}],
+            exploration={"strategy": "nsga2"},
+            promotion_policy={"dominance": "epsilon_pareto"},
+            defaults={"model": "gpt-4"},
+            measures=["accuracy"],
         )
         assert svc.config.capability_id == "my_agent"
         assert svc.config.version == "3.0"
         assert svc.config.supports_keep_alive is True
         assert svc.config.supports_streaming is True
         assert svc.config.max_batch_size == 25
+        assert svc.config.objectives == [{"name": "accuracy", "direction": "maximize"}]
+        assert svc.config.exploration == {"strategy": "nsga2"}
+        assert svc.config.promotion_policy == {"dominance": "epsilon_pareto"}
+        assert svc.config.defaults == {"model": "gpt-4"}
+        assert svc.config.measures == ["accuracy"]
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +220,46 @@ class TestDecorators:
             return {"accuracy": 1.0}
 
         assert score(None, None, {}) == {"accuracy": 1.0}
+
+    def test_declarative_spec_decorators_register_handlers(self) -> None:
+        """Objective/exploration/policy/defaults/measures decorators register."""
+        svc = TraigentService()
+
+        @svc.objectives
+        def objectives():
+            return [{"name": "accuracy", "direction": "maximize"}]
+
+        @svc.exploration
+        def exploration():
+            return {"strategy": "nsga2"}
+
+        @svc.promotion_policy
+        def promotion_policy():
+            return {"dominance": "epsilon_pareto"}
+
+        @svc.defaults
+        def defaults():
+            return {"model": "gpt-4"}
+
+        @svc.measures
+        def measures():
+            return ["accuracy"]
+
+        assert svc._objectives_handler is objectives
+        assert svc._exploration_handler is exploration
+        assert svc._promotion_policy_handler is promotion_policy
+        assert svc._defaults_handler is defaults
+        assert svc._measures_handler is measures
+
+    def test_constraints_decorator_registers_handler(self) -> None:
+        """@constraints registers the constraints declaration handler."""
+        svc = TraigentService()
+
+        @svc.constraints
+        def constraints():
+            return {"structural": [{"expr": "params.temperature <= 1.0"}]}
+
+        assert svc._constraints_handler is constraints
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +382,46 @@ class TestGetConfigSpace:
         assert tvars["model"]["type"] == "enum"
         assert tvars["options"]["type"] == "enum"
         assert tvars["label"]["type"] == "str"
+
+    def test_config_space_includes_optional_optimization_sections(self) -> None:
+        """Config-space response includes optional declarative optimization sections."""
+        svc = TraigentService(
+            capability_id="financial_qa",
+            constraints={"structural": [{"expr": "params.temperature <= 1.0"}]},
+            objectives=[{"name": "accuracy", "direction": "maximize"}],
+            exploration={"strategy": "nsga2"},
+            promotion_policy={"dominance": "epsilon_pareto"},
+            defaults={"model": "gpt-4"},
+            measures=["accuracy", "cost"],
+        )
+        result = svc.get_config_space()
+        assert result["constraints"] == {
+            "structural": [{"expr": "params.temperature <= 1.0"}]
+        }
+        assert result["objectives"] == [{"name": "accuracy", "direction": "maximize"}]
+        assert result["exploration"] == {"strategy": "nsga2"}
+        assert result["promotion_policy"] == {"dominance": "epsilon_pareto"}
+        assert result["defaults"] == {"model": "gpt-4"}
+        assert result["measures"] == ["accuracy", "cost"]
+
+    def test_config_space_decorator_sections_override_init_values(self) -> None:
+        """Decorator-declared sections override constructor-provided values."""
+        svc = TraigentService(
+            objectives=[{"name": "old_objective", "direction": "maximize"}],
+            defaults={"model": "old"},
+        )
+
+        @svc.objectives
+        def objectives():
+            return [{"name": "accuracy", "direction": "maximize"}]
+
+        @svc.defaults
+        def defaults():
+            return {"model": "gpt-4"}
+
+        result = svc.get_config_space()
+        assert result["objectives"] == [{"name": "accuracy", "direction": "maximize"}]
+        assert result["defaults"] == {"model": "gpt-4"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -985,3 +985,217 @@ class TestWrapperExports:
         assert "TraigentService" in wrapper.__all__
         assert "ServiceConfig" in wrapper.__all__
         assert "Session" in wrapper.__all__
+
+
+# ---------------------------------------------------------------------------
+# Validation error paths in get_config_space
+# ---------------------------------------------------------------------------
+class TestGetConfigSpaceValidation:
+    """Tests for validation errors in get_config_space."""
+
+    def test_tvars_handler_returns_non_dict_raises(self) -> None:
+        """Tvars handler returning non-dict should raise ValueError."""
+        svc = TraigentService()
+
+        @svc.tvars
+        def cfg():
+            return ["not", "a", "dict"]
+
+        with pytest.raises(ValueError, match="tunables handler must return a dict"):
+            svc.get_config_space()
+
+    def test_constraints_not_dict_or_list_raises(self) -> None:
+        """Constraints that are not dict or list should raise ValueError."""
+        svc = TraigentService(constraints="invalid")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="constraints must be a dict or list"):
+            svc.get_config_space()
+
+    def test_objectives_not_list_raises(self) -> None:
+        """Objectives that are not a list should raise ValueError."""
+        svc = TraigentService(objectives="invalid")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="objectives must be a list"):
+            svc.get_config_space()
+
+    def test_exploration_not_dict_raises(self) -> None:
+        """Exploration that is not a dict should raise ValueError."""
+        svc = TraigentService(exploration="invalid")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="exploration must be a dict"):
+            svc.get_config_space()
+
+    def test_promotion_policy_not_dict_raises(self) -> None:
+        """Promotion policy that is not a dict should raise ValueError."""
+        svc = TraigentService(promotion_policy="invalid")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="promotion_policy must be a dict"):
+            svc.get_config_space()
+
+    def test_defaults_not_dict_raises(self) -> None:
+        """Defaults that is not a dict should raise ValueError."""
+        svc = TraigentService(defaults="invalid")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="defaults must be a dict"):
+            svc.get_config_space()
+
+    def test_measures_not_list_of_strings_raises(self) -> None:
+        """Measures that is not a list of strings should raise ValueError."""
+        svc = TraigentService(measures=[1, 2, 3])  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="measures must be a list of strings"):
+            svc.get_config_space()
+
+    def test_sync_handler_returning_awaitable_raises(self) -> None:
+        """Sync handler that returns an awaitable should fail with coroutine cleanup."""
+        import asyncio
+
+        svc = TraigentService()
+
+        @svc.objectives
+        def objectives():
+            # Return a coroutine without awaiting — simulates accidental async usage
+            async def inner():
+                return [{"name": "accuracy", "direction": "maximize"}]
+            return inner()
+
+        with pytest.raises(
+            ValueError, match="declaration handlers must be synchronous functions"
+        ):
+            svc.get_config_space()
+
+    def test_normalize_tvars_range_and_resolution(self) -> None:
+        """Top-level range/resolution keys should be moved into domain."""
+        svc = TraigentService()
+
+        @svc.tvars
+        def cfg():
+            return {
+                "temperature": {
+                    "type": "float",
+                    "range": [0.0, 1.5],
+                    "resolution": 0.1,
+                },
+            }
+
+        result = svc.get_config_space()
+        tvar = result["tvars"][0]
+        assert tvar["domain"]["range"] == [0.0, 1.5]
+        assert tvar["domain"]["resolution"] == 0.1
+
+    def test_normalize_tvars_non_dict_domain_replaced(self) -> None:
+        """Non-dict domain should be replaced with empty dict."""
+        svc = TraigentService()
+
+        @svc.tvars
+        def cfg():
+            return {"flag": {"type": "bool", "domain": "invalid"}}
+
+        result = svc.get_config_space()
+        tvar = result["tvars"][0]
+        assert isinstance(tvar["domain"], dict)
+
+
+# ---------------------------------------------------------------------------
+# handle_execute edge cases
+# ---------------------------------------------------------------------------
+class TestHandleExecuteEdgeCases:
+    """Tests for edge cases in handle_execute."""
+
+    @pytest.mark.asyncio
+    async def test_non_dict_input_gets_uuid_and_input_as_data(self) -> None:
+        """Non-dict input should get a UUID and be passed as data."""
+        svc = TraigentService()
+        received = {}
+
+        @svc.execute
+        def run(input_id, data, config):
+            received["input_id"] = input_id
+            received["data"] = data
+            return {"output": "ok"}
+
+        resp = await svc.handle_execute({"inputs": ["raw_string"]})
+        assert resp["status"] == "completed"
+        assert len(received["input_id"]) > 0  # UUID generated
+
+    @pytest.mark.asyncio
+    async def test_partial_status_on_mixed_success_and_failure(self) -> None:
+        """Partial status when some inputs succeed and some fail."""
+        svc = TraigentService()
+        call_count = 0
+
+        @svc.execute
+        def run(input_id, data, config):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("fail on second")
+            return {"output": f"ok-{input_id}"}
+
+        resp = await svc.handle_execute(
+            {
+                "inputs": [
+                    {"input_id": "i1", "data": {}},
+                    {"input_id": "i2", "data": {}},
+                    {"input_id": "i3", "data": {}},
+                ]
+            }
+        )
+        assert resp["status"] == "partial"
+
+
+# ---------------------------------------------------------------------------
+# handle_evaluate edge cases
+# ---------------------------------------------------------------------------
+class TestHandleEvaluateEdgeCases:
+    """Tests for edge cases in handle_evaluate."""
+
+    @pytest.mark.asyncio
+    async def test_evaluations_not_list_raises(self) -> None:
+        """Evaluations must be a list."""
+        svc = TraigentService()
+
+        @svc.evaluate
+        def score(output, target, config):
+            return {"accuracy": 1.0}
+
+        with pytest.raises(ValueError, match="evaluations must be a list"):
+            await svc.handle_evaluate({"evaluations": "not_a_list"})
+
+    @pytest.mark.asyncio
+    async def test_evaluation_with_output_id(self) -> None:
+        """Evaluation with output_id instead of output."""
+        svc = TraigentService()
+        received_output = {}
+
+        @svc.evaluate
+        def score(output, target, config):
+            received_output["output"] = output
+            return {"accuracy": 1.0}
+
+        await svc.handle_evaluate(
+            {
+                "evaluations": [
+                    {
+                        "input_id": "e1",
+                        "output_id": "out-123",
+                        "target": "expected",
+                    }
+                ]
+            }
+        )
+        assert received_output["output"] == {"output_id": "out-123"}
+
+    @pytest.mark.asyncio
+    async def test_bool_metrics_excluded_from_aggregation(self) -> None:
+        """Bool-type metric values should be excluded from aggregation."""
+        svc = TraigentService()
+
+        @svc.evaluate
+        def score(output, target, config):
+            return {"accuracy": 0.9, "is_valid": True}
+
+        resp = await svc.handle_evaluate(
+            {
+                "evaluations": [
+                    {"input_id": "e1", "output": "a", "target": "a"},
+                ]
+            }
+        )
+        agg = resp["aggregate_metrics"]
+        assert "accuracy" in agg
+        assert "is_valid" not in agg  # Bool excluded

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -318,6 +318,19 @@ class TestGetConfigSpace:
         assert "domain" in tvar
         assert tvar["domain"] == {}
 
+    def test_async_declaration_handler_rejected_without_coroutine_leak(self) -> None:
+        """Async declaration handlers should fail before a coroutine object is created."""
+        svc = TraigentService()
+
+        @svc.objectives
+        async def declared_objectives():
+            return [{"name": "accuracy", "direction": "maximize"}]
+
+        with pytest.raises(
+            ValueError, match="declaration handlers must be synchronous functions"
+        ):
+            svc.get_config_space()
+
     def test_list_tvars_converted_to_enum(self) -> None:
         """Test that list-type TVAR specs are converted to enum."""
         svc = TraigentService()

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -6,9 +6,8 @@ and all decorator/handler functionality.
 
 from __future__ import annotations
 
-import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -304,6 +303,20 @@ class TestGetConfigSpace:
         tvar = result["tvars"][0]
         assert tvar["name"] == "model"
         assert tvar["domain"]["values"] == ["gpt-4", "claude-3"]
+
+    def test_empty_domain_is_preserved(self) -> None:
+        """Explicit empty domain should not be dropped for bool-like TVARs."""
+        svc = TraigentService()
+
+        @svc.tvars
+        def cfg():
+            return {"use_cache": {"type": "bool", "domain": {}}}
+
+        result = svc.get_config_space()
+        tvar = result["tvars"][0]
+        assert tvar["name"] == "use_cache"
+        assert "domain" in tvar
+        assert tvar["domain"] == {}
 
     def test_list_tvars_converted_to_enum(self) -> None:
         """Test that list-type TVAR specs are converted to enum."""

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -222,7 +222,20 @@ class TestGetConfigSpace:
         tvar = result["tvars"][0]
         assert tvar["name"] == "model"
         assert tvar["type"] == "enum"
-        assert tvar["values"] == ["gpt-4"]
+        assert tvar["domain"]["values"] == ["gpt-4"]
+
+    def test_dict_tvars_without_type_preserves_domain_fields(self) -> None:
+        """Top-level domain keys should not be dropped when type is omitted."""
+        svc = TraigentService()
+
+        @svc.tvars
+        def cfg():
+            return {"model": {"values": ["gpt-4", "claude-3"]}}
+
+        result = svc.get_config_space()
+        tvar = result["tvars"][0]
+        assert tvar["name"] == "model"
+        assert tvar["domain"]["values"] == ["gpt-4", "claude-3"]
 
     def test_list_tvars_converted_to_enum(self) -> None:
         """Test that list-type TVAR specs are converted to enum."""
@@ -324,6 +337,7 @@ class TestGetCapabilities:
         assert caps["supports_keep_alive"] is True
         assert caps["supports_streaming"] is False
         assert caps["max_batch_size"] == 50
+        assert caps["max_payload_bytes"] is None
 
     def test_capabilities_with_evaluate(self) -> None:
         """Test capabilities when evaluate handler is registered."""
@@ -349,8 +363,9 @@ class TestGetHealth:
         health = svc.get_health()
         assert health["status"] == "healthy"
         assert health["version"] == "1.2"
-        assert health["capability_id"] == "agent_x"
-        assert health["active_sessions"] == 0
+        assert isinstance(health["uptime_seconds"], float)
+        assert health["details"]["capability_id"] == "agent_x"
+        assert health["details"]["active_sessions"] == 0
 
     def test_health_with_sessions(self) -> None:
         """Test health status reflecting active sessions."""
@@ -358,7 +373,7 @@ class TestGetHealth:
         svc.create_session()
         svc.create_session()
         health = svc.get_health()
-        assert health["active_sessions"] == 2
+        assert health["details"]["active_sessions"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -426,7 +441,7 @@ class TestHandleExecute:
         resp = await svc.handle_execute({"inputs": [{"input_id": "x1", "data": {}}]})
         assert resp["outputs"][0]["output"] == "plain_string_result"
         assert resp["outputs"][0]["cost_usd"] == 0.0
-        assert resp["outputs"][0]["metrics"] == {}
+        assert "metrics" not in resp["outputs"][0]
 
     @pytest.mark.asyncio
     async def test_handler_exception_captured(self) -> None:
@@ -438,7 +453,7 @@ class TestHandleExecute:
             raise RuntimeError("boom")
 
         resp = await svc.handle_execute({"inputs": [{"input_id": "e1", "data": {}}]})
-        assert resp["status"] == "completed"
+        assert resp["status"] == "failed"
         assert resp["outputs"][0]["input_id"] == "e1"
         assert "boom" in resp["outputs"][0]["error"]
 
@@ -521,9 +536,8 @@ class TestHandleExecute:
         def run(input_id, data, config):
             return {"output": "ok"}
 
-        resp = await svc.handle_execute({"inputs": []})
-        assert resp["status"] == "completed"
-        assert resp["outputs"] == []
+        with pytest.raises(ValueError, match="inputs must be a non-empty list"):
+            await svc.handle_execute({"inputs": []})
 
     @pytest.mark.asyncio
     async def test_input_without_input_id_gets_uuid(self) -> None:
@@ -636,7 +650,8 @@ class TestHandleEvaluate:
         resp = await svc.handle_evaluate(
             {"evaluations": [{"input_id": "e1", "output": "x", "target": "y"}]}
         )
-        assert resp["status"] == "completed"
+        assert resp["status"] == "failed"
+        assert resp["results"][0]["metrics"] == {}
         assert "scoring failed" in resp["results"][0]["error"]
 
     @pytest.mark.asyncio
@@ -717,14 +732,14 @@ class TestComputeAggregateMetrics:
         result = svc._compute_aggregate_metrics([{"accuracy": 0.9}])
         assert result["accuracy"]["mean"] == pytest.approx(0.9)
         assert result["accuracy"]["std"] == pytest.approx(0.0)
-        assert result["accuracy"]["n"] == 1.0
+        assert result["accuracy"]["n"] == 1
 
     def test_multiple_values(self) -> None:
         """Test aggregate stats with multiple values."""
         svc = TraigentService()
         result = svc._compute_aggregate_metrics([{"accuracy": 0.8}, {"accuracy": 1.0}])
         assert result["accuracy"]["mean"] == pytest.approx(0.9)
-        assert result["accuracy"]["n"] == 2.0
+        assert result["accuracy"]["n"] == 2
         assert result["accuracy"]["std"] > 0.0
 
     def test_multiple_metric_names(self) -> None:
@@ -738,8 +753,8 @@ class TestComputeAggregateMetrics:
         )
         assert "accuracy" in result
         assert "f1" in result
-        assert result["accuracy"]["n"] == 2.0
-        assert result["f1"]["n"] == 2.0
+        assert result["accuracy"]["n"] == 2
+        assert result["f1"]["n"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -757,7 +772,7 @@ class TestSessionManagement:
 
     def test_handle_keep_alive_existing_session(self) -> None:
         """Test keep alive with existing session."""
-        svc = TraigentService()
+        svc = TraigentService(supports_keep_alive=True)
         sid = svc.create_session()
         old_activity = svc._sessions[sid].last_activity
         time.sleep(0.01)
@@ -770,6 +785,13 @@ class TestSessionManagement:
         svc = TraigentService()
         result = svc.handle_keep_alive("nonexistent-id")
         assert result is False
+
+    def test_handle_keep_alive_missing_session_autocreates_when_enabled(self) -> None:
+        """When keep-alive is enabled, unknown sessions are auto-created."""
+        svc = TraigentService(supports_keep_alive=True)
+        result = svc.handle_keep_alive("nonexistent-id")
+        assert result is True
+        assert "nonexistent-id" in svc._sessions
 
 
 # ---------------------------------------------------------------------------

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -183,6 +183,7 @@ class ExecutionOptions(BaseModel):
     # Hybrid API options
     hybrid_api_endpoint: str | None = None
     capability_id: str | None = None
+    hybrid_api_transport: Any | None = None
     hybrid_api_transport_type: str = "auto"
     hybrid_api_batch_size: int = 1
     hybrid_api_batch_parallelism: int = 1
@@ -322,6 +323,7 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "execution_mode": "edge_analytics",
     "hybrid_api_endpoint": None,
     "capability_id": None,
+    "hybrid_api_transport": None,
     "hybrid_api_transport_type": "auto",
     "hybrid_api_batch_size": 1,
     "hybrid_api_batch_parallelism": 1,
@@ -400,6 +402,7 @@ class LegacyOptimizeArgs:
     execution_mode: str | None = None
     hybrid_api_endpoint: str | None = None
     capability_id: str | None = None
+    hybrid_api_transport: Any | None = None
     hybrid_api_transport_type: str | None = None
     hybrid_api_batch_size: int | None = None
     hybrid_api_batch_parallelism: int | None = None
@@ -477,6 +480,7 @@ class LegacyOptimizeArgs:
             ("execution_mode", self.execution_mode),
             ("hybrid_api_endpoint", self.hybrid_api_endpoint),
             ("capability_id", self.capability_id),
+            ("hybrid_api_transport", self.hybrid_api_transport),
             ("hybrid_api_transport_type", self.hybrid_api_transport_type),
             ("hybrid_api_batch_size", self.hybrid_api_batch_size),
             ("hybrid_api_batch_parallelism", self.hybrid_api_batch_parallelism),
@@ -772,11 +776,37 @@ class JSRuntimeConfig:
         return self.runtime == "node"
 
 
+@dataclass(slots=True)
+class ResolvedExecutionOptions:
+    """Resolved execution options after merging direct and bundled settings."""
+
+    execution_mode: Any
+    hybrid_api_endpoint: Any
+    capability_id: Any
+    hybrid_api_transport: Any
+    hybrid_api_transport_type: Any
+    hybrid_api_batch_size: Any
+    hybrid_api_batch_parallelism: Any
+    hybrid_api_keep_alive: Any
+    hybrid_api_heartbeat_interval: Any
+    hybrid_api_timeout: Any
+    hybrid_api_auth_header: Any
+    hybrid_api_auto_discover_tvars: Any
+    local_storage_path: Any
+    minimal_logging: Any
+    parallel_config: Any
+    privacy_enabled: Any
+    max_total_examples: Any
+    samples_include_pruned: Any
+    js_runtime_config: JSRuntimeConfig | None
+
+
 def _resolve_execution_bundle_options(
     execution_bundle: ExecutionOptions | None,
     execution_mode: Any,
     hybrid_api_endpoint: Any,
     capability_id: Any,
+    hybrid_api_transport: Any,
     hybrid_api_transport_type: Any,
     hybrid_api_batch_size: Any,
     hybrid_api_batch_parallelism: Any,
@@ -792,48 +822,29 @@ def _resolve_execution_bundle_options(
     max_total_examples: Any,
     samples_include_pruned: Any,
     defaults: dict[str, Any],
-) -> tuple[
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    Any,
-    JSRuntimeConfig | None,
-]:
+) -> ResolvedExecutionOptions:
     """Resolve execution options from bundle and validate enterprise features."""
     if execution_bundle is None:
-        return (
-            execution_mode,
-            hybrid_api_endpoint,
-            capability_id,
-            hybrid_api_transport_type,
-            hybrid_api_batch_size,
-            hybrid_api_batch_parallelism,
-            hybrid_api_keep_alive,
-            hybrid_api_heartbeat_interval,
-            hybrid_api_timeout,
-            hybrid_api_auth_header,
-            hybrid_api_auto_discover_tvars,
-            local_storage_path,
-            minimal_logging,
-            parallel_config,
-            privacy_enabled,
-            max_total_examples,
-            samples_include_pruned,
-            None,  # js_runtime_config
+        return ResolvedExecutionOptions(
+            execution_mode=execution_mode,
+            hybrid_api_endpoint=hybrid_api_endpoint,
+            capability_id=capability_id,
+            hybrid_api_transport=hybrid_api_transport,
+            hybrid_api_transport_type=hybrid_api_transport_type,
+            hybrid_api_batch_size=hybrid_api_batch_size,
+            hybrid_api_batch_parallelism=hybrid_api_batch_parallelism,
+            hybrid_api_keep_alive=hybrid_api_keep_alive,
+            hybrid_api_heartbeat_interval=hybrid_api_heartbeat_interval,
+            hybrid_api_timeout=hybrid_api_timeout,
+            hybrid_api_auth_header=hybrid_api_auth_header,
+            hybrid_api_auto_discover_tvars=hybrid_api_auto_discover_tvars,
+            local_storage_path=local_storage_path,
+            minimal_logging=minimal_logging,
+            parallel_config=parallel_config,
+            privacy_enabled=privacy_enabled,
+            max_total_examples=max_total_examples,
+            samples_include_pruned=samples_include_pruned,
+            js_runtime_config=None,
         )
 
     # Validate enterprise-gated features
@@ -871,107 +882,113 @@ def _resolve_execution_bundle_options(
             "Supported values are 'python' (default) or 'node' (JavaScript)."
         )
 
-    return (
-        _resolve_option(
+    return ResolvedExecutionOptions(
+        execution_mode=_resolve_option(
             "execution_mode", execution_mode, execution_bundle.execution_mode, defaults
         ),
-        _resolve_option(
+        hybrid_api_endpoint=_resolve_option(
             "hybrid_api_endpoint",
             hybrid_api_endpoint,
             execution_bundle.hybrid_api_endpoint,
             defaults,
         ),
-        _resolve_option(
+        capability_id=_resolve_option(
             "capability_id",
             capability_id,
             execution_bundle.capability_id,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_transport=_resolve_option(
+            "hybrid_api_transport",
+            hybrid_api_transport,
+            execution_bundle.hybrid_api_transport,
+            defaults,
+        ),
+        hybrid_api_transport_type=_resolve_option(
             "hybrid_api_transport_type",
             hybrid_api_transport_type,
             execution_bundle.hybrid_api_transport_type,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_batch_size=_resolve_option(
             "hybrid_api_batch_size",
             hybrid_api_batch_size,
             execution_bundle.hybrid_api_batch_size,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_batch_parallelism=_resolve_option(
             "hybrid_api_batch_parallelism",
             hybrid_api_batch_parallelism,
             execution_bundle.hybrid_api_batch_parallelism,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_keep_alive=_resolve_option(
             "hybrid_api_keep_alive",
             hybrid_api_keep_alive,
             execution_bundle.hybrid_api_keep_alive,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_heartbeat_interval=_resolve_option(
             "hybrid_api_heartbeat_interval",
             hybrid_api_heartbeat_interval,
             execution_bundle.hybrid_api_heartbeat_interval,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_timeout=_resolve_option(
             "hybrid_api_timeout",
             hybrid_api_timeout,
             execution_bundle.hybrid_api_timeout,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_auth_header=_resolve_option(
             "hybrid_api_auth_header",
             hybrid_api_auth_header,
             execution_bundle.hybrid_api_auth_header,
             defaults,
         ),
-        _resolve_option(
+        hybrid_api_auto_discover_tvars=_resolve_option(
             "hybrid_api_auto_discover_tvars",
             hybrid_api_auto_discover_tvars,
             execution_bundle.hybrid_api_auto_discover_tvars,
             defaults,
         ),
-        _resolve_option(
+        local_storage_path=_resolve_option(
             "local_storage_path",
             local_storage_path,
             execution_bundle.local_storage_path,
             defaults,
         ),
-        _resolve_option(
+        minimal_logging=_resolve_option(
             "minimal_logging",
             minimal_logging,
             execution_bundle.minimal_logging,
             defaults,
         ),
-        _resolve_option(
+        parallel_config=_resolve_option(
             "parallel_config",
             parallel_config,
             execution_bundle.parallel_config,
             defaults,
         ),
-        _resolve_option(
+        privacy_enabled=_resolve_option(
             "privacy_enabled",
             privacy_enabled,
             execution_bundle.privacy_enabled,
             defaults,
         ),
-        _resolve_option(
+        max_total_examples=_resolve_option(
             "max_total_examples",
             max_total_examples,
             execution_bundle.max_total_examples,
             defaults,
         ),
-        _resolve_option(
+        samples_include_pruned=_resolve_option(
             "samples_include_pruned",
             samples_include_pruned,
             execution_bundle.samples_include_pruned,
             defaults,
         ),
-        js_runtime_config,
+        js_runtime_config=js_runtime_config,
     )
 
 
@@ -1627,6 +1644,7 @@ def optimize(
     execution_mode = combined_settings["execution_mode"]
     hybrid_api_endpoint = combined_settings["hybrid_api_endpoint"]
     capability_id = combined_settings["capability_id"]
+    hybrid_api_transport = combined_settings["hybrid_api_transport"]
     hybrid_api_transport_type = combined_settings["hybrid_api_transport_type"]
     hybrid_api_batch_size = combined_settings["hybrid_api_batch_size"]
     hybrid_api_batch_parallelism = combined_settings["hybrid_api_batch_parallelism"]
@@ -1700,30 +1718,12 @@ def optimize(
         defaults,
     )
 
-    (
-        execution_mode,
-        hybrid_api_endpoint,
-        capability_id,
-        hybrid_api_transport_type,
-        hybrid_api_batch_size,
-        hybrid_api_batch_parallelism,
-        hybrid_api_keep_alive,
-        hybrid_api_heartbeat_interval,
-        hybrid_api_timeout,
-        hybrid_api_auth_header,
-        hybrid_api_auto_discover_tvars,
-        local_storage_path,
-        minimal_logging,
-        parallel_config,
-        privacy_enabled,
-        max_total_examples,
-        samples_include_pruned,
-        js_runtime_config,
-    ) = _resolve_execution_bundle_options(
+    resolved_execution = _resolve_execution_bundle_options(
         execution_bundle,
         execution_mode,
         hybrid_api_endpoint,
         capability_id,
+        hybrid_api_transport,
         hybrid_api_transport_type,
         hybrid_api_batch_size,
         hybrid_api_batch_parallelism,
@@ -1740,6 +1740,25 @@ def optimize(
         samples_include_pruned,
         defaults,
     )
+    execution_mode = resolved_execution.execution_mode
+    hybrid_api_endpoint = resolved_execution.hybrid_api_endpoint
+    capability_id = resolved_execution.capability_id
+    hybrid_api_transport = resolved_execution.hybrid_api_transport
+    hybrid_api_transport_type = resolved_execution.hybrid_api_transport_type
+    hybrid_api_batch_size = resolved_execution.hybrid_api_batch_size
+    hybrid_api_batch_parallelism = resolved_execution.hybrid_api_batch_parallelism
+    hybrid_api_keep_alive = resolved_execution.hybrid_api_keep_alive
+    hybrid_api_heartbeat_interval = resolved_execution.hybrid_api_heartbeat_interval
+    hybrid_api_timeout = resolved_execution.hybrid_api_timeout
+    hybrid_api_auth_header = resolved_execution.hybrid_api_auth_header
+    hybrid_api_auto_discover_tvars = resolved_execution.hybrid_api_auto_discover_tvars
+    local_storage_path = resolved_execution.local_storage_path
+    minimal_logging = resolved_execution.minimal_logging
+    parallel_config = resolved_execution.parallel_config
+    privacy_enabled = resolved_execution.privacy_enabled
+    max_total_examples = resolved_execution.max_total_examples
+    samples_include_pruned = resolved_execution.samples_include_pruned
+    js_runtime_config = resolved_execution.js_runtime_config
 
     tvl_options = _resolve_tvl_options(
         tvl_spec_value, tvl_environment_value, tvl_bundle
@@ -1843,6 +1862,7 @@ def optimize(
             execution_mode=execution_mode_enum,
             hybrid_api_endpoint=hybrid_api_endpoint,
             capability_id=capability_id,
+            hybrid_api_transport=hybrid_api_transport,
             hybrid_api_transport_type=hybrid_api_transport_type,
             hybrid_api_batch_size=hybrid_api_batch_size,
             hybrid_api_batch_parallelism=hybrid_api_batch_parallelism,

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -180,6 +180,17 @@ class ExecutionOptions(BaseModel):
     js_function: str = "runTrial"
     js_timeout: float = 300.0
     js_parallel_workers: int = 1
+    # Hybrid API options
+    hybrid_api_endpoint: str | None = None
+    capability_id: str | None = None
+    hybrid_api_transport_type: str = "auto"
+    hybrid_api_batch_size: int = 1
+    hybrid_api_batch_parallelism: int = 1
+    hybrid_api_keep_alive: bool = True
+    hybrid_api_heartbeat_interval: float = 30.0
+    hybrid_api_timeout: float | None = None
+    hybrid_api_auth_header: str | None = None
+    hybrid_api_auto_discover_tvars: bool = False
 
 
 class MockModeOptions(BaseModel):
@@ -309,6 +320,16 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "auto_override_frameworks": False,  # Requires traigent-integrations plugin
     "framework_targets": None,
     "execution_mode": "edge_analytics",
+    "hybrid_api_endpoint": None,
+    "capability_id": None,
+    "hybrid_api_transport_type": "auto",
+    "hybrid_api_batch_size": 1,
+    "hybrid_api_batch_parallelism": 1,
+    "hybrid_api_keep_alive": True,
+    "hybrid_api_heartbeat_interval": 30.0,
+    "hybrid_api_timeout": None,
+    "hybrid_api_auth_header": None,
+    "hybrid_api_auto_discover_tvars": False,
     "local_storage_path": None,
     "minimal_logging": True,
     "parallel_config": None,
@@ -377,6 +398,16 @@ class LegacyOptimizeArgs:
     auto_override_frameworks: bool | None = None
     framework_targets: list[str] | None = None
     execution_mode: str | None = None
+    hybrid_api_endpoint: str | None = None
+    capability_id: str | None = None
+    hybrid_api_transport_type: str | None = None
+    hybrid_api_batch_size: int | None = None
+    hybrid_api_batch_parallelism: int | None = None
+    hybrid_api_keep_alive: bool | None = None
+    hybrid_api_heartbeat_interval: float | None = None
+    hybrid_api_timeout: float | None = None
+    hybrid_api_auth_header: str | None = None
+    hybrid_api_auto_discover_tvars: bool | None = None
     local_storage_path: str | None = None
     minimal_logging: bool | None = None
     parallel_config: ParallelConfig | dict[str, Any] | None = None
@@ -444,6 +475,16 @@ class LegacyOptimizeArgs:
             ("auto_override_frameworks", self.auto_override_frameworks),
             ("framework_targets", self.framework_targets),
             ("execution_mode", self.execution_mode),
+            ("hybrid_api_endpoint", self.hybrid_api_endpoint),
+            ("capability_id", self.capability_id),
+            ("hybrid_api_transport_type", self.hybrid_api_transport_type),
+            ("hybrid_api_batch_size", self.hybrid_api_batch_size),
+            ("hybrid_api_batch_parallelism", self.hybrid_api_batch_parallelism),
+            ("hybrid_api_keep_alive", self.hybrid_api_keep_alive),
+            ("hybrid_api_heartbeat_interval", self.hybrid_api_heartbeat_interval),
+            ("hybrid_api_timeout", self.hybrid_api_timeout),
+            ("hybrid_api_auth_header", self.hybrid_api_auth_header),
+            ("hybrid_api_auto_discover_tvars", self.hybrid_api_auto_discover_tvars),
             ("local_storage_path", self.local_storage_path),
             ("minimal_logging", self.minimal_logging),
             ("parallel_config", self.parallel_config),
@@ -734,6 +775,16 @@ class JSRuntimeConfig:
 def _resolve_execution_bundle_options(
     execution_bundle: ExecutionOptions | None,
     execution_mode: Any,
+    hybrid_api_endpoint: Any,
+    capability_id: Any,
+    hybrid_api_transport_type: Any,
+    hybrid_api_batch_size: Any,
+    hybrid_api_batch_parallelism: Any,
+    hybrid_api_keep_alive: Any,
+    hybrid_api_heartbeat_interval: Any,
+    hybrid_api_timeout: Any,
+    hybrid_api_auth_header: Any,
+    hybrid_api_auto_discover_tvars: Any,
     local_storage_path: Any,
     minimal_logging: Any,
     parallel_config: Any,
@@ -741,11 +792,41 @@ def _resolve_execution_bundle_options(
     max_total_examples: Any,
     samples_include_pruned: Any,
     defaults: dict[str, Any],
-) -> tuple[Any, Any, Any, Any, Any, Any, Any, JSRuntimeConfig | None]:
+) -> tuple[
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    Any,
+    JSRuntimeConfig | None,
+]:
     """Resolve execution options from bundle and validate enterprise features."""
     if execution_bundle is None:
         return (
             execution_mode,
+            hybrid_api_endpoint,
+            capability_id,
+            hybrid_api_transport_type,
+            hybrid_api_batch_size,
+            hybrid_api_batch_parallelism,
+            hybrid_api_keep_alive,
+            hybrid_api_heartbeat_interval,
+            hybrid_api_timeout,
+            hybrid_api_auth_header,
+            hybrid_api_auto_discover_tvars,
             local_storage_path,
             minimal_logging,
             parallel_config,
@@ -793,6 +874,66 @@ def _resolve_execution_bundle_options(
     return (
         _resolve_option(
             "execution_mode", execution_mode, execution_bundle.execution_mode, defaults
+        ),
+        _resolve_option(
+            "hybrid_api_endpoint",
+            hybrid_api_endpoint,
+            execution_bundle.hybrid_api_endpoint,
+            defaults,
+        ),
+        _resolve_option(
+            "capability_id",
+            capability_id,
+            execution_bundle.capability_id,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_transport_type",
+            hybrid_api_transport_type,
+            execution_bundle.hybrid_api_transport_type,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_batch_size",
+            hybrid_api_batch_size,
+            execution_bundle.hybrid_api_batch_size,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_batch_parallelism",
+            hybrid_api_batch_parallelism,
+            execution_bundle.hybrid_api_batch_parallelism,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_keep_alive",
+            hybrid_api_keep_alive,
+            execution_bundle.hybrid_api_keep_alive,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_heartbeat_interval",
+            hybrid_api_heartbeat_interval,
+            execution_bundle.hybrid_api_heartbeat_interval,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_timeout",
+            hybrid_api_timeout,
+            execution_bundle.hybrid_api_timeout,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_auth_header",
+            hybrid_api_auth_header,
+            execution_bundle.hybrid_api_auth_header,
+            defaults,
+        ),
+        _resolve_option(
+            "hybrid_api_auto_discover_tvars",
+            hybrid_api_auto_discover_tvars,
+            execution_bundle.hybrid_api_auto_discover_tvars,
+            defaults,
         ),
         _resolve_option(
             "local_storage_path",
@@ -1484,6 +1625,16 @@ def optimize(
     auto_override_frameworks = combined_settings["auto_override_frameworks"]
     framework_targets = combined_settings["framework_targets"]
     execution_mode = combined_settings["execution_mode"]
+    hybrid_api_endpoint = combined_settings["hybrid_api_endpoint"]
+    capability_id = combined_settings["capability_id"]
+    hybrid_api_transport_type = combined_settings["hybrid_api_transport_type"]
+    hybrid_api_batch_size = combined_settings["hybrid_api_batch_size"]
+    hybrid_api_batch_parallelism = combined_settings["hybrid_api_batch_parallelism"]
+    hybrid_api_keep_alive = combined_settings["hybrid_api_keep_alive"]
+    hybrid_api_heartbeat_interval = combined_settings["hybrid_api_heartbeat_interval"]
+    hybrid_api_timeout = combined_settings["hybrid_api_timeout"]
+    hybrid_api_auth_header = combined_settings["hybrid_api_auth_header"]
+    hybrid_api_auto_discover_tvars = combined_settings["hybrid_api_auto_discover_tvars"]
     local_storage_path = combined_settings["local_storage_path"]
     minimal_logging = combined_settings["minimal_logging"]
     parallel_config = combined_settings["parallel_config"]
@@ -1551,6 +1702,16 @@ def optimize(
 
     (
         execution_mode,
+        hybrid_api_endpoint,
+        capability_id,
+        hybrid_api_transport_type,
+        hybrid_api_batch_size,
+        hybrid_api_batch_parallelism,
+        hybrid_api_keep_alive,
+        hybrid_api_heartbeat_interval,
+        hybrid_api_timeout,
+        hybrid_api_auth_header,
+        hybrid_api_auto_discover_tvars,
         local_storage_path,
         minimal_logging,
         parallel_config,
@@ -1561,6 +1722,16 @@ def optimize(
     ) = _resolve_execution_bundle_options(
         execution_bundle,
         execution_mode,
+        hybrid_api_endpoint,
+        capability_id,
+        hybrid_api_transport_type,
+        hybrid_api_batch_size,
+        hybrid_api_batch_parallelism,
+        hybrid_api_keep_alive,
+        hybrid_api_heartbeat_interval,
+        hybrid_api_timeout,
+        hybrid_api_auth_header,
+        hybrid_api_auto_discover_tvars,
         local_storage_path,
         minimal_logging,
         parallel_config,
@@ -1670,6 +1841,16 @@ def optimize(
             auto_override_frameworks=auto_override_frameworks,
             framework_targets=framework_targets,
             execution_mode=execution_mode_enum,
+            hybrid_api_endpoint=hybrid_api_endpoint,
+            capability_id=capability_id,
+            hybrid_api_transport_type=hybrid_api_transport_type,
+            hybrid_api_batch_size=hybrid_api_batch_size,
+            hybrid_api_batch_parallelism=hybrid_api_batch_parallelism,
+            hybrid_api_keep_alive=hybrid_api_keep_alive,
+            hybrid_api_heartbeat_interval=hybrid_api_heartbeat_interval,
+            hybrid_api_timeout=hybrid_api_timeout,
+            hybrid_api_auth_header=hybrid_api_auth_header,
+            hybrid_api_auto_discover_tvars=hybrid_api_auto_discover_tvars,
             local_storage_path=local_storage_path,
             minimal_logging=minimal_logging,
             max_total_examples=max_total_examples,

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -13,15 +13,15 @@ from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-import numpy as np
-import pandas as pd
-
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 # Type checking imports to avoid circular dependencies
 if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
+
     from traigent.core.objectives import ObjectiveSchema
 
 
@@ -902,6 +902,8 @@ class OptimizationResult:
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert results to pandas DataFrame."""
+        import pandas as pd  # noqa: PLC0415
+
         data = []
         for trial in self.trials:
             row = {
@@ -1030,6 +1032,8 @@ class OptimizationResult:
                 - <metric>_mean for each metric present
                 - duration_mean
         """
+        import pandas as pd  # noqa: PLC0415
+
         if not self.trials:
             return pd.DataFrame()
 
@@ -1244,6 +1248,8 @@ class ConfigurationComparison:
 
     def get_best_configuration(self, metric: str) -> tuple[int, dict[str, Any]]:
         """Get the best configuration for a specific metric."""
+        import numpy as np  # noqa: PLC0415
+
         if metric not in self.comparison_metrics:
             raise ValueError(f"Metric '{metric}' not found in comparison") from None
 
@@ -1263,6 +1269,8 @@ class ParetoFront:
 
     def get_best_balanced_config(self) -> dict[str, Any]:
         """Get configuration with best balance across objectives."""
+        import numpy as np  # noqa: PLC0415
+
         # Simple implementation: closest to ideal point
         if len(self.configurations) == 0 or self.objective_values.size == 0:
             raise ValueError("No configurations in Pareto front")

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -17,6 +17,32 @@ from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Canonical status strings used by backend DTO payloads.
+# Keep these aligned with cloud.models enums and backend schemas.
+EXPERIMENT_RUN_STATUS_VALUES = frozenset(
+    {"not_started", "pending", "running", "completed", "failed", "cancelled"}
+)
+CONFIGURATION_RUN_STATUS_VALUES = frozenset(
+    {"not_started", "pending", "running", "completed", "failed", "cancelled", "pruned"}
+)
+
+
+def _warn_if_unknown_status(
+    *,
+    status: str,
+    allowed: frozenset[str],
+    dto_name: str,
+) -> None:
+    """Log unknown status values while preserving backward compatibility."""
+    if status not in allowed:
+        logger.warning(
+            "%s received non-canonical status '%s'. Allowed statuses: %s",
+            dto_name,
+            status,
+            sorted(allowed),
+        )
+
+
 # Try to import optigen_schemas for validation (optional)
 try:
     from optigen_schemas.validator import SchemaValidator
@@ -439,6 +465,11 @@ class ExperimentRunDTO:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API submission."""
+        _warn_if_unknown_status(
+            status=self.status,
+            allowed=EXPERIMENT_RUN_STATUS_VALUES,
+            dto_name="ExperimentRunDTO",
+        )
         result: dict[str, Any] = {
             "id": self.id,
             "experiment_id": self.experiment_id,
@@ -486,6 +517,11 @@ class ConfigurationRunDTO:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API submission."""
+        _warn_if_unknown_status(
+            status=self.status,
+            allowed=CONFIGURATION_RUN_STATUS_VALUES,
+            dto_name="ConfigurationRunDTO",
+        )
         result: dict[str, Any] = {
             "id": self.id,
             "experiment_run_id": self.experiment_run_id,

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -13,6 +13,7 @@ import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from traigent.cloud.dtos import MeasuresDict
 from traigent.cloud.validators import validate_configuration_run_submission
 from traigent.config.backend_config import BackendConfig
 from traigent.utils.env_config import is_backend_offline
@@ -358,7 +359,7 @@ class TrialOperations:
             return False
 
     def _extract_measures_from_metrics(
-        self, metrics: dict[str, float]
+        self, metrics: dict[str, Any]
     ) -> tuple[Any, Any, dict[str, Any]]:
         """Extract measures and summary_stats from metrics dict.
 
@@ -517,7 +518,7 @@ class TrialOperations:
         session_id: str,
         trial_id: str,
         config: dict[str, Any],
-        metrics: dict[str, float],
+        metrics: dict[str, Any],
         status: str,
         error_message: str | None = None,
         execution_mode: str | None = None,
@@ -552,9 +553,22 @@ class TrialOperations:
             backend_status = self.client._map_to_backend_status(status)
             mode = self.client._normalize_execution_mode(execution_mode)
 
+            # Validate key naming and cardinality for metrics while preserving
+            # backward compatibility with existing payload shapes.
+            validated_metrics: dict[str, Any] = metrics
+            try:
+                validated_metrics = dict(MeasuresDict(metrics))
+            except (TypeError, ValueError) as validation_error:
+                logger.warning(
+                    "Metrics validation warning for trial %s: %s. "
+                    "Submitting unvalidated metrics for backward compatibility.",
+                    trial_id,
+                    validation_error,
+                )
+
             # Extract measures and summary_stats from metrics
             measures, summary_stats, clean_metrics = (
-                self._extract_measures_from_metrics(metrics)
+                self._extract_measures_from_metrics(validated_metrics)
             )
 
             # Build result data

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -19,7 +19,7 @@ from traigent.config.parallel import (
     merge_parallel_configs,
     resolve_parallel_config,
 )
-from traigent.config.types import TraigentConfig
+from traigent.config.types import ExecutionMode, TraigentConfig, resolve_execution_mode
 from traigent.core.evaluator_wrapper import CustomEvaluatorWrapper
 from traigent.evaluators.base import BaseEvaluator, Dataset
 from traigent.evaluators.local import LocalEvaluator
@@ -109,7 +109,14 @@ def create_traigent_config(
     """
     return TraigentConfig(
         execution_mode=cast(
-            Literal["edge_analytics", "privacy", "hybrid", "standard", "cloud"],
+            Literal[
+                "edge_analytics",
+                "privacy",
+                "hybrid",
+                "standard",
+                "cloud",
+                "hybrid_api",
+            ],
             execution_mode,
         ),
         local_storage_path=local_storage_path,
@@ -356,6 +363,17 @@ def create_effective_evaluator(
     metric_functions: dict[str, Callable[..., Any]] | None,
     scoring_function: Callable[..., Any] | None,
     decorator_custom_evaluator: Callable[..., Any] | None,
+    hybrid_api_endpoint: str | None = None,
+    hybrid_api_capability_id: str | None = None,
+    hybrid_api_transport: Any | None = None,
+    hybrid_api_transport_type: str = "auto",
+    hybrid_api_batch_size: int = 1,
+    hybrid_api_batch_parallelism: int = 1,
+    hybrid_api_keep_alive: bool = True,
+    hybrid_api_heartbeat_interval: float = 30.0,
+    hybrid_api_timeout: float | None = None,
+    hybrid_api_auth_header: str | None = None,
+    hybrid_api_auto_discover_tvars: bool = False,
 ) -> tuple[BaseEvaluator, Any]:
     """Create the appropriate evaluator for the optimization run.
 
@@ -394,6 +412,43 @@ def create_effective_evaluator(
             ),
             None,
         )
+
+    execution_mode_enum = resolve_execution_mode(execution_mode)
+    if execution_mode_enum is ExecutionMode.HYBRID_API:
+        from traigent.evaluators.hybrid_api import HybridAPIEvaluator
+
+        if hybrid_api_transport is None and not hybrid_api_endpoint:
+            raise ValueError(
+                "hybrid_api execution mode requires hybrid_api_endpoint "
+                "or a preconfigured hybrid_api_transport."
+            )
+
+        request_timeout = (
+            hybrid_api_timeout if hybrid_api_timeout is not None else timeout
+        )
+        if request_timeout is None:
+            request_timeout = 300.0
+
+        batch_size_value = max(1, int(hybrid_api_batch_size))
+        batch_parallelism_value = max(1, int(hybrid_api_batch_parallelism))
+
+        evaluator = HybridAPIEvaluator(
+            api_endpoint=hybrid_api_endpoint,
+            transport=hybrid_api_transport,
+            transport_type=cast(
+                Literal["http", "mcp", "auto"], hybrid_api_transport_type
+            ),
+            capability_id=hybrid_api_capability_id,
+            auto_discover_tvars=hybrid_api_auto_discover_tvars,
+            batch_size=batch_size_value,
+            batch_parallelism=batch_parallelism_value,
+            keep_alive=hybrid_api_keep_alive,
+            heartbeat_interval=hybrid_api_heartbeat_interval,
+            timeout=request_timeout,
+            auth_header=hybrid_api_auth_header,
+            metrics=list(objectives),
+        )
+        return evaluator, None
 
     # Check if JS runtime is configured
     js_config = js_runtime_config

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -693,12 +693,26 @@ class OptimizedFunction:
                 else:
                     raise
         elif self.configuration_space == {}:
+            if self._allows_empty_configuration_space():
+                logger.debug(
+                    "Allowing empty local configuration_space because "
+                    "hybrid_api_auto_discover_tvars is enabled"
+                )
+                return
             # Empty config space should raise ValueError with helpful message
             raise ValueError(
                 "Configuration space cannot be empty. Please specify at least one parameter to optimize "
                 "in the @traigent.optimize decorator. Example: configuration_space={'temperature': [0.0, 0.5, 1.0], "
                 "'model': ['gpt-3.5-turbo', 'gpt-4']}"
             )
+
+    def _allows_empty_configuration_space(self) -> bool:
+        """Whether empty config space is allowed for this function."""
+        effective_mode = getattr(self, "_effective_execution_mode", None)
+        return bool(
+            effective_mode is ExecutionMode.HYBRID_API
+            and getattr(self, "hybrid_api_auto_discover_tvars", False)
+        )
 
     def _validate_dataset(self) -> None:
         """Validate dataset configuration."""
@@ -845,6 +859,117 @@ class OptimizedFunction:
             self.constraints = tvl_state["constraints"]
         if "default_config" in tvl_state:
             self.default_config = tvl_state["default_config"]
+
+    async def _apply_hybrid_discovery_overrides(
+        self,
+        evaluator: BaseEvaluator,
+        *,
+        algorithm: str | None,
+        max_trials: int | None,
+        timeout: float | None,
+        effective_config_space: dict[str, Any],
+        algorithm_kwargs: dict[str, Any],
+    ) -> tuple[str | None, int | None, float | None, dict[str, Any], dict[str, Any]]:
+        """Apply hybrid config-space discovery data to runtime settings."""
+        from types import SimpleNamespace
+
+        from traigent.hybrid.discovery import merge_config_spaces
+        from traigent.tvl.promotion_gate import PromotionGate
+
+        state: dict[str, Any] = {}
+
+        discover = getattr(evaluator, "discover_config_space", None)
+        if not callable(discover):
+            return algorithm, max_trials, timeout, effective_config_space, state
+
+        discovered_config_space = await discover()
+        if not discovered_config_space:
+            raise ValueError(
+                "Hybrid API config-space discovery returned no tunables. "
+                "Verify GET /traigent/v1/config-space."
+            )
+
+        effective_config_space = merge_config_spaces(
+            discovered_config_space,
+            effective_config_space if effective_config_space else None,
+        )
+
+        discovered_spec = getattr(evaluator, "optimization_spec", None) or {}
+        if not isinstance(discovered_spec, dict):
+            return algorithm, max_trials, timeout, effective_config_space, state
+
+        discovered_schema = discovered_spec.get("objective_schema")
+        if discovered_schema is not None:
+            state["objective_schema"] = self.objective_schema
+            self.objective_schema = discovered_schema
+
+        discovered_constraints = discovered_spec.get("constraints")
+        if isinstance(discovered_constraints, list) and discovered_constraints:
+            state["constraints"] = list(self.constraints or [])
+            self.constraints = list(self.constraints or []) + discovered_constraints
+
+        discovered_defaults = discovered_spec.get("default_config")
+        if isinstance(discovered_defaults, dict) and discovered_defaults:
+            state["default_config"] = copy.deepcopy(self.default_config)
+            self.default_config = discovered_defaults.copy()
+
+        runtime_overrides = discovered_spec.get("runtime_overrides")
+        if isinstance(runtime_overrides, dict) and runtime_overrides:
+            algorithm, max_trials, timeout = self._apply_tvl_runtime_overrides(
+                algorithm,
+                max_trials,
+                timeout,
+                algorithm_kwargs,
+                runtime_overrides,
+            )
+
+        promotion_policy = discovered_spec.get("promotion_policy")
+        if promotion_policy is not None:
+            state["promotion_gate"] = getattr(self, "promotion_gate", None)
+            artifact_like = SimpleNamespace(
+                promotion_policy=promotion_policy,
+                objective_schema=self.objective_schema,
+            )
+            self.promotion_gate = PromotionGate.from_spec_artifact(artifact_like)
+
+        discovered_measures = discovered_spec.get("measures")
+        if (
+            isinstance(discovered_measures, list)
+            and hasattr(evaluator, "metrics")
+            and isinstance(getattr(evaluator, "metrics", None), list)
+        ):
+            state["evaluator_metrics"] = list(evaluator.metrics)
+            merged_metrics: list[str] = []
+            for metric_name in [*self.objectives, *discovered_measures]:
+                if isinstance(metric_name, str) and metric_name not in merged_metrics:
+                    merged_metrics.append(metric_name)
+            if merged_metrics:
+                evaluator.metrics = merged_metrics
+
+        return algorithm, max_trials, timeout, effective_config_space, state
+
+    def _restore_hybrid_discovery_state(
+        self,
+        state: dict[str, Any] | None,
+        evaluator: BaseEvaluator | None = None,
+    ) -> None:
+        """Restore state mutated by hybrid discovery application."""
+        if not state:
+            return
+        if "constraints" in state:
+            self.constraints = state["constraints"]
+        if "default_config" in state:
+            self.default_config = state["default_config"]
+        if "objective_schema" in state:
+            self.objective_schema = state["objective_schema"]
+        if "promotion_gate" in state:
+            self.promotion_gate = state["promotion_gate"]
+        if (
+            evaluator is not None
+            and "evaluator_metrics" in state
+            and hasattr(evaluator, "metrics")
+        ):
+            evaluator.metrics = state["evaluator_metrics"]
 
     async def optimize(
         self,
@@ -1366,6 +1491,75 @@ class OptimizedFunction:
         This method orchestrates the optimization process by delegating to
         specialized helper methods for each phase of execution.
         """
+        hybrid_auto_discovery_enabled = self._allows_empty_configuration_space()
+        effective_privacy_enabled = bool(getattr(self, "privacy_enabled", False))
+        hybrid_discovery_state: dict[str, Any] | None = None
+        precreated_evaluator: BaseEvaluator | None = None
+
+        if hybrid_auto_discovery_enabled:
+            precreated_evaluator, js_process_pool = create_effective_evaluator(
+                timeout=timeout,
+                custom_evaluator=custom_evaluator,
+                effective_batch_size=None,
+                effective_thread_workers=None,
+                effective_privacy_enabled=effective_privacy_enabled,
+                objectives=self.objectives,
+                js_runtime_config=getattr(self, "js_runtime_config", None),
+                execution_mode=self.execution_mode,
+                mock_mode_config=self.mock_mode_config,
+                metric_functions=self.metric_functions,
+                scoring_function=self.scoring_function,
+                decorator_custom_evaluator=self.custom_evaluator,
+                hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
+                hybrid_api_capability_id=getattr(
+                    self, "hybrid_api_capability_id", None
+                ),
+                hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
+                hybrid_api_transport_type=getattr(
+                    self, "hybrid_api_transport_type", "auto"
+                ),
+                hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
+                hybrid_api_batch_parallelism=getattr(
+                    self, "hybrid_api_batch_parallelism", 1
+                ),
+                hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
+                hybrid_api_heartbeat_interval=getattr(
+                    self, "hybrid_api_heartbeat_interval", 30.0
+                ),
+                hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
+                hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
+                hybrid_api_auto_discover_tvars=True,
+            )
+            if js_process_pool is not None:
+                self._js_process_pool = js_process_pool
+
+            pre_discovery_space = (
+                configuration_space
+                if configuration_space is not None
+                else self.configuration_space
+            )
+            try:
+                (
+                    algorithm,
+                    max_trials,
+                    timeout,
+                    discovered_config_space,
+                    hybrid_discovery_state,
+                ) = await self._apply_hybrid_discovery_overrides(
+                    evaluator=precreated_evaluator,
+                    algorithm=algorithm,
+                    max_trials=max_trials,
+                    timeout=timeout,
+                    effective_config_space=pre_discovery_space or {},
+                    algorithm_kwargs=algorithm_kwargs,
+                )
+            except Exception:
+                close = getattr(precreated_evaluator, "close", None)
+                if callable(close):
+                    await close()
+                raise
+            configuration_space = discovered_config_space
+
         # Phase 1: Resolve and validate parameters
         algorithm, max_trials, effective_config_space = resolve_execution_parameters(
             algorithm,
@@ -1434,7 +1628,49 @@ class OptimizedFunction:
                 raw_invocations,
             )
 
-        # Phase 6: Create optimizer
+        # Phase 6: Determine privacy and create evaluator
+        if precreated_evaluator is not None:
+            evaluator = precreated_evaluator
+        else:
+            evaluator, js_process_pool = create_effective_evaluator(
+                timeout=timeout,
+                custom_evaluator=custom_evaluator,
+                effective_batch_size=effective_batch_size,
+                effective_thread_workers=effective_thread_workers,
+                effective_privacy_enabled=effective_privacy_enabled,
+                objectives=self.objectives,
+                js_runtime_config=getattr(self, "js_runtime_config", None),
+                execution_mode=self.execution_mode,
+                mock_mode_config=self.mock_mode_config,
+                metric_functions=self.metric_functions,
+                scoring_function=self.scoring_function,
+                decorator_custom_evaluator=self.custom_evaluator,
+                hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
+                hybrid_api_capability_id=getattr(
+                    self, "hybrid_api_capability_id", None
+                ),
+                hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
+                hybrid_api_transport_type=getattr(
+                    self, "hybrid_api_transport_type", "auto"
+                ),
+                hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
+                hybrid_api_batch_parallelism=getattr(
+                    self, "hybrid_api_batch_parallelism", 1
+                ),
+                hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
+                hybrid_api_heartbeat_interval=getattr(
+                    self, "hybrid_api_heartbeat_interval", 30.0
+                ),
+                hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
+                hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
+                hybrid_api_auto_discover_tvars=getattr(
+                    self, "hybrid_api_auto_discover_tvars", False
+                ),
+            )
+            if js_process_pool is not None:
+                self._js_process_pool = js_process_pool
+
+        # Phase 7: Create optimizer
         optimizer_kwargs = algorithm_kwargs.copy()
         if max_trials:
             optimizer_kwargs["max_trials"] = max_trials
@@ -1445,44 +1681,6 @@ class OptimizedFunction:
         optimizer = get_optimizer(
             algorithm, effective_config_space, self.objectives, **optimizer_kwargs
         )
-
-        # Phase 7: Determine privacy and create evaluator
-        effective_privacy_enabled = bool(getattr(self, "privacy_enabled", False))
-        evaluator, js_process_pool = create_effective_evaluator(
-            timeout=timeout,
-            custom_evaluator=custom_evaluator,
-            effective_batch_size=effective_batch_size,
-            effective_thread_workers=effective_thread_workers,
-            effective_privacy_enabled=effective_privacy_enabled,
-            objectives=self.objectives,
-            js_runtime_config=getattr(self, "js_runtime_config", None),
-            execution_mode=self.execution_mode,
-            mock_mode_config=self.mock_mode_config,
-            metric_functions=self.metric_functions,
-            scoring_function=self.scoring_function,
-            decorator_custom_evaluator=self.custom_evaluator,
-            hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
-            hybrid_api_capability_id=getattr(self, "hybrid_api_capability_id", None),
-            hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
-            hybrid_api_transport_type=getattr(
-                self, "hybrid_api_transport_type", "auto"
-            ),
-            hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
-            hybrid_api_batch_parallelism=getattr(
-                self, "hybrid_api_batch_parallelism", 1
-            ),
-            hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
-            hybrid_api_heartbeat_interval=getattr(
-                self, "hybrid_api_heartbeat_interval", 30.0
-            ),
-            hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
-            hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
-            hybrid_api_auto_discover_tvars=getattr(
-                self, "hybrid_api_auto_discover_tvars", False
-            ),
-        )
-        if js_process_pool is not None:
-            self._js_process_pool = js_process_pool
 
         # Update TraigentConfig with final privacy setting
         traigent_config.privacy_enabled = effective_privacy_enabled
@@ -1513,6 +1711,8 @@ class OptimizedFunction:
         except Exception as e:
             logger.error(f"Optimization failed: {e}")
             raise OptimizationError(f"Optimization failed: {e}") from e
+        finally:
+            self._restore_hybrid_discovery_state(hybrid_discovery_state, evaluator)
 
     async def _optimize_with_cloud_service(
         self,

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -871,8 +871,6 @@ class OptimizedFunction:
         algorithm_kwargs: dict[str, Any],
     ) -> tuple[str | None, int | None, float | None, dict[str, Any], dict[str, Any]]:
         """Apply hybrid config-space discovery data to runtime settings."""
-        from types import SimpleNamespace
-
         from traigent.hybrid.discovery import merge_config_spaces
         from traigent.tvl.promotion_gate import PromotionGate
 
@@ -926,11 +924,10 @@ class OptimizedFunction:
         promotion_policy = discovered_spec.get("promotion_policy")
         if promotion_policy is not None:
             state["promotion_gate"] = getattr(self, "promotion_gate", None)
-            artifact_like = SimpleNamespace(
+            self.promotion_gate = PromotionGate.from_policy(
                 promotion_policy=promotion_policy,
                 objective_schema=self.objective_schema,
             )
-            self.promotion_gate = PromotionGate.from_spec_artifact(artifact_like)
 
         discovered_measures = discovered_spec.get("measures")
         if (
@@ -1508,6 +1505,9 @@ class OptimizedFunction:
         precreated_evaluator: BaseEvaluator | None = None
 
         if hybrid_auto_discovery_enabled:
+            # Discovery must happen before we resolve parallel settings because
+            # the remote config-space can override optimizer/runtime parameters.
+            # Use neutral worker settings for this bootstrap evaluator instance.
             precreated_evaluator = self._create_effective_evaluator(
                 timeout=timeout,
                 custom_evaluator=custom_evaluator,

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -711,7 +711,7 @@ class OptimizedFunction:
         effective_mode = getattr(self, "_effective_execution_mode", None)
         return bool(
             effective_mode is ExecutionMode.HYBRID_API
-            and getattr(self, "hybrid_api_auto_discover_tvars", False)
+            and self.hybrid_api_auto_discover_tvars
         )
 
     def _validate_dataset(self) -> None:
@@ -1241,6 +1241,31 @@ class OptimizedFunction:
 
         return updated_algorithm, updated_max_trials, updated_timeout
 
+    def _hybrid_api_evaluator_kwargs(
+        self,
+        *,
+        force_auto_discover_tvars: bool | None = None,
+    ) -> dict[str, Any]:
+        """Build hybrid API kwargs for evaluator construction."""
+        auto_discover = (
+            force_auto_discover_tvars
+            if force_auto_discover_tvars is not None
+            else self.hybrid_api_auto_discover_tvars
+        )
+        return {
+            "hybrid_api_endpoint": self.hybrid_api_endpoint,
+            "hybrid_api_capability_id": self.hybrid_api_capability_id,
+            "hybrid_api_transport": self.hybrid_api_transport,
+            "hybrid_api_transport_type": self.hybrid_api_transport_type,
+            "hybrid_api_batch_size": self.hybrid_api_batch_size,
+            "hybrid_api_batch_parallelism": self.hybrid_api_batch_parallelism,
+            "hybrid_api_keep_alive": self.hybrid_api_keep_alive,
+            "hybrid_api_heartbeat_interval": self.hybrid_api_heartbeat_interval,
+            "hybrid_api_timeout": self.hybrid_api_timeout,
+            "hybrid_api_auth_header": self.hybrid_api_auth_header,
+            "hybrid_api_auto_discover_tvars": auto_discover,
+        }
+
     def _create_effective_evaluator(
         self,
         timeout: float | None,
@@ -1248,6 +1273,8 @@ class OptimizedFunction:
         effective_batch_size: int | None,
         effective_thread_workers: int | None,
         effective_privacy_enabled: bool,
+        *,
+        force_auto_discover_tvars: bool | None = None,
     ) -> BaseEvaluator:
         """Create the appropriate evaluator. Delegates to optimization_pipeline."""
         evaluator, js_pool = create_effective_evaluator(
@@ -1263,24 +1290,8 @@ class OptimizedFunction:
             metric_functions=self.metric_functions,
             scoring_function=self.scoring_function,
             decorator_custom_evaluator=self.custom_evaluator,
-            hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
-            hybrid_api_capability_id=getattr(self, "hybrid_api_capability_id", None),
-            hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
-            hybrid_api_transport_type=getattr(
-                self, "hybrid_api_transport_type", "auto"
-            ),
-            hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
-            hybrid_api_batch_parallelism=getattr(
-                self, "hybrid_api_batch_parallelism", 1
-            ),
-            hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
-            hybrid_api_heartbeat_interval=getattr(
-                self, "hybrid_api_heartbeat_interval", 30.0
-            ),
-            hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
-            hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
-            hybrid_api_auto_discover_tvars=getattr(
-                self, "hybrid_api_auto_discover_tvars", False
+            **self._hybrid_api_evaluator_kwargs(
+                force_auto_discover_tvars=force_auto_discover_tvars
             ),
         )
         if js_pool is not None:
@@ -1497,41 +1508,14 @@ class OptimizedFunction:
         precreated_evaluator: BaseEvaluator | None = None
 
         if hybrid_auto_discovery_enabled:
-            precreated_evaluator, js_process_pool = create_effective_evaluator(
+            precreated_evaluator = self._create_effective_evaluator(
                 timeout=timeout,
                 custom_evaluator=custom_evaluator,
                 effective_batch_size=None,
                 effective_thread_workers=None,
                 effective_privacy_enabled=effective_privacy_enabled,
-                objectives=self.objectives,
-                js_runtime_config=getattr(self, "js_runtime_config", None),
-                execution_mode=self.execution_mode,
-                mock_mode_config=self.mock_mode_config,
-                metric_functions=self.metric_functions,
-                scoring_function=self.scoring_function,
-                decorator_custom_evaluator=self.custom_evaluator,
-                hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
-                hybrid_api_capability_id=getattr(
-                    self, "hybrid_api_capability_id", None
-                ),
-                hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
-                hybrid_api_transport_type=getattr(
-                    self, "hybrid_api_transport_type", "auto"
-                ),
-                hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
-                hybrid_api_batch_parallelism=getattr(
-                    self, "hybrid_api_batch_parallelism", 1
-                ),
-                hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
-                hybrid_api_heartbeat_interval=getattr(
-                    self, "hybrid_api_heartbeat_interval", 30.0
-                ),
-                hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
-                hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
-                hybrid_api_auto_discover_tvars=True,
+                force_auto_discover_tvars=True,
             )
-            if js_process_pool is not None:
-                self._js_process_pool = js_process_pool
 
             pre_discovery_space = (
                 configuration_space
@@ -1632,43 +1616,13 @@ class OptimizedFunction:
         if precreated_evaluator is not None:
             evaluator = precreated_evaluator
         else:
-            evaluator, js_process_pool = create_effective_evaluator(
+            evaluator = self._create_effective_evaluator(
                 timeout=timeout,
                 custom_evaluator=custom_evaluator,
                 effective_batch_size=effective_batch_size,
                 effective_thread_workers=effective_thread_workers,
                 effective_privacy_enabled=effective_privacy_enabled,
-                objectives=self.objectives,
-                js_runtime_config=getattr(self, "js_runtime_config", None),
-                execution_mode=self.execution_mode,
-                mock_mode_config=self.mock_mode_config,
-                metric_functions=self.metric_functions,
-                scoring_function=self.scoring_function,
-                decorator_custom_evaluator=self.custom_evaluator,
-                hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
-                hybrid_api_capability_id=getattr(
-                    self, "hybrid_api_capability_id", None
-                ),
-                hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
-                hybrid_api_transport_type=getattr(
-                    self, "hybrid_api_transport_type", "auto"
-                ),
-                hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
-                hybrid_api_batch_parallelism=getattr(
-                    self, "hybrid_api_batch_parallelism", 1
-                ),
-                hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
-                hybrid_api_heartbeat_interval=getattr(
-                    self, "hybrid_api_heartbeat_interval", 30.0
-                ),
-                hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
-                hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
-                hybrid_api_auto_discover_tvars=getattr(
-                    self, "hybrid_api_auto_discover_tvars", False
-                ),
             )
-            if js_process_pool is not None:
-                self._js_process_pool = js_process_pool
 
         # Phase 7: Create optimizer
         optimizer_kwargs = algorithm_kwargs.copy()

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -39,10 +39,7 @@ from typing import Any, cast
 
 from traigent.api.types import OptimizationResult, OptimizationStatus
 from traigent.config import get_provider
-from traigent.config.parallel import (
-    coerce_parallel_config,
-    merge_parallel_configs,
-)
+from traigent.config.parallel import coerce_parallel_config, merge_parallel_configs
 from traigent.config.types import ExecutionMode, TraigentConfig, resolve_execution_mode
 from traigent.core.ci_approval import check_ci_approval
 from traigent.core.config_state_manager import ConfigStateManager, OptimizationState
@@ -428,6 +425,25 @@ class OptimizedFunction:
         )
         self.framework_target = self._store_optional_param(
             kwargs, sentinel, "framework_target", None
+        )
+
+        # Hybrid API evaluator configuration (execution_mode="hybrid_api")
+        self.hybrid_api_endpoint = kwargs.pop("hybrid_api_endpoint", None)
+        self.hybrid_api_capability_id = kwargs.pop("capability_id", None)
+        self.hybrid_api_transport = kwargs.pop("hybrid_api_transport", None)
+        self.hybrid_api_transport_type = kwargs.pop("hybrid_api_transport_type", "auto")
+        self.hybrid_api_batch_size = kwargs.pop("hybrid_api_batch_size", 1)
+        self.hybrid_api_batch_parallelism = kwargs.pop(
+            "hybrid_api_batch_parallelism", 1
+        )
+        self.hybrid_api_keep_alive = bool(kwargs.pop("hybrid_api_keep_alive", True))
+        self.hybrid_api_heartbeat_interval = kwargs.pop(
+            "hybrid_api_heartbeat_interval", 30.0
+        )
+        self.hybrid_api_timeout = kwargs.pop("hybrid_api_timeout", None)
+        self.hybrid_api_auth_header = kwargs.pop("hybrid_api_auth_header", None)
+        self.hybrid_api_auto_discover_tvars = bool(
+            kwargs.pop("hybrid_api_auto_discover_tvars", False)
         )
 
         # Execution knobs
@@ -1122,6 +1138,25 @@ class OptimizedFunction:
             metric_functions=self.metric_functions,
             scoring_function=self.scoring_function,
             decorator_custom_evaluator=self.custom_evaluator,
+            hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
+            hybrid_api_capability_id=getattr(self, "hybrid_api_capability_id", None),
+            hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
+            hybrid_api_transport_type=getattr(
+                self, "hybrid_api_transport_type", "auto"
+            ),
+            hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
+            hybrid_api_batch_parallelism=getattr(
+                self, "hybrid_api_batch_parallelism", 1
+            ),
+            hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
+            hybrid_api_heartbeat_interval=getattr(
+                self, "hybrid_api_heartbeat_interval", 30.0
+            ),
+            hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
+            hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
+            hybrid_api_auto_discover_tvars=getattr(
+                self, "hybrid_api_auto_discover_tvars", False
+            ),
         )
         if js_pool is not None:
             self._js_process_pool = js_pool
@@ -1426,6 +1461,25 @@ class OptimizedFunction:
             metric_functions=self.metric_functions,
             scoring_function=self.scoring_function,
             decorator_custom_evaluator=self.custom_evaluator,
+            hybrid_api_endpoint=getattr(self, "hybrid_api_endpoint", None),
+            hybrid_api_capability_id=getattr(self, "hybrid_api_capability_id", None),
+            hybrid_api_transport=getattr(self, "hybrid_api_transport", None),
+            hybrid_api_transport_type=getattr(
+                self, "hybrid_api_transport_type", "auto"
+            ),
+            hybrid_api_batch_size=getattr(self, "hybrid_api_batch_size", 1),
+            hybrid_api_batch_parallelism=getattr(
+                self, "hybrid_api_batch_parallelism", 1
+            ),
+            hybrid_api_keep_alive=getattr(self, "hybrid_api_keep_alive", True),
+            hybrid_api_heartbeat_interval=getattr(
+                self, "hybrid_api_heartbeat_interval", 30.0
+            ),
+            hybrid_api_timeout=getattr(self, "hybrid_api_timeout", None),
+            hybrid_api_auth_header=getattr(self, "hybrid_api_auth_header", None),
+            hybrid_api_auto_discover_tvars=getattr(
+                self, "hybrid_api_auto_discover_tvars", False
+            ),
         )
         if js_process_pool is not None:
             self._js_process_pool = js_process_pool

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -166,6 +166,7 @@ class HybridAPIEvaluator(BaseEvaluator):
         self._discovery: ConfigSpaceDiscovery | None = None
         self._capabilities: ServiceCapabilities | None = None
         self._session_id: str | None = None
+        self._optimization_spec: dict[str, Any] | None = None
 
     @property
     def lifecycle_manager(self) -> AgentLifecycleManager | None:
@@ -176,6 +177,11 @@ class HybridAPIEvaluator(BaseEvaluator):
     def capability_id(self) -> str | None:
         """Get the capability ID (may be auto-discovered)."""
         return self._capability_id
+
+    @property
+    def optimization_spec(self) -> dict[str, Any] | None:
+        """Optimization spec discovered from external config-space metadata."""
+        return self._optimization_spec
 
     async def _get_transport(self) -> HybridTransport:
         """Get or create the transport."""
@@ -214,6 +220,7 @@ class HybridAPIEvaluator(BaseEvaluator):
             self._discovery = ConfigSpaceDiscovery(transport)
 
         config_space = await self._discovery.fetch_and_normalize()
+        self._optimization_spec = await self._discovery.build_optimization_spec()
 
         # Update capability_id if not set
         if self._capability_id is None:

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -237,9 +237,44 @@ class HybridAPIEvaluator(BaseEvaluator):
                 transport=transport,
                 heartbeat_interval=self._heartbeat_interval,
             )
-            self._session_id = self._lifecycle_manager.create_session()
+            logger.info("Started lifecycle manager for hybrid API evaluator")
+
+        # Register only when the external service has issued a real session_id.
+        # This avoids heartbeat failures against servers that do not pre-create
+        # sessions from client-generated identifiers.
+        if self._session_id:
             await self._lifecycle_manager.register(self._session_id)
-            logger.info(f"Started lifecycle management for session {self._session_id}")
+
+    @staticmethod
+    def _coerce_metric(value: Any, default: float = 0.0) -> float:
+        """Coerce a numeric metric value to float with a safe fallback."""
+        if isinstance(value, bool):
+            return default
+        if isinstance(value, (int, float)):
+            return float(value)
+        return default
+
+    @staticmethod
+    def _find_output_item(
+        outputs: list[dict[str, Any]],
+        input_id: str,
+    ) -> dict[str, Any]:
+        """Find output item for an input_id."""
+        for out in outputs:
+            if out.get("input_id") == input_id:
+                return out
+        return {}
+
+    @staticmethod
+    def _extract_target_fields(expected: Any) -> tuple[str, Any]:
+        """Return ('target'|'target_id', value) from expected output payload."""
+        if (
+            isinstance(expected, dict)
+            and "target_id" in expected
+            and "target" not in expected
+        ):
+            return "target_id", expected["target_id"]
+        return "target", expected
 
     async def evaluate(
         self,
@@ -470,24 +505,34 @@ class HybridAPIEvaluator(BaseEvaluator):
     ) -> list[HybridExampleResult]:
         """Process response in combined mode (quality metrics included)."""
         results: list[HybridExampleResult] = []
+        fallback_cost = self._coerce_metric(response.get_total_cost()) / max(
+            len(inputs), 1
+        )
+        fallback_latency = self._coerce_metric(
+            response.operational_metrics.get("latency_ms", 0.0)
+        )
 
         for i, inp in enumerate(inputs):
             input_id = inp["input_id"]
             expected = self._extract_expected(batch[i])
 
             # Find matching output
-            output_data = None
-            per_example_metrics: dict[str, float] = {}
+            output_item = self._find_output_item(response.outputs, input_id)
+            output_data = output_item.get("output")
+            if output_data is None and "output_id" in output_item:
+                output_data = {"output_id": output_item["output_id"]}
+            per_example_metrics = (
+                output_item.get("metrics", {})
+                if isinstance(output_item.get("metrics"), dict)
+                else {}
+            )
+            error = output_item.get("error")
 
-            for out in response.outputs:
-                if out.get("input_id") == input_id:
-                    output_data = out.get("output")
-                    per_example_metrics = out.get("metrics", {})
-                    break
-
-            # Get operational metrics
-            cost = response.operational_metrics.get("cost_usd", 0.0) / len(inputs)
-            latency = response.operational_metrics.get("latency_ms", 0.0)
+            # Prefer per-item metrics, fall back to aggregate execution metrics.
+            cost = self._coerce_metric(output_item.get("cost_usd"), fallback_cost)
+            latency = self._coerce_metric(
+                output_item.get("latency_ms"), fallback_latency
+            )
 
             results.append(
                 HybridExampleResult(
@@ -497,6 +542,7 @@ class HybridAPIEvaluator(BaseEvaluator):
                     metrics=per_example_metrics,
                     cost_usd=cost,
                     latency_ms=latency,
+                    error=error if isinstance(error, str) else None,
                 )
             )
 
@@ -517,19 +563,19 @@ class HybridAPIEvaluator(BaseEvaluator):
             expected = self._extract_expected(batch[i])
 
             # Find matching output
-            output_data = None
-            for out in execute_response.outputs:
-                if out.get("input_id") == input_id:
-                    output_data = out.get("output")
-                    break
+            output_item = self._find_output_item(execute_response.outputs, input_id)
 
-            evaluations.append(
-                {
-                    "input_id": input_id,
-                    "output": output_data,
-                    "target": expected,
-                }
-            )
+            evaluation: dict[str, Any] = {"input_id": input_id}
+            if "output" in output_item:
+                evaluation["output"] = output_item.get("output")
+            elif "output_id" in output_item:
+                evaluation["output_id"] = output_item.get("output_id")
+            else:
+                evaluation["output"] = None
+
+            target_key, target_value = self._extract_target_fields(expected)
+            evaluation[target_key] = target_value
+            evaluations.append(evaluation)
 
         # Call evaluate
         eval_request = HybridEvaluateRequest(
@@ -544,27 +590,38 @@ class HybridAPIEvaluator(BaseEvaluator):
 
             # Merge execute and evaluate results
             results: list[HybridExampleResult] = []
+            fallback_cost = self._coerce_metric(
+                execute_response.get_total_cost()
+            ) / max(len(inputs), 1)
+            fallback_latency = self._coerce_metric(
+                execute_response.operational_metrics.get("latency_ms", 0.0)
+            )
             for i, inp in enumerate(inputs):
                 input_id = inp["input_id"]
                 expected = self._extract_expected(batch[i])
 
                 # Find output from execute
-                output_data = None
-                for out in execute_response.outputs:
-                    if out.get("input_id") == input_id:
-                        output_data = out.get("output")
-                        break
+                output_item = self._find_output_item(execute_response.outputs, input_id)
+                output_data = output_item.get("output")
+                if output_data is None and "output_id" in output_item:
+                    output_data = {"output_id": output_item["output_id"]}
+                execute_error = output_item.get("error")
 
                 # Find metrics from evaluate
                 per_example_metrics: dict[str, float] = {}
+                eval_error: str | None = None
                 for result in eval_response.results:
                     if result.get("input_id") == input_id:
                         per_example_metrics = result.get("metrics", {})
+                        if isinstance(result.get("error"), str):
+                            eval_error = result.get("error")
                         break
 
-                # Operational metrics per example
-                cost = execute_response.get_total_cost() / len(inputs)
-                latency = execute_response.operational_metrics.get("latency_ms", 0.0)
+                # Prefer per-item operational metrics when present.
+                cost = self._coerce_metric(output_item.get("cost_usd"), fallback_cost)
+                latency = self._coerce_metric(
+                    output_item.get("latency_ms"), fallback_latency
+                )
 
                 results.append(
                     HybridExampleResult(
@@ -574,6 +631,8 @@ class HybridAPIEvaluator(BaseEvaluator):
                         metrics=per_example_metrics,
                         cost_usd=cost,
                         latency_ms=latency,
+                        error=eval_error
+                        or (execute_error if isinstance(execute_error, str) else None),
                     )
                 )
 
@@ -591,20 +650,27 @@ class HybridAPIEvaluator(BaseEvaluator):
     ) -> list[HybridExampleResult]:
         """Process response when no evaluation is available."""
         results: list[HybridExampleResult] = []
+        fallback_cost = self._coerce_metric(response.get_total_cost()) / max(
+            len(inputs), 1
+        )
+        fallback_latency = self._coerce_metric(
+            response.operational_metrics.get("latency_ms", 0.0)
+        )
 
         for i, inp in enumerate(inputs):
             input_id = inp["input_id"]
             expected = self._extract_expected(batch[i])
 
             # Find matching output
-            output_data = None
-            for out in response.outputs:
-                if out.get("input_id") == input_id:
-                    output_data = out.get("output")
-                    break
-
-            cost = response.get_total_cost() / len(inputs)
-            latency = response.operational_metrics.get("latency_ms", 0.0)
+            output_item = self._find_output_item(response.outputs, input_id)
+            output_data = output_item.get("output")
+            if output_data is None and "output_id" in output_item:
+                output_data = {"output_id": output_item["output_id"]}
+            error = output_item.get("error")
+            cost = self._coerce_metric(output_item.get("cost_usd"), fallback_cost)
+            latency = self._coerce_metric(
+                output_item.get("latency_ms"), fallback_latency
+            )
 
             results.append(
                 HybridExampleResult(
@@ -614,6 +680,7 @@ class HybridAPIEvaluator(BaseEvaluator):
                     metrics={},  # No quality metrics
                     cost_usd=cost,
                     latency_ms=latency,
+                    error=error if isinstance(error, str) else None,
                 )
             )
 

--- a/traigent/hybrid/discovery.py
+++ b/traigent/hybrid/discovery.py
@@ -8,6 +8,7 @@ and conversion to Traigent configuration space format.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from traigent.hybrid.protocol import ConfigSpaceResponse, TVARDefinition
@@ -87,13 +88,35 @@ class ConfigSpaceDiscovery:
         """
         return self._cached_response.capability_id if self._cached_response else None
 
-    def get_constraints(self) -> dict[str, list[str]] | None:
+    def get_constraints(self) -> dict[str, Any] | list[Any] | None:
         """Get constraints from cached response.
 
         Returns:
             Constraints dict if available, None if not fetched yet.
         """
         return self._cached_response.constraints if self._cached_response else None
+
+    def get_objectives(self) -> list[dict[str, Any]] | None:
+        """Get objectives from cached response."""
+        return self._cached_response.objectives if self._cached_response else None
+
+    def get_exploration(self) -> dict[str, Any] | None:
+        """Get exploration config from cached response."""
+        return self._cached_response.exploration if self._cached_response else None
+
+    def get_promotion_policy(self) -> dict[str, Any] | None:
+        """Get promotion policy from cached response."""
+        if not self._cached_response:
+            return None
+        return self._cached_response.promotion_policy
+
+    def get_defaults(self) -> dict[str, Any] | None:
+        """Get default configuration values from cached response."""
+        return self._cached_response.defaults if self._cached_response else None
+
+    def get_measures(self) -> list[str] | None:
+        """Get declared measure names from cached response."""
+        return self._cached_response.measures if self._cached_response else None
 
     def get_tvars(self) -> list[TVARDefinition]:
         """Get raw TVAR definitions from cached response.
@@ -142,6 +165,136 @@ class ConfigSpaceDiscovery:
         Call this to force re-fetching on next access.
         """
         self._cached_response = None
+
+    @staticmethod
+    def _normalize_constraints_for_parsing(
+        constraints: dict[str, Any] | list[Any] | None,
+    ) -> dict[str, Any] | list[Any] | None:
+        """Normalize hybrid constraints into TVL parser-compatible shapes."""
+        if constraints is None:
+            return None
+        if isinstance(constraints, list):
+            return constraints
+        if not isinstance(constraints, dict):
+            return None
+
+        # TVL 0.9 typed constraints shape.
+        if "structural" in constraints or "derived" in constraints:
+            return constraints
+
+        # Backward-compatible textual shape:
+        # {"hard": ["params.a > 0"], "soft": ["params.b < 2"]}.
+        legacy_rules: list[dict[str, Any]] = []
+        for group_name, group_entries in constraints.items():
+            if not isinstance(group_entries, list):
+                continue
+            for index, entry in enumerate(group_entries):
+                if isinstance(entry, str):
+                    legacy_rules.append(
+                        {
+                            "id": f"{group_name}_{index}",
+                            "type": "expression",
+                            "rule": entry,
+                            "error_message": (
+                                f"{group_name} constraint {index} violated"
+                            ),
+                        }
+                    )
+                elif isinstance(entry, dict):
+                    legacy_rules.append(entry)
+        return legacy_rules if legacy_rules else constraints
+
+    async def build_optimization_spec(self) -> dict[str, Any]:
+        """Build optimizer-compatible spec from discovered config-space metadata."""
+        from traigent.tvl.spec_loader import (
+            TVLSpecArtifact,
+            _compile_constraints_unified,
+            _parse_exploration_section,
+            _parse_objectives,
+            _parse_promotion_policy,
+            compile_constraint_expression,
+        )
+
+        response = await self.fetch()
+        constraints_input = self._normalize_constraints_for_parsing(
+            response.constraints
+        )
+
+        resolved: dict[str, Any] = {}
+        if response.objectives is not None:
+            resolved["objectives"] = response.objectives
+        if response.exploration is not None:
+            resolved["exploration"] = response.exploration
+        if response.promotion_policy is not None:
+            resolved["promotion_policy"] = response.promotion_policy
+        if constraints_input is not None:
+            resolved["constraints"] = constraints_input
+
+        objective_schema = _parse_objectives(resolved)
+        budget, algorithm, convergence, exploration_budgets, exploration_parallelism = (
+            _parse_exploration_section(resolved)
+        )
+        promotion_policy = _parse_promotion_policy(resolved.get("promotion_policy"))
+
+        pseudo_path = Path(f"hybrid-{response.capability_id or 'unknown'}-config-space")
+        compiled_constraints, derived_constraints = _compile_constraints_unified(
+            constraints_input if constraints_input is not None else [],
+            validate_constraints=True,
+            path=pseudo_path,
+        )
+        constraint_wrappers = [
+            compiled_constraint.to_callable()
+            for compiled_constraint in compiled_constraints
+        ]
+        if derived_constraints:
+            for derived_constraint in derived_constraints:
+                compiled_derived = compile_constraint_expression(
+                    derived_constraint.require,
+                    label=f"{pseudo_path}:derived_constraint_{derived_constraint.index}",
+                )
+                constraint_wrappers.append(compiled_derived)
+
+        artifact = TVLSpecArtifact(
+            path=pseudo_path,
+            environment=None,
+            configuration_space=response.to_traigent_config_space(),
+            objective_schema=objective_schema,
+            constraints=constraint_wrappers,
+            default_config=dict(response.defaults or {}),
+            metadata={
+                "source": "hybrid_api_config_space",
+                "capability_id": response.capability_id,
+                "schema_version": response.schema_version,
+            },
+            budget=budget,
+            algorithm=algorithm,
+            promotion_policy=promotion_policy,
+            tvars=None,
+            derived_constraints=derived_constraints,
+            tvl_header=None,
+            environment_snapshot=None,
+            evaluation_set=None,
+            tvl_version=response.schema_version,
+            convergence=convergence,
+            exploration_budgets=exploration_budgets,
+            exploration_parallelism=exploration_parallelism,
+            parameter_agents=None,
+        )
+
+        return {
+            "configuration_space": artifact.configuration_space,
+            "objective_schema": artifact.objective_schema,
+            "constraints": artifact.constraints,
+            "default_config": artifact.default_config,
+            "runtime_overrides": artifact.runtime_overrides(),
+            "promotion_policy": artifact.promotion_policy,
+            "measures": list(response.measures or []),
+            "derived_constraints": artifact.derived_constraints,
+        }
+
+    async def build_tvl_artifact(self) -> dict[str, Any]:
+        """Backward-compatible alias for build_optimization_spec()."""
+        return await self.build_optimization_spec()
 
 
 def normalize_tvar_to_config_space(tvar: TVARDefinition) -> Any:

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -345,8 +345,15 @@ class HTTPTransport:
                 self.KEEP_ALIVE_PATH,
                 json_data={"session_id": session_id},
             )
-            alive: bool = data.get("alive", False)
-            return alive
+            status = data.get("status")
+            if isinstance(status, str):
+                return status.lower() == "alive"
+
+            # Backward compatibility with older wrapper servers
+            if "alive" in data:
+                return bool(data.get("alive"))
+
+            return False
         except TransportError as e:
             # Session expired or invalid
             if e.status_code == 404:

--- a/traigent/hybrid/mcp_transport.py
+++ b/traigent/hybrid/mcp_transport.py
@@ -21,10 +21,7 @@ from traigent.hybrid.protocol import (
     HybridExecuteResponse,
     ServiceCapabilities,
 )
-from traigent.hybrid.transport import (
-    TransportConnectionError,
-    TransportError,
-)
+from traigent.hybrid.transport import TransportConnectionError, TransportError
 from traigent.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -310,8 +307,12 @@ class MCPTransport:
 
         try:
             data = await self._call_tool("keep_alive", {"session_id": session_id})
-            alive: bool = data.get("alive", False)
-            return alive
+            status = data.get("status")
+            if isinstance(status, str):
+                return status.lower() == "alive"
+
+            # Backward compatibility with older integrations.
+            return bool(data.get("alive", False))
         except TransportError as e:
             # Session expired or invalid
             if "not found" in str(e).lower():

--- a/traigent/hybrid/protocol.py
+++ b/traigent/hybrid/protocol.py
@@ -12,6 +12,10 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from traigent.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
 
 @dataclass(slots=True)
 class BatchOptions:
@@ -49,6 +53,19 @@ class HybridExecuteRequest:
     session_id: str | None = None
     batch_options: BatchOptions | None = None
     timeout_ms: int = 30000
+
+    def __post_init__(self) -> None:
+        """Log malformed inputs that violate the OpenAPI contract."""
+        missing_indices: list[int] = []
+        for idx, item in enumerate(self.inputs):
+            if not isinstance(item, dict) or "input_id" not in item:
+                missing_indices.append(idx)
+
+        if missing_indices:
+            logger.warning(
+                "HybridExecuteRequest inputs missing required input_id at indices %s",
+                missing_indices,
+            )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dictionary."""
@@ -166,7 +183,8 @@ class HybridEvaluateResponse:
     request_id: str
     status: Literal["completed", "partial", "failed"]
     results: list[dict[str, Any]]
-    aggregate_metrics: dict[str, dict[str, float]]
+    aggregate_metrics: dict[str, dict[str, float | int]]
+    error: dict[str, Any] | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> HybridEvaluateResponse:
@@ -176,6 +194,7 @@ class HybridEvaluateResponse:
             status=data["status"],
             results=data.get("results", []),
             aggregate_metrics=data.get("aggregate_metrics", {}),
+            error=data.get("error"),
         )
 
 
@@ -242,10 +261,22 @@ class TVARDefinition:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TVARDefinition:
         """Create from dictionary (API response)."""
+        domain = data.get("domain", {})
+        if not isinstance(domain, dict):
+            domain = {}
+
+        # Accept wrapper-friendly top-level values/range/resolution keys.
+        if "values" in data and "values" not in domain:
+            domain["values"] = data["values"]
+        if "range" in data and "range" not in domain:
+            domain["range"] = data["range"]
+        if "resolution" in data and "resolution" not in domain:
+            domain["resolution"] = data["resolution"]
+
         return cls(
             name=data["name"],
             type=data["type"],
-            domain=data.get("domain", {}),
+            domain=domain,
             default=data.get("default"),
             agent=data.get("agent"),
             is_tool=data.get("is_tool", False),

--- a/traigent/hybrid/protocol.py
+++ b/traigent/hybrid/protocol.py
@@ -329,13 +329,23 @@ class ConfigSpaceResponse:
         schema_version: TVL schema version (e.g., "0.9")
         capability_id: Identifier for the capability
         tvars: List of TVAR definitions (also accessible as 'tunables')
-        constraints: Structural and behavioral constraints
+        constraints: Structural and behavioral constraints (legacy or typed TVL 0.9)
+        objectives: Optional objective definitions (TVL 0.9 compatible JSON)
+        exploration: Optional exploration config (strategy, budgets, convergence)
+        promotion_policy: Optional promotion policy definition
+        defaults: Optional default configuration values
+        measures: Optional metric names produced by the service
     """
 
     schema_version: str
     capability_id: str
     tvars: list[TVARDefinition]
-    constraints: dict[str, list[str]] | None = None
+    constraints: dict[str, Any] | list[Any] | None = None
+    objectives: list[dict[str, Any]] | None = None
+    exploration: dict[str, Any] | None = None
+    promotion_policy: dict[str, Any] | None = None
+    defaults: dict[str, Any] | None = None
+    measures: list[str] | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ConfigSpaceResponse:
@@ -353,6 +363,11 @@ class ConfigSpaceResponse:
             capability_id=data.get("capability_id", ""),
             tvars=tvars,
             constraints=data.get("constraints"),
+            objectives=data.get("objectives"),
+            exploration=data.get("exploration"),
+            promotion_policy=data.get("promotion_policy"),
+            defaults=data.get("defaults"),
+            measures=data.get("measures"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -372,13 +387,24 @@ class ConfigSpaceResponse:
             }
             for tvar in self.tvars
         ]
-        return {
+        result: dict[str, Any] = {
             "schema_version": self.schema_version,
             "capability_id": self.capability_id,
             "tunables": tvar_dicts,  # Client-facing name
             "tvars": tvar_dicts,  # Backward compatibility
             "constraints": self.constraints or {},
         }
+        if self.objectives is not None:
+            result["objectives"] = self.objectives
+        if self.exploration is not None:
+            result["exploration"] = self.exploration
+        if self.promotion_policy is not None:
+            result["promotion_policy"] = self.promotion_policy
+        if self.defaults is not None:
+            result["defaults"] = self.defaults
+        if self.measures is not None:
+            result["measures"] = self.measures
+        return result
 
     @property
     def tunables(self) -> list[TVARDefinition]:

--- a/traigent/tvl/promotion_gate.py
+++ b/traigent/tvl/promotion_gate.py
@@ -480,14 +480,26 @@ class PromotionGate:
         Returns:
             PromotionGate if promotion policy is defined, None otherwise.
         """
-        if artifact.promotion_policy is None:
+        return cls.from_policy(
+            promotion_policy=getattr(artifact, "promotion_policy", None),
+            objective_schema=getattr(artifact, "objective_schema", None),
+        )
+
+    @classmethod
+    def from_policy(
+        cls,
+        promotion_policy: PromotionPolicy | None,
+        objective_schema: Any | None,
+    ) -> PromotionGate | None:
+        """Create a PromotionGate from policy + objective schema."""
+        if promotion_policy is None:
             return None
 
-        # Build objective specs from the artifact's objective_schema
+        # Build objective specs from the objective schema.
         objectives: list[ObjectiveSpec] = []
 
-        if artifact.objective_schema is not None:
-            for obj_def in artifact.objective_schema.objectives:
+        if objective_schema is not None:
+            for obj_def in objective_schema.objectives:
                 # obj_def is an ObjectiveDefinition, not a dict
                 band = obj_def.band  # Already a BandTarget or None
                 band_alpha = obj_def.band_alpha if obj_def.band_alpha else 0.05
@@ -501,4 +513,4 @@ class PromotionGate:
                     )
                 )
 
-        return cls(artifact.promotion_policy, objectives)
+        return cls(promotion_policy, objectives)

--- a/traigent/utils/local_analytics.py
+++ b/traigent/utils/local_analytics.py
@@ -469,11 +469,6 @@ def collect_and_submit_analytics(config: TraigentConfig) -> None:
     This function is designed to work from both sync and async contexts.
     It runs analytics submission in the background without blocking.
     """
-    from traigent.utils.env_config import is_mock_llm
-
-    if is_mock_llm():
-        return
-
     if not config.enable_usage_analytics or config.execution_mode not in {
         ExecutionMode.EDGE_ANALYTICS.value,
     }:

--- a/traigent/wrapper/server.py
+++ b/traigent/wrapper/server.py
@@ -29,6 +29,19 @@ HEALTH_PATH = "/traigent/v1/health"
 KEEP_ALIVE_PATH = "/traigent/v1/keep-alive"
 
 
+def _make_error_response(
+    code: str,
+    message: str,
+    *,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build contract-compliant error payload."""
+    error: dict[str, Any] = {"code": code, "message": message}
+    if details:
+        error["details"] = details
+    return {"error": error}
+
+
 def create_app(service: TraigentService) -> Callable[..., Any]:
     """Create ASGI application for TraigentService.
 
@@ -79,26 +92,57 @@ def create_app(service: TraigentService) -> Callable[..., Any]:
                 session_id = request.get("session_id", "")
                 alive = service.handle_keep_alive(session_id)
                 if alive:
-                    await send_json_response(send, 200, {"alive": True})
+                    await send_json_response(
+                        send,
+                        200,
+                        {
+                            "status": "alive",
+                            "session_id": session_id,
+                        },
+                    )
                 else:
-                    await send_json_response(send, 404, {"alive": False})
+                    await send_json_response(
+                        send,
+                        404,
+                        _make_error_response(
+                            "SESSION_NOT_FOUND",
+                            f"Session not found: {session_id}",
+                        ),
+                    )
 
             else:
                 await send_json_response(
-                    send, 404, {"error": f"Not found: {method} {path}"}
+                    send,
+                    404,
+                    _make_error_response(
+                        "NOT_FOUND",
+                        f"Not found: {method} {path}",
+                    ),
                 )
 
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in request: {e}")
-            await send_json_response(send, 400, {"error": f"Invalid JSON: {e}"})
+            await send_json_response(
+                send,
+                400,
+                _make_error_response("INVALID_JSON", f"Invalid JSON: {e}"),
+            )
 
         except ValueError as e:
             logger.error(f"Request error: {e}")
-            await send_json_response(send, 400, {"error": str(e)})
+            await send_json_response(
+                send,
+                400,
+                _make_error_response("INVALID_REQUEST", str(e)),
+            )
 
         except Exception as e:
             logger.error(f"Internal error: {e}")
-            await send_json_response(send, 500, {"error": str(e)})
+            await send_json_response(
+                send,
+                500,
+                _make_error_response("INTERNAL_ERROR", str(e)),
+            )
 
     return app
 

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -142,6 +142,7 @@ class TraigentService:
 
         # Session management
         self._sessions: dict[str, Session] = {}
+        self._started_at: float = time.time()
 
         # Cached config space
         self._cached_tvars: dict[str, Any] | None = None
@@ -226,34 +227,59 @@ class TraigentService:
         """Get TVAR definitions.
 
         Returns:
-            Dictionary with schema_version, capability_id, and tvars.
+            Dictionary with schema_version, capability_id, and tunables.
         """
         if self._cached_tvars is None and self._tvars_handler is not None:
             tvars_dict = self._tvars_handler()
+            if not isinstance(tvars_dict, dict):
+                raise ValueError("tunables handler must return a dict")
             # Convert to TVL format if needed
             self._cached_tvars = self._normalize_tvars(tvars_dict)
 
         tvars = self._cached_tvars or {}
+        tunables = [{"name": name, **spec} for name, spec in tvars.items()]
 
         return {
             "schema_version": self.config.schema_version,
             "capability_id": self.config.capability_id,
-            "tvars": [{"name": name, **spec} for name, spec in tvars.items()],
+            "tunables": tunables,
+            "tvars": tunables,  # Backward compatibility alias
             "constraints": {},
         }
 
     def _normalize_tvars(self, tvars: dict[str, Any]) -> dict[str, Any]:
         """Normalize TVAR definitions to TVL format."""
-        normalized = {}
+        normalized: dict[str, dict[str, Any]] = {}
         for name, spec in tvars.items():
             if isinstance(spec, dict):
-                normalized[name] = spec
+                normalized_spec = dict(spec)
+                domain = normalized_spec.get("domain", {})
+                if not isinstance(domain, dict):
+                    domain = {}
+
+                # Accept wrapper-friendly top-level values/range/resolution and
+                # normalize to contract-compliant nested domain shape.
+                if "values" in normalized_spec and "values" not in domain:
+                    domain["values"] = normalized_spec.pop("values")
+                if "range" in normalized_spec and "range" not in domain:
+                    domain["range"] = normalized_spec.pop("range")
+                if "resolution" in normalized_spec and "resolution" not in domain:
+                    domain["resolution"] = normalized_spec.pop("resolution")
+
+                if domain:
+                    normalized_spec["domain"] = domain
+
+                normalized[name] = normalized_spec
             elif isinstance(spec, list):
                 # List of values -> enum type
                 normalized[name] = {"type": "enum", "domain": {"values": spec}}
             else:
                 # Scalar default value
-                normalized[name] = {"type": "str", "default": spec}
+                normalized[name] = {
+                    "type": "str",
+                    "domain": {"values": [spec]},
+                    "default": spec,
+                }
         return normalized
 
     def get_capabilities(self) -> dict[str, Any]:
@@ -268,6 +294,7 @@ class TraigentService:
             "supports_keep_alive": self.config.supports_keep_alive,
             "supports_streaming": self.config.supports_streaming,
             "max_batch_size": self.config.max_batch_size,
+            "max_payload_bytes": None,
         }
 
     def get_health(self) -> dict[str, Any]:
@@ -276,11 +303,15 @@ class TraigentService:
         Returns:
             Dictionary with status and details.
         """
+        uptime_seconds = max(0.0, time.time() - self._started_at)
         return {
             "status": "healthy",
             "version": self.config.version,
-            "capability_id": self.config.capability_id,
-            "active_sessions": len(self._sessions),
+            "uptime_seconds": uptime_seconds,
+            "details": {
+                "capability_id": self.config.capability_id,
+                "active_sessions": len(self._sessions),
+            },
         }
 
     async def handle_execute(
@@ -305,21 +336,29 @@ class TraigentService:
         # capability_id from request (default to self.config.capability_id)
         _ = request.get("capability_id", self.config.capability_id)
         config = request.get("config", {})
-        inputs = request.get("inputs", [])
+        inputs = request.get("inputs")
         session_id = request.get("session_id")
 
+        if not isinstance(inputs, list) or len(inputs) == 0:
+            raise ValueError("inputs must be a non-empty list")
+
         # Update session if provided
-        if session_id and session_id in self._sessions:
-            self._sessions[session_id].touch()
+        if session_id:
+            self._touch_or_create_session(session_id)
 
         start_time = time.time()
         outputs: list[dict[str, Any]] = []
         total_cost = 0.0
         all_quality_metrics: list[dict[str, float]] = []
+        failed_input_ids: list[str] = []
 
         for inp in inputs:
-            input_id = inp.get("input_id", str(uuid.uuid4()))
-            data = inp.get("data", inp)
+            if isinstance(inp, dict):
+                input_id = str(inp.get("input_id", str(uuid.uuid4())))
+                data = inp.get("data", inp)
+            else:
+                input_id = str(uuid.uuid4())
+                data = inp
 
             try:
                 # Call handler
@@ -330,28 +369,38 @@ class TraigentService:
                 # Extract output and metrics
                 if isinstance(result, dict):
                     output = result.get("output", result)
-                    cost = result.get("cost_usd", 0.0)
-                    metrics = result.get("metrics", {})
+                    cost = float(result.get("cost_usd", 0.0) or 0.0)
+                    latency_ms = result.get("latency_ms")
+                    metrics = (
+                        result.get("metrics")
+                        if isinstance(result.get("metrics"), dict)
+                        else {}
+                    )
                 else:
                     output = result
                     cost = 0.0
+                    latency_ms = None
                     metrics = {}
 
                 total_cost += cost
                 if metrics:
                     all_quality_metrics.append(metrics)
 
-                outputs.append(
-                    {
-                        "input_id": input_id,
-                        "output": output,
-                        "cost_usd": cost,
-                        "metrics": metrics,
-                    }
-                )
+                output_item: dict[str, Any] = {
+                    "input_id": input_id,
+                    "output": output,
+                    "cost_usd": cost,
+                }
+                if isinstance(latency_ms, (int, float)):
+                    output_item["latency_ms"] = float(latency_ms)
+                if metrics:
+                    output_item["metrics"] = metrics
+
+                outputs.append(output_item)
 
             except Exception as e:
                 logger.error(f"Execute failed for {input_id}: {e}")
+                failed_input_ids.append(input_id)
                 outputs.append(
                     {
                         "input_id": input_id,
@@ -360,11 +409,18 @@ class TraigentService:
                 )
 
         elapsed_ms = (time.time() - start_time) * 1000
+        successful_outputs = len(outputs) - len(failed_input_ids)
+        if successful_outputs == 0 and outputs:
+            status = "failed"
+        elif failed_input_ids:
+            status = "partial"
+        else:
+            status = "completed"
 
         response: dict[str, Any] = {
             "request_id": request_id,
             "execution_id": str(uuid.uuid4()),
-            "status": "completed",
+            "status": status,
             "outputs": outputs,
             "operational_metrics": {
                 "total_cost_usd": total_cost,
@@ -372,6 +428,17 @@ class TraigentService:
                 "latency_ms": elapsed_ms,
             },
         }
+
+        if failed_input_ids:
+            response["error"] = {
+                "code": (
+                    "EXECUTION_PARTIAL_FAILURE"
+                    if status == "partial"
+                    else "EXECUTION_FAILED"
+                ),
+                "message": "One or more inputs failed during execution",
+                "failed_inputs": failed_input_ids,
+            }
 
         # Include quality metrics if available (combined mode)
         if all_quality_metrics:
@@ -405,17 +472,25 @@ class TraigentService:
         config = request.get("config", {})
         session_id = request.get("session_id")
 
+        if not isinstance(evaluations, list):
+            raise ValueError("evaluations must be a list")
+
         # Update session if provided
-        if session_id and session_id in self._sessions:
-            self._sessions[session_id].touch()
+        if session_id:
+            self._touch_or_create_session(session_id)
 
         results: list[dict[str, Any]] = []
         all_metrics: list[dict[str, float]] = []
+        failed_input_ids: list[str] = []
 
         for evaluation in evaluations:
             input_id = evaluation.get("input_id", str(uuid.uuid4()))
             output = evaluation.get("output")
+            if output is None and "output_id" in evaluation:
+                output = {"output_id": evaluation["output_id"]}
             target = evaluation.get("target")
+            if target is None and "target_id" in evaluation:
+                target = {"target_id": evaluation["target_id"]}
 
             try:
                 # Call handler
@@ -435,19 +510,40 @@ class TraigentService:
 
             except Exception as e:
                 logger.error(f"Evaluate failed for {input_id}: {e}")
+                failed_input_ids.append(input_id)
                 results.append(
                     {
                         "input_id": input_id,
+                        "metrics": {},
                         "error": str(e),
                     }
                 )
 
+        successful_results = len(results) - len(failed_input_ids)
+        if successful_results == 0 and results:
+            status = "failed"
+        elif failed_input_ids:
+            status = "partial"
+        else:
+            status = "completed"
+
         response: dict[str, Any] = {
             "request_id": request_id,
-            "status": "completed",
+            "status": status,
             "results": results,
             "aggregate_metrics": self._compute_aggregate_metrics(all_metrics),
         }
+
+        if failed_input_ids:
+            response["error"] = {
+                "code": (
+                    "EVALUATION_PARTIAL_FAILURE"
+                    if status == "partial"
+                    else "EVALUATION_FAILED"
+                ),
+                "message": "One or more items failed during evaluation",
+                "failed_inputs": failed_input_ids,
+            }
 
         return response
 
@@ -477,20 +573,22 @@ class TraigentService:
 
     def _compute_aggregate_metrics(
         self, metrics_list: list[dict[str, float]]
-    ) -> dict[str, dict[str, float]]:
+    ) -> dict[str, dict[str, float | int]]:
         """Compute aggregate statistics (mean, std, n) for each metric."""
         if not metrics_list:
             return {}
 
-        aggregates: dict[str, dict[str, float]] = {}
+        aggregates: dict[str, dict[str, float | int]] = {}
 
         # Collect values by metric name
         values_by_metric: dict[str, list[float]] = {}
         for metrics in metrics_list:
             for name, value in metrics.items():
+                if not isinstance(value, (int, float)) or isinstance(value, bool):
+                    continue
                 if name not in values_by_metric:
                     values_by_metric[name] = []
-                values_by_metric[name].append(value)
+                values_by_metric[name].append(float(value))
 
         # Compute stats
         import statistics
@@ -499,7 +597,7 @@ class TraigentService:
             n = len(values)
             mean = sum(values) / n
             std = statistics.stdev(values) if n > 1 else 0.0
-            aggregates[name] = {"mean": mean, "std": std, "n": float(n)}
+            aggregates[name] = {"mean": mean, "std": std, "n": n}
 
         return aggregates
 
@@ -512,19 +610,34 @@ class TraigentService:
         Returns:
             True if session is alive, False if not found.
         """
-        if session_id not in self._sessions:
+        if not self.config.supports_keep_alive:
             return False
 
-        self._sessions[session_id].touch()
+        return self._touch_or_create_session(session_id)
+
+    def _touch_or_create_session(self, session_id: str) -> bool:
+        """Touch an existing session or create it when keep-alive is enabled."""
+        if not session_id:
+            return False
+
+        session = self._sessions.get(session_id)
+        if session is not None:
+            session.touch()
+            return True
+
+        if not self.config.supports_keep_alive:
+            return False
+
+        self._sessions[session_id] = Session(session_id=session_id)
         return True
 
-    def create_session(self) -> str:
+    def create_session(self, session_id: str | None = None) -> str:
         """Create a new session.
 
         Returns:
             New session ID.
         """
-        session_id = str(uuid.uuid4())
+        session_id = session_id or str(uuid.uuid4())
         self._sessions[session_id] = Session(session_id=session_id)
         return session_id
 

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -58,6 +58,12 @@ class ServiceConfig:
         supports_streaming: Whether to enable streaming support.
         max_batch_size: Maximum inputs per execute request.
         schema_version: TVL schema version.
+        constraints: Optional constraints (legacy textual or typed TVL 0.9 format).
+        objectives: Optional objective definitions.
+        exploration: Optional exploration configuration.
+        promotion_policy: Optional promotion policy definition.
+        defaults: Optional default configuration values.
+        measures: Optional declared measure names.
     """
 
     capability_id: str = "default"
@@ -66,6 +72,12 @@ class ServiceConfig:
     supports_streaming: bool = False
     max_batch_size: int = 100
     schema_version: str = "0.9"
+    constraints: dict[str, Any] | list[Any] | None = None
+    objectives: list[dict[str, Any]] | None = None
+    exploration: dict[str, Any] | None = None
+    promotion_policy: dict[str, Any] | None = None
+    defaults: dict[str, Any] | None = None
+    measures: list[str] | None = None
 
 
 @dataclass
@@ -117,6 +129,12 @@ class TraigentService:
         supports_keep_alive: bool = False,
         supports_streaming: bool = False,
         max_batch_size: int = 100,
+        constraints: dict[str, Any] | list[Any] | None = None,
+        objectives: list[dict[str, Any]] | None = None,
+        exploration: dict[str, Any] | None = None,
+        promotion_policy: dict[str, Any] | None = None,
+        defaults: dict[str, Any] | None = None,
+        measures: list[str] | None = None,
     ) -> None:
         """Initialize TraigentService.
 
@@ -126,6 +144,12 @@ class TraigentService:
             supports_keep_alive: Whether to enable keep-alive support.
             supports_streaming: Whether to enable streaming support.
             max_batch_size: Maximum inputs per execute request.
+            constraints: Optional constraints config.
+            objectives: Optional objective definitions.
+            exploration: Optional exploration configuration.
+            promotion_policy: Optional promotion policy.
+            defaults: Optional default tunable values.
+            measures: Optional declared measure names.
         """
         self.config = ServiceConfig(
             capability_id=capability_id,
@@ -133,12 +157,26 @@ class TraigentService:
             supports_keep_alive=supports_keep_alive,
             supports_streaming=supports_streaming,
             max_batch_size=max_batch_size,
+            constraints=constraints,
+            objectives=objectives,
+            exploration=exploration,
+            promotion_policy=promotion_policy,
+            defaults=defaults,
+            measures=measures,
         )
 
         # Registered handlers
         self._tvars_handler: Callable[[], dict[str, Any]] | None = None
         self._execute_handler: Callable[..., Any] | None = None
         self._evaluate_handler: Callable[..., Any] | None = None
+        self._constraints_handler: Callable[[], dict[str, Any] | list[Any]] | None = (
+            None
+        )
+        self._objectives_handler: Callable[[], list[dict[str, Any]]] | None = None
+        self._exploration_handler: Callable[[], dict[str, Any]] | None = None
+        self._promotion_policy_handler: Callable[[], dict[str, Any]] | None = None
+        self._defaults_handler: Callable[[], dict[str, Any]] | None = None
+        self._measures_handler: Callable[[], list[str]] | None = None
 
         # Session management
         self._sessions: dict[str, Session] = {}
@@ -223,6 +261,49 @@ class TraigentService:
         self._evaluate_handler = func
         return func
 
+    def constraints(self, func: F) -> F:
+        """Decorator to register constraints declaration function."""
+        self._constraints_handler = func  # type: ignore[assignment]
+        return func
+
+    def objectives(self, func: F) -> F:
+        """Decorator to register objectives declaration function."""
+        self._objectives_handler = func  # type: ignore[assignment]
+        return func
+
+    def exploration(self, func: F) -> F:
+        """Decorator to register exploration declaration function."""
+        self._exploration_handler = func  # type: ignore[assignment]
+        return func
+
+    def promotion_policy(self, func: F) -> F:
+        """Decorator to register promotion policy declaration function."""
+        self._promotion_policy_handler = func  # type: ignore[assignment]
+        return func
+
+    def defaults(self, func: F) -> F:
+        """Decorator to register default-config declaration function."""
+        self._defaults_handler = func  # type: ignore[assignment]
+        return func
+
+    def measures(self, func: F) -> F:
+        """Decorator to register declared measure names function."""
+        self._measures_handler = func  # type: ignore[assignment]
+        return func
+
+    def _resolve_declared_section(
+        self,
+        handler: Callable[[], Any] | None,
+        configured: Any,
+    ) -> Any:
+        """Resolve section value from decorator handler or constructor config."""
+        if handler is None:
+            return configured
+        value = handler()
+        if inspect.isawaitable(value):
+            raise ValueError("declaration handlers must be synchronous functions")
+        return value
+
     def get_config_space(self) -> dict[str, Any]:
         """Get TVAR definitions.
 
@@ -238,14 +319,65 @@ class TraigentService:
 
         tvars = self._cached_tvars or {}
         tunables = [{"name": name, **spec} for name, spec in tvars.items()]
+        constraints = self._resolve_declared_section(
+            self._constraints_handler,
+            self.config.constraints,
+        )
+        objectives = self._resolve_declared_section(
+            self._objectives_handler,
+            self.config.objectives,
+        )
+        exploration = self._resolve_declared_section(
+            self._exploration_handler,
+            self.config.exploration,
+        )
+        promotion_policy = self._resolve_declared_section(
+            self._promotion_policy_handler,
+            self.config.promotion_policy,
+        )
+        defaults = self._resolve_declared_section(
+            self._defaults_handler,
+            self.config.defaults,
+        )
+        measures = self._resolve_declared_section(
+            self._measures_handler,
+            self.config.measures,
+        )
 
-        return {
+        if constraints is not None and not isinstance(constraints, (dict, list)):
+            raise ValueError("constraints must be a dict or list")
+        if objectives is not None and not isinstance(objectives, list):
+            raise ValueError("objectives must be a list")
+        if exploration is not None and not isinstance(exploration, dict):
+            raise ValueError("exploration must be a dict")
+        if promotion_policy is not None and not isinstance(promotion_policy, dict):
+            raise ValueError("promotion_policy must be a dict")
+        if defaults is not None and not isinstance(defaults, dict):
+            raise ValueError("defaults must be a dict")
+        if measures is not None and (
+            not isinstance(measures, list)
+            or not all(isinstance(measure, str) for measure in measures)
+        ):
+            raise ValueError("measures must be a list of strings")
+
+        response: dict[str, Any] = {
             "schema_version": self.config.schema_version,
             "capability_id": self.config.capability_id,
             "tunables": tunables,
             "tvars": tunables,  # Backward compatibility alias
-            "constraints": {},
+            "constraints": constraints or {},
         }
+        if objectives is not None:
+            response["objectives"] = objectives
+        if exploration is not None:
+            response["exploration"] = exploration
+        if promotion_policy is not None:
+            response["promotion_policy"] = promotion_policy
+        if defaults is not None:
+            response["defaults"] = defaults
+        if measures is not None:
+            response["measures"] = measures
+        return response
 
     def _normalize_tvars(self, tvars: dict[str, Any]) -> dict[str, Any]:
         """Normalize TVAR definitions to TVL format."""

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -398,7 +398,7 @@ class TraigentService:
                 if "resolution" in normalized_spec and "resolution" not in domain:
                     domain["resolution"] = normalized_spec.pop("resolution")
 
-                if domain:
+                if domain is not None:
                     normalized_spec["domain"] = domain
 
                 normalized[name] = normalized_spec

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -299,8 +299,14 @@ class TraigentService:
         """Resolve section value from decorator handler or constructor config."""
         if handler is None:
             return configured
+        if inspect.iscoroutinefunction(handler):
+            raise ValueError("declaration handlers must be synchronous functions")
         value = handler()
         if inspect.isawaitable(value):
+            # Defensive: close accidental coroutine objects to avoid runtime warnings.
+            close = getattr(value, "close", None)
+            if callable(close):
+                close()
             raise ValueError("declaration handlers must be synchronous functions")
         return value
 


### PR DESCRIPTION
## Summary
- **Declarative optimization parity**: Hybrid API services can now declare objectives, exploration budgets, convergence criteria, promotion policies, defaults, and measures via `ConfigSpaceResponse` — achieving full feature parity with SDK decorator users
- **OpenAPI contract hardening**: Extended `hybrid-mode-openapi.yaml` with `ObjectiveDefinition`, `ExplorationConfig`, `PromotionPolicy`, and related schemas; hardened execution option resolution and transport wiring
- **Runtime discovery wiring**: `ConfigSpaceDiscovery.build_optimization_spec()` bridges hybrid API declarations into the existing TVL spec pipeline (`_apply_tvl_options_if_present`)
- **Test coverage**: 95.4% new-code coverage (641/672 lines) across all changed files, with targeted tests for trial operations, config types, discovery, transports, wrapper service/server

## Commits
- `edfe28e` fix: Repair broken CI workflows and mock-mode analytics hang (#102)
- `476c809` fix: seamless injection context + Codex audit remediation (#103)
- `144e1dc` Align hybrid API contract and Traigent integration flow
- `3f1a6fb` feat: add declarative optimization parity and runtime discovery wiring
- `f93d3ee` refactor: harden execution option resolution and transport wiring
- `d907dd3` fix: address review findings in docs and declaration/runtime safety
- `f7fe23a` test: add coverage for hybrid API feature parity new code paths

## Files changed
- **Protocol**: `hybrid/protocol.py` — objectives, exploration, promotion_policy, defaults, measures on `ConfigSpaceResponse`
- **Discovery**: `hybrid/discovery.py` — getters + `build_optimization_spec()` bridging to TVL pipeline
- **Wrapper**: `wrapper/service.py`, `wrapper/server.py` — init params, decorators, config-space response, validation
- **Evaluator**: `evaluators/hybrid_api.py` — extracts optimization spec during discovery
- **OpenAPI**: `docs/hybrid-mode-openapi.yaml` — 6 new component schemas
- **Tests**: 8 test files with 700+ lines of new coverage tests

## Test plan
- [x] All 10,362 unit tests passing (`pytest tests/unit/ -v`)
- [x] New-code coverage ≥ 85% on all changed files (actual: 95.4%)
- [x] Pre-commit hooks passing (isort, black, ruff, detect-secrets, bandit)
- [ ] CI pipeline (SonarCloud, GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)