### PR TITLE
feat(cost): canonical cost paths and integration extraction tests

### DIFF
--- a/tests/integration/test_cost_privacy_integration.py
+++ b/tests/integration/test_cost_privacy_integration.py
@@ -201,7 +201,7 @@ def test_error_visibility_in_cost_calculation():
 
 
 def test_token_estimation_with_tiktoken():
-    """Test improved token estimation using tiktoken."""
+    """No post-call token estimation should occur without usage metadata."""
     from traigent.evaluators.metrics_tracker import CostCalculator
 
     calculator = CostCalculator()
@@ -211,7 +211,8 @@ def test_token_estimation_with_tiktoken():
     prompt_length = 100  # characters
     response_length = 200  # characters
 
-    # This will use tiktoken if available, otherwise fallback
+    # With no token usage metadata and no raw prompt/response text provided,
+    # post-call tracking must not invent token counts heuristically.
     calculator._try_unified_cost_calculation(
         metrics,
         model_name="gpt-4o-mini",
@@ -221,19 +222,10 @@ def test_token_estimation_with_tiktoken():
         response_length=response_length,
     )
 
-    # Verify tokens were estimated
-    assert metrics.tokens.input_tokens > 0
-    assert metrics.tokens.output_tokens > 0
-    assert (
-        metrics.tokens.total_tokens
-        == metrics.tokens.input_tokens + metrics.tokens.output_tokens
-    )
-
-    # With better estimation, should be roughly 0.25 * length
-    assert (
-        metrics.tokens.input_tokens <= prompt_length // 2
-    )  # Should be less than simple /4
-    assert metrics.tokens.output_tokens <= response_length // 2
+    assert metrics.tokens.input_tokens == 0
+    assert metrics.tokens.output_tokens == 0
+    assert metrics.tokens.total_tokens == 0
+    assert metrics.cost.total_cost == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/optimizer_validation/tools/lint_pricing_consistency.py
+++ b/tests/optimizer_validation/tools/lint_pricing_consistency.py
@@ -270,7 +270,7 @@ class PricingLinter(ast.NodeVisitor):
                         message=(
                             f"Variable '{name}' looks like a pricing table. "
                             "Ensure it derives from "
-                            "traigent.utils.cost_calculator.FALLBACK_MODEL_PRICING."
+                            "traigent.utils.cost_calculator.ESTIMATION_MODEL_PRICING."
                         ),
                     )
                 )

--- a/tests/unit/architecture/test_pricing_consistency.py
+++ b/tests/unit/architecture/test_pricing_consistency.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from traigent.utils.cost_calculator import (
-    FALLBACK_MODEL_PRICING,
+    ESTIMATION_MODEL_PRICING,
     CostCalculator,
     _fallback_cost_from_tokens,
 )
@@ -86,7 +86,7 @@ class TestPlatformsCostMatchesCalculator:
 
 class TestValidatorModelsResolvable:
     """Every model in hooks/validator.MODEL_COST_PER_1K must trace back to
-    FALLBACK_MODEL_PRICING — either directly or as an alias whose cost
+    ESTIMATION_MODEL_PRICING — either directly or as an alias whose cost
     matches a canonical entry.
     """
 
@@ -94,17 +94,17 @@ class TestValidatorModelsResolvable:
     def test_all_validator_models_resolvable(self) -> None:
         from traigent.hooks.validator import MODEL_COST_PER_1K
 
-        # Build set of valid per-1K costs derived from FALLBACK_MODEL_PRICING.
+        # Build set of valid per-1K costs derived from ESTIMATION_MODEL_PRICING.
         # Any alias in MODEL_COST_PER_1K must have a cost matching one of these.
         canonical_per_1k = set()
-        for p in FALLBACK_MODEL_PRICING.values():
+        for p in ESTIMATION_MODEL_PRICING.values():
             avg = (p["input_cost_per_token"] + p["output_cost_per_token"]) / 2
             canonical_per_1k.add(round(avg * 1000, 12))
 
         unresolvable = []
         for model, cost in MODEL_COST_PER_1K.items():
-            # Direct entry in FALLBACK_MODEL_PRICING
-            if model in FALLBACK_MODEL_PRICING:
+            # Direct entry in ESTIMATION_MODEL_PRICING
+            if model in ESTIMATION_MODEL_PRICING:
                 continue
             # Alias — cost must match a canonical entry
             if round(cost, 12) in canonical_per_1k:
@@ -113,8 +113,8 @@ class TestValidatorModelsResolvable:
 
         assert not unresolvable, (
             f"These validator.py models are not traceable to "
-            f"FALLBACK_MODEL_PRICING: {unresolvable}. "
-            f"Add them to FALLBACK_MODEL_PRICING or as aliases in "
+            f"ESTIMATION_MODEL_PRICING: {unresolvable}. "
+            f"Add them to ESTIMATION_MODEL_PRICING or as aliases in "
             f"_build_model_cost_per_1k()."
         )
 
@@ -145,11 +145,11 @@ class TestValidatorCostMatchesCalculator:
         mismatches = []
 
         for model, per_1k_cost in MODEL_COST_PER_1K.items():
-            # Only compare models directly in FALLBACK_MODEL_PRICING.
+            # Only compare models directly in ESTIMATION_MODEL_PRICING.
             # Aliases (gpt-4, gpt-4-32k, etc.) intentionally map to different
             # canonical models for cost estimation, so they'll diverge from
             # what CostCalculator resolves for the alias name.
-            if model not in FALLBACK_MODEL_PRICING:
+            if model not in ESTIMATION_MODEL_PRICING:
                 continue
 
             canonical = _canonical_cost(model)
@@ -198,9 +198,7 @@ class TestHandlerFallbackMatchesCalculator:
 
         mismatches = []
         for model in models_to_test:
-            handler_cost = handler._fallback_cost_estimate(
-                model, INPUT_TOKENS, OUTPUT_TOKENS
-            )
+            handler_cost = handler._estimate_cost(model, INPUT_TOKENS, OUTPUT_TOKENS)
             canonical = _canonical_cost(model)
             if canonical == 0:
                 continue
@@ -257,7 +255,7 @@ class TestIntelligenceFallbackMatchesCalculator:
     Exercises the ImportError fallback in fetch_current_pricing() by
     temporarily removing get_model_pricing_per_1k from the cost_calculator
     module namespace. The fallback derives per-1K rates from
-    FALLBACK_MODEL_PRICING, so the test verifies those match canonical.
+    ESTIMATION_MODEL_PRICING, so the test verifies those match canonical.
     """
 
     @pytest.mark.unit

--- a/tests/unit/integrations/langchain/test_langchain_handler.py
+++ b/tests/unit/integrations/langchain/test_langchain_handler.py
@@ -804,77 +804,44 @@ class TestCostEstimation:
 
         return TraigentHandler(trace_id="test-trace")
 
-    def test_fallback_cost_estimate_gpt4o(self, handler):
-        """Test fallback cost estimation for GPT-4o model."""
-        cost = handler._fallback_cost_estimate("gpt-4o", 1000, 500)
-        # GPT-4o: $2.50/1M input, $10.00/1M output
-        expected = (1000 * 2.50 + 500 * 10.00) / 1_000_000
-        assert cost == pytest.approx(expected)
-
-    def test_fallback_cost_estimate_gpt35_turbo(self, handler):
-        """Test fallback cost estimation for GPT-3.5-turbo model."""
-        cost = handler._fallback_cost_estimate("gpt-3.5-turbo", 1000, 500)
-        # GPT-3.5-turbo: $0.50/1M input, $1.50/1M output
-        expected = (1000 * 0.50 + 500 * 1.50) / 1_000_000
-        assert cost == pytest.approx(expected)
-
-    def test_fallback_cost_estimate_claude(self, handler):
-        """Test fallback cost estimation for Claude models."""
-        cost = handler._fallback_cost_estimate("claude-3-5-sonnet", 1000, 500)
-        # Claude-3-5-sonnet: $3.00/1M input, $15.00/1M output
-        expected = (1000 * 3.00 + 500 * 15.00) / 1_000_000
-        assert cost == pytest.approx(expected)
-
-    def test_fallback_cost_estimate_claude_legacy_sonnet(self, handler):
-        """Test fallback resolves legacy claude-3-sonnet via alias."""
-        cost = handler._fallback_cost_estimate("claude-3-sonnet", 1000, 500)
-        # claude-3-sonnet aliases to claude-3-5-sonnet-20241022 ($3.00/$15.00 per 1M)
-        expected = (1000 * 3.00 + 500 * 15.00) / 1_000_000
-        assert cost == pytest.approx(expected)
-
-    def test_fallback_cost_estimate_claude_haiku(self, handler):
-        """Test fallback cost estimation for Claude Haiku."""
-        cost = handler._fallback_cost_estimate("claude-3-haiku", 1000, 500)
-        # Claude-3-haiku: $0.25/1M input, $1.25/1M output
-        expected = (1000 * 0.25 + 500 * 1.25) / 1_000_000
-        assert cost == pytest.approx(expected)
-
-    def test_fallback_cost_estimate_unknown_model(self, handler):
-        """Test fallback cost estimation for unknown model."""
-        cost = handler._fallback_cost_estimate("some-unknown-model", 1000, 500)
-        # Default: $1.00/1M input, $3.00/1M output
-        expected = (1000 * 1.0 + 500 * 3.0) / 1_000_000
-        assert cost == pytest.approx(expected)
-
-    def test_fallback_cost_estimate_case_insensitive(self, handler):
-        """Test that model matching is case-insensitive."""
-        cost_lower = handler._fallback_cost_estimate("gpt-4o", 1000, 500)
-        cost_upper = handler._fallback_cost_estimate("GPT-4O", 1000, 500)
-        assert cost_lower == cost_upper
-
-    def test_estimate_cost_with_litellm_available(self, handler):
-        """Test _estimate_cost when litellm is available and works."""
-        # litellm IS available in test env, so this tests the happy path
-        # For gpt-4o, litellm should return a valid cost
+    def test_estimate_cost_known_model_gpt4o(self, handler):
+        """Test cost estimation for GPT-4o via cost_from_tokens."""
         cost = handler._estimate_cost("gpt-4o", 1000, 500)
-        assert cost > 0, "Should return non-zero cost for known model"
+        assert cost > 0, "Should return positive cost for known model"
 
-    def test_estimate_cost_falls_back_for_unknown_model(self, handler):
-        """Test _estimate_cost falls back for unknown model (litellm returns 0)."""
-        # Use a model name litellm doesn't know - forces fallback path
+    def test_estimate_cost_known_model_gpt35_turbo(self, handler):
+        """Test cost estimation for GPT-3.5-turbo."""
+        cost = handler._estimate_cost("gpt-3.5-turbo", 1000, 500)
+        assert cost > 0, "Should return positive cost for known model"
+
+    def test_estimate_cost_known_model_claude(self, handler):
+        """Test cost estimation for Claude models."""
+        cost = handler._estimate_cost("claude-3-5-sonnet", 1000, 500)
+        assert cost > 0, "Should return positive cost for known model"
+
+    def test_estimate_cost_known_model_claude_haiku(self, handler):
+        """Test cost estimation for Claude Haiku."""
+        cost = handler._estimate_cost("claude-3-haiku", 1000, 500)
+        assert cost > 0, "Should return positive cost for known model"
+
+    def test_estimate_cost_unknown_model_returns_zero(self, handler):
+        """Test _estimate_cost returns 0.0 for unknown model (strict=False)."""
         cost = handler._estimate_cost("unknown-model-xyz-123", 1000, 500)
-        # Should fall back to hardcoded default estimates
-        expected = (1000 * 1.0 + 500 * 3.0) / 1_000_000
-        assert cost == pytest.approx(expected)
+        assert cost == pytest.approx(
+            0.0
+        ), "Unknown model should return 0.0 with strict=False"
 
     def test_estimate_cost_exception_handling(self, handler):
         """Test _estimate_cost handles exceptions gracefully."""
-        # Patch calculate_llm_cost to raise an exception - covers except branch
         with patch(
-            "traigent.utils.cost_calculator.calculate_llm_cost",
+            "traigent.utils.cost_calculator.cost_from_tokens",
             side_effect=Exception("Test error"),
         ):
             cost = handler._estimate_cost("gpt-4o", 1000, 500)
-            # Should fall back to hardcoded estimates via except handler
-            expected = (1000 * 2.50 + 500 * 10.00) / 1_000_000
-            assert cost == pytest.approx(expected)
+            assert cost == pytest.approx(0.0), "Should return 0.0 on exception"
+
+    def test_estimate_cost_case_insensitive(self, handler):
+        """Test that model matching is case-insensitive."""
+        cost_lower = handler._estimate_cost("gpt-4o", 1000, 500)
+        cost_upper = handler._estimate_cost("GPT-4O", 1000, 500)
+        assert cost_lower == pytest.approx(cost_upper, rel=1e-6)

--- a/tests/unit/integrations/test_cost_extraction.py
+++ b/tests/unit/integrations/test_cost_extraction.py
@@ -1,0 +1,92 @@
+"""Integration-format cost extraction tests."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
+from traigent.integrations.bedrock_client import BedrockChatResponse
+
+
+@pytest.fixture(autouse=True)
+def _disable_mock_mode(monkeypatch):
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "")
+    monkeypatch.setenv("TRAIGENT_GENERATE_MOCKS", "")
+
+
+def test_openai_response_cost_extraction() -> None:
+    usage = SimpleNamespace(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    response = SimpleNamespace(usage=usage)
+
+    metrics = extract_llm_metrics(response, model_name="gpt-4o")
+
+    assert metrics.tokens.input_tokens == 100
+    assert metrics.tokens.output_tokens == 50
+    assert metrics.cost.total_cost > 0
+
+
+def test_anthropic_response_cost_extraction() -> None:
+    usage = SimpleNamespace(input_tokens=100, output_tokens=50)
+    response = SimpleNamespace(usage=usage, model="claude-3-5-sonnet-20241022")
+
+    metrics = extract_llm_metrics(response, model_name="claude-3-5-sonnet-20241022")
+
+    assert metrics.tokens.input_tokens == 100
+    assert metrics.tokens.output_tokens == 50
+    assert metrics.cost.total_cost > 0
+
+
+def test_langchain_response_cost_extraction() -> None:
+    response = SimpleNamespace(
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+            }
+        }
+    )
+
+    metrics = extract_llm_metrics(response, model_name="gpt-4o")
+
+    assert metrics.tokens.total_tokens == 150
+    assert metrics.cost.total_cost > 0
+
+
+def test_bedrock_non_streaming_cost_extraction() -> None:
+    response = BedrockChatResponse(
+        text="ok",
+        raw={"usage": {"inputTokens": 100, "outputTokens": 50}},
+        usage={"inputTokens": 100, "outputTokens": 50},
+    )
+
+    metrics = extract_llm_metrics(response, model_name="claude-3-5-sonnet-20241022")
+
+    assert metrics.tokens.input_tokens == 100
+    assert metrics.tokens.output_tokens == 50
+    assert metrics.cost.total_cost > 0
+
+
+def test_bedrock_streaming_without_usage_warns(caplog) -> None:
+    response = BedrockChatResponse(text="ok", raw={"streamed": True}, usage=None)
+
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.metrics_tracker"):
+        metrics = extract_llm_metrics(response, model_name="claude-3-5-sonnet-20241022")
+
+    assert metrics.cost.total_cost == 0.0
+    assert any("No token usage extracted" in r.message for r in caplog.records)
+
+
+def test_unknown_model_with_usage_warns(caplog) -> None:
+    usage = SimpleNamespace(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    response = SimpleNamespace(usage=usage)
+
+    with caplog.at_level(logging.WARNING):
+        metrics = extract_llm_metrics(response, model_name="totally-fake-model-xyz")
+
+    assert metrics.tokens.total_tokens == 150
+    assert metrics.cost.total_cost == 0.0
+    assert any("Unknown model" in r.message for r in caplog.records)

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from traigent.utils.cost_calculator import (
-    FALLBACK_MODEL_PRICING,
+    ESTIMATION_MODEL_PRICING,
     TOKENCOST_AVAILABLE,
     CostBreakdown,
     CostCalculator,
@@ -102,12 +102,10 @@ class TestCostCalculatorInitialization:
         assert calculator.enable_caching is False
 
     @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_calculator_init_litellm_unavailable_warning(self) -> None:
-        """Test warning is logged when litellm is unavailable."""
-        mock_logger = MagicMock()
-        CostCalculator(logger=mock_logger)  # noqa: F841
-        mock_logger.warning.assert_called_once()
-        assert "litellm not available" in str(mock_logger.warning.call_args)
+    def test_calculator_init_litellm_unavailable_raises(self) -> None:
+        """Test RuntimeError raised when litellm is unavailable (budget safety)."""
+        with pytest.raises(RuntimeError, match="litellm is required"):
+            CostCalculator()
 
 
 class TestCostCalculatorModelMapping:
@@ -383,15 +381,14 @@ class TestCostCalculation:
         return CostCalculator(logger=MagicMock())
 
     @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_calculate_cost_litellm_unavailable(
+    def test_calculate_cost_litellm_unavailable_raises(
         self, calculator: CostCalculator
     ) -> None:
-        """Test cost calculation when litellm is unavailable."""
-        result = calculator.calculate_cost(
-            prompt="test", response="response", model_name="gpt-4o"
-        )
-        assert result.total_cost == 0.0
-        assert result.calculation_method == "litellm_unavailable"
+        """Test cost calculation raises when litellm is unavailable (budget safety)."""
+        with pytest.raises(RuntimeError, match="litellm is required"):
+            calculator.calculate_cost(
+                prompt="test", response="response", model_name="gpt-4o"
+            )
 
     def test_calculate_cost_no_model_name(self, calculator: CostCalculator) -> None:
         """Test cost calculation without model name."""
@@ -449,12 +446,14 @@ class TestCostCalculation:
         assert result.output_cost >= 0.0
 
     def test_calculate_cost_with_zero_tokens(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with zero token counts."""
+        """Test cost calculation with zero token counts enters token path."""
         result = calculator.calculate_cost(
             model_name="gpt-4o-mini", input_tokens=0, output_tokens=0
         )
-        # Should not use token_counts method with zero tokens
-        assert result.calculation_method != "token_counts"
+        # Zero tokens now enters the token path (legitimate zero cost)
+        assert result.calculation_method == "token_counts"
+        assert result.input_tokens == 0
+        assert result.output_tokens == 0
 
     def test_calculate_cost_exception_handling(
         self, calculator_with_logger: CostCalculator
@@ -562,23 +561,21 @@ class TestCalculateFromTokens:
         assert isinstance(output_cost, float)
         assert input_cost >= 0.0
         assert output_cost >= 0.0
-        # Should log debug info
-        assert calculator_with_logger.logger.debug.called
 
-    def test_calculate_from_tokens_exception_handling(
+    def test_calculate_from_tokens_raises_for_invalid_model(
         self, calculator_with_logger: CostCalculator
     ) -> None:
-        """Test token-based calculation handles exceptions."""
+        """Test token-based calculation raises for unknown model (budget safety)."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
         with (
             patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", True),
             patch("traigent.utils.cost_calculator.litellm.model_cost", {}),
+            pytest.raises(UnknownModelError),
         ):
-            input_cost, output_cost = calculator_with_logger._calculate_from_tokens(
+            calculator_with_logger._calculate_from_tokens(
                 input_tokens=100, output_tokens=50, model="invalid-model"
             )
-            # Should handle gracefully
-            assert input_cost == 0.0 or isinstance(input_cost, float)
-            assert output_cost == 0.0 or isinstance(output_cost, float)
 
 
 class TestUtilityMethods:
@@ -691,7 +688,7 @@ class TestConvenienceFunctions:
     def test_get_model_pricing_per_1k_known_model(self) -> None:
         """Model pricing convenience API returns per-1K input/output rates."""
         input_rate, output_rate = get_model_pricing_per_1k("gpt-4o")
-        expected = FALLBACK_MODEL_PRICING["gpt-4o"]
+        expected = ESTIMATION_MODEL_PRICING["gpt-4o"]
         assert input_rate == pytest.approx(expected["input_cost_per_token"] * 1000)
         assert output_rate == pytest.approx(expected["output_cost_per_token"] * 1000)
 
@@ -735,12 +732,15 @@ class TestEdgeCases:
         assert isinstance(result, CostBreakdown)
 
     def test_calculate_cost_negative_tokens(self, calculator: CostCalculator) -> None:
-        """Test cost calculation rejects negative token counts."""
+        """Test cost calculation clamps negative tokens to zero."""
         result = calculator.calculate_cost(
             model_name="gpt-4o-mini", input_tokens=-10, output_tokens=50
         )
-        # Should not use token_counts method with negative tokens
-        assert result.calculation_method != "token_counts"
+        # Negative tokens are clamped to 0, positive tokens still priced
+        assert result.calculation_method == "token_counts"
+        assert result.input_tokens == 0
+        assert result.output_tokens == 50
+        assert result.output_cost > 0
 
     def test_fuzzy_match_with_special_characters(
         self, calculator: CostCalculator
@@ -846,17 +846,18 @@ class TestAdditionalLoggerCoverage:
                 # Should log info about single match
                 mock_logger.info.assert_called()
 
-    def test_calculate_from_tokens_fallback_for_unknown_model(self) -> None:
-        """Test token calculation uses fallback for unknown models."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        # Use an unknown model that's not in litellm or fallback pricing
-        input_cost, output_cost = calculator._calculate_from_tokens(
-            100, 50, "completely-unknown-model-xyz123"
-        )
-        # Fallback returns 0 for unknown models
-        assert input_cost == 0.0
-        assert output_cost == 0.0
+    def test_calculate_from_tokens_raises_for_unknown_model(self) -> None:
+        """Test token calculation raises UnknownModelError for unknown models.
+
+        Budget-critical: returning 0.0 would silently break budget enforcement.
+        """
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        calculator = CostCalculator(logger=MagicMock())
+        with pytest.raises(UnknownModelError):
+            calculator._calculate_from_tokens(
+                100, 50, "completely-unknown-model-xyz123"
+            )
 
     @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
     def test_validate_model_name_fuzzy_match_path(self) -> None:

--- a/tests/unit/utils/test_cost_calculator_pricing.py
+++ b/tests/unit/utils/test_cost_calculator_pricing.py
@@ -149,8 +149,8 @@ class TestGetModelTokenPricing:
             assert method != "litellm"
 
     def test_fallback_dict_match(self) -> None:
-        """Model in FALLBACK_MODEL_PRICING → uses fallback_dict method."""
-        # gpt-4-turbo is in FALLBACK_MODEL_PRICING
+        """Model in ESTIMATION_MODEL_PRICING → uses fallback_dict method."""
+        # gpt-4-turbo is in ESTIMATION_MODEL_PRICING
         # Disable litellm to force fallback path
         with patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False):
             inp, out, method = get_model_token_pricing("gpt-4-turbo")

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -1,0 +1,208 @@
+"""Unit tests for cost_from_tokens() — the canonical cost entry point.
+
+Tests validate:
+- Known models return positive costs (via litellm)
+- Partial token data (input-only, output-only) is handled correctly
+- Unknown models raise UnknownModelError (strict) or return (0,0) (non-strict)
+- Provider-prefixed models resolve correctly
+- litellm unavailability raises RuntimeError (strict) or returns (0,0)
+- Negative tokens raise ValueError
+"""
+
+# Traceability: CONC-Layer-Core CONC-Quality-Performance CONC-Quality-Observability FUNC-ANALYTICS REQ-ANLY-011 SYNC-Observability
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from traigent.utils.cost_calculator import (
+    CostCalculator,
+    UnknownModelError,
+    cost_from_tokens,
+)
+
+
+class TestCostFromTokensKnownModels:
+    """Tests for known models that litellm can price."""
+
+    def test_known_model_both_tokens_positive(self) -> None:
+        """Known model with both input and output tokens returns positive costs."""
+        input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o")
+        assert input_cost > 0, "Input cost should be positive for known model"
+        assert output_cost > 0, "Output cost should be positive for known model"
+
+    def test_known_model_input_only(self) -> None:
+        """Known model with output_tokens=0 still calculates input cost."""
+        input_cost, output_cost = cost_from_tokens(100, 0, "gpt-4o")
+        assert input_cost > 0, "Input cost should be positive"
+        assert output_cost == 0.0, "Output cost should be zero with 0 output tokens"
+
+    def test_known_model_output_only(self) -> None:
+        """Known model with input_tokens=0 still calculates output cost."""
+        input_cost, output_cost = cost_from_tokens(0, 50, "gpt-4o")
+        assert input_cost == 0.0, "Input cost should be zero with 0 input tokens"
+        assert output_cost > 0, "Output cost should be positive"
+
+    def test_known_model_zero_both(self) -> None:
+        """Known model with both tokens=0 returns legitimate zeros."""
+        input_cost, output_cost = cost_from_tokens(0, 0, "gpt-4o")
+        assert input_cost == 0.0
+        assert output_cost == 0.0
+
+    def test_cost_scales_linearly(self) -> None:
+        """Cost doubles when token count doubles."""
+        cost_100, _ = cost_from_tokens(100, 0, "gpt-4o")
+        cost_200, _ = cost_from_tokens(200, 0, "gpt-4o")
+        assert abs(cost_200 - 2 * cost_100) < 1e-12, "Cost should scale linearly"
+
+    def test_different_models_different_costs(self) -> None:
+        """Different models have different per-token rates."""
+        cost_4o_in, cost_4o_out = cost_from_tokens(1000, 1000, "gpt-4o")
+        cost_mini_in, cost_mini_out = cost_from_tokens(1000, 1000, "gpt-4o-mini")
+        assert cost_4o_in > cost_mini_in, "gpt-4o should cost more than gpt-4o-mini"
+        assert cost_4o_out > cost_mini_out, "gpt-4o should cost more than gpt-4o-mini"
+
+
+class TestCostFromTokensModelResolution:
+    """Tests for model name resolution (EXACT_MODEL_MAPPING + normalization)."""
+
+    def test_provider_prefixed_model(self) -> None:
+        """Provider-prefixed model resolves correctly."""
+        cost_prefixed = cost_from_tokens(100, 50, "openai/gpt-4o")
+        cost_plain = cost_from_tokens(100, 50, "gpt-4o")
+        # Should produce identical results
+        assert cost_prefixed[0] == pytest.approx(cost_plain[0], rel=1e-6)
+        assert cost_prefixed[1] == pytest.approx(cost_plain[1], rel=1e-6)
+
+    def test_exact_model_mapping(self) -> None:
+        """Short model names resolve via EXACT_MODEL_MAPPING."""
+        # "claude-3-haiku" maps to "claude-3-haiku-20240307"
+        input_cost, output_cost = cost_from_tokens(100, 50, "claude-3-haiku")
+        assert (
+            input_cost > 0 or output_cost > 0
+        ), "Mapped model should produce positive cost"
+
+    def test_colon_prefixed_model(self) -> None:
+        """Colon-prefixed provider model resolves."""
+        cost_prefixed = cost_from_tokens(100, 50, "anthropic:claude-3-haiku")
+        cost_plain = cost_from_tokens(100, 50, "claude-3-haiku")
+        assert cost_prefixed[0] == pytest.approx(cost_plain[0], rel=1e-6)
+        assert cost_prefixed[1] == pytest.approx(cost_plain[1], rel=1e-6)
+
+
+class TestCostFromTokensUnknownModels:
+    """Tests for unknown models (strict vs non-strict)."""
+
+    def test_unknown_model_strict_raises(self) -> None:
+        """Unknown model with strict=True raises UnknownModelError."""
+        with pytest.raises(UnknownModelError, match="no pricing in litellm"):
+            cost_from_tokens(100, 50, "totally-nonexistent-model-xyz")
+
+    def test_unknown_model_nonstrict_returns_zero(self) -> None:
+        """Unknown model with strict=False returns (0.0, 0.0)."""
+        input_cost, output_cost = cost_from_tokens(
+            100, 50, "totally-nonexistent-model-xyz", strict=False
+        )
+        assert input_cost == 0.0
+        assert output_cost == 0.0
+
+    def test_unknown_model_nonstrict_logs_warning(self, caplog) -> None:
+        """Unknown model with strict=False logs a warning."""
+        with caplog.at_level(logging.WARNING, logger="traigent.utils.cost_calculator"):
+            cost_from_tokens(100, 50, "totally-nonexistent-model-xyz", strict=False)
+        assert any(
+            "Unknown model" in record.message and "zero cost" in record.message
+            for record in caplog.records
+        ), f"Expected warning about unknown model, got: {[r.message for r in caplog.records]}"
+
+    def test_unknown_model_error_is_key_error(self) -> None:
+        """UnknownModelError is a subclass of KeyError (backward compat)."""
+        with pytest.raises(KeyError):
+            cost_from_tokens(100, 50, "totally-nonexistent-model-xyz")
+
+
+class TestCostFromTokensValidation:
+    """Tests for input validation."""
+
+    def test_negative_input_tokens_raises(self) -> None:
+        """Negative input tokens raise ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            cost_from_tokens(-1, 50, "gpt-4o")
+
+    def test_negative_output_tokens_raises(self) -> None:
+        """Negative output tokens raise ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            cost_from_tokens(100, -1, "gpt-4o")
+
+    def test_both_negative_raises(self) -> None:
+        """Both negative tokens raise ValueError."""
+        with pytest.raises(ValueError, match="non-negative"):
+            cost_from_tokens(-5, -10, "gpt-4o")
+
+
+class TestCostFromTokensLitellmUnavailable:
+    """Tests for when litellm is not installed."""
+
+    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
+    def test_litellm_unavailable_strict_raises(self) -> None:
+        """strict=True raises RuntimeError when litellm is unavailable."""
+        with pytest.raises(RuntimeError, match="litellm is required"):
+            cost_from_tokens(100, 50, "gpt-4o", strict=True)
+
+    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
+    def test_litellm_unavailable_nonstrict_returns_zero(self) -> None:
+        """strict=False returns (0.0, 0.0) when litellm is unavailable."""
+        input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o", strict=False)
+        assert input_cost == 0.0
+        assert output_cost == 0.0
+
+    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
+    def test_litellm_unavailable_nonstrict_logs_warning(self, caplog) -> None:
+        """strict=False logs warning when litellm is unavailable."""
+        with caplog.at_level(logging.WARNING, logger="traigent.utils.cost_calculator"):
+            cost_from_tokens(100, 50, "gpt-4o", strict=False)
+        assert any(
+            "litellm not available" in record.message for record in caplog.records
+        )
+
+
+class TestCostFromTokensEdgeCases:
+    """Edge case tests."""
+
+    def test_large_token_counts(self) -> None:
+        """Large token counts produce proportionally large costs."""
+        input_cost, output_cost = cost_from_tokens(1_000_000, 500_000, "gpt-4o")
+        assert input_cost > 0
+        assert output_cost > 0
+
+    def test_returns_floats(self) -> None:
+        """Return values are always Python floats."""
+        input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o")
+        assert isinstance(input_cost, float)
+        assert isinstance(output_cost, float)
+
+    def test_litellm_cost_per_token_exception_falls_through(self) -> None:
+        """If litellm.cost_per_token raises, falls through to model_cost lookup."""
+        mock_litellm = MagicMock()
+        mock_litellm.cost_per_token.side_effect = Exception("test error")
+        mock_litellm.model_cost = {
+            "gpt-4o": {
+                "input_cost_per_token": 2.5e-6,
+                "output_cost_per_token": 10.0e-6,
+            }
+        }
+
+        with (
+            patch("traigent.utils.cost_calculator.litellm", mock_litellm),
+            patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", True),
+            patch(
+                "traigent.utils.cost_calculator._is_model_known_to_litellm",
+                return_value=False,
+            ),
+        ):
+            input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o")
+            assert input_cost == pytest.approx(100 * 2.5e-6)
+            assert output_cost == pytest.approx(50 * 10.0e-6)

--- a/tests/unit/utils/test_diagnostics.py
+++ b/tests/unit/utils/test_diagnostics.py
@@ -439,7 +439,9 @@ class TestTraigentDiagnostics:
         TraigentDiagnostics._check_permissions(report)
 
         # Should succeed for all test paths and exercise write/unlink mocks
-        assert mock_write.called, "write_text should have been called to test permissions"
+        assert (
+            mock_write.called
+        ), "write_text should have been called to test permissions"
         assert len(report.successes) >= 1
         assert any("Can write to" in s["message"] for s in report.successes)
 

--- a/traigent/analytics/intelligence.py
+++ b/traigent/analytics/intelligence.py
@@ -1800,8 +1800,8 @@ Generated: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")}
                             continue
 
         except ImportError:
-            # Fallback: derive from canonical FALLBACK_MODEL_PRICING
-            from traigent.utils.cost_calculator import FALLBACK_MODEL_PRICING
+            # Fallback: derive from canonical ESTIMATION_MODEL_PRICING
+            from traigent.utils.cost_calculator import ESTIMATION_MODEL_PRICING
 
             provider_prefixes = {
                 "openai": ("gpt-",),
@@ -1812,7 +1812,7 @@ Generated: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")}
                     continue
                 prefixes = provider_prefixes[provider]
                 provider_pricing: dict[str, Any] = {}
-                for model, p in FALLBACK_MODEL_PRICING.items():
+                for model, p in ESTIMATION_MODEL_PRICING.items():
                     if any(model.startswith(pfx) for pfx in prefixes):
                         provider_pricing[model] = {
                             "input": p["input_cost_per_token"] * 1000,

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, field
 from typing import Any, Optional, cast
 
 from traigent._version import get_version
-from traigent.utils.cost_calculator import calculate_llm_cost
 from traigent.utils.logging import get_logger
 
 # Initialize logger first
@@ -681,11 +680,21 @@ class AnthropicResponseHandler(ResponseHandler):
         # 2. Check for usage pattern specific to Anthropic
         if hasattr(response, "usage"):
             usage = response.usage
-            # Anthropic uses input_tokens/output_tokens instead of prompt_tokens/completion_tokens
-            has_anthropic_tokens = hasattr(usage, "input_tokens") and hasattr(
-                usage, "output_tokens"
+
+            # Anthropic uses input/output token keys; Bedrock may use camelCase.
+            def _has(u: Any, name: str) -> bool:
+                if isinstance(u, dict):
+                    return name in u
+                return hasattr(u, name)
+
+            has_anthropic_tokens = (
+                (_has(usage, "input_tokens") and _has(usage, "output_tokens"))
+                or (
+                    _has(usage, "num_input_tokens") and _has(usage, "num_output_tokens")
+                )
+                or (_has(usage, "inputTokens") and _has(usage, "outputTokens"))
             )
-            has_openai_tokens = hasattr(usage, "prompt_tokens") and hasattr(
+            has_openai_tokens = _has(usage, "prompt_tokens") and _has(
                 usage, "completion_tokens"
             )
             # Only return True if it has Anthropic tokens and NOT OpenAI tokens
@@ -719,11 +728,13 @@ class AnthropicResponseHandler(ResponseHandler):
             input_val = (
                 _get(usage, "input_tokens")
                 or _get(usage, "num_input_tokens")
+                or _get(usage, "inputTokens")
                 or _get(usage, "prompt_tokens")
             )
             output_val = (
                 _get(usage, "output_tokens")
                 or _get(usage, "num_output_tokens")
+                or _get(usage, "outputTokens")
                 or _get(usage, "completion_tokens")
             )
             total_val = _get(usage, "total_tokens")
@@ -935,8 +946,142 @@ class ResponseHandlerFactory:
         return openai
 
 
+def _calculate_cost_for_metrics(
+    metrics: ExampleMetrics,
+    model_name: str | None,
+    original_prompt: Any,
+    response_text: str | None,
+    prompt_length: int | None = None,
+    response_length: int | None = None,
+) -> None:
+    """Calculate and update cost metrics.
+
+    Uses cost_from_tokens() as the canonical cost path when token counts are
+    available, falling back to deprecated text-based functions otherwise.
+    """
+    from traigent.utils.env_config import is_mock_llm
+
+    mock_mode = is_mock_llm()
+    generate_mocks_env = os.environ.get("TRAIGENT_GENERATE_MOCKS", "").lower()
+
+    if mock_mode or generate_mocks_env == "true":
+        _handle_mock_mode(metrics, prompt_length, response_length)
+        return
+
+    if not model_name or metrics.cost.total_cost > 0.0:
+        return
+
+    try:
+        _compute_cost(
+            metrics,
+            model_name,
+            original_prompt,
+            response_text,
+        )
+    except Exception as e:
+        logger.error(
+            "Cost calculation failed for model %s: %s",
+            model_name,
+            e,
+            exc_info=True,
+        )
+        if os.environ.get("TRAIGENT_DEBUG", "").lower() == "true":
+            raise
+
+
+def _handle_mock_mode(
+    metrics: ExampleMetrics,
+    prompt_length: int | None,
+    response_length: int | None,
+) -> None:
+    """Set zero costs in mock mode, estimating tokens from text length."""
+    if prompt_length is not None and metrics.tokens.input_tokens == 0:
+        metrics.tokens.input_tokens = max(1, prompt_length // 4)
+    if response_length is not None and metrics.tokens.output_tokens == 0:
+        metrics.tokens.output_tokens = max(1, response_length // 4)
+    if metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0:
+        metrics.tokens.total_tokens = (
+            metrics.tokens.input_tokens + metrics.tokens.output_tokens
+        )
+    metrics.cost.input_cost = 0.0
+    metrics.cost.output_cost = 0.0
+    metrics.cost.total_cost = 0.0
+
+
+def _compute_cost(
+    metrics: ExampleMetrics,
+    model_name: str,
+    original_prompt: Any,
+    response_text: str | None,
+) -> None:
+    """Compute cost using cost_from_tokens (preferred) or legacy text path."""
+    from traigent.utils.cost_calculator import cost_from_tokens
+
+    # Ensure total tokens computed
+    if metrics.tokens.total_tokens == 0:
+        metrics.tokens.total_tokens = (
+            metrics.tokens.input_tokens + metrics.tokens.output_tokens
+        )
+
+    if metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0:
+        # Preferred path: use canonical cost_from_tokens directly
+        input_cost, output_cost = cost_from_tokens(
+            metrics.tokens.input_tokens,
+            metrics.tokens.output_tokens,
+            model_name,
+            strict=False,
+        )
+        metrics.cost.input_cost = input_cost
+        metrics.cost.output_cost = output_cost
+        metrics.cost.total_cost = input_cost + output_cost
+        if metrics.cost.total_cost > 0:
+            logger.debug(
+                "Cost calculated for %s: $%.6f via cost_from_tokens",
+                model_name,
+                metrics.cost.total_cost,
+            )
+    else:
+        logger.warning(
+            "No token usage extracted for model %s; "
+            "falling back to deprecated text-based cost calculation",
+            model_name,
+        )
+        # Legacy fallback: text-based cost (deprecated)
+        _try_legacy_cost_calculation(
+            metrics,
+            model_name,
+            original_prompt,
+            response_text,
+        )
+
+
+def _try_legacy_cost_calculation(
+    metrics: ExampleMetrics,
+    model_name: str,
+    original_prompt: Any,
+    response_text: str | None,
+) -> None:
+    """Legacy cost calculation using deprecated text-based functions."""
+    backward_compatible = False
+
+    if calculate_prompt_cost is not None and original_prompt is not None:
+        metrics.cost.input_cost = calculate_prompt_cost(original_prompt, model_name)
+        backward_compatible = True
+
+    if calculate_completion_cost is not None and response_text is not None:
+        metrics.cost.output_cost = calculate_completion_cost(response_text, model_name)
+        backward_compatible = True
+
+    if backward_compatible:
+        metrics.cost.total_cost = metrics.cost.input_cost + metrics.cost.output_cost
+
+
 class CostCalculator:
-    """Separate class for handling cost calculations."""
+    """Backward-compat shim — delegates to module-level functions.
+
+    .. deprecated::
+        Use ``_calculate_cost_for_metrics()`` or ``cost_from_tokens()`` directly.
+    """
 
     def __init__(self) -> None:
         self.logger = logger
@@ -950,105 +1095,14 @@ class CostCalculator:
         prompt_length: int | None = None,
         response_length: int | None = None,
     ) -> None:
-        """Calculate and update cost metrics.
-
-        Args:
-            metrics: ExampleMetrics to update with cost information
-            model_name: Model name for cost lookup
-            original_prompt: Original prompt (if not in privacy mode)
-            response_text: Response text (if not in privacy mode)
-            prompt_length: Length of prompt in privacy mode
-            response_length: Length of response in privacy mode
-        """
-        # Check if we're in mock LLM mode
-        import os
-
-        from traigent.utils.env_config import is_mock_llm
-
-        mock_mode = is_mock_llm()
-        generate_mocks_env = os.environ.get("TRAIGENT_GENERATE_MOCKS", "").lower()
-
-        # DEBUG: Log environment variables
-        self.logger.debug(
-            f"COST DEBUG: Checking mock mode - is_mock_llm={mock_mode}, "
-            f"TRAIGENT_GENERATE_MOCKS='{generate_mocks_env}', model_name='{model_name}'"
+        _calculate_cost_for_metrics(
+            metrics,
+            model_name,
+            original_prompt,
+            response_text,
+            prompt_length=prompt_length,
+            response_length=response_length,
         )
-
-        if mock_mode or generate_mocks_env == "true":
-            # In mock mode, set costs to 0 but estimate tokens if in privacy mode
-            if prompt_length is not None and metrics.tokens.input_tokens == 0:
-                # Estimate tokens from length (roughly 1 token per 4 characters)
-                metrics.tokens.input_tokens = max(1, prompt_length // 4)
-            if response_length is not None and metrics.tokens.output_tokens == 0:
-                metrics.tokens.output_tokens = max(1, response_length // 4)
-            if metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0:
-                metrics.tokens.total_tokens = (
-                    metrics.tokens.input_tokens + metrics.tokens.output_tokens
-                )
-
-            metrics.cost.input_cost = 0.0
-            metrics.cost.output_cost = 0.0
-            metrics.cost.total_cost = 0.0
-            self.logger.debug("COST DEBUG: Mock mode enabled - setting costs to 0")
-            return
-
-        if not model_name or metrics.cost.total_cost > 0.0:
-            self.logger.debug(
-                f"Cost calculation skipped - model_name: '{model_name}', current_total_cost: {metrics.cost.total_cost}"
-            )
-            return
-
-        try:
-            # Always use unified cost calculation which handles token counts properly
-            self.logger.info(
-                f"💰 COST DEBUG: Calling _try_unified_cost_calculation with model='{model_name}', "
-                f"tokens: input={metrics.tokens.input_tokens}, output={metrics.tokens.output_tokens}"
-            )
-            self._try_unified_cost_calculation(
-                metrics,
-                model_name,
-                original_prompt,
-                response_text,
-                prompt_length=prompt_length,
-                response_length=response_length,
-            )
-        except Exception as e:
-            # Make error more visible
-            self.logger.error(
-                f"Cost calculation failed for model {model_name}: {e}", exc_info=True
-            )
-            # Re-raise to make failures more visible during development
-            if os.environ.get("TRAIGENT_DEBUG", "").lower() == "true":
-                raise
-
-    def _try_legacy_cost_calculation(
-        self,
-        metrics: ExampleMetrics,
-        model_name: str,
-        original_prompt: Any,
-        response_text: str | None,
-    ) -> bool:
-        """Try backward compatible cost calculation."""
-        backward_compatible = False
-
-        if calculate_prompt_cost is not None and original_prompt is not None:
-            metrics.cost.input_cost = calculate_prompt_cost(original_prompt, model_name)
-            backward_compatible = True
-
-        if calculate_completion_cost is not None and response_text is not None:
-            metrics.cost.output_cost = calculate_completion_cost(
-                response_text, model_name
-            )
-            backward_compatible = True
-
-        if backward_compatible:
-            metrics.cost.total_cost = metrics.cost.input_cost + metrics.cost.output_cost
-            self.logger.debug(
-                f"Cost calculated using legacy litellm functions for {model_name}: ${metrics.cost.total_cost:.6f}"
-            )
-            return True
-
-        return False
 
     def _try_unified_cost_calculation(
         self,
@@ -1059,81 +1113,7 @@ class CostCalculator:
         prompt_length: int | None = None,
         response_length: int | None = None,
     ) -> None:
-        """Try unified cost calculation.
-
-        Args:
-            metrics: ExampleMetrics to update
-            model_name: Model name for cost lookup
-            original_prompt: Original prompt (if available)
-            response_text: Response text (if available)
-            prompt_length: Length of prompt in privacy mode
-            response_length: Length of response in privacy mode
-        """
-        # If we have lengths but no tokens, estimate tokens first
-        if prompt_length is not None and metrics.tokens.input_tokens == 0:
-            # Estimate token count based on average token/character ratio.
-            metrics.tokens.input_tokens = max(1, int(prompt_length * 0.25))
-
-        if response_length is not None and metrics.tokens.output_tokens == 0:
-            metrics.tokens.output_tokens = max(1, int(response_length * 0.25))
-
-        # Update total tokens if we estimated
-        if (
-            prompt_length is not None or response_length is not None
-        ) and metrics.tokens.total_tokens == 0:
-            metrics.tokens.total_tokens = (
-                metrics.tokens.input_tokens + metrics.tokens.output_tokens
-            )
-
-        # Use token counts if available, otherwise try to use prompt/response
-        cost_breakdown = calculate_llm_cost(
-            prompt=original_prompt if metrics.tokens.input_tokens == 0 else None,
-            response=response_text if metrics.tokens.output_tokens == 0 else None,
-            model_name=model_name,
-            input_tokens=(
-                metrics.tokens.input_tokens if metrics.tokens.input_tokens > 0 else None
-            ),
-            output_tokens=(
-                metrics.tokens.output_tokens
-                if metrics.tokens.output_tokens > 0
-                else None
-            ),
-            logger=self.logger,
-        )
-
-        # Update metrics with cost calculation results
-        self.logger.info(
-            f"💰 COST DEBUG: cost_breakdown returned - input_cost=${cost_breakdown.input_cost:.8f}, "
-            f"output_cost=${cost_breakdown.output_cost:.8f}, total=${cost_breakdown.total_cost:.8f}, "
-            f"method={cost_breakdown.calculation_method}"
-        )
-        metrics.cost.input_cost = cost_breakdown.input_cost
-        metrics.cost.output_cost = cost_breakdown.output_cost
-        metrics.cost.total_cost = cost_breakdown.total_cost
-
-        # Update token counts if they weren't available before
-        if cost_breakdown.input_tokens > 0 and metrics.tokens.input_tokens == 0:
-            metrics.tokens.input_tokens = cost_breakdown.input_tokens
-        if cost_breakdown.output_tokens > 0 and metrics.tokens.output_tokens == 0:
-            metrics.tokens.output_tokens = cost_breakdown.output_tokens
-        if cost_breakdown.total_tokens > 0 and metrics.tokens.total_tokens == 0:
-            metrics.tokens.total_tokens = cost_breakdown.total_tokens
-
-        # Log successful cost calculation
-        if cost_breakdown.total_cost > 0:
-            self.logger.debug(
-                f"Cost calculated for {model_name}: ${cost_breakdown.total_cost:.6f} "
-                f"(method: {cost_breakdown.calculation_method})"
-            )
-            if cost_breakdown.mapped_model != model_name:
-                self.logger.debug(
-                    f"Model mapped: {model_name} -> {cost_breakdown.mapped_model}"
-                )
-        elif metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0:
-            self.logger.debug(
-                f"No cost calculated for {model_name} despite having tokens: "
-                f"input={metrics.tokens.input_tokens}, output={metrics.tokens.output_tokens}"
-            )
+        _compute_cost(metrics, model_name, original_prompt, response_text)
 
 
 class MetricsCalculator:
@@ -1192,9 +1172,8 @@ def extract_llm_metrics(
         metrics = ExampleMetrics()
         logger.warning("No handler could process the response, using empty metrics")
 
-    # Calculate cost using separate cost calculator
-    cost_calculator = CostCalculator()
-    cost_calculator.calculate_cost(
+    # Calculate cost using canonical cost_from_tokens path
+    _calculate_cost_for_metrics(
         metrics,
         model_name,
         original_prompt,

--- a/traigent/hooks/validator.py
+++ b/traigent/hooks/validator.py
@@ -13,21 +13,21 @@ from pathlib import Path
 from typing import Any
 
 from traigent.hooks.config import HooksConfig, load_hooks_config
-from traigent.utils.cost_calculator import FALLBACK_MODEL_PRICING
+from traigent.utils.cost_calculator import ESTIMATION_MODEL_PRICING
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
 def _build_model_cost_per_1k() -> dict[str, float]:
-    """Derive MODEL_COST_PER_1K from the canonical FALLBACK_MODEL_PRICING.
+    """Derive MODEL_COST_PER_1K from the canonical ESTIMATION_MODEL_PRICING.
 
     Computes a blended (input+output)/2 average per-1K-token cost for each
     model, then adds short-name aliases so that user configs in traigent.yml
     using names like ``"gpt-4"`` or ``"claude-3-haiku"`` still resolve.
     """
     result: dict[str, float] = {}
-    for model, pricing in FALLBACK_MODEL_PRICING.items():
+    for model, pricing in ESTIMATION_MODEL_PRICING.items():
         avg_per_token = (
             pricing["input_cost_per_token"] + pricing["output_cost_per_token"]
         ) / 2
@@ -53,7 +53,7 @@ def _build_model_cost_per_1k() -> dict[str, float]:
 
 
 # Model cost estimates per 1K tokens (input + output average).
-# Derived from the canonical FALLBACK_MODEL_PRICING in cost_calculator.py.
+# Derived from the canonical ESTIMATION_MODEL_PRICING in cost_calculator.py.
 MODEL_COST_PER_1K: dict[str, float] = _build_model_cost_per_1k()
 
 # Default tokens per query estimate

--- a/traigent/integrations/langchain/handler.py
+++ b/traigent/integrations/langchain/handler.py
@@ -652,49 +652,25 @@ class TraigentHandler(BaseCallbackHandler):
     def _estimate_cost(
         self, model: str, input_tokens: int, output_tokens: int
     ) -> float:
-        """Estimate cost for LLM call.
+        """Estimate cost for LLM call via the canonical cost_from_tokens().
 
-        Uses litellm library via cost_calculator, with hardcoded fallback
-        estimates when litellm is unavailable or model is unknown.
+        Uses strict=False so unknown models return 0.0 with a warning
+        instead of raising.
         """
         try:
-            from traigent.utils.cost_calculator import (
-                LITELLM_AVAILABLE,
-                calculate_llm_cost,
+            from traigent.utils.cost_calculator import cost_from_tokens
+
+            input_cost, output_cost = cost_from_tokens(
+                input_tokens, output_tokens, model, strict=False
             )
-
-            # Try litellm-based calculation first
-            if LITELLM_AVAILABLE:
-                result = calculate_llm_cost(
-                    model_name=model,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                )
-                if result.total_cost > 0:
-                    return result.total_cost
-                # litellm returned 0 (unknown model) - fall through to estimates
-
-            # Fallback estimates (per 1M tokens) when litellm unavailable or model unknown
-            return self._fallback_cost_estimate(model, input_tokens, output_tokens)
+            return float(input_cost + output_cost)
         except Exception:
-            return self._fallback_cost_estimate(model, input_tokens, output_tokens)
-
-    def _fallback_cost_estimate(
-        self, model: str, input_tokens: int, output_tokens: int
-    ) -> float:
-        """Fallback cost estimates using the canonical pricing source."""
-        try:
-            from traigent.utils.cost_calculator import _fallback_cost_from_tokens
-
-            input_cost, output_cost = _fallback_cost_from_tokens(
-                model, input_tokens, output_tokens
+            logger.warning(
+                "Cost calculation failed for model %r with %d tokens",
+                model,
+                input_tokens + output_tokens,
             )
-            if input_cost > 0 or output_cost > 0:
-                return float(input_cost + output_cost)
-        except Exception:
-            logger.debug("Cost fallback failed for model %r", model, exc_info=True)
-        # Last resort for totally unknown models
-        return (input_tokens * 1.0 + output_tokens * 3.0) / 1_000_000
+            return 0.0
 
     def get_metrics(self) -> TraigentHandlerMetrics:
         """Get aggregated metrics from this handler session.

--- a/traigent/utils/constraints.py
+++ b/traigent/utils/constraints.py
@@ -531,10 +531,10 @@ def model_cost_constraint(max_cost_per_1k_tokens: float = 0.1) -> ResourceConstr
             )
             pass  # Fall through to fallback
 
-        # Method 2: Fallback to FALLBACK_MODEL_PRICING from cost_calculator
+        # Method 2: Fallback to ESTIMATION_MODEL_PRICING from cost_calculator
         try:
             from traigent.utils.cost_calculator import (
-                FALLBACK_MODEL_PRICING,
+                ESTIMATION_MODEL_PRICING,
                 _normalize_model_for_fallback,
             )
 
@@ -542,7 +542,7 @@ def model_cost_constraint(max_cost_per_1k_tokens: float = 0.1) -> ResourceConstr
 
             # Try exact match first
             pricing = None
-            for key, value in FALLBACK_MODEL_PRICING.items():
+            for key, value in ESTIMATION_MODEL_PRICING.items():
                 if key.lower() == base_model:
                     pricing = value
                     break
@@ -550,7 +550,7 @@ def model_cost_constraint(max_cost_per_1k_tokens: float = 0.1) -> ResourceConstr
             # Try prefix matching - prefer longest match
             if not pricing:
                 best_match_len = 0
-                for model_key, model_pricing in FALLBACK_MODEL_PRICING.items():
+                for model_key, model_pricing in ESTIMATION_MODEL_PRICING.items():
                     key_lower = model_key.lower()
                     if base_model.startswith(key_lower):
                         if len(key_lower) > best_match_len:
@@ -570,7 +570,7 @@ def model_cost_constraint(max_cost_per_1k_tokens: float = 0.1) -> ResourceConstr
                 return float(avg_cost_per_1k * (max_tokens / 1000))
 
         except ImportError:
-            pass  # FALLBACK_MODEL_PRICING not available
+            pass  # ESTIMATION_MODEL_PRICING not available
 
         # Ultimate fallback: Unknown model - return infinity to FAIL the constraint
         # This prevents unknown models from silently passing cost checks

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -50,12 +50,13 @@ except (ImportError, KeyError):
 # Backward compatibility alias
 TOKENCOST_AVAILABLE = LITELLM_AVAILABLE
 
-# Canonical model name constants (referenced in FALLBACK_MODEL_PRICING and aliases)
+# Canonical model name constants (referenced in ESTIMATION_MODEL_PRICING and aliases)
 _GPT35_TURBO = "gpt-3.5-turbo"
 _GPT4O = "gpt-4o"
 
-# Fallback pricing for models not in litellm's database (per-token costs)
-FALLBACK_MODEL_PRICING = {
+# Estimation pricing for pre-optimization cost estimation (per-token costs).
+# Post-call cost tracking uses litellm exclusively via cost_from_tokens().
+ESTIMATION_MODEL_PRICING = {
     # OpenAI
     _GPT4O: {"input_cost_per_token": 2.5e-6, "output_cost_per_token": 10.0e-6},
     "gpt-4o-mini": {"input_cost_per_token": 0.15e-6, "output_cost_per_token": 0.6e-6},
@@ -97,6 +98,9 @@ FALLBACK_MODEL_PRICING = {
     },
 }
 
+# Backward-compat alias (external code may import the old name)
+FALLBACK_MODEL_PRICING = ESTIMATION_MODEL_PRICING
+
 # Model scoring constants for fuzzy matching preference
 # Used in _calculate_model_score to prioritize model selection
 LATEST_MODEL_PRIORITY = (9999, 12, 31, 99)  # "latest" models get highest priority
@@ -136,7 +140,7 @@ def _normalize_model_name(model: str) -> str:
     Note:
         Ollama-style "model:tag" identifiers (e.g., "llama3:latest") will have
         the tag stripped. For Ollama models, use the full model name directly
-        or add to FALLBACK_MODEL_PRICING for pricing lookup.
+        or add to ESTIMATION_MODEL_PRICING for pricing lookup.
 
     Args:
         model: Raw model name
@@ -236,6 +240,9 @@ def calculate_prompt_cost(
 ) -> float:
     """Calculate INPUT cost only using litellm.
 
+    .. deprecated::
+        Use :func:`cost_from_tokens` with pre-computed token counts instead.
+
     Backward-compatible wrapper for tokencost's calculate_prompt_cost.
 
     Args:
@@ -249,6 +256,12 @@ def calculate_prompt_cost(
         UnknownModelError: If the model's pricing cannot be determined from
             litellm or the fallback pricing table.
     """
+    warnings.warn(
+        "calculate_prompt_cost() is deprecated. Use cost_from_tokens() with "
+        "pre-computed token counts instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     tokens = 0
 
     if LITELLM_AVAILABLE:
@@ -261,24 +274,15 @@ def calculate_prompt_cost(
                 "litellm cost calculation failed for model %r", model, exc_info=True
             )
 
-    # Estimate tokens from prompt if we don't have a count
-    if tokens == 0 and prompt is not None:
-        # ~3 chars per token (conservative for non-English/code)
-        prompt_str = str(prompt) if not isinstance(prompt, str) else prompt
-        tokens = max(1, len(prompt_str) // 3)
-
-    # Default to 10 tokens if we still don't have an estimate
-    estimated_tokens = tokens if tokens > 0 else 10
-
-    # Try fallback pricing
-    fallback_cost = _fallback_cost_from_tokens(model, estimated_tokens, 0)[0]
+    # Try estimation pricing with whatever token count we have
+    fallback_cost = _estimation_cost_from_tokens(model, max(tokens, 0), 0)[0]
     if fallback_cost > 0:
         return fallback_cost
 
     # Unknown model - raise exception (mimics tokencost behavior)
     raise UnknownModelError(
         f"Model '{model}' is not in litellm's pricing database or fallback table. "
-        "Add it to FALLBACK_MODEL_PRICING or use a known model."
+        "Add it to ESTIMATION_MODEL_PRICING or use a known model."
     )
 
 
@@ -312,6 +316,9 @@ def _try_litellm_completion_cost(
 def calculate_completion_cost(completion: str | None, model: str) -> float:
     """Calculate OUTPUT cost only using litellm.
 
+    .. deprecated::
+        Use :func:`cost_from_tokens` with pre-computed token counts instead.
+
     Backward-compatible wrapper for tokencost's calculate_completion_cost.
 
     Args:
@@ -325,6 +332,12 @@ def calculate_completion_cost(completion: str | None, model: str) -> float:
         UnknownModelError: If the model's pricing cannot be determined from
             litellm or the fallback pricing table.
     """
+    warnings.warn(
+        "calculate_completion_cost() is deprecated. Use cost_from_tokens() with "
+        "pre-computed token counts instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     tokens = 0
 
     if LITELLM_AVAILABLE:
@@ -337,23 +350,15 @@ def calculate_completion_cost(completion: str | None, model: str) -> float:
                 "litellm cost calculation failed for model %r", model, exc_info=True
             )
 
-    # Estimate tokens from completion if we don't have a count
-    if tokens == 0 and completion is not None:
-        # ~3 chars per token (conservative for non-English/code)
-        tokens = max(1, len(completion) // 3)
-
-    # Default to 10 tokens if we still don't have an estimate
-    estimated_tokens = tokens if tokens > 0 else 10
-
-    # Try fallback pricing
-    fallback_cost = _fallback_cost_from_tokens(model, 0, estimated_tokens)[1]
+    # Try estimation pricing with whatever token count we have
+    fallback_cost = _estimation_cost_from_tokens(model, 0, max(tokens, 0))[1]
     if fallback_cost > 0:
         return fallback_cost
 
     # Unknown model - raise exception (mimics tokencost behavior)
     raise UnknownModelError(
         f"Model '{model}' is not in litellm's pricing database or fallback table. "
-        "Add it to FALLBACK_MODEL_PRICING or use a known model."
+        "Add it to ESTIMATION_MODEL_PRICING or use a known model."
     )
 
 
@@ -373,7 +378,7 @@ def _normalize_model_for_fallback(model: str) -> str:
 
 
 # Legacy model name aliases for fallback pricing lookup.
-# Maps names not in FALLBACK_MODEL_PRICING to their closest canonical equivalent.
+# Maps names not in ESTIMATION_MODEL_PRICING to their closest canonical equivalent.
 _FALLBACK_ALIASES: dict[str, str] = {
     "claude-3-sonnet": "claude-3-5-sonnet-20241022",
     "claude-3-sonnet-20240229": "claude-3-5-sonnet-20241022",
@@ -392,7 +397,7 @@ def _find_fallback_pricing(
         Tuple of (pricing_dict, matched_key) or (None, None) if not found.
     """
     # Exact match (case-insensitive via normalized base_model)
-    for key, value in FALLBACK_MODEL_PRICING.items():
+    for key, value in ESTIMATION_MODEL_PRICING.items():
         if key.lower() == base_model:
             return value, key
 
@@ -400,7 +405,7 @@ def _find_fallback_pricing(
     best_match_len = 0
     pricing = None
     matched_key = None
-    for model_key, model_pricing in FALLBACK_MODEL_PRICING.items():
+    for model_key, model_pricing in ESTIMATION_MODEL_PRICING.items():
         key_lower = model_key.lower()
         # Check if base_model starts with key or key starts with base_model
         if base_model.startswith(key_lower):
@@ -417,10 +422,13 @@ def _find_fallback_pricing(
     return pricing, matched_key
 
 
-def _fallback_cost_from_tokens(
+def _estimation_cost_from_tokens(
     model: str, input_tokens: int, output_tokens: int, *, _quiet: bool = False
 ) -> tuple[float, float]:
-    """Calculate costs using fallback pricing dictionary.
+    """Calculate costs using estimation pricing dictionary.
+
+    Used for pre-optimization estimation only. Post-call tracking should use
+    cost_from_tokens() which uses litellm exclusively.
 
     Args:
         model: Model name (may include provider prefix)
@@ -447,7 +455,7 @@ def _fallback_cost_from_tokens(
                 _warned_models.add(model)
                 log_fn = logger.debug if _quiet else logger.warning
                 log_fn(
-                    "Using fallback pricing for model %r (matched %r)",
+                    "Using estimation pricing for model %r (matched %r)",
                     model,
                     matched_key,
                 )
@@ -457,6 +465,10 @@ def _fallback_cost_from_tokens(
         )
 
     return 0.0, 0.0
+
+
+# Backward-compat alias
+_fallback_cost_from_tokens = _estimation_cost_from_tokens
 
 
 # ---------------------------------------------------------------------------
@@ -512,7 +524,7 @@ def get_model_token_pricing(model_name: str) -> tuple[float, float, str]:
     1. **litellm**: exact per-token pricing from litellm's database.
        Models that return ``(0, 0)`` are NOT treated as free — falls through
        to heuristic tier (EMA will correct after the first trial).
-    2. **Fallback dict**: prefix-matching against ``FALLBACK_MODEL_PRICING``.
+    2. **Fallback dict**: prefix-matching against ``ESTIMATION_MODEL_PRICING``.
        Does NOT apply ``EXACT_MODEL_MAPPING`` — intentionally skipped so that
        e.g. ``gpt-4`` stays in the EXPENSIVE tier rather than being downgraded
        to ``gpt-4o`` (MID tier). The mapping is correct for runtime cost
@@ -550,7 +562,7 @@ def get_model_token_pricing(model_name: str) -> tuple[float, float, str]:
     # --- Tier 2: Fallback dict (prefix matching, no EXACT_MODEL_MAPPING) ---
     normalized = _normalize_model_for_fallback(model_name)
     # Use _quiet=True to log at DEBUG during estimation (not WARNING)
-    input_cost_fb, output_cost_fb = _fallback_cost_from_tokens(
+    input_cost_fb, output_cost_fb = _estimation_cost_from_tokens(
         normalized, 1, 1, _quiet=True
     )
     if input_cost_fb > 0 or output_cost_fb > 0:
@@ -647,9 +659,11 @@ class CostCalculator:
         self.enable_caching = enable_caching
         self._fuzzy_match_cache: dict[str, str | None] = {}
 
-        # Validate litellm availability
-        if not LITELLM_AVAILABLE and logger:
-            logger.warning("litellm not available, cost calculations will return 0")
+        if not LITELLM_AVAILABLE:
+            raise RuntimeError(
+                "litellm is required for CostCalculator but is not installed. "
+                "Install it with: pip install litellm"
+            )
 
     def calculate_cost(
         self,
@@ -670,21 +684,21 @@ class CostCalculator:
 
         Returns:
             CostBreakdown with detailed cost information
+
+        Raises:
+            UnknownModelError: If model has no pricing — budget-critical,
+                callers must handle this to avoid silent budget overruns.
         """
         if not LITELLM_AVAILABLE:
-            return CostBreakdown(
-                model_used=model_name or "unknown",
-                calculation_method="litellm_unavailable",
+            raise RuntimeError(
+                "litellm is required for cost calculation but is not installed. "
+                "Install it with: pip install litellm"
             )
 
         if not model_name:
             return CostBreakdown(calculation_method="no_model_name")
 
-        # Map model name to litellm-compatible format
         mapped_model = self._map_model_name(model_name)
-
-        # Even if mapping fails, try using the original model name with litellm
-        # litellm.cost_per_token handles provider prefixes internally
         effective_model = mapped_model or model_name
 
         result = CostBreakdown(
@@ -692,39 +706,16 @@ class CostCalculator:
         )
 
         try:
-            # Method 1: Use original prompt and response for most accurate calculation
-            if prompt and response:
-                result.input_cost = self._safe_calculate_prompt_cost(
-                    prompt, effective_model
-                )
-                result.output_cost = self._safe_calculate_completion_cost(
-                    response, effective_model
-                )
-                result.calculation_method = "prompt_and_response"
-
-            # Method 2: Use token counts if available
-            elif (
-                input_tokens
-                and output_tokens
-                and input_tokens > 0
-                and output_tokens > 0
-            ):
-                result.input_cost, result.output_cost = self._calculate_from_tokens(
-                    input_tokens, output_tokens, effective_model
-                )
-                result.input_tokens = input_tokens
-                result.output_tokens = output_tokens
-                result.calculation_method = "token_counts"
-
-            # Method 3: Response only
-            elif response:
-                result.output_cost = self._safe_calculate_completion_cost(
-                    response, effective_model
-                )
-                result.calculation_method = "response_only"
-
-            result.total_cost = result.input_cost + result.output_cost
-
+            self._populate_cost(
+                result,
+                prompt,
+                response,
+                effective_model,
+                input_tokens,
+                output_tokens,
+            )
+        except UnknownModelError:
+            raise
         except Exception as e:
             if self.logger:
                 self.logger.warning(
@@ -733,6 +724,35 @@ class CostCalculator:
             result.calculation_method = f"error_{type(e).__name__}"
 
         return result
+
+    def _populate_cost(
+        self,
+        result: CostBreakdown,
+        prompt: str | list[dict[str, Any]] | None,
+        response: str | None,
+        model: str,
+        input_tokens: int | None,
+        output_tokens: int | None,
+    ) -> None:
+        """Fill cost breakdown using the best available data."""
+        if prompt and response:
+            result.input_cost = self._safe_calculate_prompt_cost(prompt, model)
+            result.output_cost = self._safe_calculate_completion_cost(response, model)
+            result.calculation_method = "prompt_and_response"
+        elif input_tokens is not None or output_tokens is not None:
+            actual_input = max(input_tokens or 0, 0)
+            actual_output = max(output_tokens or 0, 0)
+            result.input_cost, result.output_cost = self._calculate_from_tokens(
+                actual_input, actual_output, model
+            )
+            result.input_tokens = actual_input
+            result.output_tokens = actual_output
+            result.calculation_method = "token_counts"
+        elif response:
+            result.output_cost = self._safe_calculate_completion_cost(response, model)
+            result.calculation_method = "response_only"
+
+        result.total_cost = result.input_cost + result.output_cost
 
     def _normalize_model_name(self, model_name: str) -> str:
         """Strip provider prefixes like 'openai/gpt-4o' -> 'gpt-4o'."""
@@ -956,60 +976,15 @@ class CostCalculator:
     def _calculate_from_tokens(
         self, input_tokens: int, output_tokens: int, model: str
     ) -> tuple[float, float]:
-        """Calculate costs from token counts using direct pricing information."""
-        try:
-            # First, try litellm.cost_per_token directly (handles provider prefixes)
-            if LITELLM_AVAILABLE:
-                try:
-                    input_cost, output_cost = litellm.cost_per_token(
-                        model=model,
-                        prompt_tokens=input_tokens,
-                        completion_tokens=output_tokens,
-                    )
+        """Calculate costs from token counts via cost_from_tokens().
 
-                    if self.logger:
-                        self.logger.debug(
-                            f"litellm token cost calculation for {model}: "
-                            f"input={input_tokens}=${input_cost:.8f}, "
-                            f"output={output_tokens}=${output_cost:.8f}"
-                        )
+        Delegates to the canonical cost_from_tokens() entry point.
 
-                    return float(input_cost), float(output_cost)
-                except Exception:
-                    # Model not in litellm, try direct lookup or fallback
-                    logger.debug(
-                        "litellm.cost_per_token unavailable for model %r", model
-                    )
-
-            # Try direct lookup in litellm.model_cost
-            normalized = self._normalize_model_name(model)
-            if LITELLM_AVAILABLE and normalized in litellm.model_cost:
-                cost_info = litellm.model_cost[normalized]
-
-                # Get cost per token (not per 1000 tokens)
-                input_cost_per_token = cost_info.get("input_cost_per_token", 0.0)
-                output_cost_per_token = cost_info.get("output_cost_per_token", 0.0)
-
-                # Calculate actual costs
-                input_cost = input_tokens * input_cost_per_token
-                output_cost = output_tokens * output_cost_per_token
-
-                if self.logger:
-                    self.logger.debug(
-                        f"Direct token cost calculation for {model}: "
-                        f"input={input_tokens}*{input_cost_per_token:.10f}=${input_cost:.8f}, "
-                        f"output={output_tokens}*{output_cost_per_token:.10f}=${output_cost:.8f}"
-                    )
-
-                return input_cost, output_cost
-
-            # Fallback to FALLBACK_MODEL_PRICING
-            return _fallback_cost_from_tokens(model, input_tokens, output_tokens)
-
-        except Exception as e:
-            if self.logger:
-                self.logger.debug(f"Token-based cost calculation failed: {e}")
-            return 0.0, 0.0
+        Raises:
+            UnknownModelError: If model has no pricing. Callers MUST handle
+                this — returning 0.0 would silently break budget enforcement.
+        """
+        return cost_from_tokens(input_tokens, output_tokens, model, strict=True)
 
     def get_available_models(self) -> list[str]:
         """Get list of all available litellm models (cached)."""
@@ -1061,6 +1036,102 @@ class CostCalculator:
         return result
 
 
+# ---------------------------------------------------------------------------
+# Canonical cost-from-tokens entry point
+# ---------------------------------------------------------------------------
+
+
+def cost_from_tokens(
+    input_tokens: int,
+    output_tokens: int,
+    model: str,
+    *,
+    strict: bool = True,
+) -> tuple[float, float]:
+    """Canonical cost calculation from token counts.
+
+    This is the single entry point for post-call cost tracking. It uses
+    litellm's pricing database exclusively — no heuristic estimation,
+    no fallback pricing table, no silent zeros in strict mode.
+
+    Args:
+        input_tokens: Number of input tokens (0 is valid for output-only).
+        output_tokens: Number of output tokens (0 is valid for input-only).
+        model: Model identifier (with or without provider prefix).
+        strict: If True (default), raise UnknownModelError for unpriced models.
+                If False, log warning and return (0.0, 0.0).
+
+    Returns:
+        Tuple of (input_cost_usd, output_cost_usd).
+
+    Raises:
+        UnknownModelError: When strict=True and model has no pricing.
+        RuntimeError: When strict=True and litellm is not installed.
+        ValueError: When token counts are negative.
+    """
+    if input_tokens < 0 or output_tokens < 0:
+        raise ValueError(
+            f"Token counts must be non-negative, got "
+            f"input={input_tokens}, output={output_tokens}"
+        )
+
+    if not LITELLM_AVAILABLE:
+        if strict:
+            raise RuntimeError(
+                "litellm is required for cost tracking but is not installed. "
+                "Install it with: pip install litellm"
+            )
+        logger.warning("litellm not available — returning zero cost")
+        return 0.0, 0.0
+
+    # Resolve model name through exact mapping
+    # (e.g., "claude-3-haiku" -> "claude-3-haiku-20240307")
+    normalized = _normalize_model_name(model)
+    mapped = CostCalculator.EXACT_MODEL_MAPPING.get(normalized, normalized)
+
+    # Build unique candidate list preserving priority order
+    candidates = list(dict.fromkeys([mapped, normalized, model]))
+
+    # Step 1: Try litellm.cost_per_token (handles provider prefixes internally)
+    for candidate in candidates:
+        try:
+            input_cost, output_cost = litellm.cost_per_token(
+                model=candidate,
+                prompt_tokens=input_tokens,
+                completion_tokens=output_tokens,
+            )
+            if input_cost > 0 or output_cost > 0:
+                return float(input_cost), float(output_cost)
+            # Model is known but returns (0, 0) — legitimate free tier
+            if _is_model_known_to_litellm(candidate):
+                return float(input_cost), float(output_cost)
+        except Exception:
+            continue
+
+    # Step 2: Try direct lookup in litellm.model_cost (case-insensitive)
+    model_cost_lower = {k.lower(): k for k in litellm.model_cost}
+    for candidate in candidates:
+        actual_key = model_cost_lower.get(candidate.lower())
+        if actual_key:
+            cost_info = litellm.model_cost[actual_key]
+            input_cpt = cost_info.get("input_cost_per_token", 0.0)
+            output_cpt = cost_info.get("output_cost_per_token", 0.0)
+            return (
+                float(input_tokens * input_cpt),
+                float(output_tokens * output_cpt),
+            )
+
+    # Model not found in any litellm pricing source
+    if strict:
+        raise UnknownModelError(
+            f"Model '{model}' has no pricing in litellm. "
+            "Use strict=False for pre-estimation or add the model to litellm."
+        )
+
+    logger.warning("Unknown model %r — returning zero cost (strict=False)", model)
+    return 0.0, 0.0
+
+
 # Convenience functions for simple usage
 def calculate_llm_cost(
     prompt: str | list[dict[str, Any]] | None = None,
@@ -1103,14 +1174,16 @@ def get_cost_calculator(logger=None) -> CostCalculator:
     return _global_calculator
 
 
-def get_model_pricing_per_1k(model_name: str, logger=None) -> tuple[float, float]:
+def get_model_pricing_per_1k(model_name: str) -> tuple[float, float]:
     """Get model pricing rates in USD per 1K tokens.
 
     Returns a tuple ``(input_per_1k, output_per_1k)`` via the canonical cost
-    pipeline (litellm first, fallback pricing second). Unknown models return
+    pipeline (litellm first, then estimation pricing). Unknown models return
     ``(0.0, 0.0)``.
+
+    This is a query function (not budget-enforcement), so it uses
+    strict=False to avoid raising on unknown models.
     """
-    calculator = get_cost_calculator(logger=logger)
-    input_per_1k, _ = calculator._calculate_from_tokens(1000, 0, model_name)
-    _, output_per_1k = calculator._calculate_from_tokens(0, 1000, model_name)
+    input_per_1k, _ = cost_from_tokens(1000, 0, model_name, strict=False)
+    _, output_per_1k = cost_from_tokens(0, 1000, model_name, strict=False)
     return float(input_per_1k), float(output_per_1k)


### PR DESCRIPTION
## Summary
- Complete cost architecture migration to canonical `cost_from_tokens()` path.
- Replace ad-hoc/fallback post-call costing with strict token-based costing and explicit unknown-model handling.
- Add integration-format extraction coverage for OpenAI, Anthropic, LangChain, and Bedrock usage formats.
- Update privacy-cost integration expectation to enforce no post-call token heuristics when usage metadata is absent.

## Key changes
- `traigent/utils/cost_calculator.py`
  - Canonical pricing flow via `cost_from_tokens()`.
  - Estimation pricing aliases and stricter separation between estimation and tracking paths.
- `traigent/integrations/langchain/handler.py`
  - Route handler cost estimation through canonical token cost path.
- `traigent/evaluators/metrics_tracker.py`
  - Bedrock/Anthropic dict-key extraction support (`inputTokens`/`outputTokens`).
  - Explicit warning when no token usage is extracted and legacy path is used.
- `traigent/hooks/validator.py`, `traigent/analytics/intelligence.py`, `traigent/utils/constraints.py`
  - Consistency updates for canonical pricing source naming and lookups.
- Tests
  - Added `tests/unit/integrations/test_cost_extraction.py`.
  - Added `tests/unit/utils/test_cost_from_tokens.py`.
  - Updated pricing consistency and cost calculator suites.
  - Updated `tests/integration/test_cost_privacy_integration.py` to assert no heuristic token estimation in post-call tracking.

## Validation
- `make format` ✅
- `make lint` ✅
- `make test` ⚠️ repo-wide non-scope failures remain in:
  - `tests/optimizer_validation/dimensions/test_parallel_config.py` (parallel/sequential isolation assertions)
  - `tests/examples/test_readme_examples.py::TestREADMEExamples::test_imports_in_examples` (import timeout under high xdist load)
  - `tests/unit/security/test_deployment.py::TestHealthCheckerCheckServiceHealth::test_check_service_health_handles_exceptions`
- Cost-scope suite ✅
  - `231 passed` across updated cost files:
    - `tests/unit/utils/test_cost_from_tokens.py`
    - `tests/unit/utils/test_cost_calculator.py`
    - `tests/unit/utils/test_cost_calculator_pricing.py`
    - `tests/unit/integrations/langchain/test_langchain_handler.py`
    - `tests/unit/integrations/test_cost_extraction.py`
    - `tests/unit/architecture/test_pricing_consistency.py`
    - `tests/integration/test_cost_privacy_integration.py`
