### PR TITLE
feat(config-gen): auto-config generator with --apply, TVL export, and live objects

### DIFF
--- a/tests/unit/cli/test_generate_config_command.py
+++ b/tests/unit/cli/test_generate_config_command.py
@@ -182,3 +182,171 @@ class TestGenerateConfigCLI:
         runner = CliRunner()
         result = runner.invoke(generate_config, ["/nonexistent/path.py"])
         assert result.exit_code != 0
+
+    def test_tvl_output(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file), "-o", "tvl"])
+            assert result.exit_code == 0
+            assert "TVL spec written to:" in result.output
+            tvl_file = tmp_path / "agent.tvl.yml"
+            assert tvl_file.exists()
+            content = tvl_file.read_text()
+            assert "temperature" in content
+
+    def test_apply_decorator(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                generate_config,
+                [str(source_file), "-f", "my_agent", "--apply"],
+            )
+            assert result.exit_code == 0
+            assert "Applied @traigent.optimize()" in result.output
+            assert "Backup saved to" in result.output
+            # Verify .bak file created
+            bak_file = tmp_path / "agent.py.bak"
+            assert bak_file.exists()
+            # Verify decorator inserted
+            modified = source_file.read_text()
+            assert "@traigent.optimize(" in modified
+
+    def test_apply_no_backup(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                generate_config,
+                [str(source_file), "-f", "my_agent", "--apply", "--no-backup"],
+            )
+            assert result.exit_code == 0
+            assert "Applied @traigent.optimize()" in result.output
+            assert "Backup saved to" not in result.output
+            bak_file = tmp_path / "agent.py.bak"
+            assert not bak_file.exists()
+
+    def test_apply_requires_function(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                generate_config,
+                [str(source_file), "--apply"],
+            )
+            assert result.exit_code == 1
+            assert "--apply requires --function" in result.output
+
+    def test_generate_error_handling(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            side_effect=RuntimeError("parse failure"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file)])
+            assert result.exit_code == 1
+            assert "Error: parse failure" in result.output
+
+    def test_generate_file_not_found(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            side_effect=FileNotFoundError("missing"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file)])
+            assert result.exit_code == 1
+            assert "File not found" in result.output
+
+    def test_table_output_full_sections(self, tmp_path: Path) -> None:
+        """Test table output renders all sections including structural constraints."""
+        from traigent.config_generator.types import StructuralConstraintSpec
+
+        full_result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 2.0},
+                ),
+            ),
+            objectives=(
+                ObjectiveSpec(name="accuracy", orientation="maximize", weight=0.6),
+            ),
+            safety_constraints=(
+                SafetySpec(
+                    metric_name="hallucination_rate",
+                    operator="<=",
+                    threshold=0.15,
+                ),
+            ),
+            structural_constraints=(
+                StructuralConstraintSpec(
+                    description="Low temp constraint",
+                    constraint_code="temperature.lte(1.0)",
+                ),
+            ),
+            benchmarks=(
+                BenchmarkSpec(name="QA Eval", description="Standard QA benchmark"),
+            ),
+            recommendations=(
+                TVarRecommendation(
+                    name="top_p",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                    reasoning="Explore top-p sampling",
+                    impact_estimate="medium",
+                ),
+            ),
+            warnings=("Watch out for cost",),
+            agent_type="general_llm",
+            llm_calls_made=3,
+            llm_cost_usd=0.0042,
+        )
+
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=full_result,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file)])
+            assert result.exit_code == 0
+            assert "Tunable Variables" in result.output
+            assert "Objectives" in result.output
+            assert "Safety Constraints" in result.output
+            assert "Structural Constraints" in result.output
+            assert "Benchmarks" in result.output
+            assert "Recommended Additional TVars" in result.output
+            assert "Warnings" in result.output
+            assert "Watch out for cost" in result.output
+            assert "LLM: 3 calls" in result.output
+            assert "Agent type: general_llm" in result.output

--- a/tests/unit/cli/test_generate_config_command.py
+++ b/tests/unit/cli/test_generate_config_command.py
@@ -1,0 +1,184 @@
+"""Tests for CLI command: traigent generate-config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from traigent.cli.generate_config_command import generate_config
+from traigent.config_generator.types import (
+    AutoConfigResult,
+    BenchmarkSpec,
+    ObjectiveSpec,
+    SafetySpec,
+    TVarRecommendation,
+    TVarSpec,
+)
+
+SAMPLE_SOURCE = """\
+from langchain_openai import ChatOpenAI
+
+def my_agent(query: str) -> str:
+    llm = ChatOpenAI(model="gpt-4o", temperature=0.7)
+    return llm.invoke(query)
+"""
+
+
+def _make_result() -> AutoConfigResult:
+    """Build a realistic AutoConfigResult for test output."""
+    return AutoConfigResult(
+        tvars=(
+            TVarSpec(
+                name="temperature",
+                range_type="Range",
+                range_kwargs={"low": 0.0, "high": 2.0},
+                source="preset",
+            ),
+        ),
+        objectives=(
+            ObjectiveSpec(name="accuracy", orientation="maximize", weight=0.6),
+            ObjectiveSpec(name="cost", orientation="minimize", weight=0.4),
+        ),
+        safety_constraints=(
+            SafetySpec(
+                metric_name="hallucination_rate",
+                operator="<=",
+                threshold=0.15,
+                agent_type="general_llm",
+            ),
+        ),
+        benchmarks=(
+            BenchmarkSpec(name="General LLM Evaluation", description="General eval"),
+        ),
+        recommendations=(
+            TVarRecommendation(
+                name="prompting_strategy",
+                range_type="Choices",
+                range_kwargs={"values": ["direct", "chain_of_thought"]},
+                category="prompting",
+                reasoning="Different strategies can improve output quality",
+                impact_estimate="medium",
+            ),
+        ),
+        agent_type="general_llm",
+    )
+
+
+class TestGenerateConfigCLI:
+    def test_table_output(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file)])
+            assert result.exit_code == 0
+            assert "temperature" in result.output
+            assert "accuracy" in result.output
+            assert "Tunable Variables" in result.output
+
+    def test_python_output(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file), "-o", "python"])
+            assert result.exit_code == 0
+            assert "@traigent.optimize(" in result.output
+            assert "temperature" in result.output
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file), "-o", "json"])
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["agent_type"] == "general_llm"
+            assert len(data["tvars"]) == 1
+            assert data["tvars"][0]["name"] == "temperature"
+
+    def test_invalid_subsystem(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            generate_config, [str(source_file), "--only", "invalid_sub"]
+        )
+        assert result.exit_code == 1
+        assert "Unknown subsystems" in result.output
+
+    def test_only_tvars_subsystem(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=AutoConfigResult(
+                tvars=(
+                    TVarSpec(
+                        name="temperature",
+                        range_type="Range",
+                        range_kwargs={"low": 0.0, "high": 2.0},
+                    ),
+                ),
+            ),
+        ) as mock_gen:
+            runner = CliRunner()
+            result = runner.invoke(
+                generate_config, [str(source_file), "--only", "tvars"]
+            )
+            assert result.exit_code == 0
+            # Verify subsystems kwarg was passed
+            call_kwargs = mock_gen.call_args
+            assert call_kwargs.kwargs["subsystems"] == frozenset({"tvars"})
+
+    def test_function_option(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=AutoConfigResult(),
+        ) as mock_gen:
+            runner = CliRunner()
+            result = runner.invoke(
+                generate_config,
+                [str(source_file), "--function", "my_agent"],
+            )
+            assert result.exit_code == 0
+            assert mock_gen.call_args.kwargs["function_name"] == "my_agent"
+
+    def test_enrich_flag(self, tmp_path: Path) -> None:
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=AutoConfigResult(),
+        ) as mock_gen:
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file), "--enrich"])
+            assert result.exit_code == 0
+            assert mock_gen.call_args.kwargs["enrich"] is True
+
+    def test_nonexistent_file(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(generate_config, ["/nonexistent/path.py"])
+        assert result.exit_code != 0

--- a/tests/unit/config_generator/test_agent_classifier.py
+++ b/tests/unit/config_generator/test_agent_classifier.py
@@ -1,0 +1,154 @@
+"""Tests for config_generator.agent_classifier."""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import (
+    AGENT_TYPES,
+    ClassificationResult,
+    _heuristic_classify,
+    classify_agent,
+)
+
+RAG_SOURCE = """\
+from langchain_openai import ChatOpenAI
+from chromadb import Client
+
+def rag_pipeline(query: str) -> str:
+    docs = vector_store.similarity_search(query, k=5)
+    retriever = db.as_retriever()
+    return llm.invoke(query)
+"""
+
+CHAT_SOURCE = """\
+from openai import OpenAI
+
+def chat_agent(query: str) -> str:
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": query}],
+    )
+    return response.choices[0].message.content
+"""
+
+CODE_GEN_SOURCE = """\
+def generate_and_run(prompt: str) -> str:
+    code = generate_code(prompt)
+    result = exec(code)
+    return result
+"""
+
+SUMMARIZATION_SOURCE = """\
+def summarize_document(text: str) -> str:
+    summary = llm.invoke(f"Summarize: {text}")
+    return summary
+"""
+
+CLASSIFICATION_SOURCE = """\
+def classify_intent(text: str) -> str:
+    label = predict_label(text)
+    return label
+"""
+
+ROUTER_SOURCE = """\
+def route_request(query: str) -> str:
+    agent = router.dispatch(query)
+    return agent_executor.invoke(query)
+"""
+
+GENERIC_SOURCE = """\
+def my_function(x: int) -> int:
+    return x * 2
+"""
+
+
+class TestHeuristicClassify:
+    def test_rag_agent(self) -> None:
+        result = _heuristic_classify(RAG_SOURCE)
+        assert result.agent_type == "rag"
+        assert result.confidence >= 0.5
+
+    def test_chat_agent(self) -> None:
+        result = _heuristic_classify(CHAT_SOURCE)
+        assert result.agent_type == "chat"
+        assert result.confidence >= 0.5
+
+    def test_code_gen_agent(self) -> None:
+        result = _heuristic_classify(CODE_GEN_SOURCE)
+        assert result.agent_type == "code_gen"
+        assert result.confidence >= 0.5
+
+    def test_summarization_agent(self) -> None:
+        result = _heuristic_classify(SUMMARIZATION_SOURCE)
+        assert result.agent_type == "summarization"
+        assert result.confidence >= 0.5
+
+    def test_classification_agent(self) -> None:
+        result = _heuristic_classify(CLASSIFICATION_SOURCE)
+        assert result.agent_type == "classification"
+        assert result.confidence >= 0.5
+
+    def test_router_agent(self) -> None:
+        result = _heuristic_classify(ROUTER_SOURCE)
+        assert result.agent_type == "router"
+        assert result.confidence >= 0.5
+
+    def test_generic_defaults_to_general_llm(self) -> None:
+        result = _heuristic_classify(GENERIC_SOURCE)
+        assert result.agent_type == "general_llm"
+        assert result.confidence < 0.5
+
+    def test_all_results_have_valid_agent_type(self) -> None:
+        for src in [
+            RAG_SOURCE,
+            CHAT_SOURCE,
+            CODE_GEN_SOURCE,
+            SUMMARIZATION_SOURCE,
+            CLASSIFICATION_SOURCE,
+            ROUTER_SOURCE,
+            GENERIC_SOURCE,
+        ]:
+            result = _heuristic_classify(src)
+            assert result.agent_type in AGENT_TYPES
+
+    def test_result_is_frozen(self) -> None:
+        result = _heuristic_classify(RAG_SOURCE)
+        assert isinstance(result, ClassificationResult)
+        assert result.source == "heuristic"
+
+
+class TestClassifyAgent:
+    def test_no_llm_uses_heuristic(self) -> None:
+        result = classify_agent(RAG_SOURCE, llm=None)
+        assert result.source == "heuristic"
+        assert result.agent_type == "rag"
+
+    def test_high_confidence_skips_llm(self) -> None:
+        """When heuristic confidence >= 0.8, LLM is not called."""
+        # RAG source with many matches should have high confidence
+        rich_rag = """\
+from chromadb import Client
+from pinecone import Pinecone
+def pipeline(query):
+    docs = vector_store.similarity_search(query, k=5)
+    retriever = db.as_retriever()
+    chunks = embedding.embed(query)
+    return rag_pipeline(docs, query)
+"""
+        result = classify_agent(rich_rag, llm=None)
+        assert result.agent_type == "rag"
+        assert result.confidence >= 0.8
+
+    def test_llm_non_numeric_confidence_handled(self) -> None:
+        """LLM returning non-numeric confidence should not crash."""
+        import json
+        from unittest.mock import MagicMock
+
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            {"agent_type": "rag", "confidence": "high", "reasoning": "test"}
+        )
+        # Use a generic source that triggers low heuristic confidence
+        result = classify_agent("def f(): pass", llm=llm)
+        # Should still return a result (fallback confidence = 0.5)
+        assert result is not None

--- a/tests/unit/config_generator/test_apply.py
+++ b/tests/unit/config_generator/test_apply.py
@@ -1,0 +1,413 @@
+"""Tests for config_generator.apply — decorator insertion."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from traigent.config_generator.apply import (
+    _collect_needed_imports,
+    _find_function,
+    _find_import_insertion_point,
+    _find_optimize_decorator,
+    _get_existing_imports,
+    _get_leading_whitespace,
+    _indent_decorator,
+    apply_config,
+)
+from traigent.config_generator.types import (
+    AutoConfigResult,
+    ObjectiveSpec,
+    SafetySpec,
+    TVarSpec,
+)
+
+
+@pytest.fixture()
+def simple_source() -> str:
+    return textwrap.dedent("""\
+        import os
+
+        def answer_question(query: str) -> str:
+            return "42"
+    """)
+
+
+@pytest.fixture()
+def result_with_tvars() -> AutoConfigResult:
+    return AutoConfigResult(
+        tvars=(
+            TVarSpec(
+                name="temperature",
+                range_type="Range",
+                range_kwargs={"low": 0.0, "high": 1.0},
+            ),
+        ),
+        objectives=(ObjectiveSpec(name="accuracy"),),
+    )
+
+
+@pytest.fixture()
+def result_with_safety() -> AutoConfigResult:
+    return AutoConfigResult(
+        tvars=(
+            TVarSpec(
+                name="temperature",
+                range_type="Range",
+                range_kwargs={"low": 0.0, "high": 1.0},
+            ),
+        ),
+        safety_constraints=(
+            SafetySpec(metric_name="faithfulness", operator=">=", threshold=0.85),
+        ),
+    )
+
+
+class TestApplyConfig:
+    def test_insert_decorator_on_simple_function(
+        self, tmp_path: Path, simple_source: str, result_with_tvars: AutoConfigResult
+    ) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text(simple_source)
+
+        apply_config(src, result_with_tvars, "answer_question", backup=False)
+
+        modified = src.read_text()
+        assert "@traigent.optimize(" in modified
+        assert "Range(low=0.0, high=1.0)" in modified
+        assert "def answer_question" in modified
+
+    def test_backup_created(
+        self, tmp_path: Path, simple_source: str, result_with_tvars: AutoConfigResult
+    ) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text(simple_source)
+
+        apply_config(src, result_with_tvars, "answer_question", backup=True)
+
+        bak = tmp_path / "agent.py.bak"
+        assert bak.exists()
+        assert bak.read_text() == simple_source
+
+    def test_no_backup_when_disabled(
+        self, tmp_path: Path, simple_source: str, result_with_tvars: AutoConfigResult
+    ) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text(simple_source)
+
+        apply_config(src, result_with_tvars, "answer_question", backup=False)
+
+        bak = tmp_path / "agent.py.bak"
+        assert not bak.exists()
+
+    def test_adds_import_traigent(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import os
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert "import traigent" in modified
+
+    def test_adds_range_imports(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import os
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert "from traigent import Range" in modified
+
+    def test_adds_safety_imports(
+        self, tmp_path: Path, result_with_safety: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import os
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_safety, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert "from traigent.api.safety import faithfulness" in modified
+
+    def test_skips_existing_imports(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import traigent
+            from traigent import Range
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        # Should NOT duplicate imports
+        assert modified.count("import traigent") == 1
+        assert modified.count("from traigent import Range") == 1
+
+    def test_replaces_existing_decorator(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import traigent
+
+            @traigent.optimize(
+                configuration_space={"old": (0, 1)},
+            )
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        # Old config gone, new config present
+        assert "old" not in modified
+        assert "temperature" in modified
+        # Only one @traigent.optimize
+        assert modified.count("@traigent.optimize(") == 1
+
+    def test_replaces_bare_optimize_decorator(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            from traigent import optimize
+
+            @optimize(configuration_space={"old": (0, 1)})
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert "old" not in modified
+        assert "@traigent.optimize(" in modified
+
+    def test_indentation_preserved_for_method(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            class Agent:
+                def my_method(self):
+                    pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_method", backup=False)
+
+        modified = src.read_text()
+        # Decorator should be indented to match the method
+        for line in modified.splitlines():
+            if "@traigent.optimize(" in line:
+                assert line.startswith("    @traigent.optimize(")
+                break
+        else:
+            pytest.fail("Decorator not found in modified source")
+
+    def test_function_not_found_raises(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text("def other(): pass\n")
+
+        with pytest.raises(ValueError, match="not found"):
+            apply_config(src, result_with_tvars, "missing_func", backup=False)
+
+    def test_function_name_required(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text("def f(): pass\n")
+
+        with pytest.raises(ValueError, match="function_name is required"):
+            apply_config(src, result_with_tvars, None, backup=False)
+
+    def test_syntax_error_raises(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        src = tmp_path / "agent.py"
+        src.write_text("def f(:\n")
+
+        with pytest.raises(ValueError, match="Cannot parse"):
+            apply_config(src, result_with_tvars, "f", backup=False)
+
+    def test_inserts_above_existing_decorators(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import os
+
+            @some_other_decorator
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        lines = modified.splitlines()
+        # Decorator should appear before the existing @some_other_decorator
+        optimize_idx = next(
+            i for i, l in enumerate(lines) if "@traigent.optimize(" in l
+        )
+        other_idx = next(i for i, l in enumerate(lines) if "@some_other_decorator" in l)
+        assert optimize_idx < other_idx
+
+    def test_replaces_fully_qualified_decorator(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import traigent.api.decorators
+
+            @traigent.api.decorators.optimize(configuration_space={"old": (0, 1)})
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert "old" not in modified
+        assert "@traigent.optimize(" in modified
+        assert "temperature" in modified
+
+    def test_async_function(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            import asyncio
+
+            async def my_async_func():
+                await asyncio.sleep(0)
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_async_func", backup=False)
+
+        modified = src.read_text()
+        assert "@traigent.optimize(" in modified
+        assert "async def my_async_func" in modified
+
+
+class TestHelpers:
+    def test_get_leading_whitespace(self) -> None:
+        assert _get_leading_whitespace("    def f(): pass") == "    "
+        assert _get_leading_whitespace("def f(): pass") == ""
+        assert _get_leading_whitespace("\t\tdef f(): pass") == "\t\t"
+
+    def test_indent_decorator(self) -> None:
+        code = "@traigent.optimize(\n    config={},\n)"
+        result = _indent_decorator(code, "    ")
+        assert result.startswith("    @traigent.optimize(")
+        assert "\n        config={}," in result
+
+    def test_find_function_in_ast(self) -> None:
+        import ast
+
+        tree = ast.parse("def foo(): pass\ndef bar(): pass\n")
+        assert _find_function(tree, "foo") is not None
+        assert _find_function(tree, "bar") is not None
+        assert _find_function(tree, "baz") is None
+
+    def test_find_optimize_decorator_attribute(self) -> None:
+        import ast
+
+        source = "@traigent.optimize(x=1)\ndef f(): pass\n"
+        tree = ast.parse(source)
+        func = _find_function(tree, "f")
+        assert func is not None
+        assert _find_optimize_decorator(func) is not None
+
+    def test_find_optimize_decorator_bare(self) -> None:
+        import ast
+
+        source = "@optimize(x=1)\ndef f(): pass\n"
+        tree = ast.parse(source)
+        func = _find_function(tree, "f")
+        assert func is not None
+        assert _find_optimize_decorator(func) is not None
+
+    def test_find_optimize_decorator_none(self) -> None:
+        import ast
+
+        source = "@other_decorator\ndef f(): pass\n"
+        tree = ast.parse(source)
+        func = _find_function(tree, "f")
+        assert func is not None
+        assert _find_optimize_decorator(func) is None
+
+    def test_collect_needed_imports_basic(self) -> None:
+        import ast
+
+        tree = ast.parse("import os\n")
+        code = "@traigent.optimize(\n    configuration_space={'t': Range(low=0, high=1)},\n)"
+        imports = _collect_needed_imports(code, tree)
+        assert any("import traigent" in i for i in imports)
+        assert any("Range" in i for i in imports)
+
+    def test_collect_needed_imports_skips_existing(self) -> None:
+        import ast
+
+        tree = ast.parse("import traigent\nfrom traigent import Range\n")
+        code = "@traigent.optimize(\n    configuration_space={'t': Range(low=0, high=1)},\n)"
+        imports = _collect_needed_imports(code, tree)
+        # Neither traigent nor Range should be in needed
+        assert not any("traigent" in i for i in imports)
+
+    def test_get_existing_imports_ignores_nested(self) -> None:
+        import ast
+
+        source = "import os\n\ndef f():\n    from traigent import Range\n"
+        tree = ast.parse(source)
+        existing = _get_existing_imports(tree)
+        # Only module-level 'os' should be found, not nested 'Range'
+        assert "os" in existing
+        assert "Range" not in existing
+
+    def test_find_import_insertion_point_ignores_nested(self) -> None:
+        import ast
+
+        source = "import os\n\ndef f():\n    import json\n"
+        tree = ast.parse(source)
+        pos = _find_import_insertion_point(tree)
+        # Should point after 'import os' (line 1), not after nested 'import json' (line 4)
+        assert pos == 1

--- a/tests/unit/config_generator/test_llm_backend.py
+++ b/tests/unit/config_generator/test_llm_backend.py
@@ -1,0 +1,112 @@
+"""Tests for config_generator.llm_backend."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from traigent.config_generator.llm_backend import (
+    BudgetExhausted,
+    ConfigGenLLM,
+    LiteLLMBackend,
+    NoOpLLMBackend,
+)
+
+
+class TestNoOpLLMBackend:
+    def test_complete_returns_empty(self) -> None:
+        backend = NoOpLLMBackend()
+        assert backend.complete("test prompt") == ""
+
+    def test_calls_made_zero(self) -> None:
+        backend = NoOpLLMBackend()
+        backend.complete("test")
+        assert backend.calls_made == 0
+
+    def test_total_cost_zero(self) -> None:
+        backend = NoOpLLMBackend()
+        assert backend.total_cost_usd == 0.0
+
+    def test_implements_protocol(self) -> None:
+        backend = NoOpLLMBackend()
+        assert isinstance(backend, ConfigGenLLM)
+
+
+class TestLiteLLMBackend:
+    def test_budget_enforcement(self) -> None:
+        backend = LiteLLMBackend(budget_usd=0.0)
+        with pytest.raises(BudgetExhausted, match="Budget"):
+            backend.complete("test")
+
+    def test_litellm_not_installed(self) -> None:
+        backend = LiteLLMBackend(budget_usd=1.0)
+        with patch.dict("sys.modules", {"litellm": None}):
+            with pytest.raises(BudgetExhausted, match="not installed"):
+                backend.complete("test")
+
+    def test_successful_call(self) -> None:
+        backend = LiteLLMBackend(budget_usd=1.0)
+
+        mock_usage = MagicMock()
+        mock_usage.prompt_tokens = 100
+        mock_usage.completion_tokens = 50
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "test response"
+
+        mock_response = MagicMock()
+        mock_response.usage = mock_usage
+        mock_response.choices = [mock_choice]
+
+        with patch("litellm.completion", return_value=mock_response) as mock_completion:
+            result = backend.complete("test prompt", max_tokens=512)
+
+        assert result == "test response"
+        assert backend.calls_made == 1
+        assert backend.total_cost_usd > 0
+        mock_completion.assert_called_once()
+
+    def test_cost_tracking(self) -> None:
+        backend = LiteLLMBackend(budget_usd=1.0)
+
+        mock_usage = MagicMock()
+        mock_usage.prompt_tokens = 1000
+        mock_usage.completion_tokens = 500
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "response"
+
+        mock_response = MagicMock()
+        mock_response.usage = mock_usage
+        mock_response.choices = [mock_choice]
+
+        with patch("litellm.completion", return_value=mock_response):
+            backend.complete("prompt 1")
+            backend.complete("prompt 2")
+
+        assert backend.calls_made == 2
+        assert backend.total_cost_usd > 0
+
+    def test_null_content_returns_empty(self) -> None:
+        backend = LiteLLMBackend(budget_usd=1.0)
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = None
+
+        mock_response = MagicMock()
+        mock_response.usage = None
+        mock_response.choices = [mock_choice]
+
+        with patch("litellm.completion", return_value=mock_response):
+            result = backend.complete("test")
+
+        assert result == ""
+
+    def test_implements_protocol(self) -> None:
+        backend = LiteLLMBackend()
+        assert isinstance(backend, ConfigGenLLM)
+
+    def test_default_model(self) -> None:
+        backend = LiteLLMBackend()
+        assert backend._model == "gpt-4o-mini"

--- a/tests/unit/config_generator/test_pipeline.py
+++ b/tests/unit/config_generator/test_pipeline.py
@@ -1,0 +1,183 @@
+"""Tests for config_generator.pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from traigent.config_generator.pipeline import ALL_SUBSYSTEMS, ConfigGeneratorPipeline
+from traigent.config_generator.types import AutoConfigResult
+from traigent.tuned_variables.detection_types import (
+    CandidateType,
+    DetectionConfidence,
+    DetectionResult,
+    SourceLocation,
+    TunedVariableCandidate,
+)
+
+
+def _make_detection_result(
+    names: list[str] | None = None,
+) -> DetectionResult:
+    """Build a minimal DetectionResult."""
+    if names is None:
+        names = ["temperature"]
+    candidates = tuple(
+        TunedVariableCandidate(
+            name=n,
+            canonical_name=n,
+            candidate_type=CandidateType.NUMERIC_CONTINUOUS,
+            confidence=DetectionConfidence.HIGH,
+            location=SourceLocation(line=1, col_offset=0),
+        )
+        for n in names
+    )
+    return DetectionResult(
+        function_name="my_func",
+        candidates=candidates,
+    )
+
+
+class TestConfigGeneratorPipeline:
+    def test_returns_auto_config_result(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate([_make_detection_result()])
+        assert isinstance(result, AutoConfigResult)
+
+    def test_tvars_populated(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate([_make_detection_result(["temperature"])])
+        assert len(result.tvars) >= 1
+        names = {t.name for t in result.tvars}
+        assert "temperature" in names
+
+    def test_objectives_always_have_accuracy(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code="def f(): pass",
+        )
+        obj_names = {o.name for o in result.objectives}
+        assert "accuracy" in obj_names
+
+    def test_agent_type_classified(self) -> None:
+        rag_code = (
+            "from langchain.vectorstores import Chroma\n"
+            "def my_func():\n"
+            "    retriever = Chroma()\n"
+            "    docs = retriever.similarity_search(query)\n"
+        )
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code=rag_code,
+        )
+        assert result.agent_type == "rag"
+
+    def test_safety_constraints_populated_for_rag(self) -> None:
+        rag_code = (
+            "from langchain.vectorstores import Chroma\n"
+            "def my_func():\n"
+            "    retriever = Chroma()\n"
+            "    docs = retriever.similarity_search(query)\n"
+        )
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code=rag_code,
+        )
+        assert len(result.safety_constraints) >= 1
+
+    def test_structural_constraints_for_matching_tvars(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(
+            [_make_detection_result(["temperature", "top_p"])],
+        )
+        assert len(result.structural_constraints) >= 1
+
+    def test_benchmarks_populated(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code="def f(): pass",
+        )
+        assert len(result.benchmarks) >= 1
+
+    def test_recommendations_populated(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code="def f(): pass",
+        )
+        # general_llm should recommend at least prompting_strategy
+        names = {r.name for r in result.recommendations}
+        assert "prompting_strategy" in names
+
+    def test_subsystem_filter(self) -> None:
+        pipeline = ConfigGeneratorPipeline(subsystems=frozenset({"tvars"}))
+        result = pipeline.generate([_make_detection_result()])
+        assert len(result.tvars) >= 1
+        assert len(result.objectives) == 0
+        assert len(result.safety_constraints) == 0
+        assert len(result.structural_constraints) == 0
+        assert len(result.benchmarks) == 0
+        assert len(result.recommendations) == 0
+
+    def test_empty_detection_results(self) -> None:
+        empty_result = [DetectionResult(function_name="empty", candidates=())]
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate(empty_result, source_code="def f(): pass")
+        assert isinstance(result, AutoConfigResult)
+        assert len(result.tvars) == 0
+
+    def test_no_source_code_skips_classification(self) -> None:
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate([_make_detection_result()])
+        assert result.agent_type is None
+
+    def test_multiple_detection_results(self) -> None:
+        r1 = _make_detection_result(["temperature"])
+        r2 = _make_detection_result(["max_tokens"])
+        pipeline = ConfigGeneratorPipeline()
+        result = pipeline.generate([r1, r2])
+        names = {t.name for t in result.tvars}
+        assert "temperature" in names
+        assert "max_tokens" in names
+
+    def test_all_subsystems_constant(self) -> None:
+        assert "tvars" in ALL_SUBSYSTEMS
+        assert "objectives" in ALL_SUBSYSTEMS
+        assert "safety" in ALL_SUBSYSTEMS
+        assert "structural" in ALL_SUBSYSTEMS
+        assert "benchmarks" in ALL_SUBSYSTEMS
+        assert "recommendations" in ALL_SUBSYSTEMS
+
+    def test_classification_skipped_when_no_consumers(self) -> None:
+        """Classification should not run when only tvars/structural are enabled."""
+        llm = MagicMock()
+        llm.complete.return_value = "[]"
+        llm.calls_made = 0
+        llm._spent_usd = 0.0
+        pipeline = ConfigGeneratorPipeline(
+            llm=llm,
+            subsystems=frozenset({"tvars", "structural"}),
+        )
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code="def f(): pass",
+        )
+        # Classification never ran, so agent_type should be None
+        assert result.agent_type is None
+
+    def test_llm_stats_collected(self) -> None:
+        llm = MagicMock()
+        # Return valid JSON dict (for classify_agent) or array (for other subsystems)
+        llm.complete.return_value = '{"agent_type": "general_llm", "confidence": 0.5}'
+        llm.calls_made = 5
+        llm._spent_usd = 0.03
+        pipeline = ConfigGeneratorPipeline(llm=llm)
+        result = pipeline.generate(
+            [_make_detection_result()],
+            source_code="def f(): pass",
+        )
+        assert result.llm_calls_made == 5
+        assert abs(result.llm_cost_usd - 0.03) < 1e-9

--- a/tests/unit/config_generator/test_presets/test_agent_type_catalog.py
+++ b/tests/unit/config_generator/test_presets/test_agent_type_catalog.py
@@ -1,0 +1,70 @@
+"""Tests for config_generator.presets.agent_type_catalog."""
+
+from __future__ import annotations
+
+from traigent.config_generator.presets.agent_type_catalog import (
+    all_agent_types,
+    get_safety_presets,
+)
+
+
+class TestGetSafetyPresets:
+    def test_rag_has_faithfulness(self) -> None:
+        presets = get_safety_presets("rag")
+        metrics = {p.metric_name for p in presets}
+        assert "faithfulness" in metrics
+        assert "hallucination_rate" in metrics
+
+    def test_chat_has_toxicity(self) -> None:
+        presets = get_safety_presets("chat")
+        metrics = {p.metric_name for p in presets}
+        assert "toxicity_score" in metrics
+        assert "bias_score" in metrics
+
+    def test_code_gen_has_safety_score(self) -> None:
+        presets = get_safety_presets("code_gen")
+        metrics = {p.metric_name for p in presets}
+        assert "safety_score" in metrics
+
+    def test_summarization_presets(self) -> None:
+        presets = get_safety_presets("summarization")
+        assert len(presets) >= 1
+        metrics = {p.metric_name for p in presets}
+        assert "faithfulness" in metrics
+
+    def test_classification_has_bias(self) -> None:
+        presets = get_safety_presets("classification")
+        metrics = {p.metric_name for p in presets}
+        assert "bias_score" in metrics
+
+    def test_general_llm_has_hallucination(self) -> None:
+        presets = get_safety_presets("general_llm")
+        metrics = {p.metric_name for p in presets}
+        assert "hallucination_rate" in metrics
+
+    def test_unknown_type_returns_empty(self) -> None:
+        assert get_safety_presets("unknown_type") == []
+
+    def test_all_presets_have_valid_operators(self) -> None:
+        for agent_type in all_agent_types():
+            for preset in get_safety_presets(agent_type):
+                assert preset.operator in (">=", "<=")
+                assert 0.0 <= preset.threshold <= 1.0
+                assert preset.agent_type == agent_type
+                assert preset.source == "preset"
+                assert preset.reasoning != ""
+
+
+class TestAllAgentTypes:
+    def test_returns_frozenset(self) -> None:
+        types = all_agent_types()
+        assert isinstance(types, frozenset)
+
+    def test_contains_core_types(self) -> None:
+        types = all_agent_types()
+        assert "rag" in types
+        assert "chat" in types
+        assert "general_llm" in types
+
+    def test_at_least_6_types(self) -> None:
+        assert len(all_agent_types()) >= 6

--- a/tests/unit/config_generator/test_presets/test_benchmark_catalog.py
+++ b/tests/unit/config_generator/test_presets/test_benchmark_catalog.py
@@ -1,0 +1,62 @@
+"""Tests for config_generator.presets.benchmark_catalog."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.config_generator.presets.benchmark_catalog import (
+    all_benchmark_types,
+    get_benchmark_for_agent_type,
+)
+
+
+class TestGetBenchmarkForAgentType:
+    @pytest.mark.parametrize(
+        "agent_type",
+        ["rag", "chat", "code_gen", "summarization", "classification", "general_llm"],
+    )
+    def test_known_agent_types_have_benchmarks(self, agent_type: str) -> None:
+        benchmark = get_benchmark_for_agent_type(agent_type)
+        assert benchmark is not None
+        assert benchmark.name != ""
+        assert benchmark.description != ""
+        assert benchmark.source == "catalog"
+
+    def test_unknown_agent_type_returns_none(self) -> None:
+        assert get_benchmark_for_agent_type("unknown_type") is None
+
+    def test_rag_benchmark_has_question_input(self) -> None:
+        benchmark = get_benchmark_for_agent_type("rag")
+        assert benchmark is not None
+        assert "question" in benchmark.example_schema.get("input", {})
+
+    def test_code_gen_benchmark_has_prompt_input(self) -> None:
+        benchmark = get_benchmark_for_agent_type("code_gen")
+        assert benchmark is not None
+        assert "prompt" in benchmark.example_schema.get("input", {})
+
+    def test_classification_benchmark_has_text_input(self) -> None:
+        benchmark = get_benchmark_for_agent_type("classification")
+        assert benchmark is not None
+        assert "text" in benchmark.example_schema.get("input", {})
+
+    def test_all_benchmarks_have_output_schema(self) -> None:
+        for agent_type in all_benchmark_types():
+            benchmark = get_benchmark_for_agent_type(agent_type)
+            assert benchmark is not None
+            assert "output" in benchmark.example_schema
+
+
+class TestAllBenchmarkTypes:
+    def test_returns_frozenset(self) -> None:
+        result = all_benchmark_types()
+        assert isinstance(result, frozenset)
+
+    def test_contains_known_types(self) -> None:
+        types = all_benchmark_types()
+        assert "rag" in types
+        assert "chat" in types
+        assert "general_llm" in types
+
+    def test_at_least_six_types(self) -> None:
+        assert len(all_benchmark_types()) >= 6

--- a/tests/unit/config_generator/test_presets/test_constraint_templates.py
+++ b/tests/unit/config_generator/test_presets/test_constraint_templates.py
@@ -1,0 +1,91 @@
+"""Tests for config_generator.presets.constraint_templates."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.config_generator.presets.constraint_templates import (
+    ConstraintTemplate,
+    get_matching_constraints,
+)
+
+
+class TestConstraintTemplate:
+    def test_matches_all_required_present(self) -> None:
+        tmpl = ConstraintTemplate(
+            name="test",
+            description="desc",
+            requires_tvars=frozenset({"a", "b"}),
+        )
+        assert tmpl.matches({"a", "b", "c"}) is True
+
+    def test_no_match_missing_tvar(self) -> None:
+        tmpl = ConstraintTemplate(
+            name="test",
+            description="desc",
+            requires_tvars=frozenset({"a", "b"}),
+        )
+        assert tmpl.matches({"a", "c"}) is False
+
+    def test_frozen(self) -> None:
+        tmpl = ConstraintTemplate(
+            name="test",
+            description="desc",
+            requires_tvars=frozenset({"x"}),
+        )
+        with pytest.raises(AttributeError):
+            tmpl.name = "other"  # type: ignore[misc]
+
+
+class TestGetMatchingConstraints:
+    def test_temperature_top_p(self) -> None:
+        constraints = get_matching_constraints({"temperature", "top_p"})
+        names = {c.description for c in constraints}
+        assert any("temperature" in d.lower() and "top_p" in d.lower() for d in names)
+
+    def test_model_temperature(self) -> None:
+        constraints = get_matching_constraints({"model", "temperature"})
+        assert len(constraints) >= 1
+        assert all(c.source == "template" for c in constraints)
+
+    def test_model_max_tokens(self) -> None:
+        constraints = get_matching_constraints({"model", "max_tokens"})
+        assert len(constraints) >= 1
+        assert any("max_tokens" in c.constraint_code for c in constraints)
+
+    def test_chunk_size_overlap(self) -> None:
+        constraints = get_matching_constraints({"chunk_size", "chunk_overlap"})
+        assert len(constraints) >= 1
+        assert any("chunk_overlap" in c.constraint_code for c in constraints)
+
+    def test_no_matches_for_unrelated_tvars(self) -> None:
+        constraints = get_matching_constraints({"foo", "bar"})
+        assert constraints == []
+
+    def test_empty_tvars(self) -> None:
+        constraints = get_matching_constraints(set())
+        assert constraints == []
+
+    def test_multiple_templates_match(self) -> None:
+        # temperature + top_p + model triggers 2 templates
+        constraints = get_matching_constraints({"temperature", "top_p", "model"})
+        assert len(constraints) >= 2
+
+    def test_all_constraints_have_requires_tvars(self) -> None:
+        constraints = get_matching_constraints(
+            {
+                "temperature",
+                "top_p",
+                "model",
+                "max_tokens",
+                "chunk_size",
+                "chunk_overlap",
+            }
+        )
+        for c in constraints:
+            assert len(c.requires_tvars) >= 2
+
+    def test_all_constraints_have_reasoning(self) -> None:
+        constraints = get_matching_constraints({"temperature", "top_p"})
+        for c in constraints:
+            assert c.reasoning != ""

--- a/tests/unit/config_generator/test_presets/test_range_presets.py
+++ b/tests/unit/config_generator/test_presets/test_range_presets.py
@@ -1,0 +1,107 @@
+"""Tests for config_generator.presets.range_presets."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.config_generator.presets.range_presets import (
+    all_canonical_names,
+    get_preset_range,
+    has_preset,
+)
+
+
+class TestGetPresetRange:
+    def test_temperature(self) -> None:
+        preset = get_preset_range("temperature")
+        assert preset is not None
+        assert preset["range_type"] == "Range"
+        assert preset["kwargs"]["low"] == 0.0
+        assert preset["kwargs"]["high"] == 1.0
+
+    def test_max_tokens(self) -> None:
+        preset = get_preset_range("max_tokens")
+        assert preset is not None
+        assert preset["range_type"] == "IntRange"
+        assert preset["kwargs"]["low"] == 256
+        assert preset["kwargs"]["high"] == 4096
+
+    def test_model(self) -> None:
+        preset = get_preset_range("model")
+        assert preset is not None
+        assert preset["range_type"] == "Choices"
+        assert isinstance(preset["kwargs"]["values"], list)
+        assert len(preset["kwargs"]["values"]) >= 2
+
+    def test_k(self) -> None:
+        preset = get_preset_range("k")
+        assert preset is not None
+        assert preset["range_type"] == "IntRange"
+
+    def test_prompting_strategy(self) -> None:
+        preset = get_preset_range("prompting_strategy")
+        assert preset is not None
+        assert preset["range_type"] == "Choices"
+        assert "direct" in preset["kwargs"]["values"]
+
+    def test_unknown_returns_none(self) -> None:
+        assert get_preset_range("unknown_variable") is None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "similarity_threshold",
+            "mmr_lambda",
+            "chunk_overlap_ratio",
+            "max_tokens",
+            "k",
+            "chunk_size",
+            "chunk_overlap",
+            "few_shot_count",
+            "batch_size",
+            "n",
+            "seed",
+            "top_k",
+            "model",
+            "prompting_strategy",
+            "context_format",
+            "retriever_type",
+            "embedding_model",
+            "reranker_model",
+        ],
+    )
+    def test_all_presets_have_valid_structure(self, name: str) -> None:
+        preset = get_preset_range(name)
+        assert preset is not None, f"Missing preset for {name}"
+        assert "range_type" in preset
+        assert "kwargs" in preset
+        assert preset["range_type"] in ("Range", "IntRange", "LogRange", "Choices")
+
+
+class TestHasPreset:
+    def test_known(self) -> None:
+        assert has_preset("temperature") is True
+        assert has_preset("model") is True
+
+    def test_unknown(self) -> None:
+        assert has_preset("nonexistent") is False
+
+
+class TestAllCanonicalNames:
+    def test_returns_frozenset(self) -> None:
+        names = all_canonical_names()
+        assert isinstance(names, frozenset)
+
+    def test_contains_key_names(self) -> None:
+        names = all_canonical_names()
+        assert "temperature" in names
+        assert "max_tokens" in names
+        assert "model" in names
+
+    def test_at_least_20_presets(self) -> None:
+        # We have 22 presets in the catalog
+        assert len(all_canonical_names()) >= 20

--- a/tests/unit/config_generator/test_subsystems/test_benchmarks.py
+++ b/tests/unit/config_generator/test_subsystems/test_benchmarks.py
@@ -1,0 +1,89 @@
+"""Tests for config_generator.subsystems.benchmarks."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.llm_backend import BudgetExhausted
+from traigent.config_generator.subsystems.benchmarks import generate_benchmarks
+
+
+class TestGenerateBenchmarks:
+    def test_default_returns_general_llm(self) -> None:
+        benchmarks = generate_benchmarks("def f(): pass")
+        assert len(benchmarks) == 1
+        assert benchmarks[0].source == "catalog"
+
+    def test_rag_classification(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        benchmarks = generate_benchmarks("", classification=classification)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].name == "RAG Question Answering"
+
+    def test_code_gen_classification(self) -> None:
+        classification = ClassificationResult(
+            agent_type="code_gen", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        benchmarks = generate_benchmarks("", classification=classification)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].name == "Code Generation"
+
+    def test_unknown_classification_falls_back_to_general(self) -> None:
+        classification = ClassificationResult(
+            agent_type="unknown_type",
+            confidence=0.5,
+            source="heuristic",
+            reasoning="test",
+        )
+        benchmarks = generate_benchmarks("", classification=classification)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].name == "General LLM Evaluation"
+
+    def test_llm_enrichment_replaces_catalog(self) -> None:
+        llm = MagicMock()
+        examples = [
+            {"input": {"prompt": "Hello"}, "output": "Hi there"},
+            {"input": {"prompt": "What is 2+2?"}, "output": "4"},
+            {"input": {"prompt": "Explain AI"}, "output": "AI is..."},
+        ]
+        llm.complete.return_value = json.dumps(examples)
+
+        benchmarks = generate_benchmarks("def f(): pass", llm=llm)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].source == "llm"
+        assert len(benchmarks[0].sample_examples) == 3
+
+    def test_llm_budget_exhausted_returns_catalog(self) -> None:
+        llm = MagicMock()
+        llm.complete.side_effect = BudgetExhausted(0.10)
+        benchmarks = generate_benchmarks("def f(): pass", llm=llm)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].source == "catalog"
+
+    def test_llm_invalid_json_returns_catalog(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = "not valid json"
+        benchmarks = generate_benchmarks("def f(): pass", llm=llm)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].source == "catalog"
+
+    def test_llm_empty_array_returns_catalog(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = "[]"
+        benchmarks = generate_benchmarks("def f(): pass", llm=llm)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].source == "catalog"
+
+    def test_llm_markdown_fenced_response(self) -> None:
+        llm = MagicMock()
+        examples = [{"input": {"prompt": "test"}, "output": "result"}]
+        llm.complete.return_value = "```json\n" + json.dumps(examples) + "\n```"
+
+        benchmarks = generate_benchmarks("def f(): pass", llm=llm)
+        assert len(benchmarks) == 1
+        assert benchmarks[0].source == "llm"
+        assert len(benchmarks[0].sample_examples) == 1

--- a/tests/unit/config_generator/test_subsystems/test_objectives.py
+++ b/tests/unit/config_generator/test_subsystems/test_objectives.py
@@ -1,0 +1,148 @@
+"""Tests for config_generator.subsystems.objectives."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.subsystems.objectives import (
+    _has_llm_imports,
+    _normalize_weights,
+    generate_objectives,
+)
+from traigent.config_generator.types import ObjectiveSpec, TVarSpec
+
+LLM_SOURCE = """\
+from langchain_openai import ChatOpenAI
+
+def my_agent(query: str) -> str:
+    llm = ChatOpenAI(model="gpt-4o", temperature=0.7)
+    return llm.invoke(query)
+"""
+
+GENERIC_SOURCE = """\
+def compute(x: int) -> int:
+    return x * 2
+"""
+
+
+class TestGenerateObjectives:
+    def test_always_includes_accuracy(self) -> None:
+        objectives = generate_objectives(GENERIC_SOURCE, [])
+        names = {o.name for o in objectives}
+        assert "accuracy" in names
+
+    def test_model_tvar_adds_cost(self) -> None:
+        tvars = [
+            TVarSpec(
+                name="model",
+                range_type="Choices",
+                range_kwargs={"values": ["gpt-4o"]},
+            ),
+        ]
+        objectives = generate_objectives(GENERIC_SOURCE, tvars)
+        names = {o.name for o in objectives}
+        assert "cost" in names
+
+    def test_llm_imports_add_cost_and_latency(self) -> None:
+        objectives = generate_objectives(LLM_SOURCE, [])
+        names = {o.name for o in objectives}
+        assert "cost" in names
+        assert "latency" in names
+
+    def test_rag_classification_adds_faithfulness(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.8, source="heuristic", reasoning="test"
+        )
+        objectives = generate_objectives(
+            GENERIC_SOURCE, [], classification=classification
+        )
+        names = {o.name for o in objectives}
+        assert "faithfulness" in names
+
+    def test_classification_agent_adds_f1(self) -> None:
+        classification = ClassificationResult(
+            agent_type="classification",
+            confidence=0.8,
+            source="heuristic",
+            reasoning="test",
+        )
+        objectives = generate_objectives(
+            GENERIC_SOURCE, [], classification=classification
+        )
+        names = {o.name for o in objectives}
+        assert "f1" in names
+
+    def test_weights_sum_to_one(self) -> None:
+        objectives = generate_objectives(LLM_SOURCE, [])
+        total = sum(o.weight for o in objectives)
+        assert abs(total - 1.0) < 0.01
+
+    def test_all_objectives_have_valid_orientation(self) -> None:
+        objectives = generate_objectives(LLM_SOURCE, [])
+        for obj in objectives:
+            assert obj.orientation in ("maximize", "minimize")
+
+
+class TestHasLlmImports:
+    def test_langchain(self) -> None:
+        assert _has_llm_imports("from langchain import LLM") is True
+
+    def test_openai(self) -> None:
+        assert _has_llm_imports("import openai") is True
+
+    def test_no_imports(self) -> None:
+        assert _has_llm_imports("def f(): return 1") is False
+
+
+class TestNormalizeWeights:
+    def test_normalizes_to_one(self) -> None:
+        objectives = [
+            ObjectiveSpec(name="a", weight=3.0),
+            ObjectiveSpec(name="b", weight=7.0),
+        ]
+        normalized = _normalize_weights(objectives)
+        assert abs(sum(o.weight for o in normalized) - 1.0) < 0.001
+        assert normalized[0].weight == pytest.approx(0.3, abs=0.001)
+        assert normalized[1].weight == pytest.approx(0.7, abs=0.001)
+
+    def test_zero_total_unchanged(self) -> None:
+        objectives = [
+            ObjectiveSpec(name="a", weight=0.0),
+        ]
+        normalized = _normalize_weights(objectives)
+        assert normalized[0].weight == 0.0
+
+    def test_preserves_names(self) -> None:
+        objectives = [
+            ObjectiveSpec(name="accuracy", weight=0.5),
+            ObjectiveSpec(name="cost", weight=0.5, orientation="minimize"),
+        ]
+        normalized = _normalize_weights(objectives)
+        assert normalized[0].name == "accuracy"
+        assert normalized[1].name == "cost"
+        assert normalized[1].orientation == "minimize"
+
+
+class TestLLMEnrichment:
+    def test_non_numeric_weight_handled(self) -> None:
+        """LLM returning non-numeric weight should use default, not crash."""
+        import json
+        from unittest.mock import MagicMock
+
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            [
+                {
+                    "name": "custom_metric",
+                    "orientation": "maximize",
+                    "weight": "medium",
+                    "reasoning": "test",
+                }
+            ]
+        )
+        objectives = generate_objectives("def f(): pass", [], llm=llm)
+        custom = [o for o in objectives if o.name == "custom_metric"]
+        assert len(custom) == 1
+        # Weight is the fallback 0.15 after normalization (may differ slightly)
+        assert custom[0].weight > 0

--- a/tests/unit/config_generator/test_subsystems/test_safety_constraints.py
+++ b/tests/unit/config_generator/test_subsystems/test_safety_constraints.py
@@ -1,0 +1,54 @@
+"""Tests for config_generator.subsystems.safety_constraints."""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.subsystems.safety_constraints import (
+    generate_safety_constraints,
+)
+
+RAG_SOURCE = """\
+def rag_pipeline(query):
+    docs = vector_store.similarity_search(query, k=5)
+    retriever = db.as_retriever()
+    return llm.invoke(query)
+"""
+
+
+class TestGenerateSafetyConstraints:
+    def test_rag_source_returns_safety_constraints(self) -> None:
+        constraints, classification = generate_safety_constraints(RAG_SOURCE)
+        assert classification.agent_type == "rag"
+        assert len(constraints) >= 1
+        metrics = {c.metric_name for c in constraints}
+        assert "faithfulness" in metrics
+
+    def test_with_precomputed_classification(self) -> None:
+        classification = ClassificationResult(
+            agent_type="chat",
+            confidence=0.9,
+            source="heuristic",
+            reasoning="test",
+        )
+        constraints, returned_class = generate_safety_constraints(
+            "any source", classification=classification
+        )
+        assert returned_class is classification
+        assert any(c.metric_name == "toxicity_score" for c in constraints)
+
+    def test_unknown_agent_type_returns_empty(self) -> None:
+        classification = ClassificationResult(
+            agent_type="unknown",
+            confidence=0.5,
+            source="test",
+            reasoning="test",
+        )
+        constraints, _ = generate_safety_constraints(
+            "source", classification=classification
+        )
+        assert constraints == []
+
+    def test_all_constraints_have_agent_type(self) -> None:
+        constraints, classification = generate_safety_constraints(RAG_SOURCE)
+        for c in constraints:
+            assert c.agent_type == classification.agent_type

--- a/tests/unit/config_generator/test_subsystems/test_structural_constraints.py
+++ b/tests/unit/config_generator/test_subsystems/test_structural_constraints.py
@@ -1,0 +1,109 @@
+"""Tests for config_generator.subsystems.structural_constraints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from traigent.config_generator.llm_backend import BudgetExhausted
+from traigent.config_generator.subsystems.structural_constraints import (
+    generate_structural_constraints,
+)
+from traigent.config_generator.types import TVarSpec
+
+
+def _make_tvar(name: str) -> TVarSpec:
+    return TVarSpec(name=name, range_type="Range", range_kwargs={"low": 0, "high": 1})
+
+
+class TestGenerateStructuralConstraints:
+    def test_template_matching_temp_top_p(self) -> None:
+        tvars = [_make_tvar("temperature"), _make_tvar("top_p")]
+        constraints = generate_structural_constraints(tvars)
+        assert len(constraints) >= 1
+        assert all(c.source == "template" for c in constraints)
+
+    def test_no_tvars_returns_empty(self) -> None:
+        constraints = generate_structural_constraints([])
+        assert constraints == []
+
+    def test_single_tvar_no_match(self) -> None:
+        constraints = generate_structural_constraints([_make_tvar("temperature")])
+        assert constraints == []
+
+    def test_unrelated_tvars_no_match(self) -> None:
+        tvars = [_make_tvar("foo"), _make_tvar("bar")]
+        constraints = generate_structural_constraints(tvars)
+        assert constraints == []
+
+    def test_multiple_templates_match(self) -> None:
+        tvars = [_make_tvar("temperature"), _make_tvar("top_p"), _make_tvar("model")]
+        constraints = generate_structural_constraints(tvars)
+        # Should match temp+top_p and model+temperature
+        assert len(constraints) >= 2
+
+    def test_llm_enrichment_adds_constraints(self) -> None:
+        import json
+
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            [
+                {
+                    "description": "LLM constraint",
+                    "constraint_code": "require(x.gte(0))",
+                    "reasoning": "LLM said so",
+                }
+            ]
+        )
+        tvars = [_make_tvar("x"), _make_tvar("y")]
+        constraints = generate_structural_constraints(
+            tvars, llm=llm, source_code="def f(): pass"
+        )
+        llm_constraints = [c for c in constraints if c.source == "llm"]
+        assert len(llm_constraints) == 1
+        assert llm_constraints[0].description == "LLM constraint"
+
+    def test_llm_budget_exhausted_returns_templates_only(self) -> None:
+        llm = MagicMock()
+        llm.complete.side_effect = BudgetExhausted(0.10)
+        tvars = [_make_tvar("temperature"), _make_tvar("top_p")]
+        constraints = generate_structural_constraints(tvars, llm=llm)
+        # Should still return template matches
+        assert len(constraints) >= 1
+        assert all(c.source == "template" for c in constraints)
+
+    def test_llm_invalid_json_returns_templates_only(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = "not valid json"
+        tvars = [_make_tvar("temperature"), _make_tvar("top_p")]
+        constraints = generate_structural_constraints(tvars, llm=llm)
+        assert len(constraints) >= 1
+        assert all(c.source == "template" for c in constraints)
+
+    def test_llm_not_called_with_single_tvar(self) -> None:
+        llm = MagicMock()
+        tvars = [_make_tvar("temperature")]
+        generate_structural_constraints(tvars, llm=llm)
+        llm.complete.assert_not_called()
+
+    def test_llm_markdown_code_fence(self) -> None:
+        import json
+
+        llm = MagicMock()
+        llm.complete.return_value = (
+            "```json\n"
+            + json.dumps(
+                [
+                    {
+                        "description": "fenced",
+                        "constraint_code": "x > 0",
+                        "reasoning": "r",
+                    }
+                ]
+            )
+            + "\n```"
+        )
+        tvars = [_make_tvar("a"), _make_tvar("b")]
+        constraints = generate_structural_constraints(tvars, llm=llm)
+        llm_constraints = [c for c in constraints if c.source == "llm"]
+        assert len(llm_constraints) == 1
+        assert llm_constraints[0].description == "fenced"

--- a/tests/unit/config_generator/test_subsystems/test_tvar_ranges.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_ranges.py
@@ -1,0 +1,228 @@
+"""Tests for config_generator.subsystems.tvar_ranges."""
+
+from __future__ import annotations
+
+from traigent.config_generator.subsystems.tvar_ranges import (
+    _heuristic_from_value,
+    _parse_llm_range_response,
+    generate_tvar_specs,
+)
+from traigent.tuned_variables.detection_types import (
+    CandidateType,
+    DetectionConfidence,
+    DetectionResult,
+    SourceLocation,
+    SuggestedRange,
+    TunedVariableCandidate,
+)
+
+
+def _make_candidate(
+    name: str = "temperature",
+    canonical_name: str | None = "temperature",
+    confidence: DetectionConfidence = DetectionConfidence.HIGH,
+    value: object = 0.7,
+    candidate_type: CandidateType = CandidateType.NUMERIC_CONTINUOUS,
+    suggested_range: SuggestedRange | None = None,
+) -> TunedVariableCandidate:
+    return TunedVariableCandidate(
+        name=name,
+        canonical_name=canonical_name,
+        candidate_type=candidate_type,
+        confidence=confidence,
+        current_value=value,
+        location=SourceLocation(line=1, col_offset=0),
+        reasoning="test",
+        detection_source="ast",
+        suggested_range=suggested_range,
+    )
+
+
+def _make_result(candidates: list[TunedVariableCandidate]) -> DetectionResult:
+    return DetectionResult(
+        function_name="test_func",
+        candidates=tuple(candidates),
+        warnings=(),
+        source_hash="abc123",
+        detection_strategies_used=("ast",),
+    )
+
+
+class TestGenerateTvarSpecs:
+    def test_canonical_preset_temperature(self) -> None:
+        result = _make_result([_make_candidate()])
+        specs = generate_tvar_specs([result])
+        assert len(specs) == 1
+        assert specs[0].name == "temperature"
+        assert specs[0].range_type == "Range"
+        assert specs[0].source == "preset"
+        assert specs[0].range_kwargs["low"] == 0.0
+        assert specs[0].range_kwargs["high"] == 1.0
+
+    def test_canonical_preset_max_tokens(self) -> None:
+        candidate = _make_candidate(
+            name="max_tokens",
+            canonical_name="max_tokens",
+            value=1024,
+            candidate_type=CandidateType.NUMERIC_INTEGER,
+        )
+        specs = generate_tvar_specs([_make_result([candidate])])
+        assert len(specs) == 1
+        assert specs[0].range_type == "IntRange"
+        assert specs[0].source == "preset"
+
+    def test_canonical_preset_model(self) -> None:
+        candidate = _make_candidate(
+            name="model_name",
+            canonical_name="model",
+            value="gpt-4o",
+            candidate_type=CandidateType.CATEGORICAL,
+        )
+        specs = generate_tvar_specs([_make_result([candidate])])
+        assert len(specs) == 1
+        assert specs[0].range_type == "Choices"
+
+    def test_fallback_to_suggested_range(self) -> None:
+        candidate = _make_candidate(
+            name="custom_param",
+            canonical_name=None,
+            value=0.5,
+            suggested_range=SuggestedRange(
+                range_type="Range", kwargs={"low": 0.1, "high": 0.9}
+            ),
+        )
+        specs = generate_tvar_specs([_make_result([candidate])])
+        assert len(specs) == 1
+        assert specs[0].source == "detection"
+        assert specs[0].range_kwargs == {"low": 0.1, "high": 0.9}
+
+    def test_fallback_to_heuristic(self) -> None:
+        candidate = _make_candidate(
+            name="custom_float",
+            canonical_name=None,
+            value=0.5,
+            suggested_range=None,
+        )
+        specs = generate_tvar_specs([_make_result([candidate])])
+        assert len(specs) == 1
+        assert specs[0].source == "heuristic"
+        assert specs[0].range_type == "Range"
+
+    def test_skips_low_confidence(self) -> None:
+        candidate = _make_candidate(confidence=DetectionConfidence.LOW)
+        specs = generate_tvar_specs([_make_result([candidate])])
+        assert len(specs) == 0
+
+    def test_deduplicates_by_name(self) -> None:
+        c1 = _make_candidate(name="temperature")
+        c2 = _make_candidate(name="temperature")
+        result = _make_result([c1, c2])
+        specs = generate_tvar_specs([result])
+        assert len(specs) == 1
+
+    def test_multiple_results(self) -> None:
+        r1 = _make_result([_make_candidate(name="temperature")])
+        r2 = _make_result(
+            [
+                _make_candidate(
+                    name="max_tokens",
+                    canonical_name="max_tokens",
+                    value=1024,
+                    candidate_type=CandidateType.NUMERIC_INTEGER,
+                )
+            ]
+        )
+        specs = generate_tvar_specs([r1, r2])
+        assert len(specs) == 2
+        names = {s.name for s in specs}
+        assert names == {"temperature", "max_tokens"}
+
+    def test_medium_confidence_included(self) -> None:
+        candidate = _make_candidate(confidence=DetectionConfidence.MEDIUM)
+        specs = generate_tvar_specs([_make_result([candidate])])
+        assert len(specs) == 1
+        assert specs[0].confidence == 0.7
+
+
+class TestHeuristicFromValue:
+    def test_float_positive(self) -> None:
+        spec = _heuristic_from_value("x", 0.5)
+        assert spec is not None
+        assert spec.range_type == "Range"
+        assert spec.range_kwargs["low"] == 0.25
+        assert spec.range_kwargs["high"] == 1.0
+
+    def test_float_zero(self) -> None:
+        spec = _heuristic_from_value("x", 0.0)
+        assert spec is not None
+        assert spec.range_kwargs["low"] == 0.0
+        assert spec.range_kwargs["high"] == 1.0
+
+    def test_int_positive(self) -> None:
+        spec = _heuristic_from_value("x", 100)
+        assert spec is not None
+        assert spec.range_type == "IntRange"
+        assert spec.range_kwargs["low"] == 50
+        assert spec.range_kwargs["high"] == 200
+
+    def test_int_small(self) -> None:
+        spec = _heuristic_from_value("x", 1)
+        assert spec is not None
+        assert spec.range_kwargs["low"] == 1
+        assert spec.range_kwargs["high"] >= 2
+
+    def test_string(self) -> None:
+        spec = _heuristic_from_value("x", "gpt-4o")
+        assert spec is not None
+        assert spec.range_type == "Choices"
+        assert spec.range_kwargs["values"] == ["gpt-4o"]
+
+    def test_bool(self) -> None:
+        spec = _heuristic_from_value("x", True)
+        assert spec is not None
+        assert spec.range_type == "Choices"
+        assert set(spec.range_kwargs["values"]) == {True, False}
+
+    def test_none_returns_none(self) -> None:
+        assert _heuristic_from_value("x", None) is None
+
+    def test_list_returns_none(self) -> None:
+        assert _heuristic_from_value("x", [1, 2, 3]) is None
+
+
+class TestParseLlmRangeResponse:
+    def test_valid_range_json(self) -> None:
+        response = '{"range_type": "Range", "kwargs": {"low": 0.0, "high": 2.0}}'
+        spec = _parse_llm_range_response("x", response)
+        assert spec is not None
+        assert spec.range_type == "Range"
+        assert spec.range_kwargs == {"low": 0.0, "high": 2.0}
+        assert spec.source == "llm"
+
+    def test_valid_choices_json(self) -> None:
+        response = '{"range_type": "Choices", "kwargs": {"values": ["a", "b"]}}'
+        spec = _parse_llm_range_response("x", response)
+        assert spec is not None
+        assert spec.range_type == "Choices"
+
+    def test_markdown_fenced_json(self) -> None:
+        response = (
+            '```json\n{"range_type": "IntRange", "kwargs": {"low": 1, "high": 10}}\n```'
+        )
+        spec = _parse_llm_range_response("x", response)
+        assert spec is not None
+        assert spec.range_type == "IntRange"
+
+    def test_invalid_json(self) -> None:
+        assert _parse_llm_range_response("x", "not json") is None
+
+    def test_missing_range_type(self) -> None:
+        assert _parse_llm_range_response("x", '{"kwargs": {"low": 0}}') is None
+
+    def test_invalid_range_type(self) -> None:
+        response = '{"range_type": "BadType", "kwargs": {"low": 0}}'
+        assert _parse_llm_range_response("x", response) is None
+
+    def test_missing_kwargs(self) -> None:
+        response = '{"range_type": "Range"}'
+        assert _parse_llm_range_response("x", response) is None

--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -1,0 +1,190 @@
+"""Tests for config_generator.subsystems.tvar_recommendations."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.llm_backend import BudgetExhausted
+from traigent.config_generator.subsystems.tvar_recommendations import (
+    generate_recommendations,
+)
+from traigent.config_generator.types import TVarSpec
+
+
+def _make_tvar(name: str) -> TVarSpec:
+    return TVarSpec(name=name, range_type="Range", range_kwargs={"low": 0, "high": 1})
+
+
+class TestGenerateRecommendations:
+    def test_rag_agent_recommends_prompting_strategy(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = generate_recommendations([], classification=classification)
+        names = {r.name for r in recs}
+        assert "prompting_strategy" in names
+
+    def test_rag_agent_recommends_retriever_type(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = generate_recommendations([], classification=classification)
+        names = {r.name for r in recs}
+        assert "retriever_type" in names
+
+    def test_existing_tvars_are_excluded(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        tvars = [_make_tvar("prompting_strategy")]
+        recs = generate_recommendations(tvars, classification=classification)
+        names = {r.name for r in recs}
+        assert "prompting_strategy" not in names
+
+    def test_general_llm_default(self) -> None:
+        recs = generate_recommendations([])
+        names = {r.name for r in recs}
+        assert "prompting_strategy" in names
+
+    def test_classification_agent_recommends_few_shot(self) -> None:
+        classification = ClassificationResult(
+            agent_type="classification",
+            confidence=0.9,
+            source="heuristic",
+            reasoning="test",
+        )
+        recs = generate_recommendations([], classification=classification)
+        names = {r.name for r in recs}
+        assert "few_shot_count" in names
+
+    def test_all_recs_have_range_type(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = generate_recommendations([], classification=classification)
+        for rec in recs:
+            assert rec.range_type in ("Range", "IntRange", "LogRange", "Choices")
+
+    def test_all_recs_have_category(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = generate_recommendations([], classification=classification)
+        for rec in recs:
+            assert rec.category != ""
+
+    def test_all_recs_have_impact(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = generate_recommendations([], classification=classification)
+        for rec in recs:
+            assert rec.impact_estimate in ("high", "medium", "low")
+
+    def test_unknown_agent_type_returns_empty(self) -> None:
+        classification = ClassificationResult(
+            agent_type="unknown_type",
+            confidence=0.5,
+            source="heuristic",
+            reasoning="test",
+        )
+        recs = generate_recommendations([], classification=classification)
+        assert recs == []
+
+    def test_no_duplicate_recommendations(self) -> None:
+        classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = generate_recommendations([], classification=classification)
+        names = [r.name for r in recs]
+        assert len(names) == len(set(names))
+
+
+class TestLLMEnrichment:
+    def test_llm_adds_recommendations(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            [
+                {
+                    "name": "custom_param",
+                    "range_type": "Range",
+                    "kwargs": {"low": 0.0, "high": 1.0},
+                    "category": "custom",
+                    "reasoning": "LLM suggested",
+                    "impact": "high",
+                }
+            ]
+        )
+        recs = generate_recommendations([], llm=llm, source_code="def f(): pass")
+        names = {r.name for r in recs}
+        assert "custom_param" in names
+
+    def test_llm_does_not_duplicate_preset_recs(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            [
+                {
+                    "name": "prompting_strategy",
+                    "range_type": "Choices",
+                    "kwargs": {"values": ["direct"]},
+                    "category": "prompting",
+                    "reasoning": "duplicate",
+                    "impact": "medium",
+                }
+            ]
+        )
+        recs = generate_recommendations([], llm=llm, source_code="def f(): pass")
+        ps_recs = [r for r in recs if r.name == "prompting_strategy"]
+        assert len(ps_recs) == 1  # only preset, not LLM duplicate
+
+    def test_llm_does_not_duplicate_existing_tvars(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            [
+                {
+                    "name": "temperature",
+                    "range_type": "Range",
+                    "kwargs": {"low": 0.0, "high": 2.0},
+                    "category": "model",
+                    "reasoning": "dup",
+                    "impact": "medium",
+                }
+            ]
+        )
+        tvars = [_make_tvar("temperature")]
+        recs = generate_recommendations(tvars, llm=llm, source_code="def f(): pass")
+        names = {r.name for r in recs}
+        assert "temperature" not in names
+
+    def test_llm_budget_exhausted(self) -> None:
+        llm = MagicMock()
+        llm.complete.side_effect = BudgetExhausted(0.10)
+        recs = generate_recommendations([], llm=llm)
+        # Should still return preset recommendations
+        assert len(recs) >= 1
+
+    def test_llm_invalid_json(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = "not json"
+        recs = generate_recommendations([], llm=llm)
+        assert len(recs) >= 1  # presets still returned
+
+    def test_llm_invalid_range_type_filtered(self) -> None:
+        llm = MagicMock()
+        llm.complete.return_value = json.dumps(
+            [
+                {
+                    "name": "bad_param",
+                    "range_type": "InvalidType",
+                    "kwargs": {},
+                    "category": "test",
+                    "reasoning": "bad",
+                    "impact": "low",
+                }
+            ]
+        )
+        recs = generate_recommendations([], llm=llm, source_code="def f(): pass")
+        names = {r.name for r in recs}
+        assert "bad_param" not in names

--- a/tests/unit/config_generator/test_types.py
+++ b/tests/unit/config_generator/test_types.py
@@ -143,7 +143,9 @@ class TestAutoConfigResult:
         kwargs = result.to_decorator_kwargs()
         assert kwargs == {}
 
-    def test_to_decorator_kwargs_with_tvars(self) -> None:
+    def test_to_decorator_kwargs_returns_live_objects(self) -> None:
+        from traigent.api.parameter_ranges import Choices, Range
+
         result = AutoConfigResult(
             tvars=(
                 TVarSpec(
@@ -165,16 +167,138 @@ class TestAutoConfigResult:
         kwargs = result.to_decorator_kwargs()
         assert "configuration_space" in kwargs
         assert "objectives" in kwargs
+
+        # Must return actual ParameterRange objects, not dicts
+        temp = kwargs["configuration_space"]["temperature"]
+        assert isinstance(temp, Range)
+        assert temp.low == pytest.approx(0.0)
+        assert temp.high == pytest.approx(1.0)
+
+        model = kwargs["configuration_space"]["model"]
+        assert isinstance(model, Choices)
+        assert "gpt-4o" in model.values
+
+        assert kwargs["objectives"] == ["accuracy", "cost"]
+
+    def test_to_decorator_kwargs_with_safety(self) -> None:
+        from traigent.api.safety import SafetyConstraint
+
+        result = AutoConfigResult(
+            safety_constraints=(
+                SafetySpec(
+                    metric_name="faithfulness",
+                    operator=">=",
+                    threshold=0.85,
+                ),
+                SafetySpec(
+                    metric_name="hallucination_rate",
+                    operator="<=",
+                    threshold=0.15,
+                ),
+            ),
+        )
+        kwargs = result.to_decorator_kwargs()
+        assert "safety_constraints" in kwargs
+        constraints = kwargs["safety_constraints"]
+        assert len(constraints) == 2
+        for c in constraints:
+            assert isinstance(c, SafetyConstraint)
+
+    def test_to_dict_kwargs_returns_dicts(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            objectives=(ObjectiveSpec(name="accuracy"),),
+        )
+        kwargs = result.to_dict_kwargs()
         assert kwargs["configuration_space"]["temperature"] == {
             "type": "Range",
             "low": 0.0,
             "high": 1.0,
         }
-        assert kwargs["configuration_space"]["model"] == {
-            "type": "Choices",
-            "values": ["gpt-4o"],
-        }
-        assert kwargs["objectives"] == ["accuracy", "cost"]
+        assert kwargs["objectives"] == ["accuracy"]
+
+    def test_to_tvl_spec_basic(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            objectives=(
+                ObjectiveSpec(name="accuracy", orientation="maximize", weight=0.6),
+            ),
+        )
+        spec = result.to_tvl_spec(module_name="test_agent")
+        assert spec["header"]["module"] == "test_agent"
+        assert "tvars" in spec
+        assert "objectives" in spec
+        assert spec["objectives"][0]["name"] == "accuracy"
+        assert spec["objectives"][0]["direction"] == "maximize"
+
+    def test_to_tvl_spec_with_safety(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            safety_constraints=(
+                SafetySpec(metric_name="faithfulness", operator=">=", threshold=0.85),
+            ),
+        )
+        spec = result.to_tvl_spec()
+        assert "safety" in spec
+        assert spec["safety"][0]["metric"] == "faithfulness"
+        assert spec["safety"][0]["threshold"] == pytest.approx(0.85)
+
+    def test_to_tvl_spec_with_structural_constraints(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            structural_constraints=(
+                StructuralConstraintSpec(
+                    description="Low temp for factual models",
+                    constraint_code="implies(model.equals('gpt-4o'), temperature.lte(1.0))",
+                    requires_tvars=("model", "temperature"),
+                ),
+            ),
+        )
+        spec = result.to_tvl_spec()
+        assert "constraints" in spec
+        structural = spec["constraints"]["structural"]
+        assert len(structural) == 1
+        assert structural[0]["description"] == "Low temp for factual models"
+        assert "implies" in structural[0]["code"]
+        assert structural[0]["requires"] == ["model", "temperature"]
+
+    def test_reconstruct_range_unknown_type(self) -> None:
+        from traigent.config_generator.types import _reconstruct_range
+
+        tvar = TVarSpec(name="x", range_type="UnknownRange")
+        with pytest.raises(ValueError, match="Unknown range type"):
+            _reconstruct_range(tvar)
+
+    def test_reconstruct_safety_unknown_metric(self) -> None:
+        from traigent.config_generator.types import _reconstruct_safety
+
+        sc = SafetySpec(metric_name="made_up_metric", operator=">=", threshold=0.5)
+        with pytest.raises(ValueError, match="Unknown safety metric"):
+            _reconstruct_safety(sc)
 
     def test_to_python_code_basic(self) -> None:
         result = AutoConfigResult(

--- a/tests/unit/config_generator/test_types.py
+++ b/tests/unit/config_generator/test_types.py
@@ -1,0 +1,255 @@
+"""Tests for config_generator.types."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.config_generator.types import (
+    AutoConfigResult,
+    BenchmarkSpec,
+    ObjectiveSpec,
+    SafetySpec,
+    StructuralConstraintSpec,
+    TVarRecommendation,
+    TVarSpec,
+)
+
+
+class TestTVarSpec:
+    def test_frozen(self) -> None:
+        spec = TVarSpec(
+            name="temperature",
+            range_type="Range",
+            range_kwargs={"low": 0.0, "high": 1.0},
+        )
+        with pytest.raises(AttributeError):
+            spec.name = "other"  # type: ignore[misc]
+
+    def test_to_range_code_float(self) -> None:
+        spec = TVarSpec(
+            name="temperature",
+            range_type="Range",
+            range_kwargs={"low": 0.0, "high": 2.0},
+        )
+        assert spec.to_range_code() == "Range(low=0.0, high=2.0)"
+
+    def test_to_range_code_int(self) -> None:
+        spec = TVarSpec(
+            name="max_tokens",
+            range_type="IntRange",
+            range_kwargs={"low": 256, "high": 4096},
+        )
+        assert spec.to_range_code() == "IntRange(low=256, high=4096)"
+
+    def test_to_range_code_choices(self) -> None:
+        spec = TVarSpec(
+            name="model",
+            range_type="Choices",
+            range_kwargs={"values": ["gpt-4o", "gpt-4o-mini"]},
+        )
+        assert "Choices(values=" in spec.to_range_code()
+
+    def test_defaults(self) -> None:
+        spec = TVarSpec(name="x", range_type="Range")
+        assert spec.source == "preset"
+        assert spec.confidence == 1.0
+        assert spec.reasoning == ""
+        assert spec.range_kwargs == {}
+
+
+class TestObjectiveSpec:
+    def test_defaults(self) -> None:
+        obj = ObjectiveSpec(name="accuracy")
+        assert obj.orientation == "maximize"
+        assert obj.weight == 1.0
+        assert obj.source == "default"
+
+    def test_custom_values(self) -> None:
+        obj = ObjectiveSpec(
+            name="cost", orientation="minimize", weight=0.3, source="heuristic"
+        )
+        assert obj.orientation == "minimize"
+        assert obj.weight == 0.3
+
+
+class TestBenchmarkSpec:
+    def test_creation(self) -> None:
+        bm = BenchmarkSpec(name="QA Benchmark", description="Standard QA")
+        assert bm.source == "catalog"
+        assert bm.sample_examples == ()
+
+    def test_with_schema(self) -> None:
+        schema = {"input": {"question": "str"}, "output": "str"}
+        bm = BenchmarkSpec(name="QA", example_schema=schema)
+        assert bm.example_schema == schema
+
+
+class TestSafetySpec:
+    def test_creation(self) -> None:
+        sc = SafetySpec(metric_name="hallucination_rate", operator="<=", threshold=0.15)
+        assert sc.agent_type == ""
+        assert sc.source == "preset"
+
+    def test_with_agent_type(self) -> None:
+        sc = SafetySpec(
+            metric_name="faithfulness",
+            operator=">=",
+            threshold=0.85,
+            agent_type="rag",
+            reasoning="RAG agents need high faithfulness",
+        )
+        assert sc.agent_type == "rag"
+
+
+class TestStructuralConstraintSpec:
+    def test_creation(self) -> None:
+        sc = StructuralConstraintSpec(
+            description="Conservative temperature for factual models",
+            constraint_code="implies(model.equals('gpt-4o'), temperature.lte(1.0))",
+            requires_tvars=("model", "temperature"),
+        )
+        assert "implies" in sc.constraint_code
+        assert sc.source == "template"
+
+
+class TestTVarRecommendation:
+    def test_to_range_code(self) -> None:
+        rec = TVarRecommendation(
+            name="prompting_strategy",
+            range_type="Choices",
+            range_kwargs={"values": ["direct", "chain_of_thought"]},
+            category="prompting",
+            reasoning="Try different prompting strategies",
+            impact_estimate="high",
+        )
+        assert "Choices(values=" in rec.to_range_code()
+
+    def test_defaults(self) -> None:
+        rec = TVarRecommendation(name="x", range_type="Range")
+        assert rec.impact_estimate == "medium"
+        assert rec.category == ""
+
+
+class TestAutoConfigResult:
+    def test_empty_result(self) -> None:
+        result = AutoConfigResult()
+        assert result.tvars == ()
+        assert result.objectives == ()
+        assert result.llm_calls_made == 0
+        assert result.llm_cost_usd == 0.0
+
+    def test_to_decorator_kwargs_empty(self) -> None:
+        result = AutoConfigResult()
+        kwargs = result.to_decorator_kwargs()
+        assert kwargs == {}
+
+    def test_to_decorator_kwargs_with_tvars(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+                TVarSpec(
+                    name="model",
+                    range_type="Choices",
+                    range_kwargs={"values": ["gpt-4o"]},
+                ),
+            ),
+            objectives=(
+                ObjectiveSpec(name="accuracy"),
+                ObjectiveSpec(name="cost", orientation="minimize"),
+            ),
+        )
+        kwargs = result.to_decorator_kwargs()
+        assert "configuration_space" in kwargs
+        assert "objectives" in kwargs
+        assert kwargs["configuration_space"]["temperature"] == {
+            "type": "Range",
+            "low": 0.0,
+            "high": 1.0,
+        }
+        assert kwargs["configuration_space"]["model"] == {
+            "type": "Choices",
+            "values": ["gpt-4o"],
+        }
+        assert kwargs["objectives"] == ["accuracy", "cost"]
+
+    def test_to_python_code_basic(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            objectives=(ObjectiveSpec(name="accuracy"),),
+        )
+        code = result.to_python_code()
+        assert "@traigent.optimize(" in code
+        assert "configuration_space" in code
+        assert "'temperature'" in code
+        assert "Range(low=0.0, high=1.0)" in code
+        assert "objectives=['accuracy']" in code
+
+    def test_to_python_code_with_safety(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            safety_constraints=(
+                SafetySpec(
+                    metric_name="hallucination_rate", operator="<=", threshold=0.15
+                ),
+            ),
+        )
+        code = result.to_python_code()
+        assert "safety_constraints" in code
+        # hallucination_rate is a factory function — must emit "()"
+        assert "hallucination_rate().below" in code
+
+    def test_to_python_code_factory_vs_instance_metrics(self) -> None:
+        result = AutoConfigResult(
+            safety_constraints=(
+                # Factory function metrics need "()"
+                SafetySpec(
+                    metric_name="hallucination_rate", operator="<=", threshold=0.15
+                ),
+                SafetySpec(metric_name="toxicity_score", operator="<=", threshold=0.05),
+                # Module-level instance metrics don't need "()"
+                SafetySpec(metric_name="faithfulness", operator=">=", threshold=0.85),
+            ),
+        )
+        code = result.to_python_code()
+        assert "hallucination_rate().below(0.15)" in code
+        assert "toxicity_score().below(0.05)" in code
+        assert "faithfulness.above(0.85)" in code
+        # Ensure faithfulness does NOT get "()"
+        assert "faithfulness().above" not in code
+
+    def test_to_python_code_with_recommendations(self) -> None:
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            recommendations=(
+                TVarRecommendation(
+                    name="prompting_strategy",
+                    range_type="Choices",
+                    range_kwargs={"values": ["direct", "cot"]},
+                ),
+            ),
+        )
+        code = result.to_python_code()
+        assert "# Recommended additional TVars:" in code
+        assert "prompting_strategy" in code

--- a/traigent/cli/generate_config_command.py
+++ b/traigent/cli/generate_config_command.py
@@ -44,7 +44,7 @@ import click
     "--output",
     "-o",
     "output_format",
-    type=click.Choice(["table", "python", "json"], case_sensitive=False),
+    type=click.Choice(["table", "python", "json", "tvl"], case_sensitive=False),
     default="table",
     show_default=True,
     help="Output format.",
@@ -55,6 +55,19 @@ import click
     default=None,
     help="Comma-separated subsystems to run (e.g., tvars,objectives,safety).",
 )
+@click.option(
+    "--apply",
+    "apply_decorator",
+    is_flag=True,
+    default=False,
+    help="Apply the generated config as a decorator on the target function.",
+)
+@click.option(
+    "--no-backup",
+    is_flag=True,
+    default=False,
+    help="Skip creating .bak backup when using --apply.",
+)
 def generate_config(
     path: Path,
     function_name: str | None,
@@ -63,6 +76,8 @@ def generate_config(
     budget: float,
     output_format: str,
     subsystems_str: str | None,
+    apply_decorator: bool,
+    no_backup: bool,
 ) -> None:
     """Generate a complete @traigent.optimize() configuration.
 
@@ -109,11 +124,35 @@ def generate_config(
         click.echo(f"Error: {exc}", err=True)
         raise SystemExit(1) from None
 
+    # --apply: insert/update decorator on the target function
+    if apply_decorator:
+        if not function_name:
+            click.echo(
+                "Error: --apply requires --function/-f to specify which function "
+                "to decorate.",
+                err=True,
+            )
+            raise SystemExit(1)
+        from traigent.config_generator.apply import apply_config
+
+        modified = apply_config(
+            path,
+            result,
+            function_name,
+            backup=not no_backup,
+        )
+        click.echo(f"Applied @traigent.optimize() to {function_name} in {modified}")
+        if not no_backup:
+            click.echo(f"Backup saved to {path.with_suffix('.py.bak')}")
+        return
+
     # Format and display
     if output_format == "python":
         _output_python(result)
     elif output_format == "json":
         _output_json(result)
+    elif output_format == "tvl":
+        _output_tvl(result, path)
     else:
         _output_table(result)
 
@@ -180,70 +219,82 @@ def _output_json(result):
     click.echo(json.dumps(data, indent=2))
 
 
+def _output_tvl(result, path: Path):
+    """Write a .tvl.yml spec file next to the source file."""
+    try:
+        import yaml
+    except ImportError:
+        click.echo(
+            "Error: PyYAML is required for TVL export. "
+            "Install it with: pip install pyyaml",
+            err=True,
+        )
+        raise SystemExit(1) from None
+
+    spec = result.to_tvl_spec(module_name=path.stem)
+    tvl_path = path.with_suffix(".tvl.yml")
+    tvl_path.write_text(yaml.dump(spec, default_flow_style=False, sort_keys=False))
+    click.echo(f"TVL spec written to: {tvl_path}")
+
+
+def _print_section(title: str, items, formatter) -> None:
+    """Print a titled section with separator lines."""
+    if not items:
+        return
+    click.echo(f"\n{'=' * 60}")
+    click.echo(title)
+    click.echo(f"{'=' * 60}")
+    for item in items:
+        formatter(item)
+
+
 def _output_table(result):
     """Print a human-readable table summary."""
     if result.agent_type:
         click.echo(f"\nAgent type: {result.agent_type}")
 
-    # TVars
-    if result.tvars:
-        click.echo(f"\n{'='*60}")
-        click.echo("Tunable Variables")
-        click.echo(f"{'='*60}")
-        for t in result.tvars:
-            click.echo(f"  {t.name}: {t.to_range_code()}  [{t.source}]")
+    _print_section(
+        "Tunable Variables",
+        result.tvars,
+        lambda t: click.echo(f"  {t.name}: {t.to_range_code()}  [{t.source}]"),
+    )
+    _print_section(
+        "Objectives",
+        result.objectives,
+        lambda o: click.echo(f"  {o.name} ({o.orientation}, weight={o.weight:.2f})"),
+    )
+    _print_section(
+        "Safety Constraints",
+        result.safety_constraints,
+        lambda sc: click.echo(f"  {sc.metric_name} {sc.operator} {sc.threshold}"),
+    )
+    _print_section(
+        "Structural Constraints",
+        result.structural_constraints,
+        lambda c: (
+            click.echo(f"  {c.description}"),
+            click.echo(f"    Code: {c.constraint_code.splitlines()[0]}"),
+        ),
+    )
+    _print_section(
+        "Benchmarks",
+        result.benchmarks,
+        lambda b: click.echo(f"  {b.name}: {b.description[:80]}"),
+    )
+    _print_section(
+        "Recommended Additional TVars",
+        result.recommendations,
+        lambda r: (
+            click.echo(f"  [{r.impact_estimate}] {r.name}: {r.to_range_code()}"),
+            click.echo(f"    {r.reasoning}"),
+        ),
+    )
+    _print_section(
+        "Warnings",
+        result.warnings,
+        lambda w: click.echo(f"  ! {w}"),
+    )
 
-    # Objectives
-    if result.objectives:
-        click.echo(f"\n{'='*60}")
-        click.echo("Objectives")
-        click.echo(f"{'='*60}")
-        for o in result.objectives:
-            click.echo(f"  {o.name} ({o.orientation}, weight={o.weight:.2f})")
-
-    # Safety constraints
-    if result.safety_constraints:
-        click.echo(f"\n{'='*60}")
-        click.echo("Safety Constraints")
-        click.echo(f"{'='*60}")
-        for sc in result.safety_constraints:
-            click.echo(f"  {sc.metric_name} {sc.operator} {sc.threshold}")
-
-    # Structural constraints
-    if result.structural_constraints:
-        click.echo(f"\n{'='*60}")
-        click.echo("Structural Constraints")
-        click.echo(f"{'='*60}")
-        for c in result.structural_constraints:
-            click.echo(f"  {c.description}")
-            click.echo(f"    Code: {c.constraint_code.splitlines()[0]}")
-
-    # Benchmarks
-    if result.benchmarks:
-        click.echo(f"\n{'='*60}")
-        click.echo("Benchmarks")
-        click.echo(f"{'='*60}")
-        for b in result.benchmarks:
-            click.echo(f"  {b.name}: {b.description[:80]}")
-
-    # Recommendations
-    if result.recommendations:
-        click.echo(f"\n{'='*60}")
-        click.echo("Recommended Additional TVars")
-        click.echo(f"{'='*60}")
-        for r in result.recommendations:
-            click.echo(f"  [{r.impact_estimate}] {r.name}: {r.to_range_code()}")
-            click.echo(f"    {r.reasoning}")
-
-    # Warnings
-    if result.warnings:
-        click.echo(f"\n{'='*60}")
-        click.echo("Warnings")
-        click.echo(f"{'='*60}")
-        for w in result.warnings:
-            click.echo(f"  ! {w}")
-
-    # LLM stats
     if result.llm_calls_made > 0:
         click.echo(
             f"\nLLM: {result.llm_calls_made} calls, "

--- a/traigent/cli/generate_config_command.py
+++ b/traigent/cli/generate_config_command.py
@@ -1,0 +1,253 @@
+"""CLI command: ``traigent generate-config``.
+
+Generates a complete ``@traigent.optimize(...)`` configuration from a
+Python source file using preset heuristics and optional LLM enrichment.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+
+@click.command("generate-config")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--function",
+    "-f",
+    "function_name",
+    default=None,
+    help="Analyze only this function (default: all top-level functions).",
+)
+@click.option(
+    "--enrich",
+    is_flag=True,
+    default=False,
+    help="Use LLM for richer analysis (requires API key, budgeted).",
+)
+@click.option(
+    "--model",
+    default="gpt-4o-mini",
+    show_default=True,
+    help="LLM model for enrichment mode.",
+)
+@click.option(
+    "--budget",
+    type=float,
+    default=0.10,
+    show_default=True,
+    help="Maximum LLM spend in USD for enrichment.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_format",
+    type=click.Choice(["table", "python", "json"], case_sensitive=False),
+    default="table",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--only",
+    "subsystems_str",
+    default=None,
+    help="Comma-separated subsystems to run (e.g., tvars,objectives,safety).",
+)
+def generate_config(
+    path: Path,
+    function_name: str | None,
+    enrich: bool,
+    model: str,
+    budget: float,
+    output_format: str,
+    subsystems_str: str | None,
+) -> None:
+    """Generate a complete @traigent.optimize() configuration.
+
+    PATH is a Python file to analyze. Detects tunable variables and
+    generates ranges, objectives, safety constraints, structural
+    constraints, benchmarks, and TVAR recommendations.
+
+    \b
+    Examples:
+        traigent generate-config my_agent.py
+        traigent generate-config my_agent.py --enrich
+        traigent generate-config my_agent.py -f answer_question -o python
+    """
+    from traigent.config_generator import generate_config as gen_config
+    from traigent.config_generator.pipeline import ALL_SUBSYSTEMS
+
+    # Parse subsystems
+    subsystems: frozenset[str] | None = None
+    if subsystems_str:
+        requested = frozenset(s.strip() for s in subsystems_str.split(","))
+        invalid = requested - ALL_SUBSYSTEMS
+        if invalid:
+            click.echo(
+                f"Unknown subsystems: {', '.join(sorted(invalid))}. "
+                f"Valid: {', '.join(sorted(ALL_SUBSYSTEMS))}",
+                err=True,
+            )
+            raise SystemExit(1)
+        subsystems = requested
+
+    try:
+        result = gen_config(
+            path,
+            function_name=function_name,
+            enrich=enrich,
+            model=model,
+            budget_usd=budget,
+            subsystems=subsystems,
+        )
+    except FileNotFoundError:
+        click.echo(f"File not found: {path}", err=True)
+        raise SystemExit(1) from None
+    except Exception as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from None
+
+    # Format and display
+    if output_format == "python":
+        _output_python(result)
+    elif output_format == "json":
+        _output_json(result)
+    else:
+        _output_table(result)
+
+
+def _output_python(result):
+    """Print copy-pasteable Python decorator code."""
+    click.echo(result.to_python_code())
+
+
+def _output_json(result):
+    """Print machine-readable JSON output."""
+    data = {
+        "agent_type": result.agent_type,
+        "tvars": [
+            {
+                "name": t.name,
+                "range_type": t.range_type,
+                "range_kwargs": t.range_kwargs,
+                "source": t.source,
+                "confidence": t.confidence,
+            }
+            for t in result.tvars
+        ],
+        "objectives": [
+            {
+                "name": o.name,
+                "orientation": o.orientation,
+                "weight": o.weight,
+            }
+            for o in result.objectives
+        ],
+        "safety_constraints": [
+            {
+                "metric": sc.metric_name,
+                "operator": sc.operator,
+                "threshold": sc.threshold,
+            }
+            for sc in result.safety_constraints
+        ],
+        "structural_constraints": [
+            {
+                "description": c.description,
+                "constraint_code": c.constraint_code,
+            }
+            for c in result.structural_constraints
+        ],
+        "benchmarks": [
+            {"name": b.name, "description": b.description} for b in result.benchmarks
+        ],
+        "recommendations": [
+            {
+                "name": r.name,
+                "range_code": r.to_range_code(),
+                "category": r.category,
+                "impact": r.impact_estimate,
+                "reasoning": r.reasoning,
+            }
+            for r in result.recommendations
+        ],
+        "warnings": list(result.warnings),
+        "llm_calls_made": result.llm_calls_made,
+        "llm_cost_usd": result.llm_cost_usd,
+    }
+    click.echo(json.dumps(data, indent=2))
+
+
+def _output_table(result):
+    """Print a human-readable table summary."""
+    if result.agent_type:
+        click.echo(f"\nAgent type: {result.agent_type}")
+
+    # TVars
+    if result.tvars:
+        click.echo(f"\n{'='*60}")
+        click.echo("Tunable Variables")
+        click.echo(f"{'='*60}")
+        for t in result.tvars:
+            click.echo(f"  {t.name}: {t.to_range_code()}  [{t.source}]")
+
+    # Objectives
+    if result.objectives:
+        click.echo(f"\n{'='*60}")
+        click.echo("Objectives")
+        click.echo(f"{'='*60}")
+        for o in result.objectives:
+            click.echo(f"  {o.name} ({o.orientation}, weight={o.weight:.2f})")
+
+    # Safety constraints
+    if result.safety_constraints:
+        click.echo(f"\n{'='*60}")
+        click.echo("Safety Constraints")
+        click.echo(f"{'='*60}")
+        for sc in result.safety_constraints:
+            click.echo(f"  {sc.metric_name} {sc.operator} {sc.threshold}")
+
+    # Structural constraints
+    if result.structural_constraints:
+        click.echo(f"\n{'='*60}")
+        click.echo("Structural Constraints")
+        click.echo(f"{'='*60}")
+        for c in result.structural_constraints:
+            click.echo(f"  {c.description}")
+            click.echo(f"    Code: {c.constraint_code.splitlines()[0]}")
+
+    # Benchmarks
+    if result.benchmarks:
+        click.echo(f"\n{'='*60}")
+        click.echo("Benchmarks")
+        click.echo(f"{'='*60}")
+        for b in result.benchmarks:
+            click.echo(f"  {b.name}: {b.description[:80]}")
+
+    # Recommendations
+    if result.recommendations:
+        click.echo(f"\n{'='*60}")
+        click.echo("Recommended Additional TVars")
+        click.echo(f"{'='*60}")
+        for r in result.recommendations:
+            click.echo(f"  [{r.impact_estimate}] {r.name}: {r.to_range_code()}")
+            click.echo(f"    {r.reasoning}")
+
+    # Warnings
+    if result.warnings:
+        click.echo(f"\n{'='*60}")
+        click.echo("Warnings")
+        click.echo(f"{'='*60}")
+        for w in result.warnings:
+            click.echo(f"  ! {w}")
+
+    # LLM stats
+    if result.llm_calls_made > 0:
+        click.echo(
+            f"\nLLM: {result.llm_calls_made} calls, "
+            f"${result.llm_cost_usd:.4f} spent"
+        )
+
+    click.echo()

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -1819,5 +1819,9 @@ from traigent.cli.detect_tvars_command import detect_tvars  # noqa: E402
 
 cli.add_command(detect_tvars)
 
+from traigent.cli.generate_config_command import generate_config  # noqa: E402
+
+cli.add_command(generate_config)
+
 if __name__ == "__main__":
     cli()  # pylint: disable=no-value-for-parameter

--- a/traigent/config_generator/__init__.py
+++ b/traigent/config_generator/__init__.py
@@ -1,0 +1,98 @@
+"""Auto-optimization config generator.
+
+Public API:
+
+- ``generate_config()`` — one-shot config generation from a Python file
+- ``ConfigGeneratorPipeline`` — fine-grained control over subsystems
+- ``AutoConfigResult`` — the complete output type
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from traigent.config_generator.llm_backend import ConfigGenLLM, LiteLLMBackend
+from traigent.config_generator.pipeline import ConfigGeneratorPipeline
+from traigent.config_generator.types import AutoConfigResult
+from traigent.tuned_variables.detector import TunedVariableDetector
+
+__all__ = [
+    "AutoConfigResult",
+    "ConfigGeneratorPipeline",
+    "generate_config",
+]
+
+
+def generate_config(
+    file_path: str | Path,
+    *,
+    function_name: str | None = None,
+    enrich: bool = False,
+    model: str = "gpt-4o-mini",
+    budget_usd: float = 0.10,
+    subsystems: frozenset[str] | None = None,
+) -> AutoConfigResult:
+    """Generate a complete optimization config from a Python file.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the Python source file.
+    function_name:
+        Specific function to analyze (``None`` = all top-level).
+    enrich:
+        If ``True``, use LLM for richer results.
+    model:
+        LLM model name for enrichment.
+    budget_usd:
+        Maximum LLM spend for enrichment.
+    subsystems:
+        Which subsystems to run (``None`` = all).
+    """
+    file_path = Path(file_path)
+    source_code = file_path.read_text()
+
+    # Scope source to the selected function (if specified) so that
+    # classification/objectives/safety are not influenced by unrelated
+    # functions in the same file.
+    scoped_source = source_code
+    if function_name:
+        scoped_source = _extract_function_source(source_code, function_name)
+
+    # Run detection
+    detector = TunedVariableDetector()
+    detection_results = detector.detect_from_file(file_path, function_name)
+
+    # Build LLM backend
+    llm: ConfigGenLLM | None = None
+    if enrich:
+        llm = LiteLLMBackend(model=model, budget_usd=budget_usd)
+
+    # Run pipeline
+    pipeline = ConfigGeneratorPipeline(llm=llm, subsystems=subsystems)
+    return pipeline.generate(detection_results, source_code=scoped_source)
+
+
+def _extract_function_source(source: str, function_name: str) -> str:
+    """Extract the source of a specific function from a module source string.
+
+    Raises
+    ------
+    ValueError
+        If the named function is not found in the source.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == function_name:
+                return ast.get_source_segment(source, node) or source
+
+    raise ValueError(
+        f"Function '{function_name}' not found in source. "
+        f"Check the function name and try again."
+    )

--- a/traigent/config_generator/agent_classifier.py
+++ b/traigent/config_generator/agent_classifier.py
@@ -1,0 +1,232 @@
+"""Agent type classification from source code.
+
+Classifies a function into an agent type (``"rag"``, ``"chat"``,
+``"code_gen"``, etc.) using heuristic pattern matching on the source code
+and optional LLM enrichment.
+
+This is a **shared step** used by multiple subsystems (objectives,
+safety constraints, recommendations) to avoid redundant LLM calls.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
+
+logger = logging.getLogger(__name__)
+
+# Agent types recognised by the system
+AGENT_TYPES = frozenset(
+    {
+        "rag",
+        "chat",
+        "code_gen",
+        "summarization",
+        "classification",
+        "router",
+        "general_llm",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    """Result of agent type classification."""
+
+    agent_type: str
+    confidence: float  # 0.0–1.0
+    source: str  # "heuristic" | "llm"
+    reasoning: str
+
+
+def classify_agent(
+    source_code: str,
+    *,
+    llm: ConfigGenLLM | None = None,
+) -> ClassificationResult:
+    """Classify a function's agent type from its source code.
+
+    Parameters
+    ----------
+    source_code:
+        The full source code of the file or function.
+    llm:
+        Optional LLM for more accurate classification.  When ``None``,
+        only heuristic pattern matching is used.
+    """
+    # Try heuristic first
+    heuristic_result = _heuristic_classify(source_code)
+
+    # If confidence is high or no LLM available, return heuristic
+    if heuristic_result.confidence >= 0.8 or llm is None:
+        return heuristic_result
+
+    # Try LLM enrichment
+    llm_result = _llm_classify(source_code, llm)
+    if llm_result is not None and llm_result.confidence > heuristic_result.confidence:
+        return llm_result
+
+    return heuristic_result
+
+
+# ---------------------------------------------------------------------------
+# Heuristic classification
+# ---------------------------------------------------------------------------
+
+# Pattern groups: each maps to an agent type with a confidence boost per match
+_PATTERNS: dict[str, list[re.Pattern[str]]] = {
+    "rag": [
+        re.compile(r"\bretriever\b", re.IGNORECASE),
+        re.compile(r"\bsimilarity_search\b"),
+        re.compile(r"\bvector[_\s]?store\b", re.IGNORECASE),
+        re.compile(
+            r"\bchromadb\b|\bpinecone\b|\bweaviate\b|\bqdrant\b|\bfaiss\b",
+            re.IGNORECASE,
+        ),
+        re.compile(r"\bRAG\b"),
+        re.compile(r"\bembedding\b", re.IGNORECASE),
+        re.compile(r"\bchunk\b", re.IGNORECASE),
+        re.compile(r"\bretriev\w+\b", re.IGNORECASE),
+    ],
+    "chat": [
+        re.compile(r"\bChatOpenAI\b|\bChatAnthropic\b|\bChatModel\b"),
+        re.compile(r"\bopenai\.chat\b"),
+        re.compile(r"\bmessages\s*=\s*\["),
+        re.compile(r"\brole.*user\b", re.IGNORECASE),
+        re.compile(r"\bconversation\b|\bdialogue\b", re.IGNORECASE),
+    ],
+    "code_gen": [
+        re.compile(r"\bexecute_code\b|\bexec\(|\beval\("),
+        re.compile(r"\bsubprocess\b"),
+        re.compile(r"\bcode_gen\b|\bgenerate_code\b", re.IGNORECASE),
+        re.compile(r"\bHumanEval\b|\bMBPP\b", re.IGNORECASE),
+        re.compile(r"\bcompile\b.*\brun\b", re.IGNORECASE),
+    ],
+    "summarization": [
+        re.compile(r"\bsummariz\w+\b", re.IGNORECASE),
+        re.compile(r"\bsummary\b", re.IGNORECASE),
+        re.compile(r"\bcondense\b|\bextract\b.*\bkey\b", re.IGNORECASE),
+        re.compile(r"\bTL;?DR\b", re.IGNORECASE),
+    ],
+    "classification": [
+        re.compile(r"\bclassif\w+\b", re.IGNORECASE),
+        re.compile(r"\bpredict\b.*\blabel\b", re.IGNORECASE),
+        re.compile(r"\bsentiment\b", re.IGNORECASE),
+        re.compile(r"\bcategor\w+\b", re.IGNORECASE),
+    ],
+    "router": [
+        re.compile(r"\broute\b|\brouter\b", re.IGNORECASE),
+        re.compile(r"\bdispatch\b|\bswitch\b", re.IGNORECASE),
+        re.compile(r"\bagent_executor\b", re.IGNORECASE),
+    ],
+}
+
+
+def _heuristic_classify(source_code: str) -> ClassificationResult:
+    """Classify using regex pattern matching."""
+    scores: dict[str, int] = dict.fromkeys(_PATTERNS, 0)
+
+    for agent_type, patterns in _PATTERNS.items():
+        for pattern in patterns:
+            if pattern.search(source_code):
+                scores[agent_type] += 1
+
+    # Find the best match
+    best_type = max(scores, key=scores.get)  # type: ignore[arg-type]
+    best_score = scores[best_type]
+
+    if best_score == 0:
+        return ClassificationResult(
+            agent_type="general_llm",
+            confidence=0.3,
+            source="heuristic",
+            reasoning="No specific agent patterns detected; defaulting to general LLM",
+        )
+
+    # Confidence based on number of pattern matches
+    # 1 match = 0.5, 2 = 0.65, 3+ = 0.8+
+    confidence = min(0.3 + best_score * 0.2, 0.9)
+
+    return ClassificationResult(
+        agent_type=best_type,
+        confidence=confidence,
+        source="heuristic",
+        reasoning=f"Matched {best_score} pattern(s) for '{best_type}'",
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM classification
+# ---------------------------------------------------------------------------
+
+_LLM_CLASSIFY_PROMPT = """\
+Classify the following Python function into exactly one agent type.
+
+Agent types:
+- rag: Retrieval-augmented generation (uses vector stores, document retrieval)
+- chat: Conversational chatbot (uses chat models, message history)
+- code_gen: Code generation or execution (generates/runs code)
+- summarization: Document summarization
+- classification: Text classification or labeling
+- router: Agent routing or orchestration
+- general_llm: General LLM usage (doesn't fit other categories)
+
+Source code:
+```python
+{source_code}
+```
+
+Reply with ONLY a JSON object:
+{{"agent_type": "<type>", "confidence": <0.0-1.0>, "reasoning": "<brief>"}}
+"""
+
+
+def _llm_classify(
+    source_code: str,
+    llm: ConfigGenLLM,
+) -> ClassificationResult | None:
+    """Classify using LLM."""
+    import json
+
+    prompt = _LLM_CLASSIFY_PROMPT.format(source_code=source_code[:3000])
+
+    try:
+        response = llm.complete(prompt, max_tokens=256)
+    except BudgetExhausted:
+        return None
+
+    # Parse response
+    text = response.strip()
+    if "```" in text:
+        for part in text.split("```"):
+            stripped = part.strip()
+            if stripped.startswith("json"):
+                stripped = stripped[4:].strip()
+            if stripped.startswith("{"):
+                text = stripped
+                break
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+    agent_type = data.get("agent_type", "")
+    if agent_type not in AGENT_TYPES:
+        return None
+
+    try:
+        confidence = float(data.get("confidence", 0.5))
+    except (ValueError, TypeError):
+        confidence = 0.5
+    reasoning = data.get("reasoning", "LLM classification")
+
+    return ClassificationResult(
+        agent_type=agent_type,
+        confidence=min(confidence, 1.0),
+        source="llm",
+        reasoning=reasoning,
+    )

--- a/traigent/config_generator/apply.py
+++ b/traigent/config_generator/apply.py
@@ -1,0 +1,244 @@
+"""Apply generated config as a decorator on user source files.
+
+Uses AST for analysis (finding functions, existing decorators, imports)
+and line-based string operations for insertion to preserve user formatting.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import shutil
+from pathlib import Path
+
+from traigent.config_generator.types import AutoConfigResult
+
+
+def apply_config(
+    file_path: Path,
+    result: AutoConfigResult,
+    function_name: str | None = None,
+    *,
+    backup: bool = True,
+) -> Path:
+    """Insert or update ``@traigent.optimize(...)`` on a target function.
+
+    Parameters
+    ----------
+    file_path:
+        Path to the Python source file to modify.
+    result:
+        The generated config to apply as a decorator.
+    function_name:
+        Which function to decorate. Required.
+    backup:
+        If ``True``, create a ``.py.bak`` copy before modifying.
+
+    Returns
+    -------
+    Path
+        The path to the modified file.
+
+    Raises
+    ------
+    ValueError
+        If ``function_name`` is not found in the source.
+    """
+    if not function_name:
+        raise ValueError("function_name is required for apply_config")
+
+    source = file_path.read_text()
+    lines = source.splitlines(keepends=True)
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise ValueError(f"Cannot parse {file_path}: {exc}") from exc
+
+    # Find the target function
+    func_node = _find_function(tree, function_name)
+    if func_node is None:
+        raise ValueError(f"Function '{function_name}' not found in {file_path}")
+
+    # Generate the decorator code
+    decorator_code = result.to_python_code()
+
+    # Determine the indentation of the function definition line
+    func_line = lines[func_node.lineno - 1]
+    indent = _get_leading_whitespace(func_line)
+
+    # Indent the decorator to match the function
+    indented_decorator = _indent_decorator(decorator_code, indent)
+
+    # Check for existing optimize decorator and replace or insert
+    existing = _find_optimize_decorator(func_node)
+    if existing is not None:
+        # Replace the existing decorator lines
+        start_line = existing.lineno - 1  # 0-indexed
+        end_line = existing.end_lineno  # end_lineno is 1-indexed, exclusive after slice
+        lines[start_line:end_line] = [indented_decorator + "\n"]
+    else:
+        # Insert above the first decorator or the function def itself
+        insert_line = func_node.lineno - 1
+        if func_node.decorator_list:
+            insert_line = func_node.decorator_list[0].lineno - 1
+        lines.insert(insert_line, indented_decorator + "\n")
+
+    # Ensure required imports exist
+    import_lines = _collect_needed_imports(decorator_code, tree)
+    if import_lines:
+        insert_pos = _find_import_insertion_point(tree)
+        for i, imp_line in enumerate(import_lines):
+            lines.insert(insert_pos + i, imp_line + "\n")
+
+    # Write back
+    if backup:
+        shutil.copy2(file_path, file_path.with_suffix(".py.bak"))
+
+    file_path.write_text("".join(lines))
+    return file_path
+
+
+def _find_function(
+    tree: ast.Module, name: str
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Find a top-level or class-level function by name."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == name:
+                return node
+    return None
+
+
+def _find_optimize_decorator(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> ast.expr | None:
+    """Find an existing @traigent.optimize(...) decorator on the function.
+
+    Checks for:
+    - @traigent.optimize(...)
+    - @optimize(...)
+    - @traigent.api.decorators.optimize(...)
+    """
+    for dec in func_node.decorator_list:
+        if _is_optimize_call(dec):
+            return dec
+    return None
+
+
+def _is_optimize_call(node: ast.expr) -> bool:
+    """Check if an AST node is a call to optimize in any import style."""
+    # Unwrap Call → get the func
+    call_func = node.func if isinstance(node, ast.Call) else node
+
+    # @optimize(...)
+    if isinstance(call_func, ast.Name) and call_func.id == "optimize":
+        return True
+
+    # @traigent.optimize(...)
+    if (
+        isinstance(call_func, ast.Attribute)
+        and call_func.attr == "optimize"
+        and isinstance(call_func.value, ast.Name)
+        and call_func.value.id == "traigent"
+    ):
+        return True
+
+    # @traigent.api.decorators.optimize(...)
+    if isinstance(call_func, ast.Attribute) and call_func.attr == "optimize":
+        # Walk the attribute chain
+        parts = _unpack_attribute(call_func.value)
+        if parts == ["traigent", "api", "decorators"]:
+            return True
+
+    return False
+
+
+def _unpack_attribute(node: ast.expr) -> list[str]:
+    """Unpack a.b.c into ["a", "b", "c"]."""
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):
+        return _unpack_attribute(node.value) + [node.attr]
+    return []
+
+
+def _get_leading_whitespace(line: str) -> str:
+    """Extract the exact leading whitespace from a line."""
+    match = re.match(r"^(\s*)", line)
+    return match.group(1) if match else ""
+
+
+def _indent_decorator(decorator_code: str, indent: str) -> str:
+    """Indent all lines of the decorator to the given level."""
+    lines = decorator_code.splitlines()
+    return "\n".join(indent + line for line in lines)
+
+
+# Symbols that can appear in generated decorator code and their imports.
+_RANGE_SYMBOLS = {"Range", "IntRange", "LogRange", "Choices"}
+_SAFETY_SYMBOLS = {
+    "faithfulness",
+    "hallucination_rate",
+    "toxicity_score",
+    "bias_score",
+    "safety_score",
+}
+
+
+def _collect_needed_imports(decorator_code: str, tree: ast.Module) -> list[str]:
+    """Determine which import lines are missing and need to be added."""
+    existing = _get_existing_imports(tree)
+    needed: list[str] = []
+
+    # Always need `import traigent` for @traigent.optimize(...)
+    if "traigent" not in existing:
+        needed.append("import traigent")
+
+    # Check for Range/IntRange/LogRange/Choices usage
+    range_used = {s for s in _RANGE_SYMBOLS if re.search(rf"\b{s}\(", decorator_code)}
+    range_missing = range_used - existing
+    if range_missing:
+        symbols = ", ".join(sorted(range_missing))
+        needed.append(f"from traigent import {symbols}")
+
+    # Check for safety metric usage
+    safety_used = {
+        s for s in _SAFETY_SYMBOLS if re.search(rf"\b{s}[.(]", decorator_code)
+    }
+    safety_missing = safety_used - existing
+    if safety_missing:
+        symbols = ", ".join(sorted(safety_missing))
+        needed.append(f"from traigent.api.safety import {symbols}")
+
+    return needed
+
+
+def _get_existing_imports(tree: ast.Module) -> set[str]:
+    """Collect all imported names from module-level statements only.
+
+    Ignores imports nested inside functions/classes to avoid treating
+    locally-scoped names as globally available.
+    """
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                names.add(alias.asname or alias.name)
+    return names
+
+
+def _find_import_insertion_point(tree: ast.Module) -> int:
+    """Find the line number (0-indexed) to insert new imports.
+
+    Only considers module-level import statements to avoid inserting
+    imports inside indented blocks. Returns 0 if there are no
+    top-level imports.
+    """
+    last_import_line = 0
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            end = getattr(node, "end_lineno", node.lineno)
+            if end > last_import_line:
+                last_import_line = end
+    return last_import_line

--- a/traigent/config_generator/llm_backend.py
+++ b/traigent/config_generator/llm_backend.py
@@ -1,0 +1,115 @@
+"""LLM backend abstraction for config generation.
+
+Provides a thin protocol over LiteLLM for optional LLM-enriched config
+generation.  When no LLM is available the ``NoOpLLMBackend`` silently
+returns empty strings so the pipeline degrades gracefully to preset-only
+mode.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+class BudgetExhausted(Exception):
+    """Raised when the LLM call budget has been exceeded."""
+
+
+@runtime_checkable
+class ConfigGenLLM(Protocol):
+    """Protocol for LLM calls during config generation."""
+
+    def complete(self, prompt: str, *, max_tokens: int = 1024) -> str:
+        """Send a prompt and return the completion text."""
+        ...  # pragma: no cover
+
+
+class NoOpLLMBackend:
+    """Fallback backend that returns empty strings for all calls.
+
+    Used when no LLM API key is available or when running in preset-only
+    mode.
+    """
+
+    @property
+    def calls_made(self) -> int:
+        return 0
+
+    @property
+    def total_cost_usd(self) -> float:
+        return 0.0
+
+    def complete(self, prompt: str, *, max_tokens: int = 1024) -> str:  # noqa: ARG002
+        return ""
+
+
+class LiteLLMBackend:
+    """LiteLLM-based backend with budget tracking.
+
+    Uses the cheapest capable model by default (gpt-4o-mini).  Tracks
+    cumulative spend and raises ``BudgetExhausted`` when the budget is
+    exceeded.
+
+    Parameters
+    ----------
+    model:
+        LiteLLM model identifier (e.g. ``"gpt-4o-mini"``).
+    budget_usd:
+        Maximum total spend for this backend instance.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        budget_usd: float = 0.10,
+    ) -> None:
+        self._model = model
+        self._budget_usd = budget_usd
+        self._spent_usd: float = 0.0
+        self._calls_made: int = 0
+
+    @property
+    def calls_made(self) -> int:
+        return self._calls_made
+
+    @property
+    def total_cost_usd(self) -> float:
+        return self._spent_usd
+
+    def complete(self, prompt: str, *, max_tokens: int = 1024) -> str:
+        """Call the LLM and return the completion text."""
+        if self._spent_usd >= self._budget_usd:
+            raise BudgetExhausted(
+                f"Budget of ${self._budget_usd:.2f} exceeded "
+                f"(spent ${self._spent_usd:.4f})"
+            )
+
+        try:
+            import litellm
+        except ImportError as exc:
+            logger.warning("litellm not installed; falling back to preset-only mode")
+            raise BudgetExhausted("litellm not installed") from exc
+
+        response = litellm.completion(
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+            temperature=0.0,  # Deterministic for config generation
+        )
+
+        self._calls_made += 1
+
+        # Track cost from response usage
+        usage = getattr(response, "usage", None)
+        if usage:
+            prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+            completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+            # Approximate cost for gpt-4o-mini: $0.15/1M input, $0.60/1M output
+            cost = (prompt_tokens * 0.00000015) + (completion_tokens * 0.0000006)
+            self._spent_usd += cost
+
+        content = response.choices[0].message.content
+        return content or ""

--- a/traigent/config_generator/pipeline.py
+++ b/traigent/config_generator/pipeline.py
@@ -1,0 +1,164 @@
+"""Config generator pipeline.
+
+Orchestrates all 6 subsystems in dependency order to produce
+an ``AutoConfigResult`` from a ``DetectionResult``.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import (
+    ClassificationResult,
+    classify_agent,
+)
+from traigent.config_generator.llm_backend import ConfigGenLLM
+from traigent.config_generator.subsystems.benchmarks import generate_benchmarks
+from traigent.config_generator.subsystems.objectives import generate_objectives
+from traigent.config_generator.subsystems.safety_constraints import (
+    generate_safety_constraints,
+)
+from traigent.config_generator.subsystems.structural_constraints import (
+    generate_structural_constraints,
+)
+from traigent.config_generator.subsystems.tvar_ranges import generate_tvar_specs
+from traigent.config_generator.subsystems.tvar_recommendations import (
+    generate_recommendations,
+)
+from traigent.config_generator.types import AutoConfigResult, SafetySpec
+from traigent.tuned_variables.detection_types import DetectionResult
+
+# All subsystem names that can be selectively enabled.
+ALL_SUBSYSTEMS = frozenset(
+    {
+        "tvars",
+        "objectives",
+        "safety",
+        "structural",
+        "benchmarks",
+        "recommendations",
+    }
+)
+
+
+class ConfigGeneratorPipeline:
+    """Orchestrate auto-config generation from detection results.
+
+    Parameters
+    ----------
+    llm:
+        Optional LLM backend for enrichment.  ``None`` = preset-only mode.
+    subsystems:
+        Which subsystems to run.  ``None`` means all.
+    """
+
+    def __init__(
+        self,
+        llm: ConfigGenLLM | None = None,
+        subsystems: frozenset[str] | None = None,
+    ) -> None:
+        self._llm = llm
+        self._subsystems = subsystems or ALL_SUBSYSTEMS
+
+    def generate(
+        self,
+        detection_results: list[DetectionResult],
+        source_code: str = "",
+    ) -> AutoConfigResult:
+        """Run the pipeline and return the complete config result.
+
+        Parameters
+        ----------
+        detection_results:
+            One or more ``DetectionResult`` from ``TunedVariableDetector``.
+        source_code:
+            Original function source code (for LLM context).
+        """
+        warnings: list[str] = []
+
+        # 1. TVars with ranges (foundation)
+        tvars = []
+        if "tvars" in self._subsystems:
+            tvars = generate_tvar_specs(
+                detection_results,
+                llm=self._llm,
+                source_code=source_code,
+            )
+
+        # 2. Agent classification (shared — used by objectives, safety, benchmarks, recommendations)
+        _CLASSIFICATION_CONSUMERS = {
+            "objectives",
+            "safety",
+            "benchmarks",
+            "recommendations",
+        }
+        classification: ClassificationResult | None = None
+        if source_code and self._subsystems & _CLASSIFICATION_CONSUMERS:
+            classification = classify_agent(source_code, llm=self._llm)
+
+        # 3. Objectives
+        objectives = []
+        if "objectives" in self._subsystems:
+            objectives = generate_objectives(
+                source_code,
+                tvars,
+                llm=self._llm,
+                classification=classification,
+            )
+
+        # 4. Safety constraints
+        safety: list[SafetySpec] = []
+        if "safety" in self._subsystems:
+            safety_result = generate_safety_constraints(
+                source_code,
+                llm=self._llm,
+                classification=classification,
+            )
+            safety = safety_result[0]
+
+        # 5. Structural constraints
+        structural = []
+        if "structural" in self._subsystems:
+            structural = generate_structural_constraints(
+                tvars,
+                llm=self._llm,
+                source_code=source_code,
+            )
+
+        # 6. Benchmarks
+        benchmarks = []
+        if "benchmarks" in self._subsystems:
+            benchmarks = generate_benchmarks(
+                source_code,
+                llm=self._llm,
+                classification=classification,
+            )
+
+        # 7. TVAR recommendations
+        recommendations = []
+        if "recommendations" in self._subsystems:
+            recommendations = generate_recommendations(
+                tvars,
+                llm=self._llm,
+                source_code=source_code,
+                classification=classification,
+            )
+
+        # Collect LLM stats if available
+        llm_calls = 0
+        llm_cost = 0.0
+        if self._llm is not None and hasattr(self._llm, "calls_made"):
+            llm_calls = self._llm.calls_made
+        if self._llm is not None and hasattr(self._llm, "_spent_usd"):
+            llm_cost = self._llm._spent_usd
+
+        return AutoConfigResult(
+            tvars=tuple(tvars),
+            objectives=tuple(objectives),
+            benchmarks=tuple(benchmarks),
+            safety_constraints=tuple(safety),
+            structural_constraints=tuple(structural),
+            recommendations=tuple(recommendations),
+            agent_type=classification.agent_type if classification else None,
+            warnings=tuple(warnings),
+            llm_calls_made=llm_calls,
+            llm_cost_usd=llm_cost,
+        )

--- a/traigent/config_generator/presets/__init__.py
+++ b/traigent/config_generator/presets/__init__.py
@@ -1,0 +1,1 @@
+"""Preset catalogs for the auto-config generator."""

--- a/traigent/config_generator/presets/agent_type_catalog.py
+++ b/traigent/config_generator/presets/agent_type_catalog.py
@@ -1,0 +1,126 @@
+"""Agent type → safety constraint preset mappings.
+
+Each agent type maps to a list of safety constraint specifications
+(metric name, operator, threshold) that are appropriate for that type
+of agent.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from traigent.config_generator.types import SafetySpec
+
+
+class _SafetyPreset(TypedDict):
+    metric: str
+    op: str
+    threshold: float
+    reasoning: str
+
+
+# ---------------------------------------------------------------------------
+# Safety presets by agent type
+# ---------------------------------------------------------------------------
+
+
+def get_safety_presets(agent_type: str) -> list[SafetySpec]:
+    """Return safety constraint presets for the given agent type.
+
+    Returns an empty list for unknown agent types.
+    """
+    presets = _AGENT_SAFETY_PRESETS.get(agent_type, [])
+    return [
+        SafetySpec(
+            metric_name=p["metric"],
+            operator=p["op"],
+            threshold=p["threshold"],
+            agent_type=agent_type,
+            source="preset",
+            reasoning=p["reasoning"],
+        )
+        for p in presets
+    ]
+
+
+def all_agent_types() -> frozenset[str]:
+    """Return all agent types that have safety presets."""
+    return frozenset(_AGENT_SAFETY_PRESETS.keys())
+
+
+_AGENT_SAFETY_PRESETS: dict[str, list[_SafetyPreset]] = {
+    "rag": [
+        {
+            "metric": "faithfulness",
+            "op": ">=",
+            "threshold": 0.85,
+            "reasoning": "RAG agents must ground answers in retrieved context",
+        },
+        {
+            "metric": "hallucination_rate",
+            "op": "<=",
+            "threshold": 0.15,
+            "reasoning": "RAG agents should minimize hallucinated content",
+        },
+    ],
+    "chat": [
+        {
+            "metric": "toxicity_score",
+            "op": "<=",
+            "threshold": 0.05,
+            "reasoning": "Chat agents must avoid toxic or harmful content",
+        },
+        {
+            "metric": "bias_score",
+            "op": "<=",
+            "threshold": 0.10,
+            "reasoning": "Chat agents should minimize bias in responses",
+        },
+    ],
+    "code_gen": [
+        {
+            "metric": "safety_score",
+            "op": ">=",
+            "threshold": 0.90,
+            "reasoning": "Code generation agents must produce safe, non-malicious code",
+        },
+    ],
+    "summarization": [
+        {
+            "metric": "faithfulness",
+            "op": ">=",
+            "threshold": 0.90,
+            "reasoning": "Summaries must be faithful to the source document",
+        },
+        {
+            "metric": "hallucination_rate",
+            "op": "<=",
+            "threshold": 0.10,
+            "reasoning": "Summaries should not include hallucinated information",
+        },
+    ],
+    "classification": [
+        {
+            "metric": "bias_score",
+            "op": "<=",
+            "threshold": 0.10,
+            "reasoning": "Classification agents must avoid biased predictions",
+        },
+    ],
+    "router": [
+        {
+            "metric": "hallucination_rate",
+            "op": "<=",
+            "threshold": 0.10,
+            "reasoning": "Router agents should route accurately without fabrication",
+        },
+    ],
+    "general_llm": [
+        {
+            "metric": "hallucination_rate",
+            "op": "<=",
+            "threshold": 0.15,
+            "reasoning": "General LLM agents should minimize hallucinated content",
+        },
+    ],
+}

--- a/traigent/config_generator/presets/benchmark_catalog.py
+++ b/traigent/config_generator/presets/benchmark_catalog.py
@@ -1,0 +1,95 @@
+"""Known benchmark templates by agent type.
+
+Each benchmark template provides a name, description, and example
+schema that describes what evaluation examples should look like.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.types import BenchmarkSpec
+
+
+def get_benchmark_for_agent_type(agent_type: str) -> BenchmarkSpec | None:
+    """Return a benchmark template for the given agent type, or *None*."""
+    return _BENCHMARK_CATALOG.get(agent_type)
+
+
+def all_benchmark_types() -> frozenset[str]:
+    """Return all agent types that have a benchmark template."""
+    return frozenset(_BENCHMARK_CATALOG.keys())
+
+
+_BENCHMARK_CATALOG: dict[str, BenchmarkSpec] = {
+    "rag": BenchmarkSpec(
+        name="RAG Question Answering",
+        description=(
+            "Evaluate retrieval-augmented generation: given a question and "
+            "optional context, produce a grounded answer."
+        ),
+        example_schema={
+            "input": {"question": "str", "context": "str (optional)"},
+            "output": "str (expected answer)",
+        },
+        source="catalog",
+    ),
+    "chat": BenchmarkSpec(
+        name="Conversational QA",
+        description=(
+            "Evaluate conversational ability: given a user message, "
+            "produce a helpful, accurate response."
+        ),
+        example_schema={
+            "input": {"message": "str"},
+            "output": "str (expected response)",
+        },
+        source="catalog",
+    ),
+    "code_gen": BenchmarkSpec(
+        name="Code Generation",
+        description=(
+            "Evaluate code generation: given a problem description, "
+            "produce correct, executable code."
+        ),
+        example_schema={
+            "input": {"prompt": "str", "language": "str (optional)"},
+            "output": "str (expected code)",
+        },
+        source="catalog",
+    ),
+    "summarization": BenchmarkSpec(
+        name="Document Summarization",
+        description=(
+            "Evaluate summarization quality: given a document, "
+            "produce a faithful, concise summary."
+        ),
+        example_schema={
+            "input": {"document": "str", "max_length": "int (optional)"},
+            "output": "str (expected summary)",
+        },
+        source="catalog",
+    ),
+    "classification": BenchmarkSpec(
+        name="Text Classification",
+        description=(
+            "Evaluate classification accuracy: given text, "
+            "predict the correct label."
+        ),
+        example_schema={
+            "input": {"text": "str"},
+            "output": "str (expected label)",
+        },
+        source="catalog",
+    ),
+    "general_llm": BenchmarkSpec(
+        name="General LLM Evaluation",
+        description=(
+            "General-purpose evaluation: given an input prompt, "
+            "produce a correct output."
+        ),
+        example_schema={
+            "input": {"prompt": "str"},
+            "output": "str (expected output)",
+        },
+        source="catalog",
+    ),
+}

--- a/traigent/config_generator/presets/constraint_templates.py
+++ b/traigent/config_generator/presets/constraint_templates.py
@@ -1,0 +1,146 @@
+"""Structural constraint templates triggered by TVAR combinations.
+
+Each template defines a set of required TVARs and a builder function
+that produces a human-readable description + Python constraint code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from traigent.config_generator.types import StructuralConstraintSpec
+
+
+@dataclass(frozen=True)
+class ConstraintTemplate:
+    """A template for a structural constraint between TVars."""
+
+    name: str
+    description: str
+    requires_tvars: frozenset[str]
+
+    def matches(self, tvar_names: set[str]) -> bool:
+        """Check if this template's required TVars are all present."""
+        return self.requires_tvars.issubset(tvar_names)
+
+
+def get_matching_constraints(tvar_names: set[str]) -> list[StructuralConstraintSpec]:
+    """Return all structural constraints whose required TVars are present."""
+    results: list[StructuralConstraintSpec] = []
+    for template in _CONSTRAINT_TEMPLATES:
+        if template.matches(tvar_names):
+            spec = _BUILDERS[template.name](template, tvar_names)
+            if spec is not None:
+                results.append(spec)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Template definitions
+# ---------------------------------------------------------------------------
+
+_CONSTRAINT_TEMPLATES: list[ConstraintTemplate] = [
+    ConstraintTemplate(
+        name="temperature_top_p_stability",
+        description="Avoid extreme values of both temperature and top_p simultaneously",
+        requires_tvars=frozenset({"temperature", "top_p"}),
+    ),
+    ConstraintTemplate(
+        name="model_temperature_conservative",
+        description="Conservative temperature for larger/more expensive models",
+        requires_tvars=frozenset({"model", "temperature"}),
+    ),
+    ConstraintTemplate(
+        name="model_max_tokens_scaling",
+        description="Scale max_tokens appropriately with model capability",
+        requires_tvars=frozenset({"model", "max_tokens"}),
+    ),
+    ConstraintTemplate(
+        name="chunk_size_overlap_ratio",
+        description="Chunk overlap should not exceed chunk size",
+        requires_tvars=frozenset({"chunk_size", "chunk_overlap"}),
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Builder functions
+# ---------------------------------------------------------------------------
+
+
+def _build_temp_top_p(
+    template: ConstraintTemplate, tvar_names: set[str]
+) -> StructuralConstraintSpec:
+    return StructuralConstraintSpec(
+        description=template.description,
+        constraint_code=(
+            "# Avoid numerically unstable extreme combinations\n"
+            "require(~(temperature.gte(1.5) & top_p.lte(0.2)))"
+        ),
+        requires_tvars=tuple(sorted(template.requires_tvars)),
+        source="template",
+        reasoning=(
+            "Very high temperature with very low top_p produces "
+            "unpredictable, low-quality outputs"
+        ),
+    )
+
+
+def _build_model_temperature(
+    template: ConstraintTemplate, tvar_names: set[str]
+) -> StructuralConstraintSpec:
+    return StructuralConstraintSpec(
+        description=template.description,
+        constraint_code=(
+            "# Use conservative temperature for expensive models\n"
+            "implies(model.is_in(['gpt-4o', 'gpt-4.1']), temperature.lte(1.0))"
+        ),
+        requires_tvars=tuple(sorted(template.requires_tvars)),
+        source="template",
+        reasoning=(
+            "Expensive models are often used for precision tasks; "
+            "high temperature wastes budget on noisy outputs"
+        ),
+    )
+
+
+def _build_model_max_tokens(
+    template: ConstraintTemplate, tvar_names: set[str]
+) -> StructuralConstraintSpec:
+    return StructuralConstraintSpec(
+        description=template.description,
+        constraint_code=(
+            "# Ensure mini models aren't given too many tokens\n"
+            "implies(model.is_in(['gpt-4o-mini', 'gpt-4.1-mini']), max_tokens.lte(2048))"
+        ),
+        requires_tvars=tuple(sorted(template.requires_tvars)),
+        source="template",
+        reasoning=(
+            "Smaller models have lower context windows and may produce "
+            "lower quality output with excessive token budgets"
+        ),
+    )
+
+
+def _build_chunk_overlap(
+    template: ConstraintTemplate, tvar_names: set[str]
+) -> StructuralConstraintSpec:
+    return StructuralConstraintSpec(
+        description=template.description,
+        constraint_code=(
+            "# Overlap must be less than chunk size\n"
+            "lambda config: config['chunk_overlap'] < config['chunk_size']"
+        ),
+        requires_tvars=tuple(sorted(template.requires_tvars)),
+        source="template",
+        reasoning="Chunk overlap exceeding chunk size creates redundant/empty chunks",
+    )
+
+
+_BUILDERS: dict[str, Any] = {
+    "temperature_top_p_stability": _build_temp_top_p,
+    "model_temperature_conservative": _build_model_temperature,
+    "model_max_tokens_scaling": _build_model_max_tokens,
+    "chunk_size_overlap_ratio": _build_chunk_overlap,
+}

--- a/traigent/config_generator/presets/range_presets.py
+++ b/traigent/config_generator/presets/range_presets.py
@@ -1,0 +1,156 @@
+"""Canonical TVAR name → ParameterRange preset mapping.
+
+Maps detection-canonical names (e.g. ``"temperature"``, ``"max_tokens"``)
+to the rich factory presets already defined in
+``traigent.api.parameter_ranges``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_preset_range(canonical_name: str) -> dict[str, Any] | None:
+    """Return range type + kwargs for a canonical TVAR name, or *None*.
+
+    Returns
+    -------
+    dict with ``"range_type"`` and ``"kwargs"`` keys, matching the format
+    used by ``SuggestedRange`` in the detection module.
+    """
+    return _CANONICAL_PRESETS.get(canonical_name)
+
+
+def has_preset(canonical_name: str) -> bool:
+    """Check whether a canonical preset exists for *canonical_name*."""
+    return canonical_name in _CANONICAL_PRESETS
+
+
+def all_canonical_names() -> frozenset[str]:
+    """Return all canonical names that have a preset range."""
+    return frozenset(_CANONICAL_PRESETS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Preset catalog
+#
+# Each entry mirrors the factory methods on Range / IntRange / Choices in
+# traigent/api/parameter_ranges.py but stored as plain dicts so that the
+# config_generator module does not import heavyweight ParameterRange objects
+# at module level.
+# ---------------------------------------------------------------------------
+
+_CANONICAL_PRESETS: dict[str, dict[str, Any]] = {
+    # --- Continuous float ranges (Range) ---
+    "temperature": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.0, "high": 1.0, "default": 0.7},
+    },
+    "top_p": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.1, "high": 1.0, "default": 0.9},
+    },
+    "frequency_penalty": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.0, "high": 2.0, "default": 0.0},
+    },
+    "presence_penalty": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.0, "high": 2.0, "default": 0.0},
+    },
+    "similarity_threshold": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.0, "high": 1.0},
+    },
+    "mmr_lambda": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.0, "high": 1.0},
+    },
+    "chunk_overlap_ratio": {
+        "range_type": "Range",
+        "kwargs": {"low": 0.0, "high": 0.5},
+    },
+    # --- Integer ranges (IntRange) ---
+    "max_tokens": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 256, "high": 4096},
+    },
+    "k": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 1, "high": 10},
+    },
+    "chunk_size": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 100, "high": 1000},
+    },
+    "chunk_overlap": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 0, "high": 200},
+    },
+    "few_shot_count": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 0, "high": 10},
+    },
+    "batch_size": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 1, "high": 64, "default": 16},
+    },
+    "n": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 1, "high": 5},
+    },
+    "seed": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 0, "high": 1000},
+    },
+    "top_k": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 1, "high": 100},
+    },
+    # --- Categorical (Choices) ---
+    "model": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1-nano"],
+        },
+    },
+    "prompting_strategy": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["direct", "chain_of_thought", "react", "self_consistency"],
+        },
+    },
+    "context_format": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["bullet", "numbered", "xml", "markdown", "json"],
+        },
+    },
+    "retriever_type": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["similarity", "mmr", "bm25", "hybrid"],
+        },
+    },
+    "embedding_model": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": [
+                "text-embedding-3-small",
+                "text-embedding-3-large",
+                "text-embedding-ada-002",
+            ],
+        },
+    },
+    "reranker_model": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": [
+                "none",
+                "cohere-rerank-v3",
+                "cross-encoder/ms-marco-MiniLM-L-6-v2",
+                "llm-rerank",
+            ],
+        },
+    },
+}

--- a/traigent/config_generator/subsystems/__init__.py
+++ b/traigent/config_generator/subsystems/__init__.py
@@ -1,0 +1,1 @@
+"""Config generator subsystems."""

--- a/traigent/config_generator/subsystems/benchmarks.py
+++ b/traigent/config_generator/subsystems/benchmarks.py
@@ -1,0 +1,97 @@
+"""Subsystem 3: Benchmark matching and generation.
+
+Matches the classified agent type to a benchmark template from the
+catalog and optionally uses LLM to generate sample evaluation examples.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
+from traigent.config_generator.presets.benchmark_catalog import (
+    get_benchmark_for_agent_type,
+)
+from traigent.config_generator.types import BenchmarkSpec
+
+
+def generate_benchmarks(
+    source_code: str,
+    *,
+    llm: ConfigGenLLM | None = None,
+    classification: ClassificationResult | None = None,
+) -> list[BenchmarkSpec]:
+    """Generate benchmark suggestions based on agent classification.
+
+    Parameters
+    ----------
+    source_code:
+        The function source code (used for LLM context).
+    llm:
+        Optional LLM for generating sample examples.
+    classification:
+        Pre-computed agent classification.
+    """
+    agent_type = classification.agent_type if classification else "general_llm"
+
+    # Catalog match
+    benchmark = get_benchmark_for_agent_type(agent_type)
+    if benchmark is None:
+        benchmark = get_benchmark_for_agent_type("general_llm")
+    if benchmark is None:
+        return []
+
+    # LLM enrichment: generate sample examples
+    if llm is not None:
+        enriched = _llm_generate_examples(benchmark, source_code, llm)
+        if enriched is not None:
+            return [enriched]
+
+    return [benchmark]
+
+
+def _llm_generate_examples(
+    benchmark: BenchmarkSpec,
+    source_code: str,
+    llm: ConfigGenLLM,
+) -> BenchmarkSpec | None:
+    """Ask LLM to generate sample evaluation examples."""
+    import json
+
+    prompt = (
+        f"Generate 3 sample evaluation examples for a '{benchmark.name}' benchmark.\n\n"
+        f"Expected format: {json.dumps(benchmark.example_schema, indent=2)}\n\n"
+        "Source code being evaluated:\n"
+        f"```python\n{source_code[:2000]}\n```\n\n"
+        "Reply with ONLY a JSON array of 3 examples, each with 'input' and 'output' keys.\n"
+    )
+
+    try:
+        response = llm.complete(prompt, max_tokens=1024)
+    except BudgetExhausted:
+        return None
+
+    text = response.strip()
+    if "```" in text:
+        for part in text.split("```"):
+            stripped = part.strip()
+            if stripped.startswith("json"):
+                stripped = stripped[4:].strip()
+            if stripped.startswith("["):
+                text = stripped
+                break
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, list) or len(data) == 0:
+        return None
+
+    return BenchmarkSpec(
+        name=benchmark.name,
+        description=benchmark.description,
+        example_schema=benchmark.example_schema,
+        source="llm",
+        sample_examples=tuple(data),
+    )

--- a/traigent/config_generator/subsystems/objectives.py
+++ b/traigent/config_generator/subsystems/objectives.py
@@ -1,0 +1,229 @@
+"""Subsystem 2: Generate optimization objectives.
+
+Produces default objectives (accuracy, cost, latency) based on heuristic
+analysis of the source code and detected TVARs.  Optional LLM enrichment
+adds domain-specific objectives.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
+from traigent.config_generator.types import ObjectiveSpec, TVarSpec
+
+# Framework import patterns that suggest latency is a relevant objective
+_LLM_FRAMEWORK_PATTERNS = frozenset(
+    {
+        "langchain",
+        "openai",
+        "anthropic",
+        "ChatOpenAI",
+        "ChatAnthropic",
+        "litellm",
+        "cohere",
+        "google.generativeai",
+        "mistralai",
+    }
+)
+
+
+def generate_objectives(
+    source_code: str,
+    tvars: list[TVarSpec],
+    *,
+    llm: ConfigGenLLM | None = None,
+    classification: ClassificationResult | None = None,
+) -> list[ObjectiveSpec]:
+    """Generate objectives for the optimization config.
+
+    Parameters
+    ----------
+    source_code:
+        The function source code.
+    tvars:
+        Already-resolved TVarSpecs (from subsystem 1).
+    llm:
+        Optional LLM for enrichment.
+    classification:
+        Pre-computed agent classification.
+    """
+    objectives = _heuristic_objectives(source_code, tvars, classification)
+
+    if llm is not None:
+        enriched = _llm_enrich_objectives(source_code, objectives, llm)
+        if enriched:
+            objectives = enriched
+
+    return _normalize_weights(objectives)
+
+
+def _heuristic_objectives(
+    source_code: str,
+    tvars: list[TVarSpec],
+    classification: ClassificationResult | None,
+) -> list[ObjectiveSpec]:
+    """Generate objectives from heuristic analysis."""
+    objectives: list[ObjectiveSpec] = []
+
+    # Always include accuracy
+    objectives.append(
+        ObjectiveSpec(
+            name="accuracy",
+            orientation="maximize",
+            weight=0.6,
+            source="default",
+            reasoning="Primary quality objective — always included",
+        )
+    )
+
+    # If any model-type TVAR exists, cost is relevant
+    has_model_tvar = any(
+        t.range_type == "Choices"
+        and t.name in {"model", "model_name", "model_id", "engine"}
+        for t in tvars
+    )
+    if has_model_tvar or _has_llm_imports(source_code):
+        objectives.append(
+            ObjectiveSpec(
+                name="cost",
+                orientation="minimize",
+                weight=0.2,
+                source="heuristic",
+                reasoning="Model selection detected — cost optimization applies",
+            )
+        )
+
+    # If LLM framework imports detected, latency matters
+    if _has_llm_imports(source_code):
+        objectives.append(
+            ObjectiveSpec(
+                name="latency",
+                orientation="minimize",
+                weight=0.2,
+                source="heuristic",
+                reasoning="LLM API calls detected — latency optimization applies",
+            )
+        )
+
+    # Domain-specific objectives based on agent type
+    if classification is not None:
+        if classification.agent_type == "rag":
+            objectives.append(
+                ObjectiveSpec(
+                    name="faithfulness",
+                    orientation="maximize",
+                    weight=0.15,
+                    source="heuristic",
+                    reasoning="RAG agent — faithfulness to source context is important",
+                )
+            )
+        elif classification.agent_type == "classification":
+            objectives.append(
+                ObjectiveSpec(
+                    name="f1",
+                    orientation="maximize",
+                    weight=0.15,
+                    source="heuristic",
+                    reasoning="Classification agent — F1 score measures balance of precision/recall",
+                )
+            )
+
+    return objectives
+
+
+def _has_llm_imports(source_code: str) -> bool:
+    """Check if source code contains LLM framework imports."""
+    return any(pattern in source_code for pattern in _LLM_FRAMEWORK_PATTERNS)
+
+
+def _normalize_weights(objectives: list[ObjectiveSpec]) -> list[ObjectiveSpec]:
+    """Normalize objective weights to sum to 1.0."""
+    total = sum(o.weight for o in objectives)
+    if total <= 0:
+        return objectives
+
+    return [
+        ObjectiveSpec(
+            name=o.name,
+            orientation=o.orientation,
+            weight=round(o.weight / total, 4),
+            source=o.source,
+            reasoning=o.reasoning,
+        )
+        for o in objectives
+    ]
+
+
+def _llm_enrich_objectives(
+    source_code: str,
+    current_objectives: list[ObjectiveSpec],
+    llm: ConfigGenLLM,
+) -> list[ObjectiveSpec] | None:
+    """Ask LLM to suggest additional objectives."""
+    import json
+
+    current_names = {o.name for o in current_objectives}
+    prompt = (
+        "You are configuring optimization objectives for an LLM agent function.\n\n"
+        f"Current objectives: {sorted(current_names)}\n\n"
+        "Source code:\n"
+        f"```python\n{source_code[:2000]}\n```\n\n"
+        "Suggest 0-2 additional domain-specific objectives that would improve "
+        "this agent's optimization. Only suggest objectives that are clearly "
+        "relevant based on the code.\n\n"
+        "Reply with ONLY a JSON array: "
+        '[{"name": "...", "orientation": "maximize"|"minimize", "weight": 0.1-0.3, "reasoning": "..."}]\n'
+        "Return an empty array [] if no additional objectives are needed.\n"
+    )
+
+    try:
+        response = llm.complete(prompt, max_tokens=512)
+    except BudgetExhausted:
+        return None
+
+    # Parse response
+    text = response.strip()
+    if "```" in text:
+        for part in text.split("```"):
+            stripped = part.strip()
+            if stripped.startswith("json"):
+                stripped = stripped[4:].strip()
+            if stripped.startswith("["):
+                text = stripped
+                break
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, list):
+        return None
+
+    # Merge with current objectives
+    merged = list(current_objectives)
+    for item in data:
+        name = item.get("name", "")
+        if not name or name in current_names:
+            continue
+        orientation = item.get("orientation", "maximize")
+        if orientation not in ("maximize", "minimize"):
+            continue
+        try:
+            weight = float(item.get("weight", 0.15))
+        except (ValueError, TypeError):
+            weight = 0.15
+        reasoning = item.get("reasoning", "LLM-suggested objective")
+
+        merged.append(
+            ObjectiveSpec(
+                name=name,
+                orientation=orientation,
+                weight=weight,
+                source="llm",
+                reasoning=reasoning,
+            )
+        )
+        current_names.add(name)
+
+    return merged if len(merged) > len(current_objectives) else None

--- a/traigent/config_generator/subsystems/safety_constraints.py
+++ b/traigent/config_generator/subsystems/safety_constraints.py
@@ -1,0 +1,43 @@
+"""Subsystem 4: Generate safety constraints from agent classification.
+
+Classifies the agent type and selects appropriate safety constraint
+presets from the catalog.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import (
+    ClassificationResult,
+    classify_agent,
+)
+from traigent.config_generator.llm_backend import ConfigGenLLM
+from traigent.config_generator.presets.agent_type_catalog import get_safety_presets
+from traigent.config_generator.types import SafetySpec
+
+
+def generate_safety_constraints(
+    source_code: str,
+    *,
+    llm: ConfigGenLLM | None = None,
+    classification: ClassificationResult | None = None,
+) -> tuple[list[SafetySpec], ClassificationResult]:
+    """Generate safety constraints for the given source code.
+
+    Parameters
+    ----------
+    source_code:
+        The function source code.
+    llm:
+        Optional LLM for agent classification.
+    classification:
+        Pre-computed classification result (avoids redundant calls).
+
+    Returns
+    -------
+    Tuple of (safety constraints, classification result).
+    """
+    if classification is None:
+        classification = classify_agent(source_code, llm=llm)
+
+    presets = get_safety_presets(classification.agent_type)
+    return presets, classification

--- a/traigent/config_generator/subsystems/structural_constraints.py
+++ b/traigent/config_generator/subsystems/structural_constraints.py
@@ -1,0 +1,108 @@
+"""Subsystem 5: Generate structural constraints between TVars.
+
+Uses template matching based on which TVars are present, plus optional
+LLM enrichment for domain-specific constraints.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
+from traigent.config_generator.presets.constraint_templates import (
+    get_matching_constraints,
+)
+from traigent.config_generator.types import StructuralConstraintSpec, TVarSpec
+
+
+def generate_structural_constraints(
+    tvars: list[TVarSpec],
+    *,
+    llm: ConfigGenLLM | None = None,
+    source_code: str = "",
+) -> list[StructuralConstraintSpec]:
+    """Generate structural constraints between TVars.
+
+    Parameters
+    ----------
+    tvars:
+        Resolved TVarSpecs from subsystem 1.
+    llm:
+        Optional LLM for enrichment.
+    source_code:
+        Original source code for LLM context.
+    """
+    tvar_names = {t.name for t in tvars}
+
+    # Template-based constraints
+    constraints = get_matching_constraints(tvar_names)
+
+    # LLM enrichment
+    if llm is not None and len(tvars) >= 2:
+        llm_constraints = _llm_suggest_constraints(tvars, llm, source_code)
+        constraints.extend(llm_constraints)
+
+    return constraints
+
+
+def _llm_suggest_constraints(
+    tvars: list[TVarSpec],
+    llm: ConfigGenLLM,
+    source_code: str,
+) -> list[StructuralConstraintSpec]:
+    """Ask LLM to suggest structural constraints."""
+    import json
+
+    tvar_summary = "\n".join(f"  - {t.name}: {t.to_range_code()}" for t in tvars)
+    prompt = (
+        "You are configuring structural constraints between tunable variables "
+        "in an LLM agent optimization.\n\n"
+        f"Tunable variables:\n{tvar_summary}\n\n"
+        "Source code:\n"
+        f"```python\n{source_code[:2000]}\n```\n\n"
+        "Suggest 0-2 structural constraints (relationships or dependencies) "
+        "between these variables. Only suggest constraints that are clearly "
+        "meaningful for this specific code.\n\n"
+        "Reply with ONLY a JSON array:\n"
+        '[{"description": "...", "constraint_code": "...", "reasoning": "..."}]\n'
+        "constraint_code should be a Python expression using implies(), require(), "
+        "or a lambda function.\n"
+        "Return an empty array [] if no constraints are needed.\n"
+    )
+
+    try:
+        response = llm.complete(prompt, max_tokens=512)
+    except BudgetExhausted:
+        return []
+
+    text = response.strip()
+    if "```" in text:
+        for part in text.split("```"):
+            stripped = part.strip()
+            if stripped.startswith("json"):
+                stripped = stripped[4:].strip()
+            if stripped.startswith("["):
+                text = stripped
+                break
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    results: list[StructuralConstraintSpec] = []
+    for item in data:
+        desc = item.get("description", "")
+        code = item.get("constraint_code", "")
+        reasoning = item.get("reasoning", "")
+        if desc and code:
+            results.append(
+                StructuralConstraintSpec(
+                    description=desc,
+                    constraint_code=code,
+                    source="llm",
+                    reasoning=reasoning,
+                )
+            )
+    return results

--- a/traigent/config_generator/subsystems/tvar_ranges.py
+++ b/traigent/config_generator/subsystems/tvar_ranges.py
@@ -1,0 +1,234 @@
+"""Subsystem 1: Convert detected tuned variables into resolved TVarSpecs.
+
+Maps each ``TunedVariableCandidate`` to a ``TVarSpec`` by:
+
+1. Checking the canonical name against rich presets
+   (``presets/range_presets.py``).
+2. Falling back to the ``SuggestedRange`` from the detection module.
+3. Applying value-based heuristics as a last resort.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
+from traigent.config_generator.presets.range_presets import get_preset_range
+from traigent.config_generator.types import TVarSpec
+from traigent.tuned_variables.detection_types import (
+    DetectionConfidence,
+    DetectionResult,
+    TunedVariableCandidate,
+)
+
+
+def generate_tvar_specs(
+    results: list[DetectionResult],
+    *,
+    llm: ConfigGenLLM | None = None,
+    source_code: str = "",
+) -> list[TVarSpec]:
+    """Convert detection results to resolved TVarSpecs.
+
+    Parameters
+    ----------
+    results:
+        Detection results from ``TunedVariableDetector``.
+    llm:
+        Optional LLM backend for enrichment.  When ``None``, only preset
+        and heuristic ranges are used.
+    source_code:
+        Original source code (used for LLM context).
+    """
+    specs: list[TVarSpec] = []
+    seen_names: set[str] = set()
+
+    for result in results:
+        for candidate in result.candidates:
+            # Skip LOW confidence and duplicates
+            if candidate.confidence == DetectionConfidence.LOW:
+                continue
+            if candidate.name in seen_names:
+                continue
+            seen_names.add(candidate.name)
+
+            spec = _resolve_candidate(candidate, llm=llm, source_code=source_code)
+            if spec is not None:
+                specs.append(spec)
+
+    return specs
+
+
+def _resolve_candidate(
+    candidate: TunedVariableCandidate,
+    *,
+    llm: ConfigGenLLM | None = None,
+    source_code: str = "",
+) -> TVarSpec | None:
+    """Resolve a single candidate to a TVarSpec."""
+    # Priority 1: canonical preset
+    canonical = candidate.canonical_name or candidate.name
+    preset = get_preset_range(canonical)
+    if preset is not None:
+        return TVarSpec(
+            name=candidate.name,
+            range_type=preset["range_type"],
+            range_kwargs=dict(preset["kwargs"]),
+            source="preset",
+            confidence=_confidence_score(candidate.confidence),
+            reasoning=f"Canonical preset for '{canonical}'",
+        )
+
+    # Priority 2: SuggestedRange from detection
+    if candidate.suggested_range is not None:
+        return TVarSpec(
+            name=candidate.name,
+            range_type=candidate.suggested_range.range_type,
+            range_kwargs=dict(candidate.suggested_range.kwargs),
+            source="detection",
+            confidence=_confidence_score(candidate.confidence),
+            reasoning=candidate.reasoning or "From detection suggested range",
+        )
+
+    # Priority 3: value-based heuristic
+    heuristic = _heuristic_from_value(candidate.name, candidate.current_value)
+    if heuristic is not None:
+        return heuristic
+
+    # Priority 4: LLM enrichment (optional)
+    if llm is not None and source_code:
+        enriched = _llm_resolve(candidate, llm, source_code)
+        if enriched is not None:
+            return enriched
+
+    return None
+
+
+def _confidence_score(confidence: DetectionConfidence) -> float:
+    """Map DetectionConfidence enum to numeric score."""
+    return {
+        DetectionConfidence.HIGH: 1.0,
+        DetectionConfidence.MEDIUM: 0.7,
+        DetectionConfidence.LOW: 0.3,
+    }[confidence]
+
+
+def _heuristic_from_value(name: str, value: Any) -> TVarSpec | None:
+    """Infer range from the current value type and magnitude."""
+    # Check bool BEFORE int because bool is a subclass of int in Python
+    if isinstance(value, bool):
+        return TVarSpec(
+            name=name,
+            range_type="Choices",
+            range_kwargs={"values": [True, False]},
+            source="heuristic",
+            confidence=0.6,
+            reasoning="Boolean toggle",
+        )
+
+    if isinstance(value, float):
+        if value == 0.0:
+            low, high = 0.0, 1.0
+        else:
+            low = round(max(0.0, value * 0.5), 4)
+            high = round(value * 2.0, 4)
+        return TVarSpec(
+            name=name,
+            range_type="Range",
+            range_kwargs={"low": low, "high": high},
+            source="heuristic",
+            confidence=0.5,
+            reasoning=f"Inferred from current value {value!r} (0.5x–2x)",
+        )
+
+    if isinstance(value, int):
+        low = max(1, value // 2)
+        high = max(low + 1, value * 2)
+        return TVarSpec(
+            name=name,
+            range_type="IntRange",
+            range_kwargs={"low": low, "high": high},
+            source="heuristic",
+            confidence=0.5,
+            reasoning=f"Inferred from current value {value!r} (//2–*2)",
+        )
+
+    if isinstance(value, str):
+        return TVarSpec(
+            name=name,
+            range_type="Choices",
+            range_kwargs={"values": [value]},
+            source="heuristic",
+            confidence=0.4,
+            reasoning=f"Single-value choice from current value {value!r}",
+        )
+
+    return None
+
+
+def _llm_resolve(
+    candidate: TunedVariableCandidate,
+    llm: ConfigGenLLM,
+    source_code: str,
+) -> TVarSpec | None:
+    """Ask LLM to suggest a range for an unresolved candidate."""
+    prompt = (
+        "You are helping configure an optimization search space for an LLM agent.\n\n"
+        f"Variable name: {candidate.name}\n"
+        f"Current value: {candidate.current_value!r}\n"
+        f"Type: {candidate.candidate_type.value}\n\n"
+        "Source code context:\n"
+        f"```python\n{source_code[:2000]}\n```\n\n"
+        "Suggest a reasonable optimization range for this variable.\n"
+        "Reply with ONLY a JSON object: "
+        '{"range_type": "Range"|"IntRange"|"Choices", "kwargs": {...}}\n'
+        'For Range: {"low": <float>, "high": <float>}\n'
+        'For IntRange: {"low": <int>, "high": <int>}\n'
+        'For Choices: {"values": [...]}\n'
+    )
+
+    try:
+        response = llm.complete(prompt, max_tokens=256)
+    except BudgetExhausted:
+        return None
+
+    return _parse_llm_range_response(candidate.name, response)
+
+
+def _parse_llm_range_response(name: str, response: str) -> TVarSpec | None:
+    """Parse LLM JSON response into a TVarSpec."""
+    import json
+
+    # Extract JSON from response (may have markdown fences)
+    text = response.strip()
+    if "```" in text:
+        parts = text.split("```")
+        for part in parts:
+            stripped = part.strip()
+            if stripped.startswith("json"):
+                stripped = stripped[4:].strip()
+            if stripped.startswith("{"):
+                text = stripped
+                break
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+    range_type = data.get("range_type")
+    kwargs = data.get("kwargs")
+    if not range_type or not isinstance(kwargs, dict):
+        return None
+
+    if range_type not in ("Range", "IntRange", "LogRange", "Choices"):
+        return None
+
+    return TVarSpec(
+        name=name,
+        range_type=range_type,
+        range_kwargs=kwargs,
+        source="llm",
+        confidence=0.6,
+        reasoning="LLM-suggested range",
+    )

--- a/traigent/config_generator/subsystems/tvar_recommendations.py
+++ b/traigent/config_generator/subsystems/tvar_recommendations.py
@@ -1,0 +1,252 @@
+"""Subsystem 6: TVAR recommendations.
+
+Suggests additional tunable variables the user may not have considered,
+based on agent type and what TVARs are already detected.
+"""
+
+from __future__ import annotations
+
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
+from traigent.config_generator.presets.range_presets import get_preset_range
+from traigent.config_generator.types import TVarRecommendation, TVarSpec
+
+
+def generate_recommendations(
+    tvars: list[TVarSpec],
+    *,
+    llm: ConfigGenLLM | None = None,
+    source_code: str = "",
+    classification: ClassificationResult | None = None,
+) -> list[TVarRecommendation]:
+    """Generate TVAR recommendations.
+
+    Parameters
+    ----------
+    tvars:
+        Already-detected TVarSpecs.
+    llm:
+        Optional LLM for enrichment.
+    source_code:
+        Original source code.
+    classification:
+        Pre-computed agent classification.
+    """
+    existing_names = {t.name for t in tvars}
+    agent_type = classification.agent_type if classification else "general_llm"
+
+    # Preset recommendations
+    recs = _preset_recommendations(agent_type, existing_names)
+
+    # LLM enrichment
+    if llm is not None:
+        llm_recs = _llm_recommend(tvars, agent_type, source_code, llm)
+        # Deduplicate by name
+        existing_rec_names = {r.name for r in recs}
+        for rec in llm_recs:
+            if rec.name not in existing_rec_names and rec.name not in existing_names:
+                recs.append(rec)
+                existing_rec_names.add(rec.name)
+
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# Preset recommendation catalog
+# ---------------------------------------------------------------------------
+
+_RECOMMENDATIONS: dict[str, list[dict[str, str]]] = {
+    "rag": [
+        {
+            "name": "prompting_strategy",
+            "category": "prompting",
+            "reasoning": "RAG systems benefit from different prompting strategies (direct, chain_of_thought, react)",
+            "impact": "high",
+        },
+        {
+            "name": "retriever_type",
+            "category": "retrieval",
+            "reasoning": "Different retrieval methods (similarity, MMR, BM25, hybrid) affect answer quality",
+            "impact": "high",
+        },
+        {
+            "name": "chunk_size",
+            "category": "retrieval",
+            "reasoning": "Document chunk size significantly impacts retrieval quality",
+            "impact": "medium",
+        },
+        {
+            "name": "reranker_model",
+            "category": "retrieval",
+            "reasoning": "Reranking retrieved documents can improve answer quality",
+            "impact": "medium",
+        },
+        {
+            "name": "context_format",
+            "category": "prompting",
+            "reasoning": "How retrieved context is formatted affects LLM comprehension",
+            "impact": "medium",
+        },
+    ],
+    "chat": [
+        {
+            "name": "prompting_strategy",
+            "category": "prompting",
+            "reasoning": "Different prompting strategies can dramatically change response quality",
+            "impact": "high",
+        },
+        {
+            "name": "context_format",
+            "category": "prompting",
+            "reasoning": "How context is formatted affects LLM comprehension",
+            "impact": "medium",
+        },
+    ],
+    "code_gen": [
+        {
+            "name": "prompting_strategy",
+            "category": "prompting",
+            "reasoning": "Chain-of-thought and self-consistency improve code generation accuracy",
+            "impact": "high",
+        },
+    ],
+    "summarization": [
+        {
+            "name": "prompting_strategy",
+            "category": "prompting",
+            "reasoning": "Different prompting strategies produce different summary styles",
+            "impact": "medium",
+        },
+        {
+            "name": "context_format",
+            "category": "prompting",
+            "reasoning": "Document formatting affects summarization quality",
+            "impact": "low",
+        },
+    ],
+    "classification": [
+        {
+            "name": "few_shot_count",
+            "category": "prompting",
+            "reasoning": "Number of few-shot examples significantly impacts classification accuracy",
+            "impact": "high",
+        },
+        {
+            "name": "prompting_strategy",
+            "category": "prompting",
+            "reasoning": "Chain-of-thought can improve complex classification tasks",
+            "impact": "medium",
+        },
+    ],
+    "general_llm": [
+        {
+            "name": "prompting_strategy",
+            "category": "prompting",
+            "reasoning": "Different prompting strategies can improve output quality",
+            "impact": "medium",
+        },
+    ],
+}
+
+
+def _preset_recommendations(
+    agent_type: str,
+    existing_names: set[str],
+) -> list[TVarRecommendation]:
+    """Generate recommendations from presets."""
+    templates = _RECOMMENDATIONS.get(agent_type, [])
+    recs: list[TVarRecommendation] = []
+
+    for tmpl in templates:
+        name = tmpl["name"]
+        if name in existing_names:
+            continue
+
+        preset = get_preset_range(name)
+        if preset is None:
+            continue
+
+        recs.append(
+            TVarRecommendation(
+                name=name,
+                range_type=preset["range_type"],
+                range_kwargs=dict(preset["kwargs"]),
+                category=tmpl["category"],
+                reasoning=tmpl["reasoning"],
+                impact_estimate=tmpl["impact"],
+            )
+        )
+
+    return recs
+
+
+def _llm_recommend(
+    tvars: list[TVarSpec],
+    agent_type: str,
+    source_code: str,
+    llm: ConfigGenLLM,
+) -> list[TVarRecommendation]:
+    """Ask LLM for additional TVAR recommendations."""
+    import json
+
+    tvar_summary = ", ".join(t.name for t in tvars)
+    prompt = (
+        "You are configuring an optimization search space for an LLM agent.\n\n"
+        f"Agent type: {agent_type}\n"
+        f"Current tunable variables: [{tvar_summary}]\n\n"
+        "Source code:\n"
+        f"```python\n{source_code[:2000]}\n```\n\n"
+        "Suggest 0-3 additional parameters that could be tuned to improve this "
+        "agent's performance. Consider: prompting strategies, retrieval techniques, "
+        "model selection, and domain-specific parameters.\n\n"
+        "Reply with ONLY a JSON array:\n"
+        '[{"name": "...", "range_type": "Range"|"IntRange"|"Choices", '
+        '"kwargs": {...}, "category": "...", "reasoning": "...", "impact": "high"|"medium"|"low"}]\n'
+        "Return an empty array [] if no recommendations.\n"
+    )
+
+    try:
+        response = llm.complete(prompt, max_tokens=512)
+    except BudgetExhausted:
+        return []
+
+    text = response.strip()
+    if "```" in text:
+        for part in text.split("```"):
+            stripped = part.strip()
+            if stripped.startswith("json"):
+                stripped = stripped[4:].strip()
+            if stripped.startswith("["):
+                text = stripped
+                break
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(data, list):
+        return []
+
+    results: list[TVarRecommendation] = []
+    for item in data:
+        name = item.get("name", "")
+        range_type = item.get("range_type", "")
+        kwargs = item.get("kwargs", {})
+        if not name or not range_type or not isinstance(kwargs, dict):
+            continue
+        if range_type not in ("Range", "IntRange", "LogRange", "Choices"):
+            continue
+
+        results.append(
+            TVarRecommendation(
+                name=name,
+                range_type=range_type,
+                range_kwargs=kwargs,
+                category=item.get("category", ""),
+                reasoning=item.get("reasoning", "LLM-suggested"),
+                impact_estimate=item.get("impact", "medium"),
+            )
+        )
+
+    return results

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -104,10 +104,37 @@ class AutoConfigResult:
     llm_cost_usd: float = 0.0
 
     def to_decorator_kwargs(self) -> dict[str, Any]:
-        """Convert to kwargs suitable for ``@traigent.optimize(...)``."""
+        """Convert to kwargs suitable for ``@traigent.optimize(...)``.
+
+        Returns actual ``ParameterRange`` and ``SafetyConstraint`` objects
+        that can be passed directly to the decorator.
+        """
         kwargs: dict[str, Any] = {}
 
-        # configuration_space
+        if self.tvars:
+            config_space: dict[str, Any] = {}
+            for tvar in self.tvars:
+                config_space[tvar.name] = _reconstruct_range(tvar)
+            kwargs["configuration_space"] = config_space
+
+        if self.objectives:
+            kwargs["objectives"] = [obj.name for obj in self.objectives]
+
+        if self.safety_constraints:
+            kwargs["safety_constraints"] = [
+                _reconstruct_safety(sc) for sc in self.safety_constraints
+            ]
+
+        return kwargs
+
+    def to_dict_kwargs(self) -> dict[str, Any]:
+        """Convert to serializable kwargs dict (for JSON/TVL export).
+
+        Same shape as ``to_decorator_kwargs`` but with plain dicts
+        instead of live objects.
+        """
+        kwargs: dict[str, Any] = {}
+
         if self.tvars:
             config_space: dict[str, Any] = {}
             for tvar in self.tvars:
@@ -117,11 +144,63 @@ class AutoConfigResult:
                 }
             kwargs["configuration_space"] = config_space
 
-        # objectives
         if self.objectives:
             kwargs["objectives"] = [obj.name for obj in self.objectives]
 
         return kwargs
+
+    def to_tvl_spec(self, module_name: str = "auto_generated") -> dict[str, Any]:
+        """Convert to a TVL 0.9 spec dict (YAML-serializable).
+
+        Leverages ``ConfigSpace.to_tvl_spec()`` for tvar/constraint
+        conversion and appends objectives + safety sections.
+        """
+        # Lazy import to avoid circular dependency
+        from traigent.api.config_space import ConfigSpace
+
+        # Build a ConfigSpace from live ParameterRange objects
+        decorator_kwargs = self.to_decorator_kwargs()
+        config_space = ConfigSpace.from_decorator_args(
+            configuration_space=decorator_kwargs.get("configuration_space"),
+        )
+
+        spec: dict[str, Any] = config_space.to_tvl_spec()
+        spec["header"] = {"module": module_name}
+
+        # Append structural constraints from the pipeline (stored as code
+        # strings, not live Constraint objects, so we add them directly).
+        if self.structural_constraints:
+            structural = [
+                {
+                    "description": sc.description,
+                    "code": sc.constraint_code,
+                    "requires": list(sc.requires_tvars),
+                }
+                for sc in self.structural_constraints
+            ]
+            spec.setdefault("constraints", {})["structural"] = structural
+
+        if self.objectives:
+            spec["objectives"] = [
+                {
+                    "name": obj.name,
+                    "direction": obj.orientation,
+                    "weight": obj.weight,
+                }
+                for obj in self.objectives
+            ]
+
+        if self.safety_constraints:
+            spec["safety"] = [
+                {
+                    "metric": sc.metric_name,
+                    "operator": sc.operator,
+                    "threshold": sc.threshold,
+                }
+                for sc in self.safety_constraints
+            ]
+
+        return spec
 
     def to_python_code(self) -> str:
         """Generate copy-pasteable ``@traigent.optimize(...)`` Python code."""
@@ -180,3 +259,55 @@ def _metric_expression(metric_name: str) -> str:
     if metric_name in _FACTORY_METRICS:
         return f"{metric_name}()"
     return metric_name
+
+
+def _reconstruct_range(tvar: TVarSpec) -> Any:
+    """Reconstruct a live ``ParameterRange`` from a ``TVarSpec``.
+
+    Uses lazy imports to avoid circular dependency with ``traigent.api``.
+    """
+    from traigent.api.parameter_ranges import Choices, IntRange, LogRange, Range
+
+    constructors = {
+        "Range": Range,
+        "IntRange": IntRange,
+        "LogRange": LogRange,
+        "Choices": Choices,
+    }
+    cls = constructors.get(tvar.range_type)
+    if cls is None:
+        raise ValueError(f"Unknown range type: {tvar.range_type!r}")
+    return cls(**tvar.range_kwargs, name=tvar.name)
+
+
+def _reconstruct_safety(sc: SafetySpec) -> Any:
+    """Reconstruct a live ``SafetyConstraint`` from a ``SafetySpec``.
+
+    Uses lazy imports to avoid circular dependency with ``traigent.api``.
+    """
+    from traigent.api.safety import (
+        bias_score,
+        faithfulness,
+        hallucination_rate,
+        safety_score,
+        toxicity_score,
+    )
+
+    metrics: dict[str, Any] = {
+        "faithfulness": faithfulness,
+        "hallucination_rate": hallucination_rate,
+        "toxicity_score": toxicity_score,
+        "bias_score": bias_score,
+        "safety_score": safety_score,
+    }
+    metric_or_factory = metrics.get(sc.metric_name)
+    if metric_or_factory is None:
+        raise ValueError(f"Unknown safety metric: {sc.metric_name!r}")
+
+    # Factory metrics need to be called to get an instance
+    metric = (
+        metric_or_factory() if sc.metric_name in _FACTORY_METRICS else metric_or_factory
+    )
+    if sc.operator == ">=":
+        return metric.above(sc.threshold)  # type: ignore[union-attr]
+    return metric.below(sc.threshold)  # type: ignore[union-attr]

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -1,0 +1,182 @@
+"""Output types for the auto-optimization config generator.
+
+All types are frozen dataclasses for immutability and thread safety.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TVarSpec:
+    """A fully-resolved tuned variable specification with its ParameterRange."""
+
+    name: str
+    range_type: str  # "Range", "IntRange", "LogRange", "Choices"
+    range_kwargs: dict[str, Any] = field(default_factory=dict)
+    source: str = "preset"  # "preset" | "heuristic" | "llm" | "detection"
+    confidence: float = 1.0
+    reasoning: str = ""
+
+    def to_range_code(self) -> str:
+        """Generate Python code like ``Range(low=0.0, high=2.0)``."""
+        parts = [f"{k}={v!r}" for k, v in self.range_kwargs.items()]
+        return f"{self.range_type}({', '.join(parts)})"
+
+
+@dataclass(frozen=True)
+class ObjectiveSpec:
+    """A generated objective definition."""
+
+    name: str
+    orientation: str = "maximize"  # "maximize" | "minimize"
+    weight: float = 1.0
+    source: str = "default"  # "default" | "heuristic" | "llm"
+    reasoning: str = ""
+
+
+@dataclass(frozen=True)
+class BenchmarkSpec:
+    """A benchmark suggestion with format template."""
+
+    name: str
+    description: str = ""
+    example_schema: dict[str, Any] = field(default_factory=dict)
+    source: str = "catalog"  # "catalog" | "llm"
+    sample_examples: tuple[dict[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class SafetySpec:
+    """A generated safety constraint."""
+
+    metric_name: str
+    operator: str  # ">=" | "<="
+    threshold: float
+    agent_type: str = ""
+    source: str = "preset"  # "preset" | "llm"
+    reasoning: str = ""
+
+
+@dataclass(frozen=True)
+class StructuralConstraintSpec:
+    """A generated structural constraint between TVars."""
+
+    description: str
+    constraint_code: str  # Python code string
+    requires_tvars: tuple[str, ...] = ()
+    source: str = "template"  # "template" | "llm"
+    reasoning: str = ""
+
+
+@dataclass(frozen=True)
+class TVarRecommendation:
+    """A recommended additional TVAR the user may not have considered."""
+
+    name: str
+    range_type: str
+    range_kwargs: dict[str, Any] = field(default_factory=dict)
+    category: str = ""  # "prompting" | "retrieval" | "model" | "evaluation"
+    reasoning: str = ""
+    impact_estimate: str = "medium"  # "high" | "medium" | "low"
+
+    def to_range_code(self) -> str:
+        """Generate Python code for the recommended range."""
+        parts = [f"{k}={v!r}" for k, v in self.range_kwargs.items()]
+        return f"{self.range_type}({', '.join(parts)})"
+
+
+@dataclass(frozen=True)
+class AutoConfigResult:
+    """Complete output from the auto-config generator."""
+
+    tvars: tuple[TVarSpec, ...] = ()
+    objectives: tuple[ObjectiveSpec, ...] = ()
+    benchmarks: tuple[BenchmarkSpec, ...] = ()
+    safety_constraints: tuple[SafetySpec, ...] = ()
+    structural_constraints: tuple[StructuralConstraintSpec, ...] = ()
+    recommendations: tuple[TVarRecommendation, ...] = ()
+    agent_type: str | None = None
+    warnings: tuple[str, ...] = ()
+    llm_calls_made: int = 0
+    llm_cost_usd: float = 0.0
+
+    def to_decorator_kwargs(self) -> dict[str, Any]:
+        """Convert to kwargs suitable for ``@traigent.optimize(...)``."""
+        kwargs: dict[str, Any] = {}
+
+        # configuration_space
+        if self.tvars:
+            config_space: dict[str, Any] = {}
+            for tvar in self.tvars:
+                config_space[tvar.name] = {
+                    "type": tvar.range_type,
+                    **tvar.range_kwargs,
+                }
+            kwargs["configuration_space"] = config_space
+
+        # objectives
+        if self.objectives:
+            kwargs["objectives"] = [obj.name for obj in self.objectives]
+
+        return kwargs
+
+    def to_python_code(self) -> str:
+        """Generate copy-pasteable ``@traigent.optimize(...)`` Python code."""
+        lines: list[str] = []
+        lines.append("@traigent.optimize(")
+
+        # configuration_space
+        if self.tvars:
+            lines.append("    configuration_space={")
+            for tvar in self.tvars:
+                lines.append(f"        {tvar.name!r}: {tvar.to_range_code()},")
+            lines.append("    },")
+
+        # objectives
+        if self.objectives:
+            obj_list = ", ".join(f"{o.name!r}" for o in self.objectives)
+            lines.append(f"    objectives=[{obj_list}],")
+
+        # safety_constraints
+        if self.safety_constraints:
+            lines.append("    safety_constraints=[")
+            for sc in self.safety_constraints:
+                metric_expr = _metric_expression(sc.metric_name)
+                method = "above" if sc.operator == ">=" else "below"
+                lines.append(f"        {metric_expr}.{method}({sc.threshold}),")
+            lines.append("    ],")
+
+        # recommendations as comments
+        if self.recommendations:
+            lines.append("    # Recommended additional TVars:")
+            for rec in self.recommendations:
+                lines.append(f"    #   {rec.name!r}: {rec.to_range_code()},")
+
+        lines.append(")")
+        return "\n".join(lines)
+
+
+# Metrics in traigent.api.safety that are factory functions (need "()")
+# vs module-level instances (used as-is).
+_FACTORY_METRICS = frozenset(
+    {
+        "hallucination_rate",
+        "toxicity_score",
+        "bias_score",
+        "safety_score",
+        "custom_safety",
+    }
+)
+
+
+def _metric_expression(metric_name: str) -> str:
+    """Return a valid Python expression for a safety metric.
+
+    Factory-function metrics need ``()``, module-level instances don't.
+    """
+    if metric_name in _FACTORY_METRICS:
+        return f"{metric_name}()"
+    return metric_name

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -287,6 +287,7 @@ def _reconstruct_safety(sc: SafetySpec) -> Any:
     """
     from traigent.api.safety import (
         bias_score,
+        custom_safety,
         faithfulness,
         hallucination_rate,
         safety_score,
@@ -299,6 +300,7 @@ def _reconstruct_safety(sc: SafetySpec) -> Any:
         "toxicity_score": toxicity_score,
         "bias_score": bias_score,
         "safety_score": safety_score,
+        "custom_safety": custom_safety,
     }
     metric_or_factory = metrics.get(sc.metric_name)
     if metric_or_factory is None:


### PR DESCRIPTION
## Summary
- **Auto-config generator pipeline**: Analyzes Python source files using preset heuristics + optional LLM enrichment to generate complete `@traigent.optimize(...)` configurations across 6 subsystems (tvars, objectives, safety, structural constraints, benchmarks, recommendations)
- **`--apply` flag**: AST-guided decorator insertion/update that preserves user formatting, handles existing decorators (3 import styles), and manages imports automatically
- **`--output tvl`**: Exports generated config as `.tvl.yml` spec files with structural constraint support
- **`to_decorator_kwargs()` returns live objects**: `ParameterRange` and `SafetyConstraint` instances instead of serialized dicts (old behavior preserved in `to_dict_kwargs()`)

### Key design decisions
- Line-based insertion (not AST round-trip) to preserve comments and formatting
- Module-level import detection only (`tree.body` iteration, not `ast.walk`) — per Codex review finding
- Lazy imports in `types.py` to prevent circular dependency with `traigent.api`
- Cognitive complexity kept under threshold via `_print_section` helper extraction

### Files changed (39 files, +5,703 lines)
- `traigent/config_generator/` — full pipeline: types, agent classifier, presets, subsystems, LLM backend, apply module
- `traigent/cli/generate_config_command.py` — CLI with `--apply`, `--no-backup`, `--output tvl`, `--only`, `--enrich`
- `tests/unit/config_generator/` — 214+ tests covering all modules at ≥85% coverage

## Test plan
- [x] All 214 config-generator tests pass (`pytest tests/unit/config_generator/ -v`)
- [x] CLI tests pass (`pytest tests/unit/cli/test_generate_config_command.py -v`)
- [x] Local SonarQube quality gate: OK (90.5% coverage on new code, 0 bugs, 0 vulnerabilities)
- [x] Pre-commit hooks pass (isort, black, ruff, mypy, bandit, detect-secrets)
- [x] Codex review (GPT-5.3, xhigh reasoning): 5 findings, 3 in-scope fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)