### PR TITLE
fix(cost): harden model pricing mappings and add strict runtime accounting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,10 @@ jobs:
       run: |
         ruff check traigent/ --output-format=github
 
+    - name: Enforce strict cost accounting guardrails
+      run: |
+        bash scripts/hooks/check-cost-strictness.sh
+
     - name: Type check with mypy
       run: |
         mypy traigent/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,12 @@ repos:
   # Prevent committing gitignored files
   - repo: local
     hooks:
+      - id: check-cost-strictness
+        name: Check strict cost accounting guardrails
+        language: script
+        entry: scripts/hooks/check-cost-strictness.sh
+        pass_filenames: false
+        always_run: true
       - id: check-ignored-files
         name: Check for ignored files staged for commit
         language: script

--- a/scripts/hooks/check-cost-strictness.sh
+++ b/scripts/hooks/check-cost-strictness.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Guardrail: prevent strict=False in runtime post-call cost accounting paths.
+set -euo pipefail
+
+PATTERN='cost_from_tokens\([^)]*strict=False'
+TARGET_DIR="traigent"
+ALLOWED_FILE="traigent/utils/cost_calculator.py"
+ALLOWED_FUNCTION="get_model_pricing_per_1k"
+
+if command -v rg >/dev/null 2>&1; then
+  MATCHES="$(rg -n "$PATTERN" "$TARGET_DIR" --glob '*.py' || true)"
+else
+  MATCHES="$(grep -R -n -E "$PATTERN" "$TARGET_DIR" --include='*.py' || true)"
+fi
+
+if [ -z "$MATCHES" ]; then
+  exit 0
+fi
+
+BOUNDS="$(
+  awk -v fn="$ALLOWED_FUNCTION" '
+    $0 ~ ("^def " fn "\\(") { start = NR }
+    start && /^def / && NR > start { end = NR - 1; print start ":" end; exit }
+    END {
+      if (start && !end) {
+        print start ":" NR
+      }
+    }
+  ' "$ALLOWED_FILE"
+)"
+
+if [ -z "$BOUNDS" ]; then
+  echo "ERROR: could not resolve allowed function bounds in $ALLOWED_FILE"
+  exit 1
+fi
+
+ALLOWED_START="${BOUNDS%%:*}"
+ALLOWED_END="${BOUNDS##*:}"
+VIOLATIONS=()
+
+while IFS= read -r match; do
+  [ -z "$match" ] && continue
+
+  file="${match%%:*}"
+  remainder="${match#*:}"
+  line_no="${remainder%%:*}"
+
+  if [ "$file" = "$ALLOWED_FILE" ] && [ "$line_no" -ge "$ALLOWED_START" ] && [ "$line_no" -le "$ALLOWED_END" ]; then
+    continue
+  fi
+
+  VIOLATIONS+=("$match")
+done <<< "$MATCHES"
+
+if [ "${#VIOLATIONS[@]}" -gt 0 ]; then
+  echo "ERROR: Disallowed cost_from_tokens(..., strict=False) usage detected."
+  echo "Allowed location: $ALLOWED_FILE::$ALLOWED_FUNCTION only."
+  printf '%s\n' "${VIOLATIONS[@]}"
+  exit 1
+fi
+
+exit 0

--- a/tests/integration/test_cost_enforcement_e2e.py
+++ b/tests/integration/test_cost_enforcement_e2e.py
@@ -26,9 +26,7 @@ import pytest
 # Ensure mock mode is disabled for these tests - we want real cost tracking
 os.environ["TRAIGENT_MOCK_LLM"] = "false"
 
-from traigent.api.types import (
-    TrialResult,
-)
+from traigent.api.types import TrialResult
 from traigent.config.types import TraigentConfig
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.core.stop_conditions import CostLimitStopCondition
@@ -50,6 +48,8 @@ def disable_mock_mode() -> None:
     os.environ["TRAIGENT_MOCK_LLM"] = "false"
     if "TRAIGENT_REQUIRE_COST_TRACKING" in os.environ:
         del os.environ["TRAIGENT_REQUIRE_COST_TRACKING"]
+    if "TRAIGENT_STRICT_COST_ACCOUNTING" in os.environ:
+        del os.environ["TRAIGENT_STRICT_COST_ACCOUNTING"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_cost_enforcement_sequential.py
+++ b/tests/integration/test_cost_enforcement_sequential.py
@@ -40,6 +40,8 @@ def disable_mock_mode() -> None:
     # Also clear strict mode by default
     if "TRAIGENT_REQUIRE_COST_TRACKING" in os.environ:
         del os.environ["TRAIGENT_REQUIRE_COST_TRACKING"]
+    if "TRAIGENT_STRICT_COST_ACCOUNTING" in os.environ:
+        del os.environ["TRAIGENT_STRICT_COST_ACCOUNTING"]
 
 
 class TestSequentialCostEnforcement:

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -22,6 +22,7 @@ from traigent.core.cost_enforcement import (
     CostEstimate,
     CostLimitExceeded,
     CostStatus,
+    CostTrackingRequiredError,
     OptimizationAborted,
     Permit,
 )
@@ -199,7 +200,14 @@ class TestCostEnforcerUnknownCost:
     @pytest.fixture(autouse=True)
     def clear_mock_mode(self) -> Generator[None, None, None]:
         """Ensure mock mode is disabled for tests that need real tracking."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "false"}):
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_MOCK_LLM": "false",
+                "TRAIGENT_REQUIRE_COST_TRACKING": "false",
+                "TRAIGENT_STRICT_COST_ACCOUNTING": "false",
+            },
+        ):
             yield
 
     def test_unknown_cost_triggers_fallback(self) -> None:
@@ -237,6 +245,20 @@ class TestCostEnforcerUnknownCost:
         enforcer.track_cost(None, permit=permit)
         permit = enforcer.acquire_permit()
         assert not permit.is_granted, "Third permit should be denied (limit=2)"
+
+    def test_unknown_cost_raises_when_strict_accounting_enabled(self) -> None:
+        """Strict accounting mode raises instead of entering fallback mode."""
+        config = CostEnforcerConfig(fallback_trial_limit=5)
+        enforcer = CostEnforcer(config=config)
+
+        with patch.dict(
+            os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            with pytest.raises(CostTrackingRequiredError) as exc_info:
+                enforcer.track_cost(None, permit=_create_mock_permit())
+
+        assert "TRAIGENT_STRICT_COST_ACCOUNTING=true" in str(exc_info.value)
+        assert enforcer.get_status().unknown_cost_mode is False
 
 
 class TestCostEnforcerThreadSafety:
@@ -277,7 +299,14 @@ class TestCostEnforcerAsync:
     @pytest.fixture(autouse=True)
     def clear_mock_mode(self) -> Generator[None, None, None]:
         """Ensure mock mode is disabled for tests that need real tracking."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "false"}):
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_MOCK_LLM": "false",
+                "TRAIGENT_REQUIRE_COST_TRACKING": "false",
+                "TRAIGENT_STRICT_COST_ACCOUNTING": "false",
+            },
+        ):
             yield
 
     @pytest.mark.asyncio
@@ -318,6 +347,20 @@ class TestCostEnforcerAsync:
 
         expected = 10 * 50 * 0.01
         assert abs(enforcer.accumulated_cost - expected) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_unknown_cost_async_raises_when_strict_accounting_enabled(self) -> None:
+        """Strict accounting mode raises on async unknown cost."""
+        enforcer = CostEnforcer(config=CostEnforcerConfig())
+        permit = _create_mock_permit()
+
+        with patch.dict(
+            os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            with pytest.raises(CostTrackingRequiredError) as exc_info:
+                await enforcer.track_cost_async(None, permit=permit)
+
+        assert "TRAIGENT_STRICT_COST_ACCOUNTING=true" in str(exc_info.value)
 
 
 class TestCostEnforcerApproval:

--- a/tests/unit/core/test_orchestrator_helpers.py
+++ b/tests/unit/core/test_orchestrator_helpers.py
@@ -990,6 +990,19 @@ class TestExtractCostFromResults:
         assert examples is None
         assert abs(cost - 0.10) < 0.001
 
+    def test_aggregated_metrics_cost_key_fallback(self):
+        """Falls back to aggregated_metrics['cost'] when total_cost is absent."""
+
+        class MockResult:
+            def __init__(self):
+                self.example_results = None
+                self.aggregated_metrics = {"cost": 0.07}
+
+        result = MockResult()
+        examples, cost = extract_cost_from_results(result, None, "trial_1")
+        assert examples is None
+        assert abs(cost - 0.07) < 0.001
+
     def test_total_examples_override(self):
         """Test that total_examples overrides example_results count."""
 

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -688,6 +688,7 @@ class TestComputeAggregatedMetrics:
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.05)
         assert agg["cost"] == 0.05
+        assert agg["total_cost"] == 0.05
         assert agg["success_rate"] == 0.5
 
     def test_all_successful(self, ev: HybridAPIEvaluator) -> None:

--- a/tests/unit/evaluators/test_metrics_tracker.py
+++ b/tests/unit/evaluators/test_metrics_tracker.py
@@ -1,5 +1,9 @@
 """Unit tests for MetricsTracker and summary_stats functionality."""
 
+from unittest.mock import patch
+
+import pytest
+
 from traigent.evaluators.metrics_tracker import (
     CostMetrics,
     ExampleMetrics,
@@ -200,6 +204,28 @@ class TestMetricsTracker:
         assert empty_stats["execution_time"] == 0.0
         assert empty_stats["total_examples"] == 0
         assert empty_stats["metadata"]["aggregation_method"] == "pandas.describe"
+
+    def test_extract_llm_metrics_unknown_model_raises_in_strict_mode(self):
+        """Strict cost accounting should fail on unknown priced model."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        response = {
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        }
+        with patch.dict(
+            "os.environ",
+            {
+                "TRAIGENT_STRICT_COST_ACCOUNTING": "true",
+                "TRAIGENT_MOCK_LLM": "false",
+                "TRAIGENT_GENERATE_MOCKS": "false",
+            },
+            clear=False,
+        ):
+            with pytest.raises(UnknownModelError):
+                extract_llm_metrics(
+                    response=response,
+                    model_name="unknown-model-xyz-123",
+                )
 
 
 class TestTokenMetrics:

--- a/tests/unit/integrations/langchain/test_langchain_handler.py
+++ b/tests/unit/integrations/langchain/test_langchain_handler.py
@@ -831,6 +831,16 @@ class TestCostEstimation:
             0.0
         ), "Unknown model should return 0.0 with strict=False"
 
+    def test_estimate_cost_unknown_model_raises_in_strict_mode(self, handler):
+        """Strict cost accounting raises for unknown model pricing."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            with pytest.raises(UnknownModelError):
+                handler._estimate_cost("unknown-model-xyz-123", 1000, 500)
+
     def test_estimate_cost_exception_handling(self, handler):
         """Test _estimate_cost handles exceptions gracefully."""
         with patch(

--- a/tests/unit/integrations/pydantic_ai/test_handler.py
+++ b/tests/unit/integrations/pydantic_ai/test_handler.py
@@ -319,6 +319,17 @@ class TestPydanticAIHandler:
         # Should return a float (may be 0.0 for unknown models)
         assert isinstance(cost, float)
 
+    def test_estimate_cost_unknown_model_raises_in_strict_mode(self) -> None:
+        """Strict cost accounting raises for unknown model pricing."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        handler = self._make_handler(_make_agent("openai:unknown-model-xyz-123"))
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            with pytest.raises(UnknownModelError):
+                handler._estimate_cost(100, 50)
+
     @patch(
         "traigent.utils.cost_calculator.cost_from_tokens",
         side_effect=RuntimeError("cost calc failed"),

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -969,8 +969,11 @@ class TestExactModelMappings:
     def test_map_model_name_latest_versions(self, calculator: CostCalculator) -> None:
         """Test mapping for latest version shortcuts."""
         assert calculator._map_model_name("claude-haiku") == "claude-3-haiku-20240307"
-        assert calculator._map_model_name("claude-sonnet") == "claude-3-5-sonnet-latest"
-        assert calculator._map_model_name("claude-opus") == "claude-3-opus-latest"
+        assert (
+            calculator._map_model_name("claude-sonnet")
+            == "claude-3-5-sonnet-20241022"
+        )
+        assert calculator._map_model_name("claude-opus") == "claude-3-opus-20240229"
 
     def test_map_model_name_gpt_aliases(self, calculator: CostCalculator) -> None:
         """Test GPT model aliases."""

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -968,7 +968,7 @@ class TestExactModelMappings:
 
     def test_map_model_name_latest_versions(self, calculator: CostCalculator) -> None:
         """Test mapping for latest version shortcuts."""
-        assert calculator._map_model_name("claude-haiku") == "claude-3-haiku-latest"
+        assert calculator._map_model_name("claude-haiku") == "claude-3-haiku-20240307"
         assert calculator._map_model_name("claude-sonnet") == "claude-3-5-sonnet-latest"
         assert calculator._map_model_name("claude-opus") == "claude-3-opus-latest"
 

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -92,6 +92,20 @@ class TestCostFromTokensModelResolution:
         assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
         assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
 
+    def test_claude_sonnet_alias_maps_to_priced_model(self) -> None:
+        """Legacy alias claude-sonnet resolves to priced dated model."""
+        alias_cost = cost_from_tokens(100, 50, "claude-sonnet")
+        dated_cost = cost_from_tokens(100, 50, "claude-3-5-sonnet-20241022")
+        assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
+        assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
+
+    def test_claude_opus_alias_maps_to_priced_model(self) -> None:
+        """Legacy alias claude-opus resolves to priced dated model."""
+        alias_cost = cost_from_tokens(100, 50, "claude-opus")
+        dated_cost = cost_from_tokens(100, 50, "claude-3-opus-20240229")
+        assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
+        assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
+
     def test_colon_prefixed_model(self) -> None:
         """Colon-prefixed provider model resolves."""
         cost_prefixed = cost_from_tokens(100, 50, "anthropic:claude-3-haiku")

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -85,6 +85,13 @@ class TestCostFromTokensModelResolution:
             input_cost > 0 or output_cost > 0
         ), "Mapped model should produce positive cost"
 
+    def test_claude_haiku_alias_maps_to_priced_model(self) -> None:
+        """Legacy alias claude-haiku resolves to priced dated model."""
+        alias_cost = cost_from_tokens(100, 50, "claude-haiku")
+        dated_cost = cost_from_tokens(100, 50, "claude-3-haiku-20240307")
+        assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
+        assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
+
     def test_colon_prefixed_model(self) -> None:
         """Colon-prefixed provider model resolves."""
         cost_prefixed = cost_from_tokens(100, 50, "anthropic:claude-3-haiku")

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -17,6 +17,8 @@ Environment Variables:
     TRAIGENT_COST_WARNING_THRESHOLD: Warn at this fraction of limit (default: 0.5)
     TRAIGENT_MOCK_LLM: Bypass all cost tracking when "true" (no real LLM costs)
     TRAIGENT_REQUIRE_COST_TRACKING: Raise exception if cost extraction fails (default: false)
+    TRAIGENT_STRICT_COST_ACCOUNTING: Fail fast for unknown/missing runtime costs
+        (default: false)
     TRAIGENT_COST_DIVERGENCE_THRESHOLD: Log warning if actual/estimated ratio exceeds
         this value (default: 2.0, meaning 2x divergence triggers warning)
 """
@@ -227,6 +229,17 @@ class CostEnforcer:
         there are no real LLM API costs to track.
         """
         return os.getenv("TRAIGENT_MOCK_LLM", "false").lower() == "true"
+
+    @staticmethod
+    def _require_cost_tracking() -> bool:
+        """Return True when missing runtime cost must raise immediately."""
+        require_tracking = (
+            os.environ.get("TRAIGENT_REQUIRE_COST_TRACKING", "").lower() == "true"
+        )
+        strict_accounting = (
+            os.environ.get("TRAIGENT_STRICT_COST_ACCOUNTING", "").lower() == "true"
+        )
+        return require_tracking or strict_accounting
 
     def _check_mixing(self, is_async: bool) -> None:
         """Log when switching between sync and async method usage."""
@@ -725,7 +738,8 @@ Options:
 
         Raises:
             CostTrackingRequiredError: If cost is None and
-                TRAIGENT_REQUIRE_COST_TRACKING=true.
+                TRAIGENT_REQUIRE_COST_TRACKING=true or
+                TRAIGENT_STRICT_COST_ACCOUNTING=true.
             ValueError: If a negative cost is provided.
         """
         self._check_mixing(is_async=False)
@@ -770,13 +784,11 @@ Options:
 
             # Handle unknown cost with optional strict mode
             if cost is None:
-                if (
-                    os.environ.get("TRAIGENT_REQUIRE_COST_TRACKING", "").lower()
-                    == "true"
-                ):
+                if self._require_cost_tracking():
                     raise CostTrackingRequiredError(
                         f"Cost extraction failed for {trial_desc} but "
-                        "TRAIGENT_REQUIRE_COST_TRACKING=true. "
+                        "TRAIGENT_REQUIRE_COST_TRACKING=true or "
+                        "TRAIGENT_STRICT_COST_ACCOUNTING=true. "
                         "Set to 'false' or fix cost extraction."
                     )
                 if not self._unknown_cost_mode:
@@ -991,7 +1003,8 @@ Options:
 
         Raises:
             CostTrackingRequiredError: If cost is None and
-                TRAIGENT_REQUIRE_COST_TRACKING=true.
+                TRAIGENT_REQUIRE_COST_TRACKING=true or
+                TRAIGENT_STRICT_COST_ACCOUNTING=true.
             ValueError: If a negative cost is provided.
         """
         self._check_mixing(is_async=True)
@@ -1038,13 +1051,11 @@ Options:
 
             # Handle unknown cost with optional strict mode
             if cost is None:
-                if (
-                    os.environ.get("TRAIGENT_REQUIRE_COST_TRACKING", "").lower()
-                    == "true"
-                ):
+                if self._require_cost_tracking():
                     raise CostTrackingRequiredError(
                         f"Cost extraction failed for {trial_desc} but "
-                        "TRAIGENT_REQUIRE_COST_TRACKING=true. "
+                        "TRAIGENT_REQUIRE_COST_TRACKING=true or "
+                        "TRAIGENT_STRICT_COST_ACCOUNTING=true. "
                         "Set to 'false' or fix cost extraction."
                     )
                 if not self._unknown_cost_mode:

--- a/traigent/core/orchestrator_helpers.py
+++ b/traigent/core/orchestrator_helpers.py
@@ -413,6 +413,9 @@ def extract_cost_from_results(
     if total_cost is None and hasattr(eval_result, "aggregated_metrics"):
         agg_metrics = eval_result.aggregated_metrics or {}
         total_cost = agg_metrics.get("total_cost")
+        if total_cost is None:
+            # Backward-compatible fallback for evaluators that still emit "cost".
+            total_cost = agg_metrics.get("cost")
 
     # Prefer evaluator-reported totals when available to avoid double counting
     result_total = getattr(eval_result, "total_examples", None)

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -709,6 +709,8 @@ class HybridAPIEvaluator(BaseEvaluator):
 
         aggregated: dict[str, float] = {
             "cost": total_cost,
+            # Keep canonical trial-level key for downstream extractors.
+            "total_cost": total_cost,
             "success_rate": sum(1 for r in results if r.success) / len(results),
         }
 

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -959,9 +959,10 @@ def _calculate_cost_for_metrics(
     Uses cost_from_tokens() as the canonical cost path when token counts are
     available, falling back to deprecated text-based functions otherwise.
     """
-    from traigent.utils.env_config import is_mock_llm
+    from traigent.utils.env_config import is_mock_llm, is_strict_cost_accounting
 
     mock_mode = is_mock_llm()
+    strict_cost_accounting = is_strict_cost_accounting()
     generate_mocks_env = os.environ.get("TRAIGENT_GENERATE_MOCKS", "").lower()
 
     if mock_mode or generate_mocks_env == "true":
@@ -985,7 +986,10 @@ def _calculate_cost_for_metrics(
             e,
             exc_info=True,
         )
-        if os.environ.get("TRAIGENT_DEBUG", "").lower() == "true":
+        if (
+            strict_cost_accounting
+            or os.environ.get("TRAIGENT_DEBUG", "").lower() == "true"
+        ):
             raise
 
 
@@ -1016,6 +1020,7 @@ def _compute_cost(
 ) -> None:
     """Compute cost using cost_from_tokens (preferred) or legacy text path."""
     from traigent.utils.cost_calculator import cost_from_tokens
+    from traigent.utils.env_config import is_strict_cost_accounting
 
     # Ensure total tokens computed
     if metrics.tokens.total_tokens == 0:
@@ -1025,11 +1030,12 @@ def _compute_cost(
 
     if metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0:
         # Preferred path: use canonical cost_from_tokens directly
+        strict_cost_accounting = is_strict_cost_accounting()
         input_cost, output_cost = cost_from_tokens(
             metrics.tokens.input_tokens,
             metrics.tokens.output_tokens,
             model_name,
-            strict=False,
+            strict=strict_cost_accounting,
         )
         metrics.cost.input_cost = input_cost
         metrics.cost.output_cost = output_cost

--- a/traigent/integrations/langchain/handler.py
+++ b/traigent/integrations/langchain/handler.py
@@ -654,17 +654,25 @@ class TraigentHandler(BaseCallbackHandler):
     ) -> float:
         """Estimate cost for LLM call via the canonical cost_from_tokens().
 
-        Uses strict=False so unknown models return 0.0 with a warning
-        instead of raising.
+        In default mode, unknown models return 0.0 with a warning.
+        When TRAIGENT_STRICT_COST_ACCOUNTING=true, unknown models raise.
         """
+        from traigent.utils.env_config import is_strict_cost_accounting
+
+        strict_cost_accounting = is_strict_cost_accounting()
         try:
             from traigent.utils.cost_calculator import cost_from_tokens
 
             input_cost, output_cost = cost_from_tokens(
-                input_tokens, output_tokens, model, strict=False
+                input_tokens,
+                output_tokens,
+                model,
+                strict=strict_cost_accounting,
             )
             return float(input_cost + output_cost)
         except Exception:
+            if strict_cost_accounting:
+                raise
             logger.warning(
                 "Cost calculation failed for model %r with %d tokens",
                 model,

--- a/traigent/integrations/pydantic_ai/handler.py
+++ b/traigent/integrations/pydantic_ai/handler.py
@@ -254,14 +254,22 @@ class PydanticAIHandler:
         """Estimate cost using the canonical cost_from_tokens path."""
         if input_tokens == 0 and output_tokens == 0:
             return 0.0
+        from traigent.utils.env_config import is_strict_cost_accounting
+
+        strict_cost_accounting = is_strict_cost_accounting()
         try:
             from traigent.utils.cost_calculator import cost_from_tokens
 
             input_cost, output_cost = cost_from_tokens(
-                input_tokens, output_tokens, self._model_name or "unknown", strict=False
+                input_tokens,
+                output_tokens,
+                self._model_name or "unknown",
+                strict=strict_cost_accounting,
             )
             return float(input_cost + output_cost)
         except Exception:
+            if strict_cost_accounting:
+                raise
             logger.debug(
                 "Cost estimation failed for model %s", self._model_name, exc_info=True
             )

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -624,10 +624,10 @@ class CostCalculator:
         "claude-4-sonnet": "claude-sonnet-4-20250514",
         "claude-4-opus": "claude-opus-4-20250514",
         # Add latest versions for convenience
-        # Use dated alias for pricing compatibility (litellm pricing coverage).
+        # Use dated aliases for pricing compatibility (litellm pricing coverage).
         "claude-haiku": "claude-3-haiku-20240307",
-        "claude-sonnet": "claude-3-5-sonnet-latest",
-        "claude-opus": "claude-3-opus-latest",
+        "claude-sonnet": "claude-3-5-sonnet-20241022",
+        "claude-opus": "claude-3-opus-20240229",
         # OpenAI models are usually fine as-is but add common aliases
         "gpt-3.5": _GPT35_TURBO,
         "gpt-4": _GPT4O,

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -624,7 +624,8 @@ class CostCalculator:
         "claude-4-sonnet": "claude-sonnet-4-20250514",
         "claude-4-opus": "claude-opus-4-20250514",
         # Add latest versions for convenience
-        "claude-haiku": "claude-3-haiku-latest",
+        # Use dated alias for pricing compatibility (litellm pricing coverage).
+        "claude-haiku": "claude-3-haiku-20240307",
         "claude-sonnet": "claude-3-5-sonnet-latest",
         "claude-opus": "claude-3-opus-latest",
         # OpenAI models are usually fine as-is but add common aliases

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -213,6 +213,16 @@ def is_mock_llm() -> bool:
     return get_env_var("TRAIGENT_MOCK_LLM", "false").lower() == "true"
 
 
+def is_strict_cost_accounting() -> bool:
+    """Check whether runtime cost accounting should fail fast.
+
+    When TRAIGENT_STRICT_COST_ACCOUNTING=true, post-call cost paths should:
+    - Require priced models (no silent 0.0 for unknown models)
+    - Raise on unknown/missing trial cost instead of fallback mode
+    """
+    return get_env_var("TRAIGENT_STRICT_COST_ACCOUNTING", "false").lower() == "true"
+
+
 def should_show_cloud_notice(traigent_config: "TraigentConfig") -> bool:
     """Return True when the cloud API key notice should be shown."""
     if is_mock_llm() or is_backend_offline():


### PR DESCRIPTION
## Summary
This PR fixes production cost-accounting defects and adds a strict runtime accounting mode.

### 1) Alias mapping bugs (runtime pricing)
- Fix `claude-haiku` mapping to a dated priced model.
- Fix `claude-sonnet` and `claude-opus` mappings to dated priced models.
- Add regression tests for all three aliases to ensure alias cost equals dated-model cost.

### 2) Hybrid evaluator cost key compatibility
- Keep emitting `cost` for compatibility.
- Also emit canonical `total_cost` in hybrid aggregated metrics.
- Add defensive extraction fallback in orchestrator helpers (`total_cost` -> `cost`).

### 3) Strict runtime cost accounting mode
- Add env flag: `TRAIGENT_STRICT_COST_ACCOUNTING=true`.
- Runtime cost calculation paths now fail fast on unknown/unpriced models when strict mode is enabled:
  - `metrics_tracker`
  - LangChain handler
  - PydanticAI handler
- `CostEnforcer` now treats either of these as fail-fast for missing runtime cost:
  - `TRAIGENT_REQUIRE_COST_TRACKING=true`
  - `TRAIGENT_STRICT_COST_ACCOUNTING=true`

## Why
- Prevent silent zero-cost accounting on unknown model pricing in post-call runtime paths.
- Ensure budget enforcement remains conservative and fail-fast under strict mode.
- Eliminate integration key mismatch (`cost` vs `total_cost`) that could degrade accounting accuracy.

## Validation
Executed targeted suites:
- `tests/unit/utils/test_cost_calculator.py -k "map_model_name_latest_versions"`
- `tests/unit/utils/test_cost_from_tokens.py -k "claude_haiku_alias_maps_to_priced_model or claude_sonnet_alias_maps_to_priced_model or claude_opus_alias_maps_to_priced_model"`
- `tests/unit/core/test_cost_enforcement.py tests/unit/evaluators/test_metrics_tracker.py`
- `tests/unit/integrations/langchain/test_langchain_handler.py tests/unit/integrations/pydantic_ai/test_handler.py`
- `tests/integration/test_cost_enforcement_sequential.py -k "unknown_cost or require_cost_tracking"`
- `tests/integration/test_cost_enforcement_e2e.py -k "test_e2e_04_unknown_cost_triggers_fallback"`

All passed.
