### PR TITLE
perf(cost): latch strict-mode flags per run instance

### DIFF
--- a/docs/architecture/cost-architecture-validation.md
+++ b/docs/architecture/cost-architecture-validation.md
@@ -17,6 +17,8 @@ The following items from this validation were implemented on
     unknown/unpriced models.
   - This surfaces all cost-path failures (not only `UnknownModelError`) in integration
     handlers that intentionally catch generic exceptions in non-strict mode.
+  - Strict-mode flags are latched at object construction for runtime consistency:
+    create a new handler/enforcer instance after env changes.
 - `CostEnforcer` fail-fast behavior now treats either flag as strict:
   - `TRAIGENT_REQUIRE_COST_TRACKING=true` or
   - `TRAIGENT_STRICT_COST_ACCOUNTING=true`.

--- a/tests/integration/test_cost_enforcement_sequential.py
+++ b/tests/integration/test_cost_enforcement_sequential.py
@@ -170,11 +170,17 @@ class TestSequentialCostEnforcement:
         assert cost_enforcer._trial_count == 1
         assert abs(cost_enforcer._accumulated_cost) < FLOAT_TOLERANCE  # No cost tracked
 
-    def test_require_cost_tracking_raises(self, cost_enforcer: CostEnforcer) -> None:
+    def test_require_cost_tracking_raises(self) -> None:
         """Verify TRAIGENT_REQUIRE_COST_TRACKING=true raises on None cost."""
         os.environ["TRAIGENT_REQUIRE_COST_TRACKING"] = "true"
 
         try:
+            cost_enforcer = CostEnforcer(
+                CostEnforcerConfig(
+                    limit=0.50,
+                    estimated_cost_per_trial=0.10,
+                )
+            )
             permit = cost_enforcer.acquire_permit()
             assert permit.is_granted
 

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -276,17 +276,43 @@ class TestCostEnforcerUnknownCost:
 
     def test_unknown_cost_raises_when_strict_accounting_enabled(self) -> None:
         """Strict accounting mode raises instead of entering fallback mode."""
-        config = CostEnforcerConfig(fallback_trial_limit=5)
-        enforcer = CostEnforcer(config=config)
-
         with patch.dict(
             os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
         ):
+            config = CostEnforcerConfig(fallback_trial_limit=5)
+            enforcer = CostEnforcer(config=config)
             with pytest.raises(CostTrackingRequiredError) as exc_info:
                 enforcer.track_cost(None, permit=_create_mock_permit())
 
         assert "TRAIGENT_STRICT_COST_ACCOUNTING=true" in str(exc_info.value)
         assert enforcer.get_status().unknown_cost_mode is False
+
+    def test_strict_mode_is_latched_at_init(self) -> None:
+        """Strict mode env changes after init do not affect existing enforcer."""
+        with patch.dict(
+            os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "false"}, clear=False
+        ):
+            enforcer = CostEnforcer(CostEnforcerConfig(fallback_trial_limit=5))
+
+        with patch.dict(
+            os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            enforcer.track_cost(None, permit=_create_mock_permit())
+
+        assert enforcer.get_status().unknown_cost_mode is True
+
+    def test_require_cost_tracking_is_latched_at_init(self) -> None:
+        """Require-cost-tracking env changes after init do not affect instance."""
+        with patch.dict(
+            os.environ, {"TRAIGENT_REQUIRE_COST_TRACKING": "true"}, clear=False
+        ):
+            enforcer = CostEnforcer(CostEnforcerConfig(fallback_trial_limit=5))
+
+        with patch.dict(
+            os.environ, {"TRAIGENT_REQUIRE_COST_TRACKING": "false"}, clear=False
+        ):
+            with pytest.raises(CostTrackingRequiredError):
+                enforcer.track_cost(None, permit=_create_mock_permit())
 
 
 class TestCostEnforcerUnknownCostCTD:
@@ -486,12 +512,11 @@ class TestCostEnforcerAsync:
     @pytest.mark.asyncio
     async def test_unknown_cost_async_raises_when_strict_accounting_enabled(self) -> None:
         """Strict accounting mode raises on async unknown cost."""
-        enforcer = CostEnforcer(config=CostEnforcerConfig())
-        permit = _create_mock_permit()
-
         with patch.dict(
             os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
         ):
+            enforcer = CostEnforcer(config=CostEnforcerConfig())
+            permit = _create_mock_permit()
             with pytest.raises(CostTrackingRequiredError) as exc_info:
                 await enforcer.track_cost_async(None, permit=permit)
 

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -1271,6 +1271,22 @@ class TestCostEnforcerApprovalToken:
         assert enforcer._sync_used is False
         assert enforcer._async_used is False
 
+    def test_reset_preserves_latched_require_cost_tracking(self) -> None:
+        """Reset should not change latched strict/require tracking mode."""
+        with patch.dict(
+            os.environ, {"TRAIGENT_REQUIRE_COST_TRACKING": "true"}, clear=False
+        ):
+            enforcer = CostEnforcer()
+
+        assert enforcer._require_cost_tracking() is True
+
+        # Changing env after init should not affect this instance, including after reset.
+        with patch.dict(
+            os.environ, {"TRAIGENT_REQUIRE_COST_TRACKING": "false"}, clear=False
+        ):
+            enforcer.reset()
+            assert enforcer._require_cost_tracking() is True
+
 
 # =============================================================================
 # Adaptive Cost Estimation Tests (Issue #66)

--- a/tests/unit/integrations/langchain/test_langchain_handler.py
+++ b/tests/unit/integrations/langchain/test_langchain_handler.py
@@ -831,13 +831,16 @@ class TestCostEstimation:
             0.0
         ), "Unknown model should return 0.0 with strict=False"
 
-    def test_estimate_cost_unknown_model_raises_in_strict_mode(self, handler):
+    def test_estimate_cost_unknown_model_raises_in_strict_mode(self):
         """Strict cost accounting raises for unknown model pricing."""
+        from traigent.integrations.langchain.handler import TraigentHandler
         from traigent.utils.cost_calculator import UnknownModelError
 
         with patch.dict(
             "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
         ):
+            # strict mode is latched at handler construction
+            handler = TraigentHandler(trace_id="test-trace")
             with pytest.raises(UnknownModelError):
                 handler._estimate_cost("unknown-model-xyz-123", 1000, 500)
 
@@ -855,3 +858,30 @@ class TestCostEstimation:
         cost_lower = handler._estimate_cost("gpt-4o", 1000, 500)
         cost_upper = handler._estimate_cost("GPT-4O", 1000, 500)
         assert cost_lower == pytest.approx(cost_upper, rel=1e-6)
+
+    def test_strict_mode_is_latched_at_handler_init(self):
+        """Strict flag changes after init do not alter existing handler behavior."""
+        from traigent.integrations.langchain.handler import TraigentHandler
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "false"}, clear=False
+        ):
+            non_strict_handler = TraigentHandler(trace_id="test-trace-nonstrict")
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            assert (
+                non_strict_handler._estimate_cost("unknown-model-xyz-123", 1000, 500)
+                == 0.0
+            )
+
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            strict_handler = TraigentHandler(trace_id="test-trace-strict")
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "false"}, clear=False
+        ):
+            with pytest.raises(UnknownModelError):
+                strict_handler._estimate_cost("unknown-model-xyz-123", 1000, 500)

--- a/tests/unit/integrations/pydantic_ai/test_handler.py
+++ b/tests/unit/integrations/pydantic_ai/test_handler.py
@@ -323,10 +323,11 @@ class TestPydanticAIHandler:
         """Strict cost accounting raises for unknown model pricing."""
         from traigent.utils.cost_calculator import UnknownModelError
 
-        handler = self._make_handler(_make_agent("openai:unknown-model-xyz-123"))
         with patch.dict(
             "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
         ):
+            # strict mode is latched at handler construction
+            handler = self._make_handler(_make_agent("openai:unknown-model-xyz-123"))
             with pytest.raises(UnknownModelError):
                 handler._estimate_cost(100, 50)
 
@@ -339,6 +340,31 @@ class TestPydanticAIHandler:
         handler = self._make_handler()
         cost = handler._estimate_cost(100, 50)
         assert cost == 0.0
+
+    def test_strict_mode_is_latched_at_handler_init(self) -> None:
+        """Strict flag changes after init do not alter existing handler behavior."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "false"}, clear=False
+        ):
+            non_strict_handler = self._make_handler(
+                _make_agent("openai:unknown-model-xyz-123")
+            )
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            assert non_strict_handler._estimate_cost(100, 50) == 0.0
+
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
+        ):
+            strict_handler = self._make_handler(_make_agent("openai:unknown-model-xyz-123"))
+        with patch.dict(
+            "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "false"}, clear=False
+        ):
+            with pytest.raises(UnknownModelError):
+                strict_handler._estimate_cost(100, 50)
 
     @patch(
         "traigent.integrations.pydantic_ai.handler.PydanticAIHandler._estimate_cost",

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -217,6 +217,13 @@ class CostEnforcer:
         # cause stranded permits (acquired with tracking, released without tracking).
         # If you need to change mock mode, create a new CostEnforcer instance.
         self._mock_mode_cached: bool = self._check_mock_mode()
+        # Cache strict-cost-tracking mode at init for consistent run semantics.
+        # NOTE: Changing TRAIGENT_REQUIRE_COST_TRACKING or
+        # TRAIGENT_STRICT_COST_ACCOUNTING after CostEnforcer initialization has
+        # NO EFFECT. This mirrors mock-mode latching and avoids env reads in hot paths.
+        self._require_cost_tracking_cached: bool = (
+            self._check_require_cost_tracking_mode()
+        )
 
         # Sync/async usage tracking for mixing detection (Phase 3.2)
         self._sync_used: bool = False
@@ -231,8 +238,8 @@ class CostEnforcer:
         return os.getenv("TRAIGENT_MOCK_LLM", "false").lower() == "true"
 
     @staticmethod
-    def _require_cost_tracking() -> bool:
-        """Return True when missing runtime cost must raise immediately."""
+    def _check_require_cost_tracking_mode() -> bool:
+        """Read strict cost-tracking mode from environment."""
         require_tracking = (
             os.environ.get("TRAIGENT_REQUIRE_COST_TRACKING", "").lower() == "true"
         )
@@ -240,6 +247,10 @@ class CostEnforcer:
             os.environ.get("TRAIGENT_STRICT_COST_ACCOUNTING", "").lower() == "true"
         )
         return require_tracking or strict_accounting
+
+    def _require_cost_tracking(self) -> bool:
+        """Return latched strict cost-tracking mode for this instance."""
+        return self._require_cost_tracking_cached
 
     def _check_mixing(self, is_async: bool) -> None:
         """Log when switching between sync and async method usage."""

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -978,6 +978,7 @@ def _calculate_cost_for_metrics(
             model_name,
             original_prompt,
             response_text,
+            strict_cost_accounting=strict_cost_accounting,
         )
     except Exception as e:
         logger.error(
@@ -1017,10 +1018,11 @@ def _compute_cost(
     model_name: str,
     original_prompt: Any,
     response_text: str | None,
+    *,
+    strict_cost_accounting: bool,
 ) -> None:
     """Compute cost using cost_from_tokens (preferred) or legacy text path."""
     from traigent.utils.cost_calculator import cost_from_tokens
-    from traigent.utils.env_config import is_strict_cost_accounting
 
     # Ensure total tokens computed
     if metrics.tokens.total_tokens == 0:
@@ -1030,7 +1032,6 @@ def _compute_cost(
 
     if metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0:
         # Preferred path: use canonical cost_from_tokens directly
-        strict_cost_accounting = is_strict_cost_accounting()
         input_cost, output_cost = cost_from_tokens(
             metrics.tokens.input_tokens,
             metrics.tokens.output_tokens,
@@ -1119,7 +1120,15 @@ class CostCalculator:
         prompt_length: int | None = None,
         response_length: int | None = None,
     ) -> None:
-        _compute_cost(metrics, model_name, original_prompt, response_text)
+        from traigent.utils.env_config import is_strict_cost_accounting
+
+        _compute_cost(
+            metrics,
+            model_name,
+            original_prompt,
+            response_text,
+            strict_cost_accounting=is_strict_cost_accounting(),
+        )
 
 
 class MetricsCalculator:

--- a/traigent/integrations/langchain/handler.py
+++ b/traigent/integrations/langchain/handler.py
@@ -272,11 +272,15 @@ class TraigentHandler(BaseCallbackHandler):
             )
 
         super().__init__()
+        from traigent.utils.env_config import is_strict_cost_accounting
+
         self._trace_id = trace_id or (
             trace_id_generator() if trace_id_generator else str(uuid4())
         )
         self._metric_prefix = metric_prefix
         self._include_per_node = include_per_node
+        # Latch strict mode at handler creation for consistent per-run behavior.
+        self._strict_cost_accounting = is_strict_cost_accounting()
 
         # Thread-safe state
         self._lock = threading.Lock()
@@ -657,9 +661,7 @@ class TraigentHandler(BaseCallbackHandler):
         In default mode, unknown models return 0.0 with a warning.
         When TRAIGENT_STRICT_COST_ACCOUNTING=true, unknown models raise.
         """
-        from traigent.utils.env_config import is_strict_cost_accounting
-
-        strict_cost_accounting = is_strict_cost_accounting()
+        strict_cost_accounting = self._strict_cost_accounting
         try:
             from traigent.utils.cost_calculator import cost_from_tokens
 

--- a/traigent/integrations/pydantic_ai/handler.py
+++ b/traigent/integrations/pydantic_ai/handler.py
@@ -76,6 +76,10 @@ class PydanticAIHandler:
         self._lock = threading.Lock()
         self._runs: list[AgentRunMetrics] = []
         self._model_name = self._extract_model_name(agent)
+        from traigent.utils.env_config import is_strict_cost_accounting
+
+        # Latch strict mode at handler creation for consistent per-run behavior.
+        self._strict_cost_accounting = is_strict_cost_accounting()
 
     # -----------------------------------------------------------------
     # Public run wrappers
@@ -254,9 +258,7 @@ class PydanticAIHandler:
         """Estimate cost using the canonical cost_from_tokens path."""
         if input_tokens == 0 and output_tokens == 0:
             return 0.0
-        from traigent.utils.env_config import is_strict_cost_accounting
-
-        strict_cost_accounting = is_strict_cost_accounting()
+        strict_cost_accounting = self._strict_cost_accounting
         try:
             from traigent.utils.cost_calculator import cost_from_tokens
 


### PR DESCRIPTION
## Summary
Follow-up PR to reduce hot-path env reads and make strict-mode runtime semantics explicit and consistent.

## Changes
- `CostEnforcer` now latches strict-requirement mode at init:
  - caches `TRAIGENT_REQUIRE_COST_TRACKING || TRAIGENT_STRICT_COST_ACCOUNTING`
  - removes repeated env reads on each `track_cost` / `track_cost_async`
- Integration handlers now latch strict mode at construction:
  - `TraigentHandler` (LangChain)
  - `PydanticAIHandler`
- `metrics_tracker` now reads strict mode once per cost-calculation call and passes it through (removes duplicate env read in `_compute_cost`).

## Tests
- Updated strict-mode tests to respect init-time latching semantics.
- Strengthened unknown-cost CTD tests and sequential integration strict test setup.
- Added/kept latching behavior assertions in handler tests and enforcer tests.

Targeted validation run:
- `uv run pytest -q tests/unit/core/test_cost_enforcement.py -k "unknown_cost or latched" tests/integration/test_cost_enforcement_sequential.py -k "require_cost_tracking_raises"`
- `uv run pytest -q tests/unit/integrations/langchain/test_langchain_handler.py -k "strict_mode or unknown_model_raises_in_strict_mode" tests/unit/integrations/pydantic_ai/test_handler.py -k "strict_mode"`
- `uv run pytest -q tests/unit/evaluators/test_metrics_tracker.py -k "strict_mode" tests/unit/utils/test_env_config.py -k "is_strict_cost_accounting"`

All passed.
