### PR TITLE
test(cost): add CTD pairwise matrix and harden invariants

### DIFF
--- a/tests/integration/test_cost_enforcement_parallel.py
+++ b/tests/integration/test_cost_enforcement_parallel.py
@@ -542,7 +542,7 @@ class TestParallelUnknownCostCTD:
                 try:
                     await enforcer.track_cost_async(None, permit=permit)
                     return None
-                except Exception as exc:  # pragma: no cover - asserted below
+                except Exception as exc:
                     return exc
 
             results = await asyncio.gather(*[track_unknown(p) for p in permits])

--- a/tests/integration/test_cost_enforcement_parallel.py
+++ b/tests/integration/test_cost_enforcement_parallel.py
@@ -18,16 +18,50 @@ from __future__ import annotations
 import asyncio
 import os
 import random
+from unittest.mock import patch
 
 import pytest
 
 # Ensure mock mode is disabled for these tests
 os.environ["TRAIGENT_MOCK_LLM"] = "false"
 
-from traigent.core.cost_enforcement import CostEnforcer, CostEnforcerConfig, Permit
+from traigent.core.cost_enforcement import (
+    CostEnforcer,
+    CostEnforcerConfig,
+    CostTrackingRequiredError,
+    Permit,
+)
 
 # Tolerance for floating point comparisons
 FLOAT_TOLERANCE = 1e-10
+
+
+UNKNOWN_COST_PARALLEL_PAIRWISE_CASES = [
+    pytest.param(
+        False,
+        False,
+        False,
+        id="require-off_strict-off_pre-release-off",
+    ),
+    pytest.param(
+        False,
+        True,
+        True,
+        id="require-off_strict-on_pre-release-on",
+    ),
+    pytest.param(
+        True,
+        False,
+        True,
+        id="require-on_strict-off_pre-release-on",
+    ),
+    pytest.param(
+        True,
+        True,
+        False,
+        id="require-on_strict-on_pre-release-off",
+    ),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -457,6 +491,78 @@ class TestParallelBudgetBoundaries:
 
         for permit in permits:
             await enforcer.release_permit_async(permit)
+
+
+class TestParallelUnknownCostCTD:
+    """Pairwise unknown-cost coverage in true parallel execution."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("require_tracking", "strict_accounting", "pre_release_half"),
+        UNKNOWN_COST_PARALLEL_PAIRWISE_CASES,
+    )
+    async def test_unknown_cost_parallel_pairwise(
+        self,
+        require_tracking: bool,
+        strict_accounting: bool,
+        pre_release_half: bool,
+    ) -> None:
+        """Verify strictness + permit lifecycle under concurrent unknown costs."""
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_MOCK_LLM": "false",
+                "TRAIGENT_REQUIRE_COST_TRACKING": str(require_tracking).lower(),
+                "TRAIGENT_STRICT_COST_ACCOUNTING": str(strict_accounting).lower(),
+            },
+            clear=False,
+        ):
+            enforcer = CostEnforcer(
+                CostEnforcerConfig(
+                    limit=1.0,
+                    estimated_cost_per_trial=0.10,
+                    fallback_trial_limit=10,
+                )
+            )
+
+            permits: list[Permit] = []
+            for _ in range(6):
+                permit = await enforcer.acquire_permit_async()
+                assert permit.is_granted
+                permits.append(permit)
+
+            assert enforcer.get_status().in_flight_count == 6
+
+            if pre_release_half:
+                for permit in permits[:3]:
+                    assert await enforcer.release_permit_async(permit) is True
+                assert enforcer.get_status().in_flight_count == 3
+
+            async def track_unknown(permit: Permit) -> Exception | None:
+                try:
+                    await enforcer.track_cost_async(None, permit=permit)
+                    return None
+                except Exception as exc:  # pragma: no cover - asserted below
+                    return exc
+
+            results = await asyncio.gather(*[track_unknown(p) for p in permits])
+
+            should_raise = require_tracking or strict_accounting
+            if should_raise:
+                assert all(
+                    isinstance(result, CostTrackingRequiredError)
+                    for result in results
+                )
+                assert enforcer.get_status().unknown_cost_mode is False
+            else:
+                assert all(result is None for result in results)
+                assert enforcer.get_status().unknown_cost_mode is True
+
+            status = enforcer.get_status()
+            assert status.trial_count == len(permits)
+            assert status.in_flight_count == 0
+            assert status.reserved_cost_usd == pytest.approx(0.0)
+            assert len(enforcer._active_permits) == 0
 
 
 class TestParallelHighConcurrency:

--- a/tests/unit/core/test_cost_enforcement_ctd.py
+++ b/tests/unit/core/test_cost_enforcement_ctd.py
@@ -302,6 +302,8 @@ def _build_parallel_permits(
     permit_state: str,
 ) -> list[Permit]:
     if permit_state in {"already_released", "foreign"}:
+        # Intentional: reuse one stale/foreign permit across threads to exercise
+        # lock contention around mark_released() and repeated already-released paths.
         return [base_permit, base_permit, base_permit]
 
     permits = [base_permit]
@@ -388,7 +390,11 @@ class TestCostEnforcerCTDPairwise:
 
     def test_pairwise_matrix_covers_all_valid_pairs(self) -> None:
         valid_cases = _all_valid_cases()
+        # Guard against accidental over-pruning in _is_valid_case(), which could
+        # otherwise make coverage checks pass vacuously with a shrunk domain.
+        assert len(valid_cases) == 134
         required_pairs = set().union(*(_pairs_for_case(case) for case in valid_cases))
+        assert len(required_pairs) == 107
         covered_pairs = set().union(*(_pairs_for_case(case) for case in PAIRWISE_CASES))
         assert covered_pairs >= required_pairs, (
             f"Pair coverage {len(covered_pairs & required_pairs)}/{len(required_pairs)} "

--- a/tests/unit/core/test_cost_enforcement_ctd.py
+++ b/tests/unit/core/test_cost_enforcement_ctd.py
@@ -1,0 +1,461 @@
+"""CTD-style matrix tests for CostEnforcer state transitions.
+
+This module adds constrained pairwise coverage across key cost-enforcement factors:
+- mock mode
+- cost value shape
+- strict tracking mode
+- budget state
+- permit state
+- unknown-cost mode pre-state
+- concurrency mode
+
+The matrix is intentionally constrained to meaningful operational combinations.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from itertools import combinations, product
+
+import pytest
+
+from traigent.core.cost_enforcement import (
+    CostEnforcer,
+    CostEnforcerConfig,
+    CostTrackingRequiredError,
+    Permit,
+)
+
+# Fixed reservation amount for deterministic budget-state behavior.
+ESTIMATED_COST_PER_TRIAL = 0.05
+BUDGET_LIMITS = {
+    "under_limit": 0.20,
+    "at_limit": 0.05,
+    "over_limit": 0.01,
+}
+
+
+@dataclass(frozen=True)
+class CTDCase:
+    mock_mode: bool
+    cost_value: str
+    strict_tracking: bool
+    budget_state: str
+    permit_state: str
+    unknown_cost_mode: str
+    concurrency: str
+
+
+# 11 cases are a full constrained pairwise cover; we add 10 extra high-risk cases
+# to keep this matrix explicit and easier to review in PRs.
+PAIRWISE_CASES: tuple[CTDCase, ...] = (
+    CTDCase(True, "positive", False, "under_limit", "active", "not_entered", "single"),
+    CTDCase(
+        False,
+        "positive",
+        True,
+        "at_limit",
+        "already_released",
+        "already_entered",
+        "parallel",
+    ),
+    CTDCase(False, "zero", True, "under_limit", "foreign", "not_entered", "single"),
+    CTDCase(False, "none", False, "under_limit", "active", "already_entered", "parallel"),
+    CTDCase(
+        False,
+        "none",
+        False,
+        "at_limit",
+        "already_released",
+        "not_entered",
+        "single",
+    ),
+    CTDCase(False, "zero", False, "at_limit", "foreign", "already_entered", "parallel"),
+    CTDCase(False, "positive", False, "over_limit", "active", "not_entered", "single"),
+    CTDCase(False, "zero", True, "at_limit", "active", "not_entered", "parallel"),
+    CTDCase(
+        False,
+        "zero",
+        True,
+        "under_limit",
+        "already_released",
+        "already_entered",
+        "single",
+    ),
+    CTDCase(False, "none", True, "under_limit", "foreign", "not_entered", "single"),
+    CTDCase(False, "positive", True, "under_limit", "foreign", "not_entered", "single"),
+    CTDCase(False, "none", False, "under_limit", "active", "not_entered", "single"),
+    CTDCase(False, "none", True, "under_limit", "active", "not_entered", "parallel"),
+    CTDCase(
+        False,
+        "positive",
+        False,
+        "under_limit",
+        "already_released",
+        "not_entered",
+        "single",
+    ),
+    CTDCase(
+        False,
+        "positive",
+        False,
+        "under_limit",
+        "foreign",
+        "already_entered",
+        "parallel",
+    ),
+    CTDCase(False, "zero", False, "under_limit", "active", "not_entered", "parallel"),
+    CTDCase(False, "positive", False, "at_limit", "active", "not_entered", "single"),
+    CTDCase(False, "zero", False, "at_limit", "active", "already_entered", "single"),
+    CTDCase(
+        False,
+        "none",
+        False,
+        "under_limit",
+        "foreign",
+        "already_entered",
+        "parallel",
+    ),
+    CTDCase(False, "positive", True, "under_limit", "active", "not_entered", "parallel"),
+    CTDCase(False, "zero", True, "under_limit", "foreign", "already_entered", "parallel"),
+)
+
+FACTOR_NAMES = (
+    "mock_mode",
+    "cost_value",
+    "strict_tracking",
+    "budget_state",
+    "permit_state",
+    "unknown_cost_mode",
+    "concurrency",
+)
+
+FACTOR_VALUES = {
+    "mock_mode": (True, False),
+    "cost_value": ("positive", "zero", "none"),
+    "strict_tracking": (True, False),
+    "budget_state": ("under_limit", "at_limit", "over_limit"),
+    "permit_state": ("active", "already_released", "foreign"),
+    "unknown_cost_mode": ("not_entered", "already_entered"),
+    "concurrency": ("single", "parallel"),
+}
+
+
+def _case_id(case: CTDCase) -> str:
+    return (
+        f"mock-{'on' if case.mock_mode else 'off'}_"
+        f"cost-{case.cost_value}_"
+        f"strict-{'on' if case.strict_tracking else 'off'}_"
+        f"budget-{case.budget_state}_"
+        f"permit-{case.permit_state}_"
+        f"unknown-{case.unknown_cost_mode}_"
+        f"{case.concurrency}"
+    )
+
+
+def _is_valid_case(case: CTDCase) -> bool:
+    # Mock mode bypasses all cost-accounting behavior; keep one canonical case.
+    if case.mock_mode:
+        return case == CTDCase(
+            True,
+            "positive",
+            False,
+            "under_limit",
+            "active",
+            "not_entered",
+            "single",
+        )
+
+    # Over-limit combinations are represented by a single deny-on-acquire scenario.
+    if case.budget_state == "over_limit":
+        return (
+            case.strict_tracking is False
+            and case.cost_value == "positive"
+            and case.permit_state == "active"
+            and case.unknown_cost_mode == "not_entered"
+            and case.concurrency == "single"
+        )
+
+    # strict + unknown cost fails before budget differences matter.
+    if (
+        case.cost_value == "none"
+        and case.strict_tracking
+        and case.budget_state != "under_limit"
+    ):
+        return False
+
+    return True
+
+
+def _setup_budget_state(budget_state: str) -> CostEnforcerConfig:
+    return CostEnforcerConfig(
+        limit=BUDGET_LIMITS[budget_state],
+        estimated_cost_per_trial=ESTIMATED_COST_PER_TRIAL,
+        fallback_trial_limit=6,
+    )
+
+
+def _drive_into_unknown_mode(enforcer: CostEnforcer) -> None:
+    permit = enforcer.acquire_permit()
+    assert permit.is_granted
+    enforcer.assert_invariants()
+    enforcer.track_cost(None, permit=permit)
+    enforcer.assert_invariants()
+    assert enforcer.get_status().unknown_cost_mode is True
+
+
+def _setup_permit_state(
+    enforcer: CostEnforcer,
+    permit_state: str,
+    budget_state: str,
+) -> tuple[Permit, bool]:
+    if permit_state == "foreign":
+        # Foreign permit not present in the enforcer registry.
+        return Permit(id=999_999, amount=ESTIMATED_COST_PER_TRIAL, active=True), True
+
+    permit = enforcer.acquire_permit()
+    enforcer.assert_invariants()
+
+    if budget_state == "over_limit":
+        assert permit.is_granted is False
+        return permit, False
+
+    assert permit.is_granted is True
+    if permit_state == "already_released":
+        assert enforcer.release_permit(permit) is True
+        enforcer.assert_invariants()
+
+    return permit, True
+
+
+def _seed_unknown_mode(
+    enforcer: CostEnforcer,
+    mode: str,
+    strict_tracking: bool,
+) -> None:
+    if mode == "not_entered":
+        return
+
+    # With strict tracking latched ON, unknown mode cannot be entered organically.
+    # Seed it directly to validate behavior in that pre-existing state.
+    if strict_tracking:
+        with enforcer._lock:
+            enforcer._unknown_cost_mode = True
+        enforcer.assert_invariants()
+        return
+
+    _drive_into_unknown_mode(enforcer)
+
+
+def _cost_value(label: str) -> float | None:
+    mapping: dict[str, float | None] = {
+        "positive": 0.05,
+        "zero": 0.0,
+        "none": None,
+    }
+    return mapping[label]
+
+
+def _run_single_transition(
+    enforcer: CostEnforcer,
+    permit: Permit,
+    cost_value: float | None,
+    should_raise: bool,
+) -> None:
+    if should_raise:
+        with pytest.raises(CostTrackingRequiredError):
+            enforcer.track_cost(cost_value, permit=permit)
+    else:
+        enforcer.track_cost(cost_value, permit=permit)
+    enforcer.assert_invariants()
+
+
+def _run_parallel_transitions(
+    enforcer: CostEnforcer,
+    permits: list[Permit],
+    cost_value: float | None,
+    should_raise: bool,
+) -> None:
+    def _worker(permit: Permit) -> Exception | None:
+        try:
+            enforcer.track_cost(cost_value, permit=permit)
+            enforcer.assert_invariants()
+            return None
+        except Exception as exc:
+            enforcer.assert_invariants()
+            return exc
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        results = list(executor.map(_worker, permits))
+
+    if should_raise:
+        assert all(isinstance(r, CostTrackingRequiredError) for r in results)
+    else:
+        assert all(r is None for r in results)
+    enforcer.assert_invariants()
+
+
+def _build_parallel_permits(
+    enforcer: CostEnforcer,
+    base_permit: Permit,
+    permit_state: str,
+) -> list[Permit]:
+    if permit_state in {"already_released", "foreign"}:
+        return [base_permit, base_permit, base_permit]
+
+    permits = [base_permit]
+    for _ in range(2):
+        permit = enforcer.acquire_permit()
+        enforcer.assert_invariants()
+        if permit.is_granted:
+            permits.append(permit)
+        else:
+            # Keep 3 operations by reusing a known valid permit.
+            permits.append(base_permit)
+    return permits
+
+
+def _pairs_for_case(case: CTDCase) -> set[tuple[str, object, str, object]]:
+    pairs: set[tuple[str, object, str, object]] = set()
+    case_dict = case.__dict__
+    for left, right in combinations(FACTOR_NAMES, 2):
+        pairs.add((left, case_dict[left], right, case_dict[right]))
+    return pairs
+
+
+def _all_valid_cases() -> list[CTDCase]:
+    all_cases: list[CTDCase] = []
+    for values in product(*(FACTOR_VALUES[name] for name in FACTOR_NAMES)):
+        case = CTDCase(*values)
+        if _is_valid_case(case):
+            all_cases.append(case)
+    return all_cases
+
+
+class TestCostEnforcerCTDPairwise:
+    """Constrained pairwise matrix coverage tests."""
+
+    @pytest.mark.parametrize(
+        "case",
+        [pytest.param(case, id=_case_id(case)) for case in PAIRWISE_CASES],
+    )
+    def test_cost_enforcer_transition_matrix(self, case: CTDCase, monkeypatch) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true" if case.mock_mode else "false")
+        monkeypatch.setenv(
+            "TRAIGENT_REQUIRE_COST_TRACKING",
+            "true" if case.strict_tracking else "false",
+        )
+        monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "false")
+
+        enforcer = CostEnforcer(config=_setup_budget_state(case.budget_state))
+        enforcer.assert_invariants()
+
+        _seed_unknown_mode(enforcer, case.unknown_cost_mode, case.strict_tracking)
+
+        permit, should_track = _setup_permit_state(
+            enforcer,
+            case.permit_state,
+            case.budget_state,
+        )
+        if not should_track:
+            # Over-limit path: permit denied before track_cost transition.
+            assert permit.is_granted is False
+            enforcer.assert_invariants()
+            return
+
+        cost_value = _cost_value(case.cost_value)
+        should_raise = (
+            not case.mock_mode
+            and case.cost_value == "none"
+            and case.strict_tracking is True
+        )
+
+        if case.concurrency == "single":
+            _run_single_transition(enforcer, permit, cost_value, should_raise)
+        else:
+            permits = _build_parallel_permits(enforcer, permit, case.permit_state)
+            _run_parallel_transitions(enforcer, permits, cost_value, should_raise)
+
+        status = enforcer.get_status()
+        if case.mock_mode:
+            assert status.trial_count == 0
+            assert status.accumulated_cost_usd == pytest.approx(0.0)
+            return
+
+        if case.cost_value == "none" and not case.strict_tracking:
+            assert status.unknown_cost_mode is True
+
+    def test_pairwise_matrix_covers_all_valid_pairs(self) -> None:
+        valid_cases = _all_valid_cases()
+        required_pairs = set().union(*(_pairs_for_case(case) for case in valid_cases))
+        covered_pairs = set().union(*(_pairs_for_case(case) for case in PAIRWISE_CASES))
+        assert covered_pairs >= required_pairs, (
+            f"Pair coverage {len(covered_pairs & required_pairs)}/{len(required_pairs)} "
+            "is incomplete"
+        )
+        assert 20 <= len(PAIRWISE_CASES) <= 25
+
+
+class TestCostEnforcerCTDCriticalTriples:
+    """Critical triple scenarios that must stay green."""
+
+    def test_critical_unknown_none_strict_on_parallel(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+        monkeypatch.setenv("TRAIGENT_REQUIRE_COST_TRACKING", "true")
+        monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "false")
+
+        enforcer = CostEnforcer(config=_setup_budget_state("under_limit"))
+        permits = [enforcer.acquire_permit() for _ in range(3)]
+        assert all(p.is_granted for p in permits)
+        enforcer.assert_invariants()
+
+        _run_parallel_transitions(
+            enforcer,
+            permits,
+            cost_value=None,
+            should_raise=True,
+        )
+
+    def test_critical_at_limit_already_released_permit_parallel(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+        monkeypatch.setenv("TRAIGENT_REQUIRE_COST_TRACKING", "false")
+        monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "false")
+
+        enforcer = CostEnforcer(config=_setup_budget_state("at_limit"))
+        permit = enforcer.acquire_permit()
+        assert permit.is_granted
+        assert enforcer.release_permit(permit) is True
+        enforcer.assert_invariants()
+
+        _run_parallel_transitions(
+            enforcer,
+            [permit, permit, permit],
+            cost_value=0.05,
+            should_raise=False,
+        )
+
+    def test_critical_foreign_permit_parallel_exception_path(
+        self,
+        monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+        monkeypatch.setenv("TRAIGENT_REQUIRE_COST_TRACKING", "true")
+        monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "false")
+
+        enforcer = CostEnforcer(config=_setup_budget_state("under_limit"))
+        foreign_permit = Permit(id=424242, amount=ESTIMATED_COST_PER_TRIAL, active=True)
+        enforcer.assert_invariants()
+
+        _run_parallel_transitions(
+            enforcer,
+            [foreign_permit, foreign_permit, foreign_permit],
+            cost_value=None,
+            should_raise=True,
+        )

--- a/tests/unit/core/test_orchestrator_helpers.py
+++ b/tests/unit/core/test_orchestrator_helpers.py
@@ -1003,6 +1003,27 @@ class TestExtractCostFromResults:
         assert examples is None
         assert abs(cost - 0.07) < 0.001
 
+    def test_hybrid_result_cost_key_extraction(self):
+        """Hybrid-style example metrics with `cost` are summed correctly."""
+
+        class MockHybridExample:
+            def __init__(self, cost):
+                self.metrics = {"cost": cost}
+
+        class MockHybridResult:
+            def __init__(self):
+                self.example_results = [
+                    MockHybridExample(0.011),
+                    MockHybridExample(0.013),
+                    MockHybridExample(0.017),
+                ]
+                self.aggregated_metrics = {"cost": 0.999}  # Must not override examples
+
+        result = MockHybridResult()
+        examples, cost = extract_cost_from_results(result, None, "trial_hybrid_cost_key")
+        assert examples == 3
+        assert abs(cost - 0.041) < 0.0001
+
     def test_total_examples_override(self):
         """Test that total_examples overrides example_results count."""
 

--- a/tests/unit/integrations/test_cost_extraction.py
+++ b/tests/unit/integrations/test_cost_extraction.py
@@ -90,3 +90,20 @@ def test_unknown_model_with_usage_warns(caplog) -> None:
     assert metrics.tokens.total_tokens == 150
     assert metrics.cost.total_cost == 0.0
     assert any("Unknown model" in r.message for r in caplog.records)
+
+
+def test_unknown_model_strict_accounting_false_integration_path(
+    monkeypatch,
+    caplog,
+) -> None:
+    """Unknown model with strict mode disabled should warn and stay non-fatal."""
+    monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "false")
+    usage = SimpleNamespace(prompt_tokens=120, completion_tokens=30, total_tokens=150)
+    response = SimpleNamespace(usage=usage)
+
+    with caplog.at_level(logging.WARNING):
+        metrics = extract_llm_metrics(response, model_name="nonexistent-model-for-test")
+
+    assert metrics.tokens.total_tokens == 150
+    assert metrics.cost.total_cost == 0.0
+    assert any("Unknown model" in r.message for r in caplog.records)

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -1152,11 +1152,11 @@ Options:
             I1: in_flight_count >= 0
             I2: reserved_cost >= 0
             I3: len(active_permits) == in_flight_count
-            I4: accumulated_cost + reserved_cost <= limit + ε
+            I4: accumulated_cost + reserved_cost <= limit + ε (during reservations)
             I5: Released permits have active=False (structural - verified via Permit design)
             I6: Permit IDs monotonically increasing (structural - verified via counter)
             I7: Denied permits: id=-1, amount=0 (structural - verified via construction)
-            I8: Sum of active permit amounts equals reserved_cost
+            I8: Sum of active permit amounts equals reserved_cost (normal mode)
         """
         violations: list[str] = []
 
@@ -1181,10 +1181,17 @@ Options:
                     f"in_flight_count = {self._in_flight_count}"
                 )
 
-            # I4: accumulated + reserved <= limit + ε
+            # I4: accumulated + reserved <= limit + ε (reservation phase only)
+            # Actual accumulated spend can exceed limit after execution if per-trial
+            # actuals are higher than reserved estimates. Also, unknown-cost mode
+            # enforces fallback trial-count limits rather than budget arithmetic.
             total = self._accumulated_cost + self._reserved_cost
             epsilon = 0.0001  # Floating point tolerance
-            if total > self.config.limit + epsilon:
+            if (
+                self._in_flight_count > 0
+                and not self._unknown_cost_mode
+                and total > self.config.limit + epsilon
+            ):
                 violations.append(
                     f"I4 violated: accumulated ({self._accumulated_cost:.4f}) + "
                     f"reserved ({self._reserved_cost:.4f}) = {total:.4f} > "
@@ -1196,13 +1203,16 @@ Options:
             # - I6: _permit_counter only increments, never decreases
             # - I7: Denied permits are constructed with id=-1, amount=0.0, active=False
 
-            # I8: Sum of active permit amounts equals reserved_cost
-            permit_sum = sum(p.amount for p in self._active_permits.values())
-            if abs(permit_sum - self._reserved_cost) > epsilon:
-                violations.append(
-                    f"I8 violated: sum(permit.amount) = {permit_sum:.4f} != "
-                    f"reserved_cost = {self._reserved_cost:.4f}"
-                )
+            # I8: Sum of active permit amounts equals reserved_cost in normal mode.
+            # In unknown-cost mode, permits remain tracked for single-release safety
+            # but reserved_cost accounting is intentionally bypassed.
+            if not self._unknown_cost_mode:
+                permit_sum = sum(p.amount for p in self._active_permits.values())
+                if abs(permit_sum - self._reserved_cost) > epsilon:
+                    violations.append(
+                        f"I8 violated: sum(permit.amount) = {permit_sum:.4f} != "
+                        f"reserved_cost = {self._reserved_cost:.4f}"
+                    )
 
         if violations:
             for v in violations:

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -1152,11 +1152,14 @@ Options:
             I1: in_flight_count >= 0
             I2: reserved_cost >= 0
             I3: len(active_permits) == in_flight_count
-            I4: accumulated_cost + reserved_cost <= limit + ε (during reservations)
+            I4: accumulated_cost + reserved_cost <= limit + ε
+                (enforced only when in_flight_count > 0 and not unknown_cost_mode;
+                 post-execution actuals may exceed reserved estimates)
             I5: Released permits have active=False (structural - verified via Permit design)
             I6: Permit IDs monotonically increasing (structural - verified via counter)
             I7: Denied permits: id=-1, amount=0 (structural - verified via construction)
-            I8: Sum of active permit amounts equals reserved_cost (normal mode)
+            I8: Sum of active permit amounts equals reserved_cost
+                (enforced only outside unknown_cost_mode)
         """
         violations: list[str] = []
 


### PR DESCRIPTION
## Summary
- add constrained CTD-style pairwise matrix tests for `CostEnforcer` across 7 factors
- add explicit critical-triple coverage for strict unknown-cost parallel, at-limit released permit parallel, and foreign permit parallel exception path
- add integration-level checks for hybrid `cost` key extraction and unknown-model with strict accounting disabled
- fix `CostEnforcer._verify_invariants()` to align I4/I8 checks with real runtime semantics (reservation phase + non-unknown mode)

## Why
The CTD matrix exposed a real mismatch in invariant enforcement:
- I4 was being enforced in post-reservation states where actual spend can exceed limit after execution
- I8 was being enforced in unknown-cost mode where reserved-cost accounting is intentionally bypassed

This PR aligns invariant checks with the architecture and adds durable test coverage for risky factor interactions.

## Validation
- `uv run pytest -q tests/unit/core/test_cost_enforcement_ctd.py`
- `uv run pytest -q tests/unit/core/test_cost_enforcement.py -k "TestCostEnforcerInvariants or unknown_cost_sync_pairwise or unknown_cost_async_pairwise"`
- `uv run pytest -q tests/integration/test_cost_enforcement_seamless_mode.py tests/integration/test_cost_enforcement_injection_modes.py`
- `uv run pytest -q tests/unit/core/test_orchestrator_helpers.py -k "hybrid_result_cost_key_extraction"`
- `uv run pytest -q tests/unit/integrations/test_cost_extraction.py -k "unknown_model_strict_accounting_false_integration_path"`
- `uv run ruff check tests/unit/core/test_cost_enforcement_ctd.py tests/unit/core/test_orchestrator_helpers.py tests/unit/integrations/test_cost_extraction.py traigent/core/cost_enforcement.py`
