### PR TITLE
refactor(cost): litellm-native runtime pricing + OpenRouter fallback

### DIFF
--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -117,32 +117,22 @@ class TestCostCalculatorModelMapping:
         """Create test calculator instance."""
         return CostCalculator()
 
-    def test_map_model_name_exact_match(self, calculator: CostCalculator) -> None:
-        """Test exact model name mapping."""
-        result = calculator._map_model_name("claude-3-haiku")
-        assert result == "claude-3-haiku-20240307"
-
-    def test_map_model_name_exact_match_sonnet(
+    def test_map_model_name_legacy_mapping_still_available(
         self, calculator: CostCalculator
     ) -> None:
-        """Test exact mapping for Claude Sonnet models."""
-        assert (
-            calculator._map_model_name("claude-3-sonnet") == "claude-3-sonnet-20240229"
-        )
-        assert (
-            calculator._map_model_name("claude-3-5-sonnet")
-            == "claude-3-5-sonnet-20241022"
-        )
+        """Legacy helper mapping remains available for compatibility."""
+        result = calculator._map_model_name("claude-haiku")
+        assert result == "claude-3-haiku-20240307"
 
-    def test_map_model_name_exact_match_gpt(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for GPT models."""
-        assert calculator._map_model_name("gpt-3.5") == "gpt-3.5-turbo"
-        assert calculator._map_model_name("gpt-4") == "gpt-4o"
-
-    def test_map_model_name_family_defaults(self, calculator: CostCalculator) -> None:
-        """Test model family default mapping."""
-        result = calculator._map_model_name("claude-3")
-        assert result == "claude-3-5-sonnet-latest"
+    def test_map_model_name_uses_explicit_litellm_alias(
+        self, calculator: CostCalculator
+    ) -> None:
+        with patch(
+            "traigent.utils.cost_calculator.litellm.model_alias_map",
+            {"claude-haiku": "claude-3-haiku-20240307"},
+        ):
+            result = calculator._map_model_name("claude-haiku")
+            assert result == "claude-3-haiku-20240307"
 
     def test_map_model_name_empty_string(self, calculator: CostCalculator) -> None:
         """Test mapping with empty string returns None."""
@@ -158,8 +148,11 @@ class TestCostCalculatorModelMapping:
         """Test model name mapping logs debug messages."""
         mock_logger = MagicMock()
         calculator = CostCalculator(logger=mock_logger)
-        calculator._map_model_name("claude-3-haiku")
-        # Should log debug message for exact match
+        with patch(
+            "traigent.utils.cost_calculator.litellm.model_alias_map",
+            {"my-alias": "gpt-4o"},
+        ):
+            calculator._map_model_name("my-alias")
         assert mock_logger.debug.called
 
 
@@ -1003,54 +996,45 @@ class TestFamilyDefaults:
         assert calculator._map_model_name("gpt-3.5") == "gpt-3.5-turbo"
 
 
-class TestOpenRouterPricingFallback:
-    """Tests for OpenRouter pricing cache and offline behavior."""
+class TestCustomPricingOverrides:
+    """Tests for explicit custom pricing configuration."""
 
     @pytest.fixture(autouse=True)
     def reset_cache(self):
-        old_cache = cc._OPENROUTER_MODEL_INDEX_CACHE
-        cc._OPENROUTER_MODEL_INDEX_CACHE = None
+        old_cache = cc._CUSTOM_PRICING_CACHE
+        old_cache_key = cc._CUSTOM_PRICING_CACHE_KEY
+        cc._CUSTOM_PRICING_CACHE = None
+        cc._CUSTOM_PRICING_CACHE_KEY = None
         try:
             yield
         finally:
-            cc._OPENROUTER_MODEL_INDEX_CACHE = old_cache
+            cc._CUSTOM_PRICING_CACHE = old_cache
+            cc._CUSTOM_PRICING_CACHE_KEY = old_cache_key
 
-    def test_try_openrouter_pricing_skips_when_offline(self, monkeypatch) -> None:
-        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
-        assert cc._try_openrouter_pricing("any-model") is None
+    def test_json_env_pricing_is_loaded(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            '{"x-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}',
+        )
+        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
+        assert cc._try_custom_model_pricing("x-model") == (1e-6, 2e-6)
 
-    def test_try_openrouter_pricing_uses_cache(self, monkeypatch) -> None:
-        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
-        cc._OPENROUTER_MODEL_INDEX_CACHE = {"a/model": (1e-6, 2e-6)}
-        assert cc._try_openrouter_pricing("a/model") == (1e-6, 2e-6)
+    def test_file_env_pricing_is_loaded(self, monkeypatch, tmp_path) -> None:
+        path = tmp_path / "pricing.json"
+        path.write_text(
+            '{"y-model":{"input_cost_per_token":3e-6,"output_cost_per_token":4e-6}}',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", str(path))
+        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
+        assert cc._try_custom_model_pricing("y-model") == (3e-6, 4e-6)
 
-    def test_try_openrouter_pricing_fetch_failure_returns_none(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
-        cc._OPENROUTER_MODEL_INDEX_CACHE = None
-        with patch.object(cc, "_fetch_openrouter_models", side_effect=RuntimeError):
-            assert cc._try_openrouter_pricing("unknown-model") is None
-            # Failure should cache an empty dict to avoid repeated retries.
-            assert cc._OPENROUTER_MODEL_INDEX_CACHE == {}
+    def test_invalid_json_raises(self, monkeypatch) -> None:
+        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", "{bad-json")
+        with pytest.raises(ValueError, match="invalid JSON"):
+            cc._get_custom_pricing_index()
 
-    def test_fetch_openrouter_models_parses_payload(self) -> None:
-        payload = {
-            "data": [
-                {
-                    "id": "anthropic/claude-sonnet-4.6",
-                    "pricing": {"prompt": "0.000003", "completion": "0.000015"},
-                }
-            ]
-        }
-        mock_response = MagicMock()
-        mock_response.read.return_value = str(payload).replace("'", '"').encode("utf-8")
-        mock_context = MagicMock()
-        mock_context.__enter__.return_value = mock_response
-        mock_context.__exit__.return_value = None
-
-        with patch.object(cc, "urlopen", return_value=mock_context):
-            parsed = cc._fetch_openrouter_models()
-
-        assert parsed["anthropic/claude-sonnet-4.6"] == (3e-6, 15e-6)
-        assert parsed["claude-sonnet-4.6"] == (3e-6, 15e-6)
+    def test_invalid_file_path_raises(self, monkeypatch) -> None:
+        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", "/missing/pricing.json")
+        with pytest.raises(ValueError, match="Failed to parse custom pricing file"):
+            cc._get_custom_pricing_index()

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,9 +12,13 @@ from traigent.utils.cost_calculator import (
     CostBreakdown,
     CostCalculator,
     UnknownModelError,
+    _fallback_cost_from_tokens,
+    calculate_completion_cost,
     calculate_llm_cost,
+    calculate_prompt_cost,
     get_cost_calculator,
     get_model_pricing_per_1k,
+    get_model_token_pricing,
     validate_model_support,
 )
 
@@ -112,6 +116,18 @@ class TestCostCalculatorCalculateCost:
             )
             assert result.total_cost > 0
 
+    def test_calculate_cost_logs_unexpected_exception(self) -> None:
+        mock_logger = MagicMock()
+        calculator = CostCalculator(logger=mock_logger)
+        with patch.object(calculator, "_populate_cost", side_effect=RuntimeError("boom")):
+            result = calculator.calculate_cost(
+                model_name="gpt-4o",
+                input_tokens=100,
+                output_tokens=50,
+            )
+        assert result.calculation_method == "error_RuntimeError"
+        mock_logger.warning.assert_called_once()
+
 
 class TestCustomPricingAndValidation:
     @pytest.fixture(autouse=True)
@@ -169,6 +185,25 @@ class TestCustomPricingAndValidation:
         result = calculator.validate_model_name("missing-model-zzz")
         assert result["not_found"] is True
 
+    def test_validate_model_name_none_and_empty(self) -> None:
+        calculator = CostCalculator()
+        assert calculator.validate_model_name(None)["not_found"] is True
+        assert calculator.validate_model_name("")["not_found"] is True
+
+    def test_validate_model_name_litellm_unavailable(self) -> None:
+        calculator = CostCalculator()
+        with patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False):
+            result = calculator.validate_model_name("gpt-4o")
+        assert result["error"] == "litellm library not available"
+        assert result["available"] is False
+
+    def test_validate_model_name_custom_pricing_invalid(self, monkeypatch) -> None:
+        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", "{bad-json")
+        calculator = CostCalculator()
+        result = calculator.validate_model_name("foo-model")
+        assert result["not_found"] is True
+        assert "invalid JSON" in result["error"]
+
     def test_clear_cache_resets_custom_pricing_cache(self, monkeypatch) -> None:
         monkeypatch.setenv(
             "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
@@ -210,3 +245,109 @@ class TestConvenienceFunctions:
         input_per_1k, output_per_1k = get_model_pricing_per_1k("unknown-model-xyz")
         assert input_per_1k == 0.0
         assert output_per_1k == 0.0
+
+
+class TestPricingHelpers:
+    def test_get_model_token_pricing_empty_raises(self) -> None:
+        with pytest.raises(UnknownModelError, match="has no known pricing"):
+            get_model_token_pricing("")
+
+    def test_get_model_token_pricing_known_model_zero_rate_path(self) -> None:
+        mock_litellm = MagicMock()
+        mock_litellm.cost_per_token.return_value = (0.0, 0.0)
+        with (
+            patch("traigent.utils.cost_calculator.litellm", mock_litellm),
+            patch("traigent.utils.cost_calculator._is_model_known_to_litellm", return_value=True),
+            patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", True),
+        ):
+            inp, out, method = get_model_token_pricing("known-zero-model")
+        assert inp == 0.0
+        assert out == 0.0
+        assert method == "litellm"
+
+    def test_fallback_cost_from_tokens_paths(self) -> None:
+        exact = _fallback_cost_from_tokens("gpt-4o", 100, 50, _quiet=True)
+        alias = _fallback_cost_from_tokens("claude-3-sonnet", 100, 50, _quiet=True)
+        prefix = _fallback_cost_from_tokens("gpt-4o-2024-08-06", 100, 50, _quiet=True)
+        reverse_prefix = _fallback_cost_from_tokens("gpt-4", 100, 50, _quiet=True)
+        unknown = _fallback_cost_from_tokens("unknown-model", 100, 50, _quiet=True)
+        assert exact[0] > 0
+        assert alias[0] > 0
+        assert prefix[0] > 0
+        assert reverse_prefix[0] > 0
+        assert unknown == (0.0, 0.0)
+
+
+class TestDeprecatedPromptCompletionCost:
+    @pytest.fixture(autouse=True)
+    def reset_custom_cache(self):
+        old_cache = cc._CUSTOM_PRICING_CACHE
+        old_key = cc._CUSTOM_PRICING_CACHE_KEY
+        cc._CUSTOM_PRICING_CACHE = None
+        cc._CUSTOM_PRICING_CACHE_KEY = None
+        try:
+            yield
+        finally:
+            cc._CUSTOM_PRICING_CACHE = old_cache
+            cc._CUSTOM_PRICING_CACHE_KEY = old_key
+
+    def test_calculate_prompt_cost_with_message_list(self) -> None:
+        with (
+            patch("traigent.utils.cost_calculator.litellm.token_counter", return_value=17),
+            patch("traigent.utils.cost_calculator.litellm.cost_per_token", return_value=(17e-6, 0.0)),
+            patch("traigent.utils.cost_calculator._is_model_known_to_litellm", return_value=True),
+        ):
+            cost = calculate_prompt_cost(
+                [{"role": "user", "content": "hello"}],
+                "gpt-4o",
+            )
+        assert cost == pytest.approx(17e-6)
+
+    def test_calculate_prompt_cost_unknown_raises_after_litellm_failure(self) -> None:
+        with patch(
+            "traigent.utils.cost_calculator._try_litellm_prompt_cost",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(UnknownModelError, match="has no known pricing"):
+                calculate_prompt_cost("hello", "unknown-model-z")
+
+    def test_calculate_prompt_cost_uses_custom_pricing(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            '{"custom-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}',
+        )
+        with patch(
+            "traigent.utils.cost_calculator._try_litellm_prompt_cost",
+            return_value=(None, 123),
+        ):
+            cost = calculate_prompt_cost("hello", "custom-model")
+        assert cost == pytest.approx(123e-6)
+
+    def test_calculate_completion_cost_known_zero_model_branch(self) -> None:
+        with (
+            patch("traigent.utils.cost_calculator.litellm.token_counter", return_value=12),
+            patch("traigent.utils.cost_calculator.litellm.cost_per_token", return_value=(0.0, 0.0)),
+            patch("traigent.utils.cost_calculator._is_model_known_to_litellm", return_value=True),
+        ):
+            cost = calculate_completion_cost("world", "gpt-4o")
+        assert cost == 0.0
+
+    def test_calculate_completion_cost_unknown_raises_after_litellm_failure(self) -> None:
+        with patch(
+            "traigent.utils.cost_calculator._try_litellm_completion_cost",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(UnknownModelError, match="has no known pricing"):
+                calculate_completion_cost("world", "unknown-model-z")
+
+    def test_calculate_completion_cost_uses_custom_pricing(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            '{"custom-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}',
+        )
+        with patch(
+            "traigent.utils.cost_calculator._try_litellm_completion_cost",
+            return_value=(None, 77),
+        ):
+            cost = calculate_completion_cost("world", "custom-model")
+        assert cost == pytest.approx(154e-6)

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -1,22 +1,17 @@
-"""Unit tests for cost_calculator.
-
-Tests for intelligent LLM cost calculation with fuzzy model matching.
-"""
-
-# Traceability: CONC-Layer-Core CONC-Quality-Performance CONC-Quality-Observability FUNC-ANALYTICS REQ-ANLY-011 SYNC-Observability
+"""Unit tests for cost_calculator public behaviors."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import patch
 
 import pytest
 
 import traigent.utils.cost_calculator as cc
 from traigent.utils.cost_calculator import (
-    ESTIMATION_MODEL_PRICING,
-    TOKENCOST_AVAILABLE,
     CostBreakdown,
     CostCalculator,
+    UnknownModelError,
     calculate_llm_cost,
     get_cost_calculator,
     get_model_pricing_per_1k,
@@ -25,1016 +20,193 @@ from traigent.utils.cost_calculator import (
 
 
 class TestCostBreakdown:
-    """Tests for CostBreakdown dataclass."""
-
-    def test_cost_breakdown_default_initialization(self) -> None:
-        """Test CostBreakdown initializes with default values."""
+    def test_defaults(self) -> None:
         breakdown = CostBreakdown()
-        assert breakdown.input_cost == 0.0
-        assert breakdown.output_cost == 0.0
         assert breakdown.total_cost == 0.0
-        assert breakdown.input_tokens == 0
-        assert breakdown.output_tokens == 0
         assert breakdown.total_tokens == 0
-        assert breakdown.model_used == ""
-        assert breakdown.mapped_model == ""
-        assert breakdown.calculation_method == "unknown"
 
-    def test_cost_breakdown_with_values(self) -> None:
-        """Test CostBreakdown with explicit values."""
+    def test_post_init_computes_totals(self) -> None:
         breakdown = CostBreakdown(
-            input_cost=0.001,
-            output_cost=0.002,
-            input_tokens=100,
-            output_tokens=50,
-            model_used="gpt-4o",
-            mapped_model="gpt-4o-2024-05-13",
-            calculation_method="prompt_and_response",
+            input_cost=0.1, output_cost=0.2, input_tokens=10, output_tokens=5
         )
-        assert breakdown.input_cost == 0.001
-        assert breakdown.output_cost == 0.002
-        assert breakdown.total_cost == 0.003
-        assert breakdown.input_tokens == 100
-        assert breakdown.output_tokens == 50
-        assert breakdown.total_tokens == 150
-
-    def test_cost_breakdown_post_init_total_cost(self) -> None:
-        """Test __post_init__ calculates total_cost from input and output costs."""
-        breakdown = CostBreakdown(input_cost=0.001, output_cost=0.002)
-        assert breakdown.total_cost == 0.003
-
-    def test_cost_breakdown_post_init_total_tokens(self) -> None:
-        """Test __post_init__ calculates total_tokens from input and output tokens."""
-        breakdown = CostBreakdown(input_tokens=100, output_tokens=50)
-        assert breakdown.total_tokens == 150
-
-    def test_cost_breakdown_explicit_total_cost_preserved(self) -> None:
-        """Test that explicit total_cost is not overridden if already set."""
-        breakdown = CostBreakdown(input_cost=0.001, output_cost=0.002, total_cost=0.999)
-        # total_cost should remain as explicitly set (0.999), not recalculated
-        assert breakdown.total_cost == 0.999
-
-    def test_cost_breakdown_explicit_total_tokens_preserved(self) -> None:
-        """Test that explicit total_tokens is not overridden if already set."""
-        breakdown = CostBreakdown(input_tokens=100, output_tokens=50, total_tokens=999)
-        # total_tokens should remain as explicitly set (999), not recalculated
-        assert breakdown.total_tokens == 999
+        assert breakdown.total_cost == pytest.approx(0.3)
+        assert breakdown.total_tokens == 15
 
 
-class TestCostCalculatorInitialization:
-    """Tests for CostCalculator initialization."""
-
-    def test_calculator_init_default(self) -> None:
-        """Test CostCalculator initializes with default settings."""
+class TestCostCalculatorInit:
+    def test_init_default(self) -> None:
         calculator = CostCalculator()
         assert calculator.logger is None
         assert calculator.enable_caching is True
-        assert calculator._fuzzy_match_cache == {}
-
-    def test_calculator_init_with_logger(self) -> None:
-        """Test CostCalculator initialization with custom logger."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        assert calculator.logger is mock_logger
-
-    def test_calculator_init_caching_disabled(self) -> None:
-        """Test CostCalculator initialization with caching disabled."""
-        calculator = CostCalculator(enable_caching=False)
-        assert calculator.enable_caching is False
 
     @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_calculator_init_litellm_unavailable_raises(self) -> None:
-        """Test RuntimeError raised when litellm is unavailable (budget safety)."""
+    def test_init_requires_litellm(self) -> None:
         with pytest.raises(RuntimeError, match="litellm is required"):
             CostCalculator()
 
 
-class TestCostCalculatorModelMapping:
-    """Tests for model name mapping functionality."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_map_model_name_legacy_mapping_still_available(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Legacy helper mapping remains available for compatibility."""
-        result = calculator._map_model_name("claude-haiku")
-        assert result == "claude-3-haiku-20240307"
-
-    def test_map_model_name_uses_explicit_litellm_alias(
-        self, calculator: CostCalculator
-    ) -> None:
-        with patch(
-            "traigent.utils.cost_calculator.litellm.model_alias_map",
-            {"claude-haiku": "claude-3-haiku-20240307"},
-        ):
-            result = calculator._map_model_name("claude-haiku")
-            assert result == "claude-3-haiku-20240307"
-
-    def test_map_model_name_empty_string(self, calculator: CostCalculator) -> None:
-        """Test mapping with empty string returns None."""
-        result = calculator._map_model_name("")
-        assert result is None
-
-    def test_map_model_name_none(self, calculator: CostCalculator) -> None:
-        """Test mapping with None returns None."""
-        result = calculator._map_model_name(None)
-        assert result is None
-
-    def test_map_model_name_with_logger(self) -> None:
-        """Test model name mapping logs debug messages."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        with patch(
-            "traigent.utils.cost_calculator.litellm.model_alias_map",
-            {"my-alias": "gpt-4o"},
-        ):
-            calculator._map_model_name("my-alias")
-        assert mock_logger.debug.called
-
-
-class TestCostCalculatorFuzzyMatching:
-    """Tests for fuzzy model matching functionality."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    @pytest.fixture
-    def calculator_with_logger(self) -> CostCalculator:
-        """Create calculator with mock logger."""
-        return CostCalculator(logger=MagicMock())
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_fuzzy_match_direct_match(self, calculator: CostCalculator) -> None:
-        """Test fuzzy match finds direct match in litellm."""
-        # Use a model that should exist in litellm
-        result = calculator._fuzzy_match_model("gpt-4o")
-        assert result == "gpt-4o"
-
-    def test_fuzzy_match_cache_hit(self, calculator: CostCalculator) -> None:
-        """Test fuzzy match uses cached results."""
-        # Pre-populate cache
-        calculator._fuzzy_match_cache["test-model"] = "cached-result"
-        result = calculator._fuzzy_match_model("test-model")
-        assert result == "cached-result"
-
-    def test_fuzzy_match_cache_disabled(self) -> None:
-        """Test fuzzy matching with caching disabled."""
-        calculator = CostCalculator(enable_caching=False)
-        # Should not use cache
-        calculator._fuzzy_match_cache["test-model"] = "cached-result"
-        # Result won't match cache since caching is disabled
-        result = calculator._fuzzy_match_model("test-model")
-        # Since litellm may not be available and no exact match, should return None
-        assert result is None or isinstance(result, str)
-
-    def test_fuzzy_match_short_model_name(self, calculator: CostCalculator) -> None:
-        """Test fuzzy match rejects model names shorter than 5 characters."""
-        result = calculator._perform_fuzzy_match("gpt")
-        assert result is None
-
-    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_fuzzy_match_litellm_unavailable(self, calculator: CostCalculator) -> None:
-        """Test fuzzy match returns None when litellm unavailable."""
-        result = calculator._perform_fuzzy_match("some-model")
-        assert result is None
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_perform_fuzzy_match_single_match(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test fuzzy match with single matching model."""
-        # This will depend on litellm having models, so we'll use a real example
-        result = calculator_with_logger._perform_fuzzy_match("gpt-4o-mini")
-        assert result is not None
-        assert isinstance(result, str)
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_perform_fuzzy_match_multiple_matches(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test fuzzy match selects best from multiple matches."""
-        # "gpt-4" should match multiple models in litellm
-        result = calculator_with_logger._perform_fuzzy_match("gpt-4o")
-        assert result is not None
-        # Should select the best match based on scoring
-        assert isinstance(result, str)
-
-
-class TestSemanticMatching:
-    """Tests for semantic model matching logic."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_is_semantic_match_substring_not_found(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match returns False when substring not found."""
-        result = calculator._is_semantic_match("claude", "gpt-4-turbo")
-        assert result is False
-
-    def test_is_semantic_match_too_short(self, calculator: CostCalculator) -> None:
-        """Test semantic match rejects model names too short."""
-        result = calculator._is_semantic_match("gpt", "gpt-4-turbo-preview")
-        assert result is False
-
-    def test_is_semantic_match_family_mismatch_gpt_claude(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match prevents GPT/Claude family mixing."""
-        result = calculator._is_semantic_match("gpt-4", "claude-3-sonnet")
-        assert result is False
-
-    def test_is_semantic_match_family_mismatch_claude_gpt(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match prevents Claude/GPT family mixing."""
-        result = calculator._is_semantic_match("claude-3", "gpt-4-turbo")
-        assert result is False
-
-    def test_is_semantic_match_generation_mismatch_gpt4_gpt3(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match prevents GPT-4 matching GPT-3."""
-        result = calculator._is_semantic_match("gpt-4-turbo", "gpt-3.5-turbo")
-        assert result is False
-
-    def test_is_semantic_match_generation_mismatch_gpt3_gpt4(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match prevents GPT-3 matching GPT-4."""
-        result = calculator._is_semantic_match("gpt-3.5", "gpt-4-turbo")
-        assert result is False
-
-    def test_is_semantic_match_claude_version_mismatch(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match prevents Claude-3 matching Claude-2."""
-        result = calculator._is_semantic_match("claude-3-haiku", "claude-2.1")
-        assert result is False
-
-    def test_is_semantic_match_valid_match(self, calculator: CostCalculator) -> None:
-        """Test semantic match returns True for valid matches."""
-        result = calculator._is_semantic_match(
-            "claude-3-haiku", "claude-3-haiku-20240307"
-        )
-        assert result is True
-
-
-class TestModelScoring:
-    """Tests for model scoring and selection logic."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_select_best_model_empty_list(self, calculator: CostCalculator) -> None:
-        """Test selecting best model from empty list returns empty string."""
-        result = calculator._select_best_model([], "test-model")
-        assert result == ""
-
-    def test_select_best_model_single_match(self, calculator: CostCalculator) -> None:
-        """Test selecting best model with single match."""
-        result = calculator._select_best_model(["model-v1"], "model")
-        assert result == "model-v1"
-
-    def test_select_best_model_prefers_latest(self, calculator: CostCalculator) -> None:
-        """Test selecting best model prefers 'latest' suffix."""
-        matches = ["model-v1", "model-v2", "model-latest"]
-        result = calculator._select_best_model(matches, "model")
-        assert result == "model-latest"
-
-    def test_select_best_model_prefers_newer_date(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test selecting best model prefers newer dates."""
-        matches = ["model-20240101", "model-20250101"]
-        result = calculator._select_best_model(matches, "model")
-        assert result == "model-20250101"
-
-    def test_calculate_model_score_latest(self, calculator: CostCalculator) -> None:
-        """Test model score calculation for 'latest' suffix."""
-        score = calculator._calculate_model_score("gpt-4-latest", "gpt-4")
-        assert score == (9999, 12, 31, 99)
-
-    def test_calculate_model_score_yyyymmdd_format(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test model score calculation for YYYYMMDD date format."""
-        score = calculator._calculate_model_score(
-            "claude-3-haiku-20240307", "claude-3-haiku"
-        )
-        assert score == (2024, 3, 7, 50)
-
-    def test_calculate_model_score_yyyy_mm_dd_format(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test model score calculation for YYYY-MM-DD date format."""
-        score = calculator._calculate_model_score("model-2024-03-07", "model")
-        assert score == (2024, 3, 7, 50)
-
-    def test_calculate_model_score_version_number(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test model score calculation for version numbers."""
-        score = calculator._calculate_model_score("model-v5", "model")
-        assert score == (2024, 1, 1, 5)
-
-    def test_calculate_model_score_unversioned(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test model score calculation for unversioned models."""
-        score = calculator._calculate_model_score("basic-model", "basic")
-        # Should use unversioned fallback date with specificity based on length
-        assert score[0] == 2020  # UNVERSIONED_FALLBACK_DATE year
-        assert score[1] == 1  # month
-        assert score[2] == 1  # day
-        assert score[3] > 0  # specificity (100 - len(model_name))
-
-
-class TestCostCalculation:
-    """Tests for cost calculation methods."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    @pytest.fixture
-    def calculator_with_logger(self) -> CostCalculator:
-        """Create calculator with mock logger."""
-        return CostCalculator(logger=MagicMock())
-
-    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_calculate_cost_litellm_unavailable_raises(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test cost calculation raises when litellm is unavailable (budget safety)."""
-        with pytest.raises(RuntimeError, match="litellm is required"):
-            calculator.calculate_cost(
-                prompt="test", response="response", model_name="gpt-4o"
-            )
-
-    def test_calculate_cost_no_model_name(self, calculator: CostCalculator) -> None:
-        """Test cost calculation without model name."""
-        result = calculator.calculate_cost(prompt="test", response="response")
-        assert result.total_cost == 0.0
+class TestCostCalculatorCalculateCost:
+    def test_no_model_name_returns_empty_breakdown(self) -> None:
+        calculator = CostCalculator()
+        result = calculator.calculate_cost(prompt="hi", response="hello", model_name=None)
         assert result.calculation_method == "no_model_name"
-
-    def test_calculate_cost_unknown_model_returns_zero(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test cost calculation with unknown model name returns zero cost."""
-        # Use a completely invalid model name that won't match anything in litellm
-        # The new implementation with fallback pricing still attempts calculation
-        result = calculator_with_logger.calculate_cost(
-            prompt="test", response="response", model_name="xyz123nonexistent"
-        )
-        # Unknown models return 0 cost but calculation still proceeds
         assert result.total_cost == 0.0
-        assert result.calculation_method == "prompt_and_response"
 
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_calculate_cost_prompt_and_response(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test cost calculation with prompt and response."""
+    def test_token_counts_path_for_known_model(self) -> None:
+        calculator = CostCalculator()
         result = calculator.calculate_cost(
-            prompt="Hello world", response="Hi there", model_name="gpt-4o-mini"
-        )
-        assert result.calculation_method == "prompt_and_response"
-        assert result.total_cost >= 0.0
-        assert result.input_cost >= 0.0
-        assert result.output_cost >= 0.0
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_calculate_cost_token_counts(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with token counts."""
-        result = calculator.calculate_cost(
-            model_name="gpt-4o-mini", input_tokens=100, output_tokens=50
+            model_name="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
         )
         assert result.calculation_method == "token_counts"
+        assert result.total_cost > 0
         assert result.input_tokens == 100
         assert result.output_tokens == 50
-        # Total tokens are set in the calculation, but __post_init__ runs first
-        # So we check that input and output tokens are correctly set
-        assert result.input_tokens > 0
-        assert result.output_tokens > 0
 
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_calculate_cost_response_only(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with response only."""
+    def test_token_counts_path_unknown_model_raises(self) -> None:
+        calculator = CostCalculator()
+        with pytest.raises(UnknownModelError, match="has no known pricing"):
+            calculator.calculate_cost(
+                model_name="unknown-pricing-model-x",
+                input_tokens=100,
+                output_tokens=50,
+            )
+
+    def test_prompt_response_path_known_model(self) -> None:
+        calculator = CostCalculator()
         result = calculator.calculate_cost(
-            response="Response text", model_name="gpt-4o-mini"
+            prompt="hello",
+            response="world",
+            model_name="gpt-4o-mini",
+        )
+        assert result.calculation_method == "prompt_and_response"
+        assert result.total_cost >= 0
+
+    def test_response_only_path_known_model(self) -> None:
+        calculator = CostCalculator()
+        result = calculator.calculate_cost(
+            response="world",
+            model_name="gpt-4o-mini",
         )
         assert result.calculation_method == "response_only"
-        assert result.output_cost >= 0.0
+        assert result.total_cost >= 0
 
-    def test_calculate_cost_with_zero_tokens(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with zero token counts enters token path."""
-        result = calculator.calculate_cost(
-            model_name="gpt-4o-mini", input_tokens=0, output_tokens=0
-        )
-        # Zero tokens now enters the token path (legitimate zero cost)
-        assert result.calculation_method == "token_counts"
-        assert result.input_tokens == 0
-        assert result.output_tokens == 0
-
-    def test_calculate_cost_exception_handling(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test cost calculation handles exceptions gracefully."""
-        # Mock safe calculation to raise an exception after mapping
-        with patch.object(
-            calculator_with_logger,
-            "_safe_calculate_prompt_cost",
-            side_effect=Exception("Test error"),
-        ):
-            result = calculator_with_logger.calculate_cost(
-                prompt="test", response="response", model_name="gpt-4o-mini"
-            )
-            # Should catch exception and log it
-            assert "error" in result.calculation_method.lower()
-
-
-class TestSafeCostCalculation:
-    """Tests for safe cost calculation wrapper methods."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    @pytest.fixture
-    def calculator_with_logger(self) -> CostCalculator:
-        """Create calculator with mock logger."""
-        return CostCalculator(logger=MagicMock())
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_safe_calculate_prompt_cost_success(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test safe prompt cost calculation with valid input."""
-        cost = calculator._safe_calculate_prompt_cost("Hello world", "gpt-4o-mini")
-        assert isinstance(cost, float)
-        assert cost >= 0.0
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_safe_calculate_completion_cost_success(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test safe completion cost calculation with valid input."""
-        cost = calculator._safe_calculate_completion_cost(
-            "Response text", "gpt-4o-mini"
-        )
-        assert isinstance(cost, float)
-        assert cost >= 0.0
-
-    def test_safe_calculate_prompt_cost_exception(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test safe prompt cost calculation handles exceptions."""
-        with patch(
-            "traigent.utils.cost_calculator.calculate_prompt_cost",
-            side_effect=Exception("Test error"),
-        ):
-            cost = calculator_with_logger._safe_calculate_prompt_cost(
-                "test", "invalid-model"
-            )
-            assert cost == 0.0
-            # Should log the error
-            assert calculator_with_logger.logger.debug.called
-
-    def test_safe_calculate_completion_cost_exception(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test safe completion cost calculation handles exceptions."""
-        with patch(
-            "traigent.utils.cost_calculator.calculate_completion_cost",
-            side_effect=Exception("Test error"),
-        ):
-            cost = calculator_with_logger._safe_calculate_completion_cost(
-                "test", "invalid-model"
-            )
-            assert cost == 0.0
-            # Should log the error
-            assert calculator_with_logger.logger.debug.called
-
-
-class TestCalculateFromTokens:
-    """Tests for token-based cost calculation."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    @pytest.fixture
-    def calculator_with_logger(self) -> CostCalculator:
-        """Create calculator with mock logger."""
-        return CostCalculator(logger=MagicMock())
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_calculate_from_tokens_direct_pricing(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test token-based calculation uses direct pricing when available."""
-        input_cost, output_cost = calculator_with_logger._calculate_from_tokens(
-            input_tokens=1000, output_tokens=500, model="gpt-4o-mini"
-        )
-        assert isinstance(input_cost, float)
-        assert isinstance(output_cost, float)
-        assert input_cost >= 0.0
-        assert output_cost >= 0.0
-
-    def test_calculate_from_tokens_raises_for_invalid_model(
-        self, calculator_with_logger: CostCalculator
-    ) -> None:
-        """Test token-based calculation raises for unknown model (budget safety)."""
-        from traigent.utils.cost_calculator import UnknownModelError
-
-        with (
-            patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", True),
-            patch("traigent.utils.cost_calculator.litellm.model_cost", {}),
-            pytest.raises(UnknownModelError),
-        ):
-            calculator_with_logger._calculate_from_tokens(
-                input_tokens=100, output_tokens=50, model="invalid-model"
-            )
-
-
-class TestUtilityMethods:
-    """Tests for utility methods."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_get_available_models(self, calculator: CostCalculator) -> None:
-        """Test getting list of available models."""
-        models = calculator.get_available_models()
-        assert isinstance(models, list)
-        assert len(models) > 0
-
-    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_get_available_models_litellm_unavailable(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test getting available models when litellm unavailable."""
-        models = calculator.get_available_models()
-        assert models == []
-
-    def test_clear_cache(self, calculator: CostCalculator) -> None:
-        """Test cache clearing."""
-        # Add something to cache
-        calculator._fuzzy_match_cache["test"] = "result"
-        assert len(calculator._fuzzy_match_cache) > 0
-        # Clear cache
-        calculator.clear_cache()
-        assert len(calculator._fuzzy_match_cache) == 0
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_validate_model_name_exact_match(self, calculator: CostCalculator) -> None:
-        """Test model name validation with exact match."""
-        result = calculator.validate_model_name("claude-3-haiku")
-        assert result["original"] == "claude-3-haiku"
-        assert result["mapped"] == "claude-3-haiku-20240307"
-        assert result["exact_match"] is True
-        assert result["fuzzy_match"] is False
-        assert result["family_match"] is False
-        assert result["not_found"] is False
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_validate_model_name_family_match(self, calculator: CostCalculator) -> None:
-        """Test model name validation with family match."""
-        result = calculator.validate_model_name("claude-3")
-        assert result["original"] == "claude-3"
-        assert result["mapped"] == "claude-3-5-sonnet-latest"
-        assert result["exact_match"] is False
-        assert result["family_match"] is True
-        assert result["not_found"] is False
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_validate_model_name_not_found(self, calculator: CostCalculator) -> None:
-        """Test model name validation with model not found."""
-        result = calculator.validate_model_name("nonexistent-model-xyz123")
-        assert result["original"] == "nonexistent-model-xyz123"
-        assert result["not_found"] is True
-
-    @patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False)
-    def test_validate_model_name_litellm_unavailable(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test model name validation when litellm unavailable."""
-        result = calculator.validate_model_name("gpt-4o")
-        assert result["available"] is False
-        assert "error" in result
-        assert "litellm library not available" in result["error"]
-
-
-class TestConvenienceFunctions:
-    """Tests for convenience functions."""
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_calculate_llm_cost_function(self) -> None:
-        """Test convenience function for cost calculation."""
-        result = calculate_llm_cost(
-            prompt="Hello", response="World", model_name="gpt-4o-mini"
-        )
-        assert isinstance(result, CostBreakdown)
-        assert result.model_used == "gpt-4o-mini"
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_validate_model_support_function(self) -> None:
-        """Test convenience function for model validation."""
-        result = validate_model_support("claude-3-haiku")
-        assert isinstance(result, dict)
-        assert result["original"] == "claude-3-haiku"
-
-    def test_get_cost_calculator_singleton(self) -> None:
-        """Test get_cost_calculator returns singleton instance."""
-        calc1 = get_cost_calculator()
-        calc2 = get_cost_calculator()
-        assert calc1 is calc2
-
-    def test_get_cost_calculator_with_logger(self) -> None:
-        """Test get_cost_calculator with custom logger."""
-        # Reset global calculator first
-        import traigent.utils.cost_calculator
-
-        traigent.utils.cost_calculator._global_calculator = None
-
-        mock_logger = MagicMock()
-        calc = get_cost_calculator(logger=mock_logger)
-        assert isinstance(calc, CostCalculator)
-
-    def test_get_model_pricing_per_1k_known_model(self) -> None:
-        """Model pricing convenience API returns per-1K input/output rates."""
-        input_rate, output_rate = get_model_pricing_per_1k("gpt-4o")
-        expected = ESTIMATION_MODEL_PRICING["gpt-4o"]
-        assert input_rate == pytest.approx(expected["input_cost_per_token"] * 1000)
-        assert output_rate == pytest.approx(expected["output_cost_per_token"] * 1000)
-
-    def test_get_model_pricing_per_1k_unknown_model_returns_zero(self) -> None:
-        """Unknown models return zero rates."""
-        input_rate, output_rate = get_model_pricing_per_1k("unknown-model-xyz-123")
-        assert input_rate == 0.0
-        assert output_rate == 0.0
-
-
-class TestEdgeCases:
-    """Tests for edge cases and boundary conditions."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_calculate_cost_empty_prompt(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with empty prompt."""
-        result = calculator.calculate_cost(
-            prompt="", response="response", model_name="gpt-4o-mini"
-        )
-        assert isinstance(result, CostBreakdown)
-
-    def test_calculate_cost_empty_response(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with empty response."""
-        result = calculator.calculate_cost(
-            prompt="prompt", response="", model_name="gpt-4o-mini"
-        )
-        assert isinstance(result, CostBreakdown)
-
-    def test_calculate_cost_message_list_prompt(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test cost calculation with message list as prompt."""
-        messages = [{"role": "user", "content": "Hello"}]
-        result = calculator.calculate_cost(
-            prompt=messages, response="Hi", model_name="gpt-4o-mini"
-        )
-        assert isinstance(result, CostBreakdown)
-
-    def test_calculate_cost_negative_tokens(self, calculator: CostCalculator) -> None:
-        """Test cost calculation clamps negative tokens to zero."""
-        result = calculator.calculate_cost(
-            model_name="gpt-4o-mini", input_tokens=-10, output_tokens=50
-        )
-        # Negative tokens are clamped to 0, positive tokens still priced
-        assert result.calculation_method == "token_counts"
-        assert result.input_tokens == 0
-        assert result.output_tokens == 50
-        assert result.output_cost > 0
-
-    def test_fuzzy_match_with_special_characters(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test fuzzy matching with special characters in model name."""
-        result = calculator._fuzzy_match_model("model@#$%")
-        # Should handle gracefully
-        assert result is None or isinstance(result, str)
-
-    def test_calculate_cost_very_long_prompt(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with very long prompt."""
-        long_prompt = "word " * 10000  # Very long prompt
-        result = calculator.calculate_cost(
-            prompt=long_prompt, response="response", model_name="gpt-4o-mini"
-        )
-        assert isinstance(result, CostBreakdown)
-
-    def test_calculate_cost_unicode_content(self, calculator: CostCalculator) -> None:
-        """Test cost calculation with Unicode characters."""
-        result = calculator.calculate_cost(
-            prompt="Hello 世界 🌍", response="Hi 你好 👋", model_name="gpt-4o-mini"
-        )
-        assert isinstance(result, CostBreakdown)
-
-
-class TestThreadSafety:
-    """Tests for thread safety of global calculator."""
-
-    def test_global_calculator_thread_safe(self) -> None:
-        """Test that get_cost_calculator is thread-safe."""
-        import threading
-
-        # Reset global calculator
-        import traigent.utils.cost_calculator
-
-        traigent.utils.cost_calculator._global_calculator = None
-
-        calculators = []
-
-        def get_calc() -> None:
-            calc = get_cost_calculator()
-            calculators.append(calc)
-
-        threads = [threading.Thread(target=get_calc) for _ in range(10)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        # All threads should get the same instance
-        assert len({id(c) for c in calculators}) == 1
-
-
-class TestAdditionalLoggerCoverage:
-    """Tests for additional logger code paths."""
-
-    def test_map_model_name_family_match_with_logger(self) -> None:
-        """Test family match logging is called when logger present."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        result = calculator._map_model_name("claude-3")
-        assert result == "claude-3-5-sonnet-latest"
-        # Should have called debug for family match
-        mock_logger.debug.assert_called()
-        assert "Family model mapping" in str(mock_logger.debug.call_args)
-
-    def test_fuzzy_match_cached_with_logger(self) -> None:
-        """Test cached fuzzy match logging when logger present."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        # Pre-populate cache
-        calculator._fuzzy_match_cache["test-model"] = "cached-result"
-        result = calculator._fuzzy_match_model("test-model")
-        assert result == "cached-result"
-        # Should log cache hit
-        mock_logger.debug.assert_called()
-        assert "Cached fuzzy match" in str(mock_logger.debug.call_args)
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_fuzzy_match_direct_litellm_with_logger(self) -> None:
-        """Test direct litellm match logging when logger present."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        # Use a model that should exist in litellm
-        result = calculator._fuzzy_match_model("gpt-4o-mini")
-        assert result == "gpt-4o-mini"
-        # Should log direct match
-        assert mock_logger.debug.called
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_perform_fuzzy_match_single_with_logger(self) -> None:
-        """Test single fuzzy match logging when logger present."""
-        mock_logger = MagicMock()
-        calculator = CostCalculator(logger=mock_logger)
-        # Mock to return exactly one match
-        with patch.object(calculator, "_is_semantic_match", return_value=True):
-            with patch(
-                "traigent.utils.cost_calculator.litellm.model_cost",
-                {"model-match": {}},
-            ):
-                result = calculator._perform_fuzzy_match("model")
-                assert result == "model-match"
-                # Should log info about single match
-                mock_logger.info.assert_called()
-
-    def test_calculate_from_tokens_raises_for_unknown_model(self) -> None:
-        """Test token calculation raises UnknownModelError for unknown models.
-
-        Budget-critical: returning 0.0 would silently break budget enforcement.
-        """
-        from traigent.utils.cost_calculator import UnknownModelError
-
-        calculator = CostCalculator(logger=MagicMock())
-        with pytest.raises(UnknownModelError):
-            calculator._calculate_from_tokens(
-                100, 50, "completely-unknown-model-xyz123"
-            )
-
-    @pytest.mark.skipif(not TOKENCOST_AVAILABLE, reason="litellm not available")
-    def test_validate_model_name_fuzzy_match_path(self) -> None:
-        """Test validate_model_name with fuzzy match result."""
+    def test_alias_needs_explicit_litellm_alias(self) -> None:
         calculator = CostCalculator()
-        # Use a model that will require fuzzy matching
-        with patch.object(
-            calculator, "_perform_fuzzy_match", return_value="gpt-4o-mini"
+        with pytest.raises(UnknownModelError, match="has no known pricing"):
+            calculator.calculate_cost(
+                model_name="short-alias-x",
+                input_tokens=100,
+                output_tokens=50,
+            )
+
+        with patch(
+            "traigent.utils.cost_calculator.litellm.model_alias_map",
+            {"short-alias-x": "gpt-4o"},
         ):
-            result = calculator.validate_model_name("gpt-4o")
-            assert result["mapped"] == "gpt-4o-mini"
-            assert result["fuzzy_match"] is True
+            result = calculator.calculate_cost(
+                model_name="short-alias-x",
+                input_tokens=100,
+                output_tokens=50,
+            )
+            assert result.total_cost > 0
 
 
-class TestSemanticMatchingEdgeCases:
-    """Tests for additional semantic matching edge cases."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_is_semantic_match_gpt_in_user_not_in_litellm(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match rejects when gpt in user but not in litellm."""
-        result = calculator._is_semantic_match("gpt-custom", "custom-model-xyz")
-        assert result is False
-
-    def test_is_semantic_match_claude_in_user_not_in_litellm(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match rejects when claude in user but not in litellm."""
-        result = calculator._is_semantic_match("claude-custom", "custom-model-xyz")
-        assert result is False
-
-    def test_is_semantic_match_gpt4_versus_gpt3_litellm(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match rejects gpt-4 user with gpt-3 litellm."""
-        result = calculator._is_semantic_match("gpt-4-new", "gpt-3.5-turbo-new")
-        assert result is False
-
-    def test_is_semantic_match_gpt3_versus_gpt4_litellm(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match rejects gpt-3 user with gpt-4 litellm."""
-        result = calculator._is_semantic_match("gpt-3.5-custom", "gpt-4-turbo-custom")
-        assert result is False
-
-    def test_is_semantic_match_claude3_versus_claude2_litellm(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test semantic match rejects claude-3 user with claude-2 litellm."""
-        result = calculator._is_semantic_match("claude-3-new", "claude-2.1-new")
-        assert result is False
-
-
-class TestExactModelMappings:
-    """Tests for additional exact model mappings."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_map_model_name_claude_opus(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for Claude Opus."""
-        assert calculator._map_model_name("claude-3-opus") == "claude-3-opus-20240229"
-
-    def test_map_model_name_claude_3_5_haiku(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for Claude 3.5 Haiku."""
-        assert (
-            calculator._map_model_name("claude-3-5-haiku")
-            == "claude-3-5-haiku-20241022"
-        )
-
-    def test_map_model_name_claude_3_7_sonnet(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for Claude 3.7 Sonnet."""
-        assert (
-            calculator._map_model_name("claude-3-7-sonnet")
-            == "claude-3-7-sonnet-20250219"
-        )
-
-    def test_map_model_name_claude_4_sonnet(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for Claude 4 Sonnet."""
-        assert (
-            calculator._map_model_name("claude-4-sonnet") == "claude-sonnet-4-20250514"
-        )
-
-    def test_map_model_name_claude_4_opus(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for Claude 4 Opus."""
-        assert calculator._map_model_name("claude-4-opus") == "claude-opus-4-20250514"
-
-    def test_map_model_name_gpt4o_mini(self, calculator: CostCalculator) -> None:
-        """Test exact mapping for GPT-4o mini."""
-        assert calculator._map_model_name("gpt-4o-mini") == "gpt-4o-mini"
-
-    def test_map_model_name_alternative_spellings(
-        self, calculator: CostCalculator
-    ) -> None:
-        """Test alternative spellings without dashes."""
-        assert calculator._map_model_name("claude3-haiku") == "claude-3-haiku-20240307"
-        assert (
-            calculator._map_model_name("claude3-sonnet") == "claude-3-sonnet-20240229"
-        )
-        assert calculator._map_model_name("claude3-opus") == "claude-3-opus-20240229"
-
-    def test_map_model_name_latest_versions(self, calculator: CostCalculator) -> None:
-        """Test mapping for latest version shortcuts."""
-        assert calculator._map_model_name("claude-haiku") == "claude-3-haiku-20240307"
-        assert (
-            calculator._map_model_name("claude-sonnet")
-            == "claude-3-5-sonnet-20241022"
-        )
-        assert calculator._map_model_name("claude-opus") == "claude-3-opus-20240229"
-
-    def test_map_model_name_gpt_aliases(self, calculator: CostCalculator) -> None:
-        """Test GPT model aliases."""
-        assert calculator._map_model_name("gpt4") == "gpt-4o"
-        assert calculator._map_model_name("gpt3.5") == "gpt-3.5-turbo"
-
-
-class TestFamilyDefaults:
-    """Tests for family default mappings."""
-
-    @pytest.fixture
-    def calculator(self) -> CostCalculator:
-        """Create test calculator instance."""
-        return CostCalculator()
-
-    def test_family_defaults_claude(self, calculator: CostCalculator) -> None:
-        """Test family default for generic 'claude'."""
-        assert calculator._map_model_name("claude") == "claude-3-5-sonnet-latest"
-
-    def test_family_defaults_gpt(self, calculator: CostCalculator) -> None:
-        """Test family default for generic 'gpt'."""
-        assert calculator._map_model_name("gpt") == "gpt-4o"
-
-    def test_family_defaults_gpt_3_5(self, calculator: CostCalculator) -> None:
-        """Test family default for 'gpt-3.5'."""
-        assert calculator._map_model_name("gpt-3.5") == "gpt-3.5-turbo"
-
-
-class TestCustomPricingOverrides:
-    """Tests for explicit custom pricing configuration."""
-
+class TestCustomPricingAndValidation:
     @pytest.fixture(autouse=True)
-    def reset_cache(self):
+    def reset_custom_cache(self):
         old_cache = cc._CUSTOM_PRICING_CACHE
-        old_cache_key = cc._CUSTOM_PRICING_CACHE_KEY
+        old_key = cc._CUSTOM_PRICING_CACHE_KEY
         cc._CUSTOM_PRICING_CACHE = None
         cc._CUSTOM_PRICING_CACHE_KEY = None
         try:
             yield
         finally:
             cc._CUSTOM_PRICING_CACHE = old_cache
-            cc._CUSTOM_PRICING_CACHE_KEY = old_cache_key
+            cc._CUSTOM_PRICING_CACHE_KEY = old_key
 
-    def test_json_env_pricing_is_loaded(self, monkeypatch) -> None:
+    def test_calculate_cost_uses_custom_pricing_json(self, monkeypatch) -> None:
         monkeypatch.setenv(
             "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
-            '{"x-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}',
+            json.dumps(
+                {
+                    "my-private-model": {
+                        "input_cost_per_token": 1e-6,
+                        "output_cost_per_token": 2e-6,
+                    }
+                }
+            ),
         )
         monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
-        assert cc._try_custom_model_pricing("x-model") == (1e-6, 2e-6)
-
-    def test_file_env_pricing_is_loaded(self, monkeypatch, tmp_path) -> None:
-        path = tmp_path / "pricing.json"
-        path.write_text(
-            '{"y-model":{"input_cost_per_token":3e-6,"output_cost_per_token":4e-6}}',
-            encoding="utf-8",
+        calculator = CostCalculator()
+        result = calculator.calculate_cost(
+            model_name="my-private-model",
+            input_tokens=100,
+            output_tokens=50,
         )
-        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", str(path))
-        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
-        assert cc._try_custom_model_pricing("y-model") == (3e-6, 4e-6)
+        assert result.input_cost == pytest.approx(100 * 1e-6)
+        assert result.output_cost == pytest.approx(50 * 2e-6)
 
-    def test_invalid_json_raises(self, monkeypatch) -> None:
-        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", "{bad-json")
-        with pytest.raises(ValueError, match="invalid JSON"):
-            cc._get_custom_pricing_index()
+    def test_validate_model_name_known(self) -> None:
+        calculator = CostCalculator()
+        result = calculator.validate_model_name("gpt-4o")
+        assert result["known_to_litellm"] is True
+        assert result["not_found"] is False
 
-    def test_invalid_file_path_raises(self, monkeypatch) -> None:
-        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", "/missing/pricing.json")
-        with pytest.raises(ValueError, match="Failed to parse custom pricing file"):
-            cc._get_custom_pricing_index()
+    def test_validate_model_name_custom(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            '{"foo-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}',
+        )
+        calculator = CostCalculator()
+        result = calculator.validate_model_name("foo-model")
+        assert result["custom_pricing"] is True
+        assert result["not_found"] is False
+
+    def test_validate_model_name_unknown(self) -> None:
+        calculator = CostCalculator()
+        result = calculator.validate_model_name("missing-model-zzz")
+        assert result["not_found"] is True
+
+    def test_clear_cache_resets_custom_pricing_cache(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            '{"foo-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}',
+        )
+        calculator = CostCalculator()
+        assert cc._CUSTOM_PRICING_CACHE is None
+        calculator.validate_model_name("foo-model")
+        assert cc._CUSTOM_PRICING_CACHE is not None
+        calculator.clear_cache()
+        assert cc._CUSTOM_PRICING_CACHE is None
+        assert cc._CUSTOM_PRICING_CACHE_KEY is None
+
+
+class TestConvenienceFunctions:
+    def test_calculate_llm_cost_wrapper(self) -> None:
+        result = calculate_llm_cost(
+            model_name="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        assert result.total_cost > 0
+
+    def test_validate_model_support_wrapper(self) -> None:
+        result = validate_model_support("gpt-4o")
+        assert result["known_to_litellm"] is True
+
+    def test_get_cost_calculator_returns_singleton(self) -> None:
+        c1 = get_cost_calculator()
+        c2 = get_cost_calculator()
+        assert c1 is c2
+
+    def test_get_model_pricing_per_1k_known_model(self) -> None:
+        input_per_1k, output_per_1k = get_model_pricing_per_1k("gpt-4o")
+        assert input_per_1k > 0
+        assert output_per_1k > 0
+
+    def test_get_model_pricing_per_1k_unknown_model_returns_zero(self) -> None:
+        input_per_1k, output_per_1k = get_model_pricing_per_1k("unknown-model-xyz")
+        assert input_per_1k == 0.0
+        assert output_per_1k == 0.0

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import traigent.utils.cost_calculator as cc
 from traigent.utils.cost_calculator import (
     ESTIMATION_MODEL_PRICING,
     TOKENCOST_AVAILABLE,
@@ -1000,3 +1001,56 @@ class TestFamilyDefaults:
     def test_family_defaults_gpt_3_5(self, calculator: CostCalculator) -> None:
         """Test family default for 'gpt-3.5'."""
         assert calculator._map_model_name("gpt-3.5") == "gpt-3.5-turbo"
+
+
+class TestOpenRouterPricingFallback:
+    """Tests for OpenRouter pricing cache and offline behavior."""
+
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        old_cache = cc._OPENROUTER_MODEL_INDEX_CACHE
+        cc._OPENROUTER_MODEL_INDEX_CACHE = None
+        try:
+            yield
+        finally:
+            cc._OPENROUTER_MODEL_INDEX_CACHE = old_cache
+
+    def test_try_openrouter_pricing_skips_when_offline(self, monkeypatch) -> None:
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
+        assert cc._try_openrouter_pricing("any-model") is None
+
+    def test_try_openrouter_pricing_uses_cache(self, monkeypatch) -> None:
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        cc._OPENROUTER_MODEL_INDEX_CACHE = {"a/model": (1e-6, 2e-6)}
+        assert cc._try_openrouter_pricing("a/model") == (1e-6, 2e-6)
+
+    def test_try_openrouter_pricing_fetch_failure_returns_none(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        cc._OPENROUTER_MODEL_INDEX_CACHE = None
+        with patch.object(cc, "_fetch_openrouter_models", side_effect=RuntimeError):
+            assert cc._try_openrouter_pricing("unknown-model") is None
+            # Failure should cache an empty dict to avoid repeated retries.
+            assert cc._OPENROUTER_MODEL_INDEX_CACHE == {}
+
+    def test_fetch_openrouter_models_parses_payload(self) -> None:
+        payload = {
+            "data": [
+                {
+                    "id": "anthropic/claude-sonnet-4.6",
+                    "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+                }
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.read.return_value = str(payload).replace("'", '"').encode("utf-8")
+        mock_context = MagicMock()
+        mock_context.__enter__.return_value = mock_response
+        mock_context.__exit__.return_value = None
+
+        with patch.object(cc, "urlopen", return_value=mock_context):
+            parsed = cc._fetch_openrouter_models()
+
+        assert parsed["anthropic/claude-sonnet-4.6"] == (3e-6, 15e-6)
+        assert parsed["claude-sonnet-4.6"] == (3e-6, 15e-6)

--- a/tests/unit/utils/test_cost_calculator_pricing.py
+++ b/tests/unit/utils/test_cost_calculator_pricing.py
@@ -1,190 +1,50 @@
-"""Tests for model tier classification and pricing lookup (cost_calculator.py).
-
-Tests the get_model_token_pricing() function and _classify_model_tier() helper
-added for Phase 4 model-aware cost estimation.
-"""
+"""Tests for strict model pricing lookup in cost_calculator.py."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import json
 
 import pytest
 
-from traigent.utils.cost_calculator import (
-    _TIER_CHEAP,
-    _TIER_EXPENSIVE,
-    _TIER_MID,
-    _classify_model_tier,
-    get_model_token_pricing,
-)
-
-# ---------------------------------------------------------------------------
-# _classify_model_tier
-# ---------------------------------------------------------------------------
-
-
-class TestClassifyModelTier:
-    """Tier classification with ordered regex matching."""
-
-    @pytest.mark.parametrize(
-        "model,expected_tier",
-        [
-            # GPT-4 family — ordering is critical
-            ("gpt-4o-mini", "cheap"),
-            ("gpt-4-mini", "cheap"),
-            ("gpt-4-turbo", "expensive"),
-            ("gpt-4-turbo-2024-04-09", "expensive"),
-            ("gpt-4o", "mid"),
-            ("gpt-4o-2024-08-06", "mid"),
-            ("gpt-4", "expensive"),
-            ("gpt-4-0613", "expensive"),
-            ("gpt-3.5-turbo", "cheap"),
-            ("gpt-3.5-turbo-0125", "cheap"),
-            # Anthropic models
-            ("claude-3-opus-20240229", "expensive"),
-            ("claude-opus-4-20250514", "expensive"),
-            ("claude-3-5-sonnet-20241022", "mid"),
-            ("claude-sonnet-4-20250514", "mid"),
-            ("claude-3-haiku-20240307", "cheap"),
-            ("claude-3-5-haiku-20241022", "cheap"),
-            # Generic patterns
-            ("gemini-1.5-flash", "cheap"),
-            ("gemini-2.0-flash", "cheap"),
-            ("gemini-1.5-pro", "mid"),
-            ("deepseek-chat-mini", "cheap"),
-            ("some-nano-model", "cheap"),
-            # Default (unknown)
-            ("totally-unknown-model-xyz", "mid"),
-        ],
-    )
-    def test_tier_classification(self, model: str, expected_tier: str) -> None:
-        assert _classify_model_tier(model) == expected_tier
-
-    def test_regex_ordering_lock_in_gpt4o_mini_before_gpt4o(self) -> None:
-        """gpt-4o-mini must be CHEAP, not MID (\\b treats - as boundary).
-
-        This test locks the ordering so future refactors can't silently
-        reorder rules and break classification.
-        """
-        assert _classify_model_tier("gpt-4o-mini") == "cheap"
-        assert _classify_model_tier("gpt-4o") == "mid"
-        # Verify they differ
-        assert _classify_model_tier("gpt-4o-mini") != _classify_model_tier("gpt-4o")
-
-    def test_gpt4_stays_expensive_not_downgraded(self) -> None:
-        """gpt-4 must classify as EXPENSIVE, not MID.
-
-        EXACT_MODEL_MAPPING maps gpt-4 -> gpt-4o in runtime cost calculation,
-        which would downgrade it. Tier classification intentionally skips
-        EXACT_MODEL_MAPPING for conservative pre-estimation.
-        """
-        assert _classify_model_tier("gpt-4") == "expensive"
-
-    def test_case_insensitive(self) -> None:
-        assert _classify_model_tier("GPT-4-TURBO") == "expensive"
-        assert _classify_model_tier("Claude-3-Opus") == "expensive"
-
-
-# ---------------------------------------------------------------------------
-# get_model_token_pricing
-# ---------------------------------------------------------------------------
+import traigent.utils.cost_calculator as cc
+from traigent.utils.cost_calculator import UnknownModelError, get_model_token_pricing
 
 
 class TestGetModelTokenPricing:
-    def test_returns_three_tuple(self) -> None:
-        """Return type is (input, output, method) with positive costs."""
+    def test_returns_three_tuple_for_known_model(self) -> None:
         inp, out, method = get_model_token_pricing("gpt-4o")
         assert inp > 0
         assert out > 0
-        assert isinstance(method, str)
+        assert method == "litellm"
 
-    def test_heuristic_fallback_for_unknown_model(self) -> None:
-        """Completely unknown model → heuristic mid-tier."""
-        inp, out, method = get_model_token_pricing("totally-unknown-model-abc")
-        assert method == "heuristic:mid"
-        assert inp == pytest.approx(_TIER_MID["input"])
-        assert out == pytest.approx(_TIER_MID["output"])
+    def test_provider_prefixed_model_resolves(self) -> None:
+        prefixed = get_model_token_pricing("openai/gpt-4o")
+        plain = get_model_token_pricing("gpt-4o")
+        assert prefixed[0] == pytest.approx(plain[0], rel=1e-6)
+        assert prefixed[1] == pytest.approx(plain[1], rel=1e-6)
+        assert prefixed[2] == "litellm"
 
-    def test_litellm_zero_falls_through(self) -> None:
-        """When litellm returns (0, 0), should NOT treat as free."""
-        import traigent.utils.cost_calculator as _mod
+    def test_unknown_model_raises_with_actionable_message(self) -> None:
+        with pytest.raises(UnknownModelError, match="has no known pricing"):
+            get_model_token_pricing("totally-unknown-model-abc")
 
-        mock_litellm = MagicMock()
-        mock_litellm.cost_per_token.return_value = (0.0, 0.0)
-        with (
-            patch.object(_mod, "_is_model_known_to_litellm", return_value=True),
-            patch.object(_mod, "litellm", mock_litellm),
-        ):
-            inp, out, method = get_model_token_pricing("free-model-test")
-            # Should NOT return litellm method — should fall through
-            assert method != "litellm"
-            assert inp > 0 or out > 0  # Non-zero from fallback/heuristic
-
-    def test_litellm_positive_is_used(self) -> None:
-        """When litellm returns positive pricing, use it."""
-        import traigent.utils.cost_calculator as _mod
-
-        mock_litellm = MagicMock()
-        mock_litellm.cost_per_token.return_value = (5e-6, 15e-6)
-        with (
-            patch.object(_mod, "_is_model_known_to_litellm", return_value=True),
-            patch.object(_mod, "litellm", mock_litellm),
-        ):
-            inp, out, method = get_model_token_pricing("test-model")
-            assert method == "litellm"
-            assert inp == pytest.approx(5e-6)
-            assert out == pytest.approx(15e-6)
-
-    def test_litellm_exception_falls_through(self) -> None:
-        """When litellm throws, falls through to fallback/heuristic."""
-        import traigent.utils.cost_calculator as _mod
-
-        mock_litellm = MagicMock()
-        mock_litellm.cost_per_token.side_effect = RuntimeError("boom")
-        with (
-            patch.object(_mod, "_is_model_known_to_litellm", return_value=True),
-            patch.object(_mod, "litellm", mock_litellm),
-        ):
-            inp, out, method = get_model_token_pricing("test-model")
-            assert method != "litellm"
-
-    def test_fallback_dict_match(self) -> None:
-        """Model in ESTIMATION_MODEL_PRICING → uses fallback_dict method."""
-        # gpt-4-turbo is in ESTIMATION_MODEL_PRICING
-        # Disable litellm to force fallback path
-        with patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", False):
-            inp, out, method = get_model_token_pricing("gpt-4-turbo")
-            assert method == "fallback_dict"
-            assert inp > 0
-            assert out > 0
-
-    def test_expensive_tier_pricing_values(self) -> None:
-        assert _TIER_EXPENSIVE["input"] == pytest.approx(10.0e-6)
-        assert _TIER_EXPENSIVE["output"] == pytest.approx(30.0e-6)
-
-    def test_mid_tier_pricing_values(self) -> None:
-        assert _TIER_MID["input"] == pytest.approx(3.0e-6)
-        assert _TIER_MID["output"] == pytest.approx(15.0e-6)
-
-    def test_cheap_tier_pricing_values(self) -> None:
-        assert _TIER_CHEAP["input"] == pytest.approx(0.25e-6)
-        assert _TIER_CHEAP["output"] == pytest.approx(1.25e-6)
-
-
-# ---------------------------------------------------------------------------
-# _fallback_cost_from_tokens _quiet parameter
-# ---------------------------------------------------------------------------
-
-
-class TestFallbackQuietParameter:
-    def test_quiet_does_not_raise(self) -> None:
-        """_quiet=True should not change return values."""
-        from traigent.utils.cost_calculator import _fallback_cost_from_tokens
-
-        # Known model in fallback dict
-        cost_normal = _fallback_cost_from_tokens("gpt-4o-quiet-test-1", 100, 50)
-        cost_quiet = _fallback_cost_from_tokens(
-            "gpt-4o-quiet-test-2", 100, 50, _quiet=True
+    def test_custom_pricing_json_override(self, monkeypatch) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            json.dumps(
+                {
+                    "custom-estimator-model": {
+                        "input_cost_per_token": 8e-6,
+                        "output_cost_per_token": 9e-6,
+                    }
+                }
+            ),
         )
-        # Both should return the same values (same pricing, different model keys for warn-once)
-        assert cost_normal == cost_quiet
+        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
+        cc._CUSTOM_PRICING_CACHE = None
+        cc._CUSTOM_PRICING_CACHE_KEY = None
+
+        inp, out, method = get_model_token_pricing("custom-estimator-model")
+        assert inp == pytest.approx(8e-6)
+        assert out == pytest.approx(9e-6)
+        assert method == "custom_pricing"

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -18,11 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from traigent.utils.cost_calculator import (
-    CostCalculator,
-    UnknownModelError,
-    cost_from_tokens,
-)
+from traigent.utils.cost_calculator import UnknownModelError, cost_from_tokens
 
 
 class TestCostFromTokensKnownModels:
@@ -67,7 +63,7 @@ class TestCostFromTokensKnownModels:
 
 
 class TestCostFromTokensModelResolution:
-    """Tests for model name resolution (EXACT_MODEL_MAPPING + normalization)."""
+    """Tests for model name resolution (litellm aliases + normalization)."""
 
     def test_provider_prefixed_model(self) -> None:
         """Provider-prefixed model resolves correctly."""
@@ -77,8 +73,8 @@ class TestCostFromTokensModelResolution:
         assert cost_prefixed[0] == pytest.approx(cost_plain[0], rel=1e-6)
         assert cost_prefixed[1] == pytest.approx(cost_plain[1], rel=1e-6)
 
-    def test_exact_model_mapping(self) -> None:
-        """Short model names resolve via EXACT_MODEL_MAPPING."""
+    def test_convenience_alias_resolution(self) -> None:
+        """Short model names resolve through litellm alias registration."""
         # "claude-3-haiku" maps to "claude-3-haiku-20240307"
         input_cost, output_cost = cost_from_tokens(100, 50, "claude-3-haiku")
         assert (
@@ -117,9 +113,17 @@ class TestCostFromTokensModelResolution:
 class TestCostFromTokensUnknownModels:
     """Tests for unknown models (strict vs non-strict)."""
 
+    @pytest.fixture(autouse=True)
+    def disable_openrouter_lookup(self) -> None:
+        """Keep unknown-model tests deterministic (no external network lookup)."""
+        with patch(
+            "traigent.utils.cost_calculator._try_openrouter_pricing", return_value=None
+        ):
+            yield
+
     def test_unknown_model_strict_raises(self) -> None:
         """Unknown model with strict=True raises UnknownModelError."""
-        with pytest.raises(UnknownModelError, match="no pricing in litellm"):
+        with pytest.raises(UnknownModelError, match="no pricing in litellm/OpenRouter"):
             cost_from_tokens(100, 50, "totally-nonexistent-model-xyz")
 
     def test_unknown_model_nonstrict_returns_zero(self) -> None:
@@ -227,3 +231,26 @@ class TestCostFromTokensEdgeCases:
             input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o")
             assert input_cost == pytest.approx(100 * 2.5e-6)
             assert output_cost == pytest.approx(50 * 10.0e-6)
+
+
+class TestCostFromTokensOpenRouterFallback:
+    """Tests for OpenRouter fallback resolution."""
+
+    def test_unknown_model_uses_openrouter_before_raising(self) -> None:
+        with patch(
+            "traigent.utils.cost_calculator._try_openrouter_pricing",
+            return_value=(3.0e-6, 15.0e-6),
+        ):
+            input_cost, output_cost = cost_from_tokens(100, 50, "brand-new-model")
+            assert input_cost == pytest.approx(100 * 3.0e-6)
+            assert output_cost == pytest.approx(50 * 15.0e-6)
+
+    def test_known_model_does_not_call_openrouter(self) -> None:
+        with patch(
+            "traigent.utils.cost_calculator._try_openrouter_pricing",
+            return_value=(3.0e-6, 15.0e-6),
+        ) as openrouter_mock:
+            input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o")
+            assert input_cost > 0
+            assert output_cost > 0
+            openrouter_mock.assert_not_called()

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -13,7 +13,9 @@ Tests validate:
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -63,7 +65,7 @@ class TestCostFromTokensKnownModels:
 
 
 class TestCostFromTokensModelResolution:
-    """Tests for model name resolution (litellm aliases + normalization)."""
+    """Tests for model name resolution (normalization + explicit aliases)."""
 
     def test_provider_prefixed_model(self) -> None:
         """Provider-prefixed model resolves correctly."""
@@ -73,39 +75,23 @@ class TestCostFromTokensModelResolution:
         assert cost_prefixed[0] == pytest.approx(cost_plain[0], rel=1e-6)
         assert cost_prefixed[1] == pytest.approx(cost_plain[1], rel=1e-6)
 
-    def test_convenience_alias_resolution(self) -> None:
-        """Short model names resolve through litellm alias registration."""
-        # "claude-3-haiku" maps to "claude-3-haiku-20240307"
-        input_cost, output_cost = cost_from_tokens(100, 50, "claude-3-haiku")
-        assert (
-            input_cost > 0 or output_cost > 0
-        ), "Mapped model should produce positive cost"
+    def test_alias_requires_explicit_litellm_alias_map(self) -> None:
+        """Alias names should only work when user/config registers an alias."""
+        with pytest.raises(UnknownModelError, match="has no known pricing"):
+            cost_from_tokens(100, 50, "custom-short-name")
 
-    def test_claude_haiku_alias_maps_to_priced_model(self) -> None:
-        """Legacy alias claude-haiku resolves to priced dated model."""
-        alias_cost = cost_from_tokens(100, 50, "claude-haiku")
-        dated_cost = cost_from_tokens(100, 50, "claude-3-haiku-20240307")
-        assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
-        assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
-
-    def test_claude_sonnet_alias_maps_to_priced_model(self) -> None:
-        """Legacy alias claude-sonnet resolves to priced dated model."""
-        alias_cost = cost_from_tokens(100, 50, "claude-sonnet")
-        dated_cost = cost_from_tokens(100, 50, "claude-3-5-sonnet-20241022")
-        assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
-        assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
-
-    def test_claude_opus_alias_maps_to_priced_model(self) -> None:
-        """Legacy alias claude-opus resolves to priced dated model."""
-        alias_cost = cost_from_tokens(100, 50, "claude-opus")
-        dated_cost = cost_from_tokens(100, 50, "claude-3-opus-20240229")
-        assert alias_cost[0] == pytest.approx(dated_cost[0], rel=1e-6)
-        assert alias_cost[1] == pytest.approx(dated_cost[1], rel=1e-6)
+        with patch(
+            "traigent.utils.cost_calculator.litellm.model_alias_map",
+            {"custom-short-name": "gpt-4o"},
+        ):
+            input_cost, output_cost = cost_from_tokens(100, 50, "custom-short-name")
+            assert input_cost > 0
+            assert output_cost > 0
 
     def test_colon_prefixed_model(self) -> None:
         """Colon-prefixed provider model resolves."""
-        cost_prefixed = cost_from_tokens(100, 50, "anthropic:claude-3-haiku")
-        cost_plain = cost_from_tokens(100, 50, "claude-3-haiku")
+        cost_prefixed = cost_from_tokens(100, 50, "anthropic:claude-3-haiku-20240307")
+        cost_plain = cost_from_tokens(100, 50, "claude-3-haiku-20240307")
         assert cost_prefixed[0] == pytest.approx(cost_plain[0], rel=1e-6)
         assert cost_prefixed[1] == pytest.approx(cost_plain[1], rel=1e-6)
 
@@ -113,17 +99,9 @@ class TestCostFromTokensModelResolution:
 class TestCostFromTokensUnknownModels:
     """Tests for unknown models (strict vs non-strict)."""
 
-    @pytest.fixture(autouse=True)
-    def disable_openrouter_lookup(self) -> None:
-        """Keep unknown-model tests deterministic (no external network lookup)."""
-        with patch(
-            "traigent.utils.cost_calculator._try_openrouter_pricing", return_value=None
-        ):
-            yield
-
     def test_unknown_model_strict_raises(self) -> None:
         """Unknown model with strict=True raises UnknownModelError."""
-        with pytest.raises(UnknownModelError, match="no pricing in litellm/OpenRouter"):
+        with pytest.raises(UnknownModelError, match="has no known pricing"):
             cost_from_tokens(100, 50, "totally-nonexistent-model-xyz")
 
     def test_unknown_model_nonstrict_returns_zero(self) -> None:
@@ -233,24 +211,39 @@ class TestCostFromTokensEdgeCases:
             assert output_cost == pytest.approx(50 * 10.0e-6)
 
 
-class TestCostFromTokensOpenRouterFallback:
-    """Tests for OpenRouter fallback resolution."""
+class TestCostFromTokensCustomPricing:
+    """Tests for explicit custom pricing overrides."""
 
-    def test_unknown_model_uses_openrouter_before_raising(self) -> None:
+    def test_unknown_model_uses_custom_pricing_json(self, monkeypatch) -> None:
+        pricing = {
+            "brand-new-model": {
+                "input_cost_per_token": 3.0e-6,
+                "output_cost_per_token": 15.0e-6,
+            }
+        }
+        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", json.dumps(pricing))
+        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
         with patch(
-            "traigent.utils.cost_calculator._try_openrouter_pricing",
-            return_value=(3.0e-6, 15.0e-6),
-        ):
+            "traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE", None
+        ), patch("traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE_KEY", None):
             input_cost, output_cost = cost_from_tokens(100, 50, "brand-new-model")
             assert input_cost == pytest.approx(100 * 3.0e-6)
             assert output_cost == pytest.approx(50 * 15.0e-6)
 
-    def test_known_model_does_not_call_openrouter(self) -> None:
+    def test_unknown_model_uses_custom_pricing_file(self, monkeypatch, tmp_path) -> None:
+        payload = {
+            "file-model": {
+                "input_cost_per_token": 1.0e-6,
+                "output_cost_per_token": 2.0e-6,
+            }
+        }
+        file_path = Path(tmp_path) / "pricing.json"
+        file_path.write_text(json.dumps(payload), encoding="utf-8")
+        monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", str(file_path))
+        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
         with patch(
-            "traigent.utils.cost_calculator._try_openrouter_pricing",
-            return_value=(3.0e-6, 15.0e-6),
-        ) as openrouter_mock:
-            input_cost, output_cost = cost_from_tokens(100, 50, "gpt-4o")
-            assert input_cost > 0
-            assert output_cost > 0
-            openrouter_mock.assert_not_called()
+            "traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE", None
+        ), patch("traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE_KEY", None):
+            input_cost, output_cost = cost_from_tokens(100, 50, "file-model")
+            assert input_cost == pytest.approx(100 * 1.0e-6)
+            assert output_cost == pytest.approx(50 * 2.0e-6)

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import traigent.utils.cost_calculator as cc
 from traigent.utils.cost_calculator import UnknownModelError, cost_from_tokens
 
 
@@ -62,6 +63,14 @@ class TestCostFromTokensKnownModels:
         cost_mini_in, cost_mini_out = cost_from_tokens(1000, 1000, "gpt-4o-mini")
         assert cost_4o_in > cost_mini_in, "gpt-4o should cost more than gpt-4o-mini"
         assert cost_4o_out > cost_mini_out, "gpt-4o should cost more than gpt-4o-mini"
+
+    def test_anthropic_model_known(self) -> None:
+        """Anthropic dated model IDs resolve through canonical litellm path."""
+        input_cost, output_cost = cost_from_tokens(
+            100, 50, "claude-3-haiku-20240307"
+        )
+        assert input_cost > 0
+        assert output_cost > 0
 
 
 class TestCostFromTokensModelResolution:
@@ -214,6 +223,18 @@ class TestCostFromTokensEdgeCases:
 class TestCostFromTokensCustomPricing:
     """Tests for explicit custom pricing overrides."""
 
+    @pytest.fixture(autouse=True)
+    def reset_custom_pricing_cache(self):
+        old_cache = cc._CUSTOM_PRICING_CACHE
+        old_cache_key = cc._CUSTOM_PRICING_CACHE_KEY
+        cc._CUSTOM_PRICING_CACHE = None
+        cc._CUSTOM_PRICING_CACHE_KEY = None
+        try:
+            yield
+        finally:
+            cc._CUSTOM_PRICING_CACHE = old_cache
+            cc._CUSTOM_PRICING_CACHE_KEY = old_cache_key
+
     def test_unknown_model_uses_custom_pricing_json(self, monkeypatch) -> None:
         pricing = {
             "brand-new-model": {
@@ -223,12 +244,9 @@ class TestCostFromTokensCustomPricing:
         }
         monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", json.dumps(pricing))
         monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
-        with patch(
-            "traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE", None
-        ), patch("traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE_KEY", None):
-            input_cost, output_cost = cost_from_tokens(100, 50, "brand-new-model")
-            assert input_cost == pytest.approx(100 * 3.0e-6)
-            assert output_cost == pytest.approx(50 * 15.0e-6)
+        input_cost, output_cost = cost_from_tokens(100, 50, "brand-new-model")
+        assert input_cost == pytest.approx(100 * 3.0e-6)
+        assert output_cost == pytest.approx(50 * 15.0e-6)
 
     def test_unknown_model_uses_custom_pricing_file(self, monkeypatch, tmp_path) -> None:
         payload = {
@@ -241,9 +259,6 @@ class TestCostFromTokensCustomPricing:
         file_path.write_text(json.dumps(payload), encoding="utf-8")
         monkeypatch.setenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", str(file_path))
         monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
-        with patch(
-            "traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE", None
-        ), patch("traigent.utils.cost_calculator._CUSTOM_PRICING_CACHE_KEY", None):
-            input_cost, output_cost = cost_from_tokens(100, 50, "file-model")
-            assert input_cost == pytest.approx(100 * 1.0e-6)
-            assert output_cost == pytest.approx(50 * 2.0e-6)
+        input_cost, output_cost = cost_from_tokens(100, 50, "file-model")
+        assert input_cost == pytest.approx(100 * 1.0e-6)
+        assert output_cost == pytest.approx(50 * 2.0e-6)

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -119,7 +119,8 @@ def _emit_cost_warning_once() -> None:
             f"Cost estimates are approximations based on {CYAN}litellm{RESET} library pricing.\n"
             f"Actual billing is determined by your LLM provider.\n\n"
             f"{BOLD}Configuration:{RESET}\n"
-            f"  - Convenience aliases:   {CYAN}litellm.model_alias_map{RESET} (via cost_calculator)\n"
+            f"  - Custom pricing file:   {CYAN}TRAIGENT_CUSTOM_MODEL_PRICING_FILE{RESET}\n"
+            f"  - Custom pricing JSON:   {CYAN}TRAIGENT_CUSTOM_MODEL_PRICING_JSON{RESET}\n"
             f"  - Disable for testing:   {CYAN}TRAIGENT_MOCK_LLM=true{RESET}\n"
             f"  - Full details:          {CYAN}DISCLAIMER.md{RESET}\n"
         )
@@ -130,7 +131,8 @@ def _emit_cost_warning_once() -> None:
             "Cost estimates are approximations based on litellm library pricing.\n"
             "Actual billing is determined by your LLM provider.\n\n"
             "Configuration:\n"
-            "  - Convenience aliases:   litellm.model_alias_map (via cost_calculator)\n"
+            "  - Custom pricing file:   TRAIGENT_CUSTOM_MODEL_PRICING_FILE\n"
+            "  - Custom pricing JSON:   TRAIGENT_CUSTOM_MODEL_PRICING_JSON\n"
             "  - Disable for testing:   TRAIGENT_MOCK_LLM=true\n"
             "  - Full details:          DISCLAIMER.md\n"
         )

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -119,7 +119,7 @@ def _emit_cost_warning_once() -> None:
             f"Cost estimates are approximations based on {CYAN}litellm{RESET} library pricing.\n"
             f"Actual billing is determined by your LLM provider.\n\n"
             f"{BOLD}Configuration:{RESET}\n"
-            f"  - Custom model mappings: {CYAN}traigent/utils/cost_calculator.py{RESET} (EXACT_MODEL_MAPPING)\n"
+            f"  - Convenience aliases:   {CYAN}litellm.model_alias_map{RESET} (via cost_calculator)\n"
             f"  - Disable for testing:   {CYAN}TRAIGENT_MOCK_LLM=true{RESET}\n"
             f"  - Full details:          {CYAN}DISCLAIMER.md{RESET}\n"
         )
@@ -130,7 +130,7 @@ def _emit_cost_warning_once() -> None:
             "Cost estimates are approximations based on litellm library pricing.\n"
             "Actual billing is determined by your LLM provider.\n\n"
             "Configuration:\n"
-            "  - Custom model mappings: traigent/utils/cost_calculator.py (EXACT_MODEL_MAPPING)\n"
+            "  - Convenience aliases:   litellm.model_alias_map (via cost_calculator)\n"
             "  - Disable for testing:   TRAIGENT_MOCK_LLM=true\n"
             "  - Full details:          DISCLAIMER.md\n"
         )

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -1,20 +1,21 @@
 """LLM cost calculation utilities.
 
-Runtime pricing is resolved via litellm's native model registry and alias map.
-Pre-estimation keeps a separate conservative fallback table.
+Cost resolution is intentionally fail-fast:
+- Runtime and pre-estimation pricing use litellm first.
+- Unknown models raise with actionable remediation by default.
+- Users can provide explicit custom pricing for private/unsupported models.
 """
 
 # Traceability: CONC-Layer-Core CONC-Quality-Performance CONC-Quality-Observability FUNC-ANALYTICS REQ-ANLY-011 SYNC-Observability
 
+import json
 import logging
 import os
 import re
 import threading
 import warnings
 from dataclasses import dataclass
-from json import loads
 from typing import Any
-from urllib.request import Request, urlopen
 
 logger = logging.getLogger(__name__)
 
@@ -35,48 +36,15 @@ except (ImportError, KeyError):
 # Backward compatibility alias
 TOKENCOST_AVAILABLE = LITELLM_AVAILABLE
 
-# Canonical model name constants (referenced in ESTIMATION_MODEL_PRICING and aliases)
+# Canonical model name constants (referenced in ESTIMATION_MODEL_PRICING)
 _GPT35_TURBO = "gpt-3.5-turbo"
 _GPT4O = "gpt-4o"
 
-# Convenience aliases registered into litellm's native alias map.
-# These are intentionally limited to informal shorthands and legacy names.
-_CONVENIENCE_ALIASES: dict[str, str] = {
-    "claude-haiku": "claude-3-haiku-20240307",
-    "claude-sonnet": "claude-3-5-sonnet-20241022",
-    "claude-opus": "claude-3-opus-20240229",
-    "claude3-haiku": "claude-3-haiku-20240307",
-    "claude3-sonnet": "claude-3-sonnet-20240229",
-    "claude3-opus": "claude-3-opus-20240229",
-    "claude-3-haiku": "claude-3-haiku-20240307",
-    "claude-3-sonnet": "claude-3-sonnet-20240229",
-    "claude-3-opus": "claude-3-opus-20240229",
-    "claude-3-5-sonnet": "claude-3-5-sonnet-20241022",
-    "claude-3-5-haiku": "claude-3-5-haiku-20241022",
-    "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
-    "claude-4-sonnet": "claude-sonnet-4-20250514",
-    "claude-4-opus": "claude-opus-4-20250514",
-    "gpt4": _GPT4O,
-    "gpt-3.5": _GPT35_TURBO,
-    "gpt3.5": _GPT35_TURBO,
-}
-
-
-def _register_convenience_aliases() -> None:
-    """Register Traigent's convenience aliases in litellm.model_alias_map."""
-    if not LITELLM_AVAILABLE:
-        return
-
-    alias_map = getattr(litellm, "model_alias_map", None)
-    if not isinstance(alias_map, dict):
-        litellm.model_alias_map = {}
-        alias_map = litellm.model_alias_map
-
-    for alias, target in _CONVENIENCE_ALIASES.items():
-        alias_map.setdefault(alias, target)
-
-
-_register_convenience_aliases()
+_CUSTOM_PRICING_FILE_ENV = "TRAIGENT_CUSTOM_MODEL_PRICING_FILE"
+_CUSTOM_PRICING_JSON_ENV = "TRAIGENT_CUSTOM_MODEL_PRICING_JSON"
+_CUSTOM_PRICING_CACHE: dict[str, tuple[float, float]] | None = None
+_CUSTOM_PRICING_CACHE_KEY: tuple[str, str] | None = None
+_CUSTOM_PRICING_LOCK = threading.Lock()
 
 # Estimation pricing for pre-optimization cost estimation (per-token costs).
 # Post-call cost tracking uses litellm exclusively via cost_from_tokens().
@@ -163,8 +131,8 @@ def _normalize_model_name(model: str) -> str:
 
     Note:
         Ollama-style "model:tag" identifiers (e.g., "llama3:latest") will have
-        the tag stripped. For Ollama models, use the full model name directly
-        or add to ESTIMATION_MODEL_PRICING for pricing lookup.
+        the tag stripped. For tagged models, configure explicit aliasing or
+        custom pricing if needed.
 
     Args:
         model: Raw model name
@@ -248,74 +216,129 @@ def _resolve_litellm_alias(model: str) -> str:
     return normalized
 
 
-_OPENROUTER_MODEL_INDEX_CACHE: dict[str, tuple[float, float]] | None = None
-_OPENROUTER_CACHE_LOCK = threading.Lock()
-_OPENROUTER_MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models"
+def _parse_custom_pricing_entry(
+    model: str, entry: Any, source: str
+) -> tuple[float, float]:
+    """Parse one custom pricing entry into (input_cost_per_token, output_cost_per_token)."""
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"Invalid pricing entry for model '{model}' in {source}: expected object"
+        )
+
+    input_val = entry.get("input_cost_per_token", entry.get("input"))
+    output_val = entry.get("output_cost_per_token", entry.get("output"))
+
+    if input_val is None or output_val is None:
+        raise ValueError(
+            f"Invalid pricing entry for model '{model}' in {source}: "
+            "expected input_cost_per_token/output_cost_per_token"
+        )
+
+    try:
+        input_cost = float(input_val)
+        output_cost = float(output_val)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Invalid numeric pricing for model '{model}' in {source}"
+        ) from exc
+
+    if input_cost < 0 or output_cost < 0:
+        raise ValueError(f"Invalid negative pricing for model '{model}' in {source}")
+
+    return input_cost, output_cost
 
 
-def _fetch_openrouter_models() -> dict[str, tuple[float, float]]:
-    """Fetch OpenRouter model pricing index.
+def _normalize_custom_pricing_map(
+    raw: dict[str, Any], source: str
+) -> dict[str, tuple[float, float]]:
+    """Normalize custom pricing payload into lowercase model index."""
+    normalized: dict[str, tuple[float, float]] = {}
+    for model, entry in raw.items():
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError(
+                f"Invalid model key in {source}: expected non-empty string"
+            )
+        input_cost, output_cost = _parse_custom_pricing_entry(model, entry, source)
+        keys = {model.lower(), _normalize_model_name(model).lower()}
+        for key in keys:
+            normalized[key] = (input_cost, output_cost)
+    return normalized
 
-    Returns a map of lowercase model identifiers to per-token rates:
-    ``{model_id: (input_cost_per_token, output_cost_per_token)}``
-    """
-    request = Request(
-        _OPENROUTER_MODELS_ENDPOINT,
-        headers={
-            "Accept": "application/json",
-            "User-Agent": "traigent-cost-calculator/1.0",
-        },
-    )
-    with urlopen(request, timeout=5.0) as response:  # nosec B310
-        payload = loads(response.read().decode("utf-8"))
-    data = payload.get("data", []) if isinstance(payload, dict) else []
 
-    index: dict[str, tuple[float, float]] = {}
-    for item in data:
-        if not isinstance(item, dict):
-            continue
-        model_id = item.get("id")
-        pricing = item.get("pricing", {})
-        if not isinstance(model_id, str) or not isinstance(pricing, dict):
-            continue
+def _load_custom_pricing_from_sources() -> dict[str, tuple[float, float]]:
+    """Load custom model pricing from env-configured file and/or JSON payload."""
+    pricing: dict[str, tuple[float, float]] = {}
+
+    file_path = os.environ.get(_CUSTOM_PRICING_FILE_ENV, "").strip()
+    if file_path:
         try:
-            input_rate = float(pricing.get("prompt", 0.0))
-            output_rate = float(pricing.get("completion", 0.0))
-        except (TypeError, ValueError):
-            continue
+            with open(file_path, encoding="utf-8") as f:
+                file_payload = json.load(f)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse custom pricing file '{file_path}'."
+            ) from exc
+        if not isinstance(file_payload, dict):
+            raise ValueError(
+                f"Invalid custom pricing file '{file_path}': root must be an object"
+            )
+        pricing.update(_normalize_custom_pricing_map(file_payload, file_path))
 
-        if input_rate < 0 or output_rate < 0:
-            continue
+    env_json = os.environ.get(_CUSTOM_PRICING_JSON_ENV, "").strip()
+    if env_json:
+        try:
+            env_payload = json.loads(env_json)
+        except Exception as exc:
+            raise ValueError(
+                f"Failed to parse {_CUSTOM_PRICING_JSON_ENV}: invalid JSON"
+            ) from exc
+        if not isinstance(env_payload, dict):
+            raise ValueError(
+                f"Invalid {_CUSTOM_PRICING_JSON_ENV}: root must be an object"
+            )
+        pricing.update(
+            _normalize_custom_pricing_map(env_payload, _CUSTOM_PRICING_JSON_ENV)
+        )
 
-        key = model_id.lower()
-        index[key] = (input_rate, output_rate)
-        if "/" in key:
-            bare_model = key.split("/", 1)[1]
-            index.setdefault(bare_model, (input_rate, output_rate))
-
-    return index
+    return pricing
 
 
-def _try_openrouter_pricing(model: str) -> tuple[float, float] | None:
-    """Try resolving per-token model pricing from OpenRouter's public API."""
-    if os.environ.get("TRAIGENT_OFFLINE_MODE", "").lower() == "true":
-        return None
+def _get_custom_pricing_index() -> dict[str, tuple[float, float]]:
+    """Get cached custom model pricing index keyed by lowercase model names."""
+    file_path = os.environ.get(_CUSTOM_PRICING_FILE_ENV, "").strip()
+    env_json = os.environ.get(_CUSTOM_PRICING_JSON_ENV, "").strip()
+    cache_key = (file_path, env_json)
 
-    global _OPENROUTER_MODEL_INDEX_CACHE
-    if _OPENROUTER_MODEL_INDEX_CACHE is None:
-        with _OPENROUTER_CACHE_LOCK:
-            if _OPENROUTER_MODEL_INDEX_CACHE is None:
-                try:
-                    _OPENROUTER_MODEL_INDEX_CACHE = _fetch_openrouter_models()
-                except Exception:
-                    logger.debug("OpenRouter pricing fetch failed", exc_info=True)
-                    _OPENROUTER_MODEL_INDEX_CACHE = {}
+    global _CUSTOM_PRICING_CACHE, _CUSTOM_PRICING_CACHE_KEY
+    if _CUSTOM_PRICING_CACHE is not None and _CUSTOM_PRICING_CACHE_KEY == cache_key:
+        return _CUSTOM_PRICING_CACHE
 
+    with _CUSTOM_PRICING_LOCK:
+        if _CUSTOM_PRICING_CACHE is not None and _CUSTOM_PRICING_CACHE_KEY == cache_key:
+            return _CUSTOM_PRICING_CACHE
+        _CUSTOM_PRICING_CACHE = _load_custom_pricing_from_sources()
+        _CUSTOM_PRICING_CACHE_KEY = cache_key
+        return _CUSTOM_PRICING_CACHE
+
+
+def _try_custom_model_pricing(model: str) -> tuple[float, float] | None:
+    """Try resolving pricing from explicit user-provided custom pricing."""
     normalized = _normalize_model_name(model).lower()
-    cache = _OPENROUTER_MODEL_INDEX_CACHE
-    if cache is None:
-        return None
-    return cache.get(model.lower()) or cache.get(normalized)
+    index = _get_custom_pricing_index()
+    return index.get(model.lower()) or index.get(normalized)
+
+
+def _unknown_model_resolution_message(model: str) -> str:
+    """Build actionable unknown-model remediation instructions."""
+    return (
+        f"Model '{model}' has no known pricing. "
+        "Fix by choosing one of: "
+        "1) use a provider model id that litellm can price, "
+        "2) configure litellm.model_alias_map for your alias, "
+        f"3) provide explicit pricing via {_CUSTOM_PRICING_FILE_ENV} or {_CUSTOM_PRICING_JSON_ENV}. "
+        "Example JSON: "
+        '{"my-model":{"input_cost_per_token":1e-6,"output_cost_per_token":2e-6}}'
+    )
 
 
 def _try_litellm_prompt_cost(
@@ -330,7 +353,7 @@ def _try_litellm_prompt_cost(
 
     Returns:
         Tuple of (cost_or_None, token_count). Cost is None when litellm cannot
-        determine pricing and the caller should fall through to the fallback.
+        determine pricing and the caller should try custom pricing.
     """
     model_known = _is_model_known_to_litellm(model)
     if prompt is not None:
@@ -367,7 +390,7 @@ def calculate_prompt_cost(
 
     Raises:
         UnknownModelError: If the model's pricing cannot be determined from
-            litellm or the fallback pricing table.
+            litellm or explicit custom pricing configuration.
     """
     warnings.warn(
         "calculate_prompt_cost() is deprecated. Use cost_from_tokens() with "
@@ -387,16 +410,12 @@ def calculate_prompt_cost(
                 "litellm cost calculation failed for model %r", model, exc_info=True
             )
 
-    # Try estimation pricing with whatever token count we have
-    fallback_cost = _estimation_cost_from_tokens(model, max(tokens, 0), 0)[0]
-    if fallback_cost > 0:
-        return fallback_cost
+    custom_pricing = _try_custom_model_pricing(model)
+    if custom_pricing is not None:
+        input_cost_per_token, _ = custom_pricing
+        return float(max(tokens, 0) * input_cost_per_token)
 
-    # Unknown model - raise exception (mimics tokencost behavior)
-    raise UnknownModelError(
-        f"Model '{model}' is not in litellm's pricing database or fallback table. "
-        "Add it to ESTIMATION_MODEL_PRICING or use a known model."
-    )
+    raise UnknownModelError(_unknown_model_resolution_message(model))
 
 
 def _try_litellm_completion_cost(
@@ -411,7 +430,7 @@ def _try_litellm_completion_cost(
 
     Returns:
         Tuple of (cost_or_None, token_count). Cost is None when litellm cannot
-        determine pricing and the caller should fall through to the fallback.
+        determine pricing and the caller should try custom pricing.
     """
     model_known = _is_model_known_to_litellm(model)
     if completion is not None:
@@ -443,7 +462,7 @@ def calculate_completion_cost(completion: str | None, model: str) -> float:
 
     Raises:
         UnknownModelError: If the model's pricing cannot be determined from
-            litellm or the fallback pricing table.
+            litellm or explicit custom pricing configuration.
     """
     warnings.warn(
         "calculate_completion_cost() is deprecated. Use cost_from_tokens() with "
@@ -463,16 +482,12 @@ def calculate_completion_cost(completion: str | None, model: str) -> float:
                 "litellm cost calculation failed for model %r", model, exc_info=True
             )
 
-    # Try estimation pricing with whatever token count we have
-    fallback_cost = _estimation_cost_from_tokens(model, 0, max(tokens, 0))[1]
-    if fallback_cost > 0:
-        return fallback_cost
+    custom_pricing = _try_custom_model_pricing(model)
+    if custom_pricing is not None:
+        _, output_cost_per_token = custom_pricing
+        return float(max(tokens, 0) * output_cost_per_token)
 
-    # Unknown model - raise exception (mimics tokencost behavior)
-    raise UnknownModelError(
-        f"Model '{model}' is not in litellm's pricing database or fallback table. "
-        "Add it to ESTIMATION_MODEL_PRICING or use a known model."
-    )
+    raise UnknownModelError(_unknown_model_resolution_message(model))
 
 
 def _normalize_model_for_fallback(model: str) -> str:
@@ -584,63 +599,14 @@ def _estimation_cost_from_tokens(
 _fallback_cost_from_tokens = _estimation_cost_from_tokens
 
 
-# ---------------------------------------------------------------------------
-# Heuristic tier pricing for pre-optimization cost estimation
-# ---------------------------------------------------------------------------
-
-# Per-token costs for each pricing tier (conservative estimates)
-_TIER_EXPENSIVE = {"input": 10.0e-6, "output": 30.0e-6}  # ~GPT-4-turbo class
-_TIER_MID = {"input": 3.0e-6, "output": 15.0e-6}  # ~GPT-4o / Sonnet class
-_TIER_CHEAP = {"input": 0.25e-6, "output": 1.25e-6}  # ~Haiku / Mini class
-
-# Ordered regex rules for model tier classification.
-# Order is critical: most specific patterns first to avoid substring collisions.
-# \b treats `-` as a word boundary, so "gpt-4o-mini" matches r"gpt-4o\b".
-# We rely on ordering (gpt-4o-mini checked BEFORE gpt-4o) to handle this.
-_TIER_RULES: list[tuple[re.Pattern[str], str]] = [
-    (re.compile(r"gpt-4o-mini|gpt-4-mini", re.IGNORECASE), "cheap"),
-    (re.compile(r"gpt-4-turbo", re.IGNORECASE), "expensive"),
-    (re.compile(r"gpt-4o\b", re.IGNORECASE), "mid"),
-    (re.compile(r"gpt-4\b(?!o)", re.IGNORECASE), "expensive"),
-    (re.compile(r"gpt-3\.5", re.IGNORECASE), "cheap"),
-    (re.compile(r"opus", re.IGNORECASE), "expensive"),
-    (re.compile(r"sonnet", re.IGNORECASE), "mid"),
-    (re.compile(r"haiku", re.IGNORECASE), "cheap"),
-    (re.compile(r"\bmini|flash|nano", re.IGNORECASE), "cheap"),
-    (re.compile(r"pro\b", re.IGNORECASE), "mid"),
-]
-
-_TIER_PRICING = {
-    "expensive": _TIER_EXPENSIVE,
-    "mid": _TIER_MID,
-    "cheap": _TIER_CHEAP,
-}
-
-
-def _classify_model_tier(model_name: str) -> str:
-    """Classify a model name into a pricing tier using regex matching.
-
-    Returns one of ``"expensive"``, ``"mid"``, or ``"cheap"``.
-    Falls back to ``"mid"`` (conservative) when no pattern matches.
-    """
-    for pattern, tier in _TIER_RULES:
-        if pattern.search(model_name):
-            return tier
-    return "mid"
-
-
 def get_model_token_pricing(model_name: str) -> tuple[float, float, str]:
-    """Get per-token pricing for a model, with graceful fallback.
+    """Get per-token pricing for a model with fail-fast behavior.
 
-    Uses a 3-tier lookup chain for conservative pre-optimization cost estimation:
+    Resolution order:
+    1. litellm pricing database
+    2. explicit custom pricing overrides (env/file)
 
-    1. **litellm**: exact per-token pricing from litellm's database.
-       Models that return ``(0, 0)`` are NOT treated as free — falls through
-       to heuristic tier (EMA will correct after the first trial).
-    2. **Fallback dict**: prefix-matching against ``ESTIMATION_MODEL_PRICING``.
-       Does NOT apply convenience aliases so that e.g. ``gpt-4`` stays in
-       the EXPENSIVE tier rather than being downgraded to ``gpt-4o`` (MID tier).
-    3. **Heuristic tier**: regex-based classification into EXPENSIVE / MID / CHEAP.
+    Unknown models raise ``UnknownModelError`` with remediation instructions.
 
     Args:
         model_name: Model identifier (may include provider prefix).
@@ -648,54 +614,37 @@ def get_model_token_pricing(model_name: str) -> tuple[float, float, str]:
     Returns:
         ``(input_cost_per_token, output_cost_per_token, estimation_method)``
     """
-    # --- Tier 1: litellm ---
-    if LITELLM_AVAILABLE and _is_model_known_to_litellm(model_name):
-        try:
-            input_cost, output_cost = litellm.cost_per_token(
-                model=model_name, prompt_tokens=1, completion_tokens=1
-            )
-            if input_cost > 0 or output_cost > 0:
-                logger.debug(
-                    "Model pricing from litellm for %r: input=%.2e, output=%.2e",
-                    model_name,
-                    input_cost,
-                    output_cost,
+    if not model_name or not model_name.strip():
+        raise UnknownModelError(_unknown_model_resolution_message(model_name))
+
+    normalized = _normalize_model_name(model_name)
+    alias_resolved = _resolve_litellm_alias(normalized)
+    candidates = [
+        candidate for candidate in [model_name, normalized, alias_resolved] if candidate
+    ]
+    candidates = list(dict.fromkeys(candidates))
+
+    if LITELLM_AVAILABLE:
+        for candidate in candidates:
+            try:
+                input_cost, output_cost = litellm.cost_per_token(
+                    model=candidate, prompt_tokens=1, completion_tokens=1
                 )
-                return float(input_cost), float(output_cost), "litellm"
-            # litellm returned (0, 0) — may lack pricing data. Fall through.
-        except Exception:
-            logger.debug(
-                "litellm pricing lookup failed for %r, trying fallback",
-                model_name,
-                exc_info=True,
-            )
+                if input_cost > 0 or output_cost > 0:
+                    return float(input_cost), float(output_cost), "litellm"
+                if _is_model_known_to_litellm(candidate):
+                    return float(input_cost), float(output_cost), "litellm"
+            except Exception:
+                logger.debug(
+                    "litellm pricing lookup failed for %r", candidate, exc_info=True
+                )
 
-    # --- Tier 2: Fallback dict (prefix matching, no alias remapping) ---
-    normalized = _normalize_model_for_fallback(model_name)
-    # Use _quiet=True to log at DEBUG during estimation (not WARNING)
-    input_cost_fb, output_cost_fb = _estimation_cost_from_tokens(
-        normalized, 1, 1, _quiet=True
-    )
-    if input_cost_fb > 0 or output_cost_fb > 0:
-        logger.debug(
-            "Model pricing from fallback dict for %r: input=%.2e, output=%.2e",
-            model_name,
-            input_cost_fb,
-            output_cost_fb,
-        )
-        return input_cost_fb, output_cost_fb, "fallback_dict"
+    custom_pricing = _try_custom_model_pricing(model_name)
+    if custom_pricing is not None:
+        input_cost, output_cost = custom_pricing
+        return float(input_cost), float(output_cost), "custom_pricing"
 
-    # --- Tier 3: Heuristic tier classification ---
-    tier = _classify_model_tier(model_name)
-    pricing = _TIER_PRICING[tier]
-    logger.debug(
-        "Model pricing from heuristic tier %r for %r: input=%.2e, output=%.2e",
-        tier,
-        model_name,
-        pricing["input"],
-        pricing["output"],
-    )
-    return pricing["input"], pricing["output"], f"heuristic:{tier}"
+    raise UnknownModelError(_unknown_model_resolution_message(model_name))
 
 
 @dataclass
@@ -728,16 +677,35 @@ class CostCalculator:
     compatibility with non-token paths and diagnostics.
     """
 
-    # Legacy compatibility alias (prefer module-level _CONVENIENCE_ALIASES)
-    EXACT_MODEL_MAPPING = dict(_CONVENIENCE_ALIASES)
+    # Legacy compatibility mappings (not used by canonical cost_from_tokens).
+    EXACT_MODEL_MAPPING = {
+        "claude-3-haiku": "claude-3-haiku-20240307",
+        "claude-3-sonnet": "claude-3-sonnet-20240229",
+        "claude-3-opus": "claude-3-opus-20240229",
+        "claude-3-5-sonnet": "claude-3-5-sonnet-20241022",
+        "claude-3-5-haiku": "claude-3-5-haiku-20241022",
+        "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
+        "claude-4-sonnet": "claude-sonnet-4-20250514",
+        "claude-4-opus": "claude-opus-4-20250514",
+        "claude-haiku": "claude-3-haiku-20240307",
+        "claude-sonnet": "claude-3-5-sonnet-20241022",
+        "claude-opus": "claude-3-opus-20240229",
+        "gpt-3.5": _GPT35_TURBO,
+        "gpt-4": _GPT4O,
+        "gpt4": _GPT4O,
+        "gpt3.5": _GPT35_TURBO,
+        "gpt-4o-mini": "gpt-4o-mini",
+        "claude3-haiku": "claude-3-haiku-20240307",
+        "claude3-sonnet": "claude-3-sonnet-20240229",
+        "claude3-opus": "claude-3-opus-20240229",
+    }
 
-    # Model family defaults for generic names
     FAMILY_DEFAULTS = {
-        "claude-3": "claude-3-5-sonnet-latest",  # Most capable general model
+        "claude-3": "claude-3-5-sonnet-latest",
         "claude": "claude-3-5-sonnet-latest",
-        "gpt-4": _GPT4O,  # Latest GPT-4 variant
-        "gpt": _GPT4O,  # Default to latest
-        "gpt-3.5": _GPT35_TURBO,  # Standard 3.5 model
+        "gpt-4": _GPT4O,
+        "gpt": _GPT4O,
+        "gpt-3.5": _GPT35_TURBO,
     }
 
     def __init__(self, logger=None, enable_caching: bool = True) -> None:
@@ -765,7 +733,7 @@ class CostCalculator:
         input_tokens: int | None = None,
         output_tokens: int | None = None,
     ) -> CostBreakdown:
-        """Calculate cost for an LLM request with multiple fallback methods.
+        """Calculate cost for an LLM request.
 
         Args:
             prompt: The input prompt (string or message list)
@@ -1153,9 +1121,8 @@ def cost_from_tokens(
 ) -> tuple[float, float]:
     """Canonical cost calculation from token counts.
 
-    This is the single entry point for post-call cost tracking. It uses
-    litellm's pricing database exclusively — no heuristic estimation,
-    no fallback pricing table, no silent zeros in strict mode.
+    This is the single entry point for post-call cost tracking. It is
+    fail-fast by default and does not guess pricing for unknown models.
 
     Args:
         input_tokens: Number of input tokens (0 is valid for output-only).
@@ -1189,8 +1156,6 @@ def cost_from_tokens(
 
     normalized = _normalize_model_name(model)
     alias_resolved = _resolve_litellm_alias(normalized)
-
-    # Build unique candidate list preserving priority order.
     candidates = [
         candidate for candidate in [model, normalized, alias_resolved] if candidate
     ]
@@ -1225,23 +1190,26 @@ def cost_from_tokens(
                 float(output_tokens * output_cpt),
             )
 
-    # Step 3: OpenRouter fallback (optional online pricing source)
-    openrouter_pricing = _try_openrouter_pricing(model)
-    if openrouter_pricing is not None:
-        input_rate, output_rate = openrouter_pricing
+    # Step 3: explicit custom pricing (user-provided)
+    custom_pricing = _try_custom_model_pricing(model)
+    if custom_pricing is not None:
+        input_rate, output_rate = custom_pricing
         return (
             float(input_tokens * input_rate),
             float(output_tokens * output_rate),
         )
 
-    # Model not found in litellm or OpenRouter
+    # Model not found in litellm or custom pricing config
     if strict:
-        raise UnknownModelError(
-            f"Model '{model}' has no pricing in litellm/OpenRouter. "
-            "Use strict=False for pre-estimation or register model pricing."
-        )
+        raise UnknownModelError(_unknown_model_resolution_message(model))
 
-    logger.warning("Unknown model %r — returning zero cost (strict=False)", model)
+    logger.warning(
+        "Unknown model %r — returning zero cost (strict=False). "
+        "Configure %s or %s to provide explicit pricing.",
+        model,
+        _CUSTOM_PRICING_FILE_ENV,
+        _CUSTOM_PRICING_JSON_ENV,
+    )
     return 0.0, 0.0
 
 
@@ -1291,8 +1259,8 @@ def get_model_pricing_per_1k(model_name: str) -> tuple[float, float]:
     """Get model pricing rates in USD per 1K tokens.
 
     Returns a tuple ``(input_per_1k, output_per_1k)`` via the canonical cost
-    pipeline (litellm first, then estimation pricing). Unknown models return
-    ``(0.0, 0.0)``.
+    pipeline (litellm first, then explicit custom pricing). Unknown models
+    return ``(0.0, 0.0)``.
 
     This is a query function (not budget-enforcement), so it uses
     strict=False to avoid raising on unknown models.

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -1,24 +1,7 @@
-"""
-Intelligent LLM Cost Calculator with Fuzzy Model Matching
+"""LLM cost calculation utilities.
 
-This module provides comprehensive cost calculation for LLM API calls with:
-- Exact model name mapping for litellm compatibility
-- Fuzzy matching with substring search and semantic validation
-- Intelligent date/version parsing and selection
-- Caching for performance optimization
-- Graceful fallback with informative logging
-
-Usage:
-    from traigent.utils.cost_calculator import CostCalculator
-
-    calculator = CostCalculator()
-    cost = calculator.calculate_cost(
-        prompt="Your prompt here",
-        response="Model response",
-        model_name="claude-3-haiku"
-    )
-
-This module can be copied to other repositories for consistent cost calculation.
+Runtime pricing is resolved via litellm's native model registry and alias map.
+Pre-estimation keeps a separate conservative fallback table.
 """
 
 # Traceability: CONC-Layer-Core CONC-Quality-Performance CONC-Quality-Observability FUNC-ANALYTICS REQ-ANLY-011 SYNC-Observability
@@ -29,7 +12,9 @@ import re
 import threading
 import warnings
 from dataclasses import dataclass
+from json import loads
 from typing import Any
+from urllib.request import Request, urlopen
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +38,45 @@ TOKENCOST_AVAILABLE = LITELLM_AVAILABLE
 # Canonical model name constants (referenced in ESTIMATION_MODEL_PRICING and aliases)
 _GPT35_TURBO = "gpt-3.5-turbo"
 _GPT4O = "gpt-4o"
+
+# Convenience aliases registered into litellm's native alias map.
+# These are intentionally limited to informal shorthands and legacy names.
+_CONVENIENCE_ALIASES: dict[str, str] = {
+    "claude-haiku": "claude-3-haiku-20240307",
+    "claude-sonnet": "claude-3-5-sonnet-20241022",
+    "claude-opus": "claude-3-opus-20240229",
+    "claude3-haiku": "claude-3-haiku-20240307",
+    "claude3-sonnet": "claude-3-sonnet-20240229",
+    "claude3-opus": "claude-3-opus-20240229",
+    "claude-3-haiku": "claude-3-haiku-20240307",
+    "claude-3-sonnet": "claude-3-sonnet-20240229",
+    "claude-3-opus": "claude-3-opus-20240229",
+    "claude-3-5-sonnet": "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku": "claude-3-5-haiku-20241022",
+    "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
+    "claude-4-sonnet": "claude-sonnet-4-20250514",
+    "claude-4-opus": "claude-opus-4-20250514",
+    "gpt4": _GPT4O,
+    "gpt-3.5": _GPT35_TURBO,
+    "gpt3.5": _GPT35_TURBO,
+}
+
+
+def _register_convenience_aliases() -> None:
+    """Register Traigent's convenience aliases in litellm.model_alias_map."""
+    if not LITELLM_AVAILABLE:
+        return
+
+    alias_map = getattr(litellm, "model_alias_map", None)
+    if not isinstance(alias_map, dict):
+        litellm.model_alias_map = {}
+        alias_map = litellm.model_alias_map
+
+    for alias, target in _CONVENIENCE_ALIASES.items():
+        alias_map.setdefault(alias, target)
+
+
+_register_convenience_aliases()
 
 # Estimation pricing for pre-optimization cost estimation (per-token costs).
 # Post-call cost tracking uses litellm exclusively via cost_from_tokens().
@@ -203,6 +227,95 @@ def _is_model_known_to_litellm(model: str) -> bool:
             return True
 
     return False
+
+
+def _resolve_litellm_alias(model: str) -> str:
+    """Resolve model aliases through litellm.model_alias_map if present."""
+    normalized = _normalize_model_name(model)
+    if not LITELLM_AVAILABLE:
+        return normalized
+
+    alias_map = getattr(litellm, "model_alias_map", None)
+    if not isinstance(alias_map, dict):
+        return normalized
+
+    candidates = (model, normalized, model.lower(), normalized.lower())
+    for candidate in candidates:
+        mapped = alias_map.get(candidate)
+        if isinstance(mapped, str) and mapped:
+            return mapped
+
+    return normalized
+
+
+_OPENROUTER_MODEL_INDEX_CACHE: dict[str, tuple[float, float]] | None = None
+_OPENROUTER_CACHE_LOCK = threading.Lock()
+_OPENROUTER_MODELS_ENDPOINT = "https://openrouter.ai/api/v1/models"
+
+
+def _fetch_openrouter_models() -> dict[str, tuple[float, float]]:
+    """Fetch OpenRouter model pricing index.
+
+    Returns a map of lowercase model identifiers to per-token rates:
+    ``{model_id: (input_cost_per_token, output_cost_per_token)}``
+    """
+    request = Request(
+        _OPENROUTER_MODELS_ENDPOINT,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "traigent-cost-calculator/1.0",
+        },
+    )
+    with urlopen(request, timeout=5.0) as response:  # nosec B310
+        payload = loads(response.read().decode("utf-8"))
+    data = payload.get("data", []) if isinstance(payload, dict) else []
+
+    index: dict[str, tuple[float, float]] = {}
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id")
+        pricing = item.get("pricing", {})
+        if not isinstance(model_id, str) or not isinstance(pricing, dict):
+            continue
+        try:
+            input_rate = float(pricing.get("prompt", 0.0))
+            output_rate = float(pricing.get("completion", 0.0))
+        except (TypeError, ValueError):
+            continue
+
+        if input_rate < 0 or output_rate < 0:
+            continue
+
+        key = model_id.lower()
+        index[key] = (input_rate, output_rate)
+        if "/" in key:
+            bare_model = key.split("/", 1)[1]
+            index.setdefault(bare_model, (input_rate, output_rate))
+
+    return index
+
+
+def _try_openrouter_pricing(model: str) -> tuple[float, float] | None:
+    """Try resolving per-token model pricing from OpenRouter's public API."""
+    if os.environ.get("TRAIGENT_OFFLINE_MODE", "").lower() == "true":
+        return None
+
+    global _OPENROUTER_MODEL_INDEX_CACHE
+    if _OPENROUTER_MODEL_INDEX_CACHE is None:
+        with _OPENROUTER_CACHE_LOCK:
+            if _OPENROUTER_MODEL_INDEX_CACHE is None:
+                try:
+                    _OPENROUTER_MODEL_INDEX_CACHE = _fetch_openrouter_models()
+                except Exception:
+                    logger.debug("OpenRouter pricing fetch failed", exc_info=True)
+                    _OPENROUTER_MODEL_INDEX_CACHE = {}
+
+    normalized = _normalize_model_name(model).lower()
+    cache = _OPENROUTER_MODEL_INDEX_CACHE
+    if cache is None:
+        return None
+    return cache.get(model.lower()) or cache.get(normalized)
 
 
 def _try_litellm_prompt_cost(
@@ -525,10 +638,8 @@ def get_model_token_pricing(model_name: str) -> tuple[float, float, str]:
        Models that return ``(0, 0)`` are NOT treated as free — falls through
        to heuristic tier (EMA will correct after the first trial).
     2. **Fallback dict**: prefix-matching against ``ESTIMATION_MODEL_PRICING``.
-       Does NOT apply ``EXACT_MODEL_MAPPING`` — intentionally skipped so that
-       e.g. ``gpt-4`` stays in the EXPENSIVE tier rather than being downgraded
-       to ``gpt-4o`` (MID tier). The mapping is correct for runtime cost
-       calculation but wrong for conservative pre-estimation.
+       Does NOT apply convenience aliases so that e.g. ``gpt-4`` stays in
+       the EXPENSIVE tier rather than being downgraded to ``gpt-4o`` (MID tier).
     3. **Heuristic tier**: regex-based classification into EXPENSIVE / MID / CHEAP.
 
     Args:
@@ -559,7 +670,7 @@ def get_model_token_pricing(model_name: str) -> tuple[float, float, str]:
                 exc_info=True,
             )
 
-    # --- Tier 2: Fallback dict (prefix matching, no EXACT_MODEL_MAPPING) ---
+    # --- Tier 2: Fallback dict (prefix matching, no alias remapping) ---
     normalized = _normalize_model_for_fallback(model_name)
     # Use _quiet=True to log at DEBUG during estimation (not WARNING)
     input_cost_fb, output_cost_fb = _estimation_cost_from_tokens(
@@ -610,35 +721,15 @@ class CostBreakdown:
 
 
 class CostCalculator:
-    """Intelligent LLM cost calculator with fuzzy model matching."""
+    """LLM cost calculator.
 
-    # Exact model name mappings (high confidence)
-    EXACT_MODEL_MAPPING = {
-        # Claude models - map user-friendly names to litellm expected names
-        "claude-3-haiku": "claude-3-haiku-20240307",
-        "claude-3-sonnet": "claude-3-sonnet-20240229",
-        "claude-3-opus": "claude-3-opus-20240229",
-        "claude-3-5-sonnet": "claude-3-5-sonnet-20241022",
-        "claude-3-5-haiku": "claude-3-5-haiku-20241022",
-        "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
-        "claude-4-sonnet": "claude-sonnet-4-20250514",
-        "claude-4-opus": "claude-opus-4-20250514",
-        # Add latest versions for convenience
-        # Use dated aliases for pricing compatibility (litellm pricing coverage).
-        "claude-haiku": "claude-3-haiku-20240307",
-        "claude-sonnet": "claude-3-5-sonnet-20241022",
-        "claude-opus": "claude-3-opus-20240229",
-        # OpenAI models are usually fine as-is but add common aliases
-        "gpt-3.5": _GPT35_TURBO,
-        "gpt-4": _GPT4O,
-        "gpt4": _GPT4O,
-        "gpt3.5": _GPT35_TURBO,
-        "gpt-4o-mini": "gpt-4o-mini",  # GPT-4o mini model for cost-effective usage
-        # Common alternative spellings
-        "claude3-haiku": "claude-3-haiku-20240307",
-        "claude3-sonnet": "claude-3-sonnet-20240229",
-        "claude3-opus": "claude-3-opus-20240229",
-    }
+    Runtime pricing should resolve through ``cost_from_tokens()`` using litellm
+    aliases and pricing tables. Mapping/fuzzy helpers are kept for legacy
+    compatibility with non-token paths and diagnostics.
+    """
+
+    # Legacy compatibility alias (prefer module-level _CONVENIENCE_ALIASES)
+    EXACT_MODEL_MAPPING = dict(_CONVENIENCE_ALIASES)
 
     # Model family defaults for generic names
     FAMILY_DEFAULTS = {
@@ -699,8 +790,8 @@ class CostCalculator:
         if not model_name:
             return CostBreakdown(calculation_method="no_model_name")
 
-        mapped_model = self._map_model_name(model_name)
-        effective_model = mapped_model or model_name
+        normalized_model = _normalize_model_name(model_name)
+        effective_model = _resolve_litellm_alias(normalized_model)
 
         result = CostBreakdown(
             model_used=model_name, mapped_model=effective_model or ""
@@ -763,11 +854,22 @@ class CostCalculator:
         return model_name
 
     def _map_model_name(self, model_name: str) -> str | None:
-        """Map user-friendly model names to litellm-compatible names with fuzzy matching."""
+        """Map model names to litellm-compatible names (legacy helper)."""
         if not model_name:
             return None
 
-        # Step 1: Try exact mapping
+        # Step 1: litellm-native alias resolution
+        resolved = _resolve_litellm_alias(model_name)
+        if resolved != _normalize_model_name(model_name):
+            if self.logger:
+                self.logger.debug(
+                    "litellm alias mapping: %r -> %r",
+                    model_name,
+                    resolved,
+                )
+            return resolved
+
+        # Step 2: Try exact compatibility mapping
         exact_match = self.EXACT_MODEL_MAPPING.get(model_name)
         if exact_match:
             if self.logger:
@@ -776,7 +878,7 @@ class CostCalculator:
                 )
             return exact_match
 
-        # Step 2: Try with normalized name (strip provider prefix)
+        # Step 3: Try with normalized name (strip provider prefix)
         normalized = self._normalize_model_name(model_name)
         if normalized != model_name:
             exact_match = self.EXACT_MODEL_MAPPING.get(normalized)
@@ -787,7 +889,7 @@ class CostCalculator:
                     )
                 return exact_match
 
-        # Step 3: Try family defaults for generic names
+        # Step 4: Try family defaults for generic names
         family_match = self.FAMILY_DEFAULTS.get(model_name)
         if family_match:
             if self.logger:
@@ -796,7 +898,7 @@ class CostCalculator:
                 )
             return family_match
 
-        # Step 4: Try fuzzy matching
+        # Step 5: Try fuzzy matching (legacy behavior)
         return self._fuzzy_match_model(model_name)
 
     def _fuzzy_match_model(self, user_model: str) -> str | None:
@@ -1085,13 +1187,14 @@ def cost_from_tokens(
         logger.warning("litellm not available — returning zero cost")
         return 0.0, 0.0
 
-    # Resolve model name through exact mapping
-    # (e.g., "claude-3-haiku" -> "claude-3-haiku-20240307")
     normalized = _normalize_model_name(model)
-    mapped = CostCalculator.EXACT_MODEL_MAPPING.get(normalized, normalized)
+    alias_resolved = _resolve_litellm_alias(normalized)
 
-    # Build unique candidate list preserving priority order
-    candidates = list(dict.fromkeys([mapped, normalized, model]))
+    # Build unique candidate list preserving priority order.
+    candidates = [
+        candidate for candidate in [model, normalized, alias_resolved] if candidate
+    ]
+    candidates = list(dict.fromkeys(candidates))
 
     # Step 1: Try litellm.cost_per_token (handles provider prefixes internally)
     for candidate in candidates:
@@ -1122,11 +1225,20 @@ def cost_from_tokens(
                 float(output_tokens * output_cpt),
             )
 
-    # Model not found in any litellm pricing source
+    # Step 3: OpenRouter fallback (optional online pricing source)
+    openrouter_pricing = _try_openrouter_pricing(model)
+    if openrouter_pricing is not None:
+        input_rate, output_rate = openrouter_pricing
+        return (
+            float(input_tokens * input_rate),
+            float(output_tokens * output_rate),
+        )
+
+    # Model not found in litellm or OpenRouter
     if strict:
         raise UnknownModelError(
-            f"Model '{model}' has no pricing in litellm. "
-            "Use strict=False for pre-estimation or add the model to litellm."
+            f"Model '{model}' has no pricing in litellm/OpenRouter. "
+            "Use strict=False for pre-estimation or register model pricing."
         )
 
     logger.warning("Unknown model %r — returning zero cost (strict=False)", model)

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -11,7 +11,6 @@ Cost resolution is intentionally fail-fast:
 import json
 import logging
 import os
-import re
 import threading
 import warnings
 from dataclasses import dataclass
@@ -92,17 +91,6 @@ ESTIMATION_MODEL_PRICING = {
 
 # Backward-compat alias (external code may import the old name)
 FALLBACK_MODEL_PRICING = ESTIMATION_MODEL_PRICING
-
-# Model scoring constants for fuzzy matching preference
-# Used in _calculate_model_score to prioritize model selection
-LATEST_MODEL_PRIORITY = (9999, 12, 31, 99)  # "latest" models get highest priority
-VERSION_FALLBACK_DATE = (
-    2024,
-    1,
-    1,
-)  # Base date for version-numbered models (e.g., v1, v2)
-UNVERSIONED_FALLBACK_DATE = (2020, 1, 1)  # Base date for unversioned models
-DATE_MATCH_PRIORITY = 50  # Priority value for date-matched models
 
 # Warn-once cache to de-noise fallback pricing warnings (thread-safe)
 _warned_models: set[str] = set()
@@ -670,54 +658,17 @@ class CostBreakdown:
 
 
 class CostCalculator:
-    """LLM cost calculator.
-
-    Runtime pricing should resolve through ``cost_from_tokens()`` using litellm
-    aliases and pricing tables. Mapping/fuzzy helpers are kept for legacy
-    compatibility with non-token paths and diagnostics.
-    """
-
-    # Legacy compatibility mappings (not used by canonical cost_from_tokens).
-    EXACT_MODEL_MAPPING = {
-        "claude-3-haiku": "claude-3-haiku-20240307",
-        "claude-3-sonnet": "claude-3-sonnet-20240229",
-        "claude-3-opus": "claude-3-opus-20240229",
-        "claude-3-5-sonnet": "claude-3-5-sonnet-20241022",
-        "claude-3-5-haiku": "claude-3-5-haiku-20241022",
-        "claude-3-7-sonnet": "claude-3-7-sonnet-20250219",
-        "claude-4-sonnet": "claude-sonnet-4-20250514",
-        "claude-4-opus": "claude-opus-4-20250514",
-        "claude-haiku": "claude-3-haiku-20240307",
-        "claude-sonnet": "claude-3-5-sonnet-20241022",
-        "claude-opus": "claude-3-opus-20240229",
-        "gpt-3.5": _GPT35_TURBO,
-        "gpt-4": _GPT4O,
-        "gpt4": _GPT4O,
-        "gpt3.5": _GPT35_TURBO,
-        "gpt-4o-mini": "gpt-4o-mini",
-        "claude3-haiku": "claude-3-haiku-20240307",
-        "claude3-sonnet": "claude-3-sonnet-20240229",
-        "claude3-opus": "claude-3-opus-20240229",
-    }
-
-    FAMILY_DEFAULTS = {
-        "claude-3": "claude-3-5-sonnet-latest",
-        "claude": "claude-3-5-sonnet-latest",
-        "gpt-4": _GPT4O,
-        "gpt": _GPT4O,
-        "gpt-3.5": _GPT35_TURBO,
-    }
+    """LLM cost calculator using strict canonical pricing resolution."""
 
     def __init__(self, logger=None, enable_caching: bool = True) -> None:
         """Initialize the cost calculator.
 
         Args:
             logger: Optional logger instance for debug/warning messages
-            enable_caching: Whether to cache fuzzy match results for performance
+            enable_caching: Deprecated and ignored (kept for compatibility)
         """
         self.logger = logger
         self.enable_caching = enable_caching
-        self._fuzzy_match_cache: dict[str, str | None] = {}
 
         if not LITELLM_AVAILABLE:
             raise RuntimeError(
@@ -814,235 +765,19 @@ class CostCalculator:
 
         result.total_cost = result.input_cost + result.output_cost
 
-    def _normalize_model_name(self, model_name: str) -> str:
-        """Strip provider prefixes like 'openai/gpt-4o' -> 'gpt-4o'."""
-        if "/" in model_name:
-            # Handle nested prefixes like 'openrouter/openai/gpt-4o'
-            return model_name.split("/")[-1]
-        return model_name
-
-    def _map_model_name(self, model_name: str) -> str | None:
-        """Map model names to litellm-compatible names (legacy helper)."""
-        if not model_name:
-            return None
-
-        # Step 1: litellm-native alias resolution
-        resolved = _resolve_litellm_alias(model_name)
-        if resolved != _normalize_model_name(model_name):
-            if self.logger:
-                self.logger.debug(
-                    "litellm alias mapping: %r -> %r",
-                    model_name,
-                    resolved,
-                )
-            return resolved
-
-        # Step 2: Try exact compatibility mapping
-        exact_match = self.EXACT_MODEL_MAPPING.get(model_name)
-        if exact_match:
-            if self.logger:
-                self.logger.debug(
-                    f"Exact model mapping: '{model_name}' -> '{exact_match}'"
-                )
-            return exact_match
-
-        # Step 3: Try with normalized name (strip provider prefix)
-        normalized = self._normalize_model_name(model_name)
-        if normalized != model_name:
-            exact_match = self.EXACT_MODEL_MAPPING.get(normalized)
-            if exact_match:
-                if self.logger:
-                    self.logger.debug(
-                        f"Exact model mapping (normalized): '{model_name}' -> '{exact_match}'"
-                    )
-                return exact_match
-
-        # Step 4: Try family defaults for generic names
-        family_match = self.FAMILY_DEFAULTS.get(model_name)
-        if family_match:
-            if self.logger:
-                self.logger.debug(
-                    f"Family model mapping: '{model_name}' -> '{family_match}'"
-                )
-            return family_match
-
-        # Step 5: Try fuzzy matching (legacy behavior)
-        return self._fuzzy_match_model(model_name)
-
-    def _fuzzy_match_model(self, user_model: str) -> str | None:
-        """Find best matching litellm model using fuzzy matching."""
-        # Check cache first
-        if self.enable_caching and user_model in self._fuzzy_match_cache:
-            cached_result = self._fuzzy_match_cache[user_model]
-            if self.logger and cached_result:
-                self.logger.debug(
-                    f"Cached fuzzy match: '{user_model}' -> '{cached_result}'"
-                )
-            return cached_result
-
-        # Normalize model name for checking
-        normalized = self._normalize_model_name(user_model)
-
-        # First check if the model exists as-is in litellm
-        if LITELLM_AVAILABLE and normalized in litellm.model_cost:
-            if self.logger:
-                self.logger.debug(
-                    f"Direct model match: '{user_model}' found in litellm"
-                )
-            if self.enable_caching:
-                self._fuzzy_match_cache[user_model] = normalized
-            return normalized
-
-        result = self._perform_fuzzy_match(user_model)
-
-        # Cache the result
-        if self.enable_caching:
-            self._fuzzy_match_cache[user_model] = result
-
-        return result
-
-    def _perform_fuzzy_match(self, user_model: str) -> str | None:
-        """Perform actual fuzzy matching algorithm."""
-        if not LITELLM_AVAILABLE or len(user_model) < 5:
-            return None
-
-        # Get all available litellm models
-        available_models = list(litellm.model_cost.keys())
-
-        # Normalize the user model
-        normalized_user = self._normalize_model_name(user_model)
-
-        # Find substring matches
-        matches = []
-        user_lower = normalized_user.lower()
-
-        for litellm_model in available_models:
-            # Normalize litellm model name too
-            normalized_litellm = self._normalize_model_name(litellm_model)
-            if self._is_semantic_match(user_lower, normalized_litellm.lower()):
-                matches.append(litellm_model)
-
-        if not matches:
-            if self.logger:
-                self.logger.debug(f"No fuzzy matches found for '{user_model}'")
-            return None
-
-        if len(matches) == 1:
-            result = matches[0]
-            if self.logger:
-                self.logger.info(f"Fuzzy match found: '{user_model}' -> '{result}'")
-            return str(result)
-
-        # Multiple matches - select the latest/best one
-        best_match = self._select_best_model(matches, user_model)
-        if self.logger:
-            self.logger.info(
-                f"Best fuzzy match: '{user_model}' -> '{best_match}' (from {len(matches)} options)"
-            )
-
-        return best_match
-
-    def _is_semantic_match(self, user_model: str, litellm_model: str) -> bool:
-        """Check if a litellm model is a meaningful semantic match for user model."""
-        # Basic substring matching
-        if user_model not in litellm_model:
-            return False
-
-        # Avoid over-broad matches
-        if len(user_model) < 5:
-            return False
-
-        # Special case: ensure model family alignment
-        if "gpt" in user_model and "gpt" not in litellm_model:
-            return False
-        if "claude" in user_model and "claude" not in litellm_model:
-            return False
-
-        # Avoid mixing different model generations inappropriately
-        if "gpt-4" in user_model and "gpt-3" in litellm_model:
-            return False
-        if "gpt-3" in user_model and "gpt-4" in litellm_model:
-            return False
-
-        # Check for model version mismatches that don't make sense
-        if "claude-3" in user_model and "claude-2" in litellm_model:
-            return False
-
-        return True
-
-    def _select_best_model(self, matches: list[str], user_model: str) -> str:
-        """Select the best model from multiple matches using date/version sorting."""
-        if not matches:
-            return ""
-
-        if len(matches) == 1:
-            return matches[0]
-
-        # Sort by preference: latest > dated versions > version numbers > plain names
-        scored_matches = []
-        for match in matches:
-            score = self._calculate_model_score(match, user_model)
-            scored_matches.append((score, match))
-
-        # Sort by score (highest first) and return the best match
-        scored_matches.sort(key=lambda x: x[0], reverse=True)
-        return scored_matches[0][1]
-
-    def _calculate_model_score(
-        self, model_name: str, user_model: str
-    ) -> tuple[int, int, int, int]:
-        """Calculate a sortable score for model preference."""
-        suffix = model_name.lower().replace(user_model.lower(), "")
-
-        # "latest" gets highest priority
-        if "latest" in suffix:
-            return LATEST_MODEL_PRIORITY
-
-        # Parse YYYYMMDD format
-        date_match = re.search(r"(\d{4})(\d{2})(\d{2})", suffix)
-        if date_match:
-            year, month, day = map(int, date_match.groups())
-            return (year, month, day, DATE_MATCH_PRIORITY)
-
-        # Parse YYYY-MM-DD format
-        date_match = re.search(r"(\d{4})-(\d{2})-(\d{2})", suffix)
-        if date_match:
-            year, month, day = map(int, date_match.groups())
-            return (year, month, day, DATE_MATCH_PRIORITY)
-
-        # Parse version numbers (v1, v2, etc.)
-        version_match = re.search(r"v(\d+)", suffix)
-        if version_match:
-            version = int(version_match.group(1))
-            return (*VERSION_FALLBACK_DATE, version)
-
-        # Prefer shorter model names (more specific)
-        specificity = 100 - len(model_name)
-        return (*UNVERSIONED_FALLBACK_DATE, specificity)
-
     def _safe_calculate_prompt_cost(
         self, prompt: str | list[dict[str, Any]], model: str
     ) -> float:
-        """Safely calculate prompt cost with error handling."""
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", UserWarning)
-                return calculate_prompt_cost(prompt, model)
-        except Exception as e:
-            if self.logger:
-                self.logger.debug(f"Prompt cost calculation failed: {e}")
-            return 0.0
+        """Calculate prompt cost and propagate pricing failures."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            return calculate_prompt_cost(prompt, model)
 
     def _safe_calculate_completion_cost(self, response: str, model: str) -> float:
-        """Safely calculate completion cost with error handling."""
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", UserWarning)
-                return calculate_completion_cost(response, model)
-        except Exception as e:
-            if self.logger:
-                self.logger.debug(f"Completion cost calculation failed: {e}")
-            return 0.0
+        """Calculate completion cost and propagate pricing failures."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            return calculate_completion_cost(response, model)
 
     def _calculate_from_tokens(
         self, input_tokens: int, output_tokens: int, model: str
@@ -1064,43 +799,63 @@ class CostCalculator:
         return list(litellm.model_cost.keys())
 
     def clear_cache(self) -> None:
-        """Clear the fuzzy match cache."""
-        self._fuzzy_match_cache.clear()
-        # Note: get_available_models is not cached, so no need to clear
+        """Clear internal pricing caches."""
+        global _CUSTOM_PRICING_CACHE, _CUSTOM_PRICING_CACHE_KEY
+        with _CUSTOM_PRICING_LOCK:
+            _CUSTOM_PRICING_CACHE = None
+            _CUSTOM_PRICING_CACHE_KEY = None
 
     def validate_model_name(self, model_name: str) -> dict[str, Any]:
-        """Validate and provide information about a model name."""
+        """Validate and provide information about a model name.
+
+        This method does not perform fuzzy guessing or implicit family mapping.
+        """
+        normalized = _normalize_model_name(model_name) if model_name else model_name
+        resolved = _resolve_litellm_alias(normalized) if model_name else None
         result = {
             "original": model_name,
+            "normalized": normalized,
             "mapped": None,
+            "resolved": resolved,
             "available": LITELLM_AVAILABLE,
+            "known_to_litellm": False,
+            "custom_pricing": False,
             "exact_match": False,
             "fuzzy_match": False,
             "family_match": False,
             "not_found": False,
         }
 
+        if not model_name:
+            result["not_found"] = True
+            return result
+
         if not LITELLM_AVAILABLE:
             result["error"] = "litellm library not available"
             return result
 
-        # Check exact mapping
-        if model_name in self.EXACT_MODEL_MAPPING:
-            result["mapped"] = self.EXACT_MODEL_MAPPING[model_name]
-            result["exact_match"] = True
+        candidates = [
+            candidate for candidate in [model_name, normalized, resolved] if candidate
+        ]
+        candidates = list(dict.fromkeys(candidates))
+        for candidate in candidates:
+            if _is_model_known_to_litellm(candidate):
+                result["known_to_litellm"] = True
+                result["mapped"] = candidate
+                result["not_found"] = False
+                return result
+
+        try:
+            custom_pricing = _try_custom_model_pricing(model_name)
+        except ValueError as exc:
+            result["error"] = str(exc)
+            result["not_found"] = True
             return result
 
-        # Check family mapping
-        if model_name in self.FAMILY_DEFAULTS:
-            result["mapped"] = self.FAMILY_DEFAULTS[model_name]
-            result["family_match"] = True
-            return result
-
-        # Try fuzzy matching
-        fuzzy_result = self._perform_fuzzy_match(model_name)
-        if fuzzy_result:
-            result["mapped"] = fuzzy_result
-            result["fuzzy_match"] = True
+        if custom_pricing is not None:
+            result["custom_pricing"] = True
+            result["mapped"] = resolved or normalized or model_name
+            result["not_found"] = False
             return result
 
         result["not_found"] = True


### PR DESCRIPTION
## Summary
- switch runtime cost resolution to litellm-native alias resolution
- register Traigent convenience aliases via `litellm.model_alias_map`
- add cached OpenRouter pricing fallback for models unknown to litellm (skipped in offline mode)
- update cost warning text and add regression tests for alias + fallback behavior

## Validation
- `uv run ruff check traigent/utils/cost_calculator.py traigent/core/optimized_function.py tests/unit/utils/test_cost_from_tokens.py tests/unit/utils/test_cost_calculator.py`
- `uv run pytest -q tests/unit/utils/test_cost_from_tokens.py tests/unit/utils/test_cost_calculator.py`
- `uv run pytest -q tests/unit/utils/test_cost_from_tokens.py tests/unit/utils/test_cost_calculator.py tests/unit/utils/test_cost_calculator_pricing.py tests/unit/evaluators/test_metrics_tracker.py -k "cost or strict" tests/unit/integrations/langchain/test_langchain_handler.py -k "estimate_cost or strict_mode" tests/unit/integrations/pydantic_ai/test_handler.py -k "estimate_cost or strict_mode" tests/unit/integrations/test_cost_extraction.py tests/unit/core/test_cost_enforcement.py -k "unknown_cost_sync_pairwise or unknown_cost_async_pairwise or strict_mode_is_latched_at_init"`