### PR TITLE
Fix failing tests and stabilize mock-mode optimizer seed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,31 @@
 # Contributing to Traigent
 
-See [docs/contributing/CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md) for the full contributing guide.
+This top-level guide provides quick navigation for contributors. The complete
+reference remains at
+[`docs/contributing/CONTRIBUTING.md`](docs/contributing/CONTRIBUTING.md).
+
+## Getting Started
+
+1. Read the full contributor guide linked above.
+2. Install dependencies and run tests locally before opening changes.
+3. Review existing issues to avoid duplicate work.
+
+## Code Style
+
+Follow repository linting and formatting rules. Keep changes scoped, typed, and
+covered by tests where practical.
+
+## Testing
+
+Run relevant unit/integration tests for your change. For broad changes, run the
+full suite in CI-equivalent mode.
+
+## Pull Requests
+
+Open focused pull requests with a clear summary, rationale, and test evidence.
+Link related issues and call out any known tradeoffs.
+
+## Issue Reporting
+
+When filing an issue, include reproduction steps, expected behavior, actual
+behavior, and environment details.

--- a/tests/integration/test_plugin_ctd.py
+++ b/tests/integration/test_plugin_ctd.py
@@ -537,7 +537,11 @@ class CTDTestGenerator:
                         # client APIs don't accept them as top-level kwargs:
                         # - Bedrock: extra_params (for stop_sequences, etc.)
                         # - Gemini: generation_config (for temperature, max_output_tokens, etc.)
-                        nested_dicts = ["extra_params", "generation_config"]
+                        nested_dicts = [
+                            "extra_params",
+                            "generation_config",
+                            "model_settings",
+                        ]
                         actual_value = None
                         for nested_key in nested_dicts:
                             nested = overridden_kwargs.get(nested_key, {})
@@ -566,7 +570,11 @@ class CTDTestGenerator:
             # Some plugins (e.g., Bedrock, Gemini) move unknown params to nested dicts
             original_param_preserved = "original_param" in overridden_kwargs
             if not original_param_preserved:
-                for nested_key in ["extra_params", "generation_config"]:
+                for nested_key in [
+                    "extra_params",
+                    "generation_config",
+                    "model_settings",
+                ]:
                     nested = overridden_kwargs.get(nested_key, {})
                     if isinstance(nested, dict) and "original_param" in nested:
                         original_param_preserved = True

--- a/tests/optimizer_validation/conftest.py
+++ b/tests/optimizer_validation/conftest.py
@@ -9,6 +9,7 @@ This module provides:
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -795,8 +796,11 @@ def scenario_runner(
             dict(scenario.mock_mode_config) if scenario.mock_mode_config else {}
         )
         if "random_seed" not in mock_config:
-            # Generate deterministic seed from scenario name
-            mock_config["random_seed"] = hash(scenario.name) % (2**31)
+            # Use a stable hash to avoid process-randomized Python hash() output.
+            seed_bytes = hashlib.sha256(scenario.name.encode("utf-8")).digest()
+            mock_config["random_seed"] = int.from_bytes(seed_bytes[:8], "big") % (
+                2**31
+            )
 
         # Apply decorator
         try:

--- a/traigent/api/validation_protocol.py
+++ b/traigent/api/validation_protocol.py
@@ -438,6 +438,7 @@ class SATConstraintValidator:
     """
 
     def __init__(self) -> None:
+        """Initialize with a Python validator delegate for compatibility mode."""
         self._delegate = PythonConstraintValidator()
 
     def validate_config(

--- a/traigent/integrations/langchain/handler.py
+++ b/traigent/integrations/langchain/handler.py
@@ -680,7 +680,7 @@ class TraigentHandler(BaseCallbackHandler):
             # Non-strict mode may return zero for unknown/unmapped aliases.
             # Preserve backward-compatible estimator behavior by attempting
             # the local estimation table before returning zero.
-            if not strict_cost_accounting and total_cost == 0.0 and total_tokens > 0:
+            if not strict_cost_accounting and total_cost <= 0.0 and total_tokens > 0:
                 est_input_cost, est_output_cost = _estimation_cost_from_tokens(
                     model,
                     input_tokens,

--- a/traigent/integrations/langchain/handler.py
+++ b/traigent/integrations/langchain/handler.py
@@ -662,8 +662,12 @@ class TraigentHandler(BaseCallbackHandler):
         When TRAIGENT_STRICT_COST_ACCOUNTING=true, unknown models raise.
         """
         strict_cost_accounting = self._strict_cost_accounting
+        total_tokens = input_tokens + output_tokens
         try:
-            from traigent.utils.cost_calculator import cost_from_tokens
+            from traigent.utils.cost_calculator import (
+                _estimation_cost_from_tokens,
+                cost_from_tokens,
+            )
 
             input_cost, output_cost = cost_from_tokens(
                 input_tokens,
@@ -671,14 +675,34 @@ class TraigentHandler(BaseCallbackHandler):
                 model,
                 strict=strict_cost_accounting,
             )
-            return float(input_cost + output_cost)
+            total_cost = float(input_cost + output_cost)
+
+            # Non-strict mode may return zero for unknown/unmapped aliases.
+            # Preserve backward-compatible estimator behavior by attempting
+            # the local estimation table before returning zero.
+            if not strict_cost_accounting and total_cost == 0.0 and total_tokens > 0:
+                est_input_cost, est_output_cost = _estimation_cost_from_tokens(
+                    model,
+                    input_tokens,
+                    output_tokens,
+                    _quiet=True,
+                )
+                est_total = float(est_input_cost + est_output_cost)
+                if est_total > 0.0:
+                    logger.debug(
+                        "Using estimation pricing fallback for model %r in TraigentHandler",
+                        model,
+                    )
+                    return est_total
+
+            return total_cost
         except Exception:
             if strict_cost_accounting:
                 raise
             logger.warning(
                 "Cost calculation failed for model %r with %d tokens",
                 model,
-                input_tokens + output_tokens,
+                total_tokens,
             )
             return 0.0
 


### PR DESCRIPTION
## Summary
- fix `CONTRIBUTING.md` structure/completeness expectations used by documentation tests
- extend plugin CTD verification to support nested `model_settings` kwargs
- add missing SAT validator `__init__` docstring for API documentation coverage
- restore non-strict cost estimation fallback in LangChain handler when canonical pricing returns zero
- make optimizer-validation mock seed deterministic using stable SHA-256 (instead of process-randomized `hash()`) to eliminate flakiness

## Validation
- `.venv/bin/ruff check traigent/ --output-format=github`
- `.venv/bin/black --check --diff traigent/`
- `.venv/bin/isort --check-only --diff traigent/`
- `.venv/bin/mypy traigent/`
- `bash scripts/hooks/check-cost-strictness.sh`
- `.venv/bin/python -m tests.optimizer_validation.tools.lint_pricing_consistency --format github`
- `TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true PYTHONPATH=. .venv/bin/pytest tests/unit/ -q --timeout=60 --no-cov` (11001 passed, 22 skipped, 1 xfailed)
- failing subset from report: 10/10 passed
- flaky stress check: network resilience test repeated 8x, all passed
- examples smoke parity checks: core examples runner + README examples passed
- package gate: `.venv/bin/python -m build`, `.venv/bin/twine check dist/*`, wheel install/import passed