### PR TITLE
fix(sonar): break S2083 taint chain in apply.py

### DIFF
--- a/tests/unit/config_generator/test_apply.py
+++ b/tests/unit/config_generator/test_apply.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import traigent.config_generator.apply as _apply_mod
 from traigent.config_generator.apply import (
     _collect_needed_imports,
     _find_function,
@@ -15,6 +16,7 @@ from traigent.config_generator.apply import (
     _get_existing_imports,
     _get_leading_whitespace,
     _indent_decorator,
+    _sanitize_source_path,
     apply_config,
 )
 from traigent.config_generator.types import (
@@ -23,6 +25,12 @@ from traigent.config_generator.types import (
     SafetySpec,
     TVarSpec,
 )
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let tests write to tmp_path by setting the safe base dir."""
+    monkeypatch.setattr(_apply_mod, "_SAFE_BASE_DIR", str(tmp_path))
 
 
 @pytest.fixture()
@@ -284,9 +292,9 @@ class TestApplyConfig:
         lines = modified.splitlines()
         # Decorator should appear before the existing @some_other_decorator
         optimize_idx = next(
-            i for i, l in enumerate(lines) if "@traigent.optimize(" in l
+            i for i, line in enumerate(lines) if "@traigent.optimize(" in line
         )
-        other_idx = next(i for i, l in enumerate(lines) if "@some_other_decorator" in l)
+        other_idx = next(i for i, line in enumerate(lines) if "@some_other_decorator" in line)
         assert optimize_idx < other_idx
 
     def test_replaces_fully_qualified_decorator(
@@ -326,6 +334,41 @@ class TestApplyConfig:
         modified = src.read_text()
         assert "@traigent.optimize(" in modified
         assert "async def my_async_func" in modified
+
+
+class TestSanitizeSourcePath:
+    def test_rejects_path_outside_base_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Path traversal outside the safe base directory must be rejected."""
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        monkeypatch.setattr(_apply_mod, "_SAFE_BASE_DIR", str(safe_dir))
+
+        # Create a file outside the safe dir
+        outside = tmp_path / "evil.py"
+        outside.write_text("x = 1\n")
+
+        with pytest.raises(ValueError, match="outside the allowed base directory"):
+            _sanitize_source_path(outside)
+
+    def test_rejects_non_py_file(self, tmp_path: Path) -> None:
+        txt = tmp_path / "data.txt"
+        txt.write_text("hello")
+        with pytest.raises(ValueError, match="Expected a .py file"):
+            _sanitize_source_path(txt)
+
+    def test_rejects_nonexistent_file(self, tmp_path: Path) -> None:
+        missing = tmp_path / "gone.py"
+        with pytest.raises((ValueError, OSError)):
+            _sanitize_source_path(missing)
+
+    def test_accepts_valid_py_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "ok.py"
+        src.write_text("x = 1\n")
+        result = _sanitize_source_path(src)
+        assert result.is_file()
+        assert result.suffix == ".py"
 
 
 class TestHelpers:

--- a/traigent/config_generator/apply.py
+++ b/traigent/config_generator/apply.py
@@ -7,11 +7,43 @@ and line-based string operations for insertion to preserve user formatting.
 from __future__ import annotations
 
 import ast
+import os
 import re
 import shutil
 from pathlib import Path
 
 from traigent.config_generator.types import AutoConfigResult
+
+# Base directory for path containment checks (S2083).
+# Defaults to CWD; overridable via env var for testing / CI.
+_SAFE_BASE_DIR = os.environ.get("TRAIGENT_CONFIG_BASE_DIR", "")
+
+
+def _sanitize_source_path(file_path: Path) -> Path:
+    """Resolve and validate a user-provided source file path.
+
+    Ensures the canonical path is a real ``.py`` file within a trusted
+    base directory so that no user-controlled traversal can escape it.
+
+    Returns a freshly-constructed ``Path`` whose components are derived
+    from the validated canonical string — not from the original argument.
+    """
+    base = os.path.realpath(_SAFE_BASE_DIR or os.getcwd())
+    canonical = os.path.realpath(str(file_path))
+
+    # Containment check — recognised as sanitisation by SAST (S2083)
+    if not canonical.startswith(base + os.sep) and canonical != base:
+        raise ValueError(
+            f"Path '{canonical}' is outside the allowed base directory '{base}'"
+        )
+
+    # Reconstruct Path from the validated canonical string
+    safe = Path(canonical)
+    if not safe.is_file():
+        raise ValueError(f"Not a file: {safe}")
+    if safe.suffix != ".py":
+        raise ValueError(f"Expected a .py file, got: {safe}")
+    return safe
 
 
 def apply_config(
@@ -47,14 +79,9 @@ def apply_config(
     if not function_name:
         raise ValueError("function_name is required for apply_config")
 
-    # Resolve and validate path to prevent traversal attacks (S2083)
-    resolved = file_path.resolve(strict=True)
-    if not resolved.is_file():
-        raise ValueError(f"Not a file: {resolved}")
-    if resolved.suffix != ".py":
-        raise ValueError(f"Expected a .py file, got: {resolved}")
+    safe_path = _sanitize_source_path(file_path)
 
-    source = resolved.read_text()
+    source = safe_path.read_text()
     lines = source.splitlines(keepends=True)
 
     try:
@@ -100,10 +127,10 @@ def apply_config(
 
     # Write back
     if backup:
-        shutil.copy2(resolved, resolved.with_suffix(".py.bak"))
+        shutil.copy2(safe_path, safe_path.with_suffix(".py.bak"))
 
-    resolved.write_text("".join(lines))
-    return resolved
+    safe_path.write_text("".join(lines))
+    return safe_path
 
 
 def _find_function(


### PR DESCRIPTION
## Summary
- SonarCloud Quality Gate still failing with **E Security Rating** on develop after PR #180 — the `Path(resolved.anchor) / resolved.relative_to(resolved.anchor)` approach did not break taint tracking
- This PR uses the **canonical SAST-recognized pattern**: `os.path.realpath()` + `str.startswith()` containment check against a safe base directory
- Extracts `_sanitize_source_path()` that validates and reconstructs the path from `os.path.realpath` output
- Safe base defaults to CWD; configurable via `TRAIGENT_CONFIG_BASE_DIR` env var for flexibility
- Adds 4 new tests for traversal rejection, non-.py rejection, missing file, and valid acceptance
- Fixes pre-existing E741 lint warning (ambiguous variable `l`)

## Test plan
- [x] All 30 `test_apply.py` tests pass (26 existing + 4 new)
- [x] `ruff check` passes
- [x] All pre-commit hooks pass
- [ ] SonarCloud Code Analysis passes with Security Rating A

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)