### PR TITLE
Refactor/standardize api key

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -26,8 +26,6 @@ Set your API key as an environment variable:
 
 ```bash
 export TRAIGENT_API_KEY=your_api_key_here
-# or (legacy)
-export OPTIGEN_API_KEY=your_api_key_here
 ```
 
 > Tip: Credentials saved through `traigent auth login` are resolved by the SDK automatically via the built-in Credential Manager, so you never need to copy keys into code.
@@ -120,7 +118,7 @@ traigent auth whoami tg_your_api_key_here
 Unified authentication leverages the shared `CredentialManager` to look for credentials in a secure order. When the CLI stores an API key or refresh token, the SDK reuses it automatically during runtime. This removes the need to duplicate configuration across environments while keeping sensitive material out of source code.
 
 The discovery order is:
-- System environment variables (`TRAIGENT_API_KEY`, legacy `OPTIGEN_API_KEY`)
+- System environment variable (`TRAIGENT_API_KEY`)
 - CLI-managed credentials saved via `traigent auth login` (keyring or encrypted file)
 - Development defaults only when explicit test flags are enabled
 
@@ -142,7 +140,7 @@ Credentials are stored securely using multiple layers:
 - Contents are JSON-encoded (no additional encryption)
 
 ### 3. Environment Variables
-- `TRAIGENT_API_KEY` (or legacy `OPTIGEN_API_KEY`)
+- `TRAIGENT_API_KEY`
 - Useful for CI/CD environments
 
 ## Priority Order
@@ -276,7 +274,7 @@ For automated environments:
 ```yaml
 - name: Configure Traigent
   env:
-    TRAIGENT_API_KEY: ${{ secrets.TRAIGENT_API_KEY }}  # Use OPTIGEN_API_KEY only for legacy jobs
+    TRAIGENT_API_KEY: ${{ secrets.TRAIGENT_API_KEY }}
   run: |
     # SDK automatically uses environment variable
     python your_optimization_script.py
@@ -379,10 +377,10 @@ os.environ["TRAIGENT_API_KEY"] = "your_key"
 traigent auth login
 
 # Or continue using environment variables
-export TRAIGENT_API_KEY=your_key  # export OPTIGEN_API_KEY=your_key (legacy)
+export TRAIGENT_API_KEY=your_key
 ```
 
-The new system is backward compatible - existing environment variables continue to work.
+The new system remains compatible with existing `TRAIGENT_API_KEY` workflows.
 
 ## Support
 

--- a/tests/integration/test_ctd_execution_modes.py
+++ b/tests/integration/test_ctd_execution_modes.py
@@ -428,7 +428,7 @@ async def test_ctd_execution_behavior(case, monkeypatch):
         monkeypatch.setenv("TRAIGENT_BACKEND_URL", f"https://{backend_host}")
 
     # Clear sensitive env to prevent leakage between cases
-    for key in ["TRAIGENT_API_KEY", "OPTIGEN_API_KEY", "TRAIGENT_BACKEND_URL"]:
+    for key in ["TRAIGENT_API_KEY", "TRAIGENT_BACKEND_URL"]:
         monkeypatch.delenv(key, raising=False)
 
     api_key = None

--- a/tests/integration/test_ctd_execution_modes_live.py
+++ b/tests/integration/test_ctd_execution_modes_live.py
@@ -23,7 +23,7 @@ LIVE_CASES = [case for case in CTD_CASES if case["combo"].get("has_api_key")]
 @pytest.mark.integration
 @pytest.mark.skipif(
     not os.getenv("TRAIGENT_CTD_LIVE"),
-    reason="Set TRAIGENT_CTD_LIVE=1 and provide TRAIGENT_API_KEY (or legacy OPTIGEN_API_KEY) to run live backend tests",
+    reason="Set TRAIGENT_CTD_LIVE=1 and provide TRAIGENT_API_KEY to run live backend tests",
 )
 @pytest.mark.parametrize("case", LIVE_CASES, ids=lambda payload: payload["id"])
 async def test_ctd_execution_behavior_live(case: dict, monkeypatch) -> None:
@@ -60,11 +60,9 @@ async def test_ctd_execution_behavior_live(case: dict, monkeypatch) -> None:
         monkeypatch.setenv("TRAIGENT_BACKEND_URL", "https://api.traigent.ai")
 
     # We expect an API key to be available in the environment
-    api_key = os.getenv("TRAIGENT_API_KEY") or os.getenv("OPTIGEN_API_KEY")
+    api_key = os.getenv("TRAIGENT_API_KEY")
     if not api_key:
-        pytest.skip(
-            "TRAIGENT_API_KEY (or legacy OPTIGEN_API_KEY) must be set for live backend test"
-        )
+        pytest.skip("TRAIGENT_API_KEY must be set for live backend test")
 
     # Instantiate real client
     client = TraigentClient(

--- a/tests/test_backend_config.py
+++ b/tests/test_backend_config.py
@@ -25,7 +25,6 @@ def test_backend_config():
     for var in [
         "TRAIGENT_BACKEND_URL",
         "TRAIGENT_API_URL",
-        "OPTIGEN_API_KEY",
         "TRAIGENT_API_KEY",
         "TRAIGENT_DEFAULT_LOCAL_URL",
         "TRAIGENT_ENV",
@@ -122,17 +121,6 @@ def test_backend_config():
     assert config["api_key_prefix"] == "traigent...", "Should show prefix"
     assert config["api_key_env"] == "TRAIGENT_API_KEY"
 
-    print("   Ensuring legacy OPTIGEN_API_KEY still works:")
-    os.environ["OPTIGEN_API_KEY"] = "optigen-key-67890"
-    config = BackendConfig.get_config_summary()
-    assert (
-        config["api_key_prefix"] == "traigent..."
-    ), "TRAIGENT_API_KEY should remain preferred when both set"
-    os.environ.pop("TRAIGENT_API_KEY", None)
-    config = BackendConfig.get_config_summary()
-    assert (
-        config["api_key_env"] == "OPTIGEN_API_KEY"
-    ), "Legacy OPTIGEN_API_KEY should be used when TRAIGENT_API_KEY absent"
     print("   ✅ API key configuration working correctly\n")
 
     # Test 5: Test with traigent.initialize()
@@ -143,7 +131,6 @@ def test_backend_config():
     for var in [
         "TRAIGENT_BACKEND_URL",
         "TRAIGENT_API_URL",
-        "OPTIGEN_API_KEY",
         "TRAIGENT_API_KEY",
         "TRAIGENT_DEFAULT_LOCAL_URL",
         "TRAIGENT_ENV",
@@ -151,7 +138,7 @@ def test_backend_config():
         os.environ.pop(var, None)
 
     os.environ["TRAIGENT_BACKEND_URL"] = "http://localhost:5000"
-    os.environ["OPTIGEN_API_KEY"] = "test-api-key"
+    os.environ["TRAIGENT_API_KEY"] = "test-api-key"
 
     # Initialize without explicit URL (should use env var)
     result = traigent.initialize()
@@ -175,7 +162,7 @@ def test_backend_client_config():
 
     # Set up environment for local backend
     os.environ["TRAIGENT_BACKEND_URL"] = "http://localhost:5000"
-    os.environ["OPTIGEN_API_KEY"] = "test-key"
+    os.environ["TRAIGENT_API_KEY"] = "test-key"
     os.environ["TRAIGENT_ENV"] = "development"
 
     # Import after setting env vars

--- a/tests/unit/cloud/test_credential_resolver.py
+++ b/tests/unit/cloud/test_credential_resolver.py
@@ -328,7 +328,6 @@ class TestLoadFromEnv:
                 with patch.dict(os.environ, {}, clear=True):
                     # Clear relevant env vars
                     os.environ.pop("TRAIGENT_API_KEY", None)
-                    os.environ.pop("OPTIGEN_API_KEY", None)
 
                     result = await resolver.load_from_env(AuthMode.API_KEY)
                     assert result is None

--- a/tests/unit/utils/test_error_handler.py
+++ b/tests/unit/utils/test_error_handler.py
@@ -256,9 +256,7 @@ class TestErrorHandlerAPIKeyErrors:
         with pytest.raises(APIKeyError) as exc_info:
             ErrorHandler.handle_api_key_error(error)
 
-        assert "TRAIGENT_API_KEY" in str(exc_info.value) or "OPTIGEN_API_KEY" in str(
-            exc_info.value
-        )
+        assert "TRAIGENT_API_KEY" in str(exc_info.value)
 
     def test_handle_api_key_error_generic(self):
         """Test handling of generic API key error."""

--- a/traigent/cli/local_commands.py
+++ b/traigent/cli/local_commands.py
@@ -473,7 +473,7 @@ def sync_to_cloud(
                 "❌ API key required for cloud sync. Use --api-key or set TRAIGENT_API_KEY environment variable.",
                 err=True,
             )
-            click.echo("💡 Get your API key at: https://traigent.ai/api-keys")
+            click.echo("💡 Configure a key with `traigent auth login` or export TRAIGENT_API_KEY.")
             sys.exit(1)
 
         sync_manager = SyncManager(config, api_key)

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -383,9 +383,7 @@ class AuthManager:
         self._unified_auth = self
 
         self._provided_credentials: AuthCredentials | None = None
-        initial_api_key = (
-            api_key or os.getenv("TRAIGENT_API_KEY") or os.getenv("OPTIGEN_API_KEY")
-        )
+        initial_api_key = api_key or os.getenv("TRAIGENT_API_KEY")
         initial_source = (
             "explicit" if api_key else ("environment" if initial_api_key else None)
         )

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -43,7 +43,7 @@ class CredentialManager:
         """Get API key from available sources.
 
         Priority order:
-        1. TRAIGENT_API_KEY / OPTIGEN_API_KEY environment variables
+        1. TRAIGENT_API_KEY environment variable
         2. Stored credentials from CLI auth
         3. Default test credentials (dev only)
 
@@ -182,11 +182,7 @@ class CredentialManager:
     def _get_env_api_key() -> str | None:
         """Return API key from supported environment variables."""
 
-        for env_var in ("TRAIGENT_API_KEY", "OPTIGEN_API_KEY"):
-            api_key = os.environ.get(env_var)
-            if api_key:
-                return api_key
-        return None
+        return os.environ.get("TRAIGENT_API_KEY")
 
     @classmethod
     def clear_credentials(cls) -> bool:

--- a/traigent/cloud/credential_resolver.py
+++ b/traigent/cloud/credential_resolver.py
@@ -216,9 +216,7 @@ class CredentialResolver:
                 else:
                     api_key = CredentialManager.get_api_key()
                     if not api_key:
-                        api_key = os.getenv("TRAIGENT_API_KEY") or os.getenv(
-                            "OPTIGEN_API_KEY"
-                        )
+                        api_key = os.getenv("TRAIGENT_API_KEY")
                         if api_key:
                             metadata["source"] = "environment"
 

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -164,29 +164,21 @@ class BackendConfig:
     def get_api_key(cls) -> str | None:
         """Get API key from environment.
 
-        TRAIGENT_API_KEY is preferred, falling back to OPTIGEN_API_KEY for
-        backwards compatibility.
-
         Returns:
             str | None: API key if configured, None otherwise
         """
-        env_var_preference = (
-            "TRAIGENT_API_KEY",
-            "OPTIGEN_API_KEY",
-        )
-
-        for env_var in env_var_preference:
-            api_key = os.environ.get(env_var)
-            if api_key:
-                logger.info(f"✅ Using API key from {env_var} (length={len(api_key)})")
-                return api_key
+        api_key = os.environ.get("TRAIGENT_API_KEY")
+        if api_key:
+            logger.info("✅ Using API key from TRAIGENT_API_KEY (length=%d)", len(api_key))
+            return api_key
 
         # Only warn if not in offline mode - offline mode doesn't need API keys
         from traigent.utils.env_config import is_backend_offline
 
         if not is_backend_offline():
             logger.warning(
-                "⚠️ No API key found in environment (checked TRAIGENT_API_KEY, OPTIGEN_API_KEY)"
+                "⚠️ No API key found in environment (checked TRAIGENT_API_KEY). "
+                "For cloud tracking, run `traigent auth login` or export TRAIGENT_API_KEY."
             )
         return None
 
@@ -248,10 +240,7 @@ class BackendConfig:
             "api_key_env": next(
                 (
                     env_var
-                    for env_var in (
-                        "TRAIGENT_API_KEY",
-                        "OPTIGEN_API_KEY",
-                    )
+                    for env_var in ("TRAIGENT_API_KEY",)
                     if os.environ.get(env_var)
                 ),
                 None,

--- a/walkthrough/mock/advanced/04_workflow_traces_demo.py
+++ b/walkthrough/mock/advanced/04_workflow_traces_demo.py
@@ -6,7 +6,7 @@ This example simulates a LangGraph-like workflow and sends traces to the backend
 
 Run with: python 04_workflow_traces_demo.py
 
-Uses TRAIGENT_BACKEND_URL from .env (or defaults to https://api.traigent.ai)
+Uses TRAIGENT_BACKEND_URL from .env (or defaults to http://localhost:5000)
 """
 
 import os
@@ -231,7 +231,7 @@ def main() -> None:
     print("=" * 60)
 
     # Get backend URL and auth token (uses same env vars as rest of SDK)
-    backend_url = os.environ.get("TRAIGENT_BACKEND_URL", "https://api.traigent.ai")
+    backend_url = os.environ.get("TRAIGENT_BACKEND_URL", "http://localhost:5000")
     auth_token = os.environ.get("TRAIGENT_API_KEY")
     print(f"\nBackend URL: {backend_url}")
     print(f"Auth token: {'set' if auth_token else 'NOT SET (will fail with 401)'}")

--- a/walkthrough/utils/helpers.py
+++ b/walkthrough/utils/helpers.py
@@ -57,7 +57,12 @@ def print_estimated_time(example_name: str) -> None:
 
 
 def configure_logging() -> None:
-    """Configure Traigent logging level from environment variable."""
+    """Configure Traigent logging and default local backend for walkthrough/real."""
+    # Walkthrough real scripts are local-first examples; avoid accidental cloud host fallback.
+    os.environ.setdefault("TRAIGENT_ENV", "development")
+    os.environ.setdefault("TRAIGENT_BACKEND_URL", "http://localhost:5000")
+    os.environ.setdefault("TRAIGENT_API_URL", "http://localhost:5000")
+
     log_level = os.getenv("TRAIGENT_LOG_LEVEL", "WARNING").upper()
     traigent.configure(logging_level=log_level)
 
@@ -90,16 +95,15 @@ def is_valid_traigent_key(value: str) -> bool:
 def sanitize_traigent_api_key() -> None:
     """Remove invalid Traigent API keys from environment.
 
-    Checks TRAIGENT_API_KEY and OPTIGEN_API_KEY; removes if invalid format.
+    Checks TRAIGENT_API_KEY; removes if invalid format.
     """
-    key = os.getenv("TRAIGENT_API_KEY") or os.getenv("OPTIGEN_API_KEY")
+    key = os.getenv("TRAIGENT_API_KEY")
     if key and not is_valid_traigent_key(key):
         print(
             "WARNING: Ignoring invalid TRAIGENT_API_KEY for this run. "
             "Set a valid Traigent key to enable cloud features."
         )
         os.environ.pop("TRAIGENT_API_KEY", None)
-        os.environ.pop("OPTIGEN_API_KEY", None)
 
 
 def require_openai_key(example_name: str) -> None:


### PR DESCRIPTION
# Pull Request

## Description
BREAKING CHANGE: OPTIGEN_API_KEY environment variable is no longer recognized.
Migration: Replace OPTIGEN_API_KEY with TRAIGENT_API_KEY in your environment, CI/CD pipelines, and .env files.

Note: Walkthrough scripts now default to http://localhost:5000 instead of https://api.traigent.ai to prevent accidental production API calls from examples.
(api.traigent.ai - was a placeholer for where to generate the api key)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [V] Breaking change
- [ ] Documentation update

## Testing
- [ ] Tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed

## Checklist
- [ ] Code follows style guidelines
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] No new warnings introduced