### PR TITLE
fix: remove false api.traigent.ai cloud fallback

### DIFF
--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -77,7 +77,7 @@ from traigent.cloud.client import TraigentCloudClient
 
 client = TraigentCloudClient(
     api_key="your-api-key",
-    base_url="https://api.traigent.ai"
+    base_url="http://localhost:5000"
 )
 ```
 

--- a/examples/hybrid_mode_demo/.env.example
+++ b/examples/hybrid_mode_demo/.env.example
@@ -1,0 +1,14 @@
+# Traigent Hybrid Mode Demo — Environment Configuration
+# Copy this file to the project root .env and fill in required values.
+
+# --- JS-Mastra demo server ---
+MASTRA_JS_BASE_URL=https://ai.bazak.ai
+MASTRA_JS_AUTH_TOKEN=              # Required: Bearer token for the demo server
+# MASTRA_JS_TUNABLE_ID=           # Optional: specific tunable (default: auto-select first)
+# MASTRA_JS_MAX_TRIALS=10         # Max optimization trials
+# MASTRA_JS_MAX_COST_USD=4.0      # Stop after this USD spend
+# MASTRA_JS_MAX_REASONING_LEVEL=medium  # Cap reasoning: minimal|low|medium|high|highest
+
+# --- Traigent SDK ---
+# TRAIGENT_EXECUTION_MODE=edge_analytics  # edge_analytics | hybrid
+# TRAIGENT_COST_APPROVED=false            # Set true to skip cost confirmation

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -36,6 +36,7 @@ PROJECT_ROOT = SCRIPT_DIR.parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 # Importing env_config triggers automatic .env loading from the project root.
+from traigent.api.types import OptimizationResult
 from traigent.config.types import TraigentConfig, resolve_execution_mode
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.evaluators import HybridAPIEvaluator
@@ -150,7 +151,7 @@ def build_dataset() -> Dataset:
     )
 
 
-def _print_results(result: object) -> None:
+def _print_results(result: OptimizationResult) -> None:
     """Print optimization results report."""
     print("\n" + "=" * 70)
     print("  OPTIMIZATION RESULTS")

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -15,9 +15,9 @@ Flow:
   4. Reports best config, metrics, stop reason
 
 Prerequisites:
-  - JS-Mastra demo server running at http://localhost:8080
-    (cd JS-Mastra-APIs-Validation && npm run api:dev)
-  - OPENAI_API_KEY set in the demo server's .env
+  - JS-Mastra demo server running (see .env.example for endpoint config)
+  - Copy ``examples/hybrid_mode_demo/.env.example`` to ``.env`` in the
+    project root and fill in MASTRA_JS_AUTH_TOKEN
 
 Usage:
     .venv/bin/python examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -25,7 +25,6 @@ Usage:
 
 import asyncio
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Final
@@ -36,34 +35,33 @@ SCRIPT_DIR = Path(__file__).parent.absolute()
 PROJECT_ROOT = SCRIPT_DIR.parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from traigent.config.types import TraigentConfig
+# Importing env_config triggers automatic .env loading from the project root.
+from traigent.config.types import TraigentConfig, resolve_execution_mode
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.evaluators import HybridAPIEvaluator
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.optimizers.random import RandomSearchOptimizer
+from traigent.utils.env_config import get_env_var
 
-SERVER_URL: Final[str] = os.getenv("MASTRA_JS_BASE_URL", "https://ai.bazak.ai")
-AUTH_TOKEN: Final[str] = os.getenv("MASTRA_JS_AUTH_TOKEN", "")
+# ---------------------------------------------------------------------------
+# Configuration — all values come from environment / .env (no hardcoded secrets)
+# ---------------------------------------------------------------------------
+SERVER_URL: Final[str] = get_env_var("MASTRA_JS_BASE_URL", "https://ai.bazak.ai")
+AUTH_TOKEN: Final[str] = get_env_var("MASTRA_JS_AUTH_TOKEN", "", mask_in_logs=True)
 AUTH_HEADERS: Final[dict[str, str]] = {
     "Authorization": AUTH_TOKEN,
     "User-Agent": "Traigent-SDK/1.0",
 }
-TUNABLE_ID: Final[str | None] = os.getenv(
-    "MASTRA_JS_TUNABLE_ID"
-)  # None = auto-select first
+TUNABLE_ID: Final[str | None] = get_env_var("MASTRA_JS_TUNABLE_ID")
 INPUT_IDS: Final[list[str]] = [
     "no-filter-single-search-trashcan-blue",
     "product-search-specific-model",
     "consultant-fridge",
 ]
-MAX_TRIALS: Final[int] = int(
-    os.getenv("MASTRA_JS_MAX_TRIALS", "10")
-)  # Let Traigent decide which configs to try
-MAX_COST_USD: Final[float] = float(
-    os.getenv("MASTRA_JS_MAX_COST_USD", "4.0")
-)  # Stop after spending $4
+MAX_TRIALS: Final[int] = int(get_env_var("MASTRA_JS_MAX_TRIALS", "10"))
+MAX_COST_USD: Final[float] = float(get_env_var("MASTRA_JS_MAX_COST_USD", "4.0"))
 MAX_REASONING_LEVEL: Final[str] = (
-    os.getenv("MASTRA_JS_MAX_REASONING_LEVEL", "medium").strip().lower()
+    get_env_var("MASTRA_JS_MAX_REASONING_LEVEL", "medium").strip().lower()
 )
 
 _REASONING_LEVEL_ORDER: Final[list[str]] = [
@@ -75,34 +73,6 @@ _REASONING_LEVEL_ORDER: Final[list[str]] = [
 ]
 
 
-def _resolve_execution_mode(mode: str | None) -> str:
-    """Normalize execution mode for this demo.
-
-    Supported values:
-    - edge_analytics (local)
-    - local (alias for edge_analytics)
-    - hybrid
-    """
-
-    raw = (mode or "edge_analytics").strip().lower()
-    if raw == "local":
-        return "edge_analytics"
-    if raw in {"edge_analytics", "hybrid"}:
-        return raw
-    raise ValueError(
-        "TRAIGENT_EXECUTION_MODE must be one of: edge_analytics, local, hybrid"
-    )
-
-
-def _parse_bool_env(name: str, default: bool = False) -> bool:
-    """Parse common truthy env values."""
-
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
 def _apply_reasoning_cap(
     config_space: dict[str, object],
 ) -> tuple[dict[str, object], bool]:
@@ -111,7 +81,6 @@ def _apply_reasoning_cap(
     Looks for categorical parameters with "reason" in the key and values that
     match known reasoning levels. Values above MAX_REASONING_LEVEL are removed.
     """
-
     if MAX_REASONING_LEVEL not in _REASONING_LEVEL_ORDER:
         return config_space, False
 
@@ -181,6 +150,57 @@ def build_dataset() -> Dataset:
     )
 
 
+def _print_results(result: object) -> None:
+    """Print optimization results report."""
+    print("\n" + "=" * 70)
+    print("  OPTIMIZATION RESULTS")
+    print("=" * 70)
+
+    print(f"\n  Algorithm:     {result.algorithm}")
+    print(f"  Stop reason:   {result.stop_reason}")
+    print(f"  Total trials:  {len(result.trials)}")
+    print(f"  Successful:    {len(result.successful_trials)}")
+    print(f"  Success rate:  {result.success_rate:.0%}")
+    print(f"  Duration:      {result.duration:.1f}s")
+    if result.total_cost is not None:
+        print(f"  Total cost:    ${result.total_cost:.6f}")
+
+    print("\n  Best config:")
+    print(f"    {json.dumps(result.best_config, indent=6)}")
+
+    print(f"\n  Best score:    {result.best_score:.4f}")
+    print("\n  Best metrics:")
+    for key, value in result.best_metrics.items():
+        if isinstance(value, float):
+            if "cost" in key:
+                print(f"    {key}: ${value:.6f}")
+            elif "latency" in key:
+                print(f"    {key}: {value:.0f}ms")
+            else:
+                print(f"    {key}: {value:.4f}")
+        else:
+            print(f"    {key}: {value}")
+
+    print("\n  All trials:")
+    print(f"  {'#':>3}  {'Acc':>7}  {'Cost':>9}  Config")
+    print(f"  ---  -------  ---------  {'-'*45}")
+    for i, trial in enumerate(result.trials):
+        status = "ok" if trial.is_successful else "FAIL"
+        acc = trial.metrics.get("accuracy", 0)
+        cost = trial.metrics.get("cost", 0)
+        print(
+            f"  {i+1:>3}  {acc:>7.4f}  ${cost:>8.4f}  "
+            f"{json.dumps(trial.config, separators=(',', ':'))}"
+            f"  [{status}]"
+        )
+
+    print("\n  Convergence info:")
+    for k, v in result.convergence_info.items():
+        print(f"    {k}: {v}")
+
+    print("\n" + "=" * 70)
+
+
 async def run_optimization() -> None:
     """Run Traigent optimization loop against the demo server."""
     if not check_server(SERVER_URL):
@@ -224,9 +244,18 @@ async def run_optimization() -> None:
             random_seed=42,
         )
 
-        execution_mode = _resolve_execution_mode(os.getenv("TRAIGENT_EXECUTION_MODE"))
-        cost_approved = _parse_bool_env("TRAIGENT_COST_APPROVED", default=False)
-        traigent_config = TraigentConfig(execution_mode=execution_mode)
+        # Use Traigent's resolve_execution_mode (handles canonical values).
+        # "local" is accepted as a convenience alias for "edge_analytics".
+        raw_mode = get_env_var("TRAIGENT_EXECUTION_MODE", "edge_analytics")
+        if raw_mode.strip().lower() == "local":
+            raw_mode = "edge_analytics"
+        execution_mode = resolve_execution_mode(raw_mode)
+
+        cost_approved = get_env_var(
+            "TRAIGENT_COST_APPROVED", "false"
+        ).strip().lower() in {"1", "true", "yes", "on"}
+
+        traigent_config = TraigentConfig(execution_mode=execution_mode.value)
 
         orchestrator = OptimizationOrchestrator(
             optimizer=optimizer,
@@ -241,7 +270,7 @@ async def run_optimization() -> None:
         # --- Step 3: Run optimization ---
         dataset = build_dataset()
         print(f"      Dataset: {len(dataset)} examples")
-        print(f"      Execution mode: {execution_mode}")
+        print(f"      Execution mode: {execution_mode.value}")
         print(f"      Cost limit: ${MAX_COST_USD:.2f} (approved={cost_approved})")
         print("\n[3/3] Running optimization...")
         print("-" * 70)
@@ -255,54 +284,7 @@ async def run_optimization() -> None:
             function_name="hybrid_demo_agent",
         )
 
-        # --- Report ---
-        print("\n" + "=" * 70)
-        print("  OPTIMIZATION RESULTS")
-        print("=" * 70)
-
-        print(f"\n  Algorithm:     {result.algorithm}")
-        print(f"  Stop reason:   {result.stop_reason}")
-        print(f"  Total trials:  {len(result.trials)}")
-        print(f"  Successful:    {len(result.successful_trials)}")
-        print(f"  Success rate:  {result.success_rate:.0%}")
-        print(f"  Duration:      {result.duration:.1f}s")
-        if result.total_cost is not None:
-            print(f"  Total cost:    ${result.total_cost:.6f}")
-
-        print("\n  Best config:")
-        print(f"    {json.dumps(result.best_config, indent=6)}")
-
-        print(f"\n  Best score:    {result.best_score:.4f}")
-        print("\n  Best metrics:")
-        for key, value in result.best_metrics.items():
-            if isinstance(value, float):
-                if "cost" in key:
-                    print(f"    {key}: ${value:.6f}")
-                elif "latency" in key:
-                    print(f"    {key}: {value:.0f}ms")
-                else:
-                    print(f"    {key}: {value:.4f}")
-            else:
-                print(f"    {key}: {value}")
-
-        print("\n  All trials:")
-        print(f"  {'#':>3}  {'Acc':>7}  {'Cost':>9}  Config")
-        print(f"  ---  -------  ---------  {'-'*45}")
-        for i, trial in enumerate(result.trials):
-            status = "ok" if trial.is_successful else "FAIL"
-            acc = trial.metrics.get("accuracy", 0)
-            cost = trial.metrics.get("cost", 0)
-            print(
-                f"  {i+1:>3}  {acc:>7.4f}  ${cost:>8.4f}  "
-                f"{json.dumps(trial.config, separators=(',', ':'))}"
-                f"  [{status}]"
-            )
-
-        print("\n  Convergence info:")
-        for k, v in result.convergence_info.items():
-            print(f"    {k}: {v}")
-
-        print("\n" + "=" * 70)
+        _print_results(result)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_example_scoring_e2e.py
+++ b/tests/e2e/test_example_scoring_e2e.py
@@ -377,10 +377,9 @@ class TestExampleInsightsClient:
             client = ExampleInsightsClient(api_key="test_key")
 
             # Should timeout after 1 second
+            client.timeout = 1.0
             with pytest.raises(TimeoutError, match="Scores not ready after"):
-                await client.get_example_scores(
-                    "run_123", timeout=1.0, poll_interval=0.1
-                )
+                await client.get_example_scores("run_123", poll_interval=0.1)
 
             await client.close()
 

--- a/tests/e2e/test_example_scoring_e2e.py
+++ b/tests/e2e/test_example_scoring_e2e.py
@@ -198,10 +198,10 @@ class TestExampleInsightsClient:
     async def test_client_initialization(self):
         """Client should initialize with proper configuration."""
         client = ExampleInsightsClient(
-            backend_url="https://api.traigent.ai", api_key="test_key"
+            backend_url="http://localhost:5000", api_key="test_key"
         )
 
-        assert client.backend_url == "https://api.traigent.ai"
+        assert client.backend_url == "http://localhost:5000"
         assert client.api_key == "test_key"
         assert client.timeout == 30.0
 

--- a/tests/e2e/test_privacy_decorator.py
+++ b/tests/e2e/test_privacy_decorator.py
@@ -28,7 +28,7 @@ class MockTraigentCloudClientWithPrivacyServer:
     def __init__(self, privacy_server: DummyPrivacyServer):
         self.server = privacy_server
         self.api_key = "test-privacy-key"
-        self.base_url = "https://mock-privacy.traigent.ai"
+        self.base_url = "http://localhost:5000"
 
     async def __aenter__(self):
         return self

--- a/tests/integration/test_cost_enforcement_parallel.py
+++ b/tests/integration/test_cost_enforcement_parallel.py
@@ -550,8 +550,7 @@ class TestParallelUnknownCostCTD:
             should_raise = require_tracking or strict_accounting
             if should_raise:
                 assert all(
-                    isinstance(result, CostTrackingRequiredError)
-                    for result in results
+                    isinstance(result, CostTrackingRequiredError) for result in results
                 )
                 assert enforcer.get_status().unknown_cost_mode is False
             else:

--- a/tests/integration/test_ctd_execution_modes_live.py
+++ b/tests/integration/test_ctd_execution_modes_live.py
@@ -57,7 +57,7 @@ async def test_ctd_execution_behavior_live(case: dict, monkeypatch) -> None:
     if backend_url == "local":
         monkeypatch.setenv("TRAIGENT_BACKEND_URL", "http://localhost:5000")
     elif backend_url == "prod":
-        monkeypatch.setenv("TRAIGENT_BACKEND_URL", "https://api.traigent.ai")
+        monkeypatch.setenv("TRAIGENT_BACKEND_URL", "http://localhost:5000")
 
     # We expect an API key to be available in the environment
     api_key = os.getenv("TRAIGENT_API_KEY")

--- a/tests/optimizer_validation/conftest.py
+++ b/tests/optimizer_validation/conftest.py
@@ -798,9 +798,7 @@ def scenario_runner(
         if "random_seed" not in mock_config:
             # Use a stable hash to avoid process-randomized Python hash() output.
             seed_bytes = hashlib.sha256(scenario.name.encode("utf-8")).digest()
-            mock_config["random_seed"] = int.from_bytes(seed_bytes[:8], "big") % (
-                2**31
-            )
+            mock_config["random_seed"] = int.from_bytes(seed_bytes[:8], "big") % (2**31)
 
         # Apply decorator
         try:

--- a/tests/test_backend_config.py
+++ b/tests/test_backend_config.py
@@ -40,12 +40,12 @@ def test_backend_config():
     print(f"   Environment: {config['environment']}")
     print(f"   Configured Via: {config['configured_via']}")
     assert (
-        config["backend_url"] == "https://api.traigent.ai"
-    ), "Should default to production"
-    assert config["requires_auth"], "Production should require auth"
+        config["backend_url"] == "http://localhost:5000"
+    ), "Should default to local backend"
+    assert config["is_local"], "Default should be local"
     assert config["configured_via"] == "default"
     assert (
-        config["backend_api_url"] == "https://api.traigent.ai/api/v1"
+        config["backend_api_url"] == "http://localhost:5000/api/v1"
     ), "Default API base should include versioned path"
     print("   ✅ Default configuration working correctly\n")
 
@@ -85,15 +85,15 @@ def test_backend_config():
     # Test 3b: TRAIGENT_API_URL host override
     print("3b. Testing TRAIGENT_API_URL host override:")
     os.environ.pop("TRAIGENT_BACKEND_URL", None)
-    os.environ["TRAIGENT_API_URL"] = "api.traigent.ai"
+    os.environ["TRAIGENT_API_URL"] = "api.example.com"
     config = BackendConfig.get_config_summary()
     print(f"   Backend URL: {config['backend_url']}")
     assert (
-        config["backend_url"] == "https://api.traigent.ai"
+        config["backend_url"] == "https://api.example.com"
     ), "Host-only API URL should resolve to https origin"
     assert config["configured_via"] == "TRAIGENT_API_URL"
     assert (
-        config["backend_api_url"] == "https://api.traigent.ai/api/v1"
+        config["backend_api_url"] == "https://api.example.com/api/v1"
     ), "API base should include default path"
     print("   ✅ TRAIGENT_API_URL host override working correctly\n")
 

--- a/tests/unit/agents/test_platforms.py
+++ b/tests/unit/agents/test_platforms.py
@@ -533,12 +533,15 @@ class TestOpenAIAgentExecutor:
             completion_tokens = 50
             total_tokens = 150
 
-        with patch(
-            "traigent.utils.cost_calculator.get_cost_calculator",
-            side_effect=RuntimeError("test"),
-        ), patch(
-            "traigent.agents.platforms.is_strict_cost_accounting",
-            return_value=False,
+        with (
+            patch(
+                "traigent.utils.cost_calculator.get_cost_calculator",
+                side_effect=RuntimeError("test"),
+            ),
+            patch(
+                "traigent.agents.platforms.is_strict_cost_accounting",
+                return_value=False,
+            ),
         ):
             cost = executor._calculate_cost("gpt-4o", MockUsage())
             assert cost < 1e-12
@@ -554,12 +557,15 @@ class TestOpenAIAgentExecutor:
             completion_tokens = 50
             total_tokens = 150
 
-        with patch(
-            "traigent.utils.cost_calculator.get_cost_calculator",
-            side_effect=RuntimeError("strict-test"),
-        ), patch(
-            "traigent.agents.platforms.is_strict_cost_accounting",
-            return_value=True,
+        with (
+            patch(
+                "traigent.utils.cost_calculator.get_cost_calculator",
+                side_effect=RuntimeError("strict-test"),
+            ),
+            patch(
+                "traigent.agents.platforms.is_strict_cost_accounting",
+                return_value=True,
+            ),
         ):
             with pytest.raises(RuntimeError, match="strict-test"):
                 executor._calculate_cost("gpt-4o", MockUsage())
@@ -568,12 +574,15 @@ class TestOpenAIAgentExecutor:
     async def test_estimate_cost(self, openai_agent_spec):
         """Test cost estimation."""
         executor = OpenAIAgentExecutor()
-        with patch(
-            "traigent.utils.cost_calculator.calculate_prompt_cost",
-            return_value=0.01,
-        ), patch(
-            "traigent.utils.cost_calculator.calculate_completion_cost",
-            return_value=0.02,
+        with (
+            patch(
+                "traigent.utils.cost_calculator.calculate_prompt_cost",
+                return_value=0.01,
+            ),
+            patch(
+                "traigent.utils.cost_calculator.calculate_completion_cost",
+                return_value=0.02,
+            ),
         ):
             estimate = await executor.estimate_cost(
                 openai_agent_spec, {"query": "Test query"}

--- a/tests/unit/analytics/test_example_insights.py
+++ b/tests/unit/analytics/test_example_insights.py
@@ -35,7 +35,7 @@ class TestExampleInsightsClientInit:
         with patch("traigent.utils.env_config.get_api_key", return_value="test_key"):
             client = ExampleInsightsClient()
 
-            assert client.backend_url == "https://api.traigent.ai"
+            assert client.backend_url == "http://localhost:5000"
             assert client.timeout == 30.0
             assert client.api_key == "test_key"
             assert client._client is None
@@ -61,11 +61,11 @@ class TestExampleInsightsClientInit:
         from traigent.analytics.example_insights import ExampleInsightsClient
 
         client = ExampleInsightsClient(
-            backend_url="https://api.traigent.ai/",
+            backend_url="http://localhost:5000/",
             api_key="key",
         )
 
-        assert client.backend_url == "https://api.traigent.ai"
+        assert client.backend_url == "http://localhost:5000"
 
     @pytest.mark.skipif(HTTPX_AVAILABLE, reason="Test for httpx not available")
     def test_init_raises_without_httpx(self) -> None:

--- a/tests/unit/analytics/test_example_insights.py
+++ b/tests/unit/analytics/test_example_insights.py
@@ -118,7 +118,7 @@ class TestExampleInsightsClientGetClient:
             mock_instance = MagicMock()
             mock_async_client.return_value = mock_instance
 
-            result = await client._get_client()
+            result = client._get_client()
 
             assert result == mock_instance
             mock_async_client.assert_called_once()
@@ -138,7 +138,7 @@ class TestExampleInsightsClientGetClient:
         mock_existing = MagicMock()
         client._client = mock_existing
 
-        result = await client._get_client()
+        result = client._get_client()
 
         assert result == mock_existing
 
@@ -154,7 +154,7 @@ class TestExampleInsightsClientGetClient:
             mock_instance = MagicMock()
             mock_async_client.return_value = mock_instance
 
-            await client._get_client()
+            client._get_client()
 
             call_kwargs = mock_async_client.call_args.kwargs
             # Authorization header should not be present without key
@@ -293,9 +293,9 @@ class TestGetExampleScores:
         mock_http.get.side_effect = mock_get
         client._client = mock_http
 
+        client.timeout = 5.0
         result = await client.get_example_scores(
             experiment_run_id="run_123",
-            timeout=5.0,
             poll_interval=0.01,  # Fast polling for test
         )
 
@@ -322,10 +322,10 @@ class TestGetExampleScores:
         mock_http.get.side_effect = mock_get
         client._client = mock_http
 
+        client.timeout = 0.05  # Very short timeout
         with pytest.raises(TimeoutError, match="Scores not ready"):
             await client.get_example_scores(
                 experiment_run_id="run_123",
-                timeout=0.05,  # Very short timeout
                 poll_interval=0.01,
             )
 
@@ -417,9 +417,9 @@ class TestGetDatasetQuality:
         mock_http.get.side_effect = mock_get
         client._client = mock_http
 
+        client.timeout = 5.0
         result = await client.get_dataset_quality(
             experiment_run_id="run_123",
-            timeout=5.0,
             poll_interval=0.01,
         )
 
@@ -446,10 +446,10 @@ class TestGetDatasetQuality:
         mock_http.get.side_effect = mock_get
         client._client = mock_http
 
+        client.timeout = 0.05  # Very short timeout
         with pytest.raises(TimeoutError, match="Quality metrics not ready"):
             await client.get_dataset_quality(
                 experiment_run_id="run_123",
-                timeout=0.05,
                 poll_interval=0.01,
             )
 

--- a/tests/unit/cloud/test_agent_client.py
+++ b/tests/unit/cloud/test_agent_client.py
@@ -67,7 +67,7 @@ def agent_client(mock_aiohttp_session):
     # Create a valid format API key (tg_ + 61 characters = 64 total)
     valid_api_key = "tg_" + "1234567890abcdef" * 3 + "1234567890abc"  # 64 chars total
     client = TraigentCloudClient(
-        base_url="https://api.traigent.ai", api_key=valid_api_key
+        base_url="http://localhost:5000", api_key=valid_api_key
     )
     client._session = mock_aiohttp_session
     return client
@@ -178,7 +178,7 @@ class TestAgentOptimization:
         from traigent.utils.exceptions import AuthenticationError
 
         client = TraigentCloudClient(
-            base_url="https://api.traigent.ai", api_key="test-key"
+            base_url="http://localhost:5000", api_key="test-key"
         )
         # Don't set _session - this will cause authentication to fail
 

--- a/tests/unit/cloud/test_auth_data_classes.py
+++ b/tests/unit/cloud/test_auth_data_classes.py
@@ -330,7 +330,7 @@ class TestAuthCredentials:
         assert creds.client_id is None
         assert creds.client_secret is None
         assert creds.service_key is None
-        assert creds.backend_url == "https://api.traigent.ai"
+        assert creds.backend_url is None
         assert creds.expires_at is None
         assert creds.scopes == []
         assert creds.metadata == {}

--- a/tests/unit/cloud/test_session_management.py
+++ b/tests/unit/cloud/test_session_management.py
@@ -353,7 +353,9 @@ class TestSessionManager:
         assert session.best_metrics["accuracy"] == 0.90
 
     @pytest.mark.asyncio
-    async def test_submit_lower_value_wins_for_minimize_objective(self, session_manager):
+    async def test_submit_lower_value_wins_for_minimize_objective(
+        self, session_manager
+    ):
         """For minimize objectives (e.g., latency), lower values should win."""
         session = await session_manager.create_session(
             function_name="latency_test",

--- a/tests/unit/cloud/test_session_ownership_enforcement.py
+++ b/tests/unit/cloud/test_session_ownership_enforcement.py
@@ -19,8 +19,8 @@ async def test_trial_operations_register_forbidden_logs(caplog, monkeypatch):
     monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
 
     backend_config = SimpleNamespace(
-        backend_base_url="https://api.traigent.ai",
-        api_base_url="https://api.traigent.ai/v1",
+        backend_base_url="http://localhost:5000",
+        api_base_url="http://localhost:5000/v1",
     )
     auth_core = SimpleNamespace(
         get_headers=AsyncMock(return_value={"Authorization": "Bearer tok"}),
@@ -72,8 +72,8 @@ async def test_session_operations_status_forbidden():
     """Hybrid session status should surface ownership remediation on 403."""
 
     backend_config = SimpleNamespace(
-        backend_base_url="https://api.traigent.ai",
-        api_base_url="https://api.traigent.ai/v1",
+        backend_base_url="http://localhost:5000",
+        api_base_url="http://localhost:5000/v1",
     )
     auth_core = SimpleNamespace(
         get_headers=AsyncMock(return_value={"Authorization": "Bearer tok"}),

--- a/tests/unit/cloud/test_token_manager.py
+++ b/tests/unit/cloud/test_token_manager.py
@@ -31,7 +31,7 @@ from traigent.cloud.token_manager import TokenManager
 def config():
     """Create a test configuration."""
     return UnifiedAuthConfig(
-        cloud_base_url="https://api.traigent.ai",
+        cloud_base_url="http://localhost:5000",
         token_refresh_threshold=300,
         auto_refresh=True,
         cache_credentials=False,

--- a/tests/unit/cloud/test_traigent_cloud_client.py
+++ b/tests/unit/cloud/test_traigent_cloud_client.py
@@ -48,14 +48,14 @@ class TestTraigentCloudClient:
         """Test client initialization with different parameters."""
         client = TraigentCloudClient(
             api_key="tg_test_key",
-            base_url="https://api.traigent.ai",
+            base_url="http://localhost:5000",
             enable_fallback=False,
             max_retries=5,
             timeout=60.0,
         )
 
-        assert client.base_url == "https://api.traigent.ai"
-        assert client.api_base_url == "https://api.traigent.ai/api/v1"
+        assert client.base_url == "http://localhost:5000"
+        assert client.api_base_url == "http://localhost:5000/api/v1"
         assert client.enable_fallback is False
         assert client.max_retries == 5
         assert client.timeout == 60.0

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -288,7 +288,8 @@ class TestSummaryStatsLogging:
             for msg in caplog.messages
         )
         assert not any(
-            "No summary_stats found for trial trial_abc" in msg for msg in caplog.messages
+            "No summary_stats found for trial trial_abc" in msg
+            for msg in caplog.messages
         )
 
 

--- a/tests/unit/config_generator/test_apply.py
+++ b/tests/unit/config_generator/test_apply.py
@@ -294,7 +294,9 @@ class TestApplyConfig:
         optimize_idx = next(
             i for i, line in enumerate(lines) if "@traigent.optimize(" in line
         )
-        other_idx = next(i for i, line in enumerate(lines) if "@some_other_decorator" in line)
+        other_idx = next(
+            i for i, line in enumerate(lines) if "@some_other_decorator" in line
+        )
         assert optimize_idx < other_idx
 
     def test_replaces_fully_qualified_decorator(

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -512,7 +512,9 @@ class TestCostEnforcerAsync:
         assert abs(enforcer.accumulated_cost - expected) < 0.001
 
     @pytest.mark.asyncio
-    async def test_unknown_cost_async_raises_when_strict_accounting_enabled(self) -> None:
+    async def test_unknown_cost_async_raises_when_strict_accounting_enabled(
+        self,
+    ) -> None:
         """Strict accounting mode raises on async unknown cost."""
         with patch.dict(
             os.environ, {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
@@ -696,9 +698,7 @@ class TestCostEnforcerEnvironmentVariables:
     def test_invalid_divergence_threshold_raises(self) -> None:
         """Non-numeric divergence threshold should fail fast at initialization."""
         with patch.dict(os.environ, {"TRAIGENT_COST_DIVERGENCE_THRESHOLD": "abc"}):
-            with pytest.raises(
-                ValueError, match="TRAIGENT_COST_DIVERGENCE_THRESHOLD"
-            ):
+            with pytest.raises(ValueError, match="TRAIGENT_COST_DIVERGENCE_THRESHOLD"):
                 CostEnforcer()
 
 

--- a/tests/unit/core/test_cost_enforcement_ctd.py
+++ b/tests/unit/core/test_cost_enforcement_ctd.py
@@ -61,7 +61,9 @@ PAIRWISE_CASES: tuple[CTDCase, ...] = (
         "parallel",
     ),
     CTDCase(False, "zero", True, "under_limit", "foreign", "not_entered", "single"),
-    CTDCase(False, "none", False, "under_limit", "active", "already_entered", "parallel"),
+    CTDCase(
+        False, "none", False, "under_limit", "active", "already_entered", "parallel"
+    ),
     CTDCase(
         False,
         "none",
@@ -117,8 +119,12 @@ PAIRWISE_CASES: tuple[CTDCase, ...] = (
         "already_entered",
         "parallel",
     ),
-    CTDCase(False, "positive", True, "under_limit", "active", "not_entered", "parallel"),
-    CTDCase(False, "zero", True, "under_limit", "foreign", "already_entered", "parallel"),
+    CTDCase(
+        False, "positive", True, "under_limit", "active", "not_entered", "parallel"
+    ),
+    CTDCase(
+        False, "zero", True, "under_limit", "foreign", "already_entered", "parallel"
+    ),
 )
 
 FACTOR_NAMES = (

--- a/tests/unit/core/test_orchestrator_helpers.py
+++ b/tests/unit/core/test_orchestrator_helpers.py
@@ -1020,7 +1020,9 @@ class TestExtractCostFromResults:
                 self.aggregated_metrics = {"cost": 0.999}  # Must not override examples
 
         result = MockHybridResult()
-        examples, cost = extract_cost_from_results(result, None, "trial_hybrid_cost_key")
+        examples, cost = extract_cost_from_results(
+            result, None, "trial_hybrid_cost_key"
+        )
         assert examples == 3
         assert abs(cost - 0.041) < 0.0001
 

--- a/tests/unit/integrations/pydantic_ai/test_handler.py
+++ b/tests/unit/integrations/pydantic_ai/test_handler.py
@@ -359,7 +359,9 @@ class TestPydanticAIHandler:
         with patch.dict(
             "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "true"}, clear=False
         ):
-            strict_handler = self._make_handler(_make_agent("openai:unknown-model-xyz-123"))
+            strict_handler = self._make_handler(
+                _make_agent("openai:unknown-model-xyz-123")
+            )
         with patch.dict(
             "os.environ", {"TRAIGENT_STRICT_COST_ACCOUNTING": "false"}, clear=False
         ):

--- a/tests/unit/security/test_headers.py
+++ b/tests/unit/security/test_headers.py
@@ -631,11 +631,11 @@ class TestDefaultBackendOrigin:
     @patch("traigent.security.headers.BackendConfig.get_backend_url")
     def test_default_backend_origin_with_scheme(self, mock_get_url: MagicMock) -> None:
         """Test default backend origin with full URL."""
-        mock_get_url.return_value = "https://api.traigent.ai/api/v1"
+        mock_get_url.return_value = "https://api.example.com/api/v1"
 
         origin = _default_backend_origin()
 
-        assert origin == "https://api.traigent.ai"
+        assert origin == "https://api.example.com"
 
     @patch("traigent.security.headers.BackendConfig.get_backend_url")
     def test_default_backend_origin_with_port(self, mock_get_url: MagicMock) -> None:
@@ -651,16 +651,16 @@ class TestDefaultBackendOrigin:
         self, mock_get_url: MagicMock
     ) -> None:
         """Test that trailing slashes are stripped."""
-        mock_get_url.return_value = "https://api.traigent.ai/"
+        mock_get_url.return_value = "https://api.example.com/"
 
         origin = _default_backend_origin()
 
-        assert origin == "https://api.traigent.ai"
+        assert origin == "https://api.example.com"
 
     @patch("traigent.security.headers.BackendConfig.get_backend_url")
     @patch(
         "traigent.security.headers.BackendConfig.DEFAULT_PROD_URL",
-        "https://api.traigent.ai",
+        "http://localhost:5000",
     )
     def test_default_backend_origin_fallback(self, mock_get_url: MagicMock) -> None:
         """Test fallback to DEFAULT_PROD_URL when URL is empty."""
@@ -668,7 +668,7 @@ class TestDefaultBackendOrigin:
 
         origin = _default_backend_origin()
 
-        assert origin == "https://api.traigent.ai"
+        assert origin == "http://localhost:5000"
 
     @patch("traigent.security.headers.BackendConfig.get_backend_url")
     def test_default_backend_origin_no_scheme(self, mock_get_url: MagicMock) -> None:

--- a/tests/unit/tvl/test_spec_loader.py
+++ b/tests/unit/tvl/test_spec_loader.py
@@ -115,7 +115,9 @@ def test_compiled_constraints_attach_metadata() -> None:
     assert isinstance(constraint({"response_latency_ms": 800}, None), bool)
 
 
-def test_structural_constraint_validation_rejects_unknown_params(tmp_path: Path) -> None:
+def test_structural_constraint_validation_rejects_unknown_params(
+    tmp_path: Path,
+) -> None:
     """validate_constraints=True should fail fast on unknown params.* references."""
     spec_content = """
 tvl_version: "0.9"

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -52,7 +52,9 @@ class TestCostCalculatorInit:
 class TestCostCalculatorCalculateCost:
     def test_no_model_name_returns_empty_breakdown(self) -> None:
         calculator = CostCalculator()
-        result = calculator.calculate_cost(prompt="hi", response="hello", model_name=None)
+        result = calculator.calculate_cost(
+            prompt="hi", response="hello", model_name=None
+        )
         assert result.calculation_method == "no_model_name"
         assert result.total_cost == 0.0
 
@@ -119,7 +121,9 @@ class TestCostCalculatorCalculateCost:
     def test_calculate_cost_logs_unexpected_exception(self) -> None:
         mock_logger = MagicMock()
         calculator = CostCalculator(logger=mock_logger)
-        with patch.object(calculator, "_populate_cost", side_effect=RuntimeError("boom")):
+        with patch.object(
+            calculator, "_populate_cost", side_effect=RuntimeError("boom")
+        ):
             result = calculator.calculate_cost(
                 model_name="gpt-4o",
                 input_tokens=100,
@@ -257,7 +261,10 @@ class TestPricingHelpers:
         mock_litellm.cost_per_token.return_value = (0.0, 0.0)
         with (
             patch("traigent.utils.cost_calculator.litellm", mock_litellm),
-            patch("traigent.utils.cost_calculator._is_model_known_to_litellm", return_value=True),
+            patch(
+                "traigent.utils.cost_calculator._is_model_known_to_litellm",
+                return_value=True,
+            ),
             patch("traigent.utils.cost_calculator.LITELLM_AVAILABLE", True),
         ):
             inp, out, method = get_model_token_pricing("known-zero-model")
@@ -268,9 +275,7 @@ class TestPricingHelpers:
     def test_fallback_cost_from_tokens_paths(self) -> None:
         exact = _estimation_cost_from_tokens("gpt-4o", 100, 50, _quiet=True)
         alias = _estimation_cost_from_tokens("claude-3-sonnet", 100, 50, _quiet=True)
-        prefix = _estimation_cost_from_tokens(
-            "gpt-4o-2024-08-06", 100, 50, _quiet=True
-        )
+        prefix = _estimation_cost_from_tokens("gpt-4o-2024-08-06", 100, 50, _quiet=True)
         reverse_prefix = _estimation_cost_from_tokens("gpt-4", 100, 50, _quiet=True)
         unknown = _estimation_cost_from_tokens("unknown-model", 100, 50, _quiet=True)
         assert exact[0] > 0
@@ -295,9 +300,17 @@ class TestDeprecatedPromptCompletionCost:
 
     def test_calculate_prompt_cost_with_message_list(self) -> None:
         with (
-            patch("traigent.utils.cost_calculator.litellm.token_counter", return_value=17),
-            patch("traigent.utils.cost_calculator.litellm.cost_per_token", return_value=(17e-6, 0.0)),
-            patch("traigent.utils.cost_calculator._is_model_known_to_litellm", return_value=True),
+            patch(
+                "traigent.utils.cost_calculator.litellm.token_counter", return_value=17
+            ),
+            patch(
+                "traigent.utils.cost_calculator.litellm.cost_per_token",
+                return_value=(17e-6, 0.0),
+            ),
+            patch(
+                "traigent.utils.cost_calculator._is_model_known_to_litellm",
+                return_value=True,
+            ),
         ):
             cost = calculate_prompt_cost(
                 [{"role": "user", "content": "hello"}],
@@ -327,14 +340,24 @@ class TestDeprecatedPromptCompletionCost:
 
     def test_calculate_completion_cost_known_zero_model_branch(self) -> None:
         with (
-            patch("traigent.utils.cost_calculator.litellm.token_counter", return_value=12),
-            patch("traigent.utils.cost_calculator.litellm.cost_per_token", return_value=(0.0, 0.0)),
-            patch("traigent.utils.cost_calculator._is_model_known_to_litellm", return_value=True),
+            patch(
+                "traigent.utils.cost_calculator.litellm.token_counter", return_value=12
+            ),
+            patch(
+                "traigent.utils.cost_calculator.litellm.cost_per_token",
+                return_value=(0.0, 0.0),
+            ),
+            patch(
+                "traigent.utils.cost_calculator._is_model_known_to_litellm",
+                return_value=True,
+            ),
         ):
             cost = calculate_completion_cost("world", "gpt-4o")
         assert cost == 0.0
 
-    def test_calculate_completion_cost_unknown_raises_after_litellm_failure(self) -> None:
+    def test_calculate_completion_cost_unknown_raises_after_litellm_failure(
+        self,
+    ) -> None:
         with patch(
             "traigent.utils.cost_calculator._try_litellm_completion_cost",
             side_effect=RuntimeError("boom"),

--- a/tests/unit/utils/test_cost_from_tokens.py
+++ b/tests/unit/utils/test_cost_from_tokens.py
@@ -66,9 +66,7 @@ class TestCostFromTokensKnownModels:
 
     def test_anthropic_model_known(self) -> None:
         """Anthropic dated model IDs resolve through canonical litellm path."""
-        input_cost, output_cost = cost_from_tokens(
-            100, 50, "claude-3-haiku-20240307"
-        )
+        input_cost, output_cost = cost_from_tokens(100, 50, "claude-3-haiku-20240307")
         assert input_cost > 0
         assert output_cost > 0
 
@@ -248,7 +246,9 @@ class TestCostFromTokensCustomPricing:
         assert input_cost == pytest.approx(100 * 3.0e-6)
         assert output_cost == pytest.approx(50 * 15.0e-6)
 
-    def test_unknown_model_uses_custom_pricing_file(self, monkeypatch, tmp_path) -> None:
+    def test_unknown_model_uses_custom_pricing_file(
+        self, monkeypatch, tmp_path
+    ) -> None:
         payload = {
             "file-model": {
                 "input_cost_per_token": 1.0e-6,

--- a/tests/unit/utils/test_local_analytics.py
+++ b/tests/unit/utils/test_local_analytics.py
@@ -44,7 +44,7 @@ class TestLocalAnalyticsInitialization:
             execution_mode=ExecutionMode.EDGE_ANALYTICS.value,
             enable_usage_analytics=True,
             local_storage_path=temp_storage_path,
-            analytics_endpoint="https://test.traigent.ai/analytics",
+            analytics_endpoint="http://localhost:5000/analytics",
             anonymous_user_id=None,
         )
 
@@ -56,7 +56,7 @@ class TestLocalAnalyticsInitialization:
 
         assert analytics.config == edge_analytics_config
         assert analytics.enabled is True
-        assert analytics.analytics_endpoint == "https://test.traigent.ai/analytics"
+        assert analytics.analytics_endpoint == "http://localhost:5000/analytics"
         assert isinstance(analytics.storage, LocalStorageManager)
         assert analytics.user_id is not None
         assert len(analytics.user_id) > 0

--- a/tests/unit/validation/test_validation_plugins.py
+++ b/tests/unit/validation/test_validation_plugins.py
@@ -59,7 +59,9 @@ def test_register_validator_without_overwrite_rejected() -> None:
         plugins.register_validator("duplicate", _CustomValidator, overwrite=False)
 
 
-def test_get_validator_returns_none_when_factory_raises(caplog: pytest.LogCaptureFixture) -> None:
+def test_get_validator_returns_none_when_factory_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Factory construction errors should be logged and return None."""
 
     def _broken_factory() -> Any:

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -32,6 +32,7 @@ import asyncio
 import time
 from typing import Any, cast
 
+from traigent.config.backend_config import DEFAULT_LOCAL_URL
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -53,7 +54,7 @@ class ExampleInsightsClient:
 
     def __init__(
         self,
-        backend_url: str = "http://localhost:5000",
+        backend_url: str = DEFAULT_LOCAL_URL,
         api_key: str | None = None,
         timeout: float = 30.0,
     ):

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -9,7 +9,7 @@ Usage:
     >>> from traigent.analytics import ExampleInsightsClient
     >>>
     >>> # Initialize client (requires backend authentication)
-    >>> client = ExampleInsightsClient(backend_url="https://api.traigent.ai")
+    >>> client = ExampleInsightsClient(backend_url="http://localhost:5000")
     >>>
     >>> # Trigger scoring computation (async job)
     >>> job_result = await client.compute_scores(experiment_run_id="run_123")
@@ -53,7 +53,7 @@ class ExampleInsightsClient:
 
     def __init__(
         self,
-        backend_url: str = "https://api.traigent.ai",
+        backend_url: str = "http://localhost:5000",
         api_key: str | None = None,
         timeout: float = 30.0,
     ):

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -122,6 +122,55 @@ class ExampleInsightsClient:
         """Async context manager exit."""
         await self.close()
 
+    async def _poll_endpoint(
+        self,
+        path: str,
+        error_label: str,
+        poll_interval: float,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Poll a GET endpoint until it returns 200 or timeout is reached.
+
+        Args:
+            path: API path to poll
+            error_label: Human-readable label for timeout error messages
+            poll_interval: Seconds between attempts
+            params: Optional query parameters
+
+        Returns:
+            Parsed JSON response
+
+        Raises:
+            httpx.HTTPStatusError: For non-404 HTTP errors
+            TimeoutError: If endpoint still returns 404 after ``self.timeout``
+        """
+        client = self._get_client()
+        timeout = self.timeout
+        start_time = time.monotonic()
+
+        while True:
+            try:
+                response = await client.get(path, params=params or {})
+                response.raise_for_status()
+                return cast(dict[str, Any], response.json())
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code != 404:
+                    raise
+                elapsed = time.monotonic() - start_time
+                if elapsed >= timeout:
+                    raise TimeoutError(
+                        f"{error_label} not ready after {timeout}s. "
+                        f"Check job status or increase timeout."
+                    ) from e
+                logger.debug(
+                    "%s not ready, polling again in %.1fs (elapsed: %.1fs/%ds)",
+                    error_label,
+                    poll_interval,
+                    elapsed,
+                    timeout,
+                )
+                await asyncio.sleep(poll_interval)
+
     async def compute_scores(
         self,
         experiment_run_id: str,
@@ -189,45 +238,19 @@ class ExampleInsightsClient:
             httpx.HTTPError: If request fails
             TimeoutError: If scores not ready within timeout
         """
-        client = self._get_client()
-        timeout = self.timeout
-
-        # Build query parameters
         params: dict[str, Any] = {}
         if example_ids:
             params["example_ids"] = example_ids
 
-        start_time = time.time()
-
-        while True:
-            try:
-                response = await client.get(
-                    f"/analytics/example-scoring/{experiment_run_id}/scores",
-                    params=params,
-                )
-                response.raise_for_status()
-
-                return cast(dict[str, dict[str, Any]], response.json())
-
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == 404:
-                    # Scores not yet computed - poll
-                    elapsed = time.time() - start_time
-                    if elapsed >= timeout:
-                        raise TimeoutError(
-                            f"Scores not ready after {timeout}s. "
-                            f"Check job status or increase timeout."
-                        ) from e
-
-                    logger.debug(
-                        "Scores not ready, polling again in %.1fs (elapsed: %.1fs/%ds)",
-                        poll_interval,
-                        elapsed,
-                        timeout,
-                    )
-                    await asyncio.sleep(poll_interval)
-                else:
-                    raise
+        return cast(
+            dict[str, dict[str, Any]],
+            await self._poll_endpoint(
+                f"/analytics/example-scoring/{experiment_run_id}/scores",
+                "Scores",
+                poll_interval,
+                params=params,
+            ),
+        )
 
     async def get_dataset_quality(
         self,
@@ -261,39 +284,11 @@ class ExampleInsightsClient:
             httpx.HTTPError: If request fails
             TimeoutError: If metrics not ready within timeout
         """
-        client = self._get_client()
-        timeout = self.timeout
-
-        start_time = time.time()
-
-        while True:
-            try:
-                response = await client.get(
-                    f"/analytics/example-scoring/{experiment_run_id}/dataset-quality"
-                )
-                response.raise_for_status()
-
-                return cast(dict[str, Any], response.json())
-
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code == 404:
-                    # Quality not yet computed - poll
-                    elapsed = time.time() - start_time
-                    if elapsed >= timeout:
-                        raise TimeoutError(
-                            f"Quality metrics not ready after {timeout}s. "
-                            f"Check job status or increase timeout."
-                        ) from e
-
-                    logger.debug(
-                        "Quality metrics not ready, polling again in %.1fs (elapsed: %.1fs/%ds)",
-                        poll_interval,
-                        elapsed,
-                        timeout,
-                    )
-                    await asyncio.sleep(poll_interval)
-                else:
-                    raise
+        return await self._poll_endpoint(
+            f"/analytics/example-scoring/{experiment_run_id}/dataset-quality",
+            "Quality metrics",
+            poll_interval,
+        )
 
     async def get_job_status(self, job_id: str) -> dict[str, Any]:
         """Get status of a scoring computation job.

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -89,7 +89,7 @@ class ExampleInsightsClient:
 
         self._client: httpx.AsyncClient | None = None
 
-    async def _get_client(self) -> httpx.AsyncClient:
+    def _get_client(self) -> httpx.AsyncClient:
         """Get or create async HTTP client.
 
         Returns:
@@ -143,7 +143,7 @@ class ExampleInsightsClient:
         Raises:
             httpx.HTTPError: If request fails
         """
-        client = await self._get_client()
+        client = self._get_client()
 
         response = await client.post(
             f"/analytics/example-scoring/{experiment_run_id}/compute"
@@ -156,18 +156,17 @@ class ExampleInsightsClient:
         self,
         experiment_run_id: str,
         example_ids: list[str] | None = None,
-        timeout: float | None = None,
         poll_interval: float = 2.0,
     ) -> dict[str, dict[str, Any]]:
         """Retrieve computed example scores.
 
         If scores are not yet computed, this will wait (polling) until they are
-        ready or timeout is reached.
+        ready or ``self.timeout`` is reached.  Callers needing a custom timeout
+        should use ``asyncio.timeout()`` around the call.
 
         Args:
             experiment_run_id: Experiment run ID to get scores for
             example_ids: Optional list of example IDs to filter (None = all)
-            timeout: Max time to wait for scores in seconds (None = use default)
             poll_interval: Time between polling attempts in seconds
 
         Returns:
@@ -190,8 +189,8 @@ class ExampleInsightsClient:
             httpx.HTTPError: If request fails
             TimeoutError: If scores not ready within timeout
         """
-        client = await self._get_client()
-        timeout = timeout or self.timeout
+        client = self._get_client()
+        timeout = self.timeout
 
         # Build query parameters
         params: dict[str, Any] = {}
@@ -233,17 +232,16 @@ class ExampleInsightsClient:
     async def get_dataset_quality(
         self,
         experiment_run_id: str,
-        timeout: float | None = None,
         poll_interval: float = 2.0,
     ) -> dict[str, Any]:
         """Retrieve dataset-level quality metrics.
 
         If quality metrics are not yet computed, this will wait (polling) until
-        they are ready or timeout is reached.
+        they are ready or ``self.timeout`` is reached.  Callers needing a custom
+        timeout should use ``asyncio.timeout()`` around the call.
 
         Args:
             experiment_run_id: Experiment run ID to get quality for
-            timeout: Max time to wait for metrics in seconds (None = use default)
             poll_interval: Time between polling attempts in seconds
 
         Returns:
@@ -263,8 +261,8 @@ class ExampleInsightsClient:
             httpx.HTTPError: If request fails
             TimeoutError: If metrics not ready within timeout
         """
-        client = await self._get_client()
-        timeout = timeout or self.timeout
+        client = self._get_client()
+        timeout = self.timeout
 
         start_time = time.time()
 
@@ -312,7 +310,7 @@ class ExampleInsightsClient:
         Raises:
             httpx.HTTPError: If request fails
         """
-        client = await self._get_client()
+        client = self._get_client()
 
         response = await client.get(f"/jobs/{job_id}")
         response.raise_for_status()

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -15,11 +15,11 @@ Usage:
     >>> job_result = await client.compute_scores(experiment_run_id="run_123")
     >>> print(f"Job ID: {job_result['job_id']}")
     >>>
-    >>> # Poll for completion
-    >>> scores = await client.get_example_scores(
-    ...     experiment_run_id="run_123",
-    ...     timeout=60,  # Wait up to 60s for job to complete
-    ... )
+    >>> # Poll for completion (use asyncio.timeout for custom deadline)
+    >>> async with asyncio.timeout(60):
+    ...     scores = await client.get_example_scores(
+    ...         experiment_run_id="run_123",
+    ...     )
     >>>
     >>> # Retrieve dataset quality metrics
     >>> quality = await client.get_dataset_quality(experiment_run_id="run_123")

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -194,7 +194,7 @@ def initialize(  # noqa: C901
         # Cloud mode with explicit URL
         traigent.initialize(
             api_key=os.getenv("TRAIGENT_API_KEY"),  # Use env var
-            api_url="https://api.traigent.ai"
+            api_url="http://localhost:5000"
         )
 
         # Using environment variables (recommended)

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -28,6 +28,7 @@ from traigent.cloud.api_key_manager import APIKeyManager
 from traigent.cloud.credential_resolver import CredentialResolver
 from traigent.cloud.password_auth_handler import PasswordAuthHandler
 from traigent.cloud.token_manager import TokenManager
+from traigent.config.backend_config import DEFAULT_LOCAL_URL
 from traigent.core.constants import MAX_RETRIES
 from traigent.utils.exceptions import AuthenticationError as TraigentAuthenticationError
 
@@ -149,7 +150,7 @@ class UnifiedAuthConfig:
     backend_base_url: str | None = (
         None  # Will be set from BackendConfig if not provided
     )
-    cloud_base_url: str = "http://localhost:5000"
+    cloud_base_url: str = DEFAULT_LOCAL_URL
     token_refresh_threshold: float = 300.0  # Refresh if expires within 5 minutes
     auto_refresh: bool = True
     cache_credentials: bool = True

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -85,7 +85,7 @@ class AuthCredentials:
     client_id: str | None = None
     client_secret: str | None = None
     service_key: str | None = None
-    backend_url: str | None = "https://api.traigent.ai"
+    backend_url: str | None = None  # Resolved from BackendConfig at runtime
     expires_at: float | None = None
     scopes: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -149,7 +149,7 @@ class UnifiedAuthConfig:
     backend_base_url: str | None = (
         None  # Will be set from BackendConfig if not provided
     )
-    cloud_base_url: str = "https://api.traigent.ai"
+    cloud_base_url: str = "http://localhost:5000"
     token_refresh_threshold: float = 300.0  # Refresh if expires within 5 minutes
     auto_refresh: bool = True
     cache_credentials: bool = True

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -15,6 +15,10 @@ from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
+#: Single source of truth for the default local backend URL.
+#: Import this constant instead of repeating the literal string.
+DEFAULT_LOCAL_URL = "http://localhost:5000"
+
 
 class BackendConfig:
     """Centralized backend configuration management.
@@ -24,8 +28,8 @@ class BackendConfig:
     """
 
     # Default backend URLs (overridable via environment variables)
-    _FALLBACK_LOCAL_URL = "http://localhost:5000"
-    DEFAULT_PROD_URL = _FALLBACK_LOCAL_URL  # No cloud service yet; default to local
+    _FALLBACK_LOCAL_URL = DEFAULT_LOCAL_URL
+    DEFAULT_PROD_URL = DEFAULT_LOCAL_URL  # No cloud service yet; default to local
     _DEFAULT_API_PATH = "/api/v1"
 
     @classmethod

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -25,7 +25,7 @@ class BackendConfig:
 
     # Default backend URLs (overridable via environment variables)
     _FALLBACK_LOCAL_URL = "http://localhost:5000"
-    DEFAULT_PROD_URL = "https://api.traigent.ai"
+    DEFAULT_PROD_URL = _FALLBACK_LOCAL_URL  # No cloud service yet; default to local
     _DEFAULT_API_PATH = "/api/v1"
 
     @classmethod

--- a/traigent/utils/local_analytics.py
+++ b/traigent/utils/local_analytics.py
@@ -32,7 +32,7 @@ except ModuleNotFoundError:
 logger = logging.getLogger(__name__)
 
 # Default analytics endpoint (deprecated - will use backend client instead)
-DEFAULT_ANALYTICS_ENDPOINT = "https://analytics.traigent.ai/v1/local-usage"
+DEFAULT_ANALYTICS_ENDPOINT = "http://localhost:5000/v1/local-usage"
 
 
 class LocalAnalytics:


### PR DESCRIPTION
## Summary

**Core: Remove false `api.traigent.ai` fallback URLs**
- All hardcoded `api.traigent.ai` / `analytics.traigent.ai` defaults replaced with `http://localhost:5000` (no cloud service exists yet)
- Centralized via `DEFAULT_LOCAL_URL` constant in `backend_config.py` (fixes SonarCloud S1192)
- Updated 5 source files + 12 test files

**`example_insights.py` — SonarCloud fixes + DRY refactor**
- Removed `async` from `_get_client` (S7503: no `await` needed)
- Removed `timeout` param from `get_example_scores`/`get_dataset_quality` (S7483: callers use `asyncio.timeout()`)
- Extracted `_poll_endpoint` private method to eliminate duplicate polling loops (DRY)
- Switched `time.time()` → `time.monotonic()` (immune to system clock changes)
- Updated module docstring to document `asyncio.timeout()` pattern

**`run_mastra_js_optimization.py` — Demo script professionalized**
- Replaced all `os.getenv()` with `traigent.utils.env_config.get_env_var()` (auto `.env` loading, secret masking)
- Replaced custom `_resolve_execution_mode()` / `_parse_bool_env()` with SDK builtins
- Extracted `_print_results(result: OptimizationResult)` helper (reduces cognitive complexity)
- Added `.env.example` for configuration reference

**Docs**
- Removed `api.traigent.ai` reference from `agent_optimization.md`

## Test plan
- [x] All 34 unit + e2e tests pass for `example_insights.py`
- [x] `make format` and `ruff check` clean
- [x] No remaining `api.traigent.ai` or `analytics.traigent.ai` references in `traigent/` or `tests/`
- [ ] Verify no downstream breakage in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)