### PR TITLE
fix(demo): use local dataset IDs for Bazak optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -434,3 +434,10 @@ tests/optimizer_validation/viewer/bdd_graph_data.json
 
 # Architecture diagrams (generated locally)
 *.mmd
+
+# Local discussion notes and experiments
+discussion_*.txt
+DISCUSSIONS_RECOUNT_*.md
+AutoCoder_orders.txt
+old_discussions_*/
+paper_experiments/

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -71,11 +71,12 @@ AUTH_HEADERS: Final[dict[str, str]] = {
 TUNABLE_ID: Final[str | None] = os.getenv(
     "MASTRA_JS_TUNABLE_ID"
 )  # None = auto-select first
-INPUT_IDS: Final[list[str]] = [
-    "no-filter-single-search-trashcan-blue",
-    "product-search-specific-model",
-    "consultant-fridge",
-]
+_INPUT_IDS_ENV = os.getenv("MASTRA_JS_INPUT_IDS", "")
+INPUT_IDS: Final[list[str]] = (
+    [x.strip() for x in _INPUT_IDS_ENV.split(",") if x.strip()]
+    if _INPUT_IDS_ENV
+    else [f"case_{i:03d}" for i in range(1, 6)]  # local dataset default
+)
 MAX_TRIALS: Final[int] = int(
     os.getenv("MASTRA_JS_MAX_TRIALS", "10")
 )  # Let Traigent decide which configs to try

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -52,14 +52,15 @@ def _block_443(self: _socket.socket, addr: object) -> None:
 
 _socket.socket.connect = _block_443  # type: ignore[assignment]
 
-from traigent.config.types import TraigentConfig
-from traigent.core.orchestrator import OptimizationOrchestrator
-from traigent.evaluators import HybridAPIEvaluator
-from traigent.evaluators.base import Dataset, EvaluationExample
-from traigent.optimizers.random import RandomSearchOptimizer
-
-# Restore normal socket behavior for the actual HTTP calls.
-_socket.socket.connect = _orig_connect  # type: ignore[assignment]
+try:
+    from traigent.config.types import TraigentConfig
+    from traigent.core.orchestrator import OptimizationOrchestrator
+    from traigent.evaluators import HybridAPIEvaluator
+    from traigent.evaluators.base import Dataset, EvaluationExample
+    from traigent.optimizers.random import RandomSearchOptimizer
+finally:
+    # Restore normal socket behavior for the actual HTTP calls.
+    _socket.socket.connect = _orig_connect  # type: ignore[assignment]
 
 SERVER_URL: Final[str] = os.getenv("MASTRA_JS_BASE_URL", "https://ai.bazak.ai")
 AUTH_TOKEN: Final[str] = os.getenv("MASTRA_JS_AUTH_TOKEN", "")

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -36,16 +36,36 @@ SCRIPT_DIR = Path(__file__).parent.absolute()
 PROJECT_ROOT = SCRIPT_DIR.parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
+# A dependency makes a blocking HTTPS call at import time (to
+# raw.githubusercontent.com). Temporarily block outgoing port-443
+# connections so the import finishes instantly instead of hanging.
+import socket as _socket
+
+_orig_connect = _socket.socket.connect
+
+
+def _block_443(self: _socket.socket, addr: object) -> None:
+    if isinstance(addr, tuple) and len(addr) >= 2 and addr[1] == 443:
+        raise ConnectionRefusedError("blocked during import")
+    return _orig_connect(self, addr)
+
+
+_socket.socket.connect = _block_443  # type: ignore[assignment]
+
 from traigent.config.types import TraigentConfig
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.evaluators import HybridAPIEvaluator
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.optimizers.random import RandomSearchOptimizer
 
+# Restore normal socket behavior for the actual HTTP calls.
+_socket.socket.connect = _orig_connect  # type: ignore[assignment]
+
 SERVER_URL: Final[str] = os.getenv("MASTRA_JS_BASE_URL", "https://ai.bazak.ai")
 AUTH_TOKEN: Final[str] = os.getenv("MASTRA_JS_AUTH_TOKEN", "")
 AUTH_HEADERS: Final[dict[str, str]] = {
     "Authorization": AUTH_TOKEN,
+    "x-api-key": AUTH_TOKEN,
     "User-Agent": "Traigent-SDK/1.0",
 }
 TUNABLE_ID: Final[str | None] = os.getenv(

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -98,6 +98,7 @@ class HTTPTransport:
                 }
                 if self._auth_header:
                     headers["Authorization"] = self._auth_header
+                    headers["x-api-key"] = self._auth_header
 
                 # Configure connection pooling
                 limits = httpx.Limits(


### PR DESCRIPTION
## Summary
- Default to local dataset IDs (case_001–case_005) instead of remote-only IDs
- Support `MASTRA_JS_INPUT_IDS` env var for custom/remote datasets
- Includes prior commits: auth header fixes, import-time HTTPS hang workaround

## Test plan
- [ ] Run optimization against local Bazak server with default IDs
- [ ] Override with `MASTRA_JS_INPUT_IDS=id1,id2` for remote server
- [ ] Verify trials complete with non-zero accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)