### PR TITLE
fix: per-example logging, auth fallback, unique experiment IDs

### DIFF
--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -25,6 +25,7 @@ Usage:
 
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Final
@@ -63,6 +64,11 @@ try:
 finally:
     # Restore normal socket behavior for the actual HTTP calls.
     _socket.socket.connect = _orig_connect  # type: ignore[assignment]
+
+# Enable SDK logging so per-example results are visible.
+from traigent.utils.logging import setup_logging
+
+setup_logging(level=os.getenv("TRAIGENT_LOG_LEVEL", "INFO"))
 
 # ---------------------------------------------------------------------------
 # Configuration — all values come from environment / .env (no hardcoded secrets)

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -882,6 +882,12 @@ class AuthManager:
             auth_result = await self.authenticate()
             if not auth_result.success or self._credentials is None:
                 self._authenticated = False
+                # Fall back to raw API key headers when full auth fails
+                # but an API key is available (e.g., local dev mode).
+                fallback = self._get_api_key_headers()
+                if fallback:
+                    self._add_common_headers(fallback, target)
+                    return fallback
                 return {}
 
         if not self._credentials:

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -884,6 +884,13 @@ class OptimizationOrchestrator:
         # during parallel trial execution (P1/P2/P3 fixes)
         async with self._state_lock:
             self._trials.append(trial_result)
+            logger.info(
+                "Trial #%d result: status=%s, config=%s, metrics=%s",
+                current_trial_index + 1,
+                trial_result.status,
+                trial_result.config,
+                trial_result.metrics,
+            )
             self._log_trial(trial_result)
 
             # Track cost for cost limit enforcement

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -606,6 +606,15 @@ class HybridAPIEvaluator(BaseEvaluator):
             # Execute
             execute_response = await transport.execute(request)
 
+            # Log raw execute response for observability
+            logger.info(
+                "Hybrid execute response: status=%s, outputs=%d, "
+                "operational_metrics=%s",
+                execute_response.status,
+                len(execute_response.outputs),
+                execute_response.operational_metrics,
+            )
+
             # Update session ID if returned
             if execute_response.session_id:
                 if self._session_id != execute_response.session_id:
@@ -764,6 +773,16 @@ class HybridAPIEvaluator(BaseEvaluator):
         try:
             eval_response = await transport.evaluate(eval_request)
 
+            # Log raw evaluate response for observability
+            logger.info(
+                "Hybrid evaluate response: results=%s, aggregate=%s",
+                [
+                    {"input_id": r.get("input_id"), "metrics": r.get("metrics")}
+                    for r in eval_response.results
+                ],
+                getattr(eval_response, "aggregate_metrics", None),
+            )
+
             # Merge execute and evaluate results
             results: list[HybridExampleResult] = []
             fallback_cost = self._coerce_metric(
@@ -786,6 +805,7 @@ class HybridAPIEvaluator(BaseEvaluator):
                 # Find metrics from evaluate
                 per_example_metrics: dict[str, float] = {}
                 eval_error: str | None = None
+                eval_expected: str | None = None
                 for result in eval_response.results:
                     if result.get("input_id") == input_id:
                         per_example_metrics = self._normalize_example_metrics(
@@ -793,6 +813,8 @@ class HybridAPIEvaluator(BaseEvaluator):
                         )
                         if isinstance(result.get("error"), str):
                             eval_error = result.get("error")
+                        if result.get("expected_behavior"):
+                            eval_expected = result["expected_behavior"]
                         break
 
                 # Prefer per-item operational metrics when present.
@@ -801,11 +823,24 @@ class HybridAPIEvaluator(BaseEvaluator):
                     output_item.get("latency_ms"), fallback_latency
                 )
 
+                # Log raw per-example result for observability
+                logger.info(
+                    "Hybrid example result: input_id=%s, "
+                    "output_id=%s, accuracy=%s, cost=%.6f, "
+                    "latency=%.0fms, error=%s",
+                    input_id,
+                    output_item.get("output_id"),
+                    per_example_metrics.get("accuracy"),
+                    cost,
+                    latency,
+                    eval_error or execute_error,
+                )
+
                 results.append(
                     HybridExampleResult(
                         input_id=input_id,
                         actual_output=output_data,
-                        expected_output=expected,
+                        expected_output=expected or eval_expected,
                         metrics=per_example_metrics,
                         cost_usd=cost,
                         latency_ms=latency,

--- a/traigent/utils/hashing.py
+++ b/traigent/utils/hashing.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import json
+import time
 from typing import Any
 
 from traigent.utils.numpy_compat import convert_numpy_value, is_numpy_type
@@ -97,12 +98,12 @@ def generate_experiment_hash(
     objectives: list[str],
     dataset_characteristics: dict[str, Any] | None = None,
 ) -> str:
-    """Generate deterministic experiment ID from optimization setup.
+    """Generate unique experiment ID from optimization setup.
 
-    Creates a unique, reproducible experiment ID based on the function name,
-    configuration space, objectives, and dataset characteristics. This ensures
-    that the same optimization setup always produces the same experiment ID,
-    allowing proper grouping of related experiment runs.
+    Creates a unique experiment ID based on the function name,
+    configuration space, objectives, dataset characteristics, and a
+    timestamp. Each invocation produces a new experiment ID so that
+    every optimization run is tracked separately.
 
     Args:
         function_name: Name of the function being optimized
@@ -112,20 +113,21 @@ def generate_experiment_hash(
                                 size, type, or hash for additional uniqueness
 
     Returns:
-        A deterministic experiment ID like "exp_a1b2c3d4e5f6g7h8"
+        A unique experiment ID like "exp_a1b2c3d4e5f6g7h8"
     """
     # Prepare components for hashing
     components = {
         "function_name": function_name,
         "configuration_space": configuration_space,
         "objectives": sorted(objectives),  # Sort for consistency
+        "timestamp": time.time(),
     }
 
     # Add dataset characteristics if provided
     if dataset_characteristics:
         components["dataset"] = dataset_characteristics
 
-    # Create deterministic JSON string (sorted keys ensure consistency)
+    # Create JSON string (sorted keys for readability, timestamp ensures uniqueness)
     hash_input = json.dumps(_sanitize_json_value(components), sort_keys=True)
 
     # Generate SHA256 hash and take first 16 characters for readability

--- a/traigent/utils/optimization_logger.py
+++ b/traigent/utils/optimization_logger.py
@@ -170,6 +170,50 @@ def sanitize_for_logging(
     return str(value)
 
 
+def _extract_output_text(output: Any) -> str | None:
+    """Best-effort extraction of the human-readable response text."""
+    if output is None:
+        return None
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        # Bazak-style: {"response": "...", "query": "..."}
+        for key in ("response", "text", "content", "answer"):
+            if key in output:
+                return str(output[key])
+    return None
+
+
+def _serialize_example_result(ex: Any) -> dict[str, Any]:
+    """Serialize a per-example result (dataclass or dict) for jsonl logging."""
+    if isinstance(ex, dict):
+        metrics = ex.get("metrics", {})
+        actual = ex.get("actual_output")
+        return {
+            "input_id": ex.get("input_id"),
+            "query": actual.get("query") if isinstance(actual, dict) else None,
+            "response": _extract_output_text(actual),
+            "expected": ex.get("expected_output"),
+            "accuracy": metrics.get("accuracy") if isinstance(metrics, dict) else None,
+            "cost_usd": ex.get("cost_usd", 0.0),
+            "latency_ms": ex.get("latency_ms", 0.0),
+            "error": ex.get("error"),
+        }
+    # Dataclass (e.g. HybridExampleResult)
+    metrics = getattr(ex, "metrics", {}) or {}
+    actual = getattr(ex, "actual_output", None)
+    return {
+        "input_id": getattr(ex, "input_id", None),
+        "query": actual.get("query") if isinstance(actual, dict) else None,
+        "response": _extract_output_text(actual),
+        "expected": getattr(ex, "expected_output", None),
+        "accuracy": metrics.get("accuracy") if isinstance(metrics, dict) else None,
+        "cost_usd": getattr(ex, "cost_usd", 0.0),
+        "latency_ms": getattr(ex, "latency_ms", 0.0),
+        "error": getattr(ex, "error", None),
+    }
+
+
 class OptimizationLogger:
     """Thread-safe optimization logger with versioned files and sanitization."""
 
@@ -429,8 +473,15 @@ class OptimizationLogger:
                 "duration": trial.duration,
                 "timestamp": trial.timestamp.isoformat() if trial.timestamp else None,
             }
+            example_results = (
+                trial.metadata.get("example_results") if trial.metadata else None
+            )
+            if example_results:
+                trial_data["example_results"] = [
+                    _serialize_example_result(ex) for ex in example_results
+                ]
             self._append_jsonl(trials_file, trial_data)
-            if trial.metadata and trial.metadata.get("example_results"):
+            if example_results:
                 trial_file = (
                     self.run_path
                     / "trials"
@@ -439,7 +490,38 @@ class OptimizationLogger:
                     )
                 )
                 self._atomic_write(trial_file, trial_data)
+            # Append human-readable summary table
+            self._append_trial_summary(trial, trial_data.get("example_results"))
         self._trial_buffer.clear()
+
+    def _append_trial_summary(
+        self,
+        trial: Any,
+        serialized_examples: list[dict[str, Any]] | None,
+    ) -> None:
+        """Append a human-readable summary table for one trial."""
+        summary_file = self.run_path / "trials" / "trial_summary.txt"
+        lines: list[str] = []
+        acc = trial.metrics.get("accuracy", "?") if trial.metrics else "?"
+        lines.append(
+            f"=== {trial.trial_id}  |  accuracy={acc}  |  " f"config={trial.config} ==="
+        )
+        if serialized_examples:
+            hdr = f"  {'input_id':<14} {'acc':>4}  {'expected':<22} {'response'}"
+            lines.append(hdr)
+            lines.append(f"  {'-'*14} {'-'*4}  {'-'*22} {'-'*50}")
+            for ex in serialized_examples:
+                iid = ex.get("input_id", "?")
+                a = ex.get("accuracy", "?")
+                exp = str(ex.get("expected") or "")[:22]
+                resp = str(ex.get("response") or ex.get("query") or "")[:80]
+                lines.append(f"  {iid:<14} {a!s:>4}  {exp:<22} {resp}")
+        lines.append("")
+        try:
+            with open(summary_file, "a", encoding="utf-8") as fh:
+                fh.write("\n".join(lines) + "\n")
+        except OSError:
+            pass
 
     def log_metrics_update(self, metrics: dict[str, Any]) -> None:
         timestamp = datetime.now(UTC).isoformat()


### PR DESCRIPTION
## Summary
- Add per-example query/response/expected to trials_v2.jsonl and trial_summary.txt
- Fall back to API key headers when full auth fails in SDK cloud client
- Generate unique experiment ID per run (timestamp in hash) so each optimization shows as a separate experiment on the dashboard

## Test plan
- [x] Ran 100-case Bazak optimization (3 trials) — 85-89% accuracy, all data logged
- [x] Verified per-example data in jsonl (query, response, expected fields present)
- [x] Verified new experiment created per run on backend dashboard
- [x] Auth fallback tested against local backend with `sk_dev_local_key_for_testing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)