### PR TITLE
fix(hybrid): benchmark discovery and /inputs → /benchmarks rename

### DIFF
--- a/docs/bazak-poc-overview.md
+++ b/docs/bazak-poc-overview.md
@@ -75,7 +75,7 @@ Create 50-100 test cases for the child-age-prompting scenario:
 
 ```json
 {
-  "input_id": "case_001",
+  "example_id": "case_001",
   "query": "I need a flight to Paris for me and my two kids",
   "expected_behavior": "should_ask_ages",
   "context": {"has_children": true, "child_count": 2}

--- a/docs/bazak-traigent-sequence.md
+++ b/docs/bazak-traigent-sequence.md
@@ -55,16 +55,16 @@ sequenceDiagram
         Orch->>Eval: evaluate(config, dataset)
 
         loop Batch 1..M (dataset / batch_size)
-            Note over Eval: Prepares batch of input_ids:<br/>[{input_id: "case_001"}, {input_id: "case_002"}, ...]
+            Note over Eval: Prepares batch of example_ids:<br/>[{example_id: "case_001"}, {example_id: "case_002"}, ...]
 
             Eval->>HTTP: execute(HybridExecuteRequest)
             HTTP->>Server: POST /traigent/v1/execute
-            Note right of HTTP: {tunable_id: "child-age-agent",<br/>config: {model, temperature, ...},<br/>inputs: [{input_id: "case_001"}, ...],<br/>timeout_ms: 60000}
+            Note right of HTTP: {tunable_id: "child-age-agent",<br/>config: {model, temperature, ...},<br/>examples: [{example_id: "case_001"}, ...],<br/>timeout_ms: 60000}
 
             Server->>Cap: execute(body)
 
             loop For each input in batch
-                Cap->>DS: Lookup query by input_id
+                Cap->>DS: Lookup query by example_id
                 DS-->>Cap: {query: "Cruise to Bahamas for me and my son?", expected_behavior: "should_ask_ages"}
 
                 Cap->>Agent: agent.generate(query, {instructions, modelSettings: {temperature}})
@@ -77,7 +77,7 @@ sequenceDiagram
                 Cap->>Store: Store output by output_id<br/>key: "out_case_001_exec_uuid"<br/>val: {response, cost_usd, latency_ms, ...}
             end
 
-            Cap-->>Server: {request_id, execution_id: "exec_...",<br/>status: "completed",<br/>outputs: [{input_id, output_id, cost_usd, latency_ms, tokens_used}, ...],<br/>operational_metrics: {total_cost_usd, latency_ms, ...},<br/>quality_metrics: null}
+            Cap-->>Server: {request_id, execution_id: "exec_...",<br/>status: "completed",<br/>outputs: [{example_id, output_id, cost_usd, latency_ms, tokens_used}, ...],<br/>operational_metrics: {total_cost_usd, latency_ms, ...},<br/>quality_metrics: null}
             Server-->>HTTP: 200 ExecuteResponse
             HTTP-->>Eval: HybridExecuteResponse
 
@@ -85,21 +85,21 @@ sequenceDiagram
 
             Eval->>HTTP: evaluate(HybridEvaluateRequest)
             HTTP->>Server: POST /traigent/v1/evaluate
-            Note right of HTTP: {tunable_id: "child-age-agent",<br/>execution_id: "exec_...",<br/>evaluations: [{input_id: "case_001",<br/>output_id: "out_case_001_exec_..."}, ...]}
+            Note right of HTTP: {tunable_id: "child-age-agent",<br/>execution_id: "exec_...",<br/>evaluations: [{example_id: "case_001",<br/>output_id: "out_case_001_exec_..."}, ...]}
 
             Server->>Cap: evaluate(body)
 
             loop For each evaluation item
                 Cap->>Store: Lookup response by output_id
                 Store-->>Cap: {response: "How old is your son?"}
-                Cap->>DS: Lookup expected_behavior by input_id
+                Cap->>DS: Lookup expected_behavior by example_id
                 DS-->>Cap: expected_behavior: "should_ask_ages"
                 Note right of Cap: detectAgeQuestion(response)<br/>→ true → accuracy = 1<br/><br/>If "should_ask_ages" &<br/>askedAges → accuracy=1<br/>If "should_not_ask_ages" &<br/>!askedAges → accuracy=1
             end
 
             Note right of Cap: aggregate: mean(accuracyValues),<br/>std(accuracyValues), n
 
-            Cap-->>Server: {request_id, status: "completed",<br/>results: [{input_id, metrics: {accuracy: 0 or 1}}, ...],<br/>aggregate_metrics: {accuracy: {mean, std, n}}}
+            Cap-->>Server: {request_id, status: "completed",<br/>results: [{example_id, metrics: {accuracy: 0 or 1}}, ...],<br/>aggregate_metrics: {accuracy: {mean, std, n}}}
             Server-->>HTTP: 200 EvaluateResponse
             HTTP-->>Eval: HybridEvaluateResponse
         end
@@ -119,7 +119,7 @@ sequenceDiagram
 ## Single Trial Detail (Privacy Mode — Bazak Default)
 
 Zoomed-in view of one execute+evaluate cycle in privacy mode,
-where only `input_id` and `output_id` cross the wire (no actual query/response text).
+where only `example_id` and `output_id` cross the wire (no actual query/response text).
 
 ```mermaid
 sequenceDiagram
@@ -132,7 +132,7 @@ sequenceDiagram
     Note over SDK,LLM: Execute Phase
 
     SDK->>Bazak: POST /traigent/v1/execute
-    Note right of SDK: Only IDs sent (privacy mode):<br/>{tunable_id: "child-age-agent",<br/>config: {model: "gpt-4o", temp: 0.2, ...},<br/>inputs: [{input_id: "case_042"}]}
+    Note right of SDK: Only IDs sent (privacy mode):<br/>{tunable_id: "child-age-agent",<br/>config: {model: "gpt-4o", temp: 0.2, ...},<br/>examples: [{example_id: "case_042"}]}
 
     Bazak->>Dataset: Lookup case_042
     Dataset-->>Bazak: query: "Trip for me and my 2 kids aged 5 and 8"
@@ -142,14 +142,14 @@ sequenceDiagram
 
     Bazak->>Store: Store: out_case_042_exec_abc → {response, cost, latency}
 
-    Bazak-->>SDK: {execution_id: "exec_abc",<br/>outputs: [{input_id: "case_042",<br/>output_id: "out_case_042_exec_abc",<br/>cost_usd: 0.00015, latency_ms: 820}],<br/>quality_metrics: null}
+    Bazak-->>SDK: {execution_id: "exec_abc",<br/>outputs: [{example_id: "case_042",<br/>output_id: "out_case_042_exec_abc",<br/>cost_usd: 0.00015, latency_ms: 820}],<br/>quality_metrics: null}
 
     Note over SDK: No response text returned!<br/>Only output_id + operational metrics
 
     Note over SDK,LLM: Evaluate Phase
 
     SDK->>Bazak: POST /traigent/v1/evaluate
-    Note right of SDK: References only IDs:<br/>{execution_id: "exec_abc",<br/>evaluations: [{input_id: "case_042",<br/>output_id: "out_case_042_exec_abc"}]}
+    Note right of SDK: References only IDs:<br/>{execution_id: "exec_abc",<br/>evaluations: [{example_id: "case_042",<br/>output_id: "out_case_042_exec_abc"}]}
 
     Bazak->>Store: Lookup out_case_042_exec_abc
     Store-->>Bazak: response: "Great! I can help..."
@@ -159,7 +159,7 @@ sequenceDiagram
 
     Note over Bazak: detectAgeQuestion("Great! I can help...")<br/>→ false (no age question)<br/>expected: should_not_ask_ages<br/>→ accuracy = 1 (correct!)
 
-    Bazak-->>SDK: {results: [{input_id: "case_042",<br/>metrics: {accuracy: 1}}],<br/>aggregate_metrics: {accuracy: {mean: 1.0, std: 0, n: 1}}}
+    Bazak-->>SDK: {results: [{example_id: "case_042",<br/>metrics: {accuracy: 1}}],<br/>aggregate_metrics: {accuracy: {mean: 1.0, std: 0, n: 1}}}
 
     Note over SDK: SDK sees accuracy=1 and cost=$0.00015<br/>Never saw the query or response text
 ```

--- a/docs/getting-started/minimal-integration.md
+++ b/docs/getting-started/minimal-integration.md
@@ -18,9 +18,9 @@ Minimum behavior contract:
 
 1. `capabilities` advertises whether `/evaluate` is supported.
 2. `config-space` returns at least one tunable parameter with a valid domain.
-3. `execute` accepts `tunable_id`, `config`, `inputs`, and returns:
+3. `execute` accepts `tunable_id`, `config`, `examples`, and returns:
    - `status`
-   - `outputs` (with `input_id` and either `output` or `output_id`)
+   - `outputs` (with `example_id` and either `output` or `output_id`)
    - `operational_metrics` (cost/latency fields)
 4. If combined mode is used, return non-empty `quality_metrics`.
 5. If two-phase mode is used, return `quality_metrics: null` (or omit it) and implement `/evaluate`.

--- a/docs/hybrid-mode-api-contract.md
+++ b/docs/hybrid-mode-api-contract.md
@@ -82,7 +82,7 @@ Traigent Hybrid Mode is designed with privacy as the default. **Only configurati
 
 ### How It Works
 
-1. **Inputs**: Only `input_id` is required. Your service stores input data locally and looks it up by ID.
+1. **Inputs**: Only `example_id` is required. Your service stores input data locally and looks it up by ID.
 2. **Outputs**: Return `output_id` instead of `output` content. Your service stores outputs locally.
 3. **Evaluation**: Use `output_id` and `target_id` instead of actual content. Your service performs evaluation locally.
 
@@ -105,12 +105,12 @@ For privacy-preserving mode, your service must:
 1. **Generate unique IDs**: Create stable identifiers for inputs, outputs, and targets
 2. **Track session context**: Use `session_id` to scope outputs to specific optimization runs
 3. **Store data locally**: Maintain a local mapping of IDs to actual content
-4. **Handle ID collisions**: Different optimization runs may reuse input IDs but produce different outputs - use `session_id` to distinguish
+4. **Handle ID collisions**: Different optimization runs may reuse example IDs but produce different outputs - use `session_id` to distinguish
 
 **Example ID format**:
 
 ```text
-input_id: "example_001"                    # Stable across runs
+example_id: "example_001"                  # Stable across runs
 output_id: "out_example_001_run_abc123"    # Scoped to run
 target_id: "target_001"                    # Stable across runs
 ```
@@ -118,7 +118,7 @@ target_id: "target_001"                    # Stable across runs
 ### Full-Content Datasets (Optional)
 
 If privacy is not a concern, you can send full content instead of IDs:
-- Include `data` in `InputItem`
+- Include `data` in `ExampleItem`
 - Include `output` in `OutputItem`
 - Include `output` and `target` in `EvaluationItem`
 
@@ -145,7 +145,7 @@ Return quality metrics directly in the execute response to skip the separate eva
   "status": "completed",
   "outputs": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "output_id": "out_001_run_abc",
       "cost_usd": 0.005,
       "metrics": {"accuracy": 0.92, "relevance": 0.88}
@@ -165,7 +165,7 @@ Return `quality_metrics: null` (or omit it) and set `supports_evaluate: true` in
   "status": "completed",
   "outputs": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "output_id": "out_001_run_abc",
       "cost_usd": 0.005
     }
@@ -370,13 +370,13 @@ Execute the agent with a specific configuration on a batch of inputs.
     "max_tokens": 1024,
     "use_cache": true
   },
-  "inputs": [
+  "examples": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "data": {"query": "What is machine learning?"}
     },
     {
-      "input_id": "ex_002",
+      "example_id": "ex_002",
       "data": {"query": "Explain neural networks"}
     }
   ],
@@ -395,15 +395,15 @@ Execute the agent with a specific configuration on a batch of inputs.
 | `request_id` | string | No | Idempotency key (UUID). Auto-generated if not provided |
 | `tunable_id` | string | Yes | Identifier for the tunable to invoke |
 | `config` | object | Yes | Configuration parameters (tunable values) |
-| `inputs` | array | Yes | List of input examples to process |
+| `examples` | array | Yes | List of input examples to process |
 | `session_id` | string | No | Session ID for stateful agents |
 | `batch_options` | object | No | Batch execution control |
 | `timeout_ms` | integer | No | Request timeout in milliseconds (default: 30000) |
 
-**Input Item**:
+**Example Item**:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `input_id` | string | Yes | Unique identifier for this input |
+| `example_id` | string | Yes | Unique identifier for this input |
 | `data` | object | No | Input data (optional in privacy-preserving mode) |
 
 **Batch Options**:
@@ -422,7 +422,7 @@ Execute the agent with a specific configuration on a batch of inputs.
   "status": "completed",
   "outputs": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "output": {
         "response": "Machine learning is a subset of AI...",
         "model_used": "gpt-4o-2024-01-01"
@@ -431,7 +431,7 @@ Execute the agent with a specific configuration on a batch of inputs.
       "latency_ms": 150
     },
     {
-      "input_id": "ex_002",
+      "example_id": "ex_002",
       "output": {
         "response": "Neural networks are computing systems...",
         "model_used": "gpt-4o-2024-01-01"
@@ -468,7 +468,7 @@ Execute the agent with a specific configuration on a batch of inputs.
 **Output Item**:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `input_id` | string | Yes | Matching input identifier |
+| `example_id` | string | Yes | Matching input identifier |
 | `output` | object | No | Agent output (optional in privacy-preserving mode) |
 | `output_id` | string | No | Output identifier (for privacy-preserving mode) |
 | `cost_usd` | number | No | Cost for this input |
@@ -516,12 +516,12 @@ Evaluate outputs against expected targets to measure quality.
   "execution_id": "exec_123456",
   "evaluations": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "output": {"response": "Machine learning is a subset of AI..."},
       "target": {"expected": "Machine learning is a branch of artificial intelligence..."}
     },
     {
-      "input_id": "ex_002",
+      "example_id": "ex_002",
       "output": {"response": "Neural networks are computing systems..."},
       "target": {"expected": "Neural networks are computer systems inspired by the brain..."}
     }
@@ -545,7 +545,7 @@ Evaluate outputs against expected targets to measure quality.
 **Evaluation Item**:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `input_id` | string | Yes | Matching input identifier |
+| `example_id` | string | Yes | Matching input identifier |
 | `output` | object | No | Agent output (optional in privacy-preserving mode) |
 | `output_id` | string | No | Output identifier (for privacy-preserving mode) |
 | `target` | object | No | Expected/reference output (optional in privacy-preserving mode) |
@@ -559,7 +559,7 @@ Evaluate outputs against expected targets to measure quality.
   "status": "completed",
   "results": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "metrics": {
         "accuracy": 0.92,
         "relevance": 0.88,
@@ -569,7 +569,7 @@ Evaluate outputs against expected targets to measure quality.
       }
     },
     {
-      "input_id": "ex_002",
+      "example_id": "ex_002",
       "metrics": {
         "accuracy": 0.89,
         "relevance": 0.91,
@@ -595,12 +595,12 @@ Evaluate outputs against expected targets to measure quality.
 | `status` | string | Yes | `"completed"`, `"partial"`, or `"failed"` |
 | `results` | array | Yes | Per-example evaluation results |
 | `aggregate_metrics` | object | Yes | Aggregated statistics per metric |
-| `error` | object | No | Error details for partial/failed evaluations (`code`, `message`, `failed_inputs`) |
+| `error` | object | No | Error details for partial/failed evaluations (`code`, `message`, `failed_examples`) |
 
 **Result Item**:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `input_id` | string | Yes | Matching input identifier |
+| `example_id` | string | Yes | Matching input identifier |
 | `metrics` | object | Yes | Quality metrics for this example |
 | `error` | string | No | Error message for this example when evaluation partially fails |
 
@@ -616,7 +616,7 @@ Evaluate outputs against expected targets to measure quality.
 {
   "results": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "metrics": {
         "accuracy": 0.92,
         "semantic_similarity": 0.87,

--- a/docs/hybrid-mode-client-guide.md
+++ b/docs/hybrid-mode-client-guide.md
@@ -40,7 +40,7 @@ Traigent Hybrid Mode is designed with **privacy as the default**. Only configura
 | Configuration values | Yes | Tunable values per trial |
 | Operational metrics | Yes | Cost, latency, tokens, etc. |
 | Quality metrics | Yes | Accuracy, relevance, etc. |
-| Input data content | **No** | Only input IDs |
+| Input data content | **No** | Only example IDs |
 | Output data content | **No** | Only output IDs |
 | Target data content | **No** | Only target IDs |
 
@@ -52,13 +52,14 @@ Traigent Hybrid Mode is designed with **privacy as the default**. Only configura
 @app.route("/traigent/v1/execute", methods=["POST"])
 def execute():
     outputs = []
-    for inp in inputs:
-        result = process_input(inp["input_id"])  # Look up by ID locally
-        output_id = generate_output_id(inp["input_id"], session_id)
+    for inp in examples:
+        result = process_input(inp["example_id"])  # Look up by ID locally
+        output_id = generate_output_id(inp["example_id"], session_id)
+
         store_output_locally(output_id, result)  # Store locally
 
         outputs.append({
-            "input_id": inp["input_id"],
+            "example_id": inp["example_id"],
             "output_id": output_id,  # Only transmit ID, not content
             "cost_usd": 0.005,
         })
@@ -75,13 +76,13 @@ def evaluate():
     for eval_item in evaluations:
         # Look up output locally using output_id
         output = get_output_locally(eval_item["output_id"])
-        # For ID-based datasets, target_id may be absent — use input_id to look up target
-        target_key = eval_item.get("target_id") or eval_item["input_id"]
+        # For ID-based datasets, target_id may be absent — use example_id to look up target
+        target_key = eval_item.get("target_id") or eval_item["example_id"]
         target = get_target_locally(target_key)
 
         metrics = compute_metrics(output, target)
         results.append({
-            "input_id": eval_item["input_id"],
+            "example_id": eval_item["example_id"],
             "metrics": metrics,
         })
 
@@ -97,13 +98,13 @@ This prevents accidental cross-routing in multi-service environments and aligns 
 
 For privacy-preserving mode, your service must:
 
-1. **Generate stable input IDs**: These should be consistent across optimization runs
+1. **Generate stable example IDs**: These should be consistent across optimization runs
 2. **Scope output IDs to sessions**: Include session_id to prevent collisions between runs
 3. **Store data locally**: Maintain a mapping of IDs to actual content
 
 ```python
-def generate_output_id(input_id: str, session_id: str) -> str:
-    return f"out_{input_id}_{session_id}"
+def generate_output_id(example_id: str, session_id: str) -> str:
+    return f"out_{example_id}_{session_id}"
 
 # Storage example
 output_storage: dict[str, dict] = {}
@@ -148,7 +149,7 @@ def config_space():
     }
 
 @app.execute
-async def generate_response(input_id: str, data: dict, config: dict) -> dict:
+async def generate_response(example_id: str, data: dict, config: dict) -> dict:
     result = await my_agent_logic(data["query"], **config)
     return {
         "output": result,
@@ -297,7 +298,7 @@ Measure output quality with any metrics you need:
 {
   "results": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "metrics": {
         "accuracy": 0.92,
         "semantic_similarity": 0.87,
@@ -363,21 +364,21 @@ def config_space():
 def execute():
     data = request.get_json()
     config = data.get("config", {})
-    inputs = data.get("inputs", [])
+    examples = data.get("examples", [])
 
     outputs = []
     total_cost = 0.0
 
-    for inp in inputs:
-        # Look up input data locally using input_id (ID-based datasets)
-        input_data = get_input_locally(inp["input_id"])
+    for inp in examples:
+        # Look up input data locally using example_id (ID-based datasets)
+        input_data = get_input_locally(inp["example_id"])
         result = process_input(input_data, config)
         cost = calculate_cost(config)
         total_cost += cost
 
         outputs.append({
-            "input_id": inp["input_id"],
-            "output_id": generate_output_id(inp["input_id"], data.get("session_id")),
+            "example_id": inp["example_id"],
+            "output_id": generate_output_id(inp["example_id"], data.get("session_id")),
             "cost_usd": cost,
         })
 
@@ -406,7 +407,7 @@ class ExecuteRequest(BaseModel):
     request_id: str | None = None
     tunable_id: str
     config: dict
-    inputs: list[dict]
+    examples: list[dict]
 
 @app.get("/traigent/v1/capabilities")
 async def capabilities():
@@ -428,13 +429,13 @@ async def config_space():
 @app.post("/traigent/v1/execute")
 async def execute(req: ExecuteRequest):
     outputs = []
-    for inp in req.inputs:
-        # Look up input data locally using input_id (ID-based datasets)
-        input_data = await get_input_locally(inp["input_id"])
+    for inp in req.examples:
+        # Look up input data locally using example_id (ID-based datasets)
+        input_data = await get_input_locally(inp["example_id"])
         result = await process_input(input_data, req.config)
         outputs.append({
-            "input_id": inp["input_id"],
-            "output_id": generate_output_id(inp["input_id"], req.session_id),
+            "example_id": inp["example_id"],
+            "output_id": generate_output_id(inp["example_id"], req.session_id),
             "cost_usd": 0.005,
         })
 
@@ -467,8 +468,8 @@ curl -X POST http://localhost:8080/traigent/v1/execute \
     "request_id": "550e8400-e29b-41d4-a716-446655440000",
     "tunable_id": "my_agent",
     "config": {"model": "fast", "temperature": 0.5},
-    "inputs": [
-      {"input_id": "ex_001", "data": {"query": "Hello"}}
+    "examples": [
+      {"example_id": "ex_001", "data": {"query": "Hello"}}
     ]
   }'
 
@@ -480,7 +481,7 @@ curl -X POST http://localhost:8080/traigent/v1/evaluate \
     "tunable_id": "my_agent",
     "evaluations": [
       {
-        "input_id": "ex_001",
+        "example_id": "ex_001",
         "output": {"response": "Hi there!"},
         "target": {"expected": "Hello!"}
       }
@@ -546,7 +547,7 @@ async def test_connection():
         HybridExecuteRequest(
             tunable_id="my_agent",
             config={"model": "fast"},
-            inputs=[{"input_id": "ex_001", "data": {"query": "test"}}],
+            examples=[{"example_id": "ex_001", "data": {"query": "test"}}],
         )
     )
     print(f"Status: {response.status}")
@@ -660,11 +661,11 @@ Return appropriate HTTP status codes and structured errors:
 def execute():
     try:
         data = request.get_json()
-        if not data.get("inputs"):
+        if not data.get("examples"):
             return jsonify({
                 "error": {
                     "code": "INVALID_REQUEST",
-                    "message": "inputs field is required"
+                    "message": "examples field is required"
                 }
             }), 400
 
@@ -704,7 +705,7 @@ from traigent.wrapper import (
 )
 
 @app.execute
-def run(input_id, data, config):
+def run(example_id, data, config):
     if quota_exceeded():
         raise RateLimitError("Quota exceeded", retry_after=30)  # HTTP 429
     if backend_down():
@@ -723,17 +724,17 @@ def execute():
     outputs = []
     errors = []
 
-    for inp in inputs:
+    for inp in examples:
         try:
             result = process_input(inp)
-            outputs.append({"input_id": inp["input_id"], "output": result})
+            outputs.append({"example_id": inp["example_id"], "output": result})
         except Exception as e:
-            errors.append({"input_id": inp["input_id"], "error": str(e)})
+            errors.append({"example_id": inp["example_id"], "error": str(e)})
 
     return jsonify({
         "status": "partial" if errors else "completed",
         "outputs": outputs,
-        "error": {"failed_inputs": errors} if errors else None,
+        "error": {"failed_examples": errors} if errors else None,
     })
 ```
 

--- a/docs/hybrid-mode-integration-guide.tex
+++ b/docs/hybrid-mode-integration-guide.tex
@@ -247,7 +247,7 @@ Target / expected output content               & \textcolor{privacygreen}{\textb
 \end{center}
 
 Your service stores data locally and uses opaque identifiers
-(\field{input\_id}, \field{output\_id}, \field{target\_id}) in API exchanges.
+(\field{example\_id}, \field{output\_id}, \field{target\_id}) in API exchanges.
 If privacy is not a concern, you may include full content in \field{data},
 \field{output}, and \field{target} fields. Both modes can be mixed.
 
@@ -427,9 +427,9 @@ Execute the agent with a specific configuration on a batch of inputs.
     "temperature": 0.5,
     "max_tokens": 1024
   },
-  "inputs": [
-    {"input_id": "ex_001", "data": {"query": "What is machine learning?"}},
-    {"input_id": "ex_002", "data": {"query": "Explain neural networks"}}
+  "examples": [
+    {"example_id": "ex_001", "data": {"query": "What is machine learning?"}},
+    {"example_id": "ex_002", "data": {"query": "Explain neural networks"}}
   ],
   "timeout_ms": 30000
 }
@@ -443,7 +443,7 @@ Execute the agent with a specific configuration on a batch of inputs.
 \field{request\_id}    & string (UUID) & \optional & Idempotency key (auto-generated if omitted) \\
 \field{capability\_id} & string        & \required & Capability to invoke \\
 \field{config}         & object        & \required & Configuration parameters (tunable values) \\
-\field{inputs}         & array         & \required & Input examples to process \\
+\field{examples}       & array         & \required & Examples to process \\
 \field{session\_id}    & string        & \optional & Session ID for stateful agents \\
 \field{batch\_options} & object        & \optional & Parallelism, fail-fast, per-item timeout \\
 \field{timeout\_ms}    & integer       & \optional & Request timeout in ms (default: 30\,000) \\
@@ -456,7 +456,7 @@ Each \textbf{Input Item} contains:
 \begin{center}\small
 \begin{tabularx}{\textwidth}{@{}llcX@{}}
 \toprule
-\field{input\_id} & string & \required & Unique identifier for this input \\
+\field{example\_id} & string & \required & Unique identifier for this input \\
 \field{data}      & object & \optional & Input data (omit in privacy-preserving mode) \\
 \bottomrule
 \end{tabularx}
@@ -471,7 +471,7 @@ Each \textbf{Input Item} contains:
   "status": "completed",
   "outputs": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "output": {"response": "Machine learning is a subset of AI..."},
       "cost_usd": 0.002,
       "latency_ms": 150
@@ -507,7 +507,7 @@ Each \textbf{Output Item} contains:
 \begin{center}\small
 \begin{tabularx}{\textwidth}{@{}llcX@{}}
 \toprule
-\field{input\_id}   & string & \required & Matching input identifier \\
+\field{example\_id}   & string & \required & Matching input identifier \\
 \field{output}      & object & \optional & Agent output (omit in privacy-preserving mode) \\
 \field{output\_id}  & string & \optional & Output identifier (privacy-preserving mode) \\
 \field{cost\_usd}   & number & \optional & Cost for this input \\
@@ -554,7 +554,7 @@ Evaluate outputs against expected targets. Only required when
   "execution_id": "exec_123456",
   "evaluations": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "output": {"response": "Machine learning is a subset of AI..."},
       "target": {"expected": "Machine learning is a branch of AI..."}
     }
@@ -586,7 +586,7 @@ Each \textbf{Evaluation Item} contains:
 \begin{center}\small
 \begin{tabularx}{\textwidth}{@{}llcX@{}}
 \toprule
-\field{input\_id}   & string & \required & Matching input identifier \\
+\field{example\_id}   & string & \required & Matching input identifier \\
 \field{output}      & object & \optional & Agent output (or use \field{output\_id}) \\
 \field{output\_id}  & string & \optional & Output reference (privacy-preserving mode) \\
 \field{target}      & object & \optional & Expected output (or use \field{target\_id}) \\
@@ -603,7 +603,7 @@ Each \textbf{Evaluation Item} contains:
   "status": "completed",
   "results": [
     {
-      "input_id": "ex_001",
+      "example_id": "ex_001",
       "metrics": {"accuracy": 0.92, "relevance": 0.88, "fluency": 0.95}
     }
   ],
@@ -628,7 +628,7 @@ Each \textbf{Evaluation Item} contains:
 \end{tabularx}
 \end{center}
 
-Each \textbf{Result Item}: \field{input\_id}~(required), \field{metrics}~(required object of numeric quality scores), \field{error}~(optional string).
+Each \textbf{Result Item}: \field{example\_id}~(required), \field{metrics}~(required object of numeric quality scores), \field{error}~(optional string).
 
 Each \textbf{Aggregate Metric}: \field{mean}~(number), \field{std}~(number), \field{n}~(integer).
 

--- a/docs/hybrid-mode-openapi.yaml
+++ b/docs/hybrid-mode-openapi.yaml
@@ -149,7 +149,7 @@ paths:
         This is the main endpoint where your agent processes inputs using the provided configuration.
 
         **Server implementation (privacy-preserving mode):**
-        1. For each input, use `input_id` to look up the actual query from your local dataset (e.g., an observability platform like Langfuse, an evaluation dataset, or any local data store)
+        1. For each input, use `example_id` to look up the actual query from your local dataset (e.g., an observability platform like Langfuse, an evaluation dataset, or any local data store)
         2. Run your agent with the provided `config` parameters
         3. Store the response locally, keyed by a generated `output_id`
         4. Return `output_id` + cost/latency per input (do NOT return response text)
@@ -174,8 +174,8 @@ paths:
               config:
                 model: gpt-4o
                 temperature: 0.5
-              inputs:
-                - input_id: case_001
+              examples:
+                - example_id: case_001
               timeout_ms: 30000
       responses:
         '200':
@@ -189,7 +189,7 @@ paths:
                 execution_id: exec_20240115_001
                 status: completed
                 outputs:
-                  - input_id: case_001
+                  - example_id: case_001
                     output_id: out_001_run_abc
                     cost_usd: 0.0012
                     latency_ms: 245.5
@@ -261,7 +261,7 @@ paths:
 
         **Server implementation (privacy-preserving mode):**
         1. For each evaluation item, use `output_id` to look up stored output locally
-        2. Use `input_id` (and optional `target_id`) to resolve expected behavior from local data
+        2. Use `example_id` (and optional `target_id`) to resolve expected behavior from local data
         3. Compare output vs expected and compute per-example quality metrics
         4. Return per-example metrics and aggregate statistics (`mean`, `std`, `n`)
       tags:
@@ -280,7 +280,7 @@ paths:
               tunable_id: my_agent
               execution_id: exec_123456
               evaluations:
-                - input_id: case_001
+                - example_id: case_001
                   output_id: out_001_run_abc
                   target_id: target_001
               timeout_ms: 30000
@@ -299,7 +299,7 @@ paths:
                     execution_id: exec_20240115_001
                     status: completed
                     results:
-                      - input_id: case_001
+                      - example_id: case_001
                         metrics:
                           accuracy: 0.92
                           relevance: 0.88
@@ -320,7 +320,7 @@ paths:
                     execution_id: null
                     status: completed
                     results:
-                      - input_id: case_002
+                      - example_id: case_002
                         metrics:
                           accuracy: 0.89
                           relevance: 0.91
@@ -962,20 +962,20 @@ components:
           items:
             type: string
             maxLength: 128
-    InputItem:
+    ExampleItem:
       type: object
       description: |
         Single input item for execution.
 
-        **Privacy-preserving mode**: Only `input_id` is required. Your service uses
+        **Privacy-preserving mode**: Only `example_id` is required. Your service uses
         the ID to look up the actual input data locally. The input data is never
         transmitted to Traigent.
 
         **Full-content datasets**: Include `data` with the actual input content.
       required:
-        - input_id
+        - example_id
       properties:
-        input_id:
+        example_id:
           type: string
           description: |
             Unique identifier for this input. In privacy-preserving mode, your
@@ -985,7 +985,7 @@ components:
         data:
           type: object
           description: |
-            Input data (structure defined by your agent). Optional in privacy-preserving mode where the service looks up data by input_id.
+            Input data (structure defined by your agent). Optional in privacy-preserving mode where the service looks up data by example_id.
           additionalProperties: true
           example:
             query: What is machine learning?
@@ -1014,12 +1014,12 @@ components:
           example: 5000
     ExecuteRequest:
       type: object
-      description: Request to execute agent with configuration on inputs
+      description: Request to execute agent with configuration on examples
       required:
         - request_id
         - tunable_id
         - config
-        - inputs
+        - examples
       properties:
         request_id:
           type: string
@@ -1035,11 +1035,11 @@ components:
           type: object
           description: Configuration parameters (tunable values matching config-space definitions)
           additionalProperties: true
-        inputs:
+        examples:
           type: array
-          description: List of input examples to process
+          description: List of examples to process
           items:
-            $ref: '#/components/schemas/InputItem'
+            $ref: '#/components/schemas/ExampleItem'
           minItems: 1
           maxItems: 10000
         session_id:
@@ -1067,9 +1067,9 @@ components:
 
         **Full-content datasets**: Include `output` with the actual output content.
       required:
-        - input_id
+        - example_id
       properties:
-        input_id:
+        example_id:
           type: string
           description: Matching input identifier
           maxLength: 256
@@ -1180,9 +1180,9 @@ components:
           description: Error message
           maxLength: 2048
           example: 2 of 5 inputs failed due to upstream timeout
-        failed_inputs:
+        failed_examples:
           type: array
-          description: List of failed input IDs
+          description: List of failed example IDs
           maxItems: 10000
           items:
             type: string
@@ -1257,9 +1257,9 @@ components:
 
         Note: You can mix modes - e.g., provide `output` content but use `target_id` for expected.
       required:
-        - input_id
+        - example_id
       properties:
-        input_id:
+        example_id:
           type: string
           description: Matching input identifier
           maxLength: 256
@@ -1338,10 +1338,10 @@ components:
       type: object
       description: Evaluation result for a single example
       required:
-        - input_id
+        - example_id
         - metrics
       properties:
-        input_id:
+        example_id:
           type: string
           description: Matching input identifier
           maxLength: 256

--- a/docs/hybrid-mode-openapi.yaml
+++ b/docs/hybrid-mode-openapi.yaml
@@ -171,6 +171,7 @@ paths:
             example:
               request_id: 550e8400-e29b-41d4-a716-446655440000
               tunable_id: my_agent
+              benchmark_id: spider_dev_v1
               config:
                 model: gpt-4o
                 temperature: 0.5
@@ -278,6 +279,7 @@ paths:
             example:
               request_id: 660e8400-e29b-41d4-a716-446655440001
               tunable_id: my_agent
+              benchmark_id: spider_dev_v1
               execution_id: exec_123456
               evaluations:
                 - example_id: case_001
@@ -380,6 +382,57 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '503':
           description: Service unavailable (temporary upstream/dependency outage)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /traigent/v1/benchmarks:
+    get:
+      operationId: getBenchmarks
+      summary: List available benchmarks
+      description: |
+        Returns the benchmarks available for optimization. Each benchmark contains
+        a set of example IDs and is linked to one or more tunable IDs.
+        Traigent calls this to discover which benchmarks are available for a tunable.
+      tags:
+        - Discovery
+      parameters:
+        - name: tunable_id
+          in: query
+          required: false
+          description: |
+            Filter benchmarks by tunable ID. If omitted, returns all benchmarks.
+          schema:
+            type: string
+            maxLength: 256
+        - $ref: '#/components/parameters/TraceParentHeader'
+        - $ref: '#/components/parameters/TraceStateHeader'
+      responses:
+        '200':
+          description: List of benchmarks
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BenchmarksResponse'
+              example:
+                benchmarks:
+                  - benchmark_id: spider_dev_v1
+                    tunable_ids:
+                      - my_agent
+                    example_ids:
+                      - case_001
+                      - case_002
+                      - case_003
+                    name: Spider Dev Set v1
+                benchmarks_revision: rev_20240115_001
+        '401':
+          description: Unauthorized (missing or invalid bearer token)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -1018,6 +1071,7 @@ components:
       required:
         - request_id
         - tunable_id
+        - benchmark_id
         - config
         - examples
       properties:
@@ -1031,17 +1085,22 @@ components:
           description: Identifier for the agent tunable to invoke
           maxLength: 256
           example: my_agent
+        benchmark_id:
+          type: string
+          description: Benchmark containing the examples to run. Must match a benchmark_id from the /benchmarks endpoint.
+          maxLength: 256
+          example: spider_dev_v1
         config:
           type: object
           description: Configuration parameters (tunable values matching config-space definitions)
           additionalProperties: true
         examples:
           type: array
-          description: List of examples to process
+          description: List of examples to process. Actual limit is max_batch_size from capabilities (default 100).
           items:
             $ref: '#/components/schemas/ExampleItem'
           minItems: 1
-          maxItems: 10000
+          maxItems: 100000
         session_id:
           type: string
           description: Session ID for stateful agents
@@ -1058,6 +1117,11 @@ components:
           minimum: 1000
           maximum: 600000
           example: 30000
+        benchmarks_revision:
+          type: string
+          description: Optional revision token for stale-detection. Obtained from the /benchmarks endpoint.
+          maxLength: 256
+          nullable: true
     OutputItem:
       type: object
       description: |
@@ -1292,6 +1356,7 @@ components:
       required:
         - request_id
         - tunable_id
+        - benchmark_id
         - evaluations
       properties:
         request_id:
@@ -1304,6 +1369,11 @@ components:
           description: Identifier for the evaluation tunable
           maxLength: 256
           example: my_agent
+        benchmark_id:
+          type: string
+          description: Benchmark containing the examples being evaluated. Must match a benchmark_id from the /benchmarks endpoint.
+          maxLength: 256
+          example: spider_dev_v1
         execution_id:
           type: string
           description: Reference to previous execute (for caching/correlation)
@@ -1334,6 +1404,11 @@ components:
           minimum: 1000
           maximum: 600000
           example: 30000
+        benchmarks_revision:
+          type: string
+          description: Optional revision token for stale-detection. Obtained from the /benchmarks endpoint.
+          maxLength: 256
+          nullable: true
     EvaluationResult:
       type: object
       description: Evaluation result for a single example
@@ -1432,6 +1507,65 @@ components:
         error:
           description: Error details when status is partial or failed
           $ref: '#/components/schemas/ExecutionError'
+    BenchmarkEntry:
+      type: object
+      description: A single benchmark with its associated example IDs
+      required:
+        - benchmark_id
+        - tunable_ids
+        - example_ids
+      properties:
+        benchmark_id:
+          type: string
+          description: Unique identifier for this benchmark
+          maxLength: 256
+          example: spider_dev_v1
+        tunable_ids:
+          type: array
+          description: Agents linked to this benchmark (sorted ASCII)
+          items:
+            type: string
+            maxLength: 256
+          minItems: 1
+          maxItems: 100
+          example:
+            - my_agent
+        example_ids:
+          type: array
+          description: Datapoint identifiers within this benchmark (sorted ASCII)
+          items:
+            type: string
+            maxLength: 256
+          minItems: 1
+          maxItems: 100000
+          example:
+            - case_001
+            - case_002
+            - case_003
+        name:
+          type: string
+          description: Optional display name for the benchmark
+          maxLength: 512
+          nullable: true
+          example: Spider Dev Set v1
+    BenchmarksResponse:
+      type: object
+      description: Response from benchmarks discovery endpoint
+      required:
+        - benchmarks
+      properties:
+        benchmarks:
+          type: array
+          description: List of benchmark entries (sorted by benchmark_id, ASCII)
+          items:
+            $ref: '#/components/schemas/BenchmarkEntry'
+          maxItems: 1000
+        benchmarks_revision:
+          type: string
+          description: Opaque revision token for stale-detection. Pass this value in execute/evaluate requests to detect benchmark changes.
+          maxLength: 256
+          nullable: true
+          example: rev_20240115_001
     HealthCheckResponse:
       type: object
       description: Response from health check endpoint

--- a/docs/hybrid-mode-schemas.json
+++ b/docs/hybrid-mode-schemas.json
@@ -451,13 +451,13 @@
       },
       "additionalProperties": false
     },
-    "InputItem": {
+    "ExampleItem": {
       "type": "object",
-      "title": "InputItem",
-      "description": "Single input item for execution. For privacy-preserving mode, only input_id is required - the service retrieves data locally using the ID.",
-      "required": ["input_id"],
+      "title": "ExampleItem",
+      "description": "Single example item for execution. For privacy-preserving mode, only example_id is required - the service retrieves data locally using the ID.",
+      "required": ["example_id"],
       "properties": {
-        "input_id": {
+        "example_id": {
           "type": "string",
           "description": "Unique identifier for this input. In privacy-preserving mode, the service uses this to retrieve locally-stored input data."
         },
@@ -472,8 +472,8 @@
     "ExecuteRequest": {
       "type": "object",
       "title": "ExecuteRequest",
-      "description": "Request to execute agent with configuration on inputs",
-      "required": ["tunable_id", "config", "inputs"],
+      "description": "Request to execute agent with configuration on examples",
+      "required": ["tunable_id", "config", "examples"],
       "properties": {
         "request_id": {
           "type": "string",
@@ -489,11 +489,11 @@
           "description": "Configuration parameters (tunable values)",
           "additionalProperties": true
         },
-        "inputs": {
+        "examples": {
           "type": "array",
-          "description": "List of input examples to process",
+          "description": "List of examples to process",
           "items": {
-            "$ref": "#/definitions/InputItem"
+            "$ref": "#/definitions/ExampleItem"
           },
           "minItems": 1
         },
@@ -517,12 +517,12 @@
       "type": "object",
       "title": "OutputItem",
       "description": "Output for a single input. For privacy-preserving mode, output_id can be returned instead of output content - the service stores output data locally.",
-      "required": ["input_id"],
+      "required": ["example_id"],
       "additionalProperties": true,
       "properties": {
-        "input_id": {
+        "example_id": {
           "type": "string",
-          "description": "Matching input identifier"
+          "description": "Matching example identifier"
         },
         "output": {
           "type": "object",
@@ -621,9 +621,9 @@
           "type": "string",
           "description": "Error message"
         },
-        "failed_inputs": {
+        "failed_examples": {
           "type": "array",
-          "description": "List of failed input IDs",
+          "description": "List of failed example IDs",
           "items": {
             "type": "string"
           }
@@ -680,11 +680,11 @@
       "type": "object",
       "title": "EvaluationItem",
       "description": "Single evaluation item with output and target. For privacy-preserving mode, use output_id and target_id instead of content - the service retrieves data locally using session context.",
-      "required": ["input_id"],
+      "required": ["example_id"],
       "properties": {
-        "input_id": {
+        "example_id": {
           "type": "string",
-          "description": "Matching input identifier"
+          "description": "Matching example identifier"
         },
         "output": {
           "type": "object",
@@ -775,11 +775,11 @@
       "type": "object",
       "title": "EvaluationResult",
       "description": "Evaluation result for a single example",
-      "required": ["input_id", "metrics"],
+      "required": ["example_id", "metrics"],
       "properties": {
-        "input_id": {
+        "example_id": {
           "type": "string",
-          "description": "Matching input identifier"
+          "description": "Matching example identifier"
         },
         "metrics": {
           "type": "object",

--- a/examples/hybrid_mode_demo/README.md
+++ b/examples/hybrid_mode_demo/README.md
@@ -56,7 +56,7 @@ curl -X POST http://localhost:8080/traigent/v1/execute \
     "request_id": "test-001",
     "tunable_id": "demo_agent",
     "config": {"model": "accurate", "temperature": 0.7},
-    "inputs": [{"input_id": "ex_001", "data": {"query": "What is AI?"}}]
+    "examples": [{"example_id": "ex_001", "data": {"query": "What is AI?"}}]
   }'
 ```
 
@@ -190,10 +190,10 @@ Replace the mock implementation in the `execute()` function with your actual age
 def execute():
     data = request.get_json()
     config = data.get("config", {})
-    inputs = data.get("inputs", [])
+    examples = data.get("examples", [])
 
     outputs = []
-    for inp in inputs:
+    for inp in examples:
         # Call your actual agent/LLM here
         result = my_real_agent(
             query=inp["data"]["query"],
@@ -201,7 +201,7 @@ def execute():
             temperature=config.get("temperature"),
         )
         outputs.append({
-            "input_id": inp["input_id"],
+            "example_id": inp["example_id"],
             "output": {"response": result.text},
             "cost_usd": result.cost,
             "latency_ms": result.latency,

--- a/examples/hybrid_mode_demo/app.py
+++ b/examples/hybrid_mode_demo/app.py
@@ -127,7 +127,7 @@ def execute():
             "request_id": "uuid",
             "tunable_id": "demo_agent",
             "config": {"model": "fast", "temperature": 0.5, ...},
-            "inputs": [{"input_id": "ex_001", "data": {"query": "..."}}]
+            "examples": [{"example_id": "ex_001", "data": {"query": "..."}}]
         }
 
     Response format:
@@ -143,7 +143,7 @@ def execute():
     if not isinstance(data, dict):
         return jsonify({"error": "Invalid JSON payload"}), 400
 
-    missing_fields = [field for field in ("config", "inputs") if field not in data]
+    missing_fields = [field for field in ("config", "examples") if field not in data]
     if missing_fields:
         return (
             jsonify(
@@ -156,7 +156,7 @@ def execute():
         )
 
     config = data.get("config")
-    inputs = data.get("inputs")
+    inputs = data.get("examples")
     if not isinstance(config, dict):
         return (
             jsonify(
@@ -171,7 +171,7 @@ def execute():
         return (
             jsonify(
                 {
-                    "error": "Field 'inputs' must be a non-empty array",
+                    "error": "Field 'examples' must be a non-empty array",
                     "message": "Request body failed validation",
                 }
             ),
@@ -179,11 +179,11 @@ def execute():
         )
 
     for idx, inp in enumerate(inputs):
-        if not isinstance(inp, dict) or not inp.get("input_id"):
+        if not isinstance(inp, dict) or not inp.get("example_id"):
             return (
                 jsonify(
                     {
-                        "error": f"Input at index {idx} must include non-empty 'input_id'",
+                        "error": f"Input at index {idx} must include non-empty 'example_id'",
                         "message": "Request body failed validation",
                     }
                 ),
@@ -205,7 +205,7 @@ def execute():
     start_time = time.time()
 
     for inp in inputs:
-        input_id = inp.get("input_id")
+        example_id = inp.get("example_id")
 
         # Extract config values
         model = config.get("model", "balanced")
@@ -229,8 +229,8 @@ def execute():
         # Build per-input output
         outputs.append(
             {
-                "input_id": input_id,
-                "output_id": f"out_{input_id}_{execution_id}",
+                "example_id": example_id,
+                "output_id": f"out_{example_id}_{execution_id}",
                 "cost_usd": cost_per_query,
                 "latency_ms": 50 + (100 if model == "accurate" else 0),
             }
@@ -288,7 +288,7 @@ def evaluate():
             "request_id": "uuid",
             "tunable_id": "demo_agent",
             "evaluations": [
-                {"input_id": "ex_001", "output": {...}, "target": {...}}
+                {"example_id": "ex_001", "output": {...}, "target": {...}}
             ]
         }
 
@@ -296,7 +296,7 @@ def evaluate():
         {
             "request_id": "uuid",
             "status": "completed",
-            "results": [{"input_id": "ex_001", "metrics": {"accuracy": 0.9}}],
+            "results": [{"example_id": "ex_001", "metrics": {"accuracy": 0.9}}],
             "aggregate_metrics": {"accuracy": {"mean": 0.9, "std": 0.05, "n": 10}}
         }
     """
@@ -319,7 +319,7 @@ def evaluate():
     }
 
     for eval_item in evaluations:
-        input_id = eval_item.get("input_id")
+        example_id = eval_item.get("example_id")
         output = eval_item.get("output", {})
         target = eval_item.get("target", {})
 
@@ -366,7 +366,7 @@ def evaluate():
 
         results.append(
             {
-                "input_id": input_id,
+                "example_id": example_id,
                 "metrics": metrics,
             }
         )

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -278,7 +278,7 @@ async def run_optimization() -> None:
                 f"\n[2/4] Using {len(example_ids)} example IDs from MASTRA_JS_EXAMPLE_IDS"
             )
         else:
-            print(f"\n[2/4] Discovering example IDs via GET /benchmarks...")
+            print("\n[2/4] Discovering example IDs via GET /benchmarks...")
             example_ids = await evaluator.discover_example_ids()
             print(f"      Discovered {len(example_ids)} example IDs from server")
 

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -82,10 +82,10 @@ AUTH_HEADERS: Final[dict[str, str]] = {
 }
 TUNABLE_ID: Final[str | None] = get_env_var("MASTRA_JS_TUNABLE_ID")
 _INPUT_IDS_ENV = get_env_var("MASTRA_JS_INPUT_IDS", "")
-INPUT_IDS: Final[list[str]] = (
+INPUT_IDS_OVERRIDE: Final[list[str]] = (
     [x.strip() for x in _INPUT_IDS_ENV.split(",") if x.strip()]
     if _INPUT_IDS_ENV
-    else [f"case_{i:03d}" for i in range(1, 6)]  # local dataset default
+    else []  # empty = auto-discover via GET /inputs
 )
 MAX_TRIALS: Final[int] = int(get_env_var("MASTRA_JS_MAX_TRIALS", "10"))
 MAX_COST_USD: Final[float] = float(get_env_var("MASTRA_JS_MAX_COST_USD", "4.0"))
@@ -179,10 +179,10 @@ def discover_tunable_id(url: str) -> str:
     return selected
 
 
-def build_dataset() -> Dataset:
-    """Build the dataset from the known input_ids."""
+def build_dataset(input_ids: list[str]) -> Dataset:
+    """Build the dataset from the given input_ids."""
     return Dataset(
-        [EvaluationExample(input_data={"input_id": iid}) for iid in INPUT_IDS]
+        [EvaluationExample(input_data={"input_id": iid}) for iid in input_ids]
     )
 
 
@@ -259,7 +259,7 @@ async def run_optimization() -> None:
     )
 
     async with evaluator:
-        print("\n[1/3] Discovering config space...")
+        print("\n[1/4] Discovering config space...")
         config_space = await evaluator.discover_config_space()
         config_space, reasoning_capped = _apply_reasoning_cap(config_space)
         print(f"      Found {len(config_space)} tunables:")
@@ -271,8 +271,17 @@ async def run_optimization() -> None:
                 f"(MASTRA_JS_MAX_REASONING_LEVEL)"
             )
 
-        # --- Step 2: Create optimizer + orchestrator ---
-        print(f"\n[2/3] Setting up RandomSearchOptimizer (max_trials={MAX_TRIALS})...")
+        # --- Step 2: Discover input IDs (or use override) ---
+        if INPUT_IDS_OVERRIDE:
+            input_ids = INPUT_IDS_OVERRIDE
+            print(f"\n[2/4] Using {len(input_ids)} input IDs from MASTRA_JS_INPUT_IDS")
+        else:
+            print(f"\n[2/4] Discovering input IDs via GET /inputs...")
+            input_ids = await evaluator.discover_input_ids()
+            print(f"      Discovered {len(input_ids)} input IDs from server")
+
+        # --- Step 3: Create optimizer + orchestrator ---
+        print(f"\n[3/4] Setting up RandomSearchOptimizer (max_trials={MAX_TRIALS})...")
         optimizer = RandomSearchOptimizer(
             config_space=config_space,
             objectives=["accuracy"],
@@ -303,12 +312,12 @@ async def run_optimization() -> None:
             cost_approved=cost_approved,
         )
 
-        # --- Step 3: Run optimization ---
-        dataset = build_dataset()
+        # --- Step 4: Run optimization ---
+        dataset = build_dataset(input_ids)
         print(f"      Dataset: {len(dataset)} examples")
         print(f"      Execution mode: {execution_mode.value}")
         print(f"      Cost limit: ${MAX_COST_USD:.2f} (approved={cost_approved})")
-        print("\n[3/3] Running optimization...")
+        print("\n[4/4] Running optimization...")
         print("-" * 70)
 
         async def hybrid_demo_agent():

--- a/examples/hybrid_mode_demo/run_mastra_js_optimization.py
+++ b/examples/hybrid_mode_demo/run_mastra_js_optimization.py
@@ -81,11 +81,11 @@ AUTH_HEADERS: Final[dict[str, str]] = {
     "User-Agent": "Traigent-SDK/1.0",
 }
 TUNABLE_ID: Final[str | None] = get_env_var("MASTRA_JS_TUNABLE_ID")
-_INPUT_IDS_ENV = get_env_var("MASTRA_JS_INPUT_IDS", "")
-INPUT_IDS_OVERRIDE: Final[list[str]] = (
-    [x.strip() for x in _INPUT_IDS_ENV.split(",") if x.strip()]
-    if _INPUT_IDS_ENV
-    else []  # empty = auto-discover via GET /inputs
+_EXAMPLE_IDS_ENV = get_env_var("MASTRA_JS_EXAMPLE_IDS", "")
+EXAMPLE_IDS_OVERRIDE: Final[list[str]] = (
+    [x.strip() for x in _EXAMPLE_IDS_ENV.split(",") if x.strip()]
+    if _EXAMPLE_IDS_ENV
+    else []  # empty = auto-discover via GET /benchmarks
 )
 MAX_TRIALS: Final[int] = int(get_env_var("MASTRA_JS_MAX_TRIALS", "10"))
 MAX_COST_USD: Final[float] = float(get_env_var("MASTRA_JS_MAX_COST_USD", "4.0"))
@@ -179,10 +179,10 @@ def discover_tunable_id(url: str) -> str:
     return selected
 
 
-def build_dataset(input_ids: list[str]) -> Dataset:
-    """Build the dataset from the given input_ids."""
+def build_dataset(example_ids: list[str]) -> Dataset:
+    """Build the dataset from the given example_ids."""
     return Dataset(
-        [EvaluationExample(input_data={"input_id": iid}) for iid in input_ids]
+        [EvaluationExample(input_data={"example_id": iid}) for iid in example_ids]
     )
 
 
@@ -271,14 +271,16 @@ async def run_optimization() -> None:
                 f"(MASTRA_JS_MAX_REASONING_LEVEL)"
             )
 
-        # --- Step 2: Discover input IDs (or use override) ---
-        if INPUT_IDS_OVERRIDE:
-            input_ids = INPUT_IDS_OVERRIDE
-            print(f"\n[2/4] Using {len(input_ids)} input IDs from MASTRA_JS_INPUT_IDS")
+        # --- Step 2: Discover example IDs (or use override) ---
+        if EXAMPLE_IDS_OVERRIDE:
+            example_ids = EXAMPLE_IDS_OVERRIDE
+            print(
+                f"\n[2/4] Using {len(example_ids)} example IDs from MASTRA_JS_EXAMPLE_IDS"
+            )
         else:
-            print(f"\n[2/4] Discovering input IDs via GET /inputs...")
-            input_ids = await evaluator.discover_input_ids()
-            print(f"      Discovered {len(input_ids)} input IDs from server")
+            print(f"\n[2/4] Discovering example IDs via GET /benchmarks...")
+            example_ids = await evaluator.discover_example_ids()
+            print(f"      Discovered {len(example_ids)} example IDs from server")
 
         # --- Step 3: Create optimizer + orchestrator ---
         print(f"\n[3/4] Setting up RandomSearchOptimizer (max_trials={MAX_TRIALS})...")
@@ -313,7 +315,7 @@ async def run_optimization() -> None:
         )
 
         # --- Step 4: Run optimization ---
-        dataset = build_dataset(input_ids)
+        dataset = build_dataset(example_ids)
         print(f"      Dataset: {len(dataset)} examples")
         print(f"      Execution mode: {execution_mode.value}")
         print(f"      Cost limit: ${MAX_COST_USD:.2f} (approved={cost_approved})")

--- a/examples/hybrid_mode_demo/run_optimization.py
+++ b/examples/hybrid_mode_demo/run_optimization.py
@@ -63,34 +63,34 @@ def create_evaluation_dataset() -> list[EvaluationExample]:
     """Create evaluation dataset."""
     examples = [
         {
-            "input_id": "ex_001",
+            "example_id": "ex_001",
             "query": "What is artificial intelligence?",
             "expected": "AI is the simulation of human intelligence by machines.",
         },
         {
-            "input_id": "ex_002",
+            "example_id": "ex_002",
             "query": "Explain machine learning in simple terms.",
             "expected": "Machine learning is a type of AI that learns from data.",
         },
         {
-            "input_id": "ex_003",
+            "example_id": "ex_003",
             "query": "What is deep learning?",
             "expected": "Deep learning uses neural networks with many layers.",
         },
         {
-            "input_id": "ex_004",
+            "example_id": "ex_004",
             "query": "How does natural language processing work?",
             "expected": "NLP helps computers understand human language.",
         },
         {
-            "input_id": "ex_005",
+            "example_id": "ex_005",
             "query": "What is a neural network?",
             "expected": "A neural network is a computing system inspired by the brain.",
         },
     ]
     return [
         EvaluationExample(
-            input_data={"query": ex["query"], "input_id": ex["input_id"]},
+            input_data={"query": ex["query"], "example_id": ex["example_id"]},
             expected_output=ex["expected"],
         )
         for ex in examples

--- a/examples/hybrid_mode_demo/test_mastra_js_api.py
+++ b/examples/hybrid_mode_demo/test_mastra_js_api.py
@@ -119,19 +119,19 @@ def _build_config_from_tunables(tunables: list) -> dict:
 
 
 def test_execute(tunable_id: str, config: dict):
-    """Test execute endpoint with dataset input_ids (privacy-preserving)."""
+    """Test execute endpoint with dataset example_ids (privacy-preserving)."""
     print("\n>>> Testing POST /traigent/v1/execute")
 
-    # input_ids are server-specific; these match the zap_agent benchmark dataset.
+    # example_ids are server-specific; these match the zap_agent benchmark dataset.
     # TODO: replace with dynamic discovery once traigent-api#43 is resolved.
     sent_request_id = f"test-{uuid.uuid4().hex[:8]}"
     request_data = {
         "request_id": sent_request_id,
         "tunable_id": tunable_id,
         "config": config,
-        "inputs": [
-            {"input_id": "q001"},
-            {"input_id": "q051"},
+        "examples": [
+            {"example_id": "q001"},
+            {"example_id": "q051"},
         ],
     }
 
@@ -159,17 +159,17 @@ def test_execute(tunable_id: str, config: dict):
     # Check outputs — server returns output_id (privacy-preserving)
     assert len(data["outputs"]) == 2, f"Expected 2 outputs, got {len(data['outputs'])}"
     for output in data["outputs"]:
-        assert "input_id" in output, "Output missing input_id"
+        assert "example_id" in output, "Output missing example_id"
         assert "output_id" in output, "Output missing output_id"
         assert "cost_usd" in output, "Output missing cost_usd"
 
-    # Verify input_id preservation (order-independent, catches duplicates)
+    # Verify example_id preservation (order-independent, catches duplicates)
     # See traigent-api#44 for spec wording on exact preservation requirement.
-    sent_ids = Counter(inp["input_id"] for inp in request_data["inputs"])
-    received_ids = Counter(out["input_id"] for out in data["outputs"])
+    sent_ids = Counter(inp["example_id"] for inp in request_data["examples"])
+    received_ids = Counter(out["example_id"] for out in data["outputs"])
     assert (
         sent_ids == received_ids
-    ), f"input_id mismatch: sent {dict(sent_ids)}, got {dict(received_ids)}"
+    ), f"example_id mismatch: sent {dict(sent_ids)}, got {dict(received_ids)}"
 
     # Validate quality_metrics shape when present (combined mode)
     if data.get("quality_metrics") is not None:
@@ -199,7 +199,7 @@ def test_evaluate(execute_data: dict, tunable_id: str):
     for out in execute_data["outputs"]:
         evaluations.append(
             {
-                "input_id": out["input_id"],
+                "example_id": out["example_id"],
                 "output_id": out["output_id"],
             }
         )
@@ -229,7 +229,7 @@ def test_evaluate(execute_data: dict, tunable_id: str):
     # Check results
     assert len(data["results"]) == 2, f"Expected 2 results, got {len(data['results'])}"
     for result in data["results"]:
-        assert "input_id" in result, "Result missing input_id"
+        assert "example_id" in result, "Result missing example_id"
         assert "metrics" in result, "Result missing metrics"
 
     # Check aggregate metrics — validate required fields per AggregateMetricStats
@@ -275,7 +275,7 @@ def test_error_format(tunable_id: str):
     bad_request = {
         "request_id": f"err-{uuid.uuid4().hex[:8]}",
         "tunable_id": tunable_id,
-        "inputs": [{"input_id": "q001"}],
+        "examples": [{"example_id": "q001"}],
         # 'config' deliberately omitted
     }
 

--- a/examples/tvl/reusable_safety/run_demo.py
+++ b/examples/tvl/reusable_safety/run_demo.py
@@ -1379,7 +1379,8 @@ def print_optimization_cost_summary(
         model_costs = None
 
     # Print summary table
-    print(f"""
+    print(
+        f"""
   {Colors.BOLD}┌─────────────────────────────────────────────────────────────────┐{Colors.END}
   {Colors.BOLD}│                    OPTIMIZATION STATISTICS                      │{Colors.END}
   {Colors.BOLD}├─────────────────────────────────────────────────────────────────┤{Colors.END}
@@ -1411,7 +1412,8 @@ def print_optimization_cost_summary(
   │                                                                 │
   │     • Q&A Agent:      ${qa_cost:.4f}                                  │
   │     • Support Agent:  ${support_cost:.4f}                                  │
-  │                                                                 │""")
+  │                                                                 │"""
+    )
 
     # Print model breakdown if pandas available
     if HAS_PANDAS and model_costs is not None:
@@ -1707,7 +1709,8 @@ def main() -> None:
     # Demonstrate inheritance
     print_section("Policy Inheritance")
 
-    print(f"""
+    print(
+        f"""
   {Colors.BOLD}Enterprise Policy:{Colors.END} base_safety.tvl.yml
     └── Hallucination Rate: ≤ 10%
     └── Toxicity Score: ≤ 5%
@@ -1723,7 +1726,8 @@ def main() -> None:
   - Accuracy: 3x                    - Latency: 2x
   - Latency: 1x                     - Cost: 2x
                                     - Resolution: 1x
-""")
+"""
+    )
 
     print_info("Both agents inherit the SAME safety constraints from base spec")
     print_info(
@@ -1806,7 +1810,8 @@ def main() -> None:
     qa_model = str(qa_result.best_config["model"])
     support_model = str(support_result.best_config["model"])
 
-    print(f"""
+    print(
+        f"""
   ┌─────────────────────────────────────┬─────────────────────────────────────┐
   │ {Colors.BLUE}Q&A Agent{Colors.END}                           │ {Colors.GREEN}Support Agent{Colors.END}                       │
   ├─────────────────────────────────────┼─────────────────────────────────────┤
@@ -1819,7 +1824,8 @@ def main() -> None:
   │ {Colors.GREEN}✓ Passed Safety: {qa_result.passed_trials}/{qa_result.total_trials}{Colors.END}               │ {Colors.GREEN}✓ Passed Safety: {support_result.passed_trials}/{support_result.total_trials}{Colors.END}               │
   │ {Colors.RED}✗ Rejected: {qa_result.rejected_trials}{Colors.END}                       │ {Colors.RED}✗ Rejected: {support_result.rejected_trials}{Colors.END}                       │
   └─────────────────────────────────────┴─────────────────────────────────────┘
-""")
+"""
+    )
 
     print_success(
         "Both agents enforced the SAME safety constraints from base_safety.tvl.yml"
@@ -1860,7 +1866,8 @@ def main() -> None:
     print_header("KEY TAKEAWAYS")
 
     total_rejected = qa_result.rejected_trials + support_result.rejected_trials
-    print(f"""
+    print(
+        f"""
   {Colors.GREEN}✓{Colors.END} {Colors.BOLD}Define Once, Enforce Everywhere{Colors.END}
     Update base_safety.tvl.yml → all agents inherit automatically
 
@@ -1872,7 +1879,8 @@ def main() -> None:
 
   {Colors.GREEN}✓{Colors.END} {Colors.BOLD}Full Audit Trail{Colors.END}
     Every configuration, every metric, every decision tracked
-""")
+"""
+    )
 
     print(f"\n{Colors.BOLD}Ready for a 3-week design sprint?{Colors.END}\n")
 

--- a/tests/integration/hybrid/mock_hybrid_server.py
+++ b/tests/integration/hybrid/mock_hybrid_server.py
@@ -54,7 +54,7 @@ class MockHybridServer:
     active_sessions: set[str] = field(default_factory=set)
 
     # Privacy-preserving mode: local data storage
-    # Maps input_id -> input data
+    # Maps example_id -> input data
     _input_storage: dict[str, dict[str, Any]] = field(default_factory=dict)
     # Maps output_id -> output data
     _output_storage: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -72,17 +72,17 @@ class MockHybridServer:
         self._output_storage = {}
         self._target_storage = {}
 
-    def store_input(self, input_id: str, data: dict[str, Any]) -> None:
+    def store_input(self, example_id: str, data: dict[str, Any]) -> None:
         """Store input data locally (for privacy-preserving mode)."""
-        self._input_storage[input_id] = data
+        self._input_storage[example_id] = data
 
     def store_target(self, target_id: str, data: dict[str, Any]) -> None:
         """Store target data locally (for privacy-preserving mode)."""
         self._target_storage[target_id] = data
 
-    def get_input(self, input_id: str) -> dict[str, Any]:
+    def get_input(self, example_id: str) -> dict[str, Any]:
         """Retrieve locally-stored input data by ID."""
-        return self._input_storage.get(input_id, {})
+        return self._input_storage.get(example_id, {})
 
     def get_output(self, output_id: str) -> dict[str, Any]:
         """Retrieve locally-stored output data by ID."""
@@ -139,7 +139,7 @@ class MockHybridServer:
         }
 
     def execute(self, request: dict[str, Any]) -> dict[str, Any]:
-        """Execute agent with given config on inputs.
+        """Execute agent with given config on examples.
 
         Simulates agent execution by computing mock outputs based on
         the configuration and tracking costs.
@@ -183,7 +183,7 @@ class MockHybridServer:
                 },
             }
 
-        inputs = request.get("inputs", [])
+        inputs = request.get("examples", [])
         session_id = request.get("session_id")
 
         if session_id:
@@ -195,15 +195,15 @@ class MockHybridServer:
         total_latency = 0.0
 
         for inp in inputs:
-            input_id = inp.get("input_id", str(uuid.uuid4()))
+            example_id = inp.get("example_id", str(uuid.uuid4()))
 
-            # Privacy-preserving mode: look up data locally by input_id
+            # Privacy-preserving mode: look up data locally by example_id
             # Standard mode: use data from request
             if "data" in inp:
                 data = inp["data"]
             else:
                 # Privacy-preserving: look up locally-stored input
-                data = self.get_input(input_id)
+                data = self.get_input(example_id)
 
             # Simulate output based on config
             output = self._simulate_output(config, data)
@@ -226,14 +226,14 @@ class MockHybridServer:
 
             # Build output item
             output_item: dict[str, Any] = {
-                "input_id": input_id,
+                "example_id": example_id,
                 "cost_usd": cost,
                 "latency_ms": latency,
             }
 
             if self.config.privacy_preserving:
                 # Privacy-preserving mode: store output locally and return only ID
-                output_id = f"out_{input_id}_{session_id or 'default'}"
+                output_id = f"out_{example_id}_{session_id or 'default'}"
                 self._output_storage[output_id] = output
                 output_item["output_id"] = output_id
             else:
@@ -323,7 +323,7 @@ class MockHybridServer:
         accuracy_sum = 0.0
 
         for eval_item in evaluations:
-            input_id = eval_item.get("input_id", str(uuid.uuid4()))
+            example_id = eval_item.get("example_id", str(uuid.uuid4()))
 
             # Privacy-preserving mode: look up output and target by ID
             # Standard mode: use data from request
@@ -355,7 +355,7 @@ class MockHybridServer:
 
             results.append(
                 {
-                    "input_id": input_id,
+                    "example_id": example_id,
                     "metrics": {
                         "accuracy": accuracy,
                         "relevance": quality * 0.95,

--- a/tests/integration/hybrid/test_hybrid_mode_integration.py
+++ b/tests/integration/hybrid/test_hybrid_mode_integration.py
@@ -116,15 +116,16 @@ class TestHybridModeExecution:
         """Test executing a single example."""
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate", "temperature": 0.3},
-            inputs=[{"input_id": "ex_1", "data": {"query": "test question"}}],
+            examples=[{"example_id": "ex_1", "data": {"query": "test question"}}],
         )
 
         response = await transport.execute(request)
 
         assert response.status == "completed"
         assert len(response.outputs) == 1
-        assert response.outputs[0]["input_id"] == "ex_1"
+        assert response.outputs[0]["example_id"] == "ex_1"
         assert "output" in response.outputs[0]
         assert response.operational_metrics["total_cost_usd"] > 0
 
@@ -138,14 +139,15 @@ class TestHybridModeExecution:
     ) -> None:
         """Test executing a batch of examples."""
         inputs = [
-            {"input_id": f"ex_{i}", "data": {"query": f"question {i}"}}
+            {"example_id": f"ex_{i}", "data": {"query": f"question {i}"}}
             for i in range(5)
         ]
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "balanced"},
-            inputs=inputs,
+            examples=inputs,
         )
 
         response = await transport.execute(request)
@@ -166,8 +168,9 @@ class TestHybridModeExecution:
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[{"input_id": "ex_1", "data": {}}],
+            examples=[{"example_id": "ex_1", "data": {}}],
             session_id=session_id,
         )
 
@@ -182,13 +185,14 @@ class TestHybridModeExecution:
         self, transport: MockHTTPTransport, mock_server: MockHybridServer
     ) -> None:
         """Test that different model configurations affect cost."""
-        inputs = [{"input_id": "ex_1", "data": {}}]
+        inputs = [{"example_id": "ex_1", "data": {}}]
 
         # Fast model - lower cost
         request_fast = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=inputs,
+            examples=inputs,
         )
         response_fast = await transport.execute(request_fast)
         cost_fast = response_fast.operational_metrics["total_cost_usd"]
@@ -198,8 +202,9 @@ class TestHybridModeExecution:
         # Accurate model - higher cost
         request_accurate = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate"},
-            inputs=inputs,
+            examples=inputs,
         )
         response_accurate = await transport.execute(request_accurate)
         cost_accurate = response_accurate.operational_metrics["total_cost_usd"]
@@ -228,14 +233,15 @@ class TestHybridModeEvaluation:
         """Test evaluating outputs against targets."""
         request = HybridEvaluateRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": {"quality_score": 0.9, "response": "answer 1"},
                     "target": {"expected": "correct answer"},
                 },
                 {
-                    "input_id": "ex_2",
+                    "example_id": "ex_2",
                     "output": {"quality_score": 0.7, "response": "answer 2"},
                     "target": {"expected": "correct answer"},
                 },
@@ -257,10 +263,11 @@ class TestHybridModeEvaluation:
         # Phase 1: Execute
         exec_request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate", "temperature": 0.2},
-            inputs=[
-                {"input_id": "ex_1", "data": {"query": "What is 2+2?"}},
-                {"input_id": "ex_2", "data": {"query": "Capital of France?"}},
+            examples=[
+                {"example_id": "ex_1", "data": {"query": "What is 2+2?"}},
+                {"example_id": "ex_2", "data": {"query": "Capital of France?"}},
             ],
         )
         exec_response = await transport.execute(exec_request)
@@ -270,7 +277,7 @@ class TestHybridModeEvaluation:
         # Phase 2: Evaluate
         evaluations = [
             {
-                "input_id": out["input_id"],
+                "example_id": out["example_id"],
                 "output": out["output"],
                 "target": {"expected": "correct"},
             }
@@ -279,6 +286,7 @@ class TestHybridModeEvaluation:
 
         eval_request = HybridEvaluateRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             execution_id=exec_response.execution_id,
             evaluations=evaluations,
         )
@@ -337,8 +345,9 @@ class TestHybridModeLifecycle:
         # Execute a request to register session on server
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={},
-            inputs=[{"input_id": "ex_1", "data": {}}],
+            examples=[{"example_id": "ex_1", "data": {}}],
             session_id=session_id,
         )
         await transport.execute(request)
@@ -390,12 +399,13 @@ class TestHybridModeCostControl:
         self, transport: MockHTTPTransport, mock_server: MockHybridServer
     ) -> None:
         """Test that costs are accurately tracked for single batch."""
-        inputs = [{"input_id": f"ex_{i}", "data": {}} for i in range(10)]
+        inputs = [{"example_id": f"ex_{i}", "data": {}} for i in range(10)]
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "balanced"},  # 1x cost multiplier
-            inputs=inputs,
+            examples=inputs,
         )
 
         response = await transport.execute(request)
@@ -412,13 +422,14 @@ class TestHybridModeCostControl:
 
         for batch_idx in range(3):
             inputs = [
-                {"input_id": f"batch{batch_idx}_ex_{i}", "data": {}} for i in range(5)
+                {"example_id": f"batch{batch_idx}_ex_{i}", "data": {}} for i in range(5)
             ]
 
             request = HybridExecuteRequest(
                 tunable_id="mock_test_agent",
+                benchmark_id="bench_001",
                 config={"model": "balanced"},
-                inputs=inputs,
+                examples=inputs,
             )
 
             response = await transport.execute(request)
@@ -434,10 +445,11 @@ class TestHybridModeCostControl:
         """Test extracting per-example costs from response."""
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate"},  # 2x cost
-            inputs=[
-                {"input_id": "ex_1", "data": {}},
-                {"input_id": "ex_2", "data": {}},
+            examples=[
+                {"example_id": "ex_1", "data": {}},
+                {"example_id": "ex_2", "data": {}},
             ],
         )
 
@@ -470,8 +482,9 @@ class TestHybridModeBatchControl:
         for i in range(3):
             request = HybridExecuteRequest(
                 tunable_id="mock_test_agent",
+                benchmark_id="bench_001",
                 config={"model": "fast"},
-                inputs=[{"input_id": f"ex_{i}", "data": {}}],
+                examples=[{"example_id": f"ex_{i}", "data": {}}],
             )
             await transport.execute(request)
 
@@ -483,12 +496,13 @@ class TestHybridModeBatchControl:
         self, transport: MockHTTPTransport, mock_server: MockHybridServer
     ) -> None:
         """Test sending all examples in one batch."""
-        inputs = [{"input_id": f"ex_{i}", "data": {}} for i in range(10)]
+        inputs = [{"example_id": f"ex_{i}", "data": {}} for i in range(10)]
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=inputs,
+            examples=inputs,
         )
         response = await transport.execute(request)
 
@@ -509,8 +523,9 @@ class TestHybridModeErrorHandling:
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={},
-            inputs=[{"input_id": "ex_1", "data": {}}],
+            examples=[{"example_id": "ex_1", "data": {}}],
         )
 
         response = await transport.execute(request)
@@ -526,7 +541,8 @@ class TestHybridModeErrorHandling:
 
         request = HybridEvaluateRequest(
             tunable_id="mock_test_agent",
-            evaluations=[{"input_id": "ex_1", "output": {}, "target": {}}],
+            benchmark_id="bench_001",
+            evaluations=[{"example_id": "ex_1", "output": {}, "target": {}}],
         )
 
         response = await transport.evaluate(request)
@@ -592,7 +608,7 @@ class TestHybridModePrivacyPreserving:
     """Integration tests for privacy-preserving mode.
 
     Tests that the API correctly handles:
-    - Execute with only input_id (no data content)
+    - Execute with only example_id (no data content)
     - Execute returning output_id instead of output content
     - Evaluate with output_id and target_id instead of content
     - Mixed mode (some content, some IDs)
@@ -610,21 +626,22 @@ class TestHybridModePrivacyPreserving:
         return MockHTTPTransport(privacy_server)
 
     @pytest.mark.asyncio
-    async def test_execute_privacy_mode_input_id_only(
+    async def test_execute_privacy_mode_example_id_only(
         self, privacy_transport: MockHTTPTransport, privacy_server: MockHybridServer
     ) -> None:
-        """Test execute with only input_id - data looked up locally."""
+        """Test execute with only example_id - data looked up locally."""
         # Pre-store input data on server (simulates client-side storage)
         privacy_server.store_input("ex_1", {"query": "What is AI?"})
         privacy_server.store_input("ex_2", {"query": "What is ML?"})
 
-        # Request with only input_ids, no data
+        # Request with only example_ids, no data
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate", "temperature": 0.3},
-            inputs=[
-                {"input_id": "ex_1"},  # No data field
-                {"input_id": "ex_2"},  # No data field
+            examples=[
+                {"example_id": "ex_1"},  # No data field
+                {"example_id": "ex_2"},  # No data field
             ],
         )
 
@@ -637,7 +654,7 @@ class TestHybridModePrivacyPreserving:
         for out in response.outputs:
             assert "output_id" in out
             assert "output" not in out
-            assert out["input_id"] in ["ex_1", "ex_2"]
+            assert out["example_id"] in ["ex_1", "ex_2"]
 
     @pytest.mark.asyncio
     async def test_execute_privacy_mode_returns_output_id(
@@ -646,8 +663,9 @@ class TestHybridModePrivacyPreserving:
         """Test that privacy mode returns output_id instead of output content."""
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[{"input_id": "ex_1", "data": {"query": "test"}}],
+            examples=[{"example_id": "ex_1", "data": {"query": "test"}}],
             session_id="session_123",
         )
 
@@ -687,14 +705,15 @@ class TestHybridModePrivacyPreserving:
         # Request with only IDs, no content
         request = HybridEvaluateRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output_id": "out_ex_1",  # ID instead of content
                     "target_id": "target_ex_1",  # ID instead of content
                 },
                 {
-                    "input_id": "ex_2",
+                    "example_id": "ex_2",
                     "output_id": "out_ex_2",
                     "target_id": "target_ex_2",
                 },
@@ -723,8 +742,9 @@ class TestHybridModePrivacyPreserving:
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "balanced"},
-            inputs=[{"input_id": "ex_1", "data": {"query": "test question"}}],
+            examples=[{"example_id": "ex_1", "data": {"query": "test question"}}],
         )
 
         response = await transport.execute(request)
@@ -752,14 +772,15 @@ class TestHybridModePrivacyPreserving:
 
         request = HybridEvaluateRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": {"quality_score": 0.9, "response": "answer 1"},
                     "target": {"expected": "correct answer"},  # Full content
                 },
                 {
-                    "input_id": "ex_2",
+                    "example_id": "ex_2",
                     "output": {"quality_score": 0.7, "response": "answer 2"},
                     "target_id": "target_ex_2",  # ID reference
                 },
@@ -786,13 +807,14 @@ class TestHybridModePrivacyPreserving:
         privacy_server.store_target("target_ex_1", {"expected": "4"})
         privacy_server.store_target("target_ex_2", {"expected": "Paris"})
 
-        # Phase 1: Execute with only input_ids
+        # Phase 1: Execute with only example_ids
         exec_request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate", "temperature": 0.2},
-            inputs=[
-                {"input_id": "ex_1"},
-                {"input_id": "ex_2"},
+            examples=[
+                {"example_id": "ex_1"},
+                {"example_id": "ex_2"},
             ],
             session_id=session_id,
         )
@@ -803,21 +825,22 @@ class TestHybridModePrivacyPreserving:
 
         # Collect output_ids from response
         output_ids = {
-            out["input_id"]: out["output_id"] for out in exec_response.outputs
+            out["example_id"]: out["output_id"] for out in exec_response.outputs
         }
 
         # Phase 2: Evaluate with output_ids and target_ids
         eval_request = HybridEvaluateRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             execution_id=exec_response.execution_id,
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output_id": output_ids["ex_1"],
                     "target_id": "target_ex_1",
                 },
                 {
-                    "input_id": "ex_2",
+                    "example_id": "ex_2",
                     "output_id": output_ids["ex_2"],
                     "target_id": "target_ex_2",
                 },
@@ -844,10 +867,11 @@ class TestHybridModePrivacyPreserving:
 
         request = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate"},  # 2x cost
-            inputs=[
-                {"input_id": "ex_1"},
-                {"input_id": "ex_2"},
+            examples=[
+                {"example_id": "ex_1"},
+                {"example_id": "ex_2"},
             ],
         )
 
@@ -865,18 +889,20 @@ class TestHybridModePrivacyPreserving:
         self, privacy_transport: MockHTTPTransport, privacy_server: MockHybridServer
     ) -> None:
         """Test that output_ids are scoped to sessions to prevent collisions."""
-        # Same input_id but different sessions
+        # Same example_id but different sessions
         request1 = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[{"input_id": "shared_input", "data": {"query": "test"}}],
+            examples=[{"example_id": "shared_input", "data": {"query": "test"}}],
             session_id="session_A",
         )
 
         request2 = HybridExecuteRequest(
             tunable_id="mock_test_agent",
+            benchmark_id="bench_001",
             config={"model": "accurate"},
-            inputs=[{"input_id": "shared_input", "data": {"query": "test"}}],
+            examples=[{"example_id": "shared_input", "data": {"query": "test"}}],
             session_id="session_B",
         )
 

--- a/tests/optimizer_validation/chatbot/cli.py
+++ b/tests/optimizer_validation/chatbot/cli.py
@@ -228,7 +228,8 @@ def single_query(query: str, model: str = "claude-sonnet-4-20250514") -> None:
 
 def print_help() -> None:
     """Print usage help."""
-    print("""
+    print(
+        """
 Traigent Test Suite Chatbot - Help
 ==================================
 
@@ -251,7 +252,8 @@ Tips:
   - Be specific about what you're looking for
   - Use dimension names (InjectionMode, Algorithm, etc.) for precise queries
   - Ask about coverage gaps to find missing test scenarios
-""")
+"""
+    )
 
 
 def main() -> None:

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -260,7 +260,8 @@ class TestOptimizeDecorator:
     def test_decorator_wires_evaluation_set_dataset(self, tmp_path):
         """TVL 0.9 evaluation_set.dataset populates eval_dataset when omitted."""
         spec_path = tmp_path / "evalset.tvl.yml"
-        spec_path.write_text("""tvl:
+        spec_path.write_text(
+            """tvl:
   module: test.evalset
 tvl_version: "0.9"
 evaluation_set:
@@ -272,7 +273,8 @@ tvars:
 objectives:
   - name: accuracy
     direction: maximize
-""")
+"""
+        )
 
         @optimize(tvl_spec=spec_path)
         def tvl_wrapped(question: str) -> str:
@@ -284,7 +286,8 @@ objectives:
     def test_decorator_does_not_override_explicit_eval_dataset(self, tmp_path):
         """Explicit eval_dataset beats evaluation_set in a TVL spec."""
         spec_path = tmp_path / "evalset_override.tvl.yml"
-        spec_path.write_text("""tvl:
+        spec_path.write_text(
+            """tvl:
   module: test.evalset.override
 tvl_version: "0.9"
 evaluation_set:
@@ -296,7 +299,8 @@ tvars:
 objectives:
   - name: accuracy
     direction: maximize
-""")
+"""
+        )
 
         @optimize(tvl_spec=spec_path, eval_dataset="user.jsonl")
         def tvl_wrapped(question: str) -> str:

--- a/tests/unit/cli/test_main_cli_sample_limit.py
+++ b/tests/unit/cli/test_main_cli_sample_limit.py
@@ -16,7 +16,8 @@ def _write_temp_module(root: Path) -> Path:
     module_dir.mkdir(exist_ok=True)
     module_path = module_dir / f"module_{uuid4().hex}.py"
 
-    module_path.write_text("""
+    module_path.write_text(
+        """
 last_kwargs = {}
 
 
@@ -40,7 +41,8 @@ def fake_optimized_function():
 
 
 fake_optimized_function.optimize = _optimize_stub
-""")
+"""
+    )
 
     return module_path
 

--- a/tests/unit/cli/test_validation_system.py
+++ b/tests/unit/cli/test_validation_system.py
@@ -366,7 +366,8 @@ class TestCLIIntegration:
     def test_check_command_dry_run(self, cli_runner):
         """Test check command dry run mode."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write("""
+            f.write(
+                """
 import traigent
 
 @traigent.optimize(
@@ -376,7 +377,8 @@ import traigent
 )
 def test_func():
     return "test"
-""")
+"""
+            )
             temp_file = f.name
 
         try:

--- a/tests/unit/config_generator/test_apply.py
+++ b/tests/unit/config_generator/test_apply.py
@@ -35,12 +35,14 @@ def _allow_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture()
 def simple_source() -> str:
-    return textwrap.dedent("""\
+    return textwrap.dedent(
+        """\
         import os
 
         def answer_question(query: str) -> str:
             return "42"
-    """)
+    """
+    )
 
 
 @pytest.fixture()
@@ -113,12 +115,14 @@ class TestApplyConfig:
     def test_adds_import_traigent(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import os
 
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -130,12 +134,14 @@ class TestApplyConfig:
     def test_adds_range_imports(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import os
 
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -147,12 +153,14 @@ class TestApplyConfig:
     def test_adds_safety_imports(
         self, tmp_path: Path, result_with_safety: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import os
 
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -164,13 +172,15 @@ class TestApplyConfig:
     def test_skips_existing_imports(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import traigent
             from traigent import Range
 
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -184,7 +194,8 @@ class TestApplyConfig:
     def test_replaces_existing_decorator(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import traigent
 
             @traigent.optimize(
@@ -192,7 +203,8 @@ class TestApplyConfig:
             )
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -208,13 +220,15 @@ class TestApplyConfig:
     def test_replaces_bare_optimize_decorator(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             from traigent import optimize
 
             @optimize(configuration_space={"old": (0, 1)})
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -227,11 +241,13 @@ class TestApplyConfig:
     def test_indentation_preserved_for_method(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             class Agent:
                 def my_method(self):
                     pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -276,13 +292,15 @@ class TestApplyConfig:
     def test_inserts_above_existing_decorators(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import os
 
             @some_other_decorator
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -302,13 +320,15 @@ class TestApplyConfig:
     def test_replaces_fully_qualified_decorator(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import traigent.api.decorators
 
             @traigent.api.decorators.optimize(configuration_space={"old": (0, 1)})
             def my_func():
                 pass
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 
@@ -322,12 +342,14 @@ class TestApplyConfig:
     def test_async_function(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult
     ) -> None:
-        source = textwrap.dedent("""\
+        source = textwrap.dedent(
+            """\
             import asyncio
 
             async def my_async_func():
                 await asyncio.sleep(0)
-        """)
+        """
+        )
         src = tmp_path / "agent.py"
         src.write_text(source)
 

--- a/tests/unit/evaluators/test_hybrid_api_cancelled_error.py
+++ b/tests/unit/evaluators/test_hybrid_api_cancelled_error.py
@@ -39,7 +39,7 @@ async def test_evaluate_progress_callback_propagates_cancelled_error():
     # Mock execute response
     mock_execute_response = MagicMock()
     mock_execute_response.outputs = [
-        {"input_id": "ex_0", "output": "result", "cost_usd": 0.01}
+        {"example_id": "ex_0", "output": "result", "cost_usd": 0.01}
     ]
     mock_execute_response.operational_metrics = {"latency_ms": 100}
     mock_execute_response.get_total_cost.return_value = 0.01
@@ -95,12 +95,12 @@ async def test_evaluate_outputs_propagates_cancelled_error():
     from traigent.evaluators.base import EvaluationExample
 
     batch = [EvaluationExample(input_data={"question": "q0"}, expected_output="a0")]
-    inputs = [{"input_id": "ex_0", "data": {"question": "q0"}}]
+    inputs = [{"example_id": "ex_0", "data": {"question": "q0"}}]
 
     # Mock execute response
     mock_execute_response = MagicMock()
     mock_execute_response.outputs = [
-        {"input_id": "ex_0", "output": "result", "cost_usd": 0.01}
+        {"example_id": "ex_0", "output": "result", "cost_usd": 0.01}
     ]
     mock_execute_response.execution_id = "exec_1"
     mock_execute_response.operational_metrics = {"latency_ms": 100}

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -429,6 +429,149 @@ class TestDiscoverConfigSpace:
 
 
 # ---------------------------------------------------------------------------
+# discover_input_ids tests (issue #57)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverInputIds:
+    """Tests for discover_input_ids method."""
+
+    @pytest.mark.asyncio
+    async def test_discover_input_ids_single_page(
+        self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
+    ) -> None:
+        """Returns all IDs when server responds with has_more=False."""
+        from traigent.hybrid.protocol import InputsResponse
+
+        mock_transport.inputs = AsyncMock(
+            return_value=InputsResponse(
+                tunable_id="test_cap",
+                input_ids=["case_001", "case_002", "case_003"],
+                total=3,
+                limit=10000,
+                offset=0,
+                has_more=False,
+            )
+        )
+
+        ids = await evaluator.discover_input_ids()
+
+        assert ids == ["case_001", "case_002", "case_003"]
+        mock_transport.inputs.assert_called_once_with("test_cap", limit=10000, offset=0)
+
+    @pytest.mark.asyncio
+    async def test_discover_input_ids_multi_page(
+        self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
+    ) -> None:
+        """Paginates through multiple pages to collect all IDs."""
+        from traigent.hybrid.protocol import InputsResponse
+
+        mock_transport.inputs = AsyncMock(
+            side_effect=[
+                InputsResponse(
+                    tunable_id="test_cap",
+                    input_ids=["a", "b"],
+                    total=5,
+                    limit=2,
+                    offset=0,
+                    has_more=True,
+                ),
+                InputsResponse(
+                    tunable_id="test_cap",
+                    input_ids=["c", "d"],
+                    total=5,
+                    limit=2,
+                    offset=2,
+                    has_more=True,
+                ),
+                InputsResponse(
+                    tunable_id="test_cap",
+                    input_ids=["e"],
+                    total=5,
+                    limit=2,
+                    offset=4,
+                    has_more=False,
+                ),
+            ]
+        )
+
+        ids = await evaluator.discover_input_ids(limit=2)
+
+        assert ids == ["a", "b", "c", "d", "e"]
+        assert mock_transport.inputs.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_discover_input_ids_empty_page_guard(
+        self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
+    ) -> None:
+        """Stops pagination if server returns has_more=True with empty page."""
+        from traigent.hybrid.protocol import InputsResponse
+
+        mock_transport.inputs = AsyncMock(
+            side_effect=[
+                InputsResponse(
+                    tunable_id="test_cap",
+                    input_ids=["a", "b"],
+                    total=10,
+                    limit=2,
+                    offset=0,
+                    has_more=True,
+                ),
+                InputsResponse(
+                    tunable_id="test_cap",
+                    input_ids=[],
+                    total=10,
+                    limit=2,
+                    offset=2,
+                    has_more=True,  # buggy server
+                ),
+            ]
+        )
+
+        ids = await evaluator.discover_input_ids(limit=2)
+
+        assert ids == ["a", "b"]
+        assert mock_transport.inputs.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_discover_input_ids_explicit_tunable(
+        self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
+    ) -> None:
+        """Uses explicit tunable_id when provided."""
+        from traigent.hybrid.protocol import InputsResponse
+
+        mock_transport.inputs = AsyncMock(
+            return_value=InputsResponse(
+                tunable_id="other",
+                input_ids=["x"],
+                total=1,
+                limit=10000,
+                offset=0,
+                has_more=False,
+            )
+        )
+
+        ids = await evaluator.discover_input_ids(tunable_id="other")
+
+        assert ids == ["x"]
+        mock_transport.inputs.assert_called_once_with("other", limit=10000, offset=0)
+
+    @pytest.mark.asyncio
+    async def test_discover_input_ids_no_tunable_raises(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """Raises ValueError when no tunable_id is available."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id=None,
+            keep_alive=False,
+        )
+
+        with pytest.raises(ValueError, match="tunable_id is required"):
+            await ev.discover_input_ids()
+
+
+# ---------------------------------------------------------------------------
 # _ensure_lifecycle_manager tests
 # ---------------------------------------------------------------------------
 
@@ -774,7 +917,11 @@ class TestComputeAggregatedMetrics:
         results = [
             HybridExampleResult(
                 input_id="1",
-                metrics={"accuracy": 0.9, "overall_accuracy": 0.1, "text_accuracy": 0.2},
+                metrics={
+                    "accuracy": 0.9,
+                    "overall_accuracy": 0.1,
+                    "text_accuracy": 0.2,
+                },
             ),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
@@ -812,7 +959,9 @@ class TestMetricNormalizationHelpers:
     def test_derive_accuracy_preserves_explicit_zero(self) -> None:
         """Explicit accuracy=0.0 must not be treated as missing."""
         metrics = {"accuracy": 0.0, "overall_accuracy": 0.9, "text_accuracy": 1.0}
-        assert HybridAPIEvaluator._derive_accuracy_from_metrics(metrics) == pytest.approx(0.0)
+        assert HybridAPIEvaluator._derive_accuracy_from_metrics(
+            metrics
+        ) == pytest.approx(0.0)
 
     def test_derive_accuracy_ignores_bool_accuracy_values(self) -> None:
         """Bool-valued keys must not be interpreted as numeric accuracy."""
@@ -822,7 +971,9 @@ class TestMetricNormalizationHelpers:
     def test_derive_accuracy_uses_numeric_split_accuracy(self) -> None:
         """Derive mean of numeric split accuracy keys only."""
         metrics = {"text_accuracy": 0.6, "tool_accuracy": 1.0, "aux_accuracy": "n/a"}
-        assert HybridAPIEvaluator._derive_accuracy_from_metrics(metrics) == pytest.approx(0.8)
+        assert HybridAPIEvaluator._derive_accuracy_from_metrics(
+            metrics
+        ) == pytest.approx(0.8)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -105,16 +105,16 @@ def mock_transport() -> MagicMock:
     transport.execute = AsyncMock(
         return_value=_make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "result_0"},
-                {"input_id": "ex_1", "output": "result_1"},
+                {"example_id": "ex_0", "output": "result_0"},
+                {"example_id": "ex_1", "output": "result_1"},
             ],
         )
     )
     transport.evaluate = AsyncMock(
         return_value=_make_evaluate_response(
             results=[
-                {"input_id": "ex_0", "metrics": {"accuracy": 1.0}},
-                {"input_id": "ex_1", "metrics": {"accuracy": 0.5}},
+                {"example_id": "ex_0", "metrics": {"accuracy": 1.0}},
+                {"example_id": "ex_1", "metrics": {"accuracy": 0.5}},
             ]
         )
     )
@@ -145,17 +145,17 @@ class TestHybridExampleResult:
 
     def test_success_when_no_error(self) -> None:
         """success property returns True when error is None."""
-        result = HybridExampleResult(input_id="ex_0", error=None)
+        result = HybridExampleResult(example_id="ex_0", error=None)
         assert result.success is True
 
     def test_not_success_when_error(self) -> None:
         """success property returns False when error is set."""
-        result = HybridExampleResult(input_id="ex_0", error="something went wrong")
+        result = HybridExampleResult(example_id="ex_0", error="something went wrong")
         assert result.success is False
 
     def test_default_values(self) -> None:
         """Default field values are sensible."""
-        result = HybridExampleResult(input_id="x")
+        result = HybridExampleResult(example_id="x")
         assert result.actual_output is None
         assert result.expected_output is None
         assert result.metrics == {}
@@ -429,135 +429,146 @@ class TestDiscoverConfigSpace:
 
 
 # ---------------------------------------------------------------------------
-# discover_input_ids tests (issue #57)
+# discover_example_ids tests
 # ---------------------------------------------------------------------------
 
 
-class TestDiscoverInputIds:
-    """Tests for discover_input_ids method."""
+class TestDiscoverExampleIds:
+    """Tests for discover_example_ids method."""
 
     @pytest.mark.asyncio
-    async def test_discover_input_ids_single_page(
+    async def test_discover_example_ids_single_benchmark(
         self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
     ) -> None:
-        """Returns all IDs when server responds with has_more=False."""
-        from traigent.hybrid.protocol import InputsResponse
+        """Returns all example IDs from a single benchmark."""
+        from traigent.hybrid.protocol import BenchmarkEntry, BenchmarksResponse
 
-        mock_transport.inputs = AsyncMock(
-            return_value=InputsResponse(
-                tunable_id="test_cap",
-                input_ids=["case_001", "case_002", "case_003"],
-                total=3,
-                limit=10000,
-                offset=0,
-                has_more=False,
+        mock_transport.benchmarks = AsyncMock(
+            return_value=BenchmarksResponse(
+                benchmarks=[
+                    BenchmarkEntry(
+                        benchmark_id="bench_001",
+                        tunable_ids=["test_cap"],
+                        example_ids=["case_001", "case_002", "case_003"],
+                        name="Test Benchmark",
+                    )
+                ],
+                benchmarks_revision=None,
             )
         )
 
-        ids = await evaluator.discover_input_ids()
+        ids = await evaluator.discover_example_ids()
 
         assert ids == ["case_001", "case_002", "case_003"]
-        mock_transport.inputs.assert_called_once_with("test_cap", limit=10000, offset=0)
+        mock_transport.benchmarks.assert_called_once_with(tunable_id="test_cap")
 
     @pytest.mark.asyncio
-    async def test_discover_input_ids_multi_page(
+    async def test_discover_example_ids_multiple_benchmarks_raises(
         self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
     ) -> None:
-        """Paginates through multiple pages to collect all IDs."""
-        from traigent.hybrid.protocol import InputsResponse
+        """Raises ValueError when multiple benchmarks match the tunable."""
+        from traigent.hybrid.protocol import BenchmarkEntry, BenchmarksResponse
 
-        mock_transport.inputs = AsyncMock(
-            side_effect=[
-                InputsResponse(
-                    tunable_id="test_cap",
-                    input_ids=["a", "b"],
-                    total=5,
-                    limit=2,
-                    offset=0,
-                    has_more=True,
-                ),
-                InputsResponse(
-                    tunable_id="test_cap",
-                    input_ids=["c", "d"],
-                    total=5,
-                    limit=2,
-                    offset=2,
-                    has_more=True,
-                ),
-                InputsResponse(
-                    tunable_id="test_cap",
-                    input_ids=["e"],
-                    total=5,
-                    limit=2,
-                    offset=4,
-                    has_more=False,
-                ),
-            ]
+        mock_transport.benchmarks = AsyncMock(
+            return_value=BenchmarksResponse(
+                benchmarks=[
+                    BenchmarkEntry(
+                        benchmark_id="bench_001",
+                        tunable_ids=["test_cap"],
+                        example_ids=["a", "b"],
+                    ),
+                    BenchmarkEntry(
+                        benchmark_id="bench_002",
+                        tunable_ids=["test_cap"],
+                        example_ids=["c", "d", "e"],
+                    ),
+                ],
+                benchmarks_revision=None,
+            )
         )
 
-        ids = await evaluator.discover_input_ids(limit=2)
+        with pytest.raises(ValueError, match="Multiple benchmarks match"):
+            await evaluator.discover_example_ids()
 
-        assert ids == ["a", "b", "c", "d", "e"]
-        assert mock_transport.inputs.call_count == 3
+        assert mock_transport.benchmarks.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_discover_input_ids_empty_page_guard(
+    async def test_discover_example_ids_multiple_benchmarks_with_explicit_id(
         self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
     ) -> None:
-        """Stops pagination if server returns has_more=True with empty page."""
-        from traigent.hybrid.protocol import InputsResponse
+        """Selects correct benchmark when benchmark_id is provided explicitly."""
+        from traigent.hybrid.protocol import BenchmarkEntry, BenchmarksResponse
 
-        mock_transport.inputs = AsyncMock(
-            side_effect=[
-                InputsResponse(
-                    tunable_id="test_cap",
-                    input_ids=["a", "b"],
-                    total=10,
-                    limit=2,
-                    offset=0,
-                    has_more=True,
-                ),
-                InputsResponse(
-                    tunable_id="test_cap",
-                    input_ids=[],
-                    total=10,
-                    limit=2,
-                    offset=2,
-                    has_more=True,  # buggy server
-                ),
-            ]
+        mock_transport.benchmarks = AsyncMock(
+            return_value=BenchmarksResponse(
+                benchmarks=[
+                    BenchmarkEntry(
+                        benchmark_id="bench_001",
+                        tunable_ids=["test_cap"],
+                        example_ids=["a", "b"],
+                    ),
+                    BenchmarkEntry(
+                        benchmark_id="bench_002",
+                        tunable_ids=["test_cap"],
+                        example_ids=["c", "d", "e"],
+                    ),
+                ],
+                benchmarks_revision=None,
+            )
         )
 
-        ids = await evaluator.discover_input_ids(limit=2)
+        ids = await evaluator.discover_example_ids(benchmark_id="bench_002")
 
-        assert ids == ["a", "b"]
-        assert mock_transport.inputs.call_count == 2
+        assert ids == ["c", "d", "e"]
+        assert evaluator._benchmark_id == "bench_002"
+        assert mock_transport.benchmarks.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_discover_input_ids_explicit_tunable(
+    async def test_discover_example_ids_empty_benchmarks_raises(
+        self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
+    ) -> None:
+        """Raises ValueError when no benchmarks are available."""
+        from traigent.hybrid.protocol import BenchmarksResponse
+
+        mock_transport.benchmarks = AsyncMock(
+            return_value=BenchmarksResponse(
+                benchmarks=[],
+                benchmarks_revision=None,
+            )
+        )
+
+        with pytest.raises(ValueError, match="No benchmarks found"):
+            await evaluator.discover_example_ids()
+
+        assert mock_transport.benchmarks.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_discover_example_ids_explicit_tunable(
         self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
     ) -> None:
         """Uses explicit tunable_id when provided."""
-        from traigent.hybrid.protocol import InputsResponse
+        from traigent.hybrid.protocol import BenchmarkEntry, BenchmarksResponse
 
-        mock_transport.inputs = AsyncMock(
-            return_value=InputsResponse(
-                tunable_id="other",
-                input_ids=["x"],
-                total=1,
-                limit=10000,
-                offset=0,
-                has_more=False,
+        mock_transport.benchmarks = AsyncMock(
+            return_value=BenchmarksResponse(
+                benchmarks=[
+                    BenchmarkEntry(
+                        benchmark_id="bench_001",
+                        tunable_ids=["other"],
+                        example_ids=["x"],
+                    )
+                ],
+                benchmarks_revision=None,
             )
         )
 
-        ids = await evaluator.discover_input_ids(tunable_id="other")
+        ids = await evaluator.discover_example_ids(tunable_id="other")
 
         assert ids == ["x"]
-        mock_transport.inputs.assert_called_once_with("other", limit=10000, offset=0)
+        mock_transport.benchmarks.assert_called_once_with(tunable_id="other")
 
     @pytest.mark.asyncio
-    async def test_discover_input_ids_no_tunable_raises(
+    async def test_discover_example_ids_no_tunable_raises(
         self, mock_transport: MagicMock
     ) -> None:
         """Raises ValueError when no tunable_id is available."""
@@ -568,7 +579,7 @@ class TestDiscoverInputIds:
         )
 
         with pytest.raises(ValueError, match="tunable_id is required"):
-            await ev.discover_input_ids()
+            await ev.discover_example_ids()
 
 
 # ---------------------------------------------------------------------------
@@ -826,8 +837,8 @@ class TestComputeAggregatedMetrics:
     def test_basic_metrics(self, ev: HybridAPIEvaluator) -> None:
         """Computes cost and success_rate."""
         results = [
-            HybridExampleResult(input_id="1", metrics={}),
-            HybridExampleResult(input_id="2", error="fail", metrics={}),
+            HybridExampleResult(example_id="1", metrics={}),
+            HybridExampleResult(example_id="2", error="fail", metrics={}),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.05)
         assert agg["cost"] == 0.05
@@ -837,8 +848,8 @@ class TestComputeAggregatedMetrics:
     def test_all_successful(self, ev: HybridAPIEvaluator) -> None:
         """success_rate is 1.0 when all succeed."""
         results = [
-            HybridExampleResult(input_id="1"),
-            HybridExampleResult(input_id="2"),
+            HybridExampleResult(example_id="1"),
+            HybridExampleResult(example_id="2"),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
         assert agg["success_rate"] == 1.0
@@ -846,8 +857,8 @@ class TestComputeAggregatedMetrics:
     def test_per_example_metrics_averaged(self, ev: HybridAPIEvaluator) -> None:
         """Per-example metrics are averaged across results."""
         results = [
-            HybridExampleResult(input_id="1", metrics={"accuracy": 1.0, "f1": 0.8}),
-            HybridExampleResult(input_id="2", metrics={"accuracy": 0.5, "f1": 0.6}),
+            HybridExampleResult(example_id="1", metrics={"accuracy": 1.0, "f1": 0.8}),
+            HybridExampleResult(example_id="2", metrics={"accuracy": 0.5, "f1": 0.6}),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
         assert agg["accuracy"] == pytest.approx(0.75)
@@ -856,9 +867,9 @@ class TestComputeAggregatedMetrics:
     def test_latency_averaged(self, ev: HybridAPIEvaluator) -> None:
         """Average latency is computed from positive latency values."""
         results = [
-            HybridExampleResult(input_id="1", latency_ms=100.0),
-            HybridExampleResult(input_id="2", latency_ms=200.0),
-            HybridExampleResult(input_id="3", latency_ms=0.0),  # skipped
+            HybridExampleResult(example_id="1", latency_ms=100.0),
+            HybridExampleResult(example_id="2", latency_ms=200.0),
+            HybridExampleResult(example_id="3", latency_ms=0.0),  # skipped
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
         assert agg["latency"] == pytest.approx(150.0)
@@ -866,7 +877,7 @@ class TestComputeAggregatedMetrics:
     def test_no_positive_latency(self, ev: HybridAPIEvaluator) -> None:
         """No 'latency' key when all latencies are zero."""
         results = [
-            HybridExampleResult(input_id="1", latency_ms=0.0),
+            HybridExampleResult(example_id="1", latency_ms=0.0),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
         assert "latency" not in agg
@@ -874,8 +885,8 @@ class TestComputeAggregatedMetrics:
     def test_partial_metrics(self, ev: HybridAPIEvaluator) -> None:
         """Metrics only present in some results are averaged over their count."""
         results = [
-            HybridExampleResult(input_id="1", metrics={"accuracy": 1.0}),
-            HybridExampleResult(input_id="2", metrics={}),
+            HybridExampleResult(example_id="1", metrics={"accuracy": 1.0}),
+            HybridExampleResult(example_id="2", metrics={}),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
         # accuracy only has 1 data point
@@ -886,8 +897,8 @@ class TestComputeAggregatedMetrics:
     ) -> None:
         """Derives canonical accuracy from overall_accuracy when missing."""
         results = [
-            HybridExampleResult(input_id="1", metrics={"overall_accuracy": 0.8}),
-            HybridExampleResult(input_id="2", metrics={"overall_accuracy": 0.6}),
+            HybridExampleResult(example_id="1", metrics={"overall_accuracy": 0.8}),
+            HybridExampleResult(example_id="2", metrics={"overall_accuracy": 0.6}),
         ]
         agg = ev._compute_aggregated_metrics(results, total_cost=0.0)
         assert agg["overall_accuracy"] == pytest.approx(0.7)
@@ -900,7 +911,7 @@ class TestComputeAggregatedMetrics:
         """Derives canonical accuracy from split *_accuracy metrics."""
         results = [
             HybridExampleResult(
-                input_id="1",
+                example_id="1",
                 metrics={"text_accuracy": 0.6, "tool_accuracy": 1.0},
                 latency_ms=123.0,
             ),
@@ -916,7 +927,7 @@ class TestComputeAggregatedMetrics:
         """Explicit accuracy remains the source of truth."""
         results = [
             HybridExampleResult(
-                input_id="1",
+                example_id="1",
                 metrics={
                     "accuracy": 0.9,
                     "overall_accuracy": 0.1,
@@ -994,7 +1005,7 @@ class TestExecuteBatch:
         )
         exec_response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "out0", "metrics": {"accuracy": 0.9}},
+                {"example_id": "ex_0", "output": "out0", "metrics": {"accuracy": 0.9}},
             ],
             quality_metrics={"overall_accuracy": 0.9},
         )
@@ -1009,7 +1020,7 @@ class TestExecuteBatch:
         )
 
         assert len(results) == 1
-        assert results[0].input_id == "ex_0"
+        assert results[0].example_id == "ex_0"
         assert results[0].actual_output == "out0"
         assert results[0].metrics == {"accuracy": 0.9}
         # evaluate should NOT be called in combined mode
@@ -1024,12 +1035,12 @@ class TestExecuteBatch:
             keep_alive=False,
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "out0"}],
+            outputs=[{"example_id": "ex_0", "output": "out0"}],
             quality_metrics=None,
             operational_metrics={"cost_usd": 0.02, "latency_ms": 50.0},
         )
         eval_response = _make_evaluate_response(
-            results=[{"input_id": "ex_0", "metrics": {"accuracy": 0.8}}]
+            results=[{"example_id": "ex_0", "metrics": {"accuracy": 0.8}}]
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
         mock_transport.evaluate = AsyncMock(return_value=eval_response)
@@ -1055,7 +1066,7 @@ class TestExecuteBatch:
             keep_alive=False,
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "out0"}],
+            outputs=[{"example_id": "ex_0", "output": "out0"}],
             quality_metrics=None,
             operational_metrics={"cost_usd": 0.01, "latency_ms": 30.0},
         )
@@ -1118,7 +1129,7 @@ class TestExecuteBatch:
         )
         ev._session_id = "old_session"
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "out"}],
+            outputs=[{"example_id": "ex_0", "output": "out"}],
             session_id="new_session",
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
@@ -1146,7 +1157,7 @@ class TestExecuteBatch:
         ev._lifecycle_manager = mock_lm
 
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "out"}],
+            outputs=[{"example_id": "ex_0", "output": "out"}],
             session_id="new",
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
@@ -1159,31 +1170,31 @@ class TestExecuteBatch:
         mock_lm.register.assert_awaited_once_with("new")
 
     @pytest.mark.asyncio
-    async def test_uses_input_id_from_input_data(
+    async def test_uses_example_id_from_input_data(
         self, mock_transport: MagicMock
     ) -> None:
-        """Uses input_id from the input data if present."""
+        """Uses example_id from the input data if present."""
         ev = HybridAPIEvaluator(
             transport=mock_transport,
             tunable_id="cap",
             keep_alive=False,
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "custom_id", "output": "out"}],
+            outputs=[{"example_id": "custom_id", "output": "out"}],
             quality_metrics=None,
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
         caps = _default_capabilities(supports_evaluate=False)
 
-        # EvaluationExample with input_id in input_data
+        # EvaluationExample with example_id in input_data
         example = EvaluationExample(
-            input_data={"input_id": "custom_id", "question": "?"}
+            input_data={"example_id": "custom_id", "question": "?"}
         )
         dataset = Dataset(examples=[example], name="test")
         batch = list(dataset)
 
         results = await ev._execute_batch(mock_transport, caps, {}, batch)
-        assert results[0].input_id == "custom_id"
+        assert results[0].example_id == "custom_id"
 
 
 # ---------------------------------------------------------------------------
@@ -1206,15 +1217,15 @@ class TestEvaluateOutputs:
         )
         exec_response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "result_0"},
-                {"input_id": "ex_1", "output": "result_1"},
+                {"example_id": "ex_0", "output": "result_0"},
+                {"example_id": "ex_1", "output": "result_1"},
             ],
             operational_metrics={"cost_usd": 0.04, "latency_ms": 200.0},
         )
         eval_response = _make_evaluate_response(
             results=[
-                {"input_id": "ex_0", "metrics": {"accuracy": 1.0}},
-                {"input_id": "ex_1", "metrics": {"accuracy": 0.5}},
+                {"example_id": "ex_0", "metrics": {"accuracy": 1.0}},
+                {"example_id": "ex_1", "metrics": {"accuracy": 0.5}},
             ]
         )
         mock_transport.evaluate = AsyncMock(return_value=eval_response)
@@ -1222,8 +1233,8 @@ class TestEvaluateOutputs:
         dataset = _make_dataset()
         batch = list(dataset)
         inputs = [
-            {"input_id": "ex_0", "data": {"question": "What is 2+2?"}},
-            {"input_id": "ex_1", "data": {"question": "What is 3+3?"}},
+            {"example_id": "ex_0", "data": {"question": "What is 2+2?"}},
+            {"example_id": "ex_1", "data": {"question": "What is 3+3?"}},
         ]
 
         results = await ev._evaluate_outputs(
@@ -1247,14 +1258,14 @@ class TestEvaluateOutputs:
             keep_alive=False,
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "out_0"}],
+            outputs=[{"example_id": "ex_0", "output": "out_0"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 50.0},
         )
         mock_transport.evaluate = AsyncMock(side_effect=Exception("evaluate failed"))
 
         dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "a"}])
         batch = list(dataset)
-        inputs = [{"input_id": "ex_0", "data": {"q": "?"}}]
+        inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
 
         results = await ev._evaluate_outputs(
             mock_transport, batch, inputs, exec_response
@@ -1269,15 +1280,15 @@ class TestEvaluateOutputs:
     async def test_evaluate_outputs_no_matching_output(
         self, mock_transport: MagicMock
     ) -> None:
-        """Handles case where output input_id doesn't match."""
+        """Handles case where output example_id doesn't match."""
         ev = HybridAPIEvaluator(
             transport=mock_transport,
             tunable_id="cap",
             keep_alive=False,
         )
-        # outputs have different input_id than expected
+        # outputs have different example_id than expected
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "other_id", "output": "something"}],
+            outputs=[{"example_id": "other_id", "output": "something"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 50.0},
         )
         eval_response = _make_evaluate_response(results=[])
@@ -1285,7 +1296,7 @@ class TestEvaluateOutputs:
 
         dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "a"}])
         batch = list(dataset)
-        inputs = [{"input_id": "ex_0", "data": {"q": "?"}}]
+        inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
 
         results = await ev._evaluate_outputs(
             mock_transport, batch, inputs, exec_response
@@ -1307,14 +1318,14 @@ class TestEvaluateOutputs:
             timeout=12.5,
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "result_0"}],
+            outputs=[{"example_id": "ex_0", "output": "result_0"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 100.0},
         )
         mock_transport.evaluate = AsyncMock(return_value=_make_evaluate_response())
 
         dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "a"}])
         batch = list(dataset)
-        inputs = [{"input_id": "ex_0", "data": {"q": "?"}}]
+        inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
 
         await ev._evaluate_outputs(mock_transport, batch, inputs, exec_response)
 
@@ -1339,8 +1350,8 @@ class TestProcessCombinedResponse:
         )
         response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "out0", "metrics": {"score": 0.9}},
-                {"input_id": "ex_1", "output": "out1", "metrics": {"score": 0.7}},
+                {"example_id": "ex_0", "output": "out0", "metrics": {"score": 0.9}},
+                {"example_id": "ex_1", "output": "out1", "metrics": {"score": 0.7}},
             ],
             operational_metrics={"cost_usd": 0.10, "latency_ms": 300.0},
             quality_metrics={"overall": 0.8},
@@ -1348,8 +1359,8 @@ class TestProcessCombinedResponse:
         dataset = _make_dataset()
         batch = list(dataset)
         inputs = [
-            {"input_id": "ex_0", "data": {}},
-            {"input_id": "ex_1", "data": {}},
+            {"example_id": "ex_0", "data": {}},
+            {"example_id": "ex_1", "data": {}},
         ]
 
         results = ev._process_combined_response(batch, inputs, response)
@@ -1363,20 +1374,20 @@ class TestProcessCombinedResponse:
         assert results[1].expected_output == "6"  # From dataset
 
     def test_combined_no_matching_output(self, mock_transport: MagicMock) -> None:
-        """When output input_id doesn't match, output is None."""
+        """When output example_id doesn't match, output is None."""
         ev = HybridAPIEvaluator(
             transport=mock_transport,
             tunable_id="cap",
             keep_alive=False,
         )
         response = _make_execute_response(
-            outputs=[{"input_id": "no_match", "output": "x"}],
+            outputs=[{"example_id": "no_match", "output": "x"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 10.0},
             quality_metrics={"overall": 0.5},
         )
         dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "a"}])
         batch = list(dataset)
-        inputs = [{"input_id": "ex_0", "data": {}}]
+        inputs = [{"example_id": "ex_0", "data": {}}]
 
         results = ev._process_combined_response(batch, inputs, response)
 
@@ -1401,12 +1412,12 @@ class TestProcessExecuteOnlyResponse:
             keep_alive=False,
         )
         response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "result"}],
+            outputs=[{"example_id": "ex_0", "output": "result"}],
             operational_metrics={"cost_usd": 0.02, "latency_ms": 150.0},
         )
         dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "ans"}])
         batch = list(dataset)
-        inputs = [{"input_id": "ex_0", "data": {}}]
+        inputs = [{"example_id": "ex_0", "data": {}}]
 
         results = ev._process_execute_only_response(batch, inputs, response)
 
@@ -1426,16 +1437,16 @@ class TestProcessExecuteOnlyResponse:
         )
         response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "r0"},
-                {"input_id": "ex_1", "output": "r1"},
+                {"example_id": "ex_0", "output": "r0"},
+                {"example_id": "ex_1", "output": "r1"},
             ],
             operational_metrics={"cost_usd": 0.10, "latency_ms": 100.0},
         )
         dataset = _make_dataset()
         batch = list(dataset)
         inputs = [
-            {"input_id": "ex_0", "data": {}},
-            {"input_id": "ex_1", "data": {}},
+            {"example_id": "ex_0", "data": {}},
+            {"example_id": "ex_1", "data": {}},
         ]
 
         results = ev._process_execute_only_response(batch, inputs, response)
@@ -1463,8 +1474,8 @@ class TestEvaluate:
         )
         exec_response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "r0"},
-                {"input_id": "ex_1", "output": "r1"},
+                {"example_id": "ex_0", "output": "r0"},
+                {"example_id": "ex_1", "output": "r1"},
             ],
             operational_metrics={"cost_usd": 0.04, "latency_ms": 100.0},
         )
@@ -1516,7 +1527,7 @@ class TestEvaluate:
             return_value=_default_capabilities(supports_evaluate=False)
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "r0"}],
+            outputs=[{"example_id": "ex_0", "output": "r0"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 50.0},
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
@@ -1551,7 +1562,7 @@ class TestEvaluate:
         evaluator._batch_size = 1  # Process one at a time
 
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "r0"}],
+            outputs=[{"example_id": "ex_0", "output": "r0"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 50.0},
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
@@ -1609,8 +1620,8 @@ class TestEvaluate:
         )
         exec_response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "r0"},
-                {"input_id": "ex_1", "output": "r1"},
+                {"example_id": "ex_0", "output": "r0"},
+                {"example_id": "ex_1", "output": "r1"},
             ],
             operational_metrics={"cost_usd": 0.02, "latency_ms": 100.0},
         )
@@ -1646,7 +1657,7 @@ class TestEvaluate:
             return_value=_default_capabilities(supports_evaluate=False)
         )
         exec_response = _make_execute_response(
-            outputs=[{"input_id": "ex_0", "output": "r0"}],
+            outputs=[{"example_id": "ex_0", "output": "r0"}],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 50.0},
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
@@ -1679,11 +1690,11 @@ class TestEvaluate:
         # Two separate calls for two batches
         responses = [
             _make_execute_response(
-                outputs=[{"input_id": "ex_0", "output": "r0"}],
+                outputs=[{"example_id": "ex_0", "output": "r0"}],
                 operational_metrics={"cost_usd": 0.01, "latency_ms": 50.0},
             ),
             _make_execute_response(
-                outputs=[{"input_id": "ex_0", "output": "r1"}],
+                outputs=[{"example_id": "ex_0", "output": "r1"}],
                 operational_metrics={"cost_usd": 0.02, "latency_ms": 60.0},
             ),
         ]
@@ -1705,8 +1716,8 @@ class TestEvaluate:
         )
         exec_response = _make_execute_response(
             outputs=[
-                {"input_id": "ex_0", "output": "r0"},
-                {"input_id": "ex_1", "output": "r1"},
+                {"example_id": "ex_0", "output": "r0"},
+                {"example_id": "ex_1", "output": "r1"},
             ],
         )
         mock_transport.execute = AsyncMock(return_value=exec_response)
@@ -1727,12 +1738,12 @@ class TestEvaluate:
         exec_response = _make_execute_response(
             outputs=[
                 {
-                    "input_id": "ex_0",
+                    "example_id": "ex_0",
                     "output": "r0",
                     "metrics": {"text_accuracy": 1.0, "tool_accuracy": 0.5},
                 },
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": "r1",
                     "metrics": {"text_accuracy": 0.5, "tool_accuracy": 1.0},
                 },
@@ -1766,12 +1777,12 @@ class TestEvaluate:
         exec_response = _make_execute_response(
             outputs=[
                 {
-                    "input_id": "ex_0",
+                    "example_id": "ex_0",
                     "output": "r0",
                     "metrics": {"text_accuracy": 0.8, "tool_accuracy": 0.9},
                 },
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": "r1",
                     "metrics": {"text_accuracy": 0.6, "tool_accuracy": 1.0},
                 },

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -26,6 +26,8 @@ from traigent.cloud.dtos import MeasuresDict
 from traigent.evaluators.base import Dataset, EvaluationExample, EvaluationResult
 from traigent.evaluators.hybrid_api import HybridAPIEvaluator, HybridExampleResult
 from traigent.hybrid.protocol import (
+    BenchmarkEntry,
+    BenchmarksResponse,
     HybridEvaluateResponse,
     HybridExecuteResponse,
     ServiceCapabilities,
@@ -119,6 +121,17 @@ def mock_transport() -> MagicMock:
         )
     )
     transport.capabilities = AsyncMock(return_value=_default_capabilities())
+    transport.benchmarks = AsyncMock(
+        return_value=BenchmarksResponse(
+            benchmarks=[
+                BenchmarkEntry(
+                    benchmark_id="test-bench",
+                    tunable_ids=["test_cap"],
+                    example_ids=["ex_0", "ex_1"],
+                )
+            ]
+        )
+    )
     transport.close = AsyncMock()
     transport.keep_alive = AsyncMock(return_value=True)
     return transport
@@ -1003,6 +1016,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         exec_response = _make_execute_response(
             outputs=[
                 {"example_id": "ex_0", "output": "out0", "metrics": {"accuracy": 0.9}},
@@ -1034,6 +1048,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         exec_response = _make_execute_response(
             outputs=[{"example_id": "ex_0", "output": "out0"}],
             quality_metrics=None,
@@ -1065,6 +1080,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         exec_response = _make_execute_response(
             outputs=[{"example_id": "ex_0", "output": "out0"}],
             quality_metrics=None,
@@ -1095,6 +1111,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         mock_transport.execute = AsyncMock(
             side_effect=TransportError("connection lost", status_code=500)
         )
@@ -1127,6 +1144,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         ev._session_id = "old_session"
         exec_response = _make_execute_response(
             outputs=[{"example_id": "ex_0", "output": "out"}],
@@ -1151,6 +1169,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         ev._session_id = "old"
         mock_lm = MagicMock()
         mock_lm.register = AsyncMock()
@@ -1179,6 +1198,7 @@ class TestExecuteBatch:
             tunable_id="cap",
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         exec_response = _make_execute_response(
             outputs=[{"example_id": "custom_id", "output": "out"}],
             quality_metrics=None,
@@ -1683,6 +1703,7 @@ class TestEvaluate:
             batch_size=1,  # one example per batch
             keep_alive=False,
         )
+        ev._benchmark_id = "test-bench"
         mock_transport.capabilities = AsyncMock(
             return_value=_default_capabilities(supports_evaluate=False)
         )

--- a/tests/unit/evaluators/test_local_evaluator.py
+++ b/tests/unit/evaluators/test_local_evaluator.py
@@ -412,7 +412,9 @@ class TestPromptTemplateFallbackLength:
             returns_plain_string, {"model": "gpt-4o-mini", "prompt": prompt}, dataset
         )
 
-        assert result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        assert (
+            result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        )
 
     @pytest.mark.asyncio
     async def test_privacy_uses_rendered_prompt_length_for_prompt_length_based_tokens(
@@ -441,7 +443,9 @@ class TestPromptTemplateFallbackLength:
             returns_plain_string, {"model": "gpt-4o-mini", "prompt": prompt}, dataset
         )
 
-        assert result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        assert (
+            result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        )
 
     @pytest.mark.asyncio
     async def test_non_privacy_format_failure_falls_back_to_additive_length(
@@ -469,7 +473,9 @@ class TestPromptTemplateFallbackLength:
             returns_plain_string, {"model": "gpt-4o-mini", "prompt": prompt}, dataset
         )
 
-        assert result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        assert (
+            result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        )
 
     @pytest.mark.asyncio
     async def test_privacy_format_failure_falls_back_to_additive_length(
@@ -497,7 +503,9 @@ class TestPromptTemplateFallbackLength:
             returns_plain_string, {"model": "gpt-4o-mini", "prompt": prompt}, dataset
         )
 
-        assert result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        assert (
+            result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        )
 
     @pytest.mark.asyncio
     async def test_non_privacy_without_prompt_preserves_legacy_input_estimation(
@@ -524,7 +532,9 @@ class TestPromptTemplateFallbackLength:
             returns_plain_string, {"model": "gpt-4o-mini"}, dataset
         )
 
-        assert result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        assert (
+            result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        )
 
     @pytest.mark.asyncio
     async def test_privacy_without_prompt_preserves_legacy_input_estimation(
@@ -551,4 +561,6 @@ class TestPromptTemplateFallbackLength:
             returns_plain_string, {"model": "gpt-4o-mini"}, dataset
         )
 
-        assert result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        assert (
+            result.example_results[0].metrics["input_tokens"] == expected_input_tokens
+        )

--- a/tests/unit/hybrid/test_http_transport.py
+++ b/tests/unit/hybrid/test_http_transport.py
@@ -839,6 +839,108 @@ class TestHTTPTransportAdditionalMethods:
         assert call_args.kwargs.get("timeout_override") == 45.0
 
 
+class TestHTTPTransportInputs:
+    """Tests for inputs() endpoint (issue #57)."""
+
+    @pytest.fixture
+    def transport(self) -> HTTPTransport:
+        """Create transport for testing."""
+        return HTTPTransport(base_url="http://localhost:8080")
+
+    @pytest.mark.asyncio
+    async def test_inputs_happy_path(self, transport: HTTPTransport) -> None:
+        """Test inputs returns all IDs in a single page."""
+        mock_data = {
+            "tunable_id": "child-age-agent-a",
+            "input_ids": ["case_001", "case_002", "case_003"],
+            "total": 3,
+            "limit": 100,
+            "offset": 0,
+            "has_more": False,
+        }
+
+        mock_request = AsyncMock(return_value=mock_data)
+        with patch.object(transport, "_request", mock_request):
+            resp = await transport.inputs("child-age-agent-a")
+
+        assert resp.tunable_id == "child-age-agent-a"
+        assert resp.input_ids == ["case_001", "case_002", "case_003"]
+        assert resp.total == 3
+        assert resp.has_more is False
+
+        # Verify correct path and params
+        mock_request.assert_called_once_with(
+            "GET", "/traigent/v1/inputs", params={"tunable_id": "child-age-agent-a"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_inputs_with_pagination_params(
+        self, transport: HTTPTransport
+    ) -> None:
+        """Test inputs sends limit/offset when non-default."""
+        mock_data = {
+            "tunable_id": "agent-x",
+            "input_ids": ["q006", "q007"],
+            "total": 100,
+            "limit": 5,
+            "offset": 5,
+            "has_more": True,
+        }
+
+        mock_request = AsyncMock(return_value=mock_data)
+        with patch.object(transport, "_request", mock_request):
+            resp = await transport.inputs("agent-x", limit=5, offset=5)
+
+        assert resp.has_more is True
+        assert resp.limit == 5
+        assert resp.offset == 5
+
+        # Verify limit and offset are sent as strings
+        mock_request.assert_called_once_with(
+            "GET",
+            "/traigent/v1/inputs",
+            params={"tunable_id": "agent-x", "limit": "5", "offset": "5"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_inputs_default_params_omitted(
+        self, transport: HTTPTransport
+    ) -> None:
+        """Test inputs omits limit/offset when they are defaults."""
+        mock_data = {
+            "tunable_id": "t",
+            "input_ids": [],
+            "total": 0,
+            "limit": 100,
+            "offset": 0,
+            "has_more": False,
+        }
+
+        mock_request = AsyncMock(return_value=mock_data)
+        with patch.object(transport, "_request", mock_request):
+            await transport.inputs("t", limit=100, offset=0)
+
+        # Only tunable_id should be in params
+        mock_request.assert_called_once_with(
+            "GET", "/traigent/v1/inputs", params={"tunable_id": "t"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_inputs_unknown_tunable_raises(
+        self, transport: HTTPTransport
+    ) -> None:
+        """Test inputs propagates 404 as TransportError."""
+        with patch.object(
+            transport,
+            "_request",
+            new_callable=AsyncMock,
+            side_effect=TransportError("Not found", status_code=404),
+        ):
+            with pytest.raises(TransportError) as exc_info:
+                await transport.inputs("bogus")
+            assert exc_info.value.status_code == 404
+
+
 class TestHTTPTransportContextManager:
     """Tests for async context manager."""
 

--- a/tests/unit/hybrid/test_http_transport.py
+++ b/tests/unit/hybrid/test_http_transport.py
@@ -296,7 +296,7 @@ class TestHTTPTransportMethods:
             "request_id": "req-123",
             "execution_id": "exec-456",
             "status": "completed",
-            "outputs": [{"input_id": "1", "output": {"result": "test"}}],
+            "outputs": [{"example_id": "1", "output": {"result": "test"}}],
             "operational_metrics": {"total_cost_usd": 0.001},
         }
 
@@ -305,8 +305,9 @@ class TestHTTPTransportMethods:
         ):
             request = HybridExecuteRequest(
                 tunable_id="test_agent",
+                benchmark_id="bench_001",
                 config={"model": "fast"},
-                inputs=[{"input_id": "1", "data": {}}],
+                examples=[{"example_id": "1", "data": {}}],
             )
             response = await transport.execute(request)
 
@@ -710,7 +711,7 @@ class TestHTTPTransportAdditionalMethods:
         mock_response = {
             "request_id": "req-123",
             "status": "completed",
-            "results": [{"input_id": "1", "metrics": {"accuracy": 0.95}}],
+            "results": [{"example_id": "1", "metrics": {"accuracy": 0.95}}],
             "aggregate_metrics": {"accuracy": {"mean": 0.95}},
         }
 
@@ -730,7 +731,8 @@ class TestHTTPTransportAdditionalMethods:
         ):
             request = HybridEvaluateRequest(
                 tunable_id="test_agent",
-                evaluations=[{"input_id": "1", "output": {}, "target": {}}],
+                benchmark_id="bench_001",
+                evaluations=[{"example_id": "1", "output": {}, "target": {}}],
             )
             response = await transport.evaluate(request)
 
@@ -752,6 +754,7 @@ class TestHTTPTransportAdditionalMethods:
         ):
             request = HybridEvaluateRequest(
                 tunable_id="test_agent",
+                benchmark_id="bench_001",
                 evaluations=[],
             )
             with pytest.raises(NotImplementedError):
@@ -795,8 +798,9 @@ class TestHTTPTransportAdditionalMethods:
         with patch.object(transport, "_request", mock_request):
             request = HybridExecuteRequest(
                 tunable_id="test_agent",
+                benchmark_id="bench_001",
                 config={},
-                inputs=[],
+                examples=[],
                 timeout_ms=60000,  # 60 seconds
             )
             await transport.execute(request)
@@ -830,7 +834,8 @@ class TestHTTPTransportAdditionalMethods:
         ):
             request = HybridEvaluateRequest(
                 tunable_id="test_agent",
-                evaluations=[{"input_id": "1", "output": {}, "target": {}}],
+                benchmark_id="bench_001",
+                evaluations=[{"example_id": "1", "output": {}, "target": {}}],
                 timeout_ms=45000,
             )
             await transport.evaluate(request)
@@ -839,8 +844,8 @@ class TestHTTPTransportAdditionalMethods:
         assert call_args.kwargs.get("timeout_override") == 45.0
 
 
-class TestHTTPTransportInputs:
-    """Tests for inputs() endpoint (issue #57)."""
+class TestHTTPTransportBenchmarks:
+    """Tests for benchmarks() endpoint."""
 
     @pytest.fixture
     def transport(self) -> HTTPTransport:
@@ -848,88 +853,90 @@ class TestHTTPTransportInputs:
         return HTTPTransport(base_url="http://localhost:8080")
 
     @pytest.mark.asyncio
-    async def test_inputs_happy_path(self, transport: HTTPTransport) -> None:
-        """Test inputs returns all IDs in a single page."""
+    async def test_benchmarks_happy_path(self, transport: HTTPTransport) -> None:
+        """Test benchmarks returns all benchmarks with example IDs."""
         mock_data = {
-            "tunable_id": "child-age-agent-a",
-            "input_ids": ["case_001", "case_002", "case_003"],
-            "total": 3,
-            "limit": 100,
-            "offset": 0,
-            "has_more": False,
+            "benchmarks": [
+                {
+                    "benchmark_id": "bench_001",
+                    "tunable_ids": ["child-age-agent-a"],
+                    "example_ids": ["case_001", "case_002", "case_003"],
+                    "name": "Test Benchmark",
+                }
+            ],
+            "benchmarks_revision": None,
         }
 
         mock_request = AsyncMock(return_value=mock_data)
         with patch.object(transport, "_request", mock_request):
-            resp = await transport.inputs("child-age-agent-a")
+            resp = await transport.benchmarks("child-age-agent-a")
 
-        assert resp.tunable_id == "child-age-agent-a"
-        assert resp.input_ids == ["case_001", "case_002", "case_003"]
-        assert resp.total == 3
-        assert resp.has_more is False
+        assert len(resp.benchmarks) == 1
+        assert resp.benchmarks[0].benchmark_id == "bench_001"
+        assert resp.benchmarks[0].tunable_ids == ["child-age-agent-a"]
+        assert resp.benchmarks[0].example_ids == ["case_001", "case_002", "case_003"]
+        assert resp.benchmarks_revision is None
 
         # Verify correct path and params
         mock_request.assert_called_once_with(
-            "GET", "/traigent/v1/inputs", params={"tunable_id": "child-age-agent-a"}
-        )
-
-    @pytest.mark.asyncio
-    async def test_inputs_with_pagination_params(
-        self, transport: HTTPTransport
-    ) -> None:
-        """Test inputs sends limit/offset when non-default."""
-        mock_data = {
-            "tunable_id": "agent-x",
-            "input_ids": ["q006", "q007"],
-            "total": 100,
-            "limit": 5,
-            "offset": 5,
-            "has_more": True,
-        }
-
-        mock_request = AsyncMock(return_value=mock_data)
-        with patch.object(transport, "_request", mock_request):
-            resp = await transport.inputs("agent-x", limit=5, offset=5)
-
-        assert resp.has_more is True
-        assert resp.limit == 5
-        assert resp.offset == 5
-
-        # Verify limit and offset are sent as strings
-        mock_request.assert_called_once_with(
             "GET",
-            "/traigent/v1/inputs",
-            params={"tunable_id": "agent-x", "limit": "5", "offset": "5"},
+            "/traigent/v1/benchmarks",
+            params={"tunable_id": "child-age-agent-a"},
         )
 
     @pytest.mark.asyncio
-    async def test_inputs_default_params_omitted(
-        self, transport: HTTPTransport
-    ) -> None:
-        """Test inputs omits limit/offset when they are defaults."""
+    async def test_benchmarks_no_tunable_filter(self, transport: HTTPTransport) -> None:
+        """Test benchmarks without tunable_id filter."""
         mock_data = {
-            "tunable_id": "t",
-            "input_ids": [],
-            "total": 0,
-            "limit": 100,
-            "offset": 0,
-            "has_more": False,
+            "benchmarks": [
+                {
+                    "benchmark_id": "bench_001",
+                    "tunable_ids": ["agent-x"],
+                    "example_ids": ["q006", "q007"],
+                    "name": "Bench A",
+                },
+                {
+                    "benchmark_id": "bench_002",
+                    "tunable_ids": ["agent-y"],
+                    "example_ids": ["q008"],
+                    "name": "Bench B",
+                },
+            ],
+            "benchmarks_revision": "rev_abc",
         }
 
         mock_request = AsyncMock(return_value=mock_data)
         with patch.object(transport, "_request", mock_request):
-            await transport.inputs("t", limit=100, offset=0)
+            resp = await transport.benchmarks()
 
-        # Only tunable_id should be in params
+        assert len(resp.benchmarks) == 2
+        assert resp.benchmarks_revision == "rev_abc"
+
+        # Verify no params when tunable_id is None
         mock_request.assert_called_once_with(
-            "GET", "/traigent/v1/inputs", params={"tunable_id": "t"}
+            "GET", "/traigent/v1/benchmarks", params=None
         )
 
     @pytest.mark.asyncio
-    async def test_inputs_unknown_tunable_raises(
+    async def test_benchmarks_empty_response(self, transport: HTTPTransport) -> None:
+        """Test benchmarks with empty response."""
+        mock_data = {
+            "benchmarks": [],
+            "benchmarks_revision": None,
+        }
+
+        mock_request = AsyncMock(return_value=mock_data)
+        with patch.object(transport, "_request", mock_request):
+            resp = await transport.benchmarks("t")
+
+        assert resp.benchmarks == []
+        assert resp.benchmarks_revision is None
+
+    @pytest.mark.asyncio
+    async def test_benchmarks_unknown_tunable_raises(
         self, transport: HTTPTransport
     ) -> None:
-        """Test inputs propagates 404 as TransportError."""
+        """Test benchmarks propagates 404 as TransportError."""
         with patch.object(
             transport,
             "_request",
@@ -937,7 +944,7 @@ class TestHTTPTransportInputs:
             side_effect=TransportError("Not found", status_code=404),
         ):
             with pytest.raises(TransportError) as exc_info:
-                await transport.inputs("bogus")
+                await transport.benchmarks("bogus")
             assert exc_info.value.status_code == 404
 
 

--- a/tests/unit/hybrid/test_hybrid_init.py
+++ b/tests/unit/hybrid/test_hybrid_init.py
@@ -48,6 +48,7 @@ class TestHybridExportsImportable:
             "TVARDefinition",
             "ConfigSpaceResponse",
             "HealthCheckResponse",
+            "InputsResponse",
         ]
         for dto_class in protocol_classes:
             assert hasattr(hybrid_module, dto_class), f"{dto_class} not found"
@@ -108,6 +109,7 @@ class TestHybridAllList:
             "TVARDefinition",
             "ConfigSpaceResponse",
             "HealthCheckResponse",
+            "InputsResponse",
             # Lifecycle
             "AgentLifecycleManager",
             "SessionInfo",
@@ -244,6 +246,7 @@ class TestDirectImports:
             HybridEvaluateResponse,
             HybridExecuteRequest,
             HybridExecuteResponse,
+            InputsResponse,
             ServiceCapabilities,
             TVARDefinition,
         )

--- a/tests/unit/hybrid/test_hybrid_init.py
+++ b/tests/unit/hybrid/test_hybrid_init.py
@@ -47,8 +47,9 @@ class TestHybridExportsImportable:
             "ServiceCapabilities",
             "TVARDefinition",
             "ConfigSpaceResponse",
+            "BenchmarkEntry",
+            "BenchmarksResponse",
             "HealthCheckResponse",
-            "InputsResponse",
         ]
         for dto_class in protocol_classes:
             assert hasattr(hybrid_module, dto_class), f"{dto_class} not found"
@@ -108,8 +109,9 @@ class TestHybridAllList:
             "ServiceCapabilities",
             "TVARDefinition",
             "ConfigSpaceResponse",
+            "BenchmarkEntry",
+            "BenchmarksResponse",
             "HealthCheckResponse",
-            "InputsResponse",
             # Lifecycle
             "AgentLifecycleManager",
             "SessionInfo",
@@ -240,13 +242,14 @@ class TestDirectImports:
         """Test direct import of protocol DTOs."""
         from traigent.hybrid import (  # noqa: F401
             BatchOptions,
+            BenchmarkEntry,
+            BenchmarksResponse,
             ConfigSpaceResponse,
             HealthCheckResponse,
             HybridEvaluateRequest,
             HybridEvaluateResponse,
             HybridExecuteRequest,
             HybridExecuteResponse,
-            InputsResponse,
             ServiceCapabilities,
             TVARDefinition,
         )

--- a/tests/unit/hybrid/test_mcp_transport.py
+++ b/tests/unit/hybrid/test_mcp_transport.py
@@ -378,8 +378,8 @@ class TestMCPTransportDiscoverConfigSpace:
         transport._client.read_resource.assert_called_with(CONFIG_SPACE_URI)
 
 
-class TestMCPTransportInputs:
-    """Tests for inputs method (issue #57 — not yet supported)."""
+class TestMCPTransportBenchmarks:
+    """Tests for benchmarks method (not yet supported over MCP)."""
 
     @pytest.fixture
     def transport(self) -> MCPTransport:
@@ -387,10 +387,12 @@ class TestMCPTransportInputs:
         return MCPTransport(mcp_client=mock_client)
 
     @pytest.mark.asyncio
-    async def test_inputs_raises_not_implemented(self, transport: MCPTransport) -> None:
-        """MCP transport raises NotImplementedError for inputs()."""
+    async def test_benchmarks_raises_not_implemented(
+        self, transport: MCPTransport
+    ) -> None:
+        """MCP transport raises NotImplementedError for benchmarks()."""
         with pytest.raises(NotImplementedError, match="not yet supported over MCP"):
-            await transport.inputs("some-tunable")
+            await transport.benchmarks("some-tunable")
 
 
 class TestMCPTransportExecute:
@@ -409,7 +411,7 @@ class TestMCPTransportExecute:
             "request_id": "req-123",
             "execution_id": "exec-456",
             "status": "completed",
-            "outputs": [{"input_id": "1", "output": {"result": "test"}}],
+            "outputs": [{"example_id": "1", "output": {"result": "test"}}],
             "operational_metrics": {"total_cost_usd": 0.001},
         }
         mock_response = MockMCPResponse(
@@ -420,8 +422,9 @@ class TestMCPTransportExecute:
 
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[{"input_id": "1", "data": {}}],
+            examples=[{"example_id": "1", "data": {}}],
         )
         response = await transport.execute(request)
 
@@ -454,7 +457,7 @@ class TestMCPTransportEvaluate:
         evaluate_response = {
             "request_id": "req-123",
             "status": "completed",
-            "results": [{"input_id": "1", "metrics": {"accuracy": 0.95}}],
+            "results": [{"example_id": "1", "metrics": {"accuracy": 0.95}}],
             "aggregate_metrics": {"accuracy": {"mean": 0.95}},
         }
         eval_response = MockMCPResponse(
@@ -467,7 +470,8 @@ class TestMCPTransportEvaluate:
 
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
-            evaluations=[{"input_id": "1", "output": {}, "target": {}}],
+            benchmark_id="bench_001",
+            evaluations=[{"example_id": "1", "output": {}, "target": {}}],
         )
         response = await transport.evaluate(request)
 
@@ -486,6 +490,7 @@ class TestMCPTransportEvaluate:
 
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             evaluations=[],
         )
 

--- a/tests/unit/hybrid/test_mcp_transport.py
+++ b/tests/unit/hybrid/test_mcp_transport.py
@@ -378,6 +378,21 @@ class TestMCPTransportDiscoverConfigSpace:
         transport._client.read_resource.assert_called_with(CONFIG_SPACE_URI)
 
 
+class TestMCPTransportInputs:
+    """Tests for inputs method (issue #57 — not yet supported)."""
+
+    @pytest.fixture
+    def transport(self) -> MCPTransport:
+        mock_client = MagicMock()
+        return MCPTransport(mcp_client=mock_client)
+
+    @pytest.mark.asyncio
+    async def test_inputs_raises_not_implemented(self, transport: MCPTransport) -> None:
+        """MCP transport raises NotImplementedError for inputs()."""
+        with pytest.raises(NotImplementedError, match="not yet supported over MCP"):
+            await transport.inputs("some-tunable")
+
+
 class TestMCPTransportExecute:
     """Tests for execute method."""
 

--- a/tests/unit/hybrid/test_protocol.py
+++ b/tests/unit/hybrid/test_protocol.py
@@ -38,13 +38,15 @@ class TestHybridExecuteRequest:
         """Test creating minimal execute request."""
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"temperature": 0.7},
-            inputs=[{"input_id": "ex_1", "data": {"query": "test"}}],
+            examples=[{"example_id": "ex_1", "data": {"query": "test"}}],
         )
 
         assert request.tunable_id == "test_agent"
+        assert request.benchmark_id == "bench_001"
         assert request.config == {"temperature": 0.7}
-        assert len(request.inputs) == 1
+        assert len(request.examples) == 1
         assert request.request_id  # Auto-generated
         assert request.session_id is None
         assert request.batch_options is None
@@ -54,8 +56,9 @@ class TestHybridExecuteRequest:
         """Test serialization to dictionary."""
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"model": "gpt-4"},
-            inputs=[{"input_id": "1", "data": {}}],
+            examples=[{"example_id": "1", "data": {}}],
             session_id="sess_123",
             batch_options=BatchOptions(parallelism=3),
             timeout_ms=60000,
@@ -63,8 +66,9 @@ class TestHybridExecuteRequest:
 
         d = request.to_dict()
         assert d["tunable_id"] == "test_agent"
+        assert d["benchmark_id"] == "bench_001"
         assert d["config"] == {"model": "gpt-4"}
-        assert d["inputs"] == [{"input_id": "1", "data": {}}]
+        assert d["examples"] == [{"example_id": "1", "data": {}}]
         assert d["session_id"] == "sess_123"
         assert d["batch_options"]["parallelism"] == 3
         assert d["timeout_ms"] == 60000
@@ -73,8 +77,9 @@ class TestHybridExecuteRequest:
         """Test minimal serialization excludes None fields."""
         request = HybridExecuteRequest(
             tunable_id="test",
+            benchmark_id="bench_001",
             config={},
-            inputs=[],
+            examples=[],
         )
 
         d = request.to_dict()
@@ -91,7 +96,7 @@ class TestHybridExecuteResponse:
             "request_id": "req_123",
             "execution_id": "exec_456",
             "status": "completed",
-            "outputs": [{"input_id": "1", "output": "result"}],
+            "outputs": [{"example_id": "1", "output": "result"}],
             "operational_metrics": {"cost_usd": 0.002, "latency_ms": 150},
             "session_id": "sess_789",
         }
@@ -135,8 +140,9 @@ class TestHybridEvaluateRequest:
 
     def test_minimal_request(self) -> None:
         """Test creating minimal evaluate request."""
-        request = HybridEvaluateRequest(tunable_id="test")
+        request = HybridEvaluateRequest(tunable_id="test", benchmark_id="bench_001")
         assert request.tunable_id == "test"
+        assert request.benchmark_id == "bench_001"
         assert request.request_id  # Auto-generated
         assert request.execution_id is None
         assert request.evaluations is None
@@ -146,8 +152,9 @@ class TestHybridEvaluateRequest:
         """Test serialization to dictionary."""
         request = HybridEvaluateRequest(
             tunable_id="test",
+            benchmark_id="bench_001",
             execution_id="exec_123",
-            evaluations=[{"input_id": "1", "output": {}, "target": {}}],
+            evaluations=[{"example_id": "1", "output": {}, "target": {}}],
             config={"setting": "value"},
             session_id="sess_456",
             timeout_ms=45000,
@@ -155,6 +162,7 @@ class TestHybridEvaluateRequest:
 
         d = request.to_dict()
         assert d["tunable_id"] == "test"
+        assert d["benchmark_id"] == "bench_001"
         assert d["execution_id"] == "exec_123"
         assert len(d["evaluations"]) == 1
         assert d["config"] == {"setting": "value"}
@@ -170,12 +178,12 @@ class TestHybridEvaluateResponse:
         data = {
             "request_id": "req_123",
             "status": "partial",
-            "results": [{"input_id": "1", "metrics": {"accuracy": 0.95}}],
+            "results": [{"example_id": "1", "metrics": {"accuracy": 0.95}}],
             "aggregate_metrics": {"accuracy": {"mean": 0.95, "std": 0.02, "n": 10}},
             "error": {
                 "code": "EVALUATION_PARTIAL_FAILURE",
                 "message": "One or more items failed during evaluation",
-                "failed_inputs": ["2"],
+                "failed_examples": ["2"],
             },
         }
 

--- a/tests/unit/hybrid/test_transport.py
+++ b/tests/unit/hybrid/test_transport.py
@@ -195,13 +195,16 @@ class TestHybridTransportProtocol:
             async def capabilities(self):
                 pass
 
-            async def discover_config_space(self):
+            async def discover_config_space(self, *, tunable_id=None):
                 pass
 
             async def execute(self, request):
                 pass
 
             async def evaluate(self, request):
+                pass
+
+            async def benchmarks(self, tunable_id=None):
                 pass
 
             async def health_check(self):

--- a/tests/unit/scripts/test_migrate_optuna.py
+++ b/tests/unit/scripts/test_migrate_optuna.py
@@ -22,12 +22,14 @@ def test_migration_applies_to_sqlite(tmp_path):
     migrations_dir = tmp_path / "migrations"
     migrations_dir.mkdir()
     migration = migrations_dir / "0001.sql"
-    migration.write_text("""
+    migration.write_text(
+        """
         CREATE TABLE IF NOT EXISTS optuna_demo (
             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
             created TIMESTAMPTZ DEFAULT NOW()
         );
-        """)
+        """
+    )
 
     apply_migrations(db_url, migrations_dir, dry_run=False)
 

--- a/tests/unit/test_hybrid_protocol_privacy.py
+++ b/tests/unit/test_hybrid_protocol_privacy.py
@@ -23,47 +23,50 @@ class TestInputItemPrivacy:
         """Test standard mode: input with data field."""
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[
-                {"input_id": "ex_1", "data": {"query": "What is AI?"}},
+            examples=[
+                {"example_id": "ex_1", "data": {"query": "What is AI?"}},
             ],
         )
 
         request_dict = request.to_dict()
-        assert request_dict["inputs"][0]["input_id"] == "ex_1"
-        assert request_dict["inputs"][0]["data"] == {"query": "What is AI?"}
+        assert request_dict["examples"][0]["example_id"] == "ex_1"
+        assert request_dict["examples"][0]["data"] == {"query": "What is AI?"}
 
     def test_input_without_data_privacy_mode(self) -> None:
-        """Test privacy-preserving mode: input with only input_id."""
+        """Test privacy-preserving mode: input with only example_id."""
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[
-                {"input_id": "ex_1"},  # No data field
-                {"input_id": "ex_2"},  # No data field
+            examples=[
+                {"example_id": "ex_1"},  # No data field
+                {"example_id": "ex_2"},  # No data field
             ],
         )
 
         request_dict = request.to_dict()
-        assert request_dict["inputs"][0]["input_id"] == "ex_1"
-        assert "data" not in request_dict["inputs"][0]
-        assert request_dict["inputs"][1]["input_id"] == "ex_2"
-        assert "data" not in request_dict["inputs"][1]
+        assert request_dict["examples"][0]["example_id"] == "ex_1"
+        assert "data" not in request_dict["examples"][0]
+        assert request_dict["examples"][1]["example_id"] == "ex_2"
+        assert "data" not in request_dict["examples"][1]
 
     def test_mixed_inputs(self) -> None:
         """Test mixed mode: some inputs with data, some without."""
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"model": "balanced"},
-            inputs=[
-                {"input_id": "ex_1", "data": {"query": "test"}},  # With data
-                {"input_id": "ex_2"},  # Without data
+            examples=[
+                {"example_id": "ex_1", "data": {"query": "test"}},  # With data
+                {"example_id": "ex_2"},  # Without data
             ],
         )
 
         request_dict = request.to_dict()
-        assert "data" in request_dict["inputs"][0]
-        assert "data" not in request_dict["inputs"][1]
+        assert "data" in request_dict["examples"][0]
+        assert "data" not in request_dict["examples"][1]
 
 
 class TestOutputItemPrivacy:
@@ -77,7 +80,7 @@ class TestOutputItemPrivacy:
             "status": "completed",
             "outputs": [
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": {"response": "AI is..."},
                     "cost_usd": 0.001,
                 },
@@ -86,7 +89,7 @@ class TestOutputItemPrivacy:
         }
 
         response = HybridExecuteResponse.from_dict(response_data)
-        assert response.outputs[0]["input_id"] == "ex_1"
+        assert response.outputs[0]["example_id"] == "ex_1"
         assert response.outputs[0]["output"]["response"] == "AI is..."
         assert "output_id" not in response.outputs[0]
 
@@ -98,7 +101,7 @@ class TestOutputItemPrivacy:
             "status": "completed",
             "outputs": [
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output_id": "out_ex_1_session_abc",
                     "cost_usd": 0.001,
                 },
@@ -107,7 +110,7 @@ class TestOutputItemPrivacy:
         }
 
         response = HybridExecuteResponse.from_dict(response_data)
-        assert response.outputs[0]["input_id"] == "ex_1"
+        assert response.outputs[0]["example_id"] == "ex_1"
         assert response.outputs[0]["output_id"] == "out_ex_1_session_abc"
         assert "output" not in response.outputs[0]
 
@@ -119,7 +122,7 @@ class TestOutputItemPrivacy:
             "status": "completed",
             "outputs": [
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output_id": "out_ex_1",
                     "cost_usd": 0.005,
                     "latency_ms": 150.0,
@@ -140,9 +143,10 @@ class TestEvaluationItemPrivacy:
         """Test standard mode: evaluation with full output and target content."""
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": {"response": "AI is..."},
                     "target": {"expected": "AI is artificial..."},
                 },
@@ -158,9 +162,10 @@ class TestEvaluationItemPrivacy:
         """Test privacy-preserving mode: evaluation with output_id and target_id."""
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output_id": "out_ex_1_session_abc",
                     "target_id": "target_ex_1",
                 },
@@ -178,9 +183,10 @@ class TestEvaluationItemPrivacy:
         """Test mixed mode: output content with target_id."""
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "output": {"response": "AI is..."},  # Full content
                     "target_id": "target_ex_1",  # ID reference
                 },
@@ -205,7 +211,7 @@ class TestEvaluateResponsePrivacy:
             "status": "completed",
             "results": [
                 {
-                    "input_id": "ex_1",
+                    "example_id": "ex_1",
                     "metrics": {
                         "accuracy": 0.92,
                         "relevance": 0.88,
@@ -230,8 +236,9 @@ class TestSessionIdScoping:
         """Test that session_id is included in execute request."""
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={"model": "fast"},
-            inputs=[{"input_id": "ex_1"}],
+            examples=[{"example_id": "ex_1"}],
             session_id="session_abc123",
         )
 
@@ -242,8 +249,9 @@ class TestSessionIdScoping:
         """Test that session_id is included in evaluate request."""
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             evaluations=[
-                {"input_id": "ex_1", "output_id": "out_1", "target_id": "t_1"}
+                {"example_id": "ex_1", "output_id": "out_1", "target_id": "t_1"}
             ],
             session_id="session_abc123",
         )
@@ -269,17 +277,18 @@ class TestSessionIdScoping:
 class TestPrivacyModeDocumentation:
     """Tests that verify privacy-preserving mode contract."""
 
-    def test_input_only_requires_input_id(self) -> None:
-        """Verify that input_id is the only required field for InputItem."""
+    def test_input_only_requires_example_id(self) -> None:
+        """Verify that example_id is the only required field for InputItem."""
         # This should work without data field
         request = HybridExecuteRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             config={},
-            inputs=[{"input_id": "required_only"}],
+            examples=[{"example_id": "required_only"}],
         )
 
-        assert len(request.inputs) == 1
-        assert request.inputs[0]["input_id"] == "required_only"
+        assert len(request.examples) == 1
+        assert request.examples[0]["example_id"] == "required_only"
 
     def test_output_item_flexible_fields(self) -> None:
         """Verify OutputItem accepts both output and output_id."""
@@ -289,7 +298,7 @@ class TestPrivacyModeDocumentation:
                 "request_id": "r1",
                 "execution_id": "e1",
                 "status": "completed",
-                "outputs": [{"input_id": "ex_1", "output": {"data": "content"}}],
+                "outputs": [{"example_id": "ex_1", "output": {"data": "content"}}],
                 "operational_metrics": {},
             }
         )
@@ -301,7 +310,7 @@ class TestPrivacyModeDocumentation:
                 "request_id": "r2",
                 "execution_id": "e2",
                 "status": "completed",
-                "outputs": [{"input_id": "ex_1", "output_id": "out_123"}],
+                "outputs": [{"example_id": "ex_1", "output_id": "out_123"}],
                 "operational_metrics": {},
             }
         )
@@ -311,14 +320,15 @@ class TestPrivacyModeDocumentation:
         """Verify EvaluationItem accepts both content and IDs."""
         request = HybridEvaluateRequest(
             tunable_id="test_agent",
+            benchmark_id="bench_001",
             evaluations=[
                 # All content
-                {"input_id": "ex_1", "output": {}, "target": {}},
+                {"example_id": "ex_1", "output": {}, "target": {}},
                 # All IDs
-                {"input_id": "ex_2", "output_id": "o2", "target_id": "t2"},
+                {"example_id": "ex_2", "output_id": "o2", "target_id": "t2"},
                 # Mixed
-                {"input_id": "ex_3", "output": {}, "target_id": "t3"},
-                {"input_id": "ex_4", "output_id": "o4", "target": {}},
+                {"example_id": "ex_3", "output": {}, "target_id": "t3"},
+                {"example_id": "ex_4", "output_id": "o4", "target": {}},
             ],
         )
 

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -222,7 +222,8 @@ class TestPluginRegistry:
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a mock plugin file
             plugin_file = Path(temp_dir) / "test_plugin.py"
-            plugin_file.write_text("""
+            plugin_file.write_text(
+                """
 from traigent.plugins.registry import OptimizerPlugin
 
 class TestOptimizer(OptimizerPlugin):
@@ -243,7 +244,8 @@ class TestOptimizer(OptimizerPlugin):
 
     def create_optimizer(self, **kwargs):
         return None
-""")
+"""
+            )
 
             # Mock Path.exists() to return True for plugin directories
             mock_path = Mock()

--- a/tests/unit/test_safeguards.py
+++ b/tests/unit/test_safeguards.py
@@ -660,11 +660,11 @@ class TestCIApproval:
         # Test with CI environment and invalid signature (disable mock mode to test CI approval)
         with patch.dict(
             os.environ,
-                {
-                    "CI": "true",
-                    "TRAIGENT_APPROVAL_SECRET": "test_secret",  # pragma: allowlist secret
-                    "TRAIGENT_MOCK_LLM": "false",
-                },
+            {
+                "CI": "true",
+                "TRAIGENT_APPROVAL_SECRET": "test_secret",  # pragma: allowlist secret
+                "TRAIGENT_MOCK_LLM": "false",
+            },
         ):
             with pytest.raises(OptimizationError):
                 func._check_ci_approval()

--- a/tests/unit/tools/test_lint_pricing_consistency.py
+++ b/tests/unit/tools/test_lint_pricing_consistency.py
@@ -25,42 +25,52 @@ class TestPricingConsistencyLinter:
     """Tests for P001/P002/P003 rules and allowlist behavior."""
 
     def test_p001_detects_pricing_keys(self) -> None:
-        issues = _lint("""\
+        issues = _lint(
+            """\
         rates = {"prompt": 0.005, "completion": 0.012}
-        """)
+        """
+        )
         assert any(i.code == "P001" and i.severity == Severity.ERROR for i in issues)
 
     def test_p002_detects_model_pricing_table_with_tuples(self) -> None:
-        issues = _lint("""\
+        issues = _lint(
+            """\
         cost_per_1m = {
             "gpt-4o": (2.5, 10.0),
             "gpt-4o-mini": (0.15, 0.6),
         }
-        """)
+        """
+        )
         assert any(i.code == "P002" and i.severity == Severity.ERROR for i in issues)
 
     def test_p003_detects_tuple_assignment(self) -> None:
-        issues = _lint("""\
+        issues = _lint(
+            """\
         cost_per_1m = (2.5, 10.0)
-        """)
+        """
+        )
         assert any(i.code == "P003" and i.severity == Severity.WARNING for i in issues)
 
     def test_numeric_threshold_does_not_flag_one_of_three_numeric(self) -> None:
-        issues = _lint("""\
+        issues = _lint(
+            """\
         model_table = {
             "gpt-4o": {"input": 0.0025, "meta": "x", "note": "y"},
             "gpt-4o-mini": {"input": 0.00015, "meta": "x", "note": "y"},
         }
-        """)
+        """
+        )
         assert not any(i.code == "P002" for i in issues)
 
     def test_numeric_threshold_flags_two_of_three_numeric(self) -> None:
-        issues = _lint("""\
+        issues = _lint(
+            """\
         model_table = {
             "gpt-4o": {"input": 0.0025, "output": 0.01, "meta": "x"},
             "gpt-4o-mini": {"input": 0.00015, "output": 0.0006, "meta": "x"},
         }
-        """)
+        """
+        )
         assert any(i.code == "P002" for i in issues)
 
     def test_allowlist_includes_experimental_paths_by_policy(self) -> None:

--- a/tests/unit/tools/test_llm_test_scanner.py
+++ b/tests/unit/tools/test_llm_test_scanner.py
@@ -56,146 +56,178 @@ class TestSmellDetector:
     """Test AST-based smell detection."""
 
     def test_assertion_roulette_detected(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert len(result) > 0
             assert result[0] is not None
             assert result[0].config != {}
-        """)
+        """
+        )
         roulette = [s for s in smells if s.smell_type == TestSmell.ASSERTION_ROULETTE]
         assert len(roulette) == 1
         assert "3/3" in roulette[0].description
 
     def test_assertion_roulette_not_triggered_with_messages(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert len(result) > 0, "need results"
             assert result[0] is not None, "first not none"
             assert result[0].config != {}, "config not empty"
-        """)
+        """
+        )
         roulette = [s for s in smells if s.smell_type == TestSmell.ASSERTION_ROULETTE]
         assert len(roulette) == 0
 
     def test_assertion_roulette_not_triggered_under_threshold(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert x > 0
             assert y > 0
-        """)
+        """
+        )
         roulette = [s for s in smells if s.smell_type == TestSmell.ASSERTION_ROULETTE]
         assert len(roulette) == 0
 
     def test_eager_test_by_name(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_trials_and_configs_and_metrics():
             pass
-        """)
+        """
+        )
         eager = [s for s in smells if s.smell_type == TestSmell.EAGER_TEST]
         assert len(eager) >= 1
 
     def test_eager_test_not_triggered_single_and(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_trials_and_configs():
             pass
-        """)
+        """
+        )
         eager = [s for s in smells if s.smell_type == TestSmell.EAGER_TEST]
         assert len(eager) == 0
 
     def test_magic_number_detected(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert result.score > 0.85
-        """)
+        """
+        )
         magic = [s for s in smells if s.smell_type == TestSmell.MAGIC_NUMBER]
         assert len(magic) == 1
         assert "0.85" in str(magic[0].evidence)
 
     def test_magic_number_ignores_common_values(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert len(x) >= 1
             assert score > 0
             assert count == 10
-        """)
+        """
+        )
         magic = [s for s in smells if s.smell_type == TestSmell.MAGIC_NUMBER]
         assert len(magic) == 0
 
     def test_empty_test_detected(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             result = some_function()
-        """)
+        """
+        )
         empty = [s for s in smells if s.smell_type == TestSmell.EMPTY_TEST]
         assert len(empty) == 1
 
     def test_empty_test_not_triggered_with_assert(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             result = some_function()
             assert result is not None
-        """)
+        """
+        )
         empty = [s for s in smells if s.smell_type == TestSmell.EMPTY_TEST]
         assert len(empty) == 0
 
     def test_empty_test_not_triggered_with_pytest_raises(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             with pytest.raises(ValueError):
                 bad_function()
-        """)
+        """
+        )
         empty = [s for s in smells if s.smell_type == TestSmell.EMPTY_TEST]
         assert len(empty) == 0
 
     def test_empty_test_not_triggered_with_mock_assert(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             mock_obj.assert_called_once()
-        """)
+        """
+        )
         empty = [s for s in smells if s.smell_type == TestSmell.EMPTY_TEST]
         assert len(empty) == 0
 
     def test_redundant_assert_true(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert True
-        """)
+        """
+        )
         redundant = [s for s in smells if s.smell_type == TestSmell.REDUNDANT_ASSERTION]
         assert len(redundant) == 1
         assert "assert True" in redundant[0].description
 
     def test_redundant_self_comparison(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert x == x
-        """)
+        """
+        )
         redundant = [s for s in smells if s.smell_type == TestSmell.REDUNDANT_ASSERTION]
         assert len(redundant) == 1
 
     def test_redundant_vacuous_length(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def test_example():
             assert len(items) >= 0
-        """)
+        """
+        )
         redundant = [s for s in smells if s.smell_type == TestSmell.REDUNDANT_ASSERTION]
         assert len(redundant) == 1
         assert "always true" in redundant[0].description
 
     def test_async_tests_detected(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         async def test_example():
             result = await func()
-        """)
+        """
+        )
         empty = [s for s in smells if s.smell_type == TestSmell.EMPTY_TEST]
         assert len(empty) == 1
 
     def test_non_test_functions_ignored(self):
-        smells = _detect("""\
+        smells = _detect(
+            """\
         def helper_function():
             pass
 
         def setup_module():
             pass
-        """)
+        """
+        )
         assert len(smells) == 0
 
 
@@ -208,14 +240,16 @@ class TestOracleStrengthAnalyzer:
     """Test oracle scoring heuristics."""
 
     def test_strong_oracle_high_score(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert len(result.trials) >= 1
             assert result.best_config is not None
             assert result.stop_reason == "max_trials"
             assert result.best_score > 0
             assert result.status == "completed"
-        """)
+        """
+        )
         assert report.oracle_score >= 0.7
         assert report.has_behavior_verification is True
         assert "trials" in report.checked_attributes
@@ -223,49 +257,61 @@ class TestOracleStrengthAnalyzer:
         assert "stop_reason" in report.checked_attributes
 
     def test_no_assertions_zero_score(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             result = some_function()
-        """)
+        """
+        )
         assert report.oracle_score == 0.0
         assert report.assertion_count == 0
 
     def test_isinstance_only_penalised(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert isinstance(result, dict)
             assert isinstance(result["key"], str)
-        """)
+        """
+        )
         assert "only-isinstance-checks" in report.weak_patterns
 
     def test_vacuous_length_penalised(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert len(result.trials) >= 0
-        """)
+        """
+        )
         assert "vacuous-length-checks" in report.weak_patterns
 
     def test_validator_reliance_only_penalised(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert not isinstance(result, Exception)
             validation = result_validator(scenario, result)
             assert validation.passed
-        """)
+        """
+        )
         assert "validator-reliance-only" in report.weak_patterns
 
     def test_exception_guard_only_penalised(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert not isinstance(result, Exception)
-        """)
+        """
+        )
         assert "exception-guard-only" in report.weak_patterns
 
     def test_missing_critical_checks(self):
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert result.trials is not None
-        """)
+        """
+        )
         # Only 'trials' is checked; others should be missing
         assert "best_config" in report.missing_critical_checks
         assert "best_score" in report.missing_critical_checks
@@ -273,15 +319,18 @@ class TestOracleStrengthAnalyzer:
 
     def test_score_clamped_to_zero(self):
         """Many weak patterns shouldn't push score below 0."""
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert not isinstance(result, Exception)
-        """)
+        """
+        )
         assert report.oracle_score >= 0.0
 
     def test_score_clamped_to_one(self):
         """Score shouldn't exceed 1.0 even with many attributes."""
-        report = _oracle("""\
+        report = _oracle(
+            """\
         def test_example():
             assert result.trials is not None
             assert result.best_config is not None
@@ -291,7 +340,8 @@ class TestOracleStrengthAnalyzer:
             assert result.metrics is not None
             assert result.config is not None
             assert result.score > 0
-        """)
+        """
+        )
         assert report.oracle_score <= 1.0
 
 
@@ -393,7 +443,9 @@ class TestLLMTestScanner:
 
     def test_scan_file_produces_all_sections(self, tmp_path: Path):
         test_file = tmp_path / "test_sample.py"
-        test_file.write_text(textwrap.dedent("""\
+        test_file.write_text(
+            textwrap.dedent(
+                """\
         def test_with_assert():
             assert len(result.trials) >= 1
 
@@ -404,7 +456,9 @@ class TestLLMTestScanner:
             assert not isinstance(result, Exception)
             validation = result_validator(scenario, result)
             assert validation.passed
-        """))
+        """
+            )
+        )
 
         scanner = LLMTestScanner(enable_llm=False)
         result = scanner.scan_file(test_file)

--- a/tests/unit/tuned_variables/test_dataflow_strategy.py
+++ b/tests/unit/tuned_variables/test_dataflow_strategy.py
@@ -107,37 +107,45 @@ class TestNamesInExpr:
 
 class TestDefUseBuilder:
     def test_simple_assignment(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 x = 1
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "x" in du.definitions
         assert du.definitions["x"][0].var_name == "x"
         assert du.definitions["x"][0].line > 0
 
     def test_annotated_assignment(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 x: int = 1
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "x" in du.definitions
 
     def test_augmented_assignment(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 x = 0
                 x += 1
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert len(du.definitions["x"]) == 2
 
     def test_tuple_unpacking(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 a, b = (1, 2)
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "a" in du.definitions
         assert "b" in du.definitions
@@ -145,49 +153,59 @@ class TestDefUseBuilder:
         assert du.definitions["a"][0].value_node is None
 
     def test_walrus_operator(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 if (x := compute()):
                     pass
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "x" in du.definitions
 
     def test_for_target(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 for i in items:
                     pass
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "i" in du.definitions
 
     def test_with_as_variable(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 with open("f") as handle:
                     pass
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "handle" in du.definitions
 
     def test_nested_function_skipped(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn():
                 x = 1
                 def inner():
                     y = 2
                 return x
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert "x" in du.definitions
         assert "y" not in du.definitions
 
     def test_function_parameters_recorded(self) -> None:
-        func = _parse_func("""
+        func = _parse_func(
+            """
             def fn(a, b, *args, c=1, **kwargs):
                 pass
-        """)
+        """
+        )
         du = _build_def_use_map(func)
         assert du.func_params == {"a", "b", "args", "c", "kwargs"}
 
@@ -211,61 +229,75 @@ class TestSinkFinder:
         return finder.sink_args
 
     def test_llm_invoke_detected(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 llm.invoke(prompt)
-        """)
+        """
+        )
         names = [s.var_name for s in sinks]
         assert "prompt" in names
 
     def test_chained_create_detected(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 client.chat.completions.create(model="gpt-4", temperature=0.7)
-        """)
+        """
+        )
         # Should detect literal kwargs
         params = [s.param_name for s in sinks if s.param_name]
         assert "model" in params
         assert "temperature" in params
 
     def test_module_level_completion_detected(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 result = completion(model=m, temperature=t)
-        """)
+        """
+        )
         names = [s.var_name for s in sinks]
         assert "m" in names
         assert "t" in names
 
     def test_retrieval_search_detected(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 docs = db.similarity_search(query, k=5)
-        """)
+        """
+        )
         names = [s.var_name for s in sinks]
         assert "query" in names
 
     def test_embedding_detected(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 vec = embedder.embed_query(text)
-        """)
+        """
+        )
         names = [s.var_name for s in sinks]
         assert "text" in names
 
     def test_non_sink_ignored(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 result = obj.process(data)
-        """)
+        """
+        )
         assert sinks == [], f"process() should not be a sink; got {sinks}"
 
     def test_constructor_kwargs_traced(self) -> None:
-        sinks = self._find_sinks("""
+        sinks = self._find_sinks(
+            """
             def fn():
                 llm = ChatOpenAI(temperature=0.7, model="gpt-4")
                 result = llm.invoke(prompt)
-        """)
+        """
+        )
         # The constructor kwargs should appear as sink arguments
         params = [s.param_name for s in sinks]
         assert "temperature" in params
@@ -283,37 +315,43 @@ class TestConstructorTracing:
         return DataFlowDetectionStrategy()
 
     def test_constructor_literal_kwargs(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 llm = ChatOpenAI(temperature=0.7, model="gpt-4")
                 result = llm.invoke("hello")
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         names = _names(candidates)
         assert "temperature" in names, f"temperature not found; got {names}"
         assert "model" in names, f"model not found; got {names}"
 
     def test_constructor_variable_arg_traced(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 t = 0.7
                 llm = ChatOpenAI(temperature=t)
                 result = llm.invoke("hello")
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "t")
         assert c is not None, f"t not detected; got {_names(candidates)}"
         assert c.current_value == pytest.approx(0.7)
 
     def test_unknown_constructor_ignored(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 obj = MyUnknownClass(temperature=0.7)
                 result = obj.invoke("hello")
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         # "temperature" may still be detected via the invoke() call
         # but NOT via constructor tracing (MyUnknownClass is not in hints)
@@ -336,11 +374,13 @@ class TestBackwardSlicing:
         return DataFlowDetectionStrategy()
 
     def test_direct_literal_kwarg_high_confidence(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 result = llm.invoke(temperature=0.7)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "temperature")
         assert c is not None, f"temperature not detected; got {_names(candidates)}"
@@ -348,12 +388,14 @@ class TestBackwardSlicing:
         assert c.current_value == pytest.approx(0.7)
 
     def test_one_hop_variable_high_confidence(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 t = 0.7
                 result = llm.invoke(temperature=t)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "t")
         assert c is not None, f"t not detected; got {_names(candidates)}"
@@ -362,25 +404,29 @@ class TestBackwardSlicing:
 
     def test_two_hop_transitive_medium_confidence(self, strategy) -> None:
         # t at hop 0, y at hop 1, x at hop 2 → MEDIUM
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 x = 0.7
                 y = x
                 t = y
                 result = llm.invoke(temperature=t)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "x")
         assert c is not None, f"x not detected; got {_names(candidates)}"
         assert c.confidence == DetectionConfidence.MEDIUM
 
     def test_function_param_medium_confidence(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn(temp):
                 result = llm.invoke(temperature=temp)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "temp")
         assert c is not None, f"temp not detected; got {_names(candidates)}"
@@ -389,39 +435,45 @@ class TestBackwardSlicing:
     def test_subscript_traces_base(self, strategy) -> None:
         # config is assigned from an external variable, so backward walk
         # traces through the subscript base to find the literal origin
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temp_val = 0.7
                 config = {"temperature": temp_val}
                 t = config["temperature"]
                 result = llm.invoke(temperature=t)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         # temp_val should be traced via config dict → subscript → invoke
         names = _names(candidates)
         assert "temp_val" in names, f"temp_val not traced; got {names}"
 
     def test_call_traces_args(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 x = 0.7
                 t = float(x)
                 result = llm.invoke(temperature=t)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "x")
         assert c is not None, f"x not traced through call; got {_names(candidates)}"
 
     def test_fstring_detects_variables(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 topic = "science"
                 prompt = f"Tell me about {topic}"
                 result = llm.invoke(prompt)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "topic")
         assert (
@@ -429,14 +481,16 @@ class TestBackwardSlicing:
         ), f"topic not detected in f-string; got {_names(candidates)}"
 
     def test_string_concat_detects_both(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 prefix = "Answer: "
                 query = "what is AI?"
                 prompt = prefix + query
                 result = llm.invoke(prompt)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         names = _names(candidates)
         assert "prefix" in names, f"prefix not detected; got {names}"
@@ -444,14 +498,16 @@ class TestBackwardSlicing:
 
     def test_max_hops_respected(self) -> None:
         strategy = DataFlowDetectionStrategy(max_hops=1)
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 a = 0.7
                 b = a
                 c = b
                 result = llm.invoke(temperature=c)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         names = _names(candidates)
         # With max_hops=1, only c (hop=0) and b (hop=1) should be visited.
@@ -459,13 +515,15 @@ class TestBackwardSlicing:
         assert "a" not in names, f"a should not be reached with max_hops=1; got {names}"
 
     def test_no_infinite_loop_on_self_reference(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 x = 1
                 x = x + 1
                 result = llm.invoke(temperature=x)
                 return result
-        """)
+        """
+        )
         # Should terminate without hanging
         candidates = strategy.detect(src, "fn")
         assert isinstance(candidates, list)
@@ -482,13 +540,15 @@ class TestDataFlowDetectionStrategy:
         return DataFlowDetectionStrategy()
 
     def test_langchain_pattern(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def answer(question):
                 llm = ChatOpenAI(temperature=0.7, model="gpt-4")
                 prompt = f"Answer: {question}"
                 response = llm.invoke(prompt)
                 return response.content
-        """)
+        """
+        )
         candidates = strategy.detect(src, "answer")
         names = _names(candidates)
         assert "temperature" in names
@@ -496,7 +556,8 @@ class TestDataFlowDetectionStrategy:
         assert "question" in names or "prompt" in names
 
     def test_openai_sdk_pattern(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def chat(msg):
                 response = client.chat.completions.create(
                     model="gpt-4",
@@ -504,51 +565,60 @@ class TestDataFlowDetectionStrategy:
                     temperature=0.5,
                 )
                 return response
-        """)
+        """
+        )
         candidates = strategy.detect(src, "chat")
         names = _names(candidates)
         assert "temperature" in names or "model" in names
 
     def test_rag_pattern(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def answer(question):
                 docs = retriever.similarity_search(question, k=5)
                 context = "\\n".join(d.page_content for d in docs)
                 prompt = f"Context: {context}\\nQuestion: {question}"
                 response = llm.invoke(prompt)
                 return response
-        """)
+        """
+        )
         candidates = strategy.detect(src, "answer")
         names = _names(candidates)
         # question flows to both similarity_search AND llm.invoke
         assert "question" in names, f"question not detected; got {names}"
 
     def test_empty_function_returns_empty(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 pass
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         assert candidates == []
 
     def test_no_sinks_returns_empty(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 x = 42
                 y = x + 1
                 return y
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         assert candidates == []
 
     def test_existing_tvars_filtered(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 t = 0.7
                 m = "gpt-4"
                 result = llm.invoke(temperature=t, model=m)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn", context={"existing_tvars": {"t"}})
         names = _names(candidates)
         assert "t" not in names, "existing tvar should be filtered"
@@ -557,12 +627,14 @@ class TestDataFlowDetectionStrategy:
     def test_dedup_keeps_highest_confidence(self, strategy) -> None:
         # A variable detected via both direct kwarg and transitive path
         # should keep the higher confidence.
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 t = 0.7
                 result = llm.invoke(temperature=t)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         t_candidates = [c for c in candidates if c.name == "t"]
         assert len(t_candidates) == 1, "Should be deduplicated to 1"
@@ -572,39 +644,47 @@ class TestDataFlowDetectionStrategy:
         assert candidates == []
 
     def test_function_not_found_returns_empty(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def actual():
                 llm.invoke(temperature=0.7)
-        """)
+        """
+        )
         candidates = strategy.detect(src, "nonexistent")
         assert candidates == []
 
     def test_async_function_supported(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             async def fn():
                 result = await llm.ainvoke(temperature=0.7)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         names = _names(candidates)
         assert "temperature" in names
 
     def test_detection_source_is_dataflow(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 t = 0.7
                 llm.invoke(temperature=t)
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         for c in candidates:
             assert c.detection_source == "dataflow"
 
     def test_reasoning_includes_sink_info(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 t = 0.7
                 llm.invoke(temperature=t)
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "t")
         assert c is not None
@@ -649,12 +729,14 @@ class TestCodexReviewFixes:
 
     def test_generic_bare_name_not_matched(self, strategy) -> None:
         """P1: Bare `run(cmd)` should NOT be a sink (too generic)."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 cmd = "ls -la"
                 result = run(cmd)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         assert (
             candidates == []
@@ -662,24 +744,28 @@ class TestCodexReviewFixes:
 
     def test_generic_attribute_still_matched(self, strategy) -> None:
         """P1: `obj.run(cmd)` should still be a sink (attribute context)."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 prompt = "hello"
                 result = chain.run(prompt)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         names = _names(candidates)
         assert "prompt" in names, f"chain.run() should be a sink; got {names}"
 
     def test_generic_query_bare_not_matched(self, strategy) -> None:
         """P1: Bare `query(sql)` should NOT be a sink."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 sql = "SELECT 1"
                 result = query(sql)
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         assert (
             candidates == []
@@ -691,13 +777,15 @@ class TestCodexReviewFixes:
         x is reachable at hop 0 via model=x and at hop 2 via temperature=y -> z -> x.
         With BFS, x should get HIGH confidence (hop 0), not MEDIUM (hop 2).
         """
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 x = 0.7
                 z = x
                 y = z
                 llm.invoke(model=x, temperature=y)
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "x")
         assert c is not None, f"x not detected; got {_names(candidates)}"
@@ -707,11 +795,13 @@ class TestCodexReviewFixes:
 
     def test_existing_tvars_filters_literal_kwargs(self, strategy) -> None:
         """P3: existing_tvars should filter literal kwargs too."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 result = llm.invoke(temperature=0.7, model="gpt-4")
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(
             src, "fn", context={"existing_tvars": {"temperature"}}
         )

--- a/tests/unit/tuned_variables/test_detection_strategies.py
+++ b/tests/unit/tuned_variables/test_detection_strategies.py
@@ -131,11 +131,13 @@ class TestASTDetectionStrategy:
     # -- HIGH confidence: direct name match -----------------------------------
 
     def test_detects_temperature_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 temperature = 0.7
                 return temperature
-        """)
+        """
+        )
         candidates = strategy.detect(src, "my_func")
         c = _by_name(candidates, "temperature")
         assert c is not None, "temperature should be detected"
@@ -144,11 +146,13 @@ class TestASTDetectionStrategy:
         assert c.candidate_type == CandidateType.NUMERIC_CONTINUOUS
 
     def test_detects_model_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def call_llm():
                 model = "gpt-4"
                 return model
-        """)
+        """
+        )
         candidates = strategy.detect(src, "call_llm")
         c = _by_name(candidates, "model")
         assert c is not None, "model should be detected"
@@ -157,11 +161,13 @@ class TestASTDetectionStrategy:
         assert c.candidate_type == CandidateType.CATEGORICAL
 
     def test_detects_max_tokens_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def generate():
                 max_tokens = 1024
                 return max_tokens
-        """)
+        """
+        )
         candidates = strategy.detect(src, "generate")
         c = _by_name(candidates, "max_tokens")
         assert c is not None, "max_tokens should be detected"
@@ -170,11 +176,13 @@ class TestASTDetectionStrategy:
         assert c.candidate_type == CandidateType.NUMERIC_INTEGER
 
     def test_detects_annotated_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 temperature: float = 0.9
                 return temperature
-        """)
+        """
+        )
         candidates = strategy.detect(src, "my_func")
         c = _by_name(candidates, "temperature")
         assert c is not None, "annotated assignment should be detected"
@@ -184,11 +192,13 @@ class TestASTDetectionStrategy:
     # -- HIGH confidence: kwargs in API calls ---------------------------------
 
     def test_detects_kwarg_in_call(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 result = client.create(temperature=0.7, model="gpt-4")
                 return result
-        """)
+        """
+        )
         candidates = strategy.detect(src, "my_func")
         names = _names(candidates)
         assert "temperature" in names, f"temperature kwarg not detected; got {names}"
@@ -197,11 +207,13 @@ class TestASTDetectionStrategy:
         assert c.current_value == pytest.approx(0.7)
 
     def test_detects_model_kwarg_in_call(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def chat():
                 response = openai.ChatCompletion.create(model="gpt-4o", max_tokens=512)
                 return response
-        """)
+        """
+        )
         candidates = strategy.detect(src, "chat")
         names = _names(candidates)
         assert "model" in names, f"model kwarg not detected; got {names}"
@@ -210,11 +222,13 @@ class TestASTDetectionStrategy:
     # -- MEDIUM confidence: dict keys -----------------------------------------
 
     def test_detects_dict_key(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def build_config():
                 config = {"model": "gpt-4", "temperature": 0.5}
                 return config
-        """)
+        """
+        )
         candidates = strategy.detect(src, "build_config")
         names = _names(candidates)
         assert "model" in names, f"model dict key not detected; got {names}"
@@ -224,11 +238,13 @@ class TestASTDetectionStrategy:
     # -- MEDIUM confidence: fuzzy name match ----------------------------------
 
     def test_detects_fuzzy_match_temp(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 temp = 0.8
                 return temp
-        """)
+        """
+        )
         candidates = strategy.detect(src, "my_func")
         # "temp" is a known variant of "temperature" in the universal mapping,
         # so it gets HIGH confidence (direct known-param match), not MEDIUM.
@@ -243,11 +259,13 @@ class TestASTDetectionStrategy:
     # -- MEDIUM confidence: model string heuristic ----------------------------
 
     def test_detects_model_string_heuristic(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def infer():
                 llm_model = "claude-3-opus"
                 return llm_model
-        """)
+        """
+        )
         candidates = strategy.detect(src, "infer")
         # "llm_model" is not an exact match but "claude-3-opus" looks like a model
         assert (
@@ -264,11 +282,13 @@ class TestASTDetectionStrategy:
     # -- Skips ParameterRange assignments ------------------------------------
 
     def test_skips_parameter_range_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 temperature = Range(0.0, 2.0)
                 return temperature
-        """)
+        """
+        )
         candidates = strategy.detect(src, "my_func")
         c = _by_name(candidates, "temperature")
         assert (
@@ -276,11 +296,13 @@ class TestASTDetectionStrategy:
         ), "Variable already using ParameterRange must not be re-detected"
 
     def test_skips_choices_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 model = Choices(["gpt-4", "gpt-3.5-turbo"])
                 return model
-        """)
+        """
+        )
         candidates = strategy.detect(src, "my_func")
         c = _by_name(candidates, "model")
         assert c is None, "Variable already using Choices must not be re-detected"
@@ -288,22 +310,26 @@ class TestASTDetectionStrategy:
     # -- Nested scope isolation -----------------------------------------------
 
     def test_skips_nested_function_assignment(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def outer():
                 def inner():
                     temperature = 0.9
                 return inner
-        """)
+        """
+        )
         candidates = strategy.detect(src, "outer")
         c = _by_name(candidates, "temperature")
         assert c is None, "Assignment inside nested function must be ignored"
 
     def test_skips_existing_tvar_context(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 temperature = 0.7
                 return temperature
-        """)
+        """
+        )
         candidates = strategy.detect(
             src, "my_func", context={"existing_tvars": {"temperature"}}
         )
@@ -313,10 +339,12 @@ class TestASTDetectionStrategy:
     # -- Wrong function name returns nothing ----------------------------------
 
     def test_returns_empty_for_unknown_function(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def actual_func():
                 temperature = 0.7
-        """)
+        """
+        )
         candidates = strategy.detect(src, "nonexistent_func")
         assert candidates == [], "Should return empty list for unknown function"
 
@@ -330,10 +358,12 @@ class TestASTDetectionStrategy:
     # -- Suggested ranges are populated ---------------------------------------
 
     def test_suggested_range_populated_for_temperature(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = 0.7
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "temperature")
         assert c is not None
@@ -345,10 +375,12 @@ class TestASTDetectionStrategy:
         assert "Range(" in code
 
     def test_suggested_range_populated_for_model(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 model = "gpt-4"
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "model")
         assert c is not None
@@ -357,11 +389,13 @@ class TestASTDetectionStrategy:
 
     def test_non_literal_assignment_not_detected(self, strategy) -> None:
         """Variables assigned complex expressions (not literals) must be skipped."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = compute_temperature()
                 model = os.getenv("MODEL", "gpt-4")
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         # No literal value → cannot extract; should be empty
         assert (
@@ -370,11 +404,13 @@ class TestASTDetectionStrategy:
 
     def test_detects_stop_parameter_with_list_value(self, strategy) -> None:
         """'stop' parameter with a list of strings should be detected as CATEGORICAL."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 stop = ["\\n", "END"]
                 return stop
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "stop")
         assert c is not None, "stop parameter should be detected"
@@ -384,11 +420,13 @@ class TestASTDetectionStrategy:
 
     def test_detects_stream_parameter_with_bool_value(self, strategy) -> None:
         """'stream' parameter with a bool value should be detected as BOOLEAN."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 stream = True
                 return stream
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "stream")
         assert c is not None, "stream parameter should be detected"
@@ -397,10 +435,12 @@ class TestASTDetectionStrategy:
 
     def test_canonical_name_populated_for_variant(self, strategy) -> None:
         """Variant names (e.g. model_name) should map to canonical (model)."""
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 model_name = "gpt-4"
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "model_name")
         assert c is not None, "model_name should be detected as a known variant"
@@ -411,10 +451,12 @@ class TestASTDetectionStrategy:
     # -- Source location is set -----------------------------------------------
 
     def test_source_location_line_is_positive(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = 0.5
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
         c = _by_name(candidates, "temperature")
         assert c is not None
@@ -423,13 +465,15 @@ class TestASTDetectionStrategy:
     # -- Multiple candidates in same function ---------------------------------
 
     def test_detects_multiple_candidates(self, strategy) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def pipeline():
                 model = "gpt-4"
                 temperature = 0.7
                 max_tokens = 512
                 return model, temperature, max_tokens
-        """)
+        """
+        )
         candidates = strategy.detect(src, "pipeline")
         names = _names(candidates)
         assert "model" in names, f"model not detected; got {names}"
@@ -464,11 +508,13 @@ class TestLLMDetectionStrategy:
             return response
 
         strategy = LLMDetectionStrategy(llm_callable=mock_llm)
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = 0.7
                 model = "gpt-4"
-        """)
+        """
+        )
         candidates = strategy.detect(src, "fn")
 
         assert len(candidates) == 2, f"Expected 2 candidates, got {len(candidates)}"

--- a/tests/unit/tuned_variables/test_detector.py
+++ b/tests/unit/tuned_variables/test_detector.py
@@ -98,11 +98,13 @@ class TestDetectFromSource:
         return TunedVariableDetector()  # defaults to [ASTDetectionStrategy()]
 
     def test_detects_known_param_high_confidence(self, detector) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def my_func():
                 temperature = 0.7
                 return temperature
-        """)
+        """
+        )
         result = detector.detect_from_source(src, "my_func")
 
         assert result.function_name == "my_func"
@@ -113,12 +115,14 @@ class TestDetectFromSource:
         assert c.current_value == pytest.approx(0.7)
 
     def test_returns_empty_for_no_tvars(self, detector) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def simple():
                 x = 42
                 name = "Alice"
                 return x + len(name)
-        """)
+        """
+        )
         result = detector.detect_from_source(src, "simple")
         # No known LLM param names — count should be 0
         assert result.count == 0, f"Expected 0 candidates, got {result.count}"
@@ -136,11 +140,13 @@ class TestDetectFromSource:
         ), f"Expected 16-char hash, got: {result.source_hash!r}"
 
     def test_context_existing_tvars_skips_detected(self, detector) -> None:
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = 0.7
                 max_tokens = 512
-        """)
+        """
+        )
         result = detector.detect_from_source(
             src, "fn", context={"existing_tvars": {"temperature"}}
         )
@@ -158,10 +164,12 @@ class TestDetectFromSource:
         detector = TunedVariableDetector(
             strategies=[ASTDetectionStrategy(), LLMDetectionStrategy(mock_llm)]
         )
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = 0.7
-        """)
+        """
+        )
         result = detector.detect_from_source(src, "fn")
         c = _by_name(result.candidates, "temperature")
         assert c is not None
@@ -255,7 +263,8 @@ class TestDetectFromFile:
 
     @pytest.fixture
     def sample_py_file(self, tmp_path: Path) -> Path:
-        src = _dedent("""
+        src = _dedent(
+            """
             def agent_call():
                 model = "gpt-4"
                 temperature = 0.7
@@ -264,7 +273,8 @@ class TestDetectFromFile:
             def helper():
                 x = 42
                 return x
-        """)
+        """
+        )
         f = tmp_path / "agent.py"
         f.write_text(src)
         return f
@@ -410,12 +420,14 @@ class TestDetectorResultIntegration:
     def test_to_configuration_space_only_includes_high_medium(self) -> None:
         detector = TunedVariableDetector()
         # Only temperature (HIGH confidence) should appear in config space
-        src = _dedent("""
+        src = _dedent(
+            """
             def pipeline():
                 temperature = 0.7
                 model = "gpt-4"
                 max_tokens = 512
-        """)
+        """
+        )
         result = detector.detect_from_source(src, "pipeline")
 
         cs = result.to_configuration_space()
@@ -431,10 +443,12 @@ class TestDetectorResultIntegration:
 
     def test_high_confidence_property_filters_correctly(self) -> None:
         detector = TunedVariableDetector()
-        src = _dedent("""
+        src = _dedent(
+            """
             def fn():
                 temperature = 0.7
-        """)
+        """
+        )
         result = detector.detect_from_source(src, "fn")
         high = result.high_confidence
         for c in high:

--- a/tests/unit/wrapper/test_wrapper_cancelled_error.py
+++ b/tests/unit/wrapper/test_wrapper_cancelled_error.py
@@ -77,6 +77,7 @@ async def test_handle_evaluate_propagates_cancelled_error():
     request = {
         "request_id": "req_2",
         "tunable_id": "test_agent",
+        "benchmark_id": "bench_001",
         "config": {},
         "evaluations": [
             {

--- a/tests/unit/wrapper/test_wrapper_cancelled_error.py
+++ b/tests/unit/wrapper/test_wrapper_cancelled_error.py
@@ -42,15 +42,16 @@ async def test_handle_execute_propagates_cancelled_error():
 
     @svc.execute
     async def run_agent(
-        input_id: str, data: Any, config: dict[str, Any]
+        example_id: str, data: Any, config: dict[str, Any]
     ) -> dict[str, Any]:
         raise asyncio.CancelledError
 
     request = {
         "request_id": "req_1",
         "tunable_id": "test_agent",
+        "benchmark_id": "bench_001",
         "config": {},
-        "inputs": [{"input_id": "ex_0", "data": {"question": "hi"}}],
+        "examples": [{"example_id": "ex_0", "data": {"question": "hi"}}],
     }
 
     with pytest.raises(asyncio.CancelledError):
@@ -79,7 +80,7 @@ async def test_handle_evaluate_propagates_cancelled_error():
         "config": {},
         "evaluations": [
             {
-                "input_id": "ex_0",
+                "example_id": "ex_0",
                 "output": "some output",
                 "target": "expected",
             }

--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -201,7 +201,7 @@ class TestCreateAppRoutes:
             return {"model": {"type": "enum", "values": ["gpt-4"]}}
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok", "cost_usd": 0.01}
 
         @svc.evaluate
@@ -251,8 +251,9 @@ class TestCreateAppRoutes:
         """Test POST execute endpoint."""
         request_body = json.dumps(
             {
+                "benchmark_id": "bench_001",
                 "config": {"model": "gpt-4"},
-                "inputs": [{"input_id": "i1", "data": {"q": "hi"}}],
+                "examples": [{"example_id": "i1", "data": {"q": "hi"}}],
             }
         ).encode()
         send = _SendCollector()
@@ -272,7 +273,7 @@ class TestCreateAppRoutes:
         """Test POST evaluate endpoint."""
         request_body = json.dumps(
             {
-                "evaluations": [{"input_id": "e1", "output": "a", "target": "a"}],
+                "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         ).encode()
         send = _SendCollector()
@@ -380,7 +381,7 @@ class TestCreateAppErrorHandling:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
         app = create_app(svc)
@@ -401,7 +402,7 @@ class TestCreateAppErrorHandling:
         # No execute handler -> handle_execute raises ValueError
         app = create_app(svc)
         send = _SendCollector()
-        request_body = json.dumps({"inputs": []}).encode()
+        request_body = json.dumps({"examples": []}).encode()
         await app(
             _make_scope("POST", EXECUTE_PATH),
             _make_receive(request_body),
@@ -430,11 +431,16 @@ class TestCreateAppErrorHandling:
 
     @pytest.mark.asyncio
     async def test_empty_body_treated_as_empty_dict(self) -> None:
-        """Test that empty request body is treated as empty dict."""
+        """Test that empty request body is treated as empty dict.
+
+        An empty body becomes ``{}``, which lacks ``benchmark_id``.
+        The service returns a failed response with INVALID_REQUEST
+        (not a raised exception), so the server sends it back as 200.
+        """
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
         app = create_app(svc)
@@ -444,7 +450,8 @@ class TestCreateAppErrorHandling:
             _make_receive(b""),
             send,
         )
-        assert send.status == 400
+        assert send.status == 200
+        assert send.body_json["status"] == "failed"
         assert send.body_json["error"]["code"] == "INVALID_REQUEST"
 
 
@@ -651,7 +658,7 @@ class TestErrorHandling:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             raise BadRequestError(
                 "Invalid input format",
                 error_code="VALIDATION_ERROR",
@@ -662,7 +669,8 @@ class TestErrorHandling:
         request_body = json.dumps(
             {
                 "tunable_id": "default",
-                "inputs": [{"input_id": "i1", "data": {}}],
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i1", "data": {}}],
             }
         ).encode()
 
@@ -688,7 +696,7 @@ class TestErrorHandling:
         svc = TraigentService()
 
         @svc.execute
-        async def run(input_id, data, config):
+        async def run(example_id, data, config):
             await asyncio.sleep(2)  # Longer than timeout
             return {"output": "done"}
 
@@ -696,8 +704,9 @@ class TestErrorHandling:
         request_body = json.dumps(
             {
                 "tunable_id": "default",
+                "benchmark_id": "bench_001",
                 "timeout_ms": 1000,  # 1 second timeout
-                "inputs": [{"input_id": "i1", "data": {}}],
+                "examples": [{"example_id": "i1", "data": {}}],
             }
         ).encode()
 
@@ -720,14 +729,15 @@ class TestErrorHandling:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             raise RateLimitError(retry_after=60)
 
         app = create_app(svc)
         request_body = json.dumps(
             {
                 "tunable_id": "default",
-                "inputs": [{"input_id": "i1", "data": {}}],
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i1", "data": {}}],
             }
         ).encode()
 
@@ -758,7 +768,7 @@ class TestErrorHandling:
             {
                 "tunable_id": "default",
                 "timeout_ms": 1000,  # 1 second timeout
-                "evaluations": [{"input_id": "e1", "output": "a", "target": "a"}],
+                "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         ).encode()
 
@@ -781,14 +791,15 @@ class TestErrorHandling:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             raise RateLimitError(retry_after=60)
 
         app = create_app(svc)
         request_body = json.dumps(
             {
                 "tunable_id": "default",
-                "inputs": [{"input_id": "i1", "data": {}}],
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i1", "data": {}}],
             }
         ).encode()
 

--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -273,6 +273,7 @@ class TestCreateAppRoutes:
         """Test POST evaluate endpoint."""
         request_body = json.dumps(
             {
+                "benchmark_id": "bench_001",
                 "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         ).encode()
@@ -434,7 +435,7 @@ class TestCreateAppErrorHandling:
         """Test that empty request body is treated as empty dict.
 
         An empty body becomes ``{}``, which lacks ``benchmark_id``.
-        The service returns a failed response with INVALID_REQUEST
+        The service returns a failed response with INVALID_BENCHMARK_ID
         (not a raised exception), so the server sends it back as 200.
         """
         svc = TraigentService()
@@ -452,7 +453,7 @@ class TestCreateAppErrorHandling:
         )
         assert send.status == 200
         assert send.body_json["status"] == "failed"
-        assert send.body_json["error"]["code"] == "INVALID_REQUEST"
+        assert send.body_json["error"]["code"] == "INVALID_BENCHMARK_ID"
 
 
 # ---------------------------------------------------------------------------
@@ -767,6 +768,7 @@ class TestErrorHandling:
         request_body = json.dumps(
             {
                 "tunable_id": "default",
+                "benchmark_id": "bench_001",
                 "timeout_ms": 1000,  # 1 second timeout
                 "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -185,7 +185,7 @@ class TestDecorators:
         svc = TraigentService()
 
         @svc.execute
-        async def run(input_id, data, config):
+        async def run(example_id, data, config):
             return {"output": "ok"}
 
         assert svc._execute_handler is run
@@ -195,7 +195,7 @@ class TestDecorators:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "result"}
 
         assert run("id1", {}, {}) == {"output": "result"}
@@ -529,22 +529,23 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
-            return {"output": f"processed-{input_id}", "cost_usd": 0.01}
+        def run(example_id, data, config):
+            return {"output": f"processed-{example_id}", "cost_usd": 0.01}
 
         request = {
             "request_id": "req-1",
+            "benchmark_id": "bench_001",
             "config": {"temperature": 0.5},
-            "inputs": [
-                {"input_id": "i1", "data": {"query": "hello"}},
-                {"input_id": "i2", "data": {"query": "world"}},
+            "examples": [
+                {"example_id": "i1", "data": {"query": "hello"}},
+                {"example_id": "i2", "data": {"query": "world"}},
             ],
         }
         resp = await svc.handle_execute(request)
         assert resp["request_id"] == "req-1"
         assert resp["status"] == "completed"
         assert len(resp["outputs"]) == 2
-        assert resp["outputs"][0]["input_id"] == "i1"
+        assert resp["outputs"][0]["example_id"] == "i1"
         assert resp["outputs"][0]["output"] == "processed-i1"
         assert resp["outputs"][0]["cost_usd"] == 0.01
         assert resp["operational_metrics"]["total_cost_usd"] == pytest.approx(0.02)
@@ -555,10 +556,15 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        async def run(input_id, data, config):
+        async def run(example_id, data, config):
             return {"output": "async_result", "cost_usd": 0.05}
 
-        resp = await svc.handle_execute({"inputs": [{"input_id": "a1", "data": {}}]})
+        resp = await svc.handle_execute(
+            {
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "a1", "data": {}}],
+            }
+        )
         assert resp["status"] == "completed"
         assert resp["outputs"][0]["output"] == "async_result"
         assert resp["outputs"][0]["cost_usd"] == 0.05
@@ -569,10 +575,15 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return "plain_string_result"
 
-        resp = await svc.handle_execute({"inputs": [{"input_id": "x1", "data": {}}]})
+        resp = await svc.handle_execute(
+            {
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "x1", "data": {}}],
+            }
+        )
         assert resp["outputs"][0]["output"] == "plain_string_result"
         assert resp["outputs"][0]["cost_usd"] == 0.0
         assert "metrics" not in resp["outputs"][0]
@@ -583,12 +594,17 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             raise RuntimeError("boom")
 
-        resp = await svc.handle_execute({"inputs": [{"input_id": "e1", "data": {}}]})
+        resp = await svc.handle_execute(
+            {
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "e1", "data": {}}],
+            }
+        )
         assert resp["status"] == "failed"
-        assert resp["outputs"][0]["input_id"] == "e1"
+        assert resp["outputs"][0]["example_id"] == "e1"
         assert "boom" in resp["outputs"][0]["error"]
 
     @pytest.mark.asyncio
@@ -597,10 +613,15 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
-        resp = await svc.handle_execute({"inputs": [{"input_id": "i1", "data": {}}]})
+        resp = await svc.handle_execute(
+            {
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i1", "data": {}}],
+            }
+        )
         assert "request_id" in resp
         assert len(resp["request_id"]) > 0
 
@@ -611,15 +632,16 @@ class TestHandleExecute:
         call_count = {"n": 0}
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             call_count["n"] += 1
             return {"output": f"ok-{call_count['n']}"}
 
         request = {
             "request_id": "req-idem-1",
             "tunable_id": "default",
+            "benchmark_id": "bench_001",
             "config": {"temperature": 0.2},
-            "inputs": [{"input_id": "i1", "data": {}}],
+            "examples": [{"example_id": "i1", "data": {}}],
         }
         first = await svc.handle_execute(request)
         second = await svc.handle_execute(request)
@@ -633,14 +655,15 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
         base_request = {
             "request_id": "req-idem-2",
             "tunable_id": "default",
+            "benchmark_id": "bench_001",
             "config": {"temperature": 0.2},
-            "inputs": [{"input_id": "i1", "data": {}}],
+            "examples": [{"example_id": "i1", "data": {}}],
         }
         await svc.handle_execute(base_request)
 
@@ -649,8 +672,9 @@ class TestHandleExecute:
                 {
                     "request_id": "req-idem-2",
                     "tunable_id": "default",
+                    "benchmark_id": "bench_001",
                     "config": {"temperature": 0.7},
-                    "inputs": [{"input_id": "i1", "data": {}}],
+                    "examples": [{"example_id": "i1", "data": {}}],
                 }
             )
 
@@ -661,8 +685,8 @@ class TestHandleExecute:
         svc._idempotency_cache_max_size = 3  # Small cache for testing
 
         @svc.execute
-        def run(input_id, data, config):
-            return {"output": f"result-{input_id}"}
+        def run(example_id, data, config):
+            return {"output": f"result-{example_id}"}
 
         # Fill cache to capacity
         for i in range(3):
@@ -670,7 +694,8 @@ class TestHandleExecute:
                 {
                     "request_id": f"req-{i}",
                     "tunable_id": "default",
-                    "inputs": [{"input_id": f"i{i}", "data": {}}],
+                    "benchmark_id": "bench_001",
+                    "examples": [{"example_id": f"i{i}", "data": {}}],
                 }
             )
 
@@ -682,7 +707,8 @@ class TestHandleExecute:
             {
                 "request_id": "req-3",
                 "tunable_id": "default",
-                "inputs": [{"input_id": "i3", "data": {}}],
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i3", "data": {}}],
             }
         )
 
@@ -697,7 +723,7 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
         # Create request with non-JSON-serializable object
@@ -708,8 +734,9 @@ class TestHandleExecute:
         request = {
             "request_id": "req-custom",
             "tunable_id": "default",
+            "benchmark_id": "bench_001",
             "config": {"custom_param": CustomObj()},
-            "inputs": [{"input_id": "i1", "data": {}}],
+            "examples": [{"example_id": "i1", "data": {}}],
         }
 
         # Should not raise, should use repr() fallback
@@ -724,12 +751,16 @@ class TestHandleExecute:
         old_activity = svc._sessions[sid].last_activity
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
         time.sleep(0.01)
         resp = await svc.handle_execute(
-            {"session_id": sid, "inputs": [{"input_id": "i1", "data": {}}]}
+            {
+                "session_id": sid,
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i1", "data": {}}],
+            }
         )
         assert resp["session_id"] == sid
         assert svc._sessions[sid].last_activity > old_activity
@@ -740,11 +771,15 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
         resp = await svc.handle_execute(
-            {"session_id": "nonexistent", "inputs": [{"input_id": "i1", "data": {}}]}
+            {
+                "session_id": "nonexistent",
+                "benchmark_id": "bench_001",
+                "examples": [{"example_id": "i1", "data": {}}],
+            }
         )
         assert resp["status"] == "completed"
         assert resp["session_id"] == "nonexistent"
@@ -755,7 +790,7 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {
                 "output": "ok",
                 "cost_usd": 0.0,
@@ -764,10 +799,11 @@ class TestHandleExecute:
 
         resp = await svc.handle_execute(
             {
-                "inputs": [
-                    {"input_id": "i1", "data": {}},
-                    {"input_id": "i2", "data": {}},
-                ]
+                "benchmark_id": "bench_001",
+                "examples": [
+                    {"example_id": "i1", "data": {}},
+                    {"example_id": "i2", "data": {}},
+                ],
             }
         )
         assert "quality_metrics" in resp
@@ -779,23 +815,25 @@ class TestHandleExecute:
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             return {"output": "ok"}
 
-        with pytest.raises(ValueError, match="inputs must be a non-empty list"):
-            await svc.handle_execute({"inputs": []})
+        with pytest.raises(ValueError, match="examples must be a non-empty list"):
+            await svc.handle_execute({"benchmark_id": "bench_001", "examples": []})
 
     @pytest.mark.asyncio
-    async def test_input_without_input_id_gets_uuid(self) -> None:
-        """Test that inputs without input_id get a generated UUID."""
+    async def test_example_without_example_id_gets_uuid(self) -> None:
+        """Test that examples without example_id get a generated UUID."""
         svc = TraigentService()
 
         @svc.execute
-        def run(input_id, data, config):
-            return {"output": input_id}
+        def run(example_id, data, config):
+            return {"output": example_id}
 
-        resp = await svc.handle_execute({"inputs": [{"data": {"q": "test"}}]})
-        assert len(resp["outputs"][0]["input_id"]) > 0  # UUID generated
+        resp = await svc.handle_execute(
+            {"benchmark_id": "bench_001", "examples": [{"data": {"q": "test"}}]}
+        )
+        assert len(resp["outputs"][0]["example_id"]) > 0  # UUID generated
 
     @pytest.mark.asyncio
     async def test_input_data_defaults_to_input_dict(self) -> None:
@@ -804,12 +842,12 @@ class TestHandleExecute:
         received_data = {}
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             received_data["data"] = data
             return {"output": "ok"}
 
-        inp = {"input_id": "i1", "query": "hello"}
-        await svc.handle_execute({"inputs": [inp]})
+        inp = {"example_id": "i1", "query": "hello"}
+        await svc.handle_execute({"benchmark_id": "bench_001", "examples": [inp]})
         # When 'data' key is missing, the entire input dict is passed
         assert received_data["data"] == inp
 
@@ -841,8 +879,8 @@ class TestHandleEvaluate:
                 "request_id": "eval-1",
                 "config": {},
                 "evaluations": [
-                    {"input_id": "e1", "output": "a", "target": "a"},
-                    {"input_id": "e2", "output": "a", "target": "b"},
+                    {"example_id": "e1", "output": "a", "target": "a"},
+                    {"example_id": "e2", "output": "a", "target": "b"},
                 ],
             }
         )
@@ -866,7 +904,7 @@ class TestHandleEvaluate:
             return {"f1": 0.9}
 
         resp = await svc.handle_evaluate(
-            {"evaluations": [{"input_id": "a1", "output": "x", "target": "y"}]}
+            {"evaluations": [{"example_id": "a1", "output": "x", "target": "y"}]}
         )
         assert resp["results"][0]["metrics"]["f1"] == 0.9
 
@@ -880,7 +918,7 @@ class TestHandleEvaluate:
             return 0.75
 
         resp = await svc.handle_evaluate(
-            {"evaluations": [{"input_id": "a1", "output": "x", "target": "y"}]}
+            {"evaluations": [{"example_id": "a1", "output": "x", "target": "y"}]}
         )
         assert resp["results"][0]["metrics"] == {"score": 0.75}
 
@@ -894,7 +932,7 @@ class TestHandleEvaluate:
             raise ValueError("scoring failed")
 
         resp = await svc.handle_evaluate(
-            {"evaluations": [{"input_id": "e1", "output": "x", "target": "y"}]}
+            {"evaluations": [{"example_id": "e1", "output": "x", "target": "y"}]}
         )
         assert resp["status"] == "failed"
         assert resp["results"][0]["metrics"] == {}
@@ -915,7 +953,7 @@ class TestHandleEvaluate:
         await svc.handle_evaluate(
             {
                 "session_id": sid,
-                "evaluations": [{"input_id": "e1", "output": "a", "target": "a"}],
+                "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         )
         assert svc._sessions[sid].last_activity > old_activity
@@ -947,7 +985,7 @@ class TestHandleEvaluate:
         request = {
             "request_id": "eval-idem-1",
             "tunable_id": "default",
-            "evaluations": [{"input_id": "e1", "output": "a", "target": "a"}],
+            "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
         }
         first = await svc.handle_evaluate(request)
         second = await svc.handle_evaluate(request)
@@ -968,7 +1006,7 @@ class TestHandleEvaluate:
             {
                 "request_id": "eval-idem-2",
                 "tunable_id": "default",
-                "evaluations": [{"input_id": "e1", "output": "a", "target": "a"}],
+                "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         )
 
@@ -977,7 +1015,7 @@ class TestHandleEvaluate:
                 {
                     "request_id": "eval-idem-2",
                     "tunable_id": "default",
-                    "evaluations": [{"input_id": "e1", "output": "a", "target": "b"}],
+                    "evaluations": [{"example_id": "e1", "output": "a", "target": "b"}],
                 }
             )
 
@@ -998,7 +1036,7 @@ class TestHandleEvaluate:
                     "request_id": f"eval-{i}",
                     "tunable_id": "default",
                     "evaluations": [
-                        {"input_id": f"e{i}", "output": "a", "target": "a"}
+                        {"example_id": f"e{i}", "output": "a", "target": "a"}
                     ],
                 }
             )
@@ -1011,7 +1049,7 @@ class TestHandleEvaluate:
             {
                 "request_id": "eval-3",
                 "tunable_id": "default",
-                "evaluations": [{"input_id": "e3", "output": "a", "target": "a"}],
+                "evaluations": [{"example_id": "e3", "output": "a", "target": "a"}],
             }
         )
 
@@ -1301,14 +1339,16 @@ class TestHandleExecuteEdgeCases:
         received = {}
 
         @svc.execute
-        def run(input_id, data, config):
-            received["input_id"] = input_id
+        def run(example_id, data, config):
+            received["example_id"] = example_id
             received["data"] = data
             return {"output": "ok"}
 
-        resp = await svc.handle_execute({"inputs": ["raw_string"]})
+        resp = await svc.handle_execute(
+            {"benchmark_id": "bench_001", "examples": ["raw_string"]}
+        )
         assert resp["status"] == "completed"
-        assert len(received["input_id"]) > 0  # UUID generated
+        assert len(received["example_id"]) > 0  # UUID generated
 
     @pytest.mark.asyncio
     async def test_partial_status_on_mixed_success_and_failure(self) -> None:
@@ -1317,20 +1357,21 @@ class TestHandleExecuteEdgeCases:
         call_count = 0
 
         @svc.execute
-        def run(input_id, data, config):
+        def run(example_id, data, config):
             nonlocal call_count
             call_count += 1
             if call_count == 2:
                 raise RuntimeError("fail on second")
-            return {"output": f"ok-{input_id}"}
+            return {"output": f"ok-{example_id}"}
 
         resp = await svc.handle_execute(
             {
-                "inputs": [
-                    {"input_id": "i1", "data": {}},
-                    {"input_id": "i2", "data": {}},
-                    {"input_id": "i3", "data": {}},
-                ]
+                "benchmark_id": "bench_001",
+                "examples": [
+                    {"example_id": "i1", "data": {}},
+                    {"example_id": "i2", "data": {}},
+                    {"example_id": "i3", "data": {}},
+                ],
             }
         )
         assert resp["status"] == "partial"
@@ -1369,7 +1410,7 @@ class TestHandleEvaluateEdgeCases:
             {
                 "evaluations": [
                     {
-                        "input_id": "e1",
+                        "example_id": "e1",
                         "output_id": "out-123",
                         "target": "expected",
                     }
@@ -1390,7 +1431,7 @@ class TestHandleEvaluateEdgeCases:
         resp = await svc.handle_evaluate(
             {
                 "evaluations": [
-                    {"input_id": "e1", "output": "a", "target": "a"},
+                    {"example_id": "e1", "output": "a", "target": "a"},
                 ]
             }
         )

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -877,6 +877,7 @@ class TestHandleEvaluate:
         resp = await svc.handle_evaluate(
             {
                 "request_id": "eval-1",
+                "benchmark_id": "bench_001",
                 "config": {},
                 "evaluations": [
                     {"example_id": "e1", "output": "a", "target": "a"},
@@ -904,7 +905,10 @@ class TestHandleEvaluate:
             return {"f1": 0.9}
 
         resp = await svc.handle_evaluate(
-            {"evaluations": [{"example_id": "a1", "output": "x", "target": "y"}]}
+            {
+                "benchmark_id": "bench_001",
+                "evaluations": [{"example_id": "a1", "output": "x", "target": "y"}],
+            }
         )
         assert resp["results"][0]["metrics"]["f1"] == 0.9
 
@@ -918,7 +922,10 @@ class TestHandleEvaluate:
             return 0.75
 
         resp = await svc.handle_evaluate(
-            {"evaluations": [{"example_id": "a1", "output": "x", "target": "y"}]}
+            {
+                "benchmark_id": "bench_001",
+                "evaluations": [{"example_id": "a1", "output": "x", "target": "y"}],
+            }
         )
         assert resp["results"][0]["metrics"] == {"score": 0.75}
 
@@ -932,7 +939,10 @@ class TestHandleEvaluate:
             raise ValueError("scoring failed")
 
         resp = await svc.handle_evaluate(
-            {"evaluations": [{"example_id": "e1", "output": "x", "target": "y"}]}
+            {
+                "benchmark_id": "bench_001",
+                "evaluations": [{"example_id": "e1", "output": "x", "target": "y"}],
+            }
         )
         assert resp["status"] == "failed"
         assert resp["results"][0]["metrics"] == {}
@@ -953,6 +963,7 @@ class TestHandleEvaluate:
         await svc.handle_evaluate(
             {
                 "session_id": sid,
+                "benchmark_id": "bench_001",
                 "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         )
@@ -967,7 +978,9 @@ class TestHandleEvaluate:
         def score(output, target, config):
             return {"accuracy": 1.0}
 
-        resp = await svc.handle_evaluate({"evaluations": []})
+        resp = await svc.handle_evaluate(
+            {"benchmark_id": "bench_001", "evaluations": []}
+        )
         assert resp["results"] == []
         assert resp["aggregate_metrics"] == {}
 
@@ -985,6 +998,7 @@ class TestHandleEvaluate:
         request = {
             "request_id": "eval-idem-1",
             "tunable_id": "default",
+            "benchmark_id": "bench_001",
             "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
         }
         first = await svc.handle_evaluate(request)
@@ -1006,6 +1020,7 @@ class TestHandleEvaluate:
             {
                 "request_id": "eval-idem-2",
                 "tunable_id": "default",
+                "benchmark_id": "bench_001",
                 "evaluations": [{"example_id": "e1", "output": "a", "target": "a"}],
             }
         )
@@ -1015,6 +1030,7 @@ class TestHandleEvaluate:
                 {
                     "request_id": "eval-idem-2",
                     "tunable_id": "default",
+                    "benchmark_id": "bench_001",
                     "evaluations": [{"example_id": "e1", "output": "a", "target": "b"}],
                 }
             )
@@ -1035,6 +1051,7 @@ class TestHandleEvaluate:
                 {
                     "request_id": f"eval-{i}",
                     "tunable_id": "default",
+                    "benchmark_id": "bench_001",
                     "evaluations": [
                         {"example_id": f"e{i}", "output": "a", "target": "a"}
                     ],
@@ -1049,6 +1066,7 @@ class TestHandleEvaluate:
             {
                 "request_id": "eval-3",
                 "tunable_id": "default",
+                "benchmark_id": "bench_001",
                 "evaluations": [{"example_id": "e3", "output": "a", "target": "a"}],
             }
         )
@@ -1393,7 +1411,9 @@ class TestHandleEvaluateEdgeCases:
             return {"accuracy": 1.0}
 
         with pytest.raises(ValueError, match="evaluations must be a list"):
-            await svc.handle_evaluate({"evaluations": "not_a_list"})
+            await svc.handle_evaluate(
+                {"benchmark_id": "bench_001", "evaluations": "not_a_list"}
+            )
 
     @pytest.mark.asyncio
     async def test_evaluation_with_output_id(self) -> None:
@@ -1408,13 +1428,14 @@ class TestHandleEvaluateEdgeCases:
 
         await svc.handle_evaluate(
             {
+                "benchmark_id": "bench_001",
                 "evaluations": [
                     {
                         "example_id": "e1",
                         "output_id": "out-123",
                         "target": "expected",
                     }
-                ]
+                ],
             }
         )
         assert received_output["output"] == {"output_id": "out-123"}
@@ -1430,9 +1451,10 @@ class TestHandleEvaluateEdgeCases:
 
         resp = await svc.handle_evaluate(
             {
+                "benchmark_id": "bench_001",
                 "evaluations": [
                     {"example_id": "e1", "output": "a", "target": "a"},
-                ]
+                ],
             }
         )
         agg = resp["aggregate_metrics"]

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -1775,7 +1775,9 @@ def check(
             )
             return
 
-        console.print("\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]")
+        console.print(
+            "\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]"
+        )
         validator = OptimizationValidator(threshold_pct=threshold)
 
         async def run_validations() -> tuple[list[Any], int, int]:

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -1775,9 +1775,7 @@ def check(
             )
             return
 
-        console.print(
-            "\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]"
-        )
+        console.print("\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]")
         validator = OptimizationValidator(threshold_pct=threshold)
 
         async def run_validations() -> tuple[list[Any], int, int]:

--- a/traigent/core/ci_approval.py
+++ b/traigent/core/ci_approval.py
@@ -197,8 +197,7 @@ def check_ci_approval(traigent_config: TraigentConfig) -> None:
     if _check_token_file_approval(token_file, storage_root):
         return
 
-    raise OptimizationError(
-        """
+    raise OptimizationError("""
 CI/CD Approval Required
 
 This optimization was triggered in a CI environment and requires approval.
@@ -214,5 +213,4 @@ To approve, use one of these methods:
 
 3. GitHub Actions with environment protection:
    Use 'environment: production' with required reviewers
-        """
-    )
+        """)

--- a/traigent/core/ci_approval.py
+++ b/traigent/core/ci_approval.py
@@ -197,7 +197,8 @@ def check_ci_approval(traigent_config: TraigentConfig) -> None:
     if _check_token_file_approval(token_file, storage_root):
         return
 
-    raise OptimizationError("""
+    raise OptimizationError(
+        """
 CI/CD Approval Required
 
 This optimization was triggered in a CI environment and requires approval.
@@ -213,4 +214,5 @@ To approve, use one of these methods:
 
 3. GitHub Actions with environment protection:
    Use 'environment: production' with required reviewers
-        """)
+        """
+    )

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -411,7 +411,7 @@ class OptimizedFunction:
         self.max_trials = kwargs.pop("max_trials", 50)
         kwargs["max_trials"] = self.max_trials
 
-        self.timeout = kwargs.pop("timeout", 60.0)
+        self.timeout = kwargs.pop("timeout", None)
         kwargs["timeout"] = self.timeout
 
         save_to_value = kwargs.pop("save_to", sentinel)
@@ -666,7 +666,7 @@ class OptimizedFunction:
         if self.max_trials < 0:
             raise ValueError("max_trials must be non-negative")
 
-        if self.timeout < 0:
+        if self.timeout is not None and self.timeout < 0:
             raise ValueError("timeout must be non-negative")
 
     def _validate_configuration(self) -> None:

--- a/traigent/core/stat_significance.py
+++ b/traigent/core/stat_significance.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Literal
 
 from traigent.tvl.statistics import paired_comparison_test
 
@@ -96,7 +97,7 @@ def find_equivalence_group(
     )
 
     # Direction for paired t-test
-    direction = "greater" if higher_is_better else "less"
+    direction: Literal["greater", "less"] = "greater" if higher_is_better else "less"
 
     # Build top group greedily
     top_group = [sorted_trials[0]]

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -281,14 +281,15 @@ class HybridAPIEvaluator(BaseEvaluator):
             entry for entry in resp.benchmarks if tid in entry.tunable_ids
         ]
 
-        # Large payload guard
-        total_example_ids = sum(len(e.example_ids) for e in resp.benchmarks)
+        # Large payload guard — check only benchmarks matched to this tunable
+        total_example_ids = sum(len(e.example_ids) for e in matching)
         if total_example_ids > 10000:
             logger.warning(
-                "Benchmarks response contains %d total example_ids across %d "
-                "benchmarks; consider filtering by benchmark_id to reduce payload",
+                "Matched benchmarks contain %d total example_ids across %d "
+                "benchmarks for tunable %r; consider limiting dataset size",
                 total_example_ids,
-                len(resp.benchmarks),
+                len(matching),
+                tid,
             )
 
         # Benchmark selection logic

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -25,6 +25,7 @@ from traigent.hybrid import (
     HybridEvaluateRequest,
     HybridExecuteRequest,
     HybridTransport,
+    InputsResponse,
     ServiceCapabilities,
     TransportError,
     create_transport,
@@ -236,6 +237,62 @@ class HybridAPIEvaluator(BaseEvaluator):
             self._tunable_id = self._discovery.get_tunable_id()
 
         return config_space
+
+    async def discover_input_ids(
+        self,
+        tunable_id: str | None = None,
+        *,
+        limit: int = 10000,
+    ) -> list[str]:
+        """Discover available input IDs from the external service.
+
+        Fetches all input IDs via the /inputs endpoint with pagination.
+
+        Args:
+            tunable_id: Tunable to list inputs for.
+                Falls back to self._tunable_id if not provided.
+            limit: Page size for pagination (max 10000).
+
+        Returns:
+            Complete list of input IDs for the tunable.
+
+        Raises:
+            TransportError: If discovery fails.
+            ValueError: If no tunable_id is available.
+        """
+        tid = tunable_id or self._tunable_id
+        if not tid:
+            raise ValueError(
+                "tunable_id is required for input discovery. "
+                "Set it explicitly or call discover_config_space() first."
+            )
+
+        transport = await self._get_transport()
+        all_ids: list[str] = []
+        offset = 0
+
+        while True:
+            resp: InputsResponse = await transport.inputs(
+                tid, limit=limit, offset=offset
+            )
+            all_ids.extend(resp.input_ids)
+            if not resp.has_more:
+                break
+            if not resp.input_ids:
+                logger.warning(
+                    "Server returned has_more=true with empty page at offset %d; "
+                    "stopping pagination to avoid infinite loop",
+                    offset,
+                )
+                break
+            offset += len(resp.input_ids)
+
+        logger.info(
+            "Discovered %d input IDs for tunable %s",
+            len(all_ids),
+            tid,
+        )
+        return all_ids
 
     async def _ensure_lifecycle_manager(self) -> None:
         """Ensure lifecycle manager is initialized if keep-alive enabled."""

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -876,6 +876,7 @@ class HybridAPIEvaluator(BaseEvaluator):
             evaluations.append(evaluation)
 
         # Call evaluate
+        assert self._benchmark_id is not None  # guaranteed by _ensure_benchmark_id
         eval_request = HybridEvaluateRequest(
             tunable_id=self._tunable_id or "default",
             benchmark_id=self._benchmark_id,

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -682,9 +682,14 @@ class HybridAPIEvaluator(BaseEvaluator):
             )
 
         # Build execute request
+        if not self._benchmark_id:
+            raise ValueError(
+                "benchmark_id is required but not set. "
+                "Ensure the service exposes a /benchmarks endpoint."
+            )
         request = HybridExecuteRequest(
             tunable_id=self._tunable_id or "default",
-            benchmark_id=self._benchmark_id or "",
+            benchmark_id=self._benchmark_id,
             config=config,
             examples=inputs,
             session_id=self._session_id,
@@ -856,7 +861,7 @@ class HybridAPIEvaluator(BaseEvaluator):
         # Call evaluate
         eval_request = HybridEvaluateRequest(
             tunable_id=self._tunable_id or "default",
-            benchmark_id=self._benchmark_id or "",
+            benchmark_id=self._benchmark_id,
             execution_id=execute_response.execution_id,
             evaluations=evaluations,
             session_id=self._session_id,

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -875,8 +875,12 @@ class HybridAPIEvaluator(BaseEvaluator):
             evaluation[target_key] = target_value
             evaluations.append(evaluation)
 
-        # Call evaluate
-        assert self._benchmark_id is not None  # guaranteed by _ensure_benchmark_id
+        # Call evaluate — _benchmark_id guaranteed by _ensure_benchmark_id
+        if not self._benchmark_id:
+            raise ValueError(
+                "benchmark_id is required but not set. "
+                "Ensure the service exposes a /benchmarks endpoint."
+            )
         eval_request = HybridEvaluateRequest(
             tunable_id=self._tunable_id or "default",
             benchmark_id=self._benchmark_id,

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -175,6 +175,7 @@ class HybridAPIEvaluator(BaseEvaluator):
         self._session_id: str | None = None
         self._optimization_spec: dict[str, Any] | None = None
         self._benchmark_id: str | None = None
+        self._benchmark_lock = asyncio.Lock()
 
     @property
     def lifecycle_manager(self) -> AgentLifecycleManager | None:
@@ -327,6 +328,19 @@ class HybridAPIEvaluator(BaseEvaluator):
             tid,
         )
         return selected.example_ids
+
+    async def _ensure_benchmark_id(self) -> None:
+        """Ensure ``_benchmark_id`` is populated, discovering it if needed.
+
+        Uses a lock with double-check to avoid duplicate discovery calls
+        when parallel trials start simultaneously.
+        """
+        if self._benchmark_id:
+            return
+        async with self._benchmark_lock:
+            if self._benchmark_id:
+                return  # another coroutine resolved it while we waited
+            await self.discover_example_ids()
 
     async def _ensure_lifecycle_manager(self) -> None:
         """Ensure lifecycle manager is initialized if keep-alive enabled."""
@@ -566,6 +580,9 @@ class HybridAPIEvaluator(BaseEvaluator):
         transport = await self._get_transport()
         caps = await self._get_capabilities()
 
+        # Ensure benchmark_id is resolved before any batch execution
+        await self._ensure_benchmark_id()
+
         # Initialize lifecycle manager if needed
         await self._ensure_lifecycle_manager()
 
@@ -681,7 +698,7 @@ class HybridAPIEvaluator(BaseEvaluator):
                 }
             )
 
-        # Build execute request
+        # Safety guard: benchmark_id should have been resolved by evaluate()
         if not self._benchmark_id:
             raise ValueError(
                 "benchmark_id is required but not set. "

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -21,11 +21,12 @@ from traigent.evaluators.base import BaseEvaluator, Dataset, EvaluationResult
 from traigent.hybrid import (
     AgentLifecycleManager,
     BatchOptions,
+    BenchmarkEntry,
+    BenchmarksResponse,
     ConfigSpaceDiscovery,
     HybridEvaluateRequest,
     HybridExecuteRequest,
     HybridTransport,
-    InputsResponse,
     ServiceCapabilities,
     TransportError,
     create_transport,
@@ -47,7 +48,7 @@ class HybridExampleResult:
     """Result for a single example in hybrid evaluation.
 
     Attributes:
-        input_id: Identifier for the input example
+        example_id: Identifier for the example
         actual_output: Output produced by the agent
         expected_output: Expected output (from dataset)
         metrics: Per-example quality metrics
@@ -56,7 +57,7 @@ class HybridExampleResult:
         error: Error message if failed
     """
 
-    input_id: str
+    example_id: str
     actual_output: Any = None
     expected_output: Any = None
     metrics: dict[str, float] = field(default_factory=dict)
@@ -173,6 +174,7 @@ class HybridAPIEvaluator(BaseEvaluator):
         self._capabilities: ServiceCapabilities | None = None
         self._session_id: str | None = None
         self._optimization_spec: dict[str, Any] | None = None
+        self._benchmark_id: str | None = None
 
     @property
     def lifecycle_manager(self) -> AgentLifecycleManager | None:
@@ -238,61 +240,93 @@ class HybridAPIEvaluator(BaseEvaluator):
 
         return config_space
 
-    async def discover_input_ids(
+    async def discover_example_ids(
         self,
         tunable_id: str | None = None,
         *,
-        limit: int = 10000,
+        benchmark_id: str | None = None,
     ) -> list[str]:
-        """Discover available input IDs from the external service.
+        """Discover available example IDs from the external service.
 
-        Fetches all input IDs via the /inputs endpoint with pagination.
+        Fetches benchmarks via the /benchmarks endpoint and selects the
+        appropriate benchmark for the given tunable.
 
         Args:
-            tunable_id: Tunable to list inputs for.
+            tunable_id: Tunable to list examples for.
                 Falls back to self._tunable_id if not provided.
-            limit: Page size for pagination (max 10000).
+            benchmark_id: Explicit benchmark to use. Required when
+                multiple benchmarks match the tunable.
 
         Returns:
-            Complete list of input IDs for the tunable.
+            List of example IDs from the selected benchmark.
 
         Raises:
             TransportError: If discovery fails.
-            ValueError: If no tunable_id is available.
+            ValueError: If no tunable_id is available, no benchmarks match,
+                or multiple benchmarks match without an explicit benchmark_id.
         """
         tid = tunable_id or self._tunable_id
         if not tid:
             raise ValueError(
-                "tunable_id is required for input discovery. "
+                "tunable_id is required for example discovery. "
                 "Set it explicitly or call discover_config_space() first."
             )
 
         transport = await self._get_transport()
-        all_ids: list[str] = []
-        offset = 0
+        resp: BenchmarksResponse = await transport.benchmarks(tunable_id=tid)
 
-        while True:
-            resp: InputsResponse = await transport.inputs(
-                tid, limit=limit, offset=offset
+        # Filter benchmarks where this tunable is linked
+        matching: list[BenchmarkEntry] = [
+            entry for entry in resp.benchmarks if tid in entry.tunable_ids
+        ]
+
+        # Large payload guard
+        total_example_ids = sum(len(e.example_ids) for e in resp.benchmarks)
+        if total_example_ids > 10000:
+            logger.warning(
+                "Benchmarks response contains %d total example_ids across %d "
+                "benchmarks; consider filtering by benchmark_id to reduce payload",
+                total_example_ids,
+                len(resp.benchmarks),
             )
-            all_ids.extend(resp.input_ids)
-            if not resp.has_more:
-                break
-            if not resp.input_ids:
-                logger.warning(
-                    "Server returned has_more=true with empty page at offset %d; "
-                    "stopping pagination to avoid infinite loop",
-                    offset,
+
+        # Benchmark selection logic
+        if len(matching) == 0:
+            available = [e.benchmark_id for e in resp.benchmarks]
+            raise ValueError(
+                f"No benchmarks found for tunable_id={tid!r}. "
+                f"Available benchmarks: {available}"
+            )
+        elif len(matching) == 1:
+            selected = matching[0]
+        else:
+            # Multiple matches
+            if benchmark_id is not None:
+                candidates = [e for e in matching if e.benchmark_id == benchmark_id]
+                if not candidates:
+                    available = [e.benchmark_id for e in matching]
+                    raise ValueError(
+                        f"benchmark_id={benchmark_id!r} not found among "
+                        f"benchmarks for tunable_id={tid!r}. "
+                        f"Available: {available}"
+                    )
+                selected = candidates[0]
+            else:
+                available = [e.benchmark_id for e in matching]
+                raise ValueError(
+                    f"Multiple benchmarks match tunable_id={tid!r}: {available}. "
+                    f"Pass benchmark_id= to select one."
                 )
-                break
-            offset += len(resp.input_ids)
+
+        self._benchmark_id = selected.benchmark_id
 
         logger.info(
-            "Discovered %d input IDs for tunable %s",
-            len(all_ids),
+            "Selected benchmark %s with %d example IDs for tunable %s",
+            selected.benchmark_id,
+            len(selected.example_ids),
             tid,
         )
-        return all_ids
+        return selected.example_ids
 
     async def _ensure_lifecycle_manager(self) -> None:
         """Ensure lifecycle manager is initialized if keep-alive enabled."""
@@ -330,11 +364,11 @@ class HybridAPIEvaluator(BaseEvaluator):
     @staticmethod
     def _find_output_item(
         outputs: list[dict[str, Any]],
-        input_id: str,
+        example_id: str,
     ) -> dict[str, Any]:
-        """Find output item for an input_id."""
+        """Find output item for an example_id."""
         for out in outputs:
-            if out.get("input_id") == input_id:
+            if out.get("example_id") == example_id:
                 return out
         return {}
 
@@ -635,14 +669,14 @@ class HybridAPIEvaluator(BaseEvaluator):
         Returns:
             List of results for each example.
         """
-        # Prepare inputs
+        # Prepare examples list
         inputs = []
         for i, example in enumerate(batch):
             input_data = self._extract_input(example)
-            input_id = input_data.get("input_id", f"ex_{i}")
+            example_id = input_data.get("example_id", f"ex_{i}")
             inputs.append(
                 {
-                    "input_id": input_id,
+                    "example_id": example_id,
                     "data": input_data,
                 }
             )
@@ -650,8 +684,9 @@ class HybridAPIEvaluator(BaseEvaluator):
         # Build execute request
         request = HybridExecuteRequest(
             tunable_id=self._tunable_id or "default",
+            benchmark_id=self._benchmark_id or "",
             config=config,
-            inputs=inputs,
+            examples=inputs,
             session_id=self._session_id,
             batch_options=BatchOptions(
                 parallelism=self._batch_parallelism,
@@ -699,7 +734,7 @@ class HybridAPIEvaluator(BaseEvaluator):
             # Return error results for all examples
             return [
                 HybridExampleResult(
-                    input_id=inp["input_id"],
+                    example_id=inp["example_id"],
                     expected_output=self._extract_expected(batch[i]),
                     error=str(e),
                 )
@@ -754,11 +789,11 @@ class HybridAPIEvaluator(BaseEvaluator):
         )
 
         for i, inp in enumerate(inputs):
-            input_id = inp["input_id"]
+            example_id = inp["example_id"]
             expected = self._extract_expected(batch[i])
 
             # Find matching output
-            output_item = self._find_output_item(response.outputs, input_id)
+            output_item = self._find_output_item(response.outputs, example_id)
             output_data = output_item.get("output")
             if output_data is None and "output_id" in output_item:
                 output_data = {"output_id": output_item["output_id"]}
@@ -777,7 +812,7 @@ class HybridAPIEvaluator(BaseEvaluator):
 
             results.append(
                 HybridExampleResult(
-                    input_id=input_id,
+                    example_id=example_id,
                     actual_output=output_data,
                     expected_output=expected,
                     metrics=per_example_metrics,
@@ -800,13 +835,13 @@ class HybridAPIEvaluator(BaseEvaluator):
         # Build evaluations with output + target pairs
         evaluations = []
         for i, inp in enumerate(inputs):
-            input_id = inp["input_id"]
+            example_id = inp["example_id"]
             expected = self._extract_expected(batch[i])
 
             # Find matching output
-            output_item = self._find_output_item(execute_response.outputs, input_id)
+            output_item = self._find_output_item(execute_response.outputs, example_id)
 
-            evaluation: dict[str, Any] = {"input_id": input_id}
+            evaluation: dict[str, Any] = {"example_id": example_id}
             if "output" in output_item:
                 evaluation["output"] = output_item.get("output")
             elif "output_id" in output_item:
@@ -821,6 +856,7 @@ class HybridAPIEvaluator(BaseEvaluator):
         # Call evaluate
         eval_request = HybridEvaluateRequest(
             tunable_id=self._tunable_id or "default",
+            benchmark_id=self._benchmark_id or "",
             execution_id=execute_response.execution_id,
             evaluations=evaluations,
             session_id=self._session_id,
@@ -834,7 +870,7 @@ class HybridAPIEvaluator(BaseEvaluator):
             logger.info(
                 "Hybrid evaluate response: results=%s, aggregate=%s",
                 [
-                    {"input_id": r.get("input_id"), "metrics": r.get("metrics")}
+                    {"example_id": r.get("example_id"), "metrics": r.get("metrics")}
                     for r in eval_response.results
                 ],
                 getattr(eval_response, "aggregate_metrics", None),
@@ -849,11 +885,13 @@ class HybridAPIEvaluator(BaseEvaluator):
                 execute_response.operational_metrics.get("latency_ms", 0.0)
             )
             for i, inp in enumerate(inputs):
-                input_id = inp["input_id"]
+                example_id = inp["example_id"]
                 expected = self._extract_expected(batch[i])
 
                 # Find output from execute
-                output_item = self._find_output_item(execute_response.outputs, input_id)
+                output_item = self._find_output_item(
+                    execute_response.outputs, example_id
+                )
                 output_data = output_item.get("output")
                 if output_data is None and "output_id" in output_item:
                     output_data = {"output_id": output_item["output_id"]}
@@ -864,7 +902,7 @@ class HybridAPIEvaluator(BaseEvaluator):
                 eval_error: str | None = None
                 eval_expected: str | None = None
                 for result in eval_response.results:
-                    if result.get("input_id") == input_id:
+                    if result.get("example_id") == example_id:
                         per_example_metrics = self._normalize_example_metrics(
                             result.get("metrics", {})
                         )
@@ -882,10 +920,10 @@ class HybridAPIEvaluator(BaseEvaluator):
 
                 # Log raw per-example result for observability
                 logger.info(
-                    "Hybrid example result: input_id=%s, "
+                    "Hybrid example result: example_id=%s, "
                     "output_id=%s, accuracy=%s, cost=%.6f, "
                     "latency=%.0fms, error=%s",
-                    input_id,
+                    example_id,
                     output_item.get("output_id"),
                     per_example_metrics.get("accuracy"),
                     cost,
@@ -895,7 +933,7 @@ class HybridAPIEvaluator(BaseEvaluator):
 
                 results.append(
                     HybridExampleResult(
-                        input_id=input_id,
+                        example_id=example_id,
                         actual_output=output_data,
                         expected_output=expected or eval_expected,
                         metrics=per_example_metrics,
@@ -930,11 +968,11 @@ class HybridAPIEvaluator(BaseEvaluator):
         )
 
         for i, inp in enumerate(inputs):
-            input_id = inp["input_id"]
+            example_id = inp["example_id"]
             expected = self._extract_expected(batch[i])
 
             # Find matching output
-            output_item = self._find_output_item(response.outputs, input_id)
+            output_item = self._find_output_item(response.outputs, example_id)
             output_data = output_item.get("output")
             if output_data is None and "output_id" in output_item:
                 output_data = {"output_id": output_item["output_id"]}
@@ -949,7 +987,7 @@ class HybridAPIEvaluator(BaseEvaluator):
 
             results.append(
                 HybridExampleResult(
-                    input_id=input_id,
+                    example_id=example_id,
                     actual_output=output_data,
                     expected_output=expected,
                     metrics=per_example_metrics,

--- a/traigent/hybrid/__init__.py
+++ b/traigent/hybrid/__init__.py
@@ -25,7 +25,7 @@ Usage:
         HybridExecuteRequest(
             tunable_id="my_agent",
             config={"temperature": 0.7},
-            inputs=[{"input_id": "1", "data": {...}}],
+            examples=[{"example_id": "1", "data": {...}}],
         )
     )
 """
@@ -41,13 +41,14 @@ from traigent.hybrid.discovery import (
 from traigent.hybrid.lifecycle import AgentLifecycleManager, SessionInfo
 from traigent.hybrid.protocol import (
     BatchOptions,
+    BenchmarkEntry,
+    BenchmarksResponse,
     ConfigSpaceResponse,
     HealthCheckResponse,
     HybridEvaluateRequest,
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
-    InputsResponse,
     ServiceCapabilities,
     TVARDefinition,
 )
@@ -82,7 +83,8 @@ __all__ = [
     "ServiceCapabilities",
     "TVARDefinition",
     "ConfigSpaceResponse",
-    "InputsResponse",
+    "BenchmarkEntry",
+    "BenchmarksResponse",
     "HealthCheckResponse",
     # Lifecycle
     "AgentLifecycleManager",

--- a/traigent/hybrid/__init__.py
+++ b/traigent/hybrid/__init__.py
@@ -47,6 +47,7 @@ from traigent.hybrid.protocol import (
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
+    InputsResponse,
     ServiceCapabilities,
     TVARDefinition,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "ServiceCapabilities",
     "TVARDefinition",
     "ConfigSpaceResponse",
+    "InputsResponse",
     "HealthCheckResponse",
     # Lifecycle
     "AgentLifecycleManager",

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -20,6 +20,7 @@ from traigent.hybrid.protocol import (
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
+    InputsResponse,
     ServiceCapabilities,
 )
 from traigent.hybrid.transport import (
@@ -50,6 +51,7 @@ class HTTPTransport:
     # API endpoint paths (relative to base_url)
     CAPABILITIES_PATH = "/traigent/v1/capabilities"
     CONFIG_SPACE_PATH = "/traigent/v1/config-space"
+    INPUTS_PATH = "/traigent/v1/inputs"
     EXECUTE_PATH = "/traigent/v1/execute"
     EVALUATE_PATH = "/traigent/v1/evaluate"
     HEALTH_PATH = "/traigent/v1/health"
@@ -301,6 +303,34 @@ class HTTPTransport:
             params = {"tunable_id": tunable_id}
         data = await self._request("GET", self.CONFIG_SPACE_PATH, params=params)
         return ConfigSpaceResponse.from_dict(data)
+
+    async def inputs(
+        self,
+        tunable_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> InputsResponse:
+        """Discover available benchmark input IDs for a tunable.
+
+        Args:
+            tunable_id: The tunable to list inputs for.
+            limit: Maximum number of input IDs per page (1-10000).
+            offset: Number of input IDs to skip for pagination.
+
+        Returns:
+            InputsResponse with paginated input IDs and total count.
+
+        Raises:
+            TransportError: If discovery fails or tunable_id is unknown.
+        """
+        params: dict[str, str] = {"tunable_id": tunable_id}
+        if limit != 100:
+            params["limit"] = str(limit)
+        if offset != 0:
+            params["offset"] = str(offset)
+        data = await self._request("GET", self.INPUTS_PATH, params=params)
+        return InputsResponse.from_dict(data)
 
     async def execute(
         self,

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -14,13 +14,13 @@ from typing import Any
 import httpx
 
 from traigent.hybrid.protocol import (
+    BenchmarksResponse,
     ConfigSpaceResponse,
     HealthCheckResponse,
     HybridEvaluateRequest,
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
-    InputsResponse,
     ServiceCapabilities,
 )
 from traigent.hybrid.transport import (
@@ -51,7 +51,7 @@ class HTTPTransport:
     # API endpoint paths (relative to base_url)
     CAPABILITIES_PATH = "/traigent/v1/capabilities"
     CONFIG_SPACE_PATH = "/traigent/v1/config-space"
-    INPUTS_PATH = "/traigent/v1/inputs"
+    BENCHMARKS_PATH = "/traigent/v1/benchmarks"
     EXECUTE_PATH = "/traigent/v1/execute"
     EVALUATE_PATH = "/traigent/v1/evaluate"
     HEALTH_PATH = "/traigent/v1/health"
@@ -304,33 +304,26 @@ class HTTPTransport:
         data = await self._request("GET", self.CONFIG_SPACE_PATH, params=params)
         return ConfigSpaceResponse.from_dict(data)
 
-    async def inputs(
+    async def benchmarks(
         self,
-        tunable_id: str,
-        *,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> InputsResponse:
-        """Discover available benchmark input IDs for a tunable.
+        tunable_id: str | None = None,
+    ) -> BenchmarksResponse:
+        """Discover available benchmarks and their example IDs.
 
         Args:
-            tunable_id: The tunable to list inputs for.
-            limit: Maximum number of input IDs per page (1-10000).
-            offset: Number of input IDs to skip for pagination.
+            tunable_id: Optional filter — only return benchmarks linked to this tunable.
 
         Returns:
-            InputsResponse with paginated input IDs and total count.
+            BenchmarksResponse with benchmark entries and example IDs.
 
         Raises:
             TransportError: If discovery fails or tunable_id is unknown.
         """
-        params: dict[str, str] = {"tunable_id": tunable_id}
-        if limit != 100:
-            params["limit"] = str(limit)
-        if offset != 0:
-            params["offset"] = str(offset)
-        data = await self._request("GET", self.INPUTS_PATH, params=params)
-        return InputsResponse.from_dict(data)
+        params: dict[str, str] | None = None
+        if tunable_id is not None:
+            params = {"tunable_id": tunable_id}
+        data = await self._request("GET", self.BENCHMARKS_PATH, params=params)
+        return BenchmarksResponse.from_dict(data)
 
     async def execute(
         self,

--- a/traigent/hybrid/mcp_transport.py
+++ b/traigent/hybrid/mcp_transport.py
@@ -14,13 +14,13 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from traigent.hybrid.protocol import (
+    BenchmarksResponse,
     ConfigSpaceResponse,
     HealthCheckResponse,
     HybridEvaluateRequest,
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
-    InputsResponse,
     ServiceCapabilities,
 )
 from traigent.hybrid.transport import TransportConnectionError, TransportError
@@ -236,23 +236,20 @@ class MCPTransport:
         data = await self._read_resource(uri)
         return ConfigSpaceResponse.from_dict(data)
 
-    async def inputs(
+    async def benchmarks(
         self,
-        tunable_id: str,
-        *,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> InputsResponse:
-        """Discover available input IDs via MCP.
+        tunable_id: str | None = None,
+    ) -> BenchmarksResponse:
+        """Discover available benchmarks via MCP.
 
         Not yet supported over MCP transport.
 
         Raises:
-            NotImplementedError: Always — MCP input discovery is not yet implemented.
+            NotImplementedError: Always — MCP benchmark discovery is not yet implemented.
         """
         raise NotImplementedError(
-            "Input ID discovery is not yet supported over MCP transport. "
-            "Use HTTP transport or provide input IDs explicitly."
+            "Benchmark discovery is not yet supported over MCP transport. "
+            "Use HTTP transport or provide example IDs explicitly."
         )
 
     async def execute(

--- a/traigent/hybrid/mcp_transport.py
+++ b/traigent/hybrid/mcp_transport.py
@@ -20,6 +20,7 @@ from traigent.hybrid.protocol import (
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
+    InputsResponse,
     ServiceCapabilities,
 )
 from traigent.hybrid.transport import TransportConnectionError, TransportError
@@ -234,6 +235,25 @@ class MCPTransport:
             uri = f"{CONFIG_SPACE_URI}?tunable_id={tunable_id}"
         data = await self._read_resource(uri)
         return ConfigSpaceResponse.from_dict(data)
+
+    async def inputs(
+        self,
+        tunable_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> InputsResponse:
+        """Discover available input IDs via MCP.
+
+        Not yet supported over MCP transport.
+
+        Raises:
+            NotImplementedError: Always — MCP input discovery is not yet implemented.
+        """
+        raise NotImplementedError(
+            "Input ID discovery is not yet supported over MCP transport. "
+            "Use HTTP transport or provide input IDs explicitly."
+        )
 
     async def execute(
         self,

--- a/traigent/hybrid/protocol.py
+++ b/traigent/hybrid/protocol.py
@@ -163,7 +163,7 @@ class HybridEvaluateRequest:
     """
 
     tunable_id: str
-    benchmark_id: str = ""
+    benchmark_id: str
     request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     execution_id: str | None = None
     evaluations: list[dict[str, Any]] | None = None

--- a/traigent/hybrid/protocol.py
+++ b/traigent/hybrid/protocol.py
@@ -34,36 +34,40 @@ class BatchOptions:
 
 @dataclass(slots=True)
 class HybridExecuteRequest:
-    """Request to execute agent with configuration on inputs.
+    """Request to execute agent with configuration on examples.
 
     Attributes:
         request_id: Idempotency key for retry safety (UUID)
         tunable_id: Identifier for the tunable to invoke
+        benchmark_id: Benchmark containing the examples to run
         config: Configuration parameters (TVAR values)
-        inputs: List of input examples to process
+        examples: List of examples to process
         session_id: Session ID for stateful agents (echoed from previous response)
         batch_options: Optional batch control settings
         timeout_ms: Request timeout in milliseconds
+        benchmarks_revision: Optional revision token for stale-detection
     """
 
     tunable_id: str
+    benchmark_id: str
     config: dict[str, Any]
-    inputs: list[dict[str, Any]]
+    examples: list[dict[str, Any]]
     request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     session_id: str | None = None
     batch_options: BatchOptions | None = None
     timeout_ms: int = 30000
+    benchmarks_revision: str | None = None
 
     def __post_init__(self) -> None:
-        """Log malformed inputs that violate the OpenAPI contract."""
+        """Log malformed examples that violate the OpenAPI contract."""
         missing_indices: list[int] = []
-        for idx, item in enumerate(self.inputs):
-            if not isinstance(item, dict) or "input_id" not in item:
+        for idx, item in enumerate(self.examples):
+            if not isinstance(item, dict) or "example_id" not in item:
                 missing_indices.append(idx)
 
         if missing_indices:
             logger.warning(
-                "HybridExecuteRequest inputs missing required input_id at indices %s",
+                "HybridExecuteRequest examples missing required example_id at indices %s",
                 missing_indices,
             )
 
@@ -72,8 +76,9 @@ class HybridExecuteRequest:
         result: dict[str, Any] = {
             "request_id": self.request_id,
             "tunable_id": self.tunable_id,
+            "benchmark_id": self.benchmark_id,
             "config": self.config,
-            "inputs": self.inputs,
+            "examples": self.examples,
             "timeout_ms": self.timeout_ms,
         }
         if self.session_id is not None:
@@ -84,6 +89,8 @@ class HybridExecuteRequest:
                 "fail_fast": self.batch_options.fail_fast,
                 "timeout_per_item_ms": self.batch_options.timeout_per_item_ms,
             }
+        if self.benchmarks_revision is not None:
+            result["benchmarks_revision"] = self.benchmarks_revision
         return result
 
 
@@ -146,26 +153,31 @@ class HybridEvaluateRequest:
     Attributes:
         request_id: Idempotency key for retry safety
         tunable_id: Identifier for the tunable to evaluate
+        benchmark_id: Benchmark containing the examples being evaluated
         execution_id: Reference to previous execute (avoids resending outputs)
         evaluations: List of output+target pairs to evaluate
         config: Optional config for evaluation-time parameters
         session_id: Session ID for stateful agents
         timeout_ms: Optional server-side timeout budget in milliseconds
+        benchmarks_revision: Optional revision token for stale-detection
     """
 
     tunable_id: str
+    benchmark_id: str = ""
     request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     execution_id: str | None = None
     evaluations: list[dict[str, Any]] | None = None
     config: dict[str, Any] | None = None
     session_id: str | None = None
     timeout_ms: int | None = None
+    benchmarks_revision: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dictionary."""
         result: dict[str, Any] = {
             "request_id": self.request_id,
             "tunable_id": self.tunable_id,
+            "benchmark_id": self.benchmark_id,
         }
         if self.execution_id is not None:
             result["execution_id"] = self.execution_id
@@ -177,6 +189,8 @@ class HybridEvaluateRequest:
             result["session_id"] = self.session_id
         if self.timeout_ms is not None:
             result["timeout_ms"] = self.timeout_ms
+        if self.benchmarks_revision is not None:
+            result["benchmarks_revision"] = self.benchmarks_revision
         return result
 
 
@@ -440,35 +454,55 @@ class ConfigSpaceResponse:
 
 
 @dataclass(slots=True)
-class InputsResponse:
-    """Response from input IDs discovery endpoint.
+class BenchmarkEntry:
+    """A single benchmark with its associated example IDs.
 
     Attributes:
-        tunable_id: The tunable these inputs belong to.
-        input_ids: Input identifiers valid for this tunable, sorted lexicographically.
-        total: Total number of available input IDs (across all pages).
-        limit: The limit applied for this page.
-        offset: The offset applied for this page.
-        has_more: True when more pages exist.
+        benchmark_id: Unique identifier for this benchmark.
+        tunable_ids: Agents linked to this benchmark (full list, sorted ASCII).
+        example_ids: Datapoint identifiers within this benchmark (sorted ASCII).
+        name: Optional display name for the benchmark.
     """
 
-    tunable_id: str
-    input_ids: list[str]
-    total: int
-    limit: int
-    offset: int
-    has_more: bool
+    benchmark_id: str
+    tunable_ids: list[str]
+    example_ids: list[str]
+    name: str | None = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> InputsResponse:
+    def from_dict(cls, data: dict[str, Any]) -> BenchmarkEntry:
         """Create from dictionary (API response)."""
         return cls(
-            tunable_id=data.get("tunable_id", ""),
-            input_ids=data.get("input_ids", []),
-            total=data.get("total", 0),
-            limit=data.get("limit", 100),
-            offset=data.get("offset", 0),
-            has_more=data.get("has_more", False),
+            benchmark_id=data.get("benchmark_id", ""),
+            tunable_ids=data.get("tunable_ids", []),
+            example_ids=data.get("example_ids", []),
+            name=data.get("name"),
+        )
+
+
+@dataclass(slots=True)
+class BenchmarksResponse:
+    """Response from benchmarks discovery endpoint.
+
+    Attributes:
+        benchmarks: List of benchmark entries (sorted by benchmark_id, ASCII).
+        benchmarks_revision: Optional opaque revision token for stale-detection.
+    """
+
+    benchmarks: list[BenchmarkEntry]
+    benchmarks_revision: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BenchmarksResponse:
+        """Create from dictionary (API response)."""
+        raw_benchmarks = data.get("benchmarks", [])
+        benchmarks = [
+            BenchmarkEntry.from_dict(b) if isinstance(b, dict) else b
+            for b in raw_benchmarks
+        ]
+        return cls(
+            benchmarks=benchmarks,
+            benchmarks_revision=data.get("benchmarks_revision"),
         )
 
 

--- a/traigent/hybrid/protocol.py
+++ b/traigent/hybrid/protocol.py
@@ -440,6 +440,39 @@ class ConfigSpaceResponse:
 
 
 @dataclass(slots=True)
+class InputsResponse:
+    """Response from input IDs discovery endpoint.
+
+    Attributes:
+        tunable_id: The tunable these inputs belong to.
+        input_ids: Input identifiers valid for this tunable, sorted lexicographically.
+        total: Total number of available input IDs (across all pages).
+        limit: The limit applied for this page.
+        offset: The offset applied for this page.
+        has_more: True when more pages exist.
+    """
+
+    tunable_id: str
+    input_ids: list[str]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InputsResponse:
+        """Create from dictionary (API response)."""
+        return cls(
+            tunable_id=data.get("tunable_id", ""),
+            input_ids=data.get("input_ids", []),
+            total=data.get("total", 0),
+            limit=data.get("limit", 100),
+            offset=data.get("offset", 0),
+            has_more=data.get("has_more", False),
+        )
+
+
+@dataclass(slots=True)
 class HealthCheckResponse:
     """Response from health check endpoint.
 

--- a/traigent/hybrid/transport.py
+++ b/traigent/hybrid/transport.py
@@ -11,13 +11,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 from traigent.hybrid.protocol import (
+    BenchmarksResponse,
     ConfigSpaceResponse,
     HealthCheckResponse,
     HybridEvaluateRequest,
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
-    InputsResponse,
     ServiceCapabilities,
 )
 
@@ -102,22 +102,17 @@ class HybridTransport(Protocol):
         """
         ...
 
-    async def inputs(
+    async def benchmarks(
         self,
-        tunable_id: str,
-        *,
-        limit: int = 100,
-        offset: int = 0,
-    ) -> InputsResponse:
-        """Discover available benchmark input IDs for a tunable.
+        tunable_id: str | None = None,
+    ) -> BenchmarksResponse:
+        """Discover available benchmarks and their example IDs.
 
         Args:
-            tunable_id: The tunable to list inputs for.
-            limit: Maximum number of input IDs per page (1-10000).
-            offset: Number of input IDs to skip for pagination.
+            tunable_id: Optional filter — only return benchmarks linked to this tunable.
 
         Returns:
-            InputsResponse with paginated input IDs and total count.
+            BenchmarksResponse with benchmark entries and example IDs.
 
         Raises:
             TransportError: If discovery fails or tunable_id is unknown.

--- a/traigent/hybrid/transport.py
+++ b/traigent/hybrid/transport.py
@@ -17,6 +17,7 @@ from traigent.hybrid.protocol import (
     HybridEvaluateResponse,
     HybridExecuteRequest,
     HybridExecuteResponse,
+    InputsResponse,
     ServiceCapabilities,
 )
 
@@ -98,6 +99,28 @@ class HybridTransport(Protocol):
         Raises:
             TransportError: If evaluation fails.
             NotImplementedError: If evaluate not supported.
+        """
+        ...
+
+    async def inputs(
+        self,
+        tunable_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> InputsResponse:
+        """Discover available benchmark input IDs for a tunable.
+
+        Args:
+            tunable_id: The tunable to list inputs for.
+            limit: Maximum number of input IDs per page (1-10000).
+            offset: Number of input IDs to skip for pagination.
+
+        Returns:
+            InputsResponse with paginated input IDs and total count.
+
+        Raises:
+            TransportError: If discovery fails or tunable_id is unknown.
         """
         ...
 

--- a/traigent/utils/optimization_logger.py
+++ b/traigent/utils/optimization_logger.py
@@ -190,7 +190,7 @@ def _serialize_example_result(ex: Any) -> dict[str, Any]:
         metrics = ex.get("metrics", {})
         actual = ex.get("actual_output")
         return {
-            "input_id": ex.get("input_id"),
+            "example_id": ex.get("example_id", ex.get("input_id")),
             "query": actual.get("query") if isinstance(actual, dict) else None,
             "response": _extract_output_text(actual),
             "expected": ex.get("expected_output"),
@@ -203,7 +203,7 @@ def _serialize_example_result(ex: Any) -> dict[str, Any]:
     metrics = getattr(ex, "metrics", {}) or {}
     actual = getattr(ex, "actual_output", None)
     return {
-        "input_id": getattr(ex, "input_id", None),
+        "example_id": getattr(ex, "example_id", getattr(ex, "input_id", None)),
         "query": actual.get("query") if isinstance(actual, dict) else None,
         "response": _extract_output_text(actual),
         "expected": getattr(ex, "expected_output", None),
@@ -507,11 +507,11 @@ class OptimizationLogger:
             f"=== {trial.trial_id}  |  accuracy={acc}  |  " f"config={trial.config} ==="
         )
         if serialized_examples:
-            hdr = f"  {'input_id':<14} {'acc':>4}  {'expected':<22} {'response'}"
+            hdr = f"  {'example_id':<14} {'acc':>4}  {'expected':<22} {'response'}"
             lines.append(hdr)
             lines.append(f"  {'-'*14} {'-'*4}  {'-'*22} {'-'*50}")
             for ex in serialized_examples:
-                iid = ex.get("input_id", "?")
+                iid = ex.get("example_id", "?")
                 a = ex.get("accuracy", "?")
                 exp = str(ex.get("expected") or "")[:22]
                 resp = str(ex.get("response") or ex.get("query") or "")[:80]

--- a/traigent/utils/optimization_logger.py
+++ b/traigent/utils/optimization_logger.py
@@ -190,7 +190,7 @@ def _serialize_example_result(ex: Any) -> dict[str, Any]:
         metrics = ex.get("metrics", {})
         actual = ex.get("actual_output")
         return {
-            "example_id": ex.get("example_id", ex.get("input_id")),
+            "example_id": ex.get("example_id"),
             "query": actual.get("query") if isinstance(actual, dict) else None,
             "response": _extract_output_text(actual),
             "expected": ex.get("expected_output"),
@@ -203,7 +203,7 @@ def _serialize_example_result(ex: Any) -> dict[str, Any]:
     metrics = getattr(ex, "metrics", {}) or {}
     actual = getattr(ex, "actual_output", None)
     return {
-        "example_id": getattr(ex, "example_id", getattr(ex, "input_id", None)),
+        "example_id": getattr(ex, "example_id", None),
         "query": actual.get("query") if isinstance(actual, dict) else None,
         "response": _extract_output_text(actual),
         "expected": getattr(ex, "expected_output", None),

--- a/traigent/wrapper/__init__.py
+++ b/traigent/wrapper/__init__.py
@@ -17,7 +17,7 @@ Example:
         }
 
     @app.execute
-    async def run_agent(input_id: str, data: dict, config: dict) -> dict:
+    async def run_agent(example_id: str, data: dict, config: dict) -> dict:
         # Your agent logic here
         return {"output": result, "cost_usd": 0.002, "latency_ms": 150}
 

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -17,7 +17,7 @@ Example:
         }
 
     @app.execute
-    async def run_agent(input_id: str, data: dict, config: dict) -> dict:
+    async def run_agent(example_id: str, data: dict, config: dict) -> dict:
         # Your agent logic here
         return {"output": result, "cost_usd": 0.002, "latency_ms": 150}
 
@@ -125,7 +125,7 @@ class TraigentService:
             return {"model": {"type": "enum", "values": ["gpt-4"]}}
 
         @app.execute
-        async def run(input_id, data, config):
+        async def run(example_id, data, config):
             return {"output": "result"}
 
         app.run(port=8080)
@@ -256,7 +256,7 @@ class TraigentService:
         """Decorator to register execution handler.
 
         The decorated function receives:
-            - input_id: str - Identifier for this input
+            - example_id: str - Identifier for this example
             - data: dict - Input data
             - config: dict - Configuration parameters
 
@@ -268,7 +268,7 @@ class TraigentService:
 
         Example:
             @app.execute
-            async def run_agent(input_id: str, data: dict, config: dict) -> dict:
+            async def run_agent(example_id: str, data: dict, config: dict) -> dict:
                 result = await my_llm_call(data["query"], **config)
                 return {"output": result, "cost_usd": 0.002}
         """
@@ -499,7 +499,8 @@ class TraigentService:
         """Handle execute request.
 
         Args:
-            request: Execute request with tunable_id, config, inputs.
+            request: Execute request with tunable_id, config, examples
+                (or deprecated 'inputs'), and benchmark_id.
 
         Returns:
             Execute response with outputs and metrics.
@@ -523,11 +524,30 @@ class TraigentService:
 
         tunable_id = request.get("tunable_id", self.config.tunable_id)
         config = request.get("config", {})
-        inputs = request.get("inputs")
+
+        # Backward compat: accept both "examples" (new) and "inputs" (deprecated)
+        examples = request.get("examples") or request.get("inputs")
+        if "inputs" in request and "examples" not in request:
+            logger.warning(
+                "Deprecated: use 'examples' instead of 'inputs' in execute request"
+            )
+
         session_id = request.get("session_id")
 
-        if not isinstance(inputs, list) or len(inputs) == 0:
-            raise ValueError("inputs must be a non-empty list")
+        # Validate benchmark_id is present
+        benchmark_id = request.get("benchmark_id")
+        if not benchmark_id:
+            return {
+                "request_id": request_id,
+                "status": "failed",
+                "error": {
+                    "code": "INVALID_REQUEST",
+                    "message": "Missing required field 'benchmark_id' in execute request",
+                },
+            }
+
+        if not isinstance(examples, list) or len(examples) == 0:
+            raise ValueError("examples must be a non-empty list")
 
         # Validate tunable_id matches this service
         if tunable_id != self.config.tunable_id:
@@ -538,9 +558,9 @@ class TraigentService:
 
         # Enforce max_batch_size from capabilities
         max_batch = self.config.max_batch_size
-        if max_batch and len(inputs) > max_batch:
+        if max_batch and len(examples) > max_batch:
             raise ValueError(
-                f"Batch size {len(inputs)} exceeds max_batch_size {max_batch}"
+                f"Batch size {len(examples)} exceeds max_batch_size {max_batch}"
             )
 
         # Update session if provided
@@ -551,19 +571,26 @@ class TraigentService:
         outputs: list[dict[str, Any]] = []
         total_cost = 0.0
         all_quality_metrics: list[dict[str, float]] = []
-        failed_input_ids: list[str] = []
+        failed_example_ids: list[str] = []
 
-        for inp in inputs:
+        for inp in examples:
             if isinstance(inp, dict):
-                input_id = str(inp.get("input_id", str(uuid.uuid4())))
+                # Backward compat: accept both "example_id" (new) and "input_id" (deprecated)
+                example_id = inp.get("example_id") or inp.get("input_id")
+                if "input_id" in inp and "example_id" not in inp:
+                    logger.warning(
+                        "Deprecated: use 'example_id' instead of 'input_id' "
+                        "in execute example items"
+                    )
+                example_id = str(example_id) if example_id else str(uuid.uuid4())
                 data = inp.get("data", inp)
             else:
-                input_id = str(uuid.uuid4())
+                example_id = str(uuid.uuid4())
                 data = inp
 
             try:
                 # Call handler
-                result = self._execute_handler(input_id, data, config)
+                result = self._execute_handler(example_id, data, config)
                 if inspect.isawaitable(result):
                     result = await result
 
@@ -588,7 +615,7 @@ class TraigentService:
                     all_quality_metrics.append(metrics)
 
                 output_item: dict[str, Any] = {
-                    "input_id": input_id,
+                    "example_id": example_id,
                     "output": output,
                     "cost_usd": cost,
                 }
@@ -605,20 +632,20 @@ class TraigentService:
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                logger.error(f"Execute failed for {input_id}: {e}")
-                failed_input_ids.append(input_id)
+                logger.error(f"Execute failed for {example_id}: {e}")
+                failed_example_ids.append(example_id)
                 outputs.append(
                     {
-                        "input_id": input_id,
+                        "example_id": example_id,
                         "error": str(e),
                     }
                 )
 
         elapsed_ms = (time.time() - start_time) * 1000
-        successful_outputs = len(outputs) - len(failed_input_ids)
+        successful_outputs = len(outputs) - len(failed_example_ids)
         if successful_outputs == 0 and outputs:
             status = "failed"
-        elif failed_input_ids:
+        elif failed_example_ids:
             status = "partial"
         else:
             status = "completed"
@@ -635,15 +662,15 @@ class TraigentService:
             },
         }
 
-        if failed_input_ids:
+        if failed_example_ids:
             response["error"] = {
                 "code": (
                     "EXECUTION_PARTIAL_FAILURE"
                     if status == "partial"
                     else "EXECUTION_FAILED"
                 ),
-                "message": "One or more inputs failed during execution",
-                "failed_inputs": failed_input_ids,
+                "message": "One or more examples failed during execution",
+                "failed_examples": failed_example_ids,
             }
 
         # Include quality metrics if available (combined mode)
@@ -714,10 +741,18 @@ class TraigentService:
 
         results: list[dict[str, Any]] = []
         all_metrics: list[dict[str, float]] = []
-        failed_input_ids: list[str] = []
+        failed_example_ids: list[str] = []
 
         for evaluation in evaluations:
-            input_id = evaluation.get("input_id", str(uuid.uuid4()))
+            # Backward compat: accept both "example_id" (new) and "input_id" (deprecated)
+            example_id = evaluation.get("example_id") or evaluation.get("input_id")
+            if "input_id" in evaluation and "example_id" not in evaluation:
+                logger.warning(
+                    "Deprecated: use 'example_id' instead of 'input_id' "
+                    "in evaluate items"
+                )
+            example_id = str(example_id) if example_id else str(uuid.uuid4())
+
             output = evaluation.get("output")
             if output is None and "output_id" in evaluation:
                 output = {"output_id": evaluation["output_id"]}
@@ -736,7 +771,7 @@ class TraigentService:
 
                 results.append(
                     {
-                        "input_id": input_id,
+                        "example_id": example_id,
                         "metrics": metrics,
                     }
                 )
@@ -747,20 +782,20 @@ class TraigentService:
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                logger.error(f"Evaluate failed for {input_id}: {e}")
-                failed_input_ids.append(input_id)
+                logger.error(f"Evaluate failed for {example_id}: {e}")
+                failed_example_ids.append(example_id)
                 results.append(
                     {
-                        "input_id": input_id,
+                        "example_id": example_id,
                         "metrics": {},
                         "error": str(e),
                     }
                 )
 
-        successful_results = len(results) - len(failed_input_ids)
+        successful_results = len(results) - len(failed_example_ids)
         if successful_results == 0 and results:
             status = "failed"
-        elif failed_input_ids:
+        elif failed_example_ids:
             status = "partial"
         else:
             status = "completed"
@@ -772,7 +807,7 @@ class TraigentService:
             "aggregate_metrics": self._compute_aggregate_metrics(all_metrics),
         }
 
-        if failed_input_ids:
+        if failed_example_ids:
             response["error"] = {
                 "code": (
                     "EVALUATION_PARTIAL_FAILURE"
@@ -780,7 +815,7 @@ class TraigentService:
                     else "EVALUATION_FAILED"
                 ),
                 "message": "One or more items failed during evaluation",
-                "failed_inputs": failed_input_ids,
+                "failed_examples": failed_example_ids,
             }
 
         # Cache terminal response for idempotent retries.

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -499,8 +499,8 @@ class TraigentService:
         """Handle execute request.
 
         Args:
-            request: Execute request with tunable_id, config, examples
-                (or deprecated 'inputs'), and benchmark_id.
+            request: Execute request with tunable_id, config, examples,
+                and benchmark_id.
 
         Returns:
             Execute response with outputs and metrics.
@@ -525,12 +525,7 @@ class TraigentService:
         tunable_id = request.get("tunable_id", self.config.tunable_id)
         config = request.get("config", {})
 
-        # Backward compat: accept both "examples" (new) and "inputs" (deprecated)
-        examples = request.get("examples") or request.get("inputs")
-        if "inputs" in request and "examples" not in request:
-            logger.warning(
-                "Deprecated: use 'examples' instead of 'inputs' in execute request"
-            )
+        examples = request.get("examples")
 
         session_id = request.get("session_id")
 
@@ -541,7 +536,7 @@ class TraigentService:
                 "request_id": request_id,
                 "status": "failed",
                 "error": {
-                    "code": "INVALID_REQUEST",
+                    "code": "INVALID_BENCHMARK_ID",
                     "message": "Missing required field 'benchmark_id' in execute request",
                 },
             }
@@ -575,13 +570,7 @@ class TraigentService:
 
         for inp in examples:
             if isinstance(inp, dict):
-                # Backward compat: accept both "example_id" (new) and "input_id" (deprecated)
-                example_id = inp.get("example_id") or inp.get("input_id")
-                if "input_id" in inp and "example_id" not in inp:
-                    logger.warning(
-                        "Deprecated: use 'example_id' instead of 'input_id' "
-                        "in execute example items"
-                    )
+                example_id = inp.get("example_id")
                 example_id = str(example_id) if example_id else str(uuid.uuid4())
                 data = inp.get("data", inp)
             else:
@@ -725,6 +714,18 @@ class TraigentService:
         config = request.get("config", {})
         session_id = request.get("session_id")
 
+        # Validate benchmark_id is present
+        benchmark_id = request.get("benchmark_id")
+        if not benchmark_id:
+            return {
+                "request_id": request_id,
+                "status": "failed",
+                "error": {
+                    "code": "INVALID_BENCHMARK_ID",
+                    "message": "Missing required field 'benchmark_id' in evaluate request",
+                },
+            }
+
         if not isinstance(evaluations, list):
             raise ValueError("evaluations must be a list")
 
@@ -744,13 +745,7 @@ class TraigentService:
         failed_example_ids: list[str] = []
 
         for evaluation in evaluations:
-            # Backward compat: accept both "example_id" (new) and "input_id" (deprecated)
-            example_id = evaluation.get("example_id") or evaluation.get("input_id")
-            if "input_id" in evaluation and "example_id" not in evaluation:
-                logger.warning(
-                    "Deprecated: use 'example_id' instead of 'input_id' "
-                    "in evaluate items"
-                )
+            example_id = evaluation.get("example_id")
             example_id = str(example_id) if example_id else str(uuid.uuid4())
 
             output = evaluation.get("output")


### PR DESCRIPTION
## Summary
- Rename `/inputs` endpoint to `/benchmarks` across SDK, wrapper, docs, and tests
- Add `_ensure_benchmark_id()` with asyncio.Lock double-check locking to resolve benchmark_id before batch execution
- Fail fast on missing `benchmark_id` in `_execute_batch()` safety guard
- Remove default timeout and backward-compat shims from prior PR review feedback

## Test plan
- [x] All 98 hybrid evaluator tests pass
- [x] All 376 wrapper + hybrid tests pass
- [x] 10x95 Bazak demo completed successfully (88.4% accuracy, 10/10 trials, results synced to backend)
- [x] `make format && make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)