### PR TITLE
feat: SDK publication readiness — P1 cleanup + E2E manifest (#245)

### DIFF
--- a/examples/core/multi-objective-tradeoff/run_openai_optuna.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna.py
@@ -50,7 +50,6 @@ except ImportError:  # pragma: no cover - support IDE execution paths
 from traigent.api.types import OptimizationResult  # noqa: E402
 from traigent.config.parallel import ParallelConfig  # noqa: E402
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema  # noqa: E402
-from traigent.optimizers.pruners import CeilingPruner  # noqa: E402
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -255,12 +254,6 @@ MAX_TOKENS_CHOICES = [64]
 MAX_TRIALS = int(os.getenv("TRAIGENT_MAX_TRIALS", "20"))
 BUDGET_LIMIT = _parse_float_env("TRAIGENT_BUDGET_LIMIT", 0.012)
 
-# Pruner configuration
-PRUNER_COST_THRESHOLD = _parse_float_env("TRAIGENT_COST_THRESHOLD", 0.0015)
-PRUNER_EPSILON = _parse_float_env("TRAIGENT_PRUNER_EPSILON", 1e-4) or 1e-4
-PRUNER_WARMUP_STEPS = int(os.getenv("TRAIGENT_PRUNER_WARMUP_STEPS", "1"))
-PRUNER_MIN_COMPLETED = int(os.getenv("TRAIGENT_PRUNER_MIN_COMPLETED", "1"))
-
 # Concurrency configuration
 DEFAULT_WORKERS = max(
     1, min(_parse_int_env("TRAIGENT_PARALLEL_WORKERS", os.cpu_count() or 4), 16)
@@ -311,10 +304,6 @@ print(
 print(f"Model candidates: {MODEL_CHOICES}")
 if BUDGET_LIMIT is not None:
     print(f"Budget limit: ${BUDGET_LIMIT:.6f}")
-print(
-    f"Pruner: min_completed={PRUNER_MIN_COMPLETED}, warmup_steps={PRUNER_WARMUP_STEPS}, "
-    f"epsilon={PRUNER_EPSILON}, cost_threshold={PRUNER_COST_THRESHOLD}"
-)
 print(
     "Resolved concurrency profile: "
     f"profile={CONCURRENCY_PROFILE or 'auto'}, "
@@ -603,12 +592,6 @@ _OPTIMIZE_KWARGS: dict[str, Any] = {
     "parallel_config": PARALLEL_CONFIG,
     "algorithm": "grid",
     "max_trials": MAX_TRIALS,
-    "pruner": CeilingPruner(
-        min_completed_trials=PRUNER_MIN_COMPLETED,
-        warmup_steps=PRUNER_WARMUP_STEPS,
-        epsilon=PRUNER_EPSILON,
-        cost_threshold=PRUNER_COST_THRESHOLD,
-    ),
 }
 
 if BUDGET_LIMIT is not None and BUDGET_LIMIT > 0:

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
@@ -38,7 +38,6 @@ from traigent.api.types import OptimizationResult  # noqa: E402
 from traigent.cloud.backend_client import BackendIntegratedClient  # noqa: E402
 from traigent.config.parallel import ParallelConfig  # noqa: E402
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema  # noqa: E402
-from traigent.optimizers.pruners import CeilingPruner  # noqa: E402
 
 DATA_ROOT = (
     Path(__file__).resolve().parents[2] / "datasets" / "multi-objective-tradeoff"
@@ -143,10 +142,6 @@ else:
 
 MAX_TRIALS = int(os.getenv("TRAIGENT_MAX_TRIALS", "24"))
 BUDGET_LIMIT = _parse_float_env("TRAIGENT_BUDGET_LIMIT", 0.012)
-PRUNER_COST_THRESHOLD = _parse_float_env("TRAIGENT_COST_THRESHOLD", 0.0015)
-PRUNER_EPSILON = _parse_float_env("TRAIGENT_PRUNER_EPSILON", 1e-4) or 1e-4
-PRUNER_WARMUP_STEPS = int(os.getenv("TRAIGENT_PRUNER_WARMUP_STEPS", "2"))
-PRUNER_MIN_COMPLETED = int(os.getenv("TRAIGENT_PRUNER_MIN_COMPLETED", "2"))
 
 DEFAULT_WORKERS = max(
     1, _parse_int_env("TRAIGENT_PARALLEL_WORKERS", os.cpu_count() or 4)
@@ -202,10 +197,6 @@ print(
 print(f"Model candidates: {MODEL_CHOICES}")
 if BUDGET_LIMIT is not None:
     print(f"Budget limit: ${BUDGET_LIMIT:.6f}")
-print(
-    f"Pruner: min_completed={PRUNER_MIN_COMPLETED}, warmup_steps={PRUNER_WARMUP_STEPS}, "
-    f"epsilon={PRUNER_EPSILON}, cost_threshold={PRUNER_COST_THRESHOLD}"
-)
 print(
     "Resolved concurrency: "
     f"profile={CONCURRENCY_PROFILE or 'auto'}, "
@@ -580,12 +571,6 @@ _OPTIMIZE_KWARGS: dict[str, Any] = {
     "parallel_config": PARALLEL_CONFIG,
     "algorithm": "bayesian",
     "max_trials": MAX_TRIALS,
-    "pruner": CeilingPruner(
-        min_completed_trials=PRUNER_MIN_COMPLETED,
-        warmup_steps=PRUNER_WARMUP_STEPS,
-        epsilon=PRUNER_EPSILON,
-        cost_threshold=PRUNER_COST_THRESHOLD,
-    ),
 }
 
 if BUDGET_LIMIT is not None and BUDGET_LIMIT > 0:

--- a/examples/test_all_examples.sh
+++ b/examples/test_all_examples.sh
@@ -392,6 +392,7 @@ case "$CATEGORY" in
             echo ""
             echo -e "${RED}Manifest requires all examples to pass (${skipped} skipped)${NC}"
             failed=$((failed + skipped))
+            skipped=0
         fi
         ;;
     all)

--- a/examples/test_all_examples.sh
+++ b/examples/test_all_examples.sh
@@ -13,16 +13,26 @@
 #   ./test_all_examples.sh docs                    # Run docs examples
 #   ./test_all_examples.sh ragas                   # Run RAGAS examples only
 #   ./test_all_examples.sh walkthrough             # Run walkthrough examples
-#   ./test_all_examples.sh all                     # Run all examples
+#   ./test_all_examples.sh quickstart              # Run quickstart examples
+#   ./test_all_examples.sh tvl                     # Run TVL tutorial examples
+#   ./test_all_examples.sh multi-objective         # Run multi-objective examples
+#   ./test_all_examples.sh advanced-walkthrough    # Run advanced walkthrough
+#   ./test_all_examples.sh manifest                # Run SDK manifest (35 examples, strict)
+#   ./test_all_examples.sh all                     # Run all examples (broad smoke)
 #   ./test_all_examples.sh --real core             # Real mode (needs API keys)
 #
 # CATEGORIES:
-#   core       - Main examples demonstrating Traigent features (10 examples)
-#   advanced   - Execution modes and specialized features
-#   ragas      - RAGAS evaluation integration examples (3 examples)
-#   docs       - Documentation inline examples (2 examples)
-#   walkthrough - Walkthrough tutorial examples (8 examples)
-#   all        - Run all categories
+#   core                - Main examples demonstrating Traigent features (10 examples)
+#   multi-objective     - Multi-objective tradeoff variants (5 examples)
+#   quickstart          - Quickstart tutorial examples (3 examples)
+#   tvl                 - TVL tutorial examples (5 examples)
+#   walkthrough         - Walkthrough tutorial examples (8 examples)
+#   advanced-walkthrough - Advanced walkthrough examples (5 examples)
+#   advanced            - Execution modes and specialized features
+#   ragas               - RAGAS evaluation integration examples (3 examples)
+#   docs                - Documentation inline examples (2 examples)
+#   manifest            - SDK publication manifest (35 examples, strict — skips = failure)
+#   all                 - Run all categories (broad smoke, skips OK)
 #
 # MODE FLAGS:
 #   --mock     - Use simulated LLM responses (default)
@@ -65,7 +75,7 @@ while [[ $# -gt 0 ]]; do
             MODE="$1"
             shift
             ;;
-        core|advanced|ragas|docs|walkthrough|all)
+        core|advanced|ragas|docs|walkthrough|quickstart|tvl|multi-objective|advanced-walkthrough|manifest|all)
             CATEGORY="$1"
             shift
             ;;
@@ -73,12 +83,17 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [--mock|--real] <category>"
             echo ""
             echo "Categories:"
-            echo "  core        - Main Traigent feature examples (10 examples)"
-            echo "  advanced    - Execution modes and specialized features"
-            echo "  ragas       - RAGAS evaluation integration (3 examples)"
-            echo "  docs        - Documentation inline examples (2 examples)"
-            echo "  walkthrough - Tutorial walkthrough examples (8 examples)"
-            echo "  all         - Run all categories"
+            echo "  core                - Main Traigent feature examples (10 examples)"
+            echo "  multi-objective     - Multi-objective tradeoff variants (5 examples)"
+            echo "  quickstart          - Quickstart tutorials (3 examples)"
+            echo "  tvl                 - TVL tutorials (5 examples)"
+            echo "  walkthrough         - Walkthrough tutorials (8 examples)"
+            echo "  advanced-walkthrough - Advanced walkthrough (5 examples)"
+            echo "  advanced            - Execution modes and specialized features"
+            echo "  ragas               - RAGAS evaluation integration (3 examples)"
+            echo "  docs                - Documentation inline examples (2 examples)"
+            echo "  manifest            - SDK publication manifest (35 examples, strict)"
+            echo "  all                 - Run all categories (broad smoke)"
             echo ""
             echo "Mode flags:"
             echo "  --mock      - Simulated LLM responses (default, no API keys)"
@@ -153,6 +168,51 @@ declare -a WALKTHROUGH_EXAMPLES=(
     "../walkthrough/mock/08_privacy_modes.py"
 )
 
+# Quickstart examples - getting started tutorials
+declare -a QUICKSTART_EXAMPLES=(
+    "quickstart/01_simple_qa.py"
+    "quickstart/02_customer_support_rag.py"
+    "quickstart/03_custom_objectives.py"
+)
+
+# TVL tutorial examples - TVL spec tutorials
+declare -a TVL_EXAMPLES=(
+    "tvl/tutorials/01_getting_started/run_optimization.py"
+    "tvl/tutorials/02_typed_tvars/explore_tvars.py"
+    "tvl/tutorials/03_multi_objective/analyze_tradeoffs.py"
+    "tvl/tutorials/04_promotion_policy/test_promotion.py"
+    "tvl/tutorials/05_statistical_testing/tost_demo.py"
+)
+
+# Multi-objective tradeoff variants
+declare -a MULTI_OBJECTIVE_EXAMPLES=(
+    "core/multi-objective-tradeoff/run_anthropic.py"
+    "core/multi-objective-tradeoff/run_openai.py"
+    "core/multi-objective-tradeoff/run_openai_optuna.py"
+    "core/multi-objective-tradeoff/run_openai_optuna_concurrency.py"
+    "core/multi-objective-tradeoff/run_many_providers.py"
+)
+
+# Advanced walkthrough mock examples
+declare -a ADVANCED_WALKTHROUGH_EXAMPLES=(
+    "../walkthrough/mock/advanced/01_tuned_variables.py"
+    "../walkthrough/mock/advanced/02_prompt_optimization.py"
+    "../walkthrough/mock/advanced/03_multi_agent.py"
+    "../walkthrough/mock/advanced/04_workflow_traces_demo.py"
+    "../walkthrough/mock/advanced/05_langgraph_multiagent_demo.py"
+)
+
+# Walkthrough examples for manifest (01-07 only, excludes 08_privacy_modes)
+declare -a WALKTHROUGH_MANIFEST_EXAMPLES=(
+    "../walkthrough/mock/01_tuning_qa.py"
+    "../walkthrough/mock/02_zero_code_change.py"
+    "../walkthrough/mock/03_parameter_mode.py"
+    "../walkthrough/mock/04_multi_objective.py"
+    "../walkthrough/mock/05_rag_parallel.py"
+    "../walkthrough/mock/06_custom_evaluator.py"
+    "../walkthrough/mock/07_multi_provider.py"
+)
+
 print_header() {
     echo ""
     echo -e "${CYAN}=================================================================${NC}"
@@ -168,7 +228,7 @@ run_example() {
 
     if [ ! -f "$example_path" ]; then
         echo -e "${RED}  SKIP${NC} $example (file not found)"
-        return 2
+        return 77
     fi
 
     local example_dir="$(dirname "$example_path")"
@@ -185,6 +245,12 @@ run_example() {
     if [ $exit_code -eq 0 ]; then
         echo -e "${GREEN}  PASS${NC} $example"
         return 0
+    elif [ $exit_code -eq 77 ]; then
+        echo -e "${YELLOW}  SKIP${NC} $example (dependency not installed)"
+        if [ -n "$output" ]; then
+            echo "$output" | tail -5 | sed 's/^/        /'
+        fi
+        return 77
     elif [ $exit_code -eq 124 ]; then
         echo -e "${RED}  TIMEOUT${NC} $example (exceeded ${timeout_secs}s)"
         if [ -n "$output" ]; then
@@ -211,9 +277,11 @@ run_category() {
     fi
 
     for example in "${examples[@]}"; do
-        if run_example "$example" "$TIMEOUT"; then
+        run_example "$example" "$TIMEOUT"
+        local rc=$?
+        if [ $rc -eq 0 ]; then
             ((passed++))
-        elif [ $? -eq 2 ]; then
+        elif [ $rc -eq 77 ]; then
             ((skipped++))
         else
             ((failed++))
@@ -240,7 +308,7 @@ case "$MODE" in
         export JOBLIB_TEMP_FOLDER="$TRAIGENT_RESULTS_FOLDER/joblib"
         mkdir -p "$JOBLIB_TEMP_FOLDER"
         export TRAIGENT_DATASET_ROOT="$REPO_ROOT"
-        TIMEOUT=90
+        TIMEOUT=180
         MODE_NAME="MOCK"
         ;;
 
@@ -284,10 +352,61 @@ case "$CATEGORY" in
         print_header "Walkthrough Examples" "$MODE_NAME"
         run_category "Walkthrough" "${WALKTHROUGH_EXAMPLES[@]}"
         ;;
+    quickstart)
+        print_header "Quickstart Examples" "$MODE_NAME"
+        run_category "Quickstart" "${QUICKSTART_EXAMPLES[@]}"
+        ;;
+    tvl)
+        print_header "TVL Tutorial Examples" "$MODE_NAME"
+        run_category "TVL Tutorials" "${TVL_EXAMPLES[@]}"
+        ;;
+    multi-objective)
+        print_header "Multi-Objective Examples" "$MODE_NAME"
+        run_category "Multi-Objective" "${MULTI_OBJECTIVE_EXAMPLES[@]}"
+        ;;
+    advanced-walkthrough)
+        print_header "Advanced Walkthrough Examples" "$MODE_NAME"
+        run_category "Advanced Walkthrough" "${ADVANCED_WALKTHROUGH_EXAMPLES[@]}"
+        ;;
+    manifest)
+        print_header "SDK Publication Manifest (35 examples)" "$MODE_NAME"
+        echo -e "${YELLOW}--- Core (10) ---${NC}"
+        run_category "Core" "${CORE_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Multi-Objective (5) ---${NC}"
+        run_category "Multi-Objective" "${MULTI_OBJECTIVE_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Quickstart (3) ---${NC}"
+        run_category "Quickstart" "${QUICKSTART_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- TVL Tutorials (5) ---${NC}"
+        run_category "TVL Tutorials" "${TVL_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Walkthrough (7) ---${NC}"
+        run_category "Walkthrough" "${WALKTHROUGH_MANIFEST_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Advanced Walkthrough (5) ---${NC}"
+        run_category "Advanced Walkthrough" "${ADVANCED_WALKTHROUGH_EXAMPLES[@]}"
+        # Strict: manifest requires ALL 35 to pass, no skips allowed
+        if [ $skipped -gt 0 ]; then
+            echo ""
+            echo -e "${RED}Manifest requires all examples to pass (${skipped} skipped)${NC}"
+            failed=$((failed + skipped))
+        fi
+        ;;
     all)
         print_header "All Examples" "$MODE_NAME"
         echo -e "${YELLOW}--- Core ---${NC}"
         run_category "Core" "${CORE_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Multi-Objective ---${NC}"
+        run_category "Multi-Objective" "${MULTI_OBJECTIVE_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Quickstart ---${NC}"
+        run_category "Quickstart" "${QUICKSTART_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- TVL Tutorials ---${NC}"
+        run_category "TVL Tutorials" "${TVL_EXAMPLES[@]}"
         echo ""
         echo -e "${YELLOW}--- RAGAS ---${NC}"
         run_category "RAGAS" "${RAGAS_EXAMPLES[@]}"
@@ -297,6 +416,9 @@ case "$CATEGORY" in
         echo ""
         echo -e "${YELLOW}--- Walkthrough ---${NC}"
         run_category "Walkthrough" "${WALKTHROUGH_EXAMPLES[@]}"
+        echo ""
+        echo -e "${YELLOW}--- Advanced Walkthrough ---${NC}"
+        run_category "Advanced Walkthrough" "${ADVANCED_WALKTHROUGH_EXAMPLES[@]}"
         ;;
 esac
 

--- a/walkthrough/mock/advanced/01_tuned_variables.py
+++ b/walkthrough/mock/advanced/01_tuned_variables.py
@@ -19,7 +19,7 @@ from traigent.api.parameter_ranges import Choices, IntRange, Range
 
 # Compute dataset path relative to this script
 SCRIPT_DIR = Path(__file__).parent
-DATASET_PATH = str((SCRIPT_DIR / ".." / "simple_questions.jsonl").resolve())
+DATASET_PATH = str((SCRIPT_DIR / ".." / ".." / "datasets" / "simple_questions.jsonl").resolve())
 
 # Initialize Traigent in mock mode
 traigent.initialize(execution_mode="edge_analytics")

--- a/walkthrough/mock/advanced/02_prompt_optimization.py
+++ b/walkthrough/mock/advanced/02_prompt_optimization.py
@@ -18,7 +18,7 @@ from traigent.api.parameter_ranges import Choices, Range
 
 # Compute dataset path relative to this script
 SCRIPT_DIR = Path(__file__).parent
-DATASET_PATH = str((SCRIPT_DIR / ".." / "simple_questions.jsonl").resolve())
+DATASET_PATH = str((SCRIPT_DIR / ".." / ".." / "datasets" / "simple_questions.jsonl").resolve())
 
 # Initialize Traigent in mock mode
 traigent.initialize(execution_mode="edge_analytics")

--- a/walkthrough/mock/advanced/03_multi_agent.py
+++ b/walkthrough/mock/advanced/03_multi_agent.py
@@ -18,7 +18,7 @@ from traigent.api.types import AgentDefinition
 
 # Compute dataset path relative to this script
 SCRIPT_DIR = Path(__file__).parent
-DATASET_PATH = str((SCRIPT_DIR / ".." / "simple_questions.jsonl").resolve())
+DATASET_PATH = str((SCRIPT_DIR / ".." / ".." / "datasets" / "simple_questions.jsonl").resolve())
 
 # Initialize Traigent in mock mode
 traigent.initialize(execution_mode="edge_analytics")

--- a/walkthrough/mock/advanced/05_langgraph_multiagent_demo.py
+++ b/walkthrough/mock/advanced/05_langgraph_multiagent_demo.py
@@ -452,7 +452,7 @@ def cost_metric(output: str, expected: str) -> float:
 
 
 @traigent.optimize(
-    eval_dataset=str(SCRIPT_DIR / "simple_questions.jsonl"),
+    eval_dataset=str((SCRIPT_DIR / ".." / ".." / "datasets" / "simple_questions.jsonl").resolve()),
     objectives=["accuracy", "cost"],
     metric_functions={
         "accuracy": accuracy_metric,  # Custom accuracy metric


### PR DESCRIPTION
## Summary
- **#249, #250, #251**: P1 cleanup — security finding fix, broken doc links, CI link-checker updates
- **#252**: Run all 35 manifest examples E2E in mock mode — test runner overhaul, pruner removal, dataset path fixes

## Key changes
- `test_all_examples.sh`: 6 new category arrays, `manifest` target (strict, skips=failure), timeout 90→180s, exit-77 SKIP convention, `run_category` return-code bug fix
- Removed deprecated `CeilingPruner` kwarg from 2 optuna examples
- Fixed dataset paths in 4 advanced walkthrough scripts (portable relative paths, no symlinks)
- CI doc-link checker: added `_archived` to skip list, fixed broken playground link

## Test plan
- [x] `./test_all_examples.sh manifest` → 35 passed, 0 failed, 0 skipped
- [x] `./test_all_examples.sh all` → 38 passed, 3 failed (pre-existing RAGAS, not in manifest)
- [ ] CI checks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)