### PR TITLE
feat(cli): add report example map generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,10 @@ traigent optimize path/to/module.py -a grid -n 10
 traigent validate path/to/dataset.jsonl -o accuracy -o cost
 traigent validate_config config.json
 
+# Generate local-only example-content map for FE report enrichment
+# (contains input/output locally; never sent to backend unless you upload it manually)
+traigent report-example-map --dataset data/qa_dataset.jsonl --output report_example_map.json
+
 # Manage and visualize results
 traigent results
 traigent plot <result_name> -p progress

--- a/tests/unit/cli/test_report_example_map_command.py
+++ b/tests/unit/cli/test_report_example_map_command.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from traigent.cli.main import cli
+from traigent.reporting.example_map import build_example_content_map
 
 
 def test_report_example_map_command_generates_output(tmp_path: Path):
@@ -67,3 +68,33 @@ def test_report_example_map_command_fails_on_invalid_dataset(tmp_path: Path):
 
     assert result.exit_code != 0
     assert "missing required 'input' field" in result.output.lower()
+
+
+def test_report_example_map_command_defaults_to_resolved_dataset_path(
+    tmp_path: Path, monkeypatch
+):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        json.dumps({"input": {"q": "hello"}, "output": "world"}) + "\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "example_map.json"
+
+    runner = CliRunner()
+    monkeypatch.chdir(tmp_path)
+    with patch("traigent.cli.main.WORKSPACE_ROOT", tmp_path):
+        result = runner.invoke(
+            cli,
+            [
+                "report-example-map",
+                "--dataset",
+                "dataset.jsonl",
+                "--output",
+                "example_map.json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    expected_payload = build_example_content_map(dataset)
+    assert payload["example_map"] == expected_payload["example_map"]

--- a/tests/unit/cli/test_report_example_map_command.py
+++ b/tests/unit/cli/test_report_example_map_command.py
@@ -1,0 +1,69 @@
+"""CLI tests for `traigent report-example-map` command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from traigent.cli.main import cli
+
+
+def test_report_example_map_command_generates_output(tmp_path: Path):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        "\n".join(
+            [
+                json.dumps({"input": {"q": "hello"}, "output": "world"}),
+                json.dumps({"input": {"q": "1+1"}, "output": 2}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    output = tmp_path / "example_map.json"
+
+    runner = CliRunner()
+    with patch("traigent.cli.main.WORKSPACE_ROOT", tmp_path):
+        result = runner.invoke(
+            cli,
+            [
+                "report-example-map",
+                "--dataset",
+                str(dataset),
+                "--output",
+                str(output),
+                "--dataset-identifier",
+                "dataset_for_ids",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["dataset_fingerprint"].startswith("sha256:")
+    assert len(payload["example_map"]) == 2
+
+
+def test_report_example_map_command_fails_on_invalid_dataset(tmp_path: Path):
+    dataset = tmp_path / "invalid.jsonl"
+    dataset.write_text(json.dumps({"not_input": 1}) + "\n", encoding="utf-8")
+    output = tmp_path / "example_map.json"
+
+    runner = CliRunner()
+    with patch("traigent.cli.main.WORKSPACE_ROOT", tmp_path):
+        result = runner.invoke(
+            cli,
+            [
+                "report-example-map",
+                "--dataset",
+                str(dataset),
+                "--output",
+                str(output),
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "missing required 'input' field" in result.output.lower()

--- a/tests/unit/reporting/test_example_map.py
+++ b/tests/unit/reporting/test_example_map.py
@@ -1,0 +1,78 @@
+"""Unit tests for local report example-map generation."""
+
+from __future__ import annotations
+
+import json
+
+from traigent.reporting.example_map import (
+    build_example_content_map,
+    compute_dataset_fingerprint,
+    validate_example_content_map,
+)
+from traigent.utils.example_id import compute_dataset_hash, generate_stable_example_id
+
+
+def test_build_example_content_map_from_jsonl(tmp_path):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        '\n'.join(
+            [
+                json.dumps(
+                    {"input": {"q": "Where is Paris?"}, "output": "France", "topic": "geo"}
+                ),
+                json.dumps(
+                    {
+                        "input": {"q": "2+2"},
+                        "output": 4,
+                        "difficulty": "easy",
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    payload = build_example_content_map(
+        dataset,
+        dataset_identifier="qa_dataset_v1",
+    )
+    errors = validate_example_content_map(payload)
+    assert errors == []
+    assert payload["schema_version"] == "1.0.0"
+    assert payload["dataset_fingerprint"].startswith("sha256:")
+    assert len(payload["example_map"]) == 2
+
+    dataset_hash = compute_dataset_hash("qa_dataset_v1")
+    ex0 = generate_stable_example_id(dataset_hash, 0)
+    ex1 = generate_stable_example_id(dataset_hash, 1)
+    assert payload["example_map"][ex0]["example_num"] == 1
+    assert payload["example_map"][ex0]["expected_output"] == "France"
+    assert payload["example_map"][ex1]["example_num"] == 2
+    assert payload["example_map"][ex1]["expected_output"] == 4
+
+
+def test_dataset_fingerprint_is_deterministic_and_order_sensitive():
+    examples = [
+        {"input": {"a": 1}, "expected_output": "x", "metadata": {"k": 1}},
+        {"input": {"a": 2}, "expected_output": "y", "metadata": {"k": 2}},
+    ]
+    same_order = [
+        {"input": {"a": 1}, "expected_output": "x", "metadata": {"k": 1}},
+        {"input": {"a": 2}, "expected_output": "y", "metadata": {"k": 2}},
+    ]
+    reversed_order = list(reversed(same_order))
+
+    assert compute_dataset_fingerprint(examples) == compute_dataset_fingerprint(same_order)
+    assert compute_dataset_fingerprint(examples) != compute_dataset_fingerprint(reversed_order)
+
+
+def test_validate_example_content_map_rejects_unknown_fields(tmp_path):
+    dataset = tmp_path / "dataset.json"
+    dataset.write_text(
+        json.dumps([{"input": {"x": 1}, "output": {"y": 2}}]),
+        encoding="utf-8",
+    )
+    payload = build_example_content_map(dataset)
+    payload["extra_field"] = True
+    errors = validate_example_content_map(payload)
+    assert errors

--- a/tests/unit/reporting/test_example_map.py
+++ b/tests/unit/reporting/test_example_map.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import jsonschema
+import pytest
+
+import traigent.reporting.example_map as example_map_module
 from traigent.reporting.example_map import (
     build_example_content_map,
     compute_dataset_fingerprint,
     validate_example_content_map,
 )
 from traigent.utils.example_id import compute_dataset_hash, generate_stable_example_id
+from traigent.utils.exceptions import ValidationError
 
 
 def test_build_example_content_map_from_jsonl(tmp_path):
@@ -47,8 +53,39 @@ def test_build_example_content_map_from_jsonl(tmp_path):
     ex1 = generate_stable_example_id(dataset_hash, 1)
     assert payload["example_map"][ex0]["example_num"] == 1
     assert payload["example_map"][ex0]["expected_output"] == "France"
+    assert payload["example_map"][ex0]["metadata"] == {"topic": "geo"}
     assert payload["example_map"][ex1]["example_num"] == 2
     assert payload["example_map"][ex1]["expected_output"] == 4
+    assert payload["example_map"][ex1]["metadata"] == {"difficulty": "easy"}
+
+
+def test_build_example_content_map_uses_resolved_path_for_default_ids(
+    tmp_path, monkeypatch
+):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        json.dumps({"input": {"q": "hello"}, "output": "world"}) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    relative_payload = build_example_content_map(Path("dataset.jsonl"))
+    absolute_payload = build_example_content_map(dataset)
+
+    assert relative_payload["example_map"] == absolute_payload["example_map"]
+
+
+def test_build_example_content_map_includes_empty_metadata(tmp_path):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        json.dumps({"input": {"q": "hello"}, "output": "world"}) + "\n",
+        encoding="utf-8",
+    )
+
+    payload = build_example_content_map(dataset, dataset_identifier="dataset_v1")
+    entry = next(iter(payload["example_map"].values()))
+
+    assert entry["metadata"] == {}
 
 
 def test_dataset_fingerprint_is_deterministic_and_order_sensitive():
@@ -76,3 +113,44 @@ def test_validate_example_content_map_rejects_unknown_fields(tmp_path):
     payload["extra_field"] = True
     errors = validate_example_content_map(payload)
     assert errors
+
+
+def test_validate_example_content_map_handles_schema_errors(
+    tmp_path, monkeypatch
+):
+    dataset = tmp_path / "dataset.json"
+    dataset.write_text(
+        json.dumps([{"input": {"x": 1}, "output": {"y": 2}}]),
+        encoding="utf-8",
+    )
+    payload = build_example_content_map(dataset)
+
+    def raise_schema_error(*args, **kwargs):
+        raise jsonschema.SchemaError("broken schema")
+
+    monkeypatch.setattr(example_map_module.jsonschema, "validate", raise_schema_error)
+
+    errors = validate_example_content_map(payload)
+
+    assert errors == ["Schema definition error: broken schema"]
+
+
+def test_build_example_content_map_rejects_conflicting_output_fields(tmp_path):
+    dataset = tmp_path / "dataset.jsonl"
+    dataset.write_text(
+        json.dumps(
+            {
+                "input": {"q": "test"},
+                "output": "answer_a",
+                "expected_output": "answer_b",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match="conflicting 'output' and 'expected_output' values",
+    ):
+        build_example_content_map(dataset)

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -646,7 +646,7 @@ def validate(dataset_path: str, objectives: tuple[str, ...], verbose: bool) -> N
     default=None,
     help=(
         "Identifier used for stable example_id generation. "
-        "Defaults to the dataset argument exactly as passed."
+        "Defaults to the resolved absolute dataset path."
     ),
 )
 @click.option(
@@ -683,7 +683,7 @@ def report_example_map(
         resolved_output = _resolve_workspace_path(output_candidate, "Output file")
         resolved_output.parent.mkdir(parents=True, exist_ok=True)
 
-        effective_identifier = dataset_identifier or dataset_path
+        effective_identifier = dataset_identifier or str(resolved_dataset)
         payload = build_example_content_map(
             resolved_dataset,
             dataset_identifier=effective_identifier,

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -626,6 +626,93 @@ def validate(dataset_path: str, objectives: tuple[str, ...], verbose: bool) -> N
             console.print(obj_result.get_feedback())
 
 
+@cli.command(name="report-example-map")
+@click.option(
+    "--dataset",
+    "dataset_path",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to source dataset (.jsonl or .json)",
+)
+@click.option(
+    "--output",
+    "output_path",
+    required=True,
+    type=click.Path(),
+    help="Output file path for example-content map JSON",
+)
+@click.option(
+    "--dataset-identifier",
+    default=None,
+    help=(
+        "Identifier used for stable example_id generation. "
+        "Defaults to the dataset argument exactly as passed."
+    ),
+)
+@click.option(
+    "--validate-schema/--no-validate-schema",
+    default=True,
+    show_default=True,
+    help="Validate generated map against example_content_map_schema",
+)
+def report_example_map(
+    dataset_path: str,
+    output_path: str,
+    dataset_identifier: str | None,
+    validate_schema: bool,
+) -> None:
+    """Generate local-only example-content map for report enrichment."""
+    from traigent.reporting.example_map import (
+        build_example_content_map,
+        validate_example_content_map,
+    )
+
+    try:
+        dataset_candidate = Path(dataset_path)
+        if not dataset_candidate.is_absolute():
+            dataset_candidate = Path.cwd() / dataset_candidate
+        resolved_dataset = _resolve_workspace_path(
+            dataset_candidate,
+            "Dataset file",
+            must_exist=True,
+        )
+
+        output_candidate = Path(output_path)
+        if not output_candidate.is_absolute():
+            output_candidate = Path.cwd() / output_candidate
+        resolved_output = _resolve_workspace_path(output_candidate, "Output file")
+        resolved_output.parent.mkdir(parents=True, exist_ok=True)
+
+        effective_identifier = dataset_identifier or dataset_path
+        payload = build_example_content_map(
+            resolved_dataset,
+            dataset_identifier=effective_identifier,
+        )
+        if validate_schema:
+            errors = validate_example_content_map(payload)
+            if errors:
+                raise click.ClickException(
+                    f"Generated map failed schema validation: {errors[0]}"
+                )
+
+        serialized = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+        safe_write_text(resolved_output, serialized, WORKSPACE_ROOT)
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print("\n[bold green]Example map generated successfully[/bold green]")
+    console.print(f"Dataset: {resolved_dataset}")
+    console.print(f"Output: {resolved_output}")
+    console.print(f"Schema version: {payload['schema_version']}")
+    console.print(f"Dataset fingerprint: {payload['dataset_fingerprint']}")
+    console.print(f"Examples mapped: {len(payload['example_map'])}")
+    console.print(
+        "[dim]Local-only flow: generated file stays client-side unless you share it.[/dim]"
+    )
+
+
 # -----------------------------------------------------------------------------
 # Helper functions for results commands (reduces cognitive complexity - S3776)
 # -----------------------------------------------------------------------------

--- a/traigent/reporting/__init__.py
+++ b/traigent/reporting/__init__.py
@@ -1,0 +1,13 @@
+"""Reporting helpers for optimization outputs."""
+
+from .example_map import (
+    build_example_content_map,
+    compute_dataset_fingerprint,
+    validate_example_content_map,
+)
+
+__all__ = [
+    "build_example_content_map",
+    "compute_dataset_fingerprint",
+    "validate_example_content_map",
+]

--- a/traigent/reporting/example_map.py
+++ b/traigent/reporting/example_map.py
@@ -25,7 +25,7 @@ def build_example_content_map(
     path = Path(dataset_path)
     examples = _load_examples(path)
     identifier = (
-        dataset_identifier if dataset_identifier is not None else str(dataset_path)
+        dataset_identifier if dataset_identifier is not None else str(path.resolve())
     )
     dataset_hash = compute_dataset_hash(identifier)
     example_map: dict[str, Any] = {}
@@ -36,9 +36,9 @@ def build_example_content_map(
             "example_num": index + 1,
             "input": example["input"],
             "expected_output": example["expected_output"],
+            # Keep stored entries aligned with fingerprint canonicalization.
+            "metadata": example["metadata"],
         }
-        if example.get("metadata"):
-            payload["metadata"] = example["metadata"]
         example_map[example_id] = payload
 
     return {
@@ -80,6 +80,8 @@ def validate_example_content_map(payload: dict[str, Any]) -> list[str]:
             schema=schema,
             format_checker=jsonschema.FormatChecker(),
         )
+    except jsonschema.SchemaError as exc:
+        return [f"Schema definition error: {exc.message}"]
     except jsonschema.ValidationError as exc:
         return [str(exc)]
     return []
@@ -157,7 +159,16 @@ def _normalize_example_item(item: Any, *, source: str) -> dict[str, Any]:
         raise ValidationError(
             f"Dataset entry missing required 'output' or 'expected_output' field: {source}"
         )
-    expected_output = item.get("output", item.get("expected_output"))
+    has_output = "output" in item
+    has_expected_output = "expected_output" in item
+    output_value = item.get("output")
+    expected_output_value = item.get("expected_output")
+    if has_output and has_expected_output and output_value != expected_output_value:
+        raise ValidationError(
+            "Dataset entry has conflicting 'output' and 'expected_output' values: "
+            f"{source}"
+        )
+    expected_output = output_value if has_output else expected_output_value
     metadata = {
         key: value
         for key, value in item.items()

--- a/traigent/reporting/example_map.py
+++ b/traigent/reporting/example_map.py
@@ -1,0 +1,210 @@
+"""Local-only example content map generation for report enrichment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import jsonschema
+
+from traigent.utils.example_id import compute_dataset_hash, generate_stable_example_id
+from traigent.utils.exceptions import ValidationError
+
+EXAMPLE_CONTENT_MAP_SCHEMA_VERSION = "1.0.0"
+
+
+def build_example_content_map(
+    dataset_path: str | Path,
+    *,
+    dataset_identifier: str | None = None,
+) -> dict[str, Any]:
+    """Build a local-only example content map from a dataset file."""
+    path = Path(dataset_path)
+    examples = _load_examples(path)
+    identifier = (
+        dataset_identifier if dataset_identifier is not None else str(dataset_path)
+    )
+    dataset_hash = compute_dataset_hash(identifier)
+    example_map: dict[str, Any] = {}
+
+    for index, example in enumerate(examples):
+        example_id = generate_stable_example_id(dataset_hash, index)
+        payload: dict[str, Any] = {
+            "example_num": index + 1,
+            "input": example["input"],
+            "expected_output": example["expected_output"],
+        }
+        if example.get("metadata"):
+            payload["metadata"] = example["metadata"]
+        example_map[example_id] = payload
+
+    return {
+        "schema_version": EXAMPLE_CONTENT_MAP_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "dataset_fingerprint": compute_dataset_fingerprint(examples),
+        "example_map": example_map,
+    }
+
+
+def compute_dataset_fingerprint(
+    examples: list[dict[str, Any]],
+) -> str:
+    """Compute deterministic fingerprint over dataset content and order."""
+    canonical_examples = [
+        {
+            "input": ex["input"],
+            "expected_output": ex["expected_output"],
+            "metadata": ex.get("metadata") or {},
+        }
+        for ex in examples
+    ]
+    serialized = json.dumps(
+        canonical_examples,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def validate_example_content_map(payload: dict[str, Any]) -> list[str]:
+    """Validate a generated example map against schema contract."""
+    schema = _load_example_content_map_schema()
+    try:
+        jsonschema.validate(
+            instance=payload,
+            schema=schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
+    except jsonschema.ValidationError as exc:
+        return [str(exc)]
+    return []
+
+
+def _load_example_content_map_schema() -> dict[str, Any]:
+    """Load schema from TraigentSchema package with fallback definition."""
+    try:
+        from traigent_schema import load_schema as tg_load_schema
+
+        return cast(dict[str, Any], tg_load_schema("example_content_map_schema"))
+    except (ImportError, ModuleNotFoundError):
+        return _fallback_example_content_map_schema()
+
+
+def _load_examples(path: Path) -> list[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".jsonl":
+        return _load_examples_from_jsonl(path)
+    if suffix == ".json":
+        return _load_examples_from_json(path)
+    raise ValidationError(f"Unsupported dataset format: {suffix}. Use .json or .jsonl")
+
+
+def _load_examples_from_jsonl(path: Path) -> list[dict[str, Any]]:
+    examples: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                data = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValidationError(
+                    f"Invalid JSON on line {line_no} in {path}: {exc}"
+                ) from exc
+            examples.append(_normalize_example_item(data, source=f"{path}:{line_no}"))
+    if not examples:
+        raise ValidationError(f"No examples found in dataset: {path}")
+    return examples
+
+
+def _load_examples_from_json(path: Path) -> list[dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict) and isinstance(payload.get("examples"), list):
+        items = payload["examples"]
+    elif isinstance(payload, dict):
+        items = [payload]
+    else:
+        raise ValidationError(f"Unsupported JSON dataset structure in {path}")
+
+    examples = [
+        _normalize_example_item(item, source=f"{path}:{index}")
+        for index, item in enumerate(items)
+    ]
+    if not examples:
+        raise ValidationError(f"No examples found in dataset: {path}")
+    return examples
+
+
+def _normalize_example_item(item: Any, *, source: str) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise ValidationError(f"Dataset entry must be an object: {source}")
+    if "input" not in item:
+        raise ValidationError(f"Dataset entry missing required 'input' field: {source}")
+    if "output" not in item and "expected_output" not in item:
+        raise ValidationError(
+            f"Dataset entry missing required 'output' or 'expected_output' field: {source}"
+        )
+    expected_output = item.get("output", item.get("expected_output"))
+    metadata = {
+        key: value
+        for key, value in item.items()
+        if key not in {"input", "output", "expected_output"}
+    }
+    return {
+        "input": item["input"],
+        "expected_output": expected_output,
+        "metadata": metadata,
+    }
+
+
+def _fallback_example_content_map_schema() -> dict[str, Any]:
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Example Content Map Schema",
+        "type": "object",
+        "properties": {
+            "schema_version": {
+                "type": "string",
+                "pattern": r"^\d+\.\d+\.\d+$",
+            },
+            "generated_at": {"type": "string", "format": "date-time"},
+            "dataset_fingerprint": {"type": "string"},
+            "example_map": {
+                "type": "object",
+                "patternProperties": {
+                    "^.+$": {
+                        "type": "object",
+                        "properties": {
+                            "example_num": {"type": "integer", "minimum": 1},
+                            "input": {},
+                            "expected_output": {},
+                            "metadata": {"type": "object"},
+                        },
+                        "required": ["example_num", "input", "expected_output"],
+                        "additionalProperties": False,
+                    }
+                },
+                "additionalProperties": False,
+            },
+        },
+        "required": [
+            "schema_version",
+            "generated_at",
+            "dataset_fingerprint",
+            "example_map",
+        ],
+        "additionalProperties": False,
+    }

--- a/traigent/reporting/example_map.py
+++ b/traigent/reporting/example_map.py
@@ -172,7 +172,7 @@ def _normalize_example_item(item: Any, *, source: str) -> dict[str, Any]:
 
 def _fallback_example_content_map_schema() -> dict[str, Any]:
     return {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Example Content Map Schema",
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- add a local-only `traigent report-example-map` CLI command for generating FE enrichment maps from JSON/JSONL datasets
- add `traigent.reporting.example_map` helpers for map generation, deterministic dataset fingerprinting, and schema validation
- document the command in the README and add focused unit/CLI coverage

## Testing
- PYTHONPATH=. .venv/bin/python -m pytest tests/unit/reporting/test_example_map.py tests/unit/cli/test_report_example_map_command.py