### PR TITLE
fix: send hybrid optimization config and align regression tests

### DIFF
--- a/tests/integration/backend/test_backend_integration_mock.py
+++ b/tests/integration/backend/test_backend_integration_mock.py
@@ -26,7 +26,7 @@ class TestBackendIntegrationMocked:
     def backend_client(self, backend_config):
         """Create backend client instance."""
         return BackendIntegratedClient(
-            api_key="tg_" + "a" * 61,  # Valid 64-char format
+            api_key="tg_" + "a" * 61,  # Valid 64-char format  # pragma: allowlist secret
             backend_config=backend_config,
             enable_fallback=True,
         )
@@ -214,9 +214,11 @@ class TestBackendIntegrationMocked:
 
             # Capture the actual request sent
             request_data = None
+            request_url = None
 
             def capture_request(*args, **kwargs):
-                nonlocal request_data
+                nonlocal request_data, request_url
+                request_url = args[0] if args else kwargs.get("url")
                 request_data = kwargs.get("json", {})
                 # Return the mock_post_context, not mock_response directly
                 mock_post_context = AsyncMock()
@@ -245,10 +247,15 @@ class TestBackendIntegrationMocked:
                     )
                 )
 
-            # Verify request structure for session endpoint
-            # Note: optimization_config is used locally for session info but not sent in the request
+            # Verify request structure for hybrid session endpoint
+            assert request_url == "http://localhost:5000/api/v1/hybrid/sessions"
             assert request_data is not None
             assert "problem_statement" in request_data
             assert request_data["problem_statement"] == "test_function"
             assert "search_space" in request_data
+            assert "optimization_config" in request_data
+            assert request_data["optimization_config"] == {
+                "objectives": ["maximize"],
+                "max_trials": 10,
+            }
             assert "metadata" in request_data

--- a/tests/integration/test_full_optimization.py
+++ b/tests/integration/test_full_optimization.py
@@ -163,7 +163,12 @@ class TestFullOptimizationWorkflow:
 
             # Verify results
             assert len(result.trials) == 5
-            assert result.best_score is None or result.best_score >= 0
+            if result.best_score is None:
+                session_summary = result.metadata.get("session_summary", {})
+                assert session_summary.get("reason_code") == "NO_RANKING_ELIGIBLE_TRIALS"
+                assert result.best_config == {}
+            else:
+                assert result.best_score >= 0
             assert result.algorithm == "RandomSearchOptimizer"
 
             # Should have tried different configurations

--- a/tests/integration/test_full_optimization.py
+++ b/tests/integration/test_full_optimization.py
@@ -163,7 +163,7 @@ class TestFullOptimizationWorkflow:
 
             # Verify results
             assert len(result.trials) == 5
-            assert result.best_score >= 0
+            assert result.best_score is None or result.best_score >= 0
             assert result.algorithm == "RandomSearchOptimizer"
 
             # Should have tried different configurations

--- a/tests/unit/cli/test_auth_whoami_command.py
+++ b/tests/unit/cli/test_auth_whoami_command.py
@@ -59,6 +59,9 @@ class _FakeSession:
         assert self._response is not None
         return self._response
 
+    def post(self, url: str, headers: dict[str, str]) -> _FakeResponse:
+        return self.get(url, headers)
+
 
 def _install_fake_aiohttp(
     monkeypatch: pytest.MonkeyPatch,
@@ -97,6 +100,7 @@ def test_whoami_valid_key_200(monkeypatch: pytest.MonkeyPatch) -> None:
         response=_FakeResponse(
             status=200,
             json_payload={
+                "valid": True,
                 "data": {
                     "email": "dev@traigent.ai",
                     "name": "Dev User",

--- a/tests/unit/cli/test_auth_whoami_command.py
+++ b/tests/unit/cli/test_auth_whoami_command.py
@@ -59,7 +59,9 @@ class _FakeSession:
         assert self._response is not None
         return self._response
 
-    def post(self, url: str, headers: dict[str, str]) -> _FakeResponse:
+    def post(
+        self, url: str, headers: dict[str, str] | None = None, **kwargs
+    ) -> _FakeResponse:
         return self.get(url, headers)
 
 

--- a/tests/unit/cloud/test_authentication_headers.py
+++ b/tests/unit/cloud/test_authentication_headers.py
@@ -415,6 +415,8 @@ class TestBackendIntegratedClientCore:
             assert "headers" in post_kwargs
             headers = post_kwargs["headers"]
             assert "X-API-Key" in headers or "Authorization" in headers
+            post_url = mock_aiohttp_session.post.call_args[0][0]
+            assert post_url == "http://test.backend.com/api/v1/hybrid/sessions"
 
             # Reset mock
             mock_aiohttp_session.post.reset_mock()
@@ -427,6 +429,11 @@ class TestBackendIntegratedClientCore:
             assert mock_aiohttp_session.get.called
             get_kwargs = mock_aiohttp_session.get.call_args[1]
             assert "headers" in get_kwargs
+            get_url = mock_aiohttp_session.get.call_args[0][0]
+            assert (
+                get_url
+                == "http://test.backend.com/api/v1/hybrid/sessions/session-789/status"
+            )
 
             # Reset mock and setup for finalize
             mock_aiohttp_session.post.reset_mock()
@@ -459,6 +466,11 @@ class TestBackendIntegratedClientCore:
             assert mock_aiohttp_session.post.called
             post_kwargs = mock_aiohttp_session.post.call_args[1]
             assert "headers" in post_kwargs
+            post_url = mock_aiohttp_session.post.call_args[0][0]
+            assert (
+                post_url
+                == "http://test.backend.com/api/v1/hybrid/sessions/session-789/finalize"
+            )
 
     @pytest.mark.asyncio
     async def test_backend_client_ensure_session_with_fallback(self):

--- a/tests/unit/cloud/test_session_cleanup.py
+++ b/tests/unit/cloud/test_session_cleanup.py
@@ -46,7 +46,7 @@ asyncio.run(main())
             [sys.executable, "-Walways", "-c", script],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=30,
         )
         assert (
             result.returncode == 0

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -743,6 +743,7 @@ class TestOptimizedFunction:
             config_space=sample_config_space,
             objectives=sample_objectives,
             execution_mode="cloud",
+            cloud_fallback_policy="auto",
             max_trials=3,
             eval_dataset=sample_dataset,
         )

--- a/tests/unit/test_commercial_mode.py
+++ b/tests/unit/test_commercial_mode.py
@@ -128,6 +128,7 @@ class TestOptimizedFunctionCloudMode:
                 objectives=["accuracy"],
                 configuration_space={"param": [1, 2, 3]},
                 execution_mode="cloud",
+                cloud_fallback_policy="auto",
             )
 
             # Mock the cloud optimization
@@ -168,6 +169,7 @@ class TestOptimizedFunctionCloudMode:
                 objectives=["accuracy"],
                 configuration_space={"param": [1, 2, 3]},
                 execution_mode="cloud",
+                cloud_fallback_policy="auto",
             )
 
             # Mock cloud optimization failure

--- a/tests/unit/test_privacy_mode.py
+++ b/tests/unit/test_privacy_mode.py
@@ -103,6 +103,10 @@ class TestPrivacyCompliance:
             "objectives",
             "dataset_metadata",
             "max_trials",
+            "budget",
+            "constraints",
+            "default_config",
+            "promotion_policy",
             "optimization_strategy",
             "user_id",
             "billing_tier",
@@ -271,7 +275,7 @@ class TestPrivacyCompliance:
             bad_request.dataset = Dataset(
                 [
                     EvaluationExample(
-                        input_data={"secret": "data"}, expected_output="output"
+                        input_data={"secret": "data"}, expected_output="output"  # pragma: allowlist secret
                     )
                 ]
             )

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -468,6 +468,7 @@ class SessionOperations:
                 json={
                     "problem_statement": problem_statement,
                     "search_space": search_space,
+                    "optimization_config": optimization_config,
                     "metadata": metadata,
                 },
                 headers=await self.client.auth_manager.auth.get_headers(),


### PR DESCRIPTION
## Summary
- send `optimization_config` in hybrid session creation requests
- harden hybrid URL/payload regression coverage
- align whoami, cloud fallback, privacy, and cleanup tests with current behavior

## Validation
- `.venv/bin/python -m pytest tests/integration/backend/test_backend_integration_mock.py tests/unit/cloud/test_authentication_headers.py tests/unit/cli/test_auth_whoami_command.py tests/integration/test_full_optimization.py::TestFullOptimizationWorkflow::test_random_search_optimization tests/unit/cloud/test_session_cleanup.py::TestBackendClientSessionCleanup::test_no_unclosed_warning_with_real_session tests/unit/core/test_optimized_function.py::TestOptimizedFunction::test_optimize_cloud_service_fallback tests/unit/test_commercial_mode.py::TestOptimizedFunctionCloudMode::test_optimize_with_cloud_mode_fallback tests/unit/test_privacy_mode.py::TestPrivacyCompliance::test_no_data_sent_on_session_creation`