### PR TITLE
Pass hybrid evaluate config and clean up SDK follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ def weighted_agent(question: str) -> str:
     return llm.invoke(f"Answer concisely: {question}").content
 ```
 
+Positive weights can be written as fractions (`0.7` / `0.3`) or percentages (`70` / `30`); Traigent normalizes them automatically before scoring.
+
 > **Tip**: See `examples/quickstart/03_custom_objectives.py` for a complete working example.
 
 ### Injection modes & default values

--- a/tests/unit/core/test_objectives.py
+++ b/tests/unit/core/test_objectives.py
@@ -34,8 +34,13 @@ class TestObjectiveDefinition:
 
     def test_negative_weight_validation(self):
         """Test that negative weights are rejected."""
-        with pytest.raises(ValueError, match="Weight must be non-negative"):
+        with pytest.raises(ValueError, match="Weight must be positive"):
             ObjectiveDefinition(name="cost", orientation="minimize", weight=-0.5)
+
+    def test_zero_weight_validation(self):
+        """Test that zero weights are rejected."""
+        with pytest.raises(ValueError, match="Weight must be positive"):
+            ObjectiveDefinition(name="cost", orientation="minimize", weight=0.0)
 
     def test_invalid_orientation_validation(self):
         """Test that invalid orientations are rejected."""
@@ -166,16 +171,6 @@ class TestObjectiveSchema:
         ]
 
         with pytest.raises(ValueError, match="Duplicate objective names found"):
-            ObjectiveSchema.from_objectives(objectives)
-
-    def test_zero_weights_validation(self):
-        """Test that zero total weight is rejected."""
-        objectives = [
-            ObjectiveDefinition("accuracy", "maximize", 0.0),
-            ObjectiveDefinition("cost", "minimize", 0.0),
-        ]
-
-        with pytest.raises(ValueError, match="Sum of weights must be positive"):
             ObjectiveSchema.from_objectives(objectives)
 
     def test_weights_sum_validation(self):
@@ -356,6 +351,17 @@ class TestCreateDefaultObjectives:
         assert schema.get_normalized_weight("accuracy") == 0.5
         assert schema.get_normalized_weight("cost") == 0.3
         assert schema.get_normalized_weight("custom_metric") == 0.2
+
+    def test_percentage_style_weights_are_normalized(self):
+        """Test that percentage-style weights are normalized automatically."""
+        schema = create_default_objectives(
+            ["accuracy", "cost"],
+            weights={"accuracy": 70.0, "cost": 30.0},
+        )
+
+        assert schema.weights_sum == pytest.approx(100.0)
+        assert schema.get_normalized_weight("accuracy") == pytest.approx(0.7)
+        assert schema.get_normalized_weight("cost") == pytest.approx(0.3)
 
     def test_unknown_metric_defaults(self):
         """Test that unknown metrics default to maximize."""

--- a/tests/unit/evaluators/test_hybrid_api_cancelled_error.py
+++ b/tests/unit/evaluators/test_hybrid_api_cancelled_error.py
@@ -109,6 +109,7 @@ async def test_evaluate_outputs_propagates_cancelled_error():
     with pytest.raises(asyncio.CancelledError):
         await evaluator._evaluate_outputs(
             transport=mock_transport,
+            config={"model": "gpt-4"},
             batch=batch,
             inputs=inputs,
             execute_response=mock_execute_response,

--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -1154,6 +1154,8 @@ class TestExecuteBatch:
         assert len(results) == 1
         assert results[0].metrics == {"accuracy": 0.8}
         mock_transport.evaluate.assert_awaited_once()
+        eval_request = mock_transport.evaluate.await_args.args[0]
+        assert eval_request.config == {"model": "gpt-4"}
 
     @pytest.mark.asyncio
     async def test_execute_only_mode(self, mock_transport: MagicMock) -> None:
@@ -1339,9 +1341,10 @@ class TestEvaluateOutputs:
             {"example_id": "ex_0", "data": {"question": "What is 2+2?"}},
             {"example_id": "ex_1", "data": {"question": "What is 3+3?"}},
         ]
+        config = {"judge_model": "gpt-4.1-mini"}
 
         results = await ev._evaluate_outputs(
-            mock_transport, batch, inputs, exec_response
+            mock_transport, config, batch, inputs, exec_response
         )
 
         assert len(results) == 2
@@ -1349,6 +1352,8 @@ class TestEvaluateOutputs:
         assert results[0].metrics == {"accuracy": 1.0}
         assert results[1].metrics == {"accuracy": 0.5}
         assert results[0].cost_usd == pytest.approx(0.02)  # 0.04 / 2
+        eval_request = mock_transport.evaluate.await_args.args[0]
+        assert eval_request.config == config
 
     @pytest.mark.asyncio
     async def test_evaluate_outputs_fallback_on_error(
@@ -1371,7 +1376,7 @@ class TestEvaluateOutputs:
         inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
 
         results = await ev._evaluate_outputs(
-            mock_transport, batch, inputs, exec_response
+            mock_transport, {}, batch, inputs, exec_response
         )
 
         # Should fall back to execute-only (no quality metrics)
@@ -1402,7 +1407,7 @@ class TestEvaluateOutputs:
         inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
 
         results = await ev._evaluate_outputs(
-            mock_transport, batch, inputs, exec_response
+            mock_transport, {}, batch, inputs, exec_response
         )
 
         assert len(results) == 1
@@ -1430,10 +1435,38 @@ class TestEvaluateOutputs:
         batch = list(dataset)
         inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
 
-        await ev._evaluate_outputs(mock_transport, batch, inputs, exec_response)
+        await ev._evaluate_outputs(
+            mock_transport, {"judge_model": "gpt-4"}, batch, inputs, exec_response
+        )
 
         eval_request = mock_transport.evaluate.await_args.args[0]
         assert eval_request.timeout_ms == 12500
+        assert eval_request.config == {"judge_model": "gpt-4"}
+
+    @pytest.mark.asyncio
+    async def test_evaluate_outputs_preserves_empty_config_dict(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """Empty config should be forwarded as {} rather than omitted."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id="cap",
+            keep_alive=False,
+        )
+        exec_response = _make_execute_response(
+            outputs=[{"example_id": "ex_0", "output": "result_0"}],
+            operational_metrics={"cost_usd": 0.01, "latency_ms": 100.0},
+        )
+        mock_transport.evaluate = AsyncMock(return_value=_make_evaluate_response())
+
+        dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "a"}])
+        batch = list(dataset)
+        inputs = [{"example_id": "ex_0", "data": {"q": "?"}}]
+
+        await ev._evaluate_outputs(mock_transport, {}, batch, inputs, exec_response)
+
+        eval_request = mock_transport.evaluate.await_args.args[0]
+        assert eval_request.config == {}
 
 
 # ---------------------------------------------------------------------------

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -640,7 +640,7 @@ class TraigentAuthCLI:
             console.print(f"\n[red]❌ Authentication failed: {e}[/red]")
             console.print("\nPlease check your credentials and try again.")
             console.print(
-                "If you don't have an account, visit: https://traigent.ai/signup\n"
+                "If you don't have an account, visit: https://portal.traigent.ai/login\n"
             )
             return False
         except TimeoutError as e:

--- a/traigent/cli/local_commands.py
+++ b/traigent/cli/local_commands.py
@@ -631,9 +631,9 @@ def preview_cloud_benefits() -> None:
             )
 
         click.echo("\n🎯 Ready to upgrade?")
-        click.echo("   1. Get API key: https://traigent.ai/signup")
+        click.echo("   1. Get API key: https://portal.traigent.ai/login")
         click.echo("   2. Run: traigent local sync --api-key YOUR_KEY")
-        click.echo("   3. Access dashboard: https://app.traigent.ai")
+        click.echo("   3. Access portal: https://portal.traigent.ai")
 
     except Exception as e:
         click.echo(f"Error previewing cloud benefits: {e}", err=True)

--- a/traigent/core/objectives.py
+++ b/traigent/core/objectives.py
@@ -47,7 +47,7 @@ class ObjectiveDefinition:
         name: Name of the objective (e.g., "accuracy", "cost")
         orientation: Whether to maximize or minimize this objective.
             For banded objectives, this is set to "band".
-        weight: Non-negative weight for this objective
+        weight: Positive weight for this objective
         normalization: Normalization strategy (default: "min_max")
         bounds: Optional bounds for the objective values
         unit: Optional unit of measurement (e.g., "USD", "percentage")

--- a/traigent/core/objectives.py
+++ b/traigent/core/objectives.py
@@ -71,9 +71,9 @@ class ObjectiveDefinition:
     def __post_init__(self) -> None:
         """Validate objective definition after initialization."""
         # Validate weight
-        if self.weight < 0:
+        if self.weight <= 0:
             raise ValueError(
-                f"Weight must be non-negative, got {self.weight} for objective '{self.name}'"
+                f"Weight must be positive, got {self.weight} for objective '{self.name}'"
             )
 
         # Validate orientation

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -797,7 +797,7 @@ class HybridAPIEvaluator(BaseEvaluator):
             elif caps.supports_evaluate:
                 # Two-phase mode - need separate evaluate call
                 return await self._evaluate_outputs(
-                    transport, batch, inputs, execute_response
+                    transport, config, batch, inputs, execute_response
                 )
             else:
                 # No evaluation - return outputs only
@@ -910,6 +910,7 @@ class HybridAPIEvaluator(BaseEvaluator):
     async def _evaluate_outputs(
         self,
         transport: HybridTransport,
+        config: dict[str, Any],
         batch: list[Any],
         inputs: list[dict[str, Any]],
         execute_response: Any,  # HybridExecuteResponse
@@ -947,6 +948,7 @@ class HybridAPIEvaluator(BaseEvaluator):
             benchmark_id=benchmark_id,
             execution_id=execute_response.execution_id,
             evaluations=evaluations,
+            config=config,
             session_id=self._session_id,
             timeout_ms=int(self._timeout * 1000),
         )


### PR DESCRIPTION
## Summary
- fix `#325` by forwarding the same trial config from hybrid `/execute` into `/evaluate`, including preserving empty `{}` config
- fix `#277` by updating CLI auth and upgrade messaging to point users at `https://portal.traigent.ai/login`
- narrow the actionable part of `#238` by rejecting zero-weight objectives while documenting that percentage-style weights are normalized automatically

## Testing
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m py_compile traigent/evaluators/hybrid_api.py tests/unit/evaluators/test_hybrid_api_evaluator.py tests/unit/evaluators/test_hybrid_api_cancelled_error.py traigent/cli/auth_commands.py traigent/cli/local_commands.py traigent/core/objectives.py tests/unit/core/test_objectives.py`
- `timeout 60s /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/pytest -q tests/unit/core/test_objectives.py -k 'zero_weight_validation or percentage_style_weights_are_normalized'`
- direct async sanity check confirming hybrid evaluate receives full config, preserves empty `{}`, and keeps `timeout_ms=12500`

## Notes
- I did not claim a full run of `tests/unit/evaluators/test_hybrid_api_evaluator.py`; that file hangs intermittently in this environment, so the hybrid path was verified with direct async checks instead.
- This PR is intentionally separate from `#340`, which remains focused on `#246`.