### PR TITLE
ci: add typed-session-smoke workflow

### DIFF
--- a/.github/workflows/typed-session-smoke.yml
+++ b/.github/workflows/typed-session-smoke.yml
@@ -19,8 +19,11 @@ jobs:
 
       - name: Check smoke configuration
         id: config
+        env:
+          TRAIGENT_API_KEY: ${{ secrets.TRAIGENT_API_KEY }}
+          TRAIGENT_API_URL: ${{ secrets.TRAIGENT_API_URL }}
         run: |
-          if [ -z "${{ secrets.TRAIGENT_API_KEY }}" ] || [ -z "${{ secrets.TRAIGENT_API_URL }}" ]; then
+          if [ -z "$TRAIGENT_API_KEY" ] || [ -z "$TRAIGENT_API_URL" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "Typed session smoke is not configured; skipping."
           else

--- a/.github/workflows/typed-session-smoke.yml
+++ b/.github/workflows/typed-session-smoke.yml
@@ -1,0 +1,63 @@
+name: Typed Session Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 2 * * *"
+
+jobs:
+  typed-session-smoke:
+    runs-on: ubuntu-latest
+    environment: typed-session-smoke
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check smoke configuration
+        id: config
+        run: |
+          if [ -z "${{ secrets.TRAIGENT_API_KEY }}" ] || [ -z "${{ secrets.TRAIGENT_API_URL }}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Typed session smoke is not configured; skipping."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.config.outputs.configured == 'true'
+        name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test,hybrid]"
+
+      - if: steps.config.outputs.configured == 'true'
+        name: Verify smoke backend is reachable
+        env:
+          TRAIGENT_API_URL: ${{ secrets.TRAIGENT_API_URL }}
+        run: |
+          python - <<'PY'
+          import os
+          from urllib.parse import urlparse, urlunparse
+
+          api_url = os.environ["TRAIGENT_API_URL"].rstrip("/")
+          parsed = urlparse(api_url)
+          path = parsed.path.removesuffix("/api/v1") or "/"
+          health = urlunparse(parsed._replace(path=f"{path.rstrip('/')}/health", query="", fragment=""))
+          print(health)
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
+              fh.write(f"TRAIGENT_SMOKE_HEALTH_URL={health}\n")
+          PY
+          curl -sf --max-time 10 "$TRAIGENT_SMOKE_HEALTH_URL"
+
+      - if: steps.config.outputs.configured == 'true'
+        name: Run typed session smoke
+        env:
+          TRAIGENT_HYBRID_LIVE: "1"
+          TRAIGENT_API_URL: ${{ secrets.TRAIGENT_API_URL }}
+          TRAIGENT_API_KEY: ${{ secrets.TRAIGENT_API_KEY }}
+          PYTHONPATH: .
+        run: |
+          pytest tests/integration/backend/test_hybrid_session_live.py -q --tb=short

--- a/tests/integration/backend/test_hybrid_session_live.py
+++ b/tests/integration/backend/test_hybrid_session_live.py
@@ -1,0 +1,121 @@
+"""Live backend smoke test for the interactive optimization session API."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from traigent.cloud.client import TraigentCloudClient
+
+
+def _resolve_backend_url() -> str | None:
+    return os.getenv("TRAIGENT_API_URL") or os.getenv("TRAIGENT_BACKEND_URL")
+
+
+def _score_config(config: dict[str, object]) -> dict[str, float]:
+    model = str(config["model"])
+    temperature = float(config["temperature"])
+
+    accuracy = (
+        0.9 - abs(temperature - 0.4) * 0.05
+        if model == "gpt-4o"
+        else 0.82 - abs(temperature - 0.2) * 0.04
+    )
+    cost = 0.35 if model == "gpt-4o" else 0.08
+
+    return {"accuracy": accuracy, "cost": cost}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("TRAIGENT_HYBRID_LIVE"),
+    reason=(
+        "Set TRAIGENT_HYBRID_LIVE=1 plus TRAIGENT_API_KEY and "
+        "TRAIGENT_API_URL (preferred) or TRAIGENT_BACKEND_URL to run live hybrid session tests"
+    ),
+)
+async def test_live_hybrid_session_round_trip() -> None:
+    """Exercise create/next/result/finalize against the real backend."""
+    api_key = os.getenv("TRAIGENT_API_KEY")
+    backend_url = _resolve_backend_url()
+
+    if not api_key:
+        pytest.skip("TRAIGENT_API_KEY must be set for the live hybrid session test")
+
+    if not backend_url:
+        pytest.skip(
+            "Set TRAIGENT_API_URL (preferred) or TRAIGENT_BACKEND_URL for the live hybrid session test"
+        )
+
+    session_id: str | None = None
+
+    async with TraigentCloudClient(
+        api_key=api_key,
+        base_url=backend_url,
+        enable_fallback=False,
+    ) as client:
+        try:
+            created = await client.create_optimization_session(
+                "python_hybrid_live_smoke",
+                configuration_space={
+                    "model": {
+                        "type": "categorical",
+                        "choices": ["gpt-4o-mini", "gpt-4o"],
+                    },
+                    "temperature": {
+                        "type": "float",
+                        "low": 0.0,
+                        "high": 1.0,
+                        "step": 0.2,
+                    },
+                },
+                objectives=["accuracy", "cost"],
+                dataset_metadata={"size": 4, "suite": "python-hybrid-live-smoke"},
+                max_trials=4,
+                optimization_strategy={"algorithm": "optuna"},
+            )
+
+            session_id = created.session_id
+            assert session_id
+            assert created.status.value in {"created", "active"}
+
+            next_trial = await client.get_next_trial(session_id)
+            assert next_trial.should_continue is True
+            assert next_trial.suggestion is not None
+
+            suggestion = next_trial.suggestion
+            assert suggestion.session_id == session_id
+            assert suggestion.trial_number == 1
+            assert suggestion.dataset_subset.indices
+            assert all(0 <= index < 4 for index in suggestion.dataset_subset.indices)
+
+            metrics = _score_config(suggestion.config)
+
+            await client.submit_trial_result(
+                session_id=session_id,
+                trial_id=suggestion.trial_id,
+                metrics=metrics,
+                duration=0.01,
+                status="completed",
+                metadata={"suite": "python-hybrid-live-smoke"},
+            )
+
+            finalized = await client.finalize_optimization(session_id)
+            assert finalized.session_id == session_id
+            assert finalized.total_trials >= 1
+            assert finalized.successful_trials >= 1
+            assert isinstance(finalized.best_metrics, dict)
+            assert "accuracy" in finalized.best_metrics
+            assert finalized.stop_reason in {
+                "max_trials_reached",
+                "search_complete",
+                "finalized",
+            }
+        finally:
+            if session_id:
+                try:
+                    await client.delete_session(session_id, cascade=True)
+                except Exception:
+                    pass


### PR DESCRIPTION
Adds workflow for daily typed session smoke tests against the remote backend at smoke-backend.tvl-lang.org. Uses `typed-session-smoke` GitHub Environment with `TRAIGENT_API_URL` and `TRAIGENT_API_KEY` secrets.