### PR TITLE
feat: add wrapper config-space token estimates

### DIFF
--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -245,6 +245,34 @@ class TestCreateAppRoutes:
         assert body["tunable_id"] == "test_svc"
         assert len(body["tvars"]) == 1
 
+    @pytest.mark.asyncio
+    async def test_config_space_route_includes_estimated_tokens_when_configured(
+        self,
+    ) -> None:
+        """Configured wrapper token estimates should be exposed via config-space."""
+        service = TraigentService(
+            tunable_id="test_svc",
+            estimated_tokens_per_example={"input_tokens": 100, "output_tokens": 50},
+        )
+
+        @service.tvars
+        def config_space():
+            return {"model": {"type": "enum", "values": ["gpt-4"]}}
+
+        app = create_app(service)
+        send = _SendCollector()
+        await app(
+            _make_scope("GET", CONFIG_SPACE_PATH),
+            _make_receive(),
+            send,
+        )
+        assert send.status == 200
+        body = send.body_json
+        assert body["estimated_tokens_per_example"] == {
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
+
     # --- POST /traigent/v1/execute ---
     @pytest.mark.asyncio
     async def test_execute_route(self, app, service) -> None:

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from traigent.hybrid.protocol import EstimatedTokensPerExample
 from traigent.wrapper.service import ServiceConfig, Session, TraigentService
 
 
@@ -35,6 +36,7 @@ class TestServiceConfig:
         assert cfg.promotion_policy is None
         assert cfg.defaults is None
         assert cfg.measures is None
+        assert cfg.estimated_tokens_per_example is None
 
     def test_custom_values(self) -> None:
         """Test ServiceConfig with custom values."""
@@ -51,6 +53,9 @@ class TestServiceConfig:
             promotion_policy={"dominance": "epsilon_pareto"},
             defaults={"model": "gpt-4"},
             measures=["accuracy"],
+            estimated_tokens_per_example=EstimatedTokensPerExample(
+                input_tokens=100, output_tokens=50
+            ),
         )
         assert cfg.tunable_id == "qa_agent"
         assert cfg.version == "2.5"
@@ -64,6 +69,9 @@ class TestServiceConfig:
         assert cfg.promotion_policy is not None
         assert cfg.defaults == {"model": "gpt-4"}
         assert cfg.measures == ["accuracy"]
+        assert cfg.estimated_tokens_per_example == EstimatedTokensPerExample(
+            input_tokens=100, output_tokens=50
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +122,7 @@ class TestTraigentServiceInit:
         assert svc._evaluate_handler is None
         assert svc._sessions == {}
         assert svc._cached_tvars is None
+        assert svc.config.estimated_tokens_per_example is None
 
     def test_custom_init(self) -> None:
         """Test TraigentService with custom parameters."""
@@ -128,6 +137,7 @@ class TestTraigentServiceInit:
             promotion_policy={"dominance": "epsilon_pareto"},
             defaults={"model": "gpt-4"},
             measures=["accuracy"],
+            estimated_tokens_per_example={"input_tokens": 100, "output_tokens": 50},
         )
         assert svc.config.tunable_id == "my_agent"
         assert svc.config.version == "3.0"
@@ -139,6 +149,9 @@ class TestTraigentServiceInit:
         assert svc.config.promotion_policy == {"dominance": "epsilon_pareto"}
         assert svc.config.defaults == {"model": "gpt-4"}
         assert svc.config.measures == ["accuracy"]
+        assert svc.config.estimated_tokens_per_example == EstimatedTokensPerExample(
+            input_tokens=100, output_tokens=50
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -419,6 +432,7 @@ class TestGetConfigSpace:
             promotion_policy={"dominance": "epsilon_pareto"},
             defaults={"model": "gpt-4"},
             measures=["accuracy", "cost"],
+            estimated_tokens_per_example={"input_tokens": 100, "output_tokens": 50},
         )
         result = svc.get_config_space()
         assert result["constraints"] == {
@@ -429,6 +443,10 @@ class TestGetConfigSpace:
         assert result["promotion_policy"] == {"dominance": "epsilon_pareto"}
         assert result["defaults"] == {"model": "gpt-4"}
         assert result["measures"] == ["accuracy", "cost"]
+        assert result["estimated_tokens_per_example"] == {
+            "input_tokens": 100,
+            "output_tokens": 50,
+        }
 
     def test_config_space_decorator_sections_override_init_values(self) -> None:
         """Decorator-declared sections override constructor-provided values."""
@@ -448,6 +466,46 @@ class TestGetConfigSpace:
         result = svc.get_config_space()
         assert result["objectives"] == [{"name": "accuracy", "direction": "maximize"}]
         assert result["defaults"] == {"model": "gpt-4"}
+
+    def test_config_space_omits_estimated_tokens_when_unconfigured(self) -> None:
+        """Config-space response should not emit token estimates by default."""
+        svc = TraigentService()
+        result = svc.get_config_space()
+        assert "estimated_tokens_per_example" not in result
+
+    def test_env_estimated_tokens_are_used_when_constructor_omits_them(self) -> None:
+        """Wrapper should support environment-driven token estimate configuration."""
+        with patch.dict(
+            "os.environ",
+            {
+                "TRAIGENT_ESTIMATED_INPUT_TOKENS_PER_EXAMPLE": "120",
+                "TRAIGENT_ESTIMATED_OUTPUT_TOKENS_PER_EXAMPLE": "60",
+            },
+            clear=False,
+        ):
+            svc = TraigentService()
+
+        assert svc.config.estimated_tokens_per_example == EstimatedTokensPerExample(
+            input_tokens=120, output_tokens=60
+        )
+
+    def test_constructor_estimated_tokens_override_environment(self) -> None:
+        """Explicit wrapper config should beat environment fallback values."""
+        with patch.dict(
+            "os.environ",
+            {
+                "TRAIGENT_ESTIMATED_INPUT_TOKENS_PER_EXAMPLE": "120",
+                "TRAIGENT_ESTIMATED_OUTPUT_TOKENS_PER_EXAMPLE": "60",
+            },
+            clear=False,
+        ):
+            svc = TraigentService(
+                estimated_tokens_per_example={"input_tokens": 10, "output_tokens": 5}
+            )
+
+        assert svc.config.estimated_tokens_per_example == EstimatedTokensPerExample(
+            input_tokens=10, output_tokens=5
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -507,6 +507,32 @@ class TestGetConfigSpace:
             input_tokens=10, output_tokens=5
         )
 
+    def test_partial_env_estimated_tokens_are_ignored_with_warning(self) -> None:
+        """Partial env config should be ignored rather than coercing missing values to zero."""
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "TRAIGENT_ESTIMATED_INPUT_TOKENS_PER_EXAMPLE": "120",
+                },
+                clear=False,
+            ),
+            patch("traigent.wrapper.service.logger") as mock_logger,
+        ):
+            svc = TraigentService()
+
+        assert svc.config.estimated_tokens_per_example is None
+        mock_logger.warning.assert_called_once()
+        assert "must be set together" in mock_logger.warning.call_args[0][0]
+
+    def test_invalid_estimated_tokens_type_raises_helpful_error(self) -> None:
+        """Invalid constructor values should explain all supported input types."""
+        with pytest.raises(
+            TypeError,
+            match="EstimatedTokensPerExample instance, a dict, or None",
+        ):
+            TraigentService(estimated_tokens_per_example=123)  # type: ignore[arg-type]
+
 
 # ---------------------------------------------------------------------------
 # get_capabilities tests

--- a/traigent/wrapper/__init__.py
+++ b/traigent/wrapper/__init__.py
@@ -7,7 +7,10 @@ to define their configuration space, execution logic, and evaluation logic.
 Example:
     from traigent.wrapper import TraigentService
 
-    app = TraigentService(tunable_id="my_agent")
+    app = TraigentService(
+        tunable_id="my_agent",
+        estimated_tokens_per_example={"input_tokens": 100, "output_tokens": 50},
+    )
 
     @app.tvars
     def config_space():

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -66,6 +66,13 @@ def _estimated_tokens_from_env() -> EstimatedTokensPerExample | None:
     output_tokens = os.environ.get(_ESTIMATED_OUTPUT_TOKENS_ENV)
     if input_tokens is None and output_tokens is None:
         return None
+    if input_tokens is None or output_tokens is None:
+        logger.warning(
+            "Both %s and %s must be set together; ignoring partial token estimate configuration.",
+            _ESTIMATED_INPUT_TOKENS_ENV,
+            _ESTIMATED_OUTPUT_TOKENS_ENV,
+        )
+        return None
     return EstimatedTokensPerExample.from_dict(
         {
             "input_tokens": input_tokens,
@@ -84,7 +91,9 @@ def _resolve_estimated_tokens_per_example(
         return value
     if isinstance(value, dict):
         return EstimatedTokensPerExample.from_dict(value)
-    raise TypeError("estimated_tokens_per_example must be a dict or None")
+    raise TypeError(
+        "estimated_tokens_per_example must be an EstimatedTokensPerExample instance, a dict, or None"
+    )
 
 
 @dataclass

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -38,6 +38,7 @@ import copy
 import inspect
 import json
 import math
+import os
 import re
 import time
 import uuid
@@ -45,6 +46,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar
 
+from traigent.hybrid.protocol import EstimatedTokensPerExample
 from traigent.utils.logging import get_logger
 from traigent.wrapper.errors import HybridAPIError
 
@@ -54,6 +56,35 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 # OpenAPI contract: tunable and objective names must be valid Python identifiers.
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_]\w*$")
+_ESTIMATED_INPUT_TOKENS_ENV = "TRAIGENT_ESTIMATED_INPUT_TOKENS_PER_EXAMPLE"
+_ESTIMATED_OUTPUT_TOKENS_ENV = "TRAIGENT_ESTIMATED_OUTPUT_TOKENS_PER_EXAMPLE"
+
+
+def _estimated_tokens_from_env() -> EstimatedTokensPerExample | None:
+    """Return optional per-example token estimate from environment variables."""
+    input_tokens = os.environ.get(_ESTIMATED_INPUT_TOKENS_ENV)
+    output_tokens = os.environ.get(_ESTIMATED_OUTPUT_TOKENS_ENV)
+    if input_tokens is None and output_tokens is None:
+        return None
+    return EstimatedTokensPerExample.from_dict(
+        {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        }
+    )
+
+
+def _resolve_estimated_tokens_per_example(
+    value: EstimatedTokensPerExample | dict[str, Any] | None,
+) -> EstimatedTokensPerExample | None:
+    """Normalize optional per-example token estimate from config or env."""
+    if value is None:
+        return _estimated_tokens_from_env()
+    if isinstance(value, EstimatedTokensPerExample):
+        return value
+    if isinstance(value, dict):
+        return EstimatedTokensPerExample.from_dict(value)
+    raise TypeError("estimated_tokens_per_example must be a dict or None")
 
 
 @dataclass
@@ -73,6 +104,8 @@ class ServiceConfig:
         promotion_policy: Optional promotion policy definition.
         defaults: Optional default configuration values.
         measures: Optional declared measure names.
+        estimated_tokens_per_example: Optional per-example token estimate used
+            for hybrid pre-run approval checks.
     """
 
     tunable_id: str = "default"
@@ -87,6 +120,7 @@ class ServiceConfig:
     promotion_policy: dict[str, Any] | None = None
     defaults: dict[str, Any] | None = None
     measures: list[str] | None = None
+    estimated_tokens_per_example: EstimatedTokensPerExample | None = None
 
 
 @dataclass
@@ -144,6 +178,9 @@ class TraigentService:
         promotion_policy: dict[str, Any] | None = None,
         defaults: dict[str, Any] | None = None,
         measures: list[str] | None = None,
+        estimated_tokens_per_example: (
+            EstimatedTokensPerExample | dict[str, Any] | None
+        ) = None,
     ) -> None:
         """Initialize TraigentService.
 
@@ -159,6 +196,9 @@ class TraigentService:
             promotion_policy: Optional promotion policy.
             defaults: Optional default tunable values.
             measures: Optional declared measure names.
+            estimated_tokens_per_example: Optional per-example token estimate
+                for cost approval. Falls back to environment variables when not
+                provided.
         """
         self.config = ServiceConfig(
             tunable_id=tunable_id,
@@ -172,6 +212,9 @@ class TraigentService:
             promotion_policy=promotion_policy,
             defaults=defaults,
             measures=measures,
+            estimated_tokens_per_example=_resolve_estimated_tokens_per_example(
+                estimated_tokens_per_example
+            ),
         )
 
         # Registered handlers
@@ -416,6 +459,10 @@ class TraigentService:
             response["defaults"] = defaults
         if measures is not None:
             response["measures"] = measures
+        if self.config.estimated_tokens_per_example is not None:
+            response["estimated_tokens_per_example"] = (
+                self.config.estimated_tokens_per_example.to_dict()
+            )
         return response
 
     def _normalize_tvars(self, tvars: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- add optional wrapper support for `estimated_tokens_per_example`
- allow explicit config or environment-variable fallback
- expose the field from `/traigent/v1/config-space` only when configured
- add unit coverage for configured, unconfigured, env-driven, and route behavior

Closes #339.

## Testing
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m py_compile traigent/wrapper/service.py traigent/wrapper/__init__.py tests/unit/wrapper/test_wrapper_service.py tests/unit/wrapper/test_wrapper_server.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/pytest -q tests/unit/wrapper/test_wrapper_service.py tests/unit/wrapper/test_wrapper_server.py -k 'estimated_tokens or config_space_route'`
