### PR TITLE
docs: clarify runtime dataset assignment and callback timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,53 @@ def my_agent(query: str) -> str:
 | `algorithm` | `.optimize()` method call | Search algorithm: `"random"`, `"grid"`, `"bayesian"` |
 | `max_trials` | `.optimize()` method call | Number of configurations to test |
 
+### Attach Datasets After Decoration
+
+`eval_dataset` does not have to be fixed in the decorator. You can attach or replace
+it on the wrapped function before calling `.optimize()`.
+
+```python
+import asyncio
+
+import traigent
+from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+@traigent.optimize(
+    configuration_space={"model": ["gpt-4o-mini", "gpt-4o"]},
+    objectives=["accuracy"],
+)
+def classify_review(text: str) -> str:
+    return run_classifier(text)
+
+
+classify_review.eval_dataset = Dataset(
+    examples=[
+        EvaluationExample(
+            input_data={"text": "fast shipping and great packaging"},
+            expected_output="positive",
+        ),
+        EvaluationExample(
+            input_data={"text": "arrived broken and late"},
+            expected_output="negative",
+        ),
+    ],
+    name="review-smoke-test",
+)
+
+result = asyncio.run(classify_review.optimize(max_trials=4))
+```
+
+Notes:
+
+- Supported values are the same as in the decorator: a JSONL path, a list of JSONL
+  paths, or a `Dataset` object.
+- The optimized function still runs one example at a time. Traigent reads
+  `func.eval_dataset`, then calls your function with the current example's
+  `input_data` fields as normal function arguments.
+- If you need different evaluation sets for separate runs, update
+  `func.eval_dataset` between calls to `.optimize()`.
+
 ## 🎯 Configuration Injection Modes
 
 Traigent supports two ways to inject optimized parameters into your code:
@@ -676,6 +723,19 @@ results = await my_agent.optimize()
 print(f"Total optimization cost: ${results.total_cost:.4f}")
 print(f"Best configuration cost per call: ${results.best_config_cost:.6f}")
 ```
+
+### Callback Timeout Semantics
+
+Traigent isolates callback failures so a slow or broken callback does not block the
+optimization loop. When timeout protection is enabled in `CallbackManager`:
+
+- the optimization loop stops waiting after the timeout expires
+- the callback may still continue running in its worker thread
+- `future.cancel()` only prevents execution if the callback has not started yet
+
+For callbacks with external side effects, prefer idempotent writes and avoid holding
+locks or scarce resources for a long time. If a callback must finish before the next
+trial progresses, disable timeout protection for that callback manager instance.
 
 ## 🎓 More Examples
 

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -26,6 +26,52 @@ with open("data/qa_samples.jsonl", "w") as f:
         f.write(json.dumps(row) + "\n")
 ```
 
+## Attaching a Dataset at Runtime
+
+You can also assign the dataset after decoration instead of hard-coding
+`eval_dataset=` in `@traigent.optimize(...)`.
+
+```python
+import asyncio
+
+import traigent
+from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+@traigent.optimize(
+    configuration_space={"model": ["gpt-4o-mini", "gpt-4o"]},
+    objectives=["accuracy"],
+)
+def qa_agent(question: str) -> str:
+    return answer_question(question)
+
+
+qa_agent.eval_dataset = Dataset(
+    examples=[
+        EvaluationExample(
+            input_data={"question": "What is 2+2?"},
+            expected_output="4",
+        ),
+        EvaluationExample(
+            input_data={"question": "Capital of France?"},
+            expected_output="Paris",
+        ),
+    ],
+    name="qa-smoke-test",
+)
+
+results = asyncio.run(qa_agent.optimize(max_trials=4))
+```
+
+What this does:
+
+- `qa_agent.eval_dataset` can be a JSONL path, a list of JSONL paths, or a
+  `Dataset` object.
+- Traigent evaluates the dataset outside your function. Your function still accepts
+  one example's `input_data` fields as normal arguments.
+- To swap evaluation sets between runs, assign a new value to
+  `qa_agent.eval_dataset` before the next `.optimize()` call.
+
 ## Evaluation Modes
 
 ### 1) Default semantic similarity

--- a/traigent/utils/callbacks.py
+++ b/traigent/utils/callbacks.py
@@ -519,9 +519,10 @@ class CallbackManager:
         Args:
             callbacks: List of callback instances
             timeout: Maximum seconds to wait for a callback (default 5.0).
-                Set to None or 0 to disable timeout protection. When a timeout
-                occurs, optimization continues immediately, but the callback
-                thread may still run to completion in the background.
+                Set to 0 to disable timeout protection; passing None uses the
+                default timeout (5.0 seconds). When a timeout occurs,
+                optimization continues immediately, but the callback thread may
+                still run to completion in the background.
         """
         self.callbacks = callbacks or []
         self.timeout = timeout if timeout is not None else self.DEFAULT_TIMEOUT

--- a/traigent/utils/callbacks.py
+++ b/traigent/utils/callbacks.py
@@ -491,6 +491,16 @@ class CallbackManager:
     block or crash the optimization process. All failures are logged and tracked
     for reporting.
 
+    Timeout semantics are intentionally conservative:
+
+    - the optimization loop stops waiting once the timeout expires
+    - a timed-out callback may continue running in its worker thread
+    - ``future.cancel()`` only prevents execution if the callback has not started yet
+
+    For callbacks with side effects, prefer idempotent operations and avoid holding
+    locks or scarce resources for long periods. If a callback must complete before
+    optimization proceeds, disable timeout protection for that manager instance.
+
     Attributes:
         callbacks: List of registered callbacks
         timeout: Maximum seconds to wait for a callback (default 5.0)
@@ -509,7 +519,9 @@ class CallbackManager:
         Args:
             callbacks: List of callback instances
             timeout: Maximum seconds to wait for a callback (default 5.0).
-                Set to None or 0 to disable timeout protection.
+                Set to None or 0 to disable timeout protection. When a timeout
+                occurs, optimization continues immediately, but the callback
+                thread may still run to completion in the background.
         """
         self.callbacks = callbacks or []
         self.timeout = timeout if timeout is not None else self.DEFAULT_TIMEOUT
@@ -529,6 +541,11 @@ class CallbackManager:
             method_name: Name of the method being called (for logging)
             method_func: The actual method to call
             *args: Arguments to pass to the method
+
+        Notes:
+            Timeout protection is best-effort only. A timeout stops waiting on
+            the callback future but does not forcibly terminate a callback that
+            is already running.
         """
         callback_name = callback.__class__.__name__
 


### PR DESCRIPTION
## Summary
- document the supported `func.eval_dataset = ...` pattern in the README and evaluation guide
- clarify that Traigent owns dataset iteration and still calls the optimized function one example at a time
- document callback timeout semantics in `CallbackManager` and the public README

## Issues
Closes #83
Closes #85

## Verification
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m py_compile traigent/utils/callbacks.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python - <<'PY' ...` import sanity for `Dataset` / `EvaluationExample` construction

## Notes
- This is documentation-only; no runtime behavior changed.
- The dataset injection docs intentionally correct the stale issue example: the optimized function does not iterate the dataset directly.
