### PR TITLE
feat: add public trial serialization helper

### DIFF
--- a/tests/unit/api/test_trial_serialization.py
+++ b/tests/unit/api/test_trial_serialization.py
@@ -10,6 +10,26 @@ from traigent import serialize_trials
 from traigent.api.types import ExampleResult, TrialResult, TrialStatus
 
 
+class _NestedTimestampedPayload:
+    """Test helper exposing a no-arg ``to_dict`` with nested datetimes."""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "nested_at": datetime(2026, 3, 13, 11, 58, tzinfo=UTC),
+            "status": "ok",
+        }
+
+
+class _FormatAwarePayload:
+    """Test helper exposing a ``to_dict`` that accepts ``datetime_format``."""
+
+    def to_dict(self, *, datetime_format: str = "iso") -> dict[str, object]:
+        ts = datetime(2026, 3, 13, 11, 57, tzinfo=UTC)
+        return {
+            "nested_at": ts.isoformat() if datetime_format == "iso" else ts.timestamp()
+        }
+
+
 def _build_trial_result() -> TrialResult:
     return TrialResult(
         trial_id="trial-001",
@@ -78,6 +98,28 @@ def test_trial_result_to_dict_supports_epoch_timestamps() -> None:
     )
 
 
+def test_trial_result_to_dict_serializes_nested_to_dict_datetimes() -> None:
+    trial = _build_trial_result()
+    trial.metadata["nested_payload"] = _NestedTimestampedPayload()
+
+    serialized = trial.to_dict(datetime_format="epoch")
+
+    assert serialized["metadata"]["nested_payload"]["nested_at"] == pytest.approx(
+        datetime(2026, 3, 13, 11, 58, tzinfo=UTC).timestamp()
+    )
+
+
+def test_trial_result_to_dict_forwards_datetime_format_to_nested_to_dict() -> None:
+    trial = _build_trial_result()
+    trial.metadata["format_aware_payload"] = _FormatAwarePayload()
+
+    serialized = trial.to_dict(datetime_format="epoch")
+
+    assert serialized["metadata"]["format_aware_payload"]["nested_at"] == pytest.approx(
+        datetime(2026, 3, 13, 11, 57, tzinfo=UTC).timestamp()
+    )
+
+
 def test_serialize_trials_applies_requested_options() -> None:
     trials = [_build_trial_result(), _build_trial_result()]
 
@@ -98,3 +140,8 @@ def test_serialize_trials_rejects_unknown_datetime_format() -> None:
 
     with pytest.raises(ValueError, match="datetime_format"):
         serialize_trials([trial], datetime_format="rfc3339")  # type: ignore[arg-type]
+
+
+def test_serialize_trials_rejects_unknown_datetime_format_for_empty_input() -> None:
+    with pytest.raises(ValueError, match="datetime_format"):
+        serialize_trials([], datetime_format="rfc3339")  # type: ignore[arg-type]

--- a/tests/unit/api/test_trial_serialization.py
+++ b/tests/unit/api/test_trial_serialization.py
@@ -1,0 +1,100 @@
+"""Tests for public trial serialization helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from traigent import serialize_trials
+from traigent.api.types import ExampleResult, TrialResult, TrialStatus
+
+
+def _build_trial_result() -> TrialResult:
+    return TrialResult(
+        trial_id="trial-001",
+        config={"model": "gpt-4o-mini", "temperature": 0.2},
+        metrics={"accuracy": 0.91, "cost": 0.02},
+        status=TrialStatus.COMPLETED,
+        duration=1.25,
+        timestamp=datetime(2026, 3, 13, 12, 0, tzinfo=UTC),
+        metadata={
+            "started_at": datetime(2026, 3, 13, 11, 59, tzinfo=UTC),
+            "tags": {"sdk", "export"},
+            "example_result": ExampleResult(
+                example_id="ex-1",
+                input_data={"question": "What is 2+2?"},
+                expected_output="4",
+                actual_output="4",
+                metrics={"accuracy": 1.0},
+                execution_time=0.05,
+                success=True,
+            ),
+        },
+    )
+
+
+def test_trial_result_to_dict_defaults() -> None:
+    trial = _build_trial_result()
+
+    serialized = trial.to_dict()
+
+    assert serialized["trial_id"] == "trial-001"
+    assert serialized["status"] == "completed"
+    assert serialized["duration"] == 1.25
+    assert serialized["timestamp"] == "2026-03-13T12:00:00+00:00"
+    assert serialized["config"] == {"model": "gpt-4o-mini", "temperature": 0.2}
+    assert serialized["metrics"] == {"accuracy": 0.91, "cost": 0.02}
+    assert serialized["metadata"]["started_at"] == "2026-03-13T11:59:00+00:00"
+    assert set(serialized["metadata"]["tags"]) == {"sdk", "export"}
+    assert serialized["metadata"]["example_result"]["example_id"] == "ex-1"
+
+
+def test_trial_result_to_dict_can_filter_optional_fields() -> None:
+    trial = _build_trial_result()
+
+    serialized = trial.to_dict(
+        include_config=False,
+        include_metrics=False,
+        include_metadata=False,
+    )
+
+    assert "config" not in serialized
+    assert "metrics" not in serialized
+    assert "metadata" not in serialized
+    assert serialized["status"] == "completed"
+
+
+def test_trial_result_to_dict_supports_epoch_timestamps() -> None:
+    trial = _build_trial_result()
+
+    serialized = trial.to_dict(datetime_format="epoch")
+
+    assert serialized["timestamp"] == pytest.approx(
+        datetime(2026, 3, 13, 12, 0, tzinfo=UTC).timestamp()
+    )
+    assert serialized["metadata"]["started_at"] == pytest.approx(
+        datetime(2026, 3, 13, 11, 59, tzinfo=UTC).timestamp()
+    )
+
+
+def test_serialize_trials_applies_requested_options() -> None:
+    trials = [_build_trial_result(), _build_trial_result()]
+
+    serialized = serialize_trials(
+        trials,
+        include_metadata=False,
+        datetime_format="epoch",
+    )
+
+    assert len(serialized) == 2
+    assert all("metadata" not in item for item in serialized)
+    assert all(item["status"] == "completed" for item in serialized)
+    assert all(isinstance(item["timestamp"], float) for item in serialized)
+
+
+def test_serialize_trials_rejects_unknown_datetime_format() -> None:
+    trial = _build_trial_result()
+
+    with pytest.raises(ValueError, match="datetime_format"):
+        serialize_trials([trial], datetime_format="rfc3339")  # type: ignore[arg-type]

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -98,6 +98,7 @@ from traigent.api.types import (
     SensitivityAnalysis,
     StrategyConfig,
     TrialResult,
+    serialize_trials,
 )
 from traigent.api.validation_protocol import (
     ConstraintValidator,
@@ -251,6 +252,7 @@ __all__ = [
     # Result types
     "OptimizationResult",
     "TrialResult",
+    "serialize_trials",
     "SensitivityAnalysis",
     "ConfigurationComparison",
     "ParetoFront",

--- a/traigent/api/__init__.py
+++ b/traigent/api/__init__.py
@@ -39,6 +39,7 @@ from traigent.api.types import (
     StopReason,
     StrategyConfig,
     TrialResult,
+    serialize_trials,
 )
 
 __all__ = [
@@ -54,6 +55,7 @@ __all__ = [
     # Result types
     "OptimizationResult",
     "TrialResult",
+    "serialize_trials",
     "SensitivityAnalysis",
     "ConfigurationComparison",
     "ParetoFront",

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -116,19 +116,26 @@ StopReason = Literal[
 TrialDatetimeFormat = Literal["iso", "epoch"]
 
 
+def _validate_trial_datetime_format(datetime_format: TrialDatetimeFormat) -> None:
+    """Validate supported datetime formats for public trial serialization."""
+    if datetime_format not in ("iso", "epoch"):
+        raise ValueError(
+            "datetime_format must be 'iso' or 'epoch', " f"got {datetime_format!r}"
+        )
+
+
 def _serialize_datetime(
     value: datetime,
     *,
     datetime_format: TrialDatetimeFormat,
 ) -> str | float:
     """Serialize datetime using the requested wire format."""
+    _validate_trial_datetime_format(datetime_format)
+
     if datetime_format == "iso":
         return value.isoformat()
-    if datetime_format == "epoch":
-        return value.timestamp()
-    raise ValueError(
-        "datetime_format must be 'iso' or 'epoch', " f"got {datetime_format!r}"
-    )
+
+    return value.timestamp()
 
 
 def _json_safe_trial_value(
@@ -141,11 +148,21 @@ def _json_safe_trial_value(
         return None
 
     if hasattr(value, "to_dict") and callable(value.to_dict):
+        to_dict = value.to_dict
         try:
-            return value.to_dict()
+            return _json_safe_trial_value(
+                to_dict(datetime_format=datetime_format),
+                datetime_format=datetime_format,
+            )
         except TypeError:
-            # Some objects may expose a to_dict method with required arguments.
-            pass
+            try:
+                return _json_safe_trial_value(
+                    to_dict(),
+                    datetime_format=datetime_format,
+                )
+            except TypeError:
+                # Some objects may expose a to_dict method with required arguments.
+                pass
 
     if isinstance(value, datetime):
         return _serialize_datetime(value, datetime_format=datetime_format)
@@ -282,6 +299,8 @@ def serialize_trials(
         include_metadata: Include each trial's metadata payload.
         datetime_format: Timestamp encoding, either ``"iso"`` or ``"epoch"``.
     """
+    _validate_trial_datetime_format(datetime_format)
+
     return [
         trial.to_dict(
             include_config=include_config,

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections import Counter
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -113,6 +113,82 @@ StopReason = Literal[
     "network_error",  # Connectivity failure
 ]
 
+TrialDatetimeFormat = Literal["iso", "epoch"]
+
+
+def _serialize_datetime(
+    value: datetime,
+    *,
+    datetime_format: TrialDatetimeFormat,
+) -> str | float:
+    """Serialize datetime using the requested wire format."""
+    if datetime_format == "iso":
+        return value.isoformat()
+    if datetime_format == "epoch":
+        return value.timestamp()
+    raise ValueError(
+        "datetime_format must be 'iso' or 'epoch', " f"got {datetime_format!r}"
+    )
+
+
+def _json_safe_trial_value(
+    value: Any,
+    *,
+    datetime_format: TrialDatetimeFormat,
+) -> Any:
+    """Convert a value into a JSON-safe representation for trial export."""
+    if value is None:
+        return None
+
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        try:
+            return value.to_dict()
+        except TypeError:
+            # Some objects may expose a to_dict method with required arguments.
+            pass
+
+    if isinstance(value, datetime):
+        return _serialize_datetime(value, datetime_format=datetime_format)
+
+    if isinstance(value, dict):
+        return {
+            key: _json_safe_trial_value(item, datetime_format=datetime_format)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            _json_safe_trial_value(item, datetime_format=datetime_format)
+            for item in value
+        ]
+
+    if isinstance(value, tuple):
+        return [
+            _json_safe_trial_value(item, datetime_format=datetime_format)
+            for item in value
+        ]
+
+    if isinstance(value, set):
+        return [
+            _json_safe_trial_value(item, datetime_format=datetime_format)
+            for item in value
+        ]
+
+    if isinstance(value, (str, int, float, bool)):
+        return value
+
+    if hasattr(value, "item") and callable(value.item):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
 
 @dataclass
 class Trial:
@@ -146,6 +222,75 @@ class TrialResult:
     def get_metric(self, name: str, default: float | None = None) -> float | None:
         """Get a specific metric value."""
         return self.metrics.get(name, default)
+
+    def to_dict(
+        self,
+        *,
+        include_config: bool = True,
+        include_metrics: bool = True,
+        include_metadata: bool = True,
+        datetime_format: TrialDatetimeFormat = "iso",
+    ) -> dict[str, Any]:
+        """Convert the trial result to a JSON-ready dictionary.
+
+        Args:
+            include_config: Include the trial configuration payload.
+            include_metrics: Include the trial metrics payload.
+            include_metadata: Include metadata captured during the trial.
+            datetime_format: Timestamp encoding, either ``"iso"`` or ``"epoch"``.
+        """
+        result: dict[str, Any] = {
+            "trial_id": self.trial_id,
+            "status": self.status.value,
+            "duration": float(self.duration),
+            "timestamp": _serialize_datetime(
+                self.timestamp, datetime_format=datetime_format
+            ),
+            "error_message": self.error_message,
+        }
+
+        if include_config:
+            result["config"] = _json_safe_trial_value(
+                self.config, datetime_format=datetime_format
+            )
+        if include_metrics:
+            result["metrics"] = _json_safe_trial_value(
+                self.metrics, datetime_format=datetime_format
+            )
+        if include_metadata:
+            result["metadata"] = _json_safe_trial_value(
+                self.metadata, datetime_format=datetime_format
+            )
+
+        return result
+
+
+def serialize_trials(
+    trials: Sequence[TrialResult],
+    *,
+    include_config: bool = True,
+    include_metrics: bool = True,
+    include_metadata: bool = True,
+    datetime_format: TrialDatetimeFormat = "iso",
+) -> list[dict[str, Any]]:
+    """Serialize trial results into JSON-ready dictionaries.
+
+    Args:
+        trials: Trial results to serialize.
+        include_config: Include each trial's configuration payload.
+        include_metrics: Include each trial's metrics payload.
+        include_metadata: Include each trial's metadata payload.
+        datetime_format: Timestamp encoding, either ``"iso"`` or ``"epoch"``.
+    """
+    return [
+        trial.to_dict(
+            include_config=include_config,
+            include_metrics=include_metrics,
+            include_metadata=include_metadata,
+            datetime_format=datetime_format,
+        )
+        for trial in trials
+    ]
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add `TrialResult.to_dict(...)` for JSON-ready export with optional field filtering
- add public `serialize_trials(...)` helper and export it from `traigent` and `traigent.api`
- cover ISO vs epoch timestamps, nested metadata serialization, and top-level import usage

## Issue
Closes #81

## Verification
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m py_compile traigent/api/types.py traigent/__init__.py traigent/api/__init__.py tests/unit/api/test_trial_serialization.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/pytest -q -n 0 tests/unit/api/test_trial_serialization.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/pytest -q -n 0 tests/unit/api/test_types.py -k 'TrialResult and get_metric'`
