### PR TITLE
fix: scope cloud defaults to cloud entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Connect your SDK to the Traigent cloud to see optimization results in the [porta
 
 2. Log in:
    ```bash
-   TRAIGENT_BACKEND_URL=https://api.traigent.ai traigent auth login
+   traigent auth login
    ```
 
 3. Run your optimization — results appear in the portal automatically:
@@ -381,9 +381,10 @@ No environment variables needed after login — the SDK picks up stored credenti
 | Credential  | 1st (highest)                  | 2nd                    | 3rd (default)        |
 |-------------|--------------------------------|------------------------|----------------------|
 | API Key     | `TRAIGENT_API_KEY` env var     | Stored CLI credentials | None (local only)    |
-| Backend URL | `TRAIGENT_BACKEND_URL` env var | Stored CLI credentials | `portal.traigent.ai` |
+| Backend URL | `TRAIGENT_BACKEND_URL` env var | Stored CLI credentials | `localhost:5000` (generic SDK) |
 
 > **Tip:** Use env vars for CI/automation. Use `traigent auth login` for local development.
+> Cloud-facing entry points such as `traigent auth login`, `TraigentCloudClient`, and `SyncManager` default to `portal.traigent.ai` when no backend URL is configured.
 
 ### Testing Models from Multiple Providers
 

--- a/tests/cloud/test_sync_manager.py
+++ b/tests/cloud/test_sync_manager.py
@@ -15,10 +15,7 @@ import requests
 from traigent.cloud.sync_manager import SyncManager
 from traigent.config.backend_config import BackendConfig
 from traigent.config.types import TraigentConfig
-from traigent.storage.local_storage import (
-    LocalStorageManager,
-    TrialResult,
-)
+from traigent.storage.local_storage import LocalStorageManager, TrialResult
 from traigent.utils.exceptions import TraigentStorageError
 
 
@@ -37,7 +34,7 @@ class TestSyncManager:
             minimal_logging=True,
         )
 
-        self.api_key = "test_api_key_123"
+        self.api_key = "test_api_key_123"  # pragma: allowlist secret
         self.sync_manager = SyncManager(self.config, self.api_key)
 
         # Don't create test session by default - tests will create as needed
@@ -88,7 +85,7 @@ class TestSyncManager:
         """Test sync manager initialization with API key."""
         assert self.sync_manager.config == self.config
         assert self.sync_manager.api_key == self.api_key
-        expected_base_url = BackendConfig.get_backend_api_url().rstrip("/")
+        expected_base_url = BackendConfig.get_cloud_api_url().rstrip("/")
         assert self.sync_manager.base_url == expected_base_url
         assert self.sync_manager.storage is not None
         # API key may be in X-API-Key or Authorization header
@@ -416,9 +413,7 @@ class TestSyncManager:
 
             assert result["success"] is True
             assert result["agent_id"] == "test_agent"
-            expected_endpoint = (
-                f"{BackendConfig.get_backend_api_url().rstrip('/')}/agents"
-            )
+            expected_endpoint = f"{BackendConfig.get_cloud_api_url().rstrip('/')}/agents"
             mock_post.assert_called_with(
                 expected_endpoint,
                 json=agent_data,

--- a/tests/test_backend_config.py
+++ b/tests/test_backend_config.py
@@ -39,15 +39,24 @@ def test_backend_config():
     print(f"   Requires Auth: {config['requires_auth']}")
     print(f"   Environment: {config['environment']}")
     print(f"   Configured Via: {config['configured_via']}")
-    assert config["backend_url"] == BackendConfig.DEFAULT_PROD_URL, (
-        "Should default to cloud portal"
+    assert config["backend_url"] == BackendConfig.get_default_local_url(), (
+        "Generic backend config should default to local"
     )
-    assert not config["is_local"], "Default should be cloud"
+    assert config["is_local"], "Default should remain local"
     assert config["configured_via"] == "default"
-    assert config["backend_api_url"] == f"{BackendConfig.DEFAULT_PROD_URL}/api/v1", (
-        "Default API base should include versioned path"
+    assert config["backend_api_url"] == f"{BackendConfig.get_default_local_url()}/api/v1", (
+        "Default API base should use the local backend"
     )
     print("   ✅ Default configuration working correctly\n")
+
+    print("1b. Testing cloud helper defaults:")
+    cloud_backend = BackendConfig.get_cloud_backend_url()
+    cloud_api = BackendConfig.get_cloud_api_url()
+    print(f"   Cloud Backend URL: {cloud_backend}")
+    print(f"   Cloud API URL: {cloud_api}")
+    assert cloud_backend == BackendConfig.DEFAULT_PROD_URL
+    assert cloud_api == f"{BackendConfig.DEFAULT_PROD_URL}/api/v1"
+    print("   ✅ Cloud helper defaults working correctly\n")
 
     # Test 2: Local development environment
     print("2. Testing local development environment:")
@@ -112,14 +121,14 @@ def test_backend_config():
 
     # Test 4: API key configuration
     print("4. Testing API key configuration:")
-    os.environ["TRAIGENT_API_KEY"] = "traigent-key-12345"
+    os.environ["TRAIGENT_API_KEY"] = "traigent-key-12345"  # pragma: allowlist secret
     config = BackendConfig.get_config_summary()
     print(f"   API Key Configured: {config['api_key_configured']}")
     print(f"   API Key Prefix: {config['api_key_prefix']}")
     print(f"   API Key Env: {config['api_key_env']}")
     assert config["api_key_configured"], "Should have API key"
-    assert config["api_key_prefix"] == "traigent...", "Should show prefix"
-    assert config["api_key_env"] == "TRAIGENT_API_KEY"
+    assert config["api_key_prefix"] == "traigent...", "Should show prefix"  # pragma: allowlist secret
+    assert config["api_key_env"] == "TRAIGENT_API_KEY"  # pragma: allowlist secret
 
     print("   ✅ API key configuration working correctly\n")
 
@@ -138,7 +147,7 @@ def test_backend_config():
         os.environ.pop(var, None)
 
     os.environ["TRAIGENT_BACKEND_URL"] = "http://localhost:5000"
-    os.environ["TRAIGENT_API_KEY"] = "test-api-key"
+    os.environ["TRAIGENT_API_KEY"] = "test-api-key"  # pragma: allowlist secret
 
     # Initialize without explicit URL (should use env var)
     result = traigent.initialize()
@@ -162,7 +171,7 @@ def test_backend_client_config():
 
     # Set up environment for local backend
     os.environ["TRAIGENT_BACKEND_URL"] = "http://localhost:5000"
-    os.environ["TRAIGENT_API_KEY"] = "test-key"
+    os.environ["TRAIGENT_API_KEY"] = "test-key"  # pragma: allowlist secret
     os.environ["TRAIGENT_ENV"] = "development"
 
     # Import after setting env vars
@@ -184,7 +193,7 @@ def test_backend_client_config():
     # Test BackendIntegratedClient creation
     print("Testing BackendIntegratedClient with centralized config:")
     client = BackendIntegratedClient(
-        api_key="test-key", backend_config=config, enable_fallback=True
+        api_key="test-key", backend_config=config, enable_fallback=True  # pragma: allowlist secret
     )
     print(f"   Client backend URL: {client.backend_config.backend_base_url}")
     assert client.backend_config.backend_base_url == "http://localhost:5000", (

--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -72,7 +72,7 @@ def backend_config():
 def backend_client(backend_config):
     """Create backend integrated client for testing."""
     return BackendIntegratedClient(
-        api_key="tg_test_" + "x" * 56,
+        api_key="tg_test_" + "x" * 56,  # pragma: allowlist secret
         base_url="http://localhost:8000",
         backend_config=backend_config,
         enable_fallback=True,
@@ -119,7 +119,7 @@ class TestBackendIntegratedClient:
     def test_client_initialization(self, backend_config):
         """Test client initialization."""
         client = BackendIntegratedClient(
-            api_key="test_key",
+            api_key="test_key",  # pragma: allowlist secret
             base_url="https://api.test.com",
             backend_config=backend_config,
             enable_fallback=False,
@@ -142,7 +142,11 @@ class TestBackendIntegratedClient:
         monkeypatch.delenv("TRAIGENT_API_URL", raising=False)
         monkeypatch.setenv("TRAIGENT_ENV", "production")
 
-        client = BackendIntegratedClient()
+        with patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+            return_value=None,
+        ):
+            client = BackendIntegratedClient()
 
         assert client.base_url == BackendConfig.get_backend_url()
         assert isinstance(client.backend_config, BackendClientConfig)
@@ -155,6 +159,21 @@ class TestBackendIntegratedClient:
         """Test URL normalization on initialization."""
         client = BackendIntegratedClient(base_url="https://api.test.com/")
         assert client.base_url == "https://api.test.com"
+
+    def test_explicit_base_url_overrides_default_backend_config(self, monkeypatch):
+        """Explicit base_url should propagate through backend and API URLs."""
+        monkeypatch.delenv("TRAIGENT_BACKEND_URL", raising=False)
+        monkeypatch.delenv("TRAIGENT_API_URL", raising=False)
+
+        with patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+            return_value=None,
+        ):
+            client = BackendIntegratedClient(base_url="https://api.test.com")
+
+        assert client.base_url == "https://api.test.com"
+        assert client.backend_config.backend_base_url == "https://api.test.com"
+        assert client.backend_config.api_base_url == "https://api.test.com/api/v1"
 
     @patch("traigent.cloud.backend_client.AIOHTTP_AVAILABLE", False)
     def test_client_without_aiohttp(self, backend_config):
@@ -972,7 +991,7 @@ class TestGlobalClientInstance:
         assert client is client2
 
     def test_get_backend_client_with_kwargs(self):
-        """Test get_backend_client with custom kwargs."""
+        """Explicit base_url should override default backend routing."""
         # Clear global instance
 
         traigent.cloud.backend_client._backend_client = None
@@ -981,14 +1000,15 @@ class TestGlobalClientInstance:
             backend_base_url="https://custom.backend.com"
         )
         client = get_backend_client(
-            api_key="test_key",
+            api_key="test_key",  # pragma: allowlist secret
             base_url="https://custom.api.com",
             backend_config=backend_config,
             enable_fallback=False,
         )
 
         assert client.base_url == "https://custom.api.com"
-        assert client.backend_config.backend_base_url == "https://custom.backend.com"
+        assert client.backend_config.backend_base_url == "https://custom.api.com"
+        assert client.backend_config.api_base_url == "https://custom.api.com/api/v1"
         assert client.enable_fallback is False
 
 

--- a/tests/unit/cloud/test_password_auth_handler.py
+++ b/tests/unit/cloud/test_password_auth_handler.py
@@ -10,14 +10,40 @@ from traigent.cloud.auth import InvalidCredentialsError
 from traigent.cloud.password_auth_handler import PasswordAuthHandler
 
 
+def test_default_backend_no_longer_implies_dev_mode():
+    """Cloud auth should not infer dev mode from the generic backend fallback."""
+    handler = PasswordAuthHandler()
+
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+            return_value=None,
+        ),
+    ):
+        assert handler._is_dev_mode_enabled() is False
+
+
+def test_explicit_local_backend_still_enables_dev_mode():
+    """Explicit localhost backend configuration should still enable dev mode."""
+    handler = PasswordAuthHandler()
+
+    with patch.dict(
+        "os.environ",
+        {"TRAIGENT_BACKEND_URL": "http://localhost:5000"},
+        clear=True,
+    ):
+        assert handler._is_dev_mode_enabled() is True
+
+
 @pytest.mark.asyncio
 async def test_invalid_credentials_propagate_even_in_dev_mode():
     """Wrong credentials should fail loudly instead of returning mock tokens."""
     handler = PasswordAuthHandler()
     credentials = {
         "email": "dev@example.com",
-        "password": "password123",
-    }  # pragma: allowlist secret
+        "password": "password123",  # pragma: allowlist secret
+    }
 
     with (
         patch.object(handler, "_is_dev_mode_enabled", return_value=True),
@@ -36,8 +62,8 @@ async def test_dev_mode_still_falls_back_on_backend_outage():
     handler = PasswordAuthHandler()
     credentials = {
         "email": "dev@example.com",
-        "password": "password123",
-    }  # pragma: allowlist secret
+        "password": "password123",  # pragma: allowlist secret
+    }
 
     with (
         patch.object(handler, "_is_dev_mode_enabled", return_value=True),

--- a/tests/unit/cloud/test_traigent_cloud_client.py
+++ b/tests/unit/cloud/test_traigent_cloud_client.py
@@ -70,12 +70,15 @@ class TestTraigentCloudClient:
         ]:
             monkeypatch.delenv(var, raising=False)
 
-        monkeypatch.setenv("TRAIGENT_ENV", "production")
-
-        client = TraigentCloudClient()
+        with patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+            return_value=None,
+        ):
+            monkeypatch.setenv("TRAIGENT_ENV", "production")
+            client = TraigentCloudClient()
 
         assert client.base_url == BackendConfig.DEFAULT_PROD_URL
-        assert client.api_base_url == BackendConfig.get_backend_api_url()
+        assert client.api_base_url == BackendConfig.get_cloud_api_url()
         assert client.enable_fallback is True
         assert client.max_retries == 3
         assert client.timeout == 30.0

--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -1,9 +1,4 @@
-"""Tests for BackendConfig stored credential fallback and CLI auth payload.
-
-Validates that BackendConfig.get_api_key() and get_backend_url() correctly
-fall through to CLI-stored credentials when environment variables are absent,
-and that the CLI login sends the correct permissions and headers.
-"""
+"""Tests for BackendConfig URL/credential resolution and CLI auth payload."""
 
 from __future__ import annotations
 
@@ -118,15 +113,14 @@ class TestBackendConfigStoredBackendUrl:
         ):
             result = BackendConfig.get_backend_url()
 
-        # Default is DEFAULT_PROD_URL (cloud portal)
-        assert result == BackendConfig.DEFAULT_PROD_URL
+        assert result == BackendConfig.get_default_local_url()
 
 
 class TestBackendConfigDefaultBehavior:
     """Verify default URL behavior for different environment configurations."""
 
-    def test_no_env_no_creds_defaults_to_cloud(self):
-        """External SDK user with no env vars should get cloud portal URL."""
+    def test_no_env_no_creds_defaults_to_local(self):
+        """Generic backend resolution should stay local when nothing is configured."""
         with (
             patch.dict("os.environ", {}, clear=True),
             patch(
@@ -136,7 +130,22 @@ class TestBackendConfigDefaultBehavior:
         ):
             result = BackendConfig.get_backend_url()
 
-        assert result == BackendConfig.DEFAULT_PROD_URL
+        assert result == BackendConfig.get_default_local_url()
+
+    def test_cloud_helpers_default_to_cloud(self):
+        """Cloud-facing entry points should default to the portal URL."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+                return_value=None,
+            ),
+        ):
+            backend_result = BackendConfig.get_cloud_backend_url()
+            api_result = BackendConfig.get_cloud_api_url()
+
+        assert backend_result == BackendConfig.DEFAULT_PROD_URL
+        assert api_result == f"{BackendConfig.DEFAULT_PROD_URL}/api/v1"
 
     def test_development_env_defaults_to_local(self):
         """Internal dev with TRAIGENT_ENV=development should get localhost."""
@@ -172,12 +181,16 @@ class TestBackendConfigDefaultBehavior:
 
         assert result == "https://custom.example.com"
 
-    def test_cloud_default_warns_without_any_credentials(self):
-        """Defaulting to cloud without any credentials should log a warning."""
+    def test_cloud_env_warns_without_any_credentials(self):
+        """Defaulting backend client config to cloud via env should log a warning."""
         from traigent.cloud.backend_components import BackendClientConfig
 
         with (
-            patch.dict("os.environ", {}, clear=True),
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_BACKEND_URL": BackendConfig.DEFAULT_PROD_URL},
+                clear=True,
+            ),
             patch(
                 "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
                 return_value=None,
@@ -194,12 +207,16 @@ class TestBackendConfigDefaultBehavior:
         warning_msg = mock_logger.warning.call_args[0][0]
         assert "no credentials found" in warning_msg
 
-    def test_cloud_default_no_warning_with_stored_api_key(self):
-        """Should NOT warn when stored API key credentials exist."""
+    def test_cloud_env_no_warning_with_stored_api_key(self):
+        """Should NOT warn when cloud env config is paired with stored API keys."""
         from traigent.cloud.backend_components import BackendClientConfig
 
         with (
-            patch.dict("os.environ", {}, clear=True),
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_BACKEND_URL": BackendConfig.DEFAULT_PROD_URL},
+                clear=True,
+            ),
             patch(
                 "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
                 return_value=None,
@@ -214,12 +231,16 @@ class TestBackendConfigDefaultBehavior:
 
         mock_logger.warning.assert_not_called()
 
-    def test_cloud_default_no_warning_with_stored_jwt_credentials(self):
+    def test_cloud_env_no_warning_with_stored_jwt_credentials(self):
         """JWT-authenticated CLI users should not get a missing-credentials warning."""
         from traigent.cloud.backend_components import BackendClientConfig
 
         with (
-            patch.dict("os.environ", {}, clear=True),
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_BACKEND_URL": BackendConfig.DEFAULT_PROD_URL},
+                clear=True,
+            ),
             patch(
                 "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
                 return_value=None,

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -74,8 +74,8 @@ class TraigentAuthCLI:
         self.config_dir = TRAIGENT_CONFIG_DIR
         self.credentials_file = CREDENTIALS_FILE
         self.auth_manager = AuthManager()
-        self.backend_url = BackendConfig.get_backend_url()
-        self.backend_api_url = BackendConfig.get_backend_api_url()
+        self.backend_url = BackendConfig.get_cloud_backend_url()
+        self.backend_api_url = BackendConfig.get_cloud_api_url()
 
         # Ensure config directory exists
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -861,7 +861,7 @@ class TraigentAuthCLI:
         console.print("Configure your Traigent SDK settings.\n")
 
         # Backend URL configuration
-        current_backend = BackendConfig.get_backend_url()
+        current_backend = BackendConfig.get_cloud_backend_url()
         console.print(f"Current backend: [cyan]{current_backend}[/cyan]")
 
         change_backend = Prompt.ask(
@@ -1045,7 +1045,7 @@ def whoami(key: str) -> None:
         sys.exit(1)
 
     # Check with backend
-    backend_api_url = BackendConfig.get_backend_api_url()
+    backend_api_url = BackendConfig.get_cloud_api_url()
     console.print(f"[dim]Backend: {backend_api_url}[/dim]")
 
     async def check_key() -> bool:

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -148,11 +148,9 @@ class UnifiedAuthConfig:
 
     default_mode: AuthMode = AuthMode.API_KEY
     backend_base_url: str | None = (
-        None  # Will be set from BackendConfig if not provided
+        None  # Will be set from cloud backend config if not provided
     )
-    cloud_base_url: str = (
-        ""  # Resolved from BackendConfig.DEFAULT_PROD_URL in __post_init__
-    )
+    cloud_base_url: str = ""  # Resolved from cloud backend config in __post_init__
     token_refresh_threshold: float = 300.0  # Refresh if expires within 5 minutes
     auto_refresh: bool = True
     cache_credentials: bool = True
@@ -166,9 +164,9 @@ class UnifiedAuthConfig:
         from traigent.config.backend_config import BackendConfig
 
         if self.backend_base_url is None:
-            self.backend_base_url = BackendConfig.get_backend_url()
+            self.backend_base_url = BackendConfig.get_cloud_backend_url()
         if not self.cloud_base_url:
-            self.cloud_base_url = BackendConfig.DEFAULT_PROD_URL
+            self.cloud_base_url = BackendConfig.get_cloud_backend_url()
 
 
 @dataclass
@@ -1435,7 +1433,9 @@ class AuthManager:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.get_backend_api_url()
+        backend_api_url = BackendConfig.build_api_base(
+            self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
+        )
         login_url = f"{backend_api_url}/auth/login"
 
         client = ResilientClient(

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -169,21 +169,44 @@ class BackendIntegratedClient:
 
         self.backend_config = backend_config or BackendClientConfig()
 
-        effective_base_url = base_url or self.backend_config.backend_base_url
+        explicit_base_origin = None
+        explicit_api_base = None
+        if base_url:
+            parsed_origin, parsed_path = BackendConfig.split_api_url(base_url)
+            explicit_base_origin = (
+                parsed_origin or BackendConfig.normalize_backend_origin(base_url)
+            )
+            if explicit_base_origin:
+                explicit_api_base = (
+                    f"{explicit_base_origin}"
+                    f"{parsed_path or BackendConfig.get_default_api_path()}"
+                )
+
+        effective_base_url = (
+            explicit_base_origin or base_url or self.backend_config.backend_base_url
+        )
         if effective_base_url is None:
             effective_base_url = BackendConfig.get_backend_url()
 
         # Validate and sanitize URLs
         self.base_url = self._api_ops.validate_and_sanitize_url(effective_base_url)
 
-        backend_base_url = self.backend_config.backend_base_url or self.base_url
+        backend_base_url = self.base_url
+        if not explicit_base_origin:
+            backend_base_url = self.backend_config.backend_base_url or self.base_url
         self.backend_config.backend_base_url = self._api_ops.validate_and_sanitize_url(
             backend_base_url
         )
 
-        api_base_candidate = (
-            self.backend_config.api_base_url or BackendConfig.get_backend_api_url()
-        )
+        if explicit_api_base and not getattr(
+            self.backend_config, "api_explicitly_set", False
+        ):
+            api_base_candidate = explicit_api_base
+        else:
+            api_base_candidate = (
+                self.backend_config.api_base_url
+                or BackendConfig.build_api_base(self.backend_config.backend_base_url)
+            )
         self.api_base_url = self._api_ops.validate_and_sanitize_url(api_base_candidate)
         self.backend_config.api_base_url = self.api_base_url
 

--- a/traigent/cloud/backend_components.py
+++ b/traigent/cloud/backend_components.py
@@ -18,7 +18,7 @@ import os
 import secrets
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
@@ -39,6 +39,8 @@ class BackendClientConfig:
     mcp_server_path: str | None = None
     enable_session_sync: bool = True
     session_sync_interval: float = 5.0
+    backend_explicitly_set: bool = field(init=False, repr=False, default=False)
+    api_explicitly_set: bool = field(init=False, repr=False, default=False)
 
     def __post_init__(self) -> None:
         """Populate missing configuration using global backend settings."""
@@ -48,7 +50,8 @@ class BackendClientConfig:
         api_env = os.environ.get("TRAIGENT_API_URL")
 
         # Track if backend_base_url was explicitly provided
-        backend_explicitly_set = self.backend_base_url is not None
+        self.backend_explicitly_set = self.backend_base_url is not None
+        self.api_explicitly_set = self.api_base_url is not None
 
         if self.backend_base_url is not None:
             normalized = BackendConfig.normalize_backend_origin(self.backend_base_url)
@@ -62,7 +65,7 @@ class BackendClientConfig:
         # Skip if the caller explicitly passed the URL (not our default).
         # Use a silent predicate so this path does not emit duplicate warnings.
         if (
-            not backend_explicitly_set
+            not self.backend_explicitly_set
             and self.backend_base_url
             and self.backend_base_url.rstrip("/")
             == BackendConfig.DEFAULT_PROD_URL.rstrip("/")
@@ -88,7 +91,7 @@ class BackendClientConfig:
         elif api_env:
             self.api_base_url = BackendConfig.get_backend_api_url()
             # Only derive backend_base_url from API URL if not explicitly provided
-            if not backend_explicitly_set:
+            if not self.backend_explicitly_set:
                 self.backend_base_url = BackendConfig.get_backend_url().rstrip("/")
         elif self.backend_base_url is not None:
             self.api_base_url = BackendConfig.build_api_base(self.backend_base_url)

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -300,8 +300,8 @@ class TraigentCloudClient(BaseTraigentClient):
                 f"{origin}{path or BackendConfig.get_default_api_path()}"
             )
         else:
-            resolved_origin = BackendConfig.get_backend_url()
-            api_base_candidate = BackendConfig.get_backend_api_url()
+            resolved_origin = BackendConfig.get_cloud_backend_url()
+            api_base_candidate = BackendConfig.get_cloud_api_url()
 
         self.base_url = resolved_origin.rstrip("/")
         self.api_base_url = api_base_candidate.rstrip("/")

--- a/traigent/cloud/password_auth_handler.py
+++ b/traigent/cloud/password_auth_handler.py
@@ -202,7 +202,8 @@ class PasswordAuthHandler:
         try:
             from traigent.config.backend_config import BackendConfig
 
-            if BackendConfig.is_local_backend():
+            configured_backend = BackendConfig.get_configured_backend_url()
+            if configured_backend and BackendConfig.is_local_origin(configured_backend):
                 return True
         except Exception as e:
             logger.debug(f"Could not check local backend status: {e}")
@@ -221,7 +222,7 @@ class PasswordAuthHandler:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.get_backend_api_url()
+        backend_api_url = BackendConfig.get_cloud_api_url()
         login_url = f"{backend_api_url}/auth/login"
 
         client = ResilientClient(

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -46,7 +46,7 @@ class SyncManager:
         self.config = config
         self.storage = LocalStorageManager(config.get_local_storage_path())
         self.api_key = api_key
-        self.base_url = BackendConfig.get_backend_api_url().rstrip("/")
+        self.base_url = BackendConfig.get_cloud_api_url().rstrip("/")
 
         # Setup HTTP client - always create a requests session for sync operations
         # Include both X-API-Key and Authorization for backward compatibility

--- a/traigent/cloud/token_manager.py
+++ b/traigent/cloud/token_manager.py
@@ -320,7 +320,9 @@ class TokenManager:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.get_backend_api_url()
+        backend_api_url = BackendConfig.build_api_base(
+            self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
+        )
         refresh_url = f"{backend_api_url}/auth/refresh"
 
         client = ResilientClient(

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -29,7 +29,8 @@ class BackendConfig:
 
     # Default backend URLs (overridable via environment variables)
     _FALLBACK_LOCAL_URL = DEFAULT_LOCAL_URL
-    DEFAULT_PROD_URL = "https://portal.traigent.ai"
+    DEFAULT_CLOUD_URL = "https://portal.traigent.ai"
+    DEFAULT_PROD_URL = DEFAULT_CLOUD_URL  # Backward-compatible alias
     _DEFAULT_API_PATH = "/api/v1"
 
     @classmethod
@@ -99,16 +100,8 @@ class BackendConfig:
         return (origin, path)
 
     @classmethod
-    def get_backend_url(cls) -> str:
-        """Get backend origin URL from environment, stored credentials, or default.
-
-        Priority:
-            1. TRAIGENT_BACKEND_URL environment variable
-            2. TRAIGENT_API_URL environment variable (origin extracted)
-            3. Stored CLI credentials (backend_url from ``traigent auth login``)
-            4. Default URL based on TRAIGENT_ENV
-        """
-
+    def _get_configured_backend_origin(cls) -> str | None:
+        """Return an explicitly configured backend origin, if any."""
         backend_env = os.environ.get("TRAIGENT_BACKEND_URL")
         api_env = os.environ.get("TRAIGENT_API_URL")
 
@@ -136,22 +129,49 @@ class BackendConfig:
         except Exception:
             pass
 
-        env = os.environ.get("TRAIGENT_ENV", "production").lower()
-        if env in ("development", "dev", "local"):
-            default_local = cls._get_default_local_url()
-            logger.debug("Using default local URL: %s", default_local)
-            return default_local
-
-        logger.debug("Using default production URL: %s", cls.DEFAULT_PROD_URL)
-        return cls.DEFAULT_PROD_URL
+        return None
 
     @classmethod
-    def get_backend_api_url(cls) -> str:
-        """Return the base API URL (including version path)."""
+    def get_configured_backend_url(cls) -> str | None:
+        """Return an explicitly configured backend origin, if available."""
+
+        return cls._get_configured_backend_origin()
+
+    @classmethod
+    def get_backend_url(cls) -> str:
+        """Get backend origin URL from environment, stored credentials, or local default.
+
+        Priority:
+            1. TRAIGENT_BACKEND_URL environment variable
+            2. TRAIGENT_API_URL environment variable (origin extracted)
+            3. Stored CLI credentials (backend_url from ``traigent auth login``)
+            4. Local default URL
+        """
+
+        configured_origin = cls._get_configured_backend_origin()
+        if configured_origin:
+            return configured_origin
+
+        default_local = cls._get_default_local_url()
+        logger.debug("Using default local URL: %s", default_local)
+        return default_local
+
+    @classmethod
+    def get_cloud_backend_url(cls) -> str:
+        """Get backend origin URL for cloud-facing entry points."""
+
+        configured_origin = cls._get_configured_backend_origin()
+        if configured_origin:
+            return configured_origin
+
+        logger.debug("Using default cloud URL: %s", cls.DEFAULT_CLOUD_URL)
+        return cls.DEFAULT_CLOUD_URL
+
+    @classmethod
+    def _build_api_url(cls, backend_origin: str) -> str:
+        """Return the API base URL, respecting explicit API-path overrides."""
 
         api_env = os.environ.get("TRAIGENT_API_URL")
-        backend_origin = cls.get_backend_url()
-
         if api_env:
             origin, path = cls._extract_origin_and_path(api_env)
             if origin:
@@ -159,6 +179,18 @@ class BackendConfig:
                 return f"{origin}{api_path}"
 
         return f"{backend_origin}{cls._DEFAULT_API_PATH}"
+
+    @classmethod
+    def get_backend_api_url(cls) -> str:
+        """Return the base API URL (including version path)."""
+
+        return cls._build_api_url(cls.get_backend_url())
+
+    @classmethod
+    def get_cloud_api_url(cls) -> str:
+        """Return the cloud API base URL (including version path)."""
+
+        return cls._build_api_url(cls.get_cloud_backend_url())
 
     @classmethod
     def normalize_backend_origin(cls, value: str | None) -> str | None:
@@ -184,6 +216,18 @@ class BackendConfig:
         """Public helper returning origin/path components for an API URL."""
 
         return cls._extract_origin_and_path(value)
+
+    @classmethod
+    def is_local_origin(cls, value: str | None) -> bool:
+        """Return True when the provided backend origin targets localhost."""
+
+        normalized = cls._normalize_origin(value)
+        if not normalized:
+            return False
+
+        parsed = urlparse(normalized)
+        hostname = (parsed.hostname or "").lower()
+        return hostname in {"localhost", "127.0.0.1", "::1"}
 
     @classmethod
     def get_api_key(cls) -> str | None:
@@ -253,8 +297,7 @@ class BackendConfig:
         Returns:
             bool: True if backend URL points to localhost
         """
-        backend_url = cls.get_backend_url()
-        return "localhost" in backend_url or "127.0.0.1" in backend_url
+        return cls.is_local_origin(cls.get_backend_url())
 
     @classmethod
     def requires_authentication(cls) -> bool:


### PR DESCRIPTION
## Summary

This is the corrective follow-up to `#343`.

`#343` solved a real onboarding problem for public SDK users, but it changed the low-level backend default too broadly. That created two regressions:
- generic backend/integration paths silently switched from local fallback to cloud routing
- `BackendIntegratedClient(base_url=...)` could still keep `backend_base_url` / `api_base_url` pointed at the cloud default instead of the explicit override

This PR narrows the cloud default to cloud-facing entry points and restores predictable generic backend behavior.

### What changed

- restore generic `BackendConfig.get_backend_url()` / `get_backend_api_url()` to local-default behavior
- add dedicated cloud helpers: `get_cloud_backend_url()` / `get_cloud_api_url()`
- update cloud-facing entry points to use cloud defaults:
  - `TraigentCloudClient`
  - `traigent auth login` / auth CLI cloud calls
  - unified auth / password login / token refresh
  - `SyncManager`
- fix `BackendIntegratedClient(base_url=...)` so explicit `base_url` propagates through `backend_base_url` and derived `api_base_url`
- stop password auth from inferring dev mode from the generic local fallback; dev mode now requires an explicit local/dev signal
- update docs/tests to reflect the split:
  - generic SDK/backend integration defaults local
  - cloud-specific entry points default to `https://portal.traigent.ai`

## Why this shape

The public-SDK onboarding goal is valid, but it belongs at the product layer, not as a global backend-config semantic change.

After this patch:
- public cloud login/client flows still work out of the box
- local/internal backend code paths keep their previous semantics
- explicit URL overrides win consistently

## Test plan

- `python3 -m py_compile traigent/config/backend_config.py traigent/cloud/backend_components.py traigent/cloud/backend_client.py traigent/cloud/client.py traigent/cli/auth_commands.py traigent/cloud/auth.py traigent/cloud/password_auth_handler.py traigent/cloud/token_manager.py traigent/cloud/sync_manager.py`
- `pytest -q tests/unit/config/test_backend_config_stored_creds.py tests/unit/cloud/test_backend_client.py tests/unit/cloud/test_traigent_cloud_client.py tests/unit/cloud/test_password_auth_handler.py`
- `pytest -q tests/cloud/test_sync_manager.py -k 'initialization_with_api_key or test_initialization_with_api_key or test_sync_agent_success'`
- `pytest -q tests/test_backend_config.py`
- `ruff check traigent/config/backend_config.py traigent/cloud/backend_components.py traigent/cloud/backend_client.py traigent/cloud/client.py traigent/cli/auth_commands.py traigent/cloud/auth.py traigent/cloud/password_auth_handler.py traigent/cloud/token_manager.py traigent/cloud/sync_manager.py tests/unit/config/test_backend_config_stored_creds.py tests/unit/cloud/test_backend_client.py tests/unit/cloud/test_traigent_cloud_client.py tests/unit/cloud/test_password_auth_handler.py tests/cloud/test_sync_manager.py tests/test_backend_config.py`

## Direct regression check

With no env vars and no stored backend URL:
- `BackendConfig.get_backend_url()` -> `http://localhost:5000`
- `BackendConfig.get_cloud_backend_url()` -> `https://portal.traigent.ai`
- `BackendIntegratedClient(base_url="http://localhost:9999")` now resolves:
  - `client.base_url == http://localhost:9999`
  - `backend_config.backend_base_url == http://localhost:9999`
  - `backend_config.api_base_url == http://localhost:9999/api/v1`
- `PasswordAuthHandler()._is_dev_mode_enabled()` -> `False`
