### PR TITLE
fix: compute typed session smoke health URL inline

### DIFF
--- a/.github/workflows/typed-session-smoke.yml
+++ b/.github/workflows/typed-session-smoke.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           TRAIGENT_API_URL: ${{ secrets.TRAIGENT_API_URL }}
         run: |
-          python - <<'PY'
+          HEALTH_URL=$(python - <<'PY'
           import os
           from urllib.parse import urlparse, urlunparse
 
@@ -47,10 +47,10 @@ jobs:
           path = parsed.path.removesuffix("/api/v1") or "/"
           health = urlunparse(parsed._replace(path=f"{path.rstrip('/')}/health", query="", fragment=""))
           print(health)
-          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
-              fh.write(f"TRAIGENT_SMOKE_HEALTH_URL={health}\n")
           PY
-          curl -sf --max-time 10 "$TRAIGENT_SMOKE_HEALTH_URL"
+          )
+          echo "Health URL: $HEALTH_URL"
+          curl -sf --max-time 10 "$HEALTH_URL"
 
       - if: steps.config.outputs.configured == 'true'
         name: Run typed session smoke


### PR DESCRIPTION
## Summary

Fix the `Verify smoke backend is reachable` step in `typed-session-smoke.yml`.

The previous workflow wrote `TRAIGENT_SMOKE_HEALTH_URL` into `$GITHUB_ENV` and then tried to read it in the same `run:` block. GitHub Actions does not expose `GITHUB_ENV` writes until the next step, so the `curl` command could end up with an empty/malformed URL.

This patch computes the health URL inline with command substitution and curls it immediately in the same shell step:

```bash
HEALTH_URL=$(python ...)
curl -sf --max-time 10 "$HEALTH_URL"
```

## Why this is needed on `develop`

PR `#342` merged the same logic to `main`, but `develop` still has the broken version of the workflow.

## Validation

- workflow YAML parses successfully
- diff is limited to `.github/workflows/typed-session-smoke.yml`
- `git diff --check` passes

## Expected outcome

After merge, the typed session smoke workflow should no longer fail in `Verify smoke backend is reachable` with a malformed URL / `curl` exit code `3`.
