### PR TITLE
fix: align hybrid wrapper benchmark errors with contract

### DIFF
--- a/docs/hybrid-mode-openapi.yaml
+++ b/docs/hybrid-mode-openapi.yaml
@@ -202,15 +202,24 @@ paths:
                   tokens_output: 450
                 quality_metrics: null
         '400':
-          description: Invalid request (e.g., missing required fields, invalid config values)
+          description: Invalid request (e.g., missing benchmark_id, empty examples, tunable mismatch)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: INVALID_CONFIG
-                  message: 'Invalid configuration: temperature must be between 0 and 2'
+              examples:
+                missing-benchmark-id:
+                  summary: Missing benchmark_id
+                  value:
+                    error:
+                      code: INVALID_BENCHMARK_ID
+                      message: Missing required field 'benchmark_id' in execute request
+                invalid-request:
+                  summary: Wrapper-level request validation failure
+                  value:
+                    error:
+                      code: INVALID_REQUEST
+                      message: examples must be a non-empty list
         '401':
           description: Unauthorized
           content:
@@ -336,15 +345,24 @@ paths:
                         std: 0.04
                         'n': 5
         '400':
-          description: Invalid request (e.g., missing required fields, unknown execution_id)
+          description: Invalid request (e.g., missing benchmark_id or malformed evaluations payload)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: INVALID_REQUEST
-                  message: execution_id exec_unknown not found
+              examples:
+                missing-benchmark-id:
+                  summary: Missing benchmark_id
+                  value:
+                    error:
+                      code: INVALID_BENCHMARK_ID
+                      message: Missing required field 'benchmark_id' in evaluate request
+                invalid-request:
+                  summary: Wrapper-level request validation failure
+                  value:
+                    error:
+                      code: INVALID_REQUEST
+                      message: evaluations must be a list
         '401':
           description: Unauthorized
           content:
@@ -1096,11 +1114,10 @@ components:
           additionalProperties: true
         examples:
           type: array
-          description: List of examples to process. Actual limit is max_batch_size from capabilities (default 100).
+          description: List of examples to process. Actual limit is enforced by max_batch_size from capabilities (default 100), not by a static schema cap.
           items:
             $ref: '#/components/schemas/ExampleItem'
           minItems: 1
-          maxItems: 100000
         session_id:
           type: string
           description: Session ID for stateful agents
@@ -1246,8 +1263,7 @@ components:
           example: 2 of 5 inputs failed due to upstream timeout
         failed_examples:
           type: array
-          description: List of failed example IDs
-          maxItems: 10000
+          description: List of failed example IDs. Length matches the failed subset of the request batch.
           items:
             type: string
             maxLength: 256
@@ -1282,10 +1298,9 @@ components:
             - failed
         outputs:
           type: array
-          description: Per-input results
+          description: Per-input results. Length matches the request batch size after wrapper validation.
           items:
             $ref: '#/components/schemas/OutputItem'
-          maxItems: 10000
         operational_metrics:
           description: Aggregate operational metrics from the execution batch
           $ref: '#/components/schemas/OperationalMetrics'
@@ -1382,9 +1397,8 @@ components:
           example: exec_20240115_001
         evaluations:
           type: array
-          description: List of output+target pairs to evaluate
+          description: List of output+target pairs to evaluate. Implementations should reject oversize batches at runtime instead of relying on a static schema cap.
           minItems: 1
-          maxItems: 10000
           items:
             $ref: '#/components/schemas/EvaluationItem'
         config:
@@ -1495,10 +1509,9 @@ components:
             - failed
         results:
           type: array
-          description: Per-example evaluation results
+          description: Per-example evaluation results. Length matches the evaluated request batch after wrapper validation.
           items:
             $ref: '#/components/schemas/EvaluationResult'
-          maxItems: 10000
         aggregate_metrics:
           type: object
           description: Aggregated statistics per metric

--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -459,7 +459,7 @@ class TestCreateAppErrorHandling:
         assert "unexpected" in send.body_json["error"]["message"]
 
     @pytest.mark.asyncio
-    async def test_empty_body_treated_as_empty_dict(self) -> None:
+    async def test_empty_body_returns_400_benchmark_error(self) -> None:
         """Empty execute payloads should return a structured 400 benchmark error."""
         svc = TraigentService()
 

--- a/tests/unit/wrapper/test_wrapper_server.py
+++ b/tests/unit/wrapper/test_wrapper_server.py
@@ -460,12 +460,7 @@ class TestCreateAppErrorHandling:
 
     @pytest.mark.asyncio
     async def test_empty_body_treated_as_empty_dict(self) -> None:
-        """Test that empty request body is treated as empty dict.
-
-        An empty body becomes ``{}``, which lacks ``benchmark_id``.
-        The service returns a failed response with INVALID_BENCHMARK_ID
-        (not a raised exception), so the server sends it back as 200.
-        """
+        """Empty execute payloads should return a structured 400 benchmark error."""
         svc = TraigentService()
 
         @svc.execute
@@ -479,9 +474,36 @@ class TestCreateAppErrorHandling:
             _make_receive(b""),
             send,
         )
-        assert send.status == 200
-        assert send.body_json["status"] == "failed"
+        assert send.status == 400
         assert send.body_json["error"]["code"] == "INVALID_BENCHMARK_ID"
+        assert "benchmark_id" in send.body_json["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_missing_benchmark_returns_400(self) -> None:
+        """Evaluate requests without benchmark_id should fail with INVALID_BENCHMARK_ID."""
+        svc = TraigentService()
+
+        @svc.evaluate
+        def score(output, target, config):
+            return {"accuracy": 1.0}
+
+        app = create_app(svc)
+        send = _SendCollector()
+        request_body = json.dumps(
+            {
+                "evaluations": [
+                    {"example_id": "e1", "output": "a", "target": "a"},
+                ]
+            }
+        ).encode()
+        await app(
+            _make_scope("POST", EVALUATE_PATH),
+            _make_receive(request_body),
+            send,
+        )
+        assert send.status == 400
+        assert send.body_json["error"]["code"] == "INVALID_BENCHMARK_ID"
+        assert "benchmark_id" in send.body_json["error"]["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -907,8 +907,17 @@ class TestHandleExecute:
             await svc.handle_execute({"benchmark_id": "bench_001", "examples": []})
 
     @pytest.mark.asyncio
-    async def test_missing_benchmark_id_raises_structured_error(self) -> None:
-        """Execute requests without benchmark_id should raise INVALID_BENCHMARK_ID."""
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"examples": [{"example_id": "i1", "data": {}}]},
+            {"benchmark_id": "", "examples": [{"example_id": "i1", "data": {}}]},
+        ],
+    )
+    async def test_missing_benchmark_id_raises_structured_error(
+        self, payload: dict[str, object]
+    ) -> None:
+        """Execute requests without a usable benchmark_id should raise INVALID_BENCHMARK_ID."""
         svc = TraigentService()
 
         @svc.execute
@@ -916,7 +925,7 @@ class TestHandleExecute:
             return {"output": "ok"}
 
         with pytest.raises(BadRequestError) as exc_info:
-            await svc.handle_execute({"examples": [{"example_id": "i1", "data": {}}]})
+            await svc.handle_execute(payload)
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.error_code == "INVALID_BENCHMARK_ID"
@@ -1517,8 +1526,26 @@ class TestHandleEvaluateEdgeCases:
             )
 
     @pytest.mark.asyncio
-    async def test_missing_benchmark_id_raises_structured_error(self) -> None:
-        """Evaluate requests without benchmark_id should raise INVALID_BENCHMARK_ID."""
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {
+                "evaluations": [
+                    {"example_id": "e1", "output": "a", "target": "a"},
+                ]
+            },
+            {
+                "benchmark_id": "",
+                "evaluations": [
+                    {"example_id": "e1", "output": "a", "target": "a"},
+                ],
+            },
+        ],
+    )
+    async def test_missing_benchmark_id_raises_structured_error(
+        self, payload: dict[str, object]
+    ) -> None:
+        """Evaluate requests without a usable benchmark_id should raise INVALID_BENCHMARK_ID."""
         svc = TraigentService()
 
         @svc.evaluate
@@ -1526,13 +1553,7 @@ class TestHandleEvaluateEdgeCases:
             return {"accuracy": 1.0}
 
         with pytest.raises(BadRequestError) as exc_info:
-            await svc.handle_evaluate(
-                {
-                    "evaluations": [
-                        {"example_id": "e1", "output": "a", "target": "a"},
-                    ]
-                }
-            )
+            await svc.handle_evaluate(payload)
 
         assert exc_info.value.status_code == 400
         assert exc_info.value.error_code == "INVALID_BENCHMARK_ID"

--- a/tests/unit/wrapper/test_wrapper_service.py
+++ b/tests/unit/wrapper/test_wrapper_service.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from traigent.hybrid.protocol import EstimatedTokensPerExample
+from traigent.wrapper.errors import BadRequestError
 from traigent.wrapper.service import ServiceConfig, Session, TraigentService
 
 
@@ -906,6 +907,22 @@ class TestHandleExecute:
             await svc.handle_execute({"benchmark_id": "bench_001", "examples": []})
 
     @pytest.mark.asyncio
+    async def test_missing_benchmark_id_raises_structured_error(self) -> None:
+        """Execute requests without benchmark_id should raise INVALID_BENCHMARK_ID."""
+        svc = TraigentService()
+
+        @svc.execute
+        def run(example_id, data, config):
+            return {"output": "ok"}
+
+        with pytest.raises(BadRequestError) as exc_info:
+            await svc.handle_execute({"examples": [{"example_id": "i1", "data": {}}]})
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.error_code == "INVALID_BENCHMARK_ID"
+        assert "benchmark_id" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_example_without_example_id_gets_uuid(self) -> None:
         """Test that examples without example_id get a generated UUID."""
         svc = TraigentService()
@@ -1498,6 +1515,28 @@ class TestHandleEvaluateEdgeCases:
             await svc.handle_evaluate(
                 {"benchmark_id": "bench_001", "evaluations": "not_a_list"}
             )
+
+    @pytest.mark.asyncio
+    async def test_missing_benchmark_id_raises_structured_error(self) -> None:
+        """Evaluate requests without benchmark_id should raise INVALID_BENCHMARK_ID."""
+        svc = TraigentService()
+
+        @svc.evaluate
+        def score(output, target, config):
+            return {"accuracy": 1.0}
+
+        with pytest.raises(BadRequestError) as exc_info:
+            await svc.handle_evaluate(
+                {
+                    "evaluations": [
+                        {"example_id": "e1", "output": "a", "target": "a"},
+                    ]
+                }
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.error_code == "INVALID_BENCHMARK_ID"
+        assert "benchmark_id" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_evaluation_with_output_id(self) -> None:

--- a/traigent/wrapper/service.py
+++ b/traigent/wrapper/service.py
@@ -48,7 +48,7 @@ from typing import Any, Literal, TypeVar
 
 from traigent.hybrid.protocol import EstimatedTokensPerExample
 from traigent.utils.logging import get_logger
-from traigent.wrapper.errors import HybridAPIError
+from traigent.wrapper.errors import BadRequestError, HybridAPIError
 
 logger = get_logger(__name__)
 
@@ -585,17 +585,13 @@ class TraigentService:
 
         session_id = request.get("session_id")
 
-        # Validate benchmark_id is present
+        # Validate benchmark_id is present before any handler work.
         benchmark_id = request.get("benchmark_id")
         if not benchmark_id:
-            return {
-                "request_id": request_id,
-                "status": "failed",
-                "error": {
-                    "code": "INVALID_BENCHMARK_ID",
-                    "message": "Missing required field 'benchmark_id' in execute request",
-                },
-            }
+            raise BadRequestError(
+                "Missing required field 'benchmark_id' in execute request",
+                error_code="INVALID_BENCHMARK_ID",
+            )
 
         if not isinstance(examples, list) or len(examples) == 0:
             raise ValueError("examples must be a non-empty list")
@@ -770,17 +766,13 @@ class TraigentService:
         config = request.get("config", {})
         session_id = request.get("session_id")
 
-        # Validate benchmark_id is present
+        # Validate benchmark_id is present before any handler work.
         benchmark_id = request.get("benchmark_id")
         if not benchmark_id:
-            return {
-                "request_id": request_id,
-                "status": "failed",
-                "error": {
-                    "code": "INVALID_BENCHMARK_ID",
-                    "message": "Missing required field 'benchmark_id' in evaluate request",
-                },
-            }
+            raise BadRequestError(
+                "Missing required field 'benchmark_id' in evaluate request",
+                error_code="INVALID_BENCHMARK_ID",
+            )
 
         if not isinstance(evaluations, list):
             raise ValueError("evaluations must be a list")


### PR DESCRIPTION
## Summary
- return HTTP 400 `INVALID_BENCHMARK_ID` for execute/evaluate requests missing `benchmark_id`
- update wrapper tests to cover the structured benchmark error path
- re-baseline `docs/hybrid-mode-openapi.yaml` so benchmark-specific 400 examples match the wrapper and stale static batch-size caps are removed from execute/evaluate arrays

Closes #234

## Validation
- `python3 -m py_compile traigent/wrapper/service.py tests/unit/wrapper/test_wrapper_service.py tests/unit/wrapper/test_wrapper_server.py`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` for `docs/hybrid-mode-openapi.yaml`
- `pytest -q -o addopts='' tests/unit/wrapper/test_wrapper_service.py -k 'missing_benchmark_id or empty_inputs_list or evaluations_not_list'`
- `pytest -q -o addopts='' tests/unit/wrapper/test_wrapper_server.py -k 'empty_body_treated_as_empty_dict or evaluate_missing_benchmark_returns_400'`

## Notes
- In this environment the repo default `pytest` addopts require xdist, so the targeted wrapper tests were run with `-o addopts=''`.