### PR TITLE
feat: preserve structured failed-trial error context

### DIFF
--- a/tests/unit/api/test_trial_serialization.py
+++ b/tests/unit/api/test_trial_serialization.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 import pytest
 
 from traigent import serialize_trials
-from traigent.api.types import ExampleResult, TrialResult, TrialStatus
+from traigent.api.types import ExampleResult, TrialError, TrialResult, TrialStatus
 
 
 class _NestedTimestampedPayload:
@@ -96,6 +96,32 @@ def test_trial_result_to_dict_supports_epoch_timestamps() -> None:
     assert serialized["metadata"]["started_at"] == pytest.approx(
         datetime(2026, 3, 13, 11, 59, tzinfo=UTC).timestamp()
     )
+
+
+def test_trial_result_to_dict_serializes_structured_error_context() -> None:
+    trial = _build_trial_result()
+    trial.status = TrialStatus.FAILED
+    trial.error_message = "Connection timeout"
+    trial.error = TrialError(
+        message="Connection timeout",
+        error_type="TimeoutError",
+        traceback="Traceback (most recent call last): ...",
+        timestamp=datetime(2026, 3, 13, 11, 56, tzinfo=UTC),
+        config={"model": "gpt-4o-mini", "temperature": 0.2},
+    )
+
+    serialized = trial.to_dict(datetime_format="epoch")
+
+    assert serialized["error_message"] == "Connection timeout"
+    assert serialized["error"]["message"] == "Connection timeout"
+    assert serialized["error"]["error_type"] == "TimeoutError"
+    assert serialized["error"]["timestamp"] == pytest.approx(
+        datetime(2026, 3, 13, 11, 56, tzinfo=UTC).timestamp()
+    )
+    assert serialized["error"]["config"] == {
+        "model": "gpt-4o-mini",
+        "temperature": 0.2,
+    }
 
 
 def test_trial_result_to_dict_serializes_nested_to_dict_datetimes() -> None:

--- a/tests/unit/api/test_types.py
+++ b/tests/unit/api/test_types.py
@@ -21,6 +21,7 @@ from traigent.api.types import (
     SensitivityAnalysis,
     StrategyConfig,
     Trial,
+    TrialError,
     TrialResult,
     TrialStatus,
 )
@@ -107,6 +108,47 @@ class TestTrial:
 class TestTrialResult:
     """Test TrialResult dataclass."""
 
+    def test_trial_error_from_exception(self):
+        """Test structured error creation from an exception."""
+        try:
+            raise ValueError("Connection timeout")
+        except ValueError as exc:
+            error = TrialError.from_exception(
+                exc,
+                config={"model": "gpt-4", "temperature": 0.5},
+            )
+
+        assert error.message == "Connection timeout"
+        assert error.error_type == "ValueError"
+        assert "raise ValueError" in error.traceback
+        assert error.config == {"model": "gpt-4", "temperature": 0.5}
+
+    def test_trial_error_from_dict_supports_iso_and_epoch_timestamps(self):
+        """Test structured error reconstruction from serialized dictionaries."""
+        iso_error = TrialError.from_dict(
+            {
+                "message": "boom",
+                "error_type": "RuntimeError",
+                "traceback": "Traceback...",
+                "timestamp": "2026-03-14T08:00:00+00:00",
+                "config": {"model": "gpt-4o"},
+            }
+        )
+        epoch_error = TrialError.from_dict(
+            {
+                "message": "boom",
+                "error_type": "RuntimeError",
+                "traceback": "Traceback...",
+                "timestamp": 1773475200.0,
+                "config": {"model": "gpt-4o-mini"},
+            }
+        )
+
+        assert iso_error.timestamp.isoformat() == "2026-03-14T08:00:00+00:00"
+        assert iso_error.config == {"model": "gpt-4o"}
+        assert epoch_error.timestamp.timestamp() == pytest.approx(1773475200.0)
+        assert epoch_error.config == {"model": "gpt-4o-mini"}
+
     def test_trial_result_creation(self):
         """Test creating a TrialResult instance."""
         now = datetime.now()
@@ -128,6 +170,13 @@ class TestTrialResult:
 
     def test_trial_result_with_error(self):
         """Test TrialResult with error."""
+        error = TrialError(
+            message="Connection timeout",
+            error_type="TimeoutError",
+            traceback="Traceback (most recent call last): ...",
+            timestamp=datetime.now(),
+            config={},
+        )
         result = TrialResult(
             trial_id="trial_002",
             config={},
@@ -136,10 +185,14 @@ class TestTrialResult:
             duration=0.5,
             timestamp=datetime.now(),
             error_message="Connection timeout",
+            error=error,
         )
 
         assert result.status == TrialStatus.FAILED
         assert result.error_message == "Connection timeout"
+        assert result.error is error
+        assert result.error_type == "TimeoutError"
+        assert result.error_traceback == "Traceback (most recent call last): ..."
         assert not result.is_successful
 
     def test_is_successful_property(self):

--- a/tests/unit/core/test_trial_result_factory.py
+++ b/tests/unit/core/test_trial_result_factory.py
@@ -424,22 +424,29 @@ class TestBuildFailedResult:
 
     def test_basic_failed_result(self, eval_config):
         """Test basic failed result construction."""
-        error = ValueError("Test error")
-
-        result = build_failed_result(
-            trial_id="trial_789",
-            evaluation_config=eval_config,
-            duration=0.3,
-            error=error,
-            progress_state=None,
-            optuna_trial_id=None,
-        )
+        try:
+            raise ValueError("Test error")
+        except ValueError as error:
+            result = build_failed_result(
+                trial_id="trial_789",
+                evaluation_config=eval_config,
+                duration=0.3,
+                error=error,
+                progress_state=None,
+                optuna_trial_id=None,
+            )
 
         assert result.trial_id == "trial_789"
         assert result.config == eval_config
         assert result.status == TrialStatus.FAILED
         assert result.duration == 0.3
         assert result.error_message == "Test error"
+        assert result.error is not None
+        assert result.error.message == "Test error"
+        assert result.error.error_type == "ValueError"
+        assert "raise ValueError" in result.error.traceback
+        assert result.error.config == eval_config
+        assert result.error.timestamp.tzinfo == UTC
 
     def test_failed_with_progress_state(self, eval_config, progress_state):
         """Test failed result with progress state."""

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -97,6 +97,7 @@ from traigent.api.types import (
     ParetoFront,
     SensitivityAnalysis,
     StrategyConfig,
+    TrialError,
     TrialResult,
     serialize_trials,
 )
@@ -251,6 +252,7 @@ __all__ = [
     "create_quick_plot",
     # Result types
     "OptimizationResult",
+    "TrialError",
     "TrialResult",
     "serialize_trials",
     "SensitivityAnalysis",

--- a/traigent/api/__init__.py
+++ b/traigent/api/__init__.py
@@ -38,6 +38,7 @@ from traigent.api.types import (
     SensitivityAnalysis,
     StopReason,
     StrategyConfig,
+    TrialError,
     TrialResult,
     serialize_trials,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "get_version_info",
     # Result types
     "OptimizationResult",
+    "TrialError",
     "TrialResult",
     "serialize_trials",
     "SensitivityAnalysis",

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import traceback as traceback_module
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -219,6 +220,84 @@ class Trial:
 
 
 @dataclass
+class TrialError:
+    """Structured diagnostic context for a failed trial."""
+
+    message: str
+    error_type: str
+    traceback: str
+    timestamp: datetime
+    config: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_exception(
+        cls,
+        exc: Exception,
+        *,
+        config: Mapping[str, Any],
+        timestamp: datetime | None = None,
+    ) -> TrialError:
+        """Build a structured trial error from an exception."""
+        formatted_traceback = "".join(
+            traceback_module.format_exception(type(exc), exc, exc.__traceback__)
+        ).strip()
+        if not formatted_traceback:
+            formatted_traceback = "".join(
+                traceback_module.format_exception_only(type(exc), exc)
+            ).strip()
+
+        return cls(
+            message=str(exc),
+            error_type=type(exc).__name__,
+            traceback=formatted_traceback,
+            timestamp=timestamp or datetime.now(UTC),
+            config=dict(config),
+        )
+
+    def to_dict(
+        self,
+        *,
+        datetime_format: TrialDatetimeFormat = "iso",
+    ) -> dict[str, Any]:
+        """Convert structured error details to a JSON-ready dictionary."""
+        return {
+            "message": self.message,
+            "error_type": self.error_type,
+            "traceback": self.traceback,
+            "timestamp": _serialize_datetime(
+                self.timestamp, datetime_format=datetime_format
+            ),
+            "config": _json_safe_trial_value(
+                self.config, datetime_format=datetime_format
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> TrialError:
+        """Reconstruct a structured trial error from a dictionary."""
+        raw_timestamp = data.get("timestamp")
+        timestamp = datetime.now(UTC)
+        if isinstance(raw_timestamp, str):
+            try:
+                timestamp = datetime.fromisoformat(raw_timestamp)
+            except ValueError:
+                pass
+        elif isinstance(raw_timestamp, (int, float)):
+            timestamp = datetime.fromtimestamp(raw_timestamp, UTC)
+
+        raw_config = data.get("config")
+        config = raw_config if isinstance(raw_config, dict) else {}
+
+        return cls(
+            message=str(data.get("message", "")),
+            error_type=str(data.get("error_type", "")),
+            traceback=str(data.get("traceback", "")),
+            timestamp=timestamp,
+            config=config,
+        )
+
+
+@dataclass
 class TrialResult:
     """Result of a single optimization trial."""
 
@@ -230,6 +309,7 @@ class TrialResult:
     timestamp: datetime
     error_message: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    error: TrialError | None = None
 
     @property
     def is_successful(self) -> bool:
@@ -239,6 +319,16 @@ class TrialResult:
     def get_metric(self, name: str, default: float | None = None) -> float | None:
         """Get a specific metric value."""
         return self.metrics.get(name, default)
+
+    @property
+    def error_type(self) -> str | None:
+        """Get the error type for a failed trial, when available."""
+        return self.error.error_type if self.error else None
+
+    @property
+    def error_traceback(self) -> str | None:
+        """Get the formatted traceback for a failed trial, when available."""
+        return self.error.traceback if self.error else None
 
     def to_dict(
         self,
@@ -264,6 +354,9 @@ class TrialResult:
                 self.timestamp, datetime_format=datetime_format
             ),
             "error_message": self.error_message,
+            "error": _json_safe_trial_value(
+                self.error, datetime_format=datetime_format
+            ),
         }
 
         if include_config:

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -10,6 +10,7 @@ from typing import Any
 from traigent.api.types import (
     ComparabilityInfo,
     MetricCoverage,
+    TrialError,
     TrialResult,
     TrialStatus,
 )
@@ -356,6 +357,7 @@ def build_failed_result(
     """Create a failed :class:`TrialResult` instance."""
 
     logger.warning("Trial %s failed: %s", trial_id, error)
+    error_details = TrialError.from_exception(error, config=evaluation_config)
 
     metadata: dict[str, Any] = (
         {"optuna_trial_id": optuna_trial_id} if optuna_trial_id is not None else {}
@@ -399,6 +401,7 @@ def build_failed_result(
         timestamp=datetime.now(UTC),
         error_message=str(error),
         metadata=metadata,
+        error=error_details,
     )
 
 


### PR DESCRIPTION
## Summary
- add a public TrialError type for structured failed-trial diagnostics
- attach structured error context to TrialResult while keeping error_message for compatibility
- populate structured errors in build_failed_result() and cover serialization/export paths

## Testing
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/pytest -q -o addopts='' tests/unit/api/test_trial_serialization.py tests/unit/core/test_trial_result_factory.py tests/unit/api/test_types.py
- python3 -m py_compile traigent/api/types.py traigent/core/trial_result_factory.py traigent/__init__.py traigent/api/__init__.py tests/unit/api/test_trial_serialization.py tests/unit/api/test_types.py tests/unit/core/test_trial_result_factory.py

Closes #68