### PR TITLE
refactor: make ConfigSpace immutable

### DIFF
--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -179,6 +179,32 @@ class TestConfigSpaceFromDecoratorArgs:
 
         assert len(space.constraints) == 1
 
+    def test_from_decorator_args_snapshots_mapping_and_constraints(self) -> None:
+        """Factory inputs should be copied into immutable ConfigSpace storage."""
+        temp = Range(0.0, 2.0, name="temperature")
+        model = Choices(["gpt-4", "gpt-3.5"], name="model")
+        constraint = require(temp.gte(0.1))
+        raw_configuration_space = {"temperature": temp}
+        raw_inline_params = {"model": model}
+        constraints = [constraint]
+
+        space = ConfigSpace.from_decorator_args(
+            configuration_space=MappingProxyType(raw_configuration_space),
+            inline_params=MappingProxyType(raw_inline_params),
+            constraints=constraints,
+        )
+
+        assert isinstance(space.tvars, MappingProxyType)
+        assert isinstance(space.constraints, tuple)
+
+        raw_configuration_space["max_tokens"] = IntRange(100, 4096, name="max_tokens")
+        raw_inline_params["model"] = Choices(["gpt-4o-mini"], name="model")
+        constraints.append(require(model.equals("gpt-4")))
+
+        assert list(space.tvars.keys()) == ["temperature", "model"]
+        assert tuple(space.tvars["model"].values) == ("gpt-4", "gpt-3.5")
+        assert space.constraints == (constraint,)
+
     def test_from_decorator_args_skips_non_range_values(self) -> None:
         """Test that non-range values are skipped."""
         space = ConfigSpace.from_decorator_args(

--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -11,6 +11,9 @@ Tests cover:
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+from types import MappingProxyType
+
 import pytest
 
 from traigent.api.config_space import ConfigSpace
@@ -55,6 +58,36 @@ class TestConfigSpaceCreation:
         )
 
         assert space.description == "Test config space"
+
+    def test_tvars_and_constraints_are_stored_immutably(self) -> None:
+        """ConfigSpace should snapshot mutable constructor inputs."""
+        temp = Range(0.0, 2.0, name="temperature")
+        model = Choices(["gpt-4", "gpt-3.5"], name="model")
+        constraints = [implies(model.equals("gpt-4"), temp.lte(0.7))]
+        tvars = {"temperature": temp}
+
+        space = ConfigSpace(tvars=tvars, constraints=constraints)
+
+        assert isinstance(space.tvars, MappingProxyType)
+        assert isinstance(space.constraints, tuple)
+
+        tvars["model"] = model
+        constraints.append(require(temp.gte(0.1)))
+
+        assert list(space.tvars.keys()) == ["temperature"]
+        assert len(space.constraints) == 1
+
+    def test_config_space_is_frozen(self) -> None:
+        """Direct mutation should be rejected."""
+        temp = Range(0.0, 2.0, name="temperature")
+        space = ConfigSpace(tvars={"temperature": temp})
+
+        with pytest.raises(TypeError):
+            space.tvars["model"] = Choices(["gpt-4"], name="model")
+        with pytest.raises(AttributeError):
+            space.constraints.append(require(temp.gte(0.1)))  # type: ignore[attr-defined]
+        with pytest.raises(FrozenInstanceError):
+            space.description = "mutated"
 
     def test_repr(self) -> None:
         """Test ConfigSpace string representation."""

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -110,8 +110,8 @@ class ConfigSpace:
     @classmethod
     def from_decorator_args(
         cls,
-        configuration_space: dict[str, Any] | None = None,
-        inline_params: dict[str, Any] | None = None,
+        configuration_space: Mapping[str, Any] | None = None,
+        inline_params: Mapping[str, Any] | None = None,
         constraints: Sequence[Constraint] | None = None,
         description: str | None = None,
     ) -> ConfigSpace:
@@ -124,8 +124,8 @@ class ConfigSpace:
         3. Or a combination of both
 
         Args:
-            configuration_space: Dict of parameter definitions
-            inline_params: Inline parameter definitions from **kwargs
+            configuration_space: Mapping of parameter definitions
+            inline_params: Mapping of inline parameter definitions
             constraints: List of structural constraints
             description: Optional description
 
@@ -154,12 +154,12 @@ class ConfigSpace:
 
     @classmethod
     def _process_param_dict(
-        cls, params: dict[str, Any], tvars: dict[str, ParameterRange]
+        cls, params: Mapping[str, Any], tvars: dict[str, ParameterRange]
     ) -> None:
         """Process a parameter dictionary and add ranges to tvars.
 
         Args:
-            params: Dictionary of parameter definitions
+            params: Mapping of parameter definitions
             tvars: Target dictionary to populate with ParameterRange instances
         """
         for name, value in params.items():

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -69,8 +69,8 @@ class ConfigSpace:
     the TVL ecosystem.
 
     Attributes:
-        tvars: Dict mapping parameter names to their ParameterRange definitions
-        constraints: List of structural constraints on the configuration space
+        tvars: Read-only mapping of parameter names to ParameterRange definitions
+        constraints: Immutable tuple of structural constraints on the space
         description: Optional description of the configuration space
 
     Example:

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -32,7 +32,9 @@ Example:
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from traigent.api.constraints import Constraint
@@ -54,7 +56,7 @@ if TYPE_CHECKING:
     from traigent.tvl.models import StructuralConstraint, TVarDecl
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConfigSpace:
     """A complete configuration space with TVARs and constraints.
 
@@ -84,12 +86,15 @@ class ConfigSpace:
         ... )
     """
 
-    tvars: dict[str, ParameterRange]
-    constraints: list[Constraint] = field(default_factory=list)
+    tvars: Mapping[str, ParameterRange]
+    constraints: tuple[Constraint, ...] = field(default_factory=tuple)
     description: str | None = None
 
     def __post_init__(self) -> None:
         """Validate the configuration space after initialization."""
+        object.__setattr__(self, "tvars", MappingProxyType(dict(self.tvars)))
+        object.__setattr__(self, "constraints", tuple(self.constraints))
+
         # Ensure all tvars have unique names
         seen_names: set[str] = set()
         for name, tvar in self.tvars.items():
@@ -107,7 +112,7 @@ class ConfigSpace:
         cls,
         configuration_space: dict[str, Any] | None = None,
         inline_params: dict[str, Any] | None = None,
-        constraints: list[Constraint] | None = None,
+        constraints: Sequence[Constraint] | None = None,
         description: str | None = None,
     ) -> ConfigSpace:
         """Build ConfigSpace from decorator arguments.
@@ -143,7 +148,7 @@ class ConfigSpace:
 
         return cls(
             tvars=tvars,
-            constraints=constraints or [],
+            constraints=tuple(constraints or ()),
             description=description,
         )
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -773,8 +773,8 @@ def _build_constraint_scope_var_names(
         sources.append(raw_configuration_space)
     elif hasattr(raw_configuration_space, "tvars"):
         tvars = getattr(raw_configuration_space, "tvars", None)
-        if isinstance(tvars, dict):
-            sources.append(tvars)
+        if isinstance(tvars, Mapping):
+            sources.append(dict(tvars))
     if inline_params:
         sources.append(inline_params)
 

--- a/traigent/api/parameter_ranges.py
+++ b/traigent/api/parameter_ranges.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import logging
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
@@ -999,17 +999,20 @@ def normalize_configuration_space(
 
     # Start with explicit config_space (lower precedence)
     if config_space:
+        normalized_config_space: Mapping[str, Any]
         # Handle ConfigSpace objects by extracting their tvars
         if hasattr(config_space, "tvars") and hasattr(config_space, "constraints"):
-            # It's a ConfigSpace object - extract the tvars dict
-            config_space = config_space.tvars
-        elif not isinstance(config_space, dict):
+            # It's a ConfigSpace object - extract the tvars mapping
+            normalized_config_space = config_space.tvars
+        elif isinstance(config_space, Mapping):
+            normalized_config_space = config_space
+        else:
             from traigent.utils.exceptions import ValidationError
 
             raise ValidationError(
                 f"Expected dictionary for configuration_space, got {type(config_space).__name__}"
             )
-        for key, value in config_space.items():
+        for key, value in normalized_config_space.items():
             _process_param_entry(key, value, result, defaults)
 
     # Add/override with inline parameters (higher precedence)

--- a/traigent_validation/base.py
+++ b/traigent_validation/base.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from traigent.api.constraints import Constraint
     from traigent.api.parameter_ranges import ParameterRange
@@ -59,16 +59,16 @@ class ConstraintValidator(Protocol):
     def validate_config(
         self,
         config: dict[str, Any],
-        constraints: list[Constraint],
-        var_names: dict[int, str],
+        constraints: Sequence[Constraint],
+        var_names: Mapping[int, str],
     ) -> ValidationResult:
         """Validate one configuration against a set of constraints."""
         ...
 
     def check_satisfiability(
         self,
-        tvars: dict[str, ParameterRange],
-        constraints: list[Constraint],
+        tvars: Mapping[str, ParameterRange],
+        constraints: Sequence[Constraint],
     ) -> SatResult:
         """Check if any valid configuration can satisfy the constraints."""
         ...

--- a/traigent_validation/validators.py
+++ b/traigent_validation/validators.py
@@ -13,7 +13,7 @@ from traigent_validation.base import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from traigent.api.constraints import Constraint
     from traigent.api.parameter_ranges import ParameterRange
@@ -32,20 +32,21 @@ class PythonConstraintValidator:
     def validate_config(
         self,
         config: dict[str, Any],
-        constraints: list[Constraint],
-        var_names: dict[int, str],
+        constraints: Sequence[Constraint],
+        var_names: Mapping[int, str],
     ) -> ValidationResult:
         violations: list[ConstraintViolation] = []
+        resolved_var_names = dict(var_names)
 
         for i, constraint in enumerate(constraints):
             try:
-                is_satisfied = constraint.evaluate(config, var_names)
+                is_satisfied = constraint.evaluate(config, resolved_var_names)
                 if not is_satisfied:
                     relevant_values = self._get_relevant_values(
-                        config, constraint, var_names
+                        config, constraint, resolved_var_names
                     )
                     message = self._build_violation_message(
-                        constraint, config, var_names
+                        constraint, config, resolved_var_names
                     )
                     violations.append(
                         ConstraintViolation(
@@ -75,8 +76,8 @@ class PythonConstraintValidator:
 
     def check_satisfiability(
         self,
-        tvars: dict[str, ParameterRange],
-        constraints: list[Constraint],
+        tvars: Mapping[str, ParameterRange],
+        constraints: Sequence[Constraint],
     ) -> SatResult:
         if not constraints:
             return SatResult(status=SatStatus.SAT, message="No constraints to satisfy")
@@ -218,15 +219,15 @@ class SATConstraintValidator:
     def validate_config(
         self,
         config: dict[str, Any],
-        constraints: list[Constraint],
-        var_names: dict[int, str],
+        constraints: Sequence[Constraint],
+        var_names: Mapping[int, str],
     ) -> ValidationResult:
         return self._delegate.validate_config(config, constraints, var_names)
 
     def check_satisfiability(
         self,
-        tvars: dict[str, ParameterRange],
-        constraints: list[Constraint],
+        tvars: Mapping[str, ParameterRange],
+        constraints: Sequence[Constraint],
     ) -> SatResult:
         return self._delegate.check_satisfiability(tvars, constraints)
 


### PR DESCRIPTION
## Summary
- make ConfigSpace a frozen dataclass with immutable mapping and tuple storage
- snapshot mutable constructor inputs so later caller mutation cannot change the config space
- update decorator and parameter-range plumbing to accept immutable ConfigSpace mappings

## Testing
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/pytest -q -o addopts='' tests/unit/api/test_config_space.py tests/unit/api/test_decorators.py -k 'ConfigSpace or config_space'
- python3 -m py_compile traigent/api/config_space.py traigent/api/decorators.py traigent/api/parameter_ranges.py tests/unit/api/test_config_space.py

Closes #63
