### PR TITLE
refactor: type parameter range config values

### DIFF
--- a/tests/unit/api/test_parameter_ranges.py
+++ b/tests/unit/api/test_parameter_ranges.py
@@ -17,8 +17,11 @@ from traigent.api.parameter_ranges import (
     LogRange,
     ParameterRange,
     Range,
+    is_float_range_config_dict,
     is_inline_param_definition,
+    is_int_range_config_dict,
     is_parameter_range,
+    is_parameter_range_config_dict,
     normalize_config_value,
     normalize_configuration_space,
     normalize_parameter_value,
@@ -131,6 +134,14 @@ class TestRange:
         with pytest.raises(AttributeError):
             r.low = 0.5  # type: ignore[misc]
 
+    def test_range_config_type_guard(self):
+        """Float range config values should narrow correctly at runtime."""
+        simple = Range(0.0, 1.0).to_config_value()
+        advanced = Range(0.0, 1.0, step=0.1).to_config_value()
+
+        assert not is_float_range_config_dict(simple)
+        assert is_float_range_config_dict(advanced)
+
 
 class TestIntRange:
     """Tests for IntRange class."""
@@ -167,6 +178,14 @@ class TestIntRange:
         config = r.to_config_value()
         assert isinstance(config, dict)
         assert config["log"] is True
+
+    def test_int_range_config_type_guard(self):
+        """Int range config values should narrow correctly at runtime."""
+        simple = IntRange(1, 10).to_config_value()
+        advanced = IntRange(1, 10, step=1).to_config_value()
+
+        assert not is_int_range_config_dict(simple)
+        assert is_int_range_config_dict(advanced)
 
     def test_int_range_type_validation_float_low(self):
         """Test validation: bounds must be integers."""
@@ -288,6 +307,11 @@ class TestChoices:
         """Test choices converts to list."""
         c = Choices(["a", "b", "c"])
         assert c.to_config_value() == ["a", "b", "c"]
+
+    def test_parameter_range_config_dict_guard_excludes_choices(self):
+        """Generic config guard should not classify choice lists as dict values."""
+        config = Choices(["a", "b", "c"]).to_config_value()
+        assert not is_parameter_range_config_dict(config)
 
     def test_choices_to_list(self):
         """Test to_list() method."""

--- a/tests/unit/api/test_parameter_ranges_typing.py
+++ b/tests/unit/api/test_parameter_ranges_typing.py
@@ -1,0 +1,71 @@
+"""Typing tests for parameter range config value helpers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def test_parameter_range_config_value_typing_with_mypy(tmp_path: Path) -> None:
+    """Mypy should narrow range config unions via the exported type guards."""
+    pytest.importorskip("mypy")
+
+    snippet = tmp_path / "typing_check.py"
+    snippet.write_text(
+        textwrap.dedent(
+            """
+            from typing import Literal, assert_type
+
+            from traigent.api.parameter_ranges import (
+                FloatRangeConfigDict,
+                FloatRangeConfigValue,
+                IntRange,
+                IntRangeConfigDict,
+                IntRangeConfigValue,
+                LogRange,
+                Range,
+                is_float_range_config_dict,
+                is_int_range_config_dict,
+            )
+
+            float_value = Range(0.0, 1.0, step=0.1).to_config_value()
+            assert_type(float_value, FloatRangeConfigValue)
+            if is_float_range_config_dict(float_value):
+                assert_type(float_value, FloatRangeConfigDict)
+                assert_type(float_value["low"], float)
+
+            int_value = IntRange(1, 10, step=1).to_config_value()
+            assert_type(int_value, IntRangeConfigValue)
+            if is_int_range_config_dict(int_value):
+                assert_type(int_value, IntRangeConfigDict)
+                assert_type(int_value["high"], int)
+
+            log_value = LogRange(0.001, 1.0).to_config_value()
+            assert_type(log_value, FloatRangeConfigDict)
+            assert_type(log_value["type"], Literal["float"])
+            """
+        ),
+            encoding="utf-8",
+        )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--config-file",
+            "pyproject.toml",
+            str(snippet),
+            "traigent/api/parameter_ranges.py",
+        ],
+        cwd=Path(__file__).resolve().parents[3],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/traigent/api/parameter_ranges.py
+++ b/traigent/api/parameter_ranges.py
@@ -37,7 +37,19 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Literal,
+    NotRequired,
+    TypeAlias,
+    TypedDict,
+    TypeGuard,
+    TypeVar,
+    cast,
+    overload,
+)
 
 if TYPE_CHECKING:
     from traigent.api.config_space import ConfigSpace
@@ -50,6 +62,35 @@ from traigent.api.constraint_builders import (
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+class FloatRangeConfigDict(TypedDict):
+    """Dictionary form emitted for float ranges with advanced options."""
+
+    type: Literal["float"]
+    low: float
+    high: float
+    step: NotRequired[float]
+    log: NotRequired[bool]
+
+
+class IntRangeConfigDict(TypedDict):
+    """Dictionary form emitted for integer ranges with advanced options."""
+
+    type: Literal["int"]
+    low: int
+    high: int
+    step: NotRequired[int]
+    log: NotRequired[bool]
+
+
+FloatRangeTuple: TypeAlias = tuple[float, float]
+IntRangeTuple: TypeAlias = tuple[int, int]
+FloatRangeConfigValue: TypeAlias = FloatRangeTuple | FloatRangeConfigDict
+IntRangeConfigValue: TypeAlias = IntRangeTuple | IntRangeConfigDict
+ParameterRangeConfigValue: TypeAlias = (
+    FloatRangeConfigValue | IntRangeConfigValue | list[Any]
+)
 
 
 class ParameterRange(ABC):
@@ -82,7 +123,7 @@ class ParameterRange(ABC):
     name: str | None
 
     @abstractmethod
-    def to_config_value(self) -> tuple[Any, ...] | list[Any] | dict[str, Any]:
+    def to_config_value(self) -> ParameterRangeConfigValue:
         """Convert to the internal configuration space format.
 
         Returns:
@@ -159,7 +200,7 @@ class Range(NumericConstraintBuilderMixin, ParameterRange):
                 f"default {self.default} is outside range [{self.low}, {self.high}]"
             )
 
-    def to_config_value(self) -> tuple[float, float] | dict[str, Any]:
+    def to_config_value(self) -> FloatRangeConfigValue:
         """Convert to internal format.
 
         Returns tuple for simple ranges, dict when log/step is set.
@@ -167,7 +208,7 @@ class Range(NumericConstraintBuilderMixin, ParameterRange):
         if self.step is None and not self.log:
             return (self.low, self.high)
         # Use dict format for advanced options
-        result: dict[str, Any] = {
+        result: FloatRangeConfigDict = {
             "type": "float",
             "low": self.low,
             "high": self.high,
@@ -363,14 +404,14 @@ class IntRange(NumericConstraintBuilderMixin, ParameterRange):
                 f"default {self.default} is outside range [{self.low}, {self.high}]"
             )
 
-    def to_config_value(self) -> tuple[int, int] | dict[str, Any]:
+    def to_config_value(self) -> IntRangeConfigValue:
         """Convert to internal format.
 
         Returns tuple for simple ranges, dict when log/step is set.
         """
         if self.step is None and not self.log:
             return (self.low, self.high)
-        result: dict[str, Any] = {
+        result: IntRangeConfigDict = {
             "type": "int",
             "low": self.low,
             "high": self.high,
@@ -557,7 +598,7 @@ class LogRange(NumericConstraintBuilderMixin, ParameterRange):
                 f"default {self.default} is outside range [{self.low}, {self.high}]"
             )
 
-    def to_config_value(self) -> dict[str, Any]:
+    def to_config_value(self) -> FloatRangeConfigDict:
         """Convert to internal format with log=True."""
         return {
             "type": "float",
@@ -880,6 +921,27 @@ def is_parameter_range(value: Any) -> bool:
     return isinstance(value, ParameterRange)
 
 
+def is_float_range_config_dict(
+    value: FloatRangeConfigValue,
+) -> TypeGuard[FloatRangeConfigDict]:
+    """Narrow a float range config value to its dict form."""
+    return isinstance(value, dict)
+
+
+def is_int_range_config_dict(
+    value: IntRangeConfigValue,
+) -> TypeGuard[IntRangeConfigDict]:
+    """Narrow an int range config value to its dict form."""
+    return isinstance(value, dict)
+
+
+def is_parameter_range_config_dict(
+    value: ParameterRangeConfigValue,
+) -> TypeGuard[FloatRangeConfigDict | IntRangeConfigDict]:
+    """Narrow a parameter config value to an advanced numeric dict form."""
+    return isinstance(value, dict)
+
+
 def is_inline_param_definition(value: Any) -> bool:
     """Check if a value looks like an inline parameter definition.
 
@@ -905,9 +967,43 @@ def is_inline_param_definition(value: Any) -> bool:
     return False
 
 
+@overload
+def normalize_config_value(value: Range) -> FloatRangeConfigValue: ...
+
+
+@overload
+def normalize_config_value(value: IntRange) -> IntRangeConfigValue: ...
+
+
+@overload
+def normalize_config_value(value: LogRange) -> FloatRangeConfigDict: ...
+
+
+@overload
+def normalize_config_value(value: Choices[T]) -> list[T]: ...
+
+
+@overload
+def normalize_config_value(value: tuple[Any, ...]) -> tuple[Any, ...]: ...
+
+
+@overload
+def normalize_config_value(value: list[T]) -> list[T]: ...
+
+
+@overload
+def normalize_config_value(value: dict[str, Any]) -> dict[str, Any]: ...
+
+
+@overload
 def normalize_config_value(
     value: ParameterRange | tuple[Any, ...] | list[Any] | dict[str, Any],
-) -> tuple[Any, ...] | list[Any] | dict[str, Any]:
+) -> ParameterRangeConfigValue | tuple[Any, ...] | list[Any] | dict[str, Any]: ...
+
+
+def normalize_config_value(
+    value: ParameterRange | tuple[Any, ...] | list[Any] | dict[str, Any],
+) -> ParameterRangeConfigValue | tuple[Any, ...] | list[Any] | dict[str, Any]:
     """Convert a ParameterRange to its primitive format.
 
     If value is already a primitive (tuple/list/dict), returns it unchanged.
@@ -923,9 +1019,43 @@ def normalize_config_value(
     return value  # type: ignore[return-value]
 
 
+@overload
+def normalize_parameter_value(value: Range) -> FloatRangeConfigValue: ...
+
+
+@overload
+def normalize_parameter_value(value: IntRange) -> IntRangeConfigValue: ...
+
+
+@overload
+def normalize_parameter_value(value: LogRange) -> FloatRangeConfigDict: ...
+
+
+@overload
+def normalize_parameter_value(value: Choices[T]) -> list[T]: ...
+
+
+@overload
+def normalize_parameter_value(value: tuple[Any, ...]) -> tuple[Any, ...]: ...
+
+
+@overload
+def normalize_parameter_value(value: list[T]) -> list[T]: ...
+
+
+@overload
+def normalize_parameter_value(value: dict[str, Any]) -> dict[str, Any]: ...
+
+
+@overload
 def normalize_parameter_value(
-    value: Any,
-) -> tuple[Any, ...] | list[Any] | dict[str, Any]:
+    value: ParameterRange | tuple[Any, ...] | list[Any] | dict[str, Any],
+) -> ParameterRangeConfigValue | tuple[Any, ...] | list[Any] | dict[str, Any]: ...
+
+
+def normalize_parameter_value(
+    value: ParameterRange | tuple[Any, ...] | list[Any] | dict[str, Any],
+) -> ParameterRangeConfigValue | tuple[Any, ...] | list[Any] | dict[str, Any]:
     """Normalize a ParameterRange or primitive configuration value.
 
     Alias for normalize_config_value to match API naming expectations.
@@ -1025,11 +1155,21 @@ def normalize_configuration_space(
 
 __all__ = [
     "ParameterRange",
+    "FloatRangeConfigDict",
+    "IntRangeConfigDict",
+    "FloatRangeTuple",
+    "IntRangeTuple",
+    "FloatRangeConfigValue",
+    "IntRangeConfigValue",
+    "ParameterRangeConfigValue",
     "Range",
     "IntRange",
     "LogRange",
     "Choices",
     "is_parameter_range",
+    "is_float_range_config_dict",
+    "is_int_range_config_dict",
+    "is_parameter_range_config_dict",
     "is_inline_param_definition",
     "normalize_config_value",
     "normalize_parameter_value",


### PR DESCRIPTION
Closes #62

## Summary
- introduce explicit TypedDict/type-alias config value shapes for parameter ranges
- add exported TypeGuard helpers so callers can narrow float/int range dict forms safely
- add runtime guard coverage and a focused mypy-backed typing test for to_config_value()

## Verification
- uv run --extra dev pytest -o addopts= tests/unit/api/test_parameter_ranges.py tests/unit/api/test_parameter_ranges_typing.py\n- uv run --extra dev mypy traigent/api/parameter_ranges.py traigent/api/config_space.py traigent/optimizers/optuna_utils.py traigent/utils/validation.py