### PR TITLE
refactor: clarify choices config value typing

### DIFF
--- a/tests/unit/api/test_parameter_ranges_typing.py
+++ b/tests/unit/api/test_parameter_ranges_typing.py
@@ -21,6 +21,8 @@ def test_parameter_range_config_value_typing_with_mypy(tmp_path: Path) -> None:
             from typing import Literal, assert_type
 
             from traigent.api.parameter_ranges import (
+                Choices,
+                ChoicesConfigValue,
                 FloatRangeConfigDict,
                 FloatRangeConfigValue,
                 IntRange,
@@ -47,10 +49,14 @@ def test_parameter_range_config_value_typing_with_mypy(tmp_path: Path) -> None:
             log_value = LogRange(0.001, 1.0).to_config_value()
             assert_type(log_value, FloatRangeConfigDict)
             assert_type(log_value["type"], Literal["float"])
+
+            choices: Choices[str] = Choices(["gpt-4", "gpt-4.1"])
+            choice_value = choices.to_config_value()
+            assert_type(choice_value, ChoicesConfigValue[str])
             """
         ),
-            encoding="utf-8",
-        )
+        encoding="utf-8",
+    )
 
     result = subprocess.run(
         [

--- a/traigent/api/parameter_ranges.py
+++ b/traigent/api/parameter_ranges.py
@@ -86,10 +86,13 @@ class IntRangeConfigDict(TypedDict):
 
 FloatRangeTuple: TypeAlias = tuple[float, float]
 IntRangeTuple: TypeAlias = tuple[int, int]
+ChoicesConfigValue: TypeAlias = list[T]
 FloatRangeConfigValue: TypeAlias = FloatRangeTuple | FloatRangeConfigDict
 IntRangeConfigValue: TypeAlias = IntRangeTuple | IntRangeConfigDict
+# ParameterRange itself is not generic, so the categorical branch erases the
+# element type at the aggregate alias and is recovered on concrete overloads.
 ParameterRangeConfigValue: TypeAlias = (
-    FloatRangeConfigValue | IntRangeConfigValue | list[Any]
+    FloatRangeConfigValue | IntRangeConfigValue | ChoicesConfigValue[Any]
 )
 
 
@@ -717,7 +720,7 @@ class Choices(CategoricalConstraintBuilderMixin, ParameterRange, Generic[T]):
                 f"Set enforce_type=False to allow mixed types."
             )
 
-    def to_config_value(self) -> list[T]:
+    def to_config_value(self) -> ChoicesConfigValue[T]:
         """Convert to internal list format."""
         return list(self.values)
 
@@ -980,7 +983,7 @@ def normalize_config_value(value: LogRange) -> FloatRangeConfigDict: ...
 
 
 @overload
-def normalize_config_value(value: Choices[T]) -> list[T]: ...
+def normalize_config_value(value: Choices[T]) -> ChoicesConfigValue[T]: ...
 
 
 @overload
@@ -1032,7 +1035,7 @@ def normalize_parameter_value(value: LogRange) -> FloatRangeConfigDict: ...
 
 
 @overload
-def normalize_parameter_value(value: Choices[T]) -> list[T]: ...
+def normalize_parameter_value(value: Choices[T]) -> ChoicesConfigValue[T]: ...
 
 
 @overload
@@ -1159,6 +1162,7 @@ __all__ = [
     "IntRangeConfigDict",
     "FloatRangeTuple",
     "IntRangeTuple",
+    "ChoicesConfigValue",
     "FloatRangeConfigValue",
     "IntRangeConfigValue",
     "ParameterRangeConfigValue",


### PR DESCRIPTION
## Summary
- export a dedicated `ChoicesConfigValue[T]` alias for categorical config values
- use the alias in `Choices.to_config_value()` and the public normalization overloads
- extend the mypy regression test to assert the categorical path and clean up the test formatting nit

## Verification
- `uv run --extra dev pytest -o addopts='' tests/unit/api/test_parameter_ranges.py tests/unit/api/test_parameter_ranges_typing.py`
- `uv run --extra dev mypy traigent/api/parameter_ranges.py traigent/api/config_space.py traigent/optimizers/optuna_utils.py traigent/utils/validation.py`
