### PR TITLE
feat: preserve ConfigSpace TVL round-trip fidelity

### DIFF
--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -531,6 +531,126 @@ class TestTVLExport:
 
         assert spec["description"] == "Test space"
 
+    def test_to_tvl_spec_includes_range_type_extension_and_agent(self) -> None:
+        """TVL export should retain SDK-specific ParameterRange identity."""
+        learning_rate = LogRange(
+            1e-5,
+            1e-1,
+            name="learning_rate",
+            unit="ratio",
+            default=1e-3,
+            agent="optimizer",
+        )
+
+        spec = ConfigSpace(tvars={"learning_rate": learning_rate}).to_tvl_spec()
+
+        tvar = spec["tvars"][0]
+        assert tvar["x_traigent_parameter_range"] == "LogRange"
+        assert tvar["agent"] == "optimizer"
+        assert tvar["unit"] == "ratio"
+        assert tvar["default"] == 1e-3
+
+
+class TestTVLImport:
+    """Tests for ConfigSpace.from_tvl_spec."""
+
+    def test_from_tvl_spec_round_trips_parameter_range_subclasses(self) -> None:
+        """Import should preserve exact ParameterRange subclasses and metadata."""
+        space = ConfigSpace(
+            tvars={
+                "temperature": Range(
+                    0.1,
+                    1.5,
+                    step=0.1,
+                    default=0.7,
+                    name="temperature",
+                    unit="ratio",
+                    agent="writer",
+                ),
+                "learning_rate": LogRange(
+                    1e-5,
+                    1e-1,
+                    default=1e-3,
+                    name="learning_rate",
+                    unit="ratio",
+                    agent="optimizer",
+                ),
+                "beam_width": IntRange(
+                    1,
+                    8,
+                    step=1,
+                    default=2,
+                    name="beam_width",
+                    unit="count",
+                    agent="planner",
+                ),
+                "model": Choices(
+                    ["gpt-4o", "gpt-4.1"],
+                    default="gpt-4o",
+                    name="model",
+                    agent="router",
+                ),
+            },
+            description="TVL round-trip",
+        )
+
+        restored = ConfigSpace.from_tvl_spec(space.to_tvl_spec())
+
+        assert isinstance(restored.tvars["temperature"], Range)
+        assert not isinstance(restored.tvars["temperature"], LogRange)
+        assert restored.tvars["temperature"].step == 0.1
+        assert restored.tvars["temperature"].agent == "writer"
+
+        assert isinstance(restored.tvars["learning_rate"], LogRange)
+        assert restored.tvars["learning_rate"].default == 1e-3
+        assert restored.tvars["learning_rate"].agent == "optimizer"
+
+        assert isinstance(restored.tvars["beam_width"], IntRange)
+        assert restored.tvars["beam_width"].log is False
+        assert restored.tvars["beam_width"].step == 1
+        assert restored.tvars["beam_width"].agent == "planner"
+
+        assert isinstance(restored.tvars["model"], Choices)
+        assert tuple(restored.tvars["model"].values) == ("gpt-4o", "gpt-4.1")
+        assert restored.tvars["model"].default == "gpt-4o"
+        assert restored.tvars["model"].agent == "router"
+        assert restored.description == "TVL round-trip"
+
+    def test_from_tvl_spec_round_trips_constraints(self) -> None:
+        """Import should preserve constraint structure and metadata."""
+        temp = Range(0.0, 2.0, name="temperature")
+        model = Choices(["gpt-4", "gpt-3.5"], name="model")
+
+        space = ConfigSpace(
+            tvars={"temperature": temp, "model": model},
+            constraints=[
+                imply := implies(
+                    model.equals("gpt-4"),
+                    temp.lte(0.7),
+                    description="GPT-4 requires low temperature",
+                    id="c1",
+                ),
+                standalone := require(
+                    temp.gte(0.1),
+                    description="Temperature must stay positive",
+                    id="c2",
+                ),
+            ],
+            description="Constraint round-trip",
+        )
+
+        spec = space.to_tvl_spec()
+        restored = ConfigSpace.from_tvl_spec(spec)
+
+        assert restored.description == "Constraint round-trip"
+        assert len(restored.constraints) == 2
+        assert [c.id for c in restored.constraints] == [imply.id, standalone.id]
+        assert [c.description for c in restored.constraints] == [
+            imply.description,
+            standalone.description,
+        ]
+        assert restored.to_tvl_spec() == spec
+
 
 class TestInferTvarType:
     """Tests for ConfigSpace._infer_tvar_type."""

--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -16,7 +16,7 @@ from types import MappingProxyType
 
 import pytest
 
-from traigent.api.config_space import ConfigSpace
+from traigent.api.config_space import ConfigSpace, _ImportedConstraintExpression
 from traigent.api.constraints import implies, require
 from traigent.api.parameter_ranges import Choices, IntRange, LogRange, Range
 from traigent.api.validation_protocol import SatStatus
@@ -649,7 +649,54 @@ class TestTVLImport:
             imply.description,
             standalone.description,
         ]
+
+        imported_implication = restored.constraints[0]
+        assert isinstance(imported_implication.when, _ImportedConstraintExpression)
+        assert imported_implication.when._evaluator is None
+        assert restored.validate({"temperature": 0.5, "model": "gpt-4"}).is_valid
+        assert imported_implication.when._evaluator is not None
+        assert not restored.validate({"temperature": 0.9, "model": "gpt-4"}).is_valid
+
         assert restored.to_tvl_spec() == spec
+
+    def test_from_tvl_spec_without_sdk_extension_uses_fallback_inference(self) -> None:
+        """Plain TVL specs should still import without SDK-specific fields."""
+        restored = ConfigSpace.from_tvl_spec(
+            {
+                "tvars": [
+                    {
+                        "name": "temperature",
+                        "type": "float",
+                        "domain": {"kind": "range", "range": [0.01, 1.0], "log": True},
+                    },
+                    {
+                        "name": "model",
+                        "type": "enum[str]",
+                        "domain": {"kind": "enum", "values": ["gpt-4o", "gpt-4.1"]},
+                    },
+                ]
+            }
+        )
+
+        assert isinstance(restored.tvars["temperature"], LogRange)
+        assert isinstance(restored.tvars["model"], Choices)
+        assert tuple(restored.tvars["model"].values) == ("gpt-4o", "gpt-4.1")
+
+    def test_from_tvl_spec_rejects_non_integral_intrange_fields(self) -> None:
+        """IntRange import should fail on non-integral numeric fields."""
+        with pytest.raises(ValueError, match="must be integral"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "beam_width",
+                            "type": "int",
+                            "x_traigent_parameter_range": "IntRange",
+                            "domain": {"kind": "range", "range": [1, 8], "resolution": 1.5},
+                        }
+                    ]
+                }
+            )
 
 
 class TestInferTvarType:

--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -13,13 +13,34 @@ from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
 from types import MappingProxyType
+from typing import Any
 
 import pytest
 
 from traigent.api.config_space import ConfigSpace, _ImportedConstraintExpression
 from traigent.api.constraints import implies, require
-from traigent.api.parameter_ranges import Choices, IntRange, LogRange, Range
+from traigent.api.parameter_ranges import (
+    Choices,
+    IntRange,
+    LogRange,
+    ParameterRange,
+    Range,
+)
 from traigent.api.validation_protocol import SatStatus
+
+
+class DummyParameterRange(ParameterRange):
+    """Minimal ParameterRange used to exercise fallback TVL logic."""
+
+    def __init__(self, value: Any) -> None:
+        self.value = value
+        self.name = None
+
+    def to_config_value(self) -> tuple[Any, ...] | list[Any] | dict[str, Any]:
+        return self.value
+
+    def get_default(self) -> Any | None:
+        return None
 
 
 class TestConfigSpaceCreation:
@@ -697,6 +718,219 @@ class TestTVLImport:
                     ]
                 }
             )
+
+    def test_from_tvl_spec_supports_legacy_configuration_space(self) -> None:
+        """Legacy configuration_space specs should still import."""
+        restored = ConfigSpace.from_tvl_spec(
+            {
+                "configuration_space": {
+                    "temperature": {"low": 0.0, "high": 1.0},
+                    "model": {"choices": ["gpt-4o", "gpt-4.1"]},
+                },
+                "constraints": [
+                    {
+                        "expr": "params.temperature >= 0.1",
+                        "description": "positive temp",
+                        "id": "legacy-1",
+                    }
+                ],
+                "description": "legacy spec",
+            }
+        )
+
+        assert isinstance(restored.tvars["temperature"], Range)
+        assert isinstance(restored.tvars["model"], Choices)
+        assert restored.description == "legacy spec"
+        assert restored.constraints[0].id == "legacy-1"
+
+    def test_from_tvl_spec_rejects_invalid_top_level_sections(self) -> None:
+        """Top-level TVL import validation should fail fast on malformed input."""
+        with pytest.raises(ValueError, match="must define either 'tvars' or 'configuration_space'"):
+            ConfigSpace.from_tvl_spec({"description": "missing space"})
+
+        with pytest.raises(ValueError, match="configuration_space must be a mapping"):
+            ConfigSpace.from_tvl_spec({"configuration_space": []})
+
+        with pytest.raises(ValueError, match="description must be a string"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "temperature",
+                            "type": "float",
+                            "domain": [0.0, 1.0],
+                        }
+                    ],
+                    "description": 123,
+                }
+            )
+
+    def test_from_tvl_spec_rejects_invalid_tvar_entries(self) -> None:
+        """TVAR import should validate list shape, names, and domains."""
+        with pytest.raises(ValueError, match="must be a non-empty list"):
+            ConfigSpace.from_tvl_spec({"tvars": []})
+
+        with pytest.raises(ValueError, match="TVAR at index 0 must be a mapping"):
+            ConfigSpace.from_tvl_spec({"tvars": ["bad"]})
+
+        with pytest.raises(ValueError, match="requires a 'name' string"):
+            ConfigSpace.from_tvl_spec({"tvars": [{"type": "float", "domain": [0.0, 1.0]}]})
+
+        with pytest.raises(ValueError, match="range domain must contain a 2-item list"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "temperature",
+                            "type": "float",
+                            "domain": {"kind": "range", "range": [0.0]},
+                        }
+                    ]
+                }
+            )
+
+        with pytest.raises(ValueError, match="unsupported domain kind"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "temperature",
+                            "type": "float",
+                            "domain": {"kind": "mystery", "range": [0.0, 1.0]},
+                        }
+                    ]
+                }
+            )
+
+        with pytest.raises(ValueError, match="domain must be a list or mapping"):
+            ConfigSpace.from_tvl_spec(
+                {"tvars": [{"name": "temperature", "type": "float", "domain": "bad"}]}
+            )
+
+    def test_from_tvl_spec_rejects_invalid_choices_extension_shape(self) -> None:
+        """Choices extension import requires a values list."""
+        with pytest.raises(ValueError, match="Choices spec requires 'values'"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "model",
+                            "type": "enum[str]",
+                            "x_traigent_parameter_range": "Choices",
+                            "domain": {"kind": "range", "range": [0.0, 1.0]},
+                        }
+                    ]
+                }
+            )
+
+    def test_from_tvl_spec_rejects_invalid_integral_values(self) -> None:
+        """Integer field coercion should reject invalid bool/string inputs."""
+        with pytest.raises(ValueError, match="got bool"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "beam_width",
+                            "type": "int",
+                            "x_traigent_parameter_range": "IntRange",
+                            "domain": {"kind": "range", "range": [True, 8]},
+                        }
+                    ]
+                }
+            )
+
+        with pytest.raises(ValueError, match="got str"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {
+                            "name": "beam_width",
+                            "type": "int",
+                            "x_traigent_parameter_range": "IntRange",
+                            "domain": {"kind": "range", "range": [1, 8]},
+                            "default": "2",
+                        }
+                    ]
+                }
+            )
+
+    def test_from_tvl_spec_rejects_invalid_constraints(self) -> None:
+        """Constraint import should validate structure and metadata types."""
+        with pytest.raises(ValueError, match="constraints must be a list or mapping"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {"name": "temperature", "type": "float", "domain": [0.0, 1.0]}
+                    ],
+                    "constraints": "bad",
+                }
+            )
+
+        with pytest.raises(ValueError, match="Constraint at index 0 must be a mapping"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {"name": "temperature", "type": "float", "domain": [0.0, 1.0]}
+                    ],
+                    "constraints": [123],
+                }
+            )
+
+        with pytest.raises(ValueError, match="description must be a string"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {"name": "temperature", "type": "float", "domain": [0.0, 1.0]}
+                    ],
+                    "constraints": [{"expr": "params.temperature >= 0.1", "description": 123}],
+                }
+            )
+
+        with pytest.raises(ValueError, match="id must be a string"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {"name": "temperature", "type": "float", "domain": [0.0, 1.0]}
+                    ],
+                    "constraints": [{"expr": "params.temperature >= 0.1", "id": 123}],
+                }
+            )
+
+        with pytest.raises(ValueError, match="must define 'expr' or both 'when' and 'then'"):
+            ConfigSpace.from_tvl_spec(
+                {
+                    "tvars": [
+                        {"name": "temperature", "type": "float", "domain": [0.0, 1.0]}
+                    ],
+                    "constraints": [{"when": "params.temperature >= 0.1"}],
+                }
+            )
+
+    def test_imported_constraint_expression_explain_and_list_constraints(self) -> None:
+        """Imported expression wrappers should support explain and list-style constraints."""
+        restored = ConfigSpace.from_tvl_spec(
+            {
+                "tvars": [
+                    {"name": "temperature", "type": "float", "domain": [0.0, 1.0]}
+                ],
+                "constraints": [{"expr": "params.temperature >= 0.1"}],
+            }
+        )
+
+        expr = restored.constraints[0].expr
+        assert isinstance(expr, _ImportedConstraintExpression)
+        assert expr.explain() == "params.temperature >= 0.1"
+
+    def test_fallback_domain_and_type_logic_for_unknown_parameter_range(self) -> None:
+        """Unknown ParameterRange subclasses should use generic fallback export."""
+        list_domain = ConfigSpace._tvar_to_domain(DummyParameterRange(["a", "b"]))
+        tuple_domain = ConfigSpace._tvar_to_domain(DummyParameterRange((1, 2)))
+        scalar_domain = ConfigSpace._tvar_to_domain(DummyParameterRange({"kind": "x"}))
+
+        assert ConfigSpace._infer_tvar_type(DummyParameterRange(["x"])) == "float"
+        assert list_domain == {"kind": "enum", "values": ["a", "b"]}
+        assert tuple_domain == {"kind": "range", "range": [1, 2]}
+        assert scalar_domain == {"kind": "enum", "values": [{"kind": "x"}]}
 
 
 class TestInferTvarType:

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -32,7 +32,7 @@ Example:
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
@@ -61,28 +61,31 @@ class _ImportedConstraintExpression(BoolExpr):
     """Opaque TVL expression imported from a serialized spec."""
 
     expression: str
+    _evaluator: Callable[[dict[str, Any], dict[str, Any] | None], bool] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
 
-    def to_expression(self, var_names: dict[int, str] | str) -> str:
+    def to_expression(self, _var_names: dict[int, str] | str) -> str:
         """Return the original expression unchanged."""
-        del var_names
         return self.expression
 
     def evaluate_config(
-        self, config: dict[str, Any], var_names: dict[int, str]
+        self, config: dict[str, Any], _var_names: dict[int, str]
     ) -> bool:
         """Evaluate the stored TVL expression against a config."""
-        del var_names
-        from traigent.tvl.spec_loader import compile_constraint_expression
+        evaluator = self._evaluator
+        if evaluator is None:
+            from traigent.tvl.spec_loader import compile_constraint_expression
 
-        evaluator = compile_constraint_expression(
-            self.expression,
-            label=f"imported_constraint:{self.expression}",
-        )
+            evaluator = compile_constraint_expression(
+                self.expression,
+                label=f"imported_constraint:{self.expression}",
+            )
+            object.__setattr__(self, "_evaluator", evaluator)
         return bool(evaluator(config, None))
 
-    def explain(self, var_names: dict[int, str] | None = None) -> str:
+    def explain(self, _var_names: dict[int, str] | None = None) -> str:
         """Surface the raw expression for human-readable diagnostics."""
-        del var_names
         return self.expression
 
 
@@ -315,12 +318,26 @@ class ConfigSpace:
             )
 
         if range_type == "IntRange":
+            low = cls._coerce_integral_spec_value(name, "low", spec_dict["low"])
+            high = cls._coerce_integral_spec_value(name, "high", spec_dict["high"])
+            if low is None or high is None:  # pragma: no cover - defensive guard
+                raise ValueError(f"TVAR '{name}' IntRange bounds are required")
             return IntRange(
-                low=int(spec_dict["low"]),
-                high=int(spec_dict["high"]),
-                step=spec_dict.get("step"),
+                low=low,
+                high=high,
+                step=cls._coerce_integral_spec_value(
+                    name,
+                    "step",
+                    spec_dict.get("step"),
+                    allow_none=True,
+                ),
                 log=bool(spec_dict.get("log", False)),
-                default=spec_dict.get("default"),
+                default=cls._coerce_integral_spec_value(
+                    name,
+                    "default",
+                    spec_dict.get("default"),
+                    allow_none=True,
+                ),
                 name=name,
                 unit=spec_dict.get("unit"),
                 agent=spec_dict.get("agent"),
@@ -339,6 +356,40 @@ class ConfigSpace:
             )
 
         return cls._dict_to_range(name, spec_dict)
+
+    @staticmethod
+    def _coerce_integral_spec_value(
+        name: str,
+        field_name: str,
+        value: Any,
+        *,
+        allow_none: bool = False,
+    ) -> int | None:
+        """Coerce an imported TVL field to int without silent truncation."""
+        if value is None:
+            if allow_none:
+                return None
+            raise ValueError(f"TVAR '{name}' field '{field_name}' is required")
+
+        if isinstance(value, bool):
+            raise ValueError(
+                f"TVAR '{name}' field '{field_name}' must be an integer, got bool"
+            )
+
+        if isinstance(value, int):
+            return value
+
+        if isinstance(value, float):
+            if value.is_integer():
+                return int(value)
+            raise ValueError(
+                f"TVAR '{name}' field '{field_name}' must be integral, got {value!r}"
+            )
+
+        raise ValueError(
+            f"TVAR '{name}' field '{field_name}' must be an integer, "
+            f"got {type(value).__name__}"
+        )
 
     @classmethod
     def _constraints_from_spec(cls, constraints_section: Any) -> tuple[Constraint, ...]:

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
-from traigent.api.constraints import Constraint
+from traigent.api.constraints import BoolExpr, Constraint
 from traigent.api.parameter_ranges import (
     Choices,
     IntRange,
@@ -54,6 +54,36 @@ from traigent.api.validation_protocol import (
 
 if TYPE_CHECKING:
     from traigent.tvl.models import StructuralConstraint, TVarDecl
+
+
+@dataclass(frozen=True)
+class _ImportedConstraintExpression(BoolExpr):
+    """Opaque TVL expression imported from a serialized spec."""
+
+    expression: str
+
+    def to_expression(self, var_names: dict[int, str] | str) -> str:
+        """Return the original expression unchanged."""
+        del var_names
+        return self.expression
+
+    def evaluate_config(
+        self, config: dict[str, Any], var_names: dict[int, str]
+    ) -> bool:
+        """Evaluate the stored TVL expression against a config."""
+        del var_names
+        from traigent.tvl.spec_loader import compile_constraint_expression
+
+        evaluator = compile_constraint_expression(
+            self.expression,
+            label=f"imported_constraint:{self.expression}",
+        )
+        return bool(evaluator(config, None))
+
+    def explain(self, var_names: dict[int, str] | None = None) -> str:
+        """Surface the raw expression for human-readable diagnostics."""
+        del var_names
+        return self.expression
 
 
 @dataclass(frozen=True)
@@ -170,6 +200,207 @@ class ConfigSpace:
             elif isinstance(value, dict):
                 tvars[name] = cls._dict_to_range(name, value)
             # Skip non-range values (they might be other decorator args)
+
+    @classmethod
+    def from_tvl_spec(cls, spec: Mapping[str, Any]) -> ConfigSpace:
+        """Build ConfigSpace from a TVL spec dictionary."""
+        if "tvars" in spec:
+            tvars = cls._tvars_from_spec(spec["tvars"])
+        elif "configuration_space" in spec:
+            configuration_space = spec["configuration_space"]
+            if not isinstance(configuration_space, Mapping):
+                raise ValueError("TVL configuration_space must be a mapping")
+            tvars = {}
+            cls._process_param_dict(configuration_space, tvars)
+        else:
+            raise ValueError(
+                "TVL spec must define either 'tvars' or 'configuration_space'"
+            )
+
+        constraints = cls._constraints_from_spec(spec.get("constraints"))
+        description = spec.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValueError("TVL description must be a string when provided")
+
+        return cls(tvars=tvars, constraints=constraints, description=description)
+
+    @classmethod
+    def _tvars_from_spec(cls, tvars_section: Any) -> dict[str, ParameterRange]:
+        """Reconstruct ParameterRange instances from a TVL tvars section."""
+        if not isinstance(tvars_section, list) or not tvars_section:
+            raise ValueError("TVL 'tvars' must be a non-empty list")
+
+        tvars: dict[str, ParameterRange] = {}
+        for idx, entry in enumerate(tvars_section):
+            if not isinstance(entry, Mapping):
+                raise ValueError(f"TVAR at index {idx} must be a mapping")
+            name = entry.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError(f"TVAR at index {idx} requires a 'name' string")
+            tvars[name] = cls._spec_entry_to_range(name, entry)
+        return tvars
+
+    @classmethod
+    def _spec_entry_to_range(
+        cls, name: str, entry: Mapping[str, Any]
+    ) -> ParameterRange:
+        """Convert a TVL tvar entry back into a ParameterRange."""
+        domain = entry.get("domain")
+        if isinstance(domain, list):
+            spec_dict: dict[str, Any] = {
+                "values": list(domain),
+                "default": entry.get("default"),
+            }
+        elif isinstance(domain, Mapping):
+            kind = domain.get("kind")
+            if kind == "enum":
+                spec_dict = {
+                    "values": list(domain.get("values", [])),
+                    "default": entry.get("default"),
+                }
+            elif kind == "range":
+                range_values = domain.get("range")
+                if not isinstance(range_values, list) or len(range_values) != 2:
+                    raise ValueError(
+                        f"TVAR '{name}' range domain must contain a 2-item list"
+                    )
+                spec_dict = {
+                    "low": range_values[0],
+                    "high": range_values[1],
+                    "step": domain.get("resolution"),
+                    "log": bool(domain.get("log", False)),
+                    "default": entry.get("default"),
+                }
+            else:
+                raise ValueError(f"TVAR '{name}' has unsupported domain kind '{kind}'")
+        else:
+            raise ValueError(f"TVAR '{name}' domain must be a list or mapping")
+
+        if isinstance(entry.get("unit"), str):
+            spec_dict["unit"] = entry["unit"]
+        if isinstance(entry.get("agent"), str):
+            spec_dict["agent"] = entry["agent"]
+
+        range_type = entry.get("x_traigent_parameter_range")
+        return cls._build_parameter_range(name, spec_dict, range_type)
+
+    @classmethod
+    def _build_parameter_range(
+        cls,
+        name: str,
+        spec_dict: dict[str, Any],
+        range_type: Any,
+    ) -> ParameterRange:
+        """Reconstruct the exact ParameterRange subclass from a TVL entry."""
+        if range_type == "Choices":
+            values = spec_dict.get("values")
+            if not isinstance(values, list):
+                raise ValueError(f"TVAR '{name}' Choices spec requires 'values'")
+            return Choices(
+                values=values,
+                name=name,
+                default=spec_dict.get("default"),
+                unit=spec_dict.get("unit"),
+                agent=spec_dict.get("agent"),
+            )
+
+        if range_type == "LogRange":
+            return LogRange(
+                low=float(spec_dict["low"]),
+                high=float(spec_dict["high"]),
+                default=spec_dict.get("default"),
+                name=name,
+                unit=spec_dict.get("unit"),
+                agent=spec_dict.get("agent"),
+            )
+
+        if range_type == "IntRange":
+            return IntRange(
+                low=int(spec_dict["low"]),
+                high=int(spec_dict["high"]),
+                step=spec_dict.get("step"),
+                log=bool(spec_dict.get("log", False)),
+                default=spec_dict.get("default"),
+                name=name,
+                unit=spec_dict.get("unit"),
+                agent=spec_dict.get("agent"),
+            )
+
+        if range_type == "Range":
+            return Range(
+                low=float(spec_dict["low"]),
+                high=float(spec_dict["high"]),
+                step=spec_dict.get("step"),
+                log=bool(spec_dict.get("log", False)),
+                default=spec_dict.get("default"),
+                name=name,
+                unit=spec_dict.get("unit"),
+                agent=spec_dict.get("agent"),
+            )
+
+        return cls._dict_to_range(name, spec_dict)
+
+    @classmethod
+    def _constraints_from_spec(cls, constraints_section: Any) -> tuple[Constraint, ...]:
+        """Rebuild structural constraints from a TVL constraints section."""
+        if constraints_section is None:
+            return ()
+
+        entries: list[Any]
+        if isinstance(constraints_section, list):
+            entries = constraints_section
+        elif isinstance(constraints_section, Mapping):
+            structural = constraints_section.get("structural", [])
+            if not isinstance(structural, list):
+                raise ValueError("TVL 'constraints.structural' must be a list")
+            entries = structural
+        else:
+            raise ValueError("TVL constraints must be a list or mapping")
+
+        constraints: list[Constraint] = []
+        for idx, entry in enumerate(entries):
+            if not isinstance(entry, Mapping):
+                raise ValueError(f"Constraint at index {idx} must be a mapping")
+
+            expr = entry.get("expr")
+            when = entry.get("when")
+            then = entry.get("then")
+            description = entry.get("description")
+            constraint_id = entry.get("id")
+
+            if description is not None and not isinstance(description, str):
+                raise ValueError(
+                    f"Constraint at index {idx} description must be a string"
+                )
+            if constraint_id is not None and not isinstance(constraint_id, str):
+                raise ValueError(f"Constraint at index {idx} id must be a string")
+
+            if isinstance(expr, str):
+                constraints.append(
+                    Constraint(
+                        expr=_ImportedConstraintExpression(expr),
+                        description=description,
+                        id=constraint_id,
+                    )
+                )
+                continue
+
+            if isinstance(when, str) and isinstance(then, str):
+                constraints.append(
+                    Constraint(
+                        when=_ImportedConstraintExpression(when),
+                        then=_ImportedConstraintExpression(then),
+                        description=description,
+                        id=constraint_id,
+                    )
+                )
+                continue
+
+            raise ValueError(
+                f"Constraint at index {idx} must define 'expr' or both 'when' and 'then'"
+            )
+
+        return tuple(constraints)
 
     @classmethod
     def _sequence_to_range(
@@ -407,11 +638,14 @@ class ConfigSpace:
             "name": name,
             "type": self._infer_tvar_type(tvar),
             "domain": self._tvar_to_domain(tvar),
+            "x_traigent_parameter_range": type(tvar).__name__,
         }
         if hasattr(tvar, "unit") and tvar.unit:
             tvar_dict["unit"] = tvar.unit
         if hasattr(tvar, "default") and tvar.default is not None:
             tvar_dict["default"] = tvar.default
+        if hasattr(tvar, "agent") and tvar.agent:
+            tvar_dict["agent"] = tvar.agent
         return tvar_dict
 
     def _build_constraints_list(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- add `ConfigSpace.from_tvl_spec(...)` to rebuild parameter ranges, structural constraints, and description from a TVL spec dict
- preserve exact `ParameterRange` subclasses on export via an SDK extension field and round-trip agent/unit/default metadata
- import structural constraint expressions as opaque BoolExpr instances so exported specs can be reconstructed without losing constraint fidelity

## Verification
- `uv run --extra dev pytest -o addopts='' tests/unit/api/test_config_space.py`
- `uv run --extra dev pytest -o addopts='' tests/unit/api/test_config_space.py tests/unit/tvl/test_spec_loader.py tests/unit/tvl/test_spec_loader_v09.py`
- `uv run --extra dev mypy traigent/api/config_space.py`
