### PR TITLE
refactor: skip overlapping callback invocations

### DIFF
--- a/tests/unit/utils/test_callbacks.py
+++ b/tests/unit/utils/test_callbacks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 import time
 from datetime import UTC, datetime
 from typing import Any
@@ -2005,6 +2006,75 @@ class TestCallbackManagerTimeoutAndIsolation:
         manager.on_optimization_complete(result)
 
         assert manager._executor is None
+
+    def test_running_callback_is_skipped_while_previous_invocation_is_active(
+        self, mock_callback: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test a callback method is not re-entered while its prior call runs."""
+        started = threading.Event()
+        release = threading.Event()
+        invocation_count = 0
+
+        def slow_callback(*args: Any, **kwargs: Any) -> None:
+            nonlocal invocation_count
+            invocation_count += 1
+            started.set()
+            release.wait(timeout=1.0)
+
+        mock_callback.on_trial_start.side_effect = slow_callback
+        caplog.set_level(logging.WARNING)
+
+        with contextlib.closing(
+            CallbackManager(
+                callbacks=[mock_callback],
+                timeout=0.05,
+                max_callback_threads=2,
+            )
+        ) as manager:
+            manager.on_trial_start(0, {"model": "gpt-4"})
+            assert started.wait(timeout=0.2)
+
+            manager.on_trial_start(1, {"model": "gpt-4o"})
+
+            assert invocation_count == 1
+            assert len(manager.callback_failures) == 1
+            assert manager.callback_failures[0].error_type == "timeout"
+            assert any("still running" in record.message for record in caplog.records)
+
+            release.set()
+
+    def test_callback_can_run_again_after_previous_invocation_finishes(
+        self, mock_callback: MagicMock
+    ) -> None:
+        """Test callback tracking is cleared once the running invocation finishes."""
+        release = threading.Event()
+        allow_completion = threading.Event()
+        invocation_count = 0
+
+        def slow_then_finish(*args: Any, **kwargs: Any) -> None:
+            nonlocal invocation_count
+            invocation_count += 1
+            release.set()
+            allow_completion.wait(timeout=1.0)
+
+        mock_callback.on_trial_start.side_effect = slow_then_finish
+
+        with contextlib.closing(
+            CallbackManager(
+                callbacks=[mock_callback],
+                timeout=0.05,
+                max_callback_threads=2,
+            )
+        ) as manager:
+            manager.on_trial_start(0, {"model": "gpt-4"})
+            assert release.wait(timeout=0.2)
+
+            allow_completion.set()
+            time.sleep(0.05)
+
+            manager.on_trial_start(1, {"model": "gpt-4o"})
+
+            assert invocation_count == 2
 
     def test_multiple_callbacks_with_timeout_mixed_results(
         self, caplog: pytest.LogCaptureFixture

--- a/traigent/utils/callbacks.py
+++ b/traigent/utils/callbacks.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+CallbackInvocationKey = tuple[int, str]
+
 
 def _shutdown_callback_executor(
     executor: concurrent.futures.ThreadPoolExecutor,
@@ -549,6 +551,10 @@ class CallbackManager:
         self._executor: concurrent.futures.ThreadPoolExecutor | None = None
         self._executor_lock = threading.Lock()
         self._executor_finalizer: weakref.finalize | None = None
+        self._running_callbacks: dict[
+            CallbackInvocationKey, concurrent.futures.Future[Any]
+        ] = {}
+        self._running_callbacks_lock = threading.Lock()
 
     def _ensure_executor(self) -> concurrent.futures.ThreadPoolExecutor:
         """Create or return the shared callback executor."""
@@ -578,8 +584,59 @@ class CallbackManager:
             self._executor = None
             self._executor_finalizer = None
 
+        with self._running_callbacks_lock:
+            self._running_callbacks.clear()
+
         if finalizer is not None and finalizer.alive:
             finalizer()
+
+    def _clear_running_callback(
+        self,
+        key: CallbackInvocationKey,
+        future: concurrent.futures.Future[Any],
+    ) -> None:
+        """Remove a completed callback from the running-callback registry."""
+        with self._running_callbacks_lock:
+            current_future = self._running_callbacks.get(key)
+            if current_future is future:
+                self._running_callbacks.pop(key, None)
+
+    def _submit_callback(
+        self,
+        callback_name: str,
+        callback: OptimizationCallback,
+        method_name: str,
+        method_func: Callable[..., Any],
+        *args: Any,
+    ) -> concurrent.futures.Future[Any] | None:
+        """Submit a callback unless the same method is already running."""
+        executor = self._ensure_executor()
+        key = (id(callback), method_name)
+
+        with self._running_callbacks_lock:
+            current_future = self._running_callbacks.get(key)
+            if current_future is not None:
+                if current_future.done():
+                    self._running_callbacks.pop(key, None)
+                else:
+                    logger.warning(
+                        f"Callback {callback_name}.{method_name} is still running "
+                        "from a previous invocation - skipping"
+                    )
+                    return None
+
+            future = executor.submit(contextvars.Context().run, method_func, *args)
+            self._running_callbacks[key] = future
+
+        self_ref = weakref.ref(self)
+
+        def _cleanup(done_future: concurrent.futures.Future[Any]) -> None:
+            manager = self_ref()
+            if manager is not None:
+                manager._clear_running_callback(key, done_future)
+
+        future.add_done_callback(_cleanup)
+        return future
 
     def _invoke_callback_safe(
         self,
@@ -617,8 +674,16 @@ class CallbackManager:
 
         # Use a shared ThreadPoolExecutor for timeout protection to avoid
         # creating a new thread pool per callback invocation.
-        executor = self._ensure_executor()
-        future = executor.submit(contextvars.Context().run, method_func, *args)
+        future = self._submit_callback(
+            callback_name,
+            callback,
+            method_name,
+            method_func,
+            *args,
+        )
+        if future is None:
+            return
+
         try:
             future.result(timeout=self.timeout)
         except concurrent.futures.TimeoutError:

--- a/traigent/utils/callbacks.py
+++ b/traigent/utils/callbacks.py
@@ -625,6 +625,8 @@ class CallbackManager:
                     )
                     return None
 
+            # Start callbacks in a fresh context so pooled worker threads do not
+            # retain or inherit caller-specific contextvars across invocations.
             future = executor.submit(contextvars.Context().run, method_func, *args)
             self._running_callbacks[key] = future
 


### PR DESCRIPTION
## Summary
- prevent the same callback method from being invoked again while its previous timeout-protected call is still running
- clean up running-callback tracking when futures finish so later invocations can proceed normally
- add regression coverage for skip-while-running and post-completion recovery

## Notes
- stacked on top of #359; once that merges, this PR will collapse to the overlap-prevention delta

## Testing
- uv run --extra dev pytest -o addopts='' tests/unit/utils/test_callbacks.py
- uv run --extra dev mypy traigent/utils/callbacks.py

Closes #86
