### PR TITLE
fix(ci): install PyYAML for release-gate review job

### DIFF
--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -271,6 +271,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install release-review tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install PyYAML
       - name: Build release id
         id: release_id
         env:


### PR DESCRIPTION
## Summary
- install PyYAML in the release-review-consistency job
- keep the fix limited to the missing runtime dependency for generate_tracking.py
- leave develop/main conflict handling out of scope for this PR

## Validation
- parsed .github/workflows/release-review.yml with PyYAML
- created a clean temp venv, installed PyYAML, and verified import yaml
- ran .release_review/automation/validate_release_review_consistency.py
- ran .release_review/automation/generate_tracking.py with a local output root
