### PR TITLE
fix: resolve full-suite regression failures

### DIFF
--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -19,6 +19,19 @@ sys.path.insert(0, str(PROJECT_ROOT))
 class TestDocumentationConsistency(unittest.TestCase):
     """Test documentation consistency with implementation."""
 
+    @staticmethod
+    def _is_overload_stub(node: ast.AST) -> bool:
+        """Return True for typing-only overload declarations."""
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return False
+
+        for decorator in node.decorator_list:
+            if isinstance(decorator, ast.Name) and decorator.id == "overload":
+                return True
+            if isinstance(decorator, ast.Attribute) and decorator.attr == "overload":
+                return True
+        return False
+
     @classmethod
     def setUpClass(cls):
         """Set up test environment."""
@@ -139,7 +152,11 @@ class TestDocumentationConsistency(unittest.TestCase):
                 try:
                     tree = ast.parse(content)
                     for node in ast.walk(tree):
-                        if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+                        if isinstance(
+                            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+                        ):
+                            if self._is_overload_stub(node):
+                                continue
                             # Skip private functions
                             if node.name.startswith("_") and node.name != "__init__":
                                 continue

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from traigent.api.constraints import BoolExpr, Constraint
 from traigent.api.parameter_ranges import (
@@ -139,6 +139,22 @@ class ConfigSpace:
             if hasattr(tvar, "name") and tvar.name is None:
                 # Note: We can't modify frozen dataclasses, so we just validate
                 pass
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return a pickle-safe representation of the config space."""
+        return {
+            "tvars": dict(self.tvars),
+            "constraints": tuple(self.constraints),
+            "description": self.description,
+        }
+
+    def __setstate__(self, state: Mapping[str, Any]) -> None:
+        """Restore immutable state after unpickling."""
+        object.__setattr__(self, "tvars", MappingProxyType(dict(state["tvars"])))
+        object.__setattr__(
+            self, "constraints", tuple(cast(Sequence[Constraint], state["constraints"]))
+        )
+        object.__setattr__(self, "description", state.get("description"))
 
     @classmethod
     def from_decorator_args(

--- a/traigent/cloud/api_key_manager.py
+++ b/traigent/cloud/api_key_manager.py
@@ -256,7 +256,8 @@ class APIKeyManager:
         credentials = self._get_credentials_fn() if self._get_credentials_fn else None
         if credentials and credentials.api_key:
             api_key: str | None = credentials.api_key
-            return api_key
+            if self.validate_format(api_key):
+                return api_key
 
         provided = (
             self._get_provided_credentials_fn()
@@ -265,14 +266,16 @@ class APIKeyManager:
         )
         if provided and provided.api_key:
             provided_key: str | None = provided.api_key
-            return provided_key
+            if self.validate_format(provided_key):
+                return provided_key
 
         last_result = (
             self._get_last_auth_result_fn() if self._get_last_auth_result_fn else None
         )
         if last_result and last_result.credentials:
             result_key: str | None = last_result.credentials.api_key
-            return result_key
+            if self.validate_format(result_key):
+                return result_key
 
         return None
 
@@ -317,7 +320,7 @@ class APIKeyManager:
             return False
 
         allowed = set(
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"  # pragma: allowlist secret
         )
         return all(char in allowed for char in key[3:])
 

--- a/traigent/optimizers/service_registry.py
+++ b/traigent/optimizers/service_registry.py
@@ -70,6 +70,7 @@ class RemoteServiceRegistry:
         self._health_checks: dict[str, bool] = {}
         self._selection_strategies: dict[str, Callable[..., Any]] = {}
         self._background_tasks: set[asyncio.Task[Any]] = set()
+        self._background_task_monitors: set[asyncio.Task[Any]] = set()
 
         # Register default selection strategies
         self._register_default_strategies()
@@ -82,16 +83,21 @@ class RemoteServiceRegistry:
             try:
                 await asyncio.shield(task)
             except asyncio.CancelledError:
-                return
+                if task.done():
+                    self._background_tasks.discard(task)
+                raise
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.error("Background service task failed", exc_info=exc)
             finally:
-                self._background_tasks.discard(task)
+                if task.done():
+                    self._background_tasks.discard(task)
 
-        asyncio.create_task(
+        monitor = asyncio.create_task(
             _monitor_background_task(),
             name=f"{task.get_name()}_monitor",
         )
+        self._background_task_monitors.add(monitor)
+        monitor.add_done_callback(self._background_task_monitors.discard)
 
     def register_service(
         self, service: RemoteOptimizationService, auto_connect: bool = True

--- a/traigent/optimizers/service_registry.py
+++ b/traigent/optimizers/service_registry.py
@@ -76,18 +76,22 @@ class RemoteServiceRegistry:
 
     def _register_background_task(self, task: asyncio.Task[Any]) -> None:
         """Keep background tasks alive until completion and surface failures."""
+        self._background_tasks.add(task)
 
-        def _on_done(fut: asyncio.Task[Any]) -> None:
-            self._background_tasks.discard(fut)
-            if fut.cancelled():
-                return
+        async def _monitor_background_task() -> None:
             try:
-                fut.result()
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                return
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.error("Background service task failed", exc_info=exc)
+            finally:
+                self._background_tasks.discard(task)
 
-        self._background_tasks.add(task)
-        task.add_done_callback(_on_done)
+        asyncio.create_task(
+            _monitor_background_task(),
+            name=f"{task.get_name()}_monitor",
+        )
 
     def register_service(
         self, service: RemoteOptimizationService, auto_connect: bool = True

--- a/traigent/utils/local_analytics.py
+++ b/traigent/utils/local_analytics.py
@@ -524,7 +524,7 @@ def collect_and_submit_analytics(config: TraigentConfig) -> None:
                     except Exception as e:
                         logger.debug(f"Analytics submission failed: {e}")
 
-            task = asyncio.create_task(_submit_wrapper(), name="analytics_submit")
+            task = asyncio.ensure_future(_submit_wrapper())
             _register_background_task(task)
         except RuntimeError:
             # No running loop, we're in a sync context


### PR DESCRIPTION
## Summary
- restore pickle-safe ConfigSpace serialization and skip typing-only overload stubs in docs coverage
- reject invalid fallback API keys before cloud agent optimization reaches the network
- make background analytics/service task handling deterministic for full-suite tests

## Testing
- pytest -o addopts='' tests/test_documentation.py tests/unit/api/test_se_review_bugs.py tests/unit/api/test_config_space.py tests/unit/cloud/test_agent_client.py tests/unit/optimizers/test_service_registry.py tests/utils/test_local_analytics.py tests/unit/utils/test_local_analytics.py tests/e2e/test_performance_benchmarks.py -q --tb=short
- .venv/bin/python -m pytest -o addopts='' tests/test_documentation.py tests/unit/api/test_se_review_bugs.py tests/unit/api/test_config_space.py tests/unit/cloud/test_agent_client.py tests/unit/optimizers/test_service_registry.py tests/utils/test_local_analytics.py tests/unit/utils/test_local_analytics.py tests/e2e/test_performance_benchmarks.py -q --tb=short -n auto