### PR TITLE
feat: add [recommended] install extra for quick install (#378)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ and an optional `--tvl-environment staging` flag.
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[integrations]"   # Core + LangChain/OpenAI/Anthropic
+pip install -e ".[recommended]"   # All integrations, analytics, Bayesian, visualization
 python -c "import traigent; print('✅ Traigent ready')"
 ```
 
@@ -271,7 +271,7 @@ python -c "import traigent; print('✅ Traigent ready')"
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 uv venv && source .venv/bin/activate
-uv pip install -e ".[integrations]"
+uv pip install -e ".[recommended]"
 python -c "import traigent; print('✅ Traigent ready')"
 ```
 
@@ -361,7 +361,7 @@ Connect your SDK to the Traigent cloud to see optimization results in the [porta
 
 1. Install the SDK:
    ```bash
-   pip install -e ".[integrations]"
+   pip install -e ".[recommended]"
    ```
 
 2. Log in:
@@ -424,20 +424,24 @@ LiteLLM supports 100+ LLM providers with a consistent API, making it easy to com
 
 When installing Traigent, you can choose specific feature sets:
 
-| Feature Set      | Description                   | Use Case                         |
-| ---------------- | ----------------------------- | -------------------------------- |
-| `[core]`         | Basic functionality (default) | Minimal install                  |
-| `[analytics]`    | Analytics and visualization   | View optimization results        |
-| `[bayesian]`     | Bayesian optimization         | Advanced optimization algorithms |
-| `[integrations]` | Framework integrations        | LangChain, OpenAI, Anthropic     |
-| `[dev]`          | Development tools             | pytest, black, ruff, mypy        |
-| `[all]`          | Complete installation         | All optional features            |
+| Feature Set      | Description                            | Use Case                         |
+| ---------------- | -------------------------------------- | -------------------------------- |
+| `[recommended]`  | **All user-facing features (default)** | Quick install — everything you need |
+| `[core]`         | Basic functionality only               | Minimal install                  |
+| `[integrations]` | Framework integrations                 | LangChain, OpenAI, Anthropic     |
+| `[analytics]`    | Analytics and visualization            | View optimization results        |
+| `[bayesian]`     | Bayesian optimization                  | Advanced optimization algorithms |
+| `[dev]`          | Development tools                      | pytest, black, ruff, mypy        |
+| `[all]`          | Complete installation                  | All optional features            |
 
 **Recommended installs:**
 
 ```bash
-# For running examples and development
-pip install -e ".[dev,integrations,analytics]"
+# Quick install — all user-facing features
+pip install -e ".[recommended]"
+
+# For development/contributing
+pip install -e ".[recommended,dev]"
 
 # For everything (largest install)
 pip install -e ".[all]"
@@ -943,7 +947,7 @@ This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENS
 
 | Problem | Fix |
 |---------|-----|
-| `ModuleNotFoundError` | `pip install -e ".[integrations]"` or check your venv is activated |
+| `ModuleNotFoundError` | `pip install -e ".[recommended]"` or check your venv is activated |
 | 0.0% accuracy | Set `TRAIGENT_MOCK_LLM=true` for demo mode, or check dataset format |
 | Missing API keys | Copy `.env.example` to `.env` and add your keys; or use mock mode |
 | Permission errors | Use `pip install --user` or create a fresh venv |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,7 +10,7 @@ Release-ready, minimal install steps for the SDK and examples.
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[integrations]"          # Core + LangChain/OpenAI/Anthropic
+pip install -e ".[recommended]"           # All integrations, analytics, Bayesian, visualization
 ```
 
 ### Faster path (uv)
@@ -19,7 +19,7 @@ pip install -e ".[integrations]"          # Core + LangChain/OpenAI/Anthropic
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 uv venv && source .venv/bin/activate
-uv pip install -e ".[integrations]"       # Same extras, faster resolver
+uv pip install -e ".[recommended]"        # Same extras, faster resolver
 ```
 
 ### PyPI vs source installs
@@ -30,11 +30,12 @@ For the latest changes, install from source (GitHub). If you're on a pinned rele
 
 | Extra | What's included | Install example |
 | --- | --- | --- |
+| **`recommended`** | **All user-facing features (integrations + analytics + bayesian + visualization + hybrid + pydanticai)** | **`pip install -e ".[recommended]"`** |
+| `integrations` | LangChain, OpenAI, Anthropic, MLflow, W&B | `pip install -e ".[integrations]"` |
 | `analytics` | numpy, pandas, matplotlib | `pip install -e ".[analytics]"` |
 | `bayesian` | Optuna + sklearn/scipy | `pip install -e ".[bayesian]"` |
-| `integrations` | LangChain, OpenAI, Anthropic, MLflow, W&B | `pip install -e ".[integrations]"` |
-| `security` | FastAPI, JWT, cryptography, Redis | `pip install -e ".[security]"` |
 | `visualization` | matplotlib, plotly | `pip install -e ".[visualization]"` |
+| `security` | FastAPI, JWT, cryptography, Redis | `pip install -e ".[security]"` |
 | `test` | pytest + tooling | `pip install -e ".[test]"` |
 | `dev` | Linters + tests | `pip install -e ".[dev]"` |
 | `docs` | MkDocs tooling | `pip install -e ".[docs]"` |
@@ -46,7 +47,7 @@ For the latest changes, install from source (GitHub). If you're on a pinned rele
 - **Run examples (no API keys):**
 
   ```bash
-  pip install -e ".[integrations]"
+  pip install -e ".[recommended]"
   export TRAIGENT_MOCK_LLM=true
   python examples/core/hello-world/run.py
   ```
@@ -54,7 +55,7 @@ For the latest changes, install from source (GitHub). If you're on a pinned rele
 - **Develop/contribute:**
 
   ```bash
-  pip install -e ".[dev,integrations,analytics]"
+  pip install -e ".[recommended,dev]"
   TRAIGENT_MOCK_LLM=true pytest tests/ -q
   ```
 
@@ -79,9 +80,9 @@ PY
 
 ## Troubleshooting (quick fixes)
 
-- **`ModuleNotFoundError: langchain`** — install integrations: `pip install -e ".[integrations]"`.
+- **`ModuleNotFoundError: langchain`** — install recommended extras: `pip install -e ".[recommended]"`.
 - **Missing API keys** — copy `.env.example` to `.env` and set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` (skip if using `TRAIGENT_MOCK_LLM=true`). On Ubuntu desktop, you can also store keys in GNOME Keyring and run via `python3 tools/keyring_run.py` (see `docs/guides/secrets_management.md`).
-- **Virtualenv confusion** — recreate: `deactivate; rm -rf .venv; python -m venv .venv; source .venv/bin/activate; pip install -e ".[integrations]"`.
+- **Virtualenv confusion** — recreate: `deactivate; rm -rf .venv; python -m venv .venv; source .venv/bin/activate; pip install -e ".[recommended]"`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ cloud = [
     "boto3>=1.28.0",
 ]
 
+# Recommended bundle for end users — everything needed to run optimizations
+# out of the box without dev/test/docs overhead
+recommended = [
+    "traigent[integrations,analytics,bayesian,visualization,hybrid,pydanticai]",
+]
+
 # All optional features combined (playground/examples moved to TraigentDemo)
 all = [
     "traigent[analytics,bayesian,integrations,pydanticai,security,visualization,test,tracing,hybrid]"


### PR DESCRIPTION
## Summary
- Adds a new `[recommended]` pip extra in `pyproject.toml` that bundles: `integrations`, `analytics`, `bayesian`, `visualization`, `hybrid`, `pydanticai`
- Updates README and `docs/getting-started/installation.md` to use `pip install -e ".[recommended]"` as the default quick install command
- Users now get all user-facing features in one command without dev/test/docs overhead

Closes #378

## Test plan
- [ ] Verify `pip install -e ".[recommended]"` installs all expected packages
- [ ] Verify `python -c "import traigent; print('ready')"` works after install
- [ ] Review README and installation docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)