### PR TITLE
fix: clean up README install & docs (venv step, uv removal, doc index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ python walkthrough/mock/01_tuning_qa.py
 | | |
 | --- | --- |
 | **Get started** | [Installation](docs/getting-started/installation.md) · [5-minute tutorial](docs/getting-started/GETTING_STARTED.md) |
-| **User guides** | [Injection Modes](docs/user-guide/injection_modes.md) · [Configuration Spaces](docs/user-guide/configuration-spaces.md) · [Tuned Variables](docs/user-guide/tuned_variables.md) · [Evaluation](docs/user-guide/evaluation_guide.md) |
+| **User guides** | [Injection Modes](docs/user-guide/injection_modes.md) · [Configuration Spaces](docs/user-guide/configuration-spaces.md) · [Evaluation](docs/user-guide/evaluation_guide.md) |
+| **Tunable Variable Language** | [TVL Guide](docs/user-guide/tuned_variables.md) |
 | **Advanced** | [Agent Optimization](docs/user-guide/agent_optimization.md) · [Optuna Integration](docs/user-guide/optuna_integration.md) · [JS Bridge](docs/guides/js-bridge.md) |
 | **API reference** | [Decorator Reference](docs/api-reference/decorator-reference.md) · [Constraint DSL](docs/features/constraint-dsl.md) |
 
@@ -117,7 +118,7 @@ git clone https://github.com/Traigent/Traigent.git && cd Traigent
 pip install -e ".[recommended]"
 ```
 
-> Not on PyPI yet — install from source. Use `uv pip install` for faster installs.
+> Not on PyPI yet — install from source.
 
 | Feature Set | Description |
 |-------------|-------------|

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Traigent finds the best LLM parameters for your specific task — model, tempera
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git && cd Traigent
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"
 ```
 
@@ -115,6 +116,7 @@ All examples run with `TRAIGENT_MOCK_LLM=true` — no API keys needed.
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git && cd Traigent
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"
 ```
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -7,6 +7,7 @@ The fastest path to optimize an LLM workflow with **zero code changes**.
 1) Install from source (recommended for examples):
 
 ```bash
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"        # All integrations, analytics, Bayesian, visualization
 export TRAIGENT_MOCK_LLM=true          # Run examples without API keys
 python walkthrough/mock/01_tuning_qa.py


### PR DESCRIPTION
## Summary
- Add `python3 -m venv .venv` step to install instructions (README + GETTING_STARTED)
- Remove uv reference, pip only
- Move Constraint DSL to API reference row in doc index
- Add Tunable Variable Language as its own row in doc index

## Test plan
- [x] Clean simulation: fresh clone → venv → install → `walkthrough/mock/01_tuning_qa.py` ✅
- [x] All 8 walkthrough steps verified working from clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)