### PR TITLE
docs: reorder Choose Your Path to funnel users toward cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ python walkthrough/mock/01_tuning_qa.py
 | | |
 | --- | --- |
 | **Get started** | [Installation](docs/getting-started/installation.md) · [5-minute tutorial](docs/getting-started/GETTING_STARTED.md) |
-| **User guides** | [Injection Modes](docs/user-guide/injection_modes.md) · [Configuration Spaces](docs/user-guide/configuration-spaces.md) · [Tuned Variables](docs/user-guide/tuned_variables.md) · [Evaluation](docs/user-guide/evaluation_guide.md) |
+| **User guides** | [Injection Modes](docs/user-guide/injection_modes.md) · [Configuration Spaces](docs/user-guide/configuration-spaces.md) · [Evaluation](docs/user-guide/evaluation_guide.md) |
+| **Tunable Variable Language** | [TVL Guide](docs/user-guide/tuned_variables.md) |
 | **Advanced** | [Agent Optimization](docs/user-guide/agent_optimization.md) · [Optuna Integration](docs/user-guide/optuna_integration.md) · [JS Bridge](docs/guides/js-bridge.md) |
 | **API reference** | [Decorator Reference](docs/api-reference/decorator-reference.md) · [Constraint DSL](docs/features/constraint-dsl.md) |
 
@@ -117,7 +118,7 @@ git clone https://github.com/Traigent/Traigent.git && cd Traigent
 pip install -e ".[recommended]"
 ```
 
-> Not on PyPI yet — install from source. Use `uv pip install` for faster installs.
+> Not on PyPI yet — install from source.
 
 | Feature Set | Description |
 |-------------|-------------|

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Traigent finds the best LLM parameters for your specific task — model, tempera
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git && cd Traigent
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"
 ```
 
@@ -115,6 +116,7 @@ All examples run with `TRAIGENT_MOCK_LLM=true` — no API keys needed.
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git && cd Traigent
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ python walkthrough/mock/01_tuning_qa.py
 | Goal | Resource | Time |
 |------|----------|------|
 | **Get started quickly** | [Quick Start Guide](docs/getting-started/GETTING_STARTED.md) | 5 min |
-| **Try examples locally** | [Mock walkthrough](walkthrough/mock/) (8 progressive steps) | 15 min |
 | **Understand the architecture** | [Architecture Overview](#-architecture-overview) | 5 min |
 | **Connect to Traigent Cloud** | [Cloud Setup](#-traigent-cloud) | 5 min |
+| **Try examples locally, see them on the cloud** | [Mock walkthrough](walkthrough/mock/) (8 progressive steps) | 15 min |
 | **Read the full API reference** | [Decorator Reference →](docs/api-reference/decorator-reference.md) | — |
 
 <details>

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -7,6 +7,7 @@ The fastest path to optimize an LLM workflow with **zero code changes**.
 1) Install from source (recommended for examples):
 
 ```bash
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"        # All integrations, analytics, Bayesian, visualization
 export TRAIGENT_MOCK_LLM=true          # Run examples without API keys
 python walkthrough/mock/01_tuning_qa.py


### PR DESCRIPTION
## Summary
- Reorders the "Choose Your Path" table so **Connect to Traigent Cloud** appears before the walkthrough
- Renames "Try examples locally" → "Try examples locally, see them on the cloud" to encourage portal setup first

## Test plan
- [ ] Verify table renders correctly on GitHub
- [ ] Confirm anchor links (`#-architecture-overview`, `#-traigent-cloud`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)