### PR TITLE
feat(ux): interactive pause-on-error and default progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ def multi_provider_agent(question: str) -> str:
 | **Framework support** | LangChain, OpenAI SDK, Anthropic, LiteLLM, and any LLM provider |
 | **Cost tracking** | Integrated tokencost library with 500+ model pricing |
 | **Parallel execution** | Concurrent trials and example-level parallelism |
+| **Error resilience** | Interactive pause on rate limits and budget caps — resume or stop gracefully |
+| **Live progress** | Auto-enabled progress bar in interactive terminals (`progress_bar=False` to disable) |
 | **Privacy-first** | Local execution mode keeps all data on your machine |
 
 **[TraigentDemo →](https://github.com/Traigent/TraigentDemo)** — Streamlit playground, use cases, and research benchmarks
@@ -252,6 +254,7 @@ Provide a JSONL dataset — Traigent scores outputs using semantic similarity by
 | `eval_dataset` | `@traigent.optimize()` | Dataset for evaluation |
 | `algorithm` | `.optimize()` call | `"random"`, `"grid"`, `"bayesian"` |
 | `max_trials` | `.optimize()` call | Number of configurations to test |
+| `progress_bar` | `.optimize()` call | `True` / `False` / `None` (auto) — live progress bar |
 
 ### Injection Modes
 

--- a/tests/unit/core/test_default_progress_bar.py
+++ b/tests/unit/core/test_default_progress_bar.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-
 from traigent.core.optimized_function import _resolve_callbacks
 from traigent.utils.callbacks import ProgressBarCallback
 
@@ -78,11 +77,16 @@ class TestResolveCallbacks:
         assert callbacks[1] is dec_cb
 
     def test_force_progress_bar_non_interactive(self):
-        """progress_bar=True forces injection even in non-interactive mode.
+        """progress_bar=True forces injection even in non-interactive mode."""
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = False
+            callbacks = _resolve_callbacks(None, None, progress_bar=True)
 
-        Note: current implementation only auto-injects when isatty()=True.
-        progress_bar=None with isatty=False should not inject.
-        """
+        assert len(callbacks) == 1
+        assert isinstance(callbacks[0], ProgressBarCallback)
+
+    def test_auto_skips_non_interactive(self):
+        """progress_bar=None with isatty=False should not inject."""
         with patch("traigent.core.optimized_function.sys") as mock_sys:
             mock_sys.stdin.isatty.return_value = False
             callbacks = _resolve_callbacks(None, None, progress_bar=None)

--- a/tests/unit/core/test_default_progress_bar.py
+++ b/tests/unit/core/test_default_progress_bar.py
@@ -1,0 +1,90 @@
+"""Tests for default progress bar auto-registration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+from traigent.core.optimized_function import _resolve_callbacks
+from traigent.utils.callbacks import ProgressBarCallback
+
+
+class TestResolveCallbacks:
+    def test_auto_enabled_interactive(self):
+        """ProgressBarCallback auto-injected when stdin is a TTY."""
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = True
+            callbacks = _resolve_callbacks(None, None, progress_bar=None)
+
+        assert len(callbacks) == 1
+        assert isinstance(callbacks[0], ProgressBarCallback)
+
+    def test_disabled_explicit(self):
+        """progress_bar=False suppresses auto-injection."""
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = True
+            callbacks = _resolve_callbacks(None, None, progress_bar=False)
+
+        assert len(callbacks) == 0
+
+    def test_skipped_non_interactive(self):
+        """No auto-injection when stdin is not a TTY."""
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = False
+            callbacks = _resolve_callbacks(None, None, progress_bar=None)
+
+        assert len(callbacks) == 0
+
+    def test_not_duplicated(self):
+        """User-provided ProgressBarCallback is not duplicated."""
+        existing = ProgressBarCallback()
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = True
+            callbacks = _resolve_callbacks([existing], None, progress_bar=None)
+
+        progress_bars = [cb for cb in callbacks if isinstance(cb, ProgressBarCallback)]
+        assert len(progress_bars) == 1
+        assert progress_bars[0] is existing
+
+    def test_explicit_callbacks_preserved(self):
+        """Explicit callbacks are preserved alongside auto-injected bar."""
+
+        class CustomCallback:
+            pass
+
+        custom = CustomCallback()
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = True
+            callbacks = _resolve_callbacks([custom], None, progress_bar=None)
+
+        assert len(callbacks) == 2
+        assert callbacks[0] is not custom  # ProgressBarCallback inserted first
+        assert isinstance(callbacks[0], ProgressBarCallback)
+        assert callbacks[1] is custom
+
+    def test_decorator_callbacks_used_when_no_explicit(self):
+        """Decorator callbacks used as fallback."""
+
+        class DecoratorCb:
+            pass
+
+        dec_cb = DecoratorCb()
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = True
+            callbacks = _resolve_callbacks(None, [dec_cb], progress_bar=None)
+
+        assert len(callbacks) == 2
+        assert isinstance(callbacks[0], ProgressBarCallback)
+        assert callbacks[1] is dec_cb
+
+    def test_force_progress_bar_non_interactive(self):
+        """progress_bar=True forces injection even in non-interactive mode.
+
+        Note: current implementation only auto-injects when isatty()=True.
+        progress_bar=None with isatty=False should not inject.
+        """
+        with patch("traigent.core.optimized_function.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = False
+            callbacks = _resolve_callbacks(None, None, progress_bar=None)
+
+        assert len(callbacks) == 0

--- a/tests/unit/core/test_exception_handler.py
+++ b/tests/unit/core/test_exception_handler.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-
 from traigent.core.exception_handler import (
     TerminalPausePrompt,
     VendorErrorCategory,

--- a/tests/unit/core/test_exception_handler.py
+++ b/tests/unit/core/test_exception_handler.py
@@ -175,3 +175,43 @@ class TestTerminalPausePromptBudget:
             mock_stdin.isatty.return_value = True
             result = prompt.prompt_budget_pause(1.50, 2.00)
         assert result == "stop"
+
+    def test_keyboard_interrupt_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_infinity_input_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="inf"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_zero_input_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="0"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_empty_input_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value=""),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"

--- a/tests/unit/core/test_exception_handler.py
+++ b/tests/unit/core/test_exception_handler.py
@@ -1,0 +1,178 @@
+"""Tests for traigent.core.exception_handler module."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+from traigent.core.exception_handler import (
+    TerminalPausePrompt,
+    VendorErrorCategory,
+    classify_vendor_error,
+)
+from traigent.utils.exceptions import (
+    QuotaExceededError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
+
+# ---------------------------------------------------------------------------
+# classify_vendor_error
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyVendorError:
+    def test_rate_limit_error(self):
+        exc = RateLimitError("Rate limit exceeded")
+        assert classify_vendor_error(exc) == VendorErrorCategory.RATE_LIMIT
+
+    def test_quota_exceeded_error(self):
+        exc = QuotaExceededError("Quota exhausted")
+        assert classify_vendor_error(exc) == VendorErrorCategory.QUOTA_EXHAUSTED
+
+    def test_service_unavailable_error(self):
+        exc = ServiceUnavailableError("Service down")
+        assert classify_vendor_error(exc) == VendorErrorCategory.SERVICE_UNAVAILABLE
+
+    def test_generic_429_in_message(self):
+        exc = RuntimeError("HTTP 429 Too Many Requests")
+        assert classify_vendor_error(exc) == VendorErrorCategory.RATE_LIMIT
+
+    def test_generic_quota_in_message(self):
+        exc = RuntimeError("insufficient_quota for this model")
+        assert classify_vendor_error(exc) == VendorErrorCategory.QUOTA_EXHAUSTED
+
+    def test_generic_503_in_message(self):
+        exc = RuntimeError("HTTP 503 Service Unavailable")
+        assert classify_vendor_error(exc) == VendorErrorCategory.SERVICE_UNAVAILABLE
+
+    def test_non_vendor_error_returns_none(self):
+        exc = ValueError("Invalid argument")
+        assert classify_vendor_error(exc) is None
+
+    def test_generic_exception_no_match(self):
+        exc = RuntimeError("Something unexpected happened")
+        assert classify_vendor_error(exc) is None
+
+
+# ---------------------------------------------------------------------------
+# TerminalPausePrompt
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalPausePromptVendor:
+    def test_non_interactive_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            result = prompt.prompt_vendor_pause(
+                RuntimeError("rate limit"), VendorErrorCategory.RATE_LIMIT
+            )
+        assert result == "stop"
+
+    def test_interactive_resume(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="r"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_vendor_pause(
+                RuntimeError("rate limit"), VendorErrorCategory.RATE_LIMIT
+            )
+        assert result == "resume"
+
+    def test_interactive_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="s"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_vendor_pause(
+                RuntimeError("rate limit"), VendorErrorCategory.RATE_LIMIT
+            )
+        assert result == "stop"
+
+    def test_eof_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_vendor_pause(
+                RuntimeError("rate limit"), VendorErrorCategory.RATE_LIMIT
+            )
+        assert result == "stop"
+
+    def test_keyboard_interrupt_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_vendor_pause(
+                RuntimeError("rate limit"), VendorErrorCategory.RATE_LIMIT
+            )
+        assert result == "stop"
+
+
+class TestTerminalPausePromptBudget:
+    def test_non_interactive_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_interactive_raise_limit(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="5.0"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "raise:5.0"
+
+    def test_interactive_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="s"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_invalid_input_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="abc"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_limit_below_accumulated_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", return_value="1.0"),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"
+
+    def test_eof_returns_stop(self):
+        prompt = TerminalPausePrompt()
+        with (
+            patch("sys.stdin") as mock_stdin,
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_budget_pause(1.50, 2.00)
+        assert result == "stop"

--- a/tests/unit/core/test_pause_on_error.py
+++ b/tests/unit/core/test_pause_on_error.py
@@ -157,3 +157,141 @@ class TestVendorPauseErrorPropagation:
         exc = VendorPauseError("some error")
         assert exc.category is None
         assert exc.original_error is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed budget response handling
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedBudgetResponse:
+    """Test _handle_budget_limit_pause with malformed adapter responses."""
+
+    @pytest.fixture
+    def mock_orchestrator(self):
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        orch = MagicMock()
+        orch._handle_budget_limit_pause = (
+            OptimizationOrchestrator._handle_budget_limit_pause.__get__(orch)
+        )
+        status_mock = MagicMock()
+        status_mock.accumulated_cost_usd = 1.50
+        orch.cost_enforcer.get_status.return_value = status_mock
+        orch.cost_enforcer.config.limit = 2.00
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_malformed_raise_value_returns_break(self, mock_orchestrator):
+        """raise:abc triggers ValueError catch → break."""
+        adapter = MockPromptAdapter(budget_response="raise:abc")
+        mock_orchestrator._prompt_adapter = adapter
+
+        result = await mock_orchestrator._handle_budget_limit_pause()
+
+        assert result == "break"
+        mock_orchestrator.cost_enforcer.update_limit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_raise_returns_break(self, mock_orchestrator):
+        """raise: (empty after colon) triggers IndexError/ValueError catch."""
+        adapter = MockPromptAdapter(budget_response="raise:")
+        mock_orchestrator._prompt_adapter = adapter
+
+        result = await mock_orchestrator._handle_budget_limit_pause()
+
+        assert result == "break"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_response_returns_break(self, mock_orchestrator):
+        """Random string that doesn't start with 'raise:' → break."""
+        adapter = MockPromptAdapter(budget_response="unknown_response")
+        mock_orchestrator._prompt_adapter = adapter
+
+        result = await mock_orchestrator._handle_budget_limit_pause()
+
+        assert result == "break"
+
+
+# ---------------------------------------------------------------------------
+# Trial lifecycle: vendor error re-raise
+# ---------------------------------------------------------------------------
+
+
+class TestTrialLifecycleVendorReraise:
+    """Test that vendor errors in _execute_trial_with_tracing are re-raised."""
+
+    def test_classify_and_reraise_rate_limit(self):
+        """RateLimitError should be classified and wrapped in VendorPauseError."""
+        from traigent.core.exception_handler import classify_vendor_error
+        from traigent.utils.exceptions import RateLimitError
+
+        exc = RateLimitError("429 Too Many Requests")
+        category = classify_vendor_error(exc)
+        assert category == VendorErrorCategory.RATE_LIMIT
+
+        # Simulate what trial_lifecycle does
+        pause_error = VendorPauseError(str(exc), original_error=exc, category=category)
+        assert pause_error.original_error is exc
+        assert pause_error.category == VendorErrorCategory.RATE_LIMIT
+
+    def test_classify_and_reraise_quota(self):
+        from traigent.core.exception_handler import classify_vendor_error
+        from traigent.utils.exceptions import QuotaExceededError
+
+        exc = QuotaExceededError("Quota exhausted")
+        category = classify_vendor_error(exc)
+        assert category == VendorErrorCategory.QUOTA_EXHAUSTED
+
+        pause_error = VendorPauseError(str(exc), original_error=exc, category=category)
+        assert pause_error.category == VendorErrorCategory.QUOTA_EXHAUSTED
+
+    def test_classify_and_reraise_service_unavailable(self):
+        from traigent.core.exception_handler import classify_vendor_error
+        from traigent.utils.exceptions import ServiceUnavailableError
+
+        exc = ServiceUnavailableError("Service down")
+        category = classify_vendor_error(exc)
+        assert category == VendorErrorCategory.SERVICE_UNAVAILABLE
+
+        pause_error = VendorPauseError(str(exc), original_error=exc, category=category)
+        assert pause_error.category == VendorErrorCategory.SERVICE_UNAVAILABLE
+
+    def test_non_vendor_not_reclassified(self):
+        """Non-vendor errors should not be classified."""
+        from traigent.core.exception_handler import classify_vendor_error
+
+        exc = ValueError("bad argument")
+        assert classify_vendor_error(exc) is None
+
+
+# ---------------------------------------------------------------------------
+# Parallel batch vendor error detection
+# ---------------------------------------------------------------------------
+
+
+class TestParallelBatchVendorDetection:
+    """Test the post-batch vendor error check in _run_parallel_batch."""
+
+    def test_all_vendor_failures_detected(self):
+        """When all results have vendor error messages, classify detects them."""
+        from traigent.core.exception_handler import classify_vendor_error
+
+        error_messages = [
+            "429 Too Many Requests",
+            "Rate limit exceeded",
+            "quota exhausted for model",
+        ]
+        for msg in error_messages:
+            category = classify_vendor_error(RuntimeError(msg))
+            assert category is not None, f"Failed to classify: {msg}"
+
+    def test_mixed_results_not_detected(self):
+        """When some results are non-vendor, don't classify as vendor outage."""
+        from traigent.core.exception_handler import classify_vendor_error
+
+        vendor_msg = "429 Too Many Requests"
+        normal_msg = "Division by zero in user function"
+
+        assert classify_vendor_error(RuntimeError(vendor_msg)) is not None
+        assert classify_vendor_error(RuntimeError(normal_msg)) is None

--- a/tests/unit/core/test_pause_on_error.py
+++ b/tests/unit/core/test_pause_on_error.py
@@ -1,0 +1,158 @@
+"""Tests for pause-on-error integration in orchestrator and trial lifecycle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from traigent.utils.exceptions import VendorPauseError
+
+# ---------------------------------------------------------------------------
+# Mock prompt adapter for testing
+# ---------------------------------------------------------------------------
+
+
+class MockPromptAdapter:
+    """Controllable prompt adapter for testing."""
+
+    def __init__(self, vendor_response: str = "stop", budget_response: str = "stop"):
+        self.vendor_response = vendor_response
+        self.budget_response = budget_response
+        self.vendor_calls: list[tuple] = []
+        self.budget_calls: list[tuple] = []
+
+    def prompt_vendor_pause(self, error, category):
+        self.vendor_calls.append((error, category))
+        return self.vendor_response
+
+    def prompt_budget_pause(self, accumulated, limit):
+        self.budget_calls.append((accumulated, limit))
+        return self.budget_response
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator handler methods (unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleVendorPause:
+    """Test _handle_vendor_pause on the orchestrator."""
+
+    @pytest.fixture
+    def mock_orchestrator(self):
+        """Create a minimal mock orchestrator with handler methods."""
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        # We test the methods directly by calling them on a mock
+        orch = MagicMock()
+        # Bind the real method
+        orch._handle_vendor_pause = (
+            OptimizationOrchestrator._handle_vendor_pause.__get__(orch)
+        )
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_resume_returns_continue(self, mock_orchestrator):
+        adapter = MockPromptAdapter(vendor_response="resume")
+        mock_orchestrator._prompt_adapter = adapter
+
+        exc = VendorPauseError("rate limit", category="rate_limit")
+        result = await mock_orchestrator._handle_vendor_pause(exc)
+
+        assert result == "continue"
+        assert len(adapter.vendor_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_returns_break(self, mock_orchestrator):
+        adapter = MockPromptAdapter(vendor_response="stop")
+        mock_orchestrator._prompt_adapter = adapter
+
+        exc = VendorPauseError("rate limit", category="rate_limit")
+        result = await mock_orchestrator._handle_vendor_pause(exc)
+
+        assert result == "break"
+
+    @pytest.mark.asyncio
+    async def test_no_adapter_returns_break(self, mock_orchestrator):
+        mock_orchestrator._prompt_adapter = None
+
+        exc = VendorPauseError("rate limit", category="rate_limit")
+        result = await mock_orchestrator._handle_vendor_pause(exc)
+
+        assert result == "break"
+
+
+class TestHandleBudgetLimitPause:
+    """Test _handle_budget_limit_pause on the orchestrator."""
+
+    @pytest.fixture
+    def mock_orchestrator(self):
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        orch = MagicMock()
+        orch._handle_budget_limit_pause = (
+            OptimizationOrchestrator._handle_budget_limit_pause.__get__(orch)
+        )
+
+        # Mock cost enforcer
+        status_mock = MagicMock()
+        status_mock.accumulated_cost_usd = 1.50
+        orch.cost_enforcer.get_status.return_value = status_mock
+        orch.cost_enforcer.config.limit = 2.00
+
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_raise_limit_returns_continue(self, mock_orchestrator):
+        adapter = MockPromptAdapter(budget_response="raise:5.0")
+        mock_orchestrator._prompt_adapter = adapter
+
+        result = await mock_orchestrator._handle_budget_limit_pause()
+
+        assert result == "continue"
+        mock_orchestrator.cost_enforcer.update_limit.assert_called_once_with(5.0)
+        assert len(adapter.budget_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_returns_break(self, mock_orchestrator):
+        adapter = MockPromptAdapter(budget_response="stop")
+        mock_orchestrator._prompt_adapter = adapter
+
+        result = await mock_orchestrator._handle_budget_limit_pause()
+
+        assert result == "break"
+        mock_orchestrator.cost_enforcer.update_limit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_adapter_returns_break(self, mock_orchestrator):
+        mock_orchestrator._prompt_adapter = None
+
+        result = await mock_orchestrator._handle_budget_limit_pause()
+
+        assert result == "break"
+
+
+# ---------------------------------------------------------------------------
+# VendorPauseError propagation from trial_lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestVendorPauseErrorPropagation:
+    """Test that VendorPauseError is raised correctly."""
+
+    def test_vendor_pause_error_attributes(self):
+        original = RuntimeError("429 Too Many Requests")
+        exc = VendorPauseError(
+            "rate limit hit",
+            original_error=original,
+            category="rate_limit",
+        )
+        assert exc.original_error is original
+        assert exc.category == "rate_limit"
+        assert "rate limit hit" in str(exc)
+
+    def test_vendor_pause_error_default_category(self):
+        exc = VendorPauseError("some error")
+        assert exc.category == "unknown"
+        assert exc.original_error is None

--- a/tests/unit/core/test_pause_on_error.py
+++ b/tests/unit/core/test_pause_on_error.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from traigent.core.exception_handler import VendorErrorCategory
 from traigent.utils.exceptions import VendorPauseError
 
 # ---------------------------------------------------------------------------
@@ -57,7 +58,7 @@ class TestHandleVendorPause:
         adapter = MockPromptAdapter(vendor_response="resume")
         mock_orchestrator._prompt_adapter = adapter
 
-        exc = VendorPauseError("rate limit", category="rate_limit")
+        exc = VendorPauseError("rate limit", category=VendorErrorCategory.RATE_LIMIT)
         result = await mock_orchestrator._handle_vendor_pause(exc)
 
         assert result == "continue"
@@ -68,7 +69,7 @@ class TestHandleVendorPause:
         adapter = MockPromptAdapter(vendor_response="stop")
         mock_orchestrator._prompt_adapter = adapter
 
-        exc = VendorPauseError("rate limit", category="rate_limit")
+        exc = VendorPauseError("rate limit", category=VendorErrorCategory.RATE_LIMIT)
         result = await mock_orchestrator._handle_vendor_pause(exc)
 
         assert result == "break"
@@ -77,7 +78,7 @@ class TestHandleVendorPause:
     async def test_no_adapter_returns_break(self, mock_orchestrator):
         mock_orchestrator._prompt_adapter = None
 
-        exc = VendorPauseError("rate limit", category="rate_limit")
+        exc = VendorPauseError("rate limit", category=VendorErrorCategory.RATE_LIMIT)
         result = await mock_orchestrator._handle_vendor_pause(exc)
 
         assert result == "break"
@@ -146,13 +147,13 @@ class TestVendorPauseErrorPropagation:
         exc = VendorPauseError(
             "rate limit hit",
             original_error=original,
-            category="rate_limit",
+            category=VendorErrorCategory.RATE_LIMIT,
         )
         assert exc.original_error is original
-        assert exc.category == "rate_limit"
+        assert exc.category == VendorErrorCategory.RATE_LIMIT
         assert "rate limit hit" in str(exc)
 
     def test_vendor_pause_error_default_category(self):
         exc = VendorPauseError("some error")
-        assert exc.category == "unknown"
+        assert exc.category is None
         assert exc.original_error is None

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -149,6 +149,7 @@ from traigent.utils.exceptions import (
     OptimizationStateError,
     TraigentDeprecationWarning,
     TraigentWarning,
+    VendorPauseError,
 )
 from traigent.utils.importance import ParameterImportanceAnalyzer
 from traigent.utils.multi_objective import MultiObjectiveMetrics, ParetoFrontCalculator

--- a/traigent/core/exception_handler.py
+++ b/traigent/core/exception_handler.py
@@ -165,8 +165,7 @@ class TerminalPausePrompt:
         """
         if not sys.stdin.isatty():
             logger.info(
-                "Non-interactive mode: auto-stopping at budget limit "
-                "($%.2f / $%.2f)",
+                "Non-interactive mode: auto-stopping at budget limit ($%.2f / $%.2f)",
                 accumulated,
                 limit,
             )

--- a/traigent/core/exception_handler.py
+++ b/traigent/core/exception_handler.py
@@ -1,0 +1,203 @@
+"""Vendor error classification and interactive pause prompts.
+
+Provides error classification for vendor/provider errors (rate limits, quota
+exhaustion, service unavailability) and an injectable prompt adapter for
+interactive pause-and-resume during optimization runs.
+
+The TerminalPausePrompt is the default implementation, using ``input()`` for
+interactive terminals and auto-stopping in non-interactive environments (CI,
+pipes, scripts).
+"""
+
+from __future__ import annotations
+
+import sys
+from enum import Enum
+from typing import Protocol
+
+from traigent.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class VendorErrorCategory(Enum):
+    """Categories of vendor errors that can trigger interactive pause."""
+
+    RATE_LIMIT = "rate_limit"
+    QUOTA_EXHAUSTED = "quota_exhausted"
+    SERVICE_UNAVAILABLE = "service_unavailable"
+
+
+class PausePromptAdapter(Protocol):
+    """Protocol for interactive pause prompts. Injectable for testing."""
+
+    def prompt_vendor_pause(
+        self, error: Exception, category: VendorErrorCategory
+    ) -> str:
+        """Prompt user after vendor error. Returns 'resume' or 'stop'."""
+        ...
+
+    def prompt_budget_pause(self, accumulated: float, limit: float) -> str:
+        """Prompt user after budget limit. Returns 'raise:<amount>' or 'stop'."""
+        ...
+
+
+_VENDOR_ERROR_PATTERNS: list[tuple[str, VendorErrorCategory]] = [
+    ("rate limit", VendorErrorCategory.RATE_LIMIT),
+    ("rate_limit", VendorErrorCategory.RATE_LIMIT),
+    ("ratelimit", VendorErrorCategory.RATE_LIMIT),
+    ("429", VendorErrorCategory.RATE_LIMIT),
+    ("too many requests", VendorErrorCategory.RATE_LIMIT),
+    ("quota", VendorErrorCategory.QUOTA_EXHAUSTED),
+    ("quota_exceeded", VendorErrorCategory.QUOTA_EXHAUSTED),
+    ("insufficient_quota", VendorErrorCategory.QUOTA_EXHAUSTED),
+    ("service unavailable", VendorErrorCategory.SERVICE_UNAVAILABLE),
+    ("503", VendorErrorCategory.SERVICE_UNAVAILABLE),
+    ("overloaded", VendorErrorCategory.SERVICE_UNAVAILABLE),
+    ("server_error", VendorErrorCategory.SERVICE_UNAVAILABLE),
+]
+
+
+def classify_vendor_error(exc: Exception) -> VendorErrorCategory | None:
+    """Classify an exception as a vendor-pausable error category.
+
+    Checks against known Traigent exception types first, then falls back
+    to pattern-matching the exception message string.
+
+    Args:
+        exc: The exception to classify.
+
+    Returns:
+        VendorErrorCategory if the error is vendor-pausable, None otherwise.
+    """
+    from traigent.utils.exceptions import (
+        QuotaExceededError,
+        RateLimitError,
+        ServiceUnavailableError,
+    )
+
+    if isinstance(exc, RateLimitError):
+        return VendorErrorCategory.RATE_LIMIT
+    if isinstance(exc, QuotaExceededError):
+        return VendorErrorCategory.QUOTA_EXHAUSTED
+    if isinstance(exc, ServiceUnavailableError):
+        return VendorErrorCategory.SERVICE_UNAVAILABLE
+
+    # Fallback: pattern-match the error message
+    msg = str(exc).lower()
+    for pattern, category in _VENDOR_ERROR_PATTERNS:
+        if pattern in msg:
+            return category
+
+    return None
+
+
+_CATEGORY_DESCRIPTIONS: dict[VendorErrorCategory, str] = {
+    VendorErrorCategory.RATE_LIMIT: (
+        "The LLM provider is rate-limiting requests. "
+        "This usually resolves after a short wait."
+    ),
+    VendorErrorCategory.QUOTA_EXHAUSTED: (
+        "The LLM provider quota has been exhausted. "
+        "Check your billing dashboard or wait for the quota to reset."
+    ),
+    VendorErrorCategory.SERVICE_UNAVAILABLE: (
+        "The LLM provider service is temporarily unavailable. "
+        "This is usually a transient issue."
+    ),
+}
+
+
+class TerminalPausePrompt:
+    """Default terminal-based prompt implementation.
+
+    Uses ``input()`` for interactive prompts. In non-interactive mode
+    (``sys.stdin.isatty()`` is False), automatically returns ``"stop"``.
+    """
+
+    def prompt_vendor_pause(
+        self, error: Exception, category: VendorErrorCategory
+    ) -> str:
+        """Prompt user to resume or stop after a vendor error.
+
+        Args:
+            error: The original vendor exception.
+            category: Classified error category.
+
+        Returns:
+            ``"resume"`` or ``"stop"``.
+        """
+        if not sys.stdin.isatty():
+            logger.info(
+                "Non-interactive mode: auto-stopping after vendor error (%s)",
+                category.value,
+            )
+            return "stop"
+
+        description = _CATEGORY_DESCRIPTIONS.get(category, str(error))
+        print(f"\n⚠️  Vendor error: {category.value}")
+        print(f"   {description}")
+        print(f"   Error: {error}")
+        print()
+        print("Options:")
+        print("  [r] Resume optimization")
+        print("  [s] Stop and return partial results")
+
+        try:
+            choice = input("\nYour choice (r/s): ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return "stop"
+
+        if choice in ("r", "resume"):
+            return "resume"
+        return "stop"
+
+    def prompt_budget_pause(self, accumulated: float, limit: float) -> str:
+        """Prompt user to raise budget or stop after budget limit reached.
+
+        Args:
+            accumulated: Total cost accumulated so far (USD).
+            limit: Current cost limit (USD).
+
+        Returns:
+            ``"raise:<new_limit>"`` or ``"stop"``.
+        """
+        if not sys.stdin.isatty():
+            logger.info(
+                "Non-interactive mode: auto-stopping at budget limit "
+                "($%.2f / $%.2f)",
+                accumulated,
+                limit,
+            )
+            return "stop"
+
+        print(f"\n💰 Budget limit reached: ${accumulated:.2f} / ${limit:.2f}")
+        print()
+        print("Options:")
+        print("  Enter a new limit (e.g. 5.0) to raise and continue")
+        print("  [s] Stop and return partial results")
+
+        try:
+            choice = input("\nNew limit or 's' to stop: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return "stop"
+
+        if choice in ("s", "stop", ""):
+            return "stop"
+
+        try:
+            new_limit = float(choice)
+            if new_limit <= accumulated:
+                print(
+                    f"  New limit must be greater than current spend (${accumulated:.2f})"
+                )
+                return "stop"
+            if not (0 < new_limit < float("inf")):
+                print("  Invalid amount. Stopping.")
+                return "stop"
+            return f"raise:{new_limit}"
+        except ValueError:
+            print("  Invalid input. Stopping.")
+            return "stop"

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -109,8 +109,10 @@ def _resolve_callbacks(
     callbacks = list(explicit_callbacks or decorator_callbacks or [])
     if progress_bar is not False:
         has_progress = any(isinstance(cb, ProgressBarCallback) for cb in callbacks)
-        if not has_progress and sys.stdin.isatty():
-            callbacks.insert(0, ProgressBarCallback())
+        if not has_progress:
+            # True = always inject; None = inject only in interactive terminals
+            if progress_bar is True or sys.stdin.isatty():
+                callbacks.insert(0, ProgressBarCallback())
     return callbacks
 
 
@@ -1152,6 +1154,10 @@ class OptimizedFunction:
             tvl_spec: Optional TVL spec path to load at runtime.
             tvl_environment: Environment overlay to apply when loading the spec.
             tvl: Structured TVL options (dict or TVLOptions) for runtime overrides.
+            progress_bar: Controls the live progress bar during optimization.
+                ``True`` forces a progress bar even in non-interactive mode,
+                ``False`` suppresses it, ``None`` (default) auto-enables in
+                interactive terminals (``sys.stdin.isatty()``).
             **algorithm_kwargs: Additional algorithm-specific parameters.
                 For grid search (algorithm="grid"):
                     - parameter_order: dict[str, int | float] controlling iteration order.
@@ -1267,6 +1273,8 @@ class OptimizedFunction:
             tvl_spec: Optional TVL spec path
             tvl_environment: Environment overlay for TVL spec
             tvl: Structured TVL options
+            progress_bar: ``True`` to force, ``False`` to suppress, ``None``
+                (default) auto-enables in interactive terminals.
             **algorithm_kwargs: Additional algorithm parameters
 
         Returns:

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -84,6 +84,36 @@ from traigent.utils.validation import (
 
 logger = get_logger(__name__)
 
+
+def _resolve_callbacks(
+    explicit_callbacks: list[Any] | None,
+    decorator_callbacks: list[Any] | None,
+    progress_bar: bool | None,
+) -> list[Any]:
+    """Resolve callbacks with optional auto-injection of ProgressBarCallback.
+
+    Used by both ``optimize()`` and ``optimize_sync()`` to keep behavior
+    consistent. Auto-enables a progress bar in interactive terminals unless
+    the caller explicitly disables it.
+
+    Args:
+        explicit_callbacks: Callbacks passed directly to optimize().
+        decorator_callbacks: Callbacks stored on the decorator/OptimizedFunction.
+        progress_bar: ``True`` to force, ``False`` to suppress, ``None`` for auto.
+
+    Returns:
+        Resolved list of callback instances.
+    """
+    from traigent.utils.callbacks import ProgressBarCallback
+
+    callbacks = list(explicit_callbacks or decorator_callbacks or [])
+    if progress_bar is not False:
+        has_progress = any(isinstance(cb, ProgressBarCallback) for cb in callbacks)
+        if not has_progress and sys.stdin.isatty():
+            callbacks.insert(0, ProgressBarCallback())
+    return callbacks
+
+
 # Module-level flag to ensure cost warning is emitted only once per process
 _COST_WARNING_EMITTED = False
 
@@ -1102,6 +1132,7 @@ class OptimizedFunction:
         tvl_spec: str | Path | None = None,
         tvl_environment: str | None = None,
         tvl: TVLOptions | dict[str, Any] | None = None,
+        progress_bar: bool | None = None,
         **algorithm_kwargs: Any,
     ) -> OptimizationResult:
         """Run optimization on the function.
@@ -1177,8 +1208,8 @@ class OptimizedFunction:
 
         timeout = timeout if timeout is not None else getattr(self, "timeout", None)
         save_to = save_to if save_to is not None else getattr(self, "save_to", None)
-        callbacks = (
-            callbacks if callbacks is not None else getattr(self, "callbacks", None)
+        callbacks = _resolve_callbacks(
+            callbacks, getattr(self, "callbacks", None), progress_bar
         )
 
         try:
@@ -1213,6 +1244,7 @@ class OptimizedFunction:
         tvl_spec: str | Path | None = None,
         tvl_environment: str | None = None,
         tvl: TVLOptions | dict[str, Any] | None = None,
+        progress_bar: bool | None = None,
         **algorithm_kwargs: Any,
     ) -> OptimizationResult:
         """Run optimization synchronously (convenience wrapper).
@@ -1265,6 +1297,7 @@ class OptimizedFunction:
             tvl_spec=tvl_spec,
             tvl_environment=tvl_environment,
             tvl=tvl,
+            progress_bar=progress_bar,
             **algorithm_kwargs,
         )
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1581,7 +1581,34 @@ class OptimizationOrchestrator:
             scheduled_configs, results, scheduled_optuna_ids, session_id, trial_count
         )
 
-        # Phase 9: Checkpoint logging
+        # Phase 9: Check for batch-wide vendor errors (parallel mode)
+        # VendorPauseError is caught inside each trial and converted to a
+        # failed TrialResult. If the entire batch failed with vendor-like
+        # errors, prompt the user before scheduling the next batch.
+        if self._prompt_adapter is not None and results:
+            from traigent.core.exception_handler import classify_vendor_error
+
+            vendor_failures = 0
+            for r in results:
+                trial = getattr(r, "result", r)
+                if (
+                    isinstance(trial, TrialResult)
+                    and trial.status == TrialStatus.FAILED
+                    and trial.error_message
+                    and classify_vendor_error(RuntimeError(trial.error_message))
+                    is not None
+                ):
+                    vendor_failures += 1
+            if vendor_failures > 0 and vendor_failures == len(results):
+                exc = VendorPauseError(
+                    f"All {vendor_failures} parallel trials failed with vendor errors",
+                )
+                decision = await self._handle_vendor_pause(exc)
+                if decision == "break":
+                    self._stop_reason = "vendor_error_user_stop"
+                    return trial_count, "break"
+
+        # Phase 10: Checkpoint logging
         self._maybe_log_checkpoint(trial_count)
 
         return trial_count, "continue"
@@ -1856,16 +1883,20 @@ class OptimizationOrchestrator:
                 trial_count
             )
             if budget_stop:
-                # Interactive pause: let user raise the budget limit
-                if self._prompt_adapter is not None:
-                    decision = await self._handle_budget_limit_pause()
-                    if decision == "continue":
-                        continue
                 if not self._stop_reason:
                     self._stop_reason = budget_stop
                 break
 
             if self._should_stop(trial_count):
+                # Interactive pause on cost limit — let user raise budget
+                if (
+                    self._stop_reason == "cost_limit"
+                    and self._prompt_adapter is not None
+                ):
+                    decision = await self._handle_budget_limit_pause()
+                    if decision == "continue":
+                        self._stop_reason = None
+                        continue
                 break
 
             try:
@@ -1936,7 +1967,11 @@ class OptimizationOrchestrator:
             self.cost_enforcer.config.limit,
         )
         if decision.startswith("raise:"):
-            new_limit = float(decision.split(":")[1])
+            try:
+                new_limit = float(decision.split(":")[1])
+            except (ValueError, IndexError):
+                logger.warning("Malformed budget response: %s", decision)
+                return "break"
             self.cost_enforcer.update_limit(new_limit)
             logger.info("User raised cost limit to $%.2f", new_limit)
             return "continue"

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1565,10 +1565,12 @@ class OptimizationOrchestrator:
         ceilings = self._allocate_trial_ceilings(trial_descriptors)
 
         # Phase 7: Schedule and run trials
-        scheduled_configs, scheduled_optuna_ids, results = (
-            await self._schedule_and_run_parallel_trials(
-                func, trial_descriptors, ceilings, session_id, trial_count
-            )
+        (
+            scheduled_configs,
+            scheduled_optuna_ids,
+            results,
+        ) = await self._schedule_and_run_parallel_trials(
+            func, trial_descriptors, ceilings, session_id, trial_count
         )
 
         if not results:
@@ -1878,14 +1880,15 @@ class OptimizationOrchestrator:
                         remaining_samples=remaining_samples,
                     )
                 else:
-                    trial_count, action = (
-                        await self._trial_lifecycle.run_sequential_trial(
-                            func=func,
-                            dataset=dataset,
-                            session_id=session_id,
-                            function_name=function_identifier,
-                            trial_count=trial_count,
-                        )
+                    (
+                        trial_count,
+                        action,
+                    ) = await self._trial_lifecycle.run_sequential_trial(
+                        func=func,
+                        dataset=dataset,
+                        session_id=session_id,
+                        function_name=function_identifier,
+                        trial_count=trial_count,
                     )
             except VendorPauseError as e:
                 decision = await self._handle_vendor_pause(e)

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1605,7 +1605,7 @@ class OptimizationOrchestrator:
                 )
                 decision = await self._handle_vendor_pause(exc)
                 if decision == "break":
-                    self._stop_reason = "vendor_error_user_stop"
+                    self._stop_reason = "vendor_error"
                     return trial_count, "break"
 
         # Phase 10: Checkpoint logging
@@ -1924,7 +1924,7 @@ class OptimizationOrchestrator:
             except VendorPauseError as e:
                 decision = await self._handle_vendor_pause(e)
                 if decision == "break":
-                    self._stop_reason = "vendor_error_user_stop"
+                    self._stop_reason = "vendor_error"
                     break
                 continue  # User chose to resume — retry
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -8,6 +8,7 @@ import asyncio
 import copy
 import inspect
 import math
+import sys
 import time
 import uuid
 from collections.abc import Callable, Sequence
@@ -82,7 +83,7 @@ from traigent.optimizers.base import BaseOptimizer
 from traigent.tvl.promotion_gate import PromotionGate
 from traigent.utils.callbacks import CallbackManager, OptimizationCallback, ProgressInfo
 from traigent.utils.env_config import is_backend_offline
-from traigent.utils.exceptions import OptimizationError
+from traigent.utils.exceptions import OptimizationError, VendorPauseError
 from traigent.utils.function_identity import (
     FunctionDescriptor,
     resolve_function_descriptor,
@@ -207,6 +208,16 @@ class OptimizationOrchestrator:
         self._backend_client: BackendIntegratedClient | None = None
         self.backend_client = self._initialize_backend_client()
         self._initialize_runtime_state()
+
+        # Interactive pause prompt adapter (None in non-interactive environments)
+        from traigent.core.exception_handler import (
+            PausePromptAdapter,
+            TerminalPausePrompt,
+        )
+
+        self._prompt_adapter: PausePromptAdapter | None = (
+            TerminalPausePrompt() if sys.stdin.isatty() else None
+        )
 
         # Workflow trace manager for span collection and backend submission
         self._workflow_trace_manager = WorkflowTraceManager(
@@ -1843,6 +1854,11 @@ class OptimizationOrchestrator:
                 trial_count
             )
             if budget_stop:
+                # Interactive pause: let user raise the budget limit
+                if self._prompt_adapter is not None:
+                    decision = await self._handle_budget_limit_pause()
+                    if decision == "continue":
+                        continue
                 if not self._stop_reason:
                     self._stop_reason = budget_stop
                 break
@@ -1850,29 +1866,79 @@ class OptimizationOrchestrator:
             if self._should_stop(trial_count):
                 break
 
-            if self.parallel_trials > 1:
-                trial_count, action = await self._run_parallel_batch(
-                    func=func,
-                    dataset=dataset,
-                    session_id=session_id,
-                    function_name=function_identifier,
-                    trial_count=trial_count,
-                    remaining=remaining,
-                    remaining_samples=remaining_samples,
-                )
-            else:
-                trial_count, action = await self._trial_lifecycle.run_sequential_trial(
-                    func=func,
-                    dataset=dataset,
-                    session_id=session_id,
-                    function_name=function_identifier,
-                    trial_count=trial_count,
-                )
+            try:
+                if self.parallel_trials > 1:
+                    trial_count, action = await self._run_parallel_batch(
+                        func=func,
+                        dataset=dataset,
+                        session_id=session_id,
+                        function_name=function_identifier,
+                        trial_count=trial_count,
+                        remaining=remaining,
+                        remaining_samples=remaining_samples,
+                    )
+                else:
+                    trial_count, action = (
+                        await self._trial_lifecycle.run_sequential_trial(
+                            func=func,
+                            dataset=dataset,
+                            session_id=session_id,
+                            function_name=function_identifier,
+                            trial_count=trial_count,
+                        )
+                    )
+            except VendorPauseError as e:
+                decision = await self._handle_vendor_pause(e)
+                if decision == "break":
+                    self._stop_reason = "vendor_error_user_stop"
+                    break
+                continue  # User chose to resume — retry
 
             if action == "break":
                 break
 
         return trial_count
+
+    async def _handle_vendor_pause(self, exc: VendorPauseError) -> str:
+        """Prompt user to resume or stop after a vendor error.
+
+        Returns:
+            ``"continue"`` to retry the trial, ``"break"`` to stop.
+        """
+        if self._prompt_adapter is None:
+            return "break"
+        decision = await asyncio.to_thread(
+            self._prompt_adapter.prompt_vendor_pause,
+            exc.original_error or exc,
+            exc.category,
+        )
+        if decision == "resume":
+            logger.info("User chose to resume after vendor error: %s", exc.category)
+            return "continue"
+        logger.info("User chose to stop after vendor error: %s", exc.category)
+        return "break"
+
+    async def _handle_budget_limit_pause(self) -> str:
+        """Prompt user to raise budget limit or stop.
+
+        Returns:
+            ``"continue"`` to retry with new limit, ``"break"`` to stop.
+        """
+        if self._prompt_adapter is None:
+            return "break"
+        status = self.cost_enforcer.get_status()
+        decision = await asyncio.to_thread(
+            self._prompt_adapter.prompt_budget_pause,
+            status.accumulated_cost_usd,
+            self.cost_enforcer.config.limit,
+        )
+        if decision.startswith("raise:"):
+            new_limit = float(decision.split(":")[1])
+            self.cost_enforcer.update_limit(new_limit)
+            logger.info("User raised cost limit to $%.2f", new_limit)
+            return "continue"
+        logger.info("User chose to stop at budget limit")
+        return "break"
 
     async def _finalize_optimization(
         self,

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1582,31 +1582,10 @@ class OptimizationOrchestrator:
         )
 
         # Phase 9: Check for batch-wide vendor errors (parallel mode)
-        # VendorPauseError is caught inside each trial and converted to a
-        # failed TrialResult. If the entire batch failed with vendor-like
-        # errors, prompt the user before scheduling the next batch.
-        if self._prompt_adapter is not None and results:
-            from traigent.core.exception_handler import classify_vendor_error
-
-            vendor_failures = 0
-            for r in results:
-                trial = getattr(r, "result", r)
-                if (
-                    isinstance(trial, TrialResult)
-                    and trial.status == TrialStatus.FAILED
-                    and trial.error_message
-                    and classify_vendor_error(RuntimeError(trial.error_message))
-                    is not None
-                ):
-                    vendor_failures += 1
-            if vendor_failures > 0 and vendor_failures == len(results):
-                exc = VendorPauseError(
-                    f"All {vendor_failures} parallel trials failed with vendor errors",
-                )
-                decision = await self._handle_vendor_pause(exc)
-                if decision == "break":
-                    self._stop_reason = "vendor_error"
-                    return trial_count, "break"
+        vendor_stop = await self._check_batch_vendor_errors(results)
+        if vendor_stop:
+            self._stop_reason = "vendor_error"
+            return trial_count, "break"
 
         # Phase 10: Checkpoint logging
         self._maybe_log_checkpoint(trial_count)
@@ -1887,51 +1866,82 @@ class OptimizationOrchestrator:
                     self._stop_reason = budget_stop
                 break
 
-            if self._should_stop(trial_count):
-                # Interactive pause on cost limit — let user raise budget
-                if (
-                    self._stop_reason == "cost_limit"
-                    and self._prompt_adapter is not None
-                ):
-                    decision = await self._handle_budget_limit_pause()
-                    if decision == "continue":
-                        self._stop_reason = None
-                        continue
+            stop_action = await self._check_stop_with_budget_pause(trial_count)
+            if stop_action == "break":
                 break
+            if stop_action == "continue":
+                continue
 
-            try:
-                if self.parallel_trials > 1:
-                    trial_count, action = await self._run_parallel_batch(
-                        func=func,
-                        dataset=dataset,
-                        session_id=session_id,
-                        function_name=function_identifier,
-                        trial_count=trial_count,
-                        remaining=remaining,
-                        remaining_samples=remaining_samples,
-                    )
-                else:
-                    (
-                        trial_count,
-                        action,
-                    ) = await self._trial_lifecycle.run_sequential_trial(
-                        func=func,
-                        dataset=dataset,
-                        session_id=session_id,
-                        function_name=function_identifier,
-                        trial_count=trial_count,
-                    )
-            except VendorPauseError as e:
-                decision = await self._handle_vendor_pause(e)
-                if decision == "break":
-                    self._stop_reason = "vendor_error"
-                    break
-                continue  # User chose to resume — retry
+            trial_count, action = await self._dispatch_trial(
+                func,
+                dataset,
+                session_id,
+                function_identifier,
+                trial_count,
+                remaining,
+                remaining_samples,
+            )
 
             if action == "break":
                 break
 
         return trial_count
+
+    async def _check_stop_with_budget_pause(self, trial_count: int) -> str | None:
+        """Check stop conditions; offer budget pause on cost limit.
+
+        Returns:
+            ``"break"`` to stop, ``"continue"`` to retry after raising limit,
+            ``None`` to proceed normally.
+        """
+        if not self._should_stop(trial_count):
+            return None
+        if self._stop_reason == "cost_limit" and self._prompt_adapter is not None:
+            decision = await self._handle_budget_limit_pause()
+            if decision == "continue":
+                self._stop_reason = None
+                return "continue"
+        return "break"
+
+    async def _dispatch_trial(
+        self,
+        func: Callable[..., Any],
+        dataset: Dataset,
+        session_id: str | None,
+        function_identifier: str | None,
+        trial_count: int,
+        remaining: float,
+        remaining_samples: float,
+    ) -> tuple[int, str]:
+        """Run a single trial iteration (sequential or parallel) with vendor pause.
+
+        Returns:
+            ``(trial_count, action)`` where action is ``"continue"`` or ``"break"``.
+        """
+        try:
+            if self.parallel_trials > 1:
+                return await self._run_parallel_batch(
+                    func=func,
+                    dataset=dataset,
+                    session_id=session_id,
+                    function_name=function_identifier,
+                    trial_count=trial_count,
+                    remaining=remaining,
+                    remaining_samples=remaining_samples,
+                )
+            return await self._trial_lifecycle.run_sequential_trial(
+                func=func,
+                dataset=dataset,
+                session_id=session_id,
+                function_name=function_identifier,
+                trial_count=trial_count,
+            )
+        except VendorPauseError as e:
+            decision = await self._handle_vendor_pause(e)
+            if decision == "break":
+                self._stop_reason = "vendor_error"
+                return trial_count, "break"
+            return trial_count, "continue"  # User chose to resume
 
     async def _handle_vendor_pause(self, exc: VendorPauseError) -> str:
         """Prompt user to resume or stop after a vendor error.
@@ -1977,6 +1987,42 @@ class OptimizationOrchestrator:
             return "continue"
         logger.info("User chose to stop at budget limit")
         return "break"
+
+    async def _check_batch_vendor_errors(
+        self, results: list[PermittedTrialResult]
+    ) -> bool:
+        """Check if an entire parallel batch failed with vendor errors.
+
+        When all trials in a batch fail with vendor-like errors (rate limit,
+        quota, service unavailable), prompt the user to resume or stop.
+
+        Returns:
+            True if the user chose to stop, False otherwise.
+        """
+        if self._prompt_adapter is None or not results:
+            return False
+
+        from traigent.core.exception_handler import classify_vendor_error
+
+        vendor_failures = 0
+        for r in results:
+            trial = getattr(r, "result", r)
+            if (
+                isinstance(trial, TrialResult)
+                and trial.status == TrialStatus.FAILED
+                and trial.error_message
+                and classify_vendor_error(RuntimeError(trial.error_message)) is not None
+            ):
+                vendor_failures += 1
+
+        if vendor_failures == 0 or vendor_failures < len(results):
+            return False
+
+        exc = VendorPauseError(
+            f"All {vendor_failures} parallel trials failed with vendor errors",
+        )
+        decision = await self._handle_vendor_pause(exc)
+        return decision == "break"
 
     async def _finalize_optimization(
         self,

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -39,8 +39,12 @@ from traigent.evaluators.base import Dataset
 from traigent.utils.error_handler import APIKeyError
 from traigent.utils.exceptions import (
     OptimizationError,
+    QuotaExceededError,
+    RateLimitError,
+    ServiceUnavailableError,
     TrialPrunedError,
     TVLConstraintError,
+    VendorPauseError,
 )
 from traigent.utils.logging import get_logger
 
@@ -188,6 +192,21 @@ class TrialLifecycle:
         if orchestrator.cost_enforcer is not None:
             permit = await orchestrator.cost_enforcer.acquire_permit_async()
             if not permit.is_granted:
+                # Interactive pause: let user raise the budget limit
+                prompt_adapter = getattr(orchestrator, "_prompt_adapter", None)
+                if prompt_adapter is not None:
+                    import asyncio
+
+                    decision = await asyncio.to_thread(
+                        prompt_adapter.prompt_budget_pause,
+                        orchestrator.cost_enforcer.get_status().accumulated_cost_usd,
+                        orchestrator.cost_enforcer.config.limit,
+                    )
+                    if decision.startswith("raise:"):
+                        new_limit = float(decision.split(":")[1])
+                        orchestrator.cost_enforcer.update_limit(new_limit)
+                        return trial_count, "continue"
+
                 logger.info(
                     "Sequential trial cancelled due to cost limit reached (config=%s)",
                     config_for_run,
@@ -430,6 +449,38 @@ class TrialLifecycle:
         except asyncio.CancelledError:
             # SonarQube S7497: CancelledError must always be re-raised
             raise
+
+        except (
+            RateLimitError,
+            QuotaExceededError,
+            ServiceUnavailableError,
+        ) as vendor_exc:
+            # Re-raise as VendorPauseError so the orchestrator can prompt
+            # the user to resume or stop, instead of silently failing.
+            from traigent.core.exception_handler import classify_vendor_error
+
+            category = classify_vendor_error(vendor_exc)
+            if category is not None:
+                raise VendorPauseError(
+                    str(vendor_exc),
+                    original_error=vendor_exc,
+                    category=category.value,
+                ) from vendor_exc
+            # Defensive: if classify returns None, fall through to generic
+            logger.exception("Trial %s vendor error not classified", trial_id)
+            result = self._build_trial_error_result(
+                trial_id,
+                evaluation_config,
+                start_time,
+                lease,
+                progress_state,
+                optuna_trial_id,
+                vendor_exc,
+            )
+            record_trial_result(span, status="failed", error=str(vendor_exc))
+            end_time = time.time()
+            self._collect_workflow_span(trial_id, result, start_time, end_time)
+            return result
 
         except Exception as exc:
             logger.exception("Trial %s execution failed unexpectedly", trial_id)

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -442,30 +442,15 @@ class TrialLifecycle:
         ) as vendor_exc:
             # Re-raise as VendorPauseError so the orchestrator can prompt
             # the user to resume or stop, instead of silently failing.
+            # classify_vendor_error is guaranteed to match for these types.
             from traigent.core.exception_handler import classify_vendor_error
 
             category = classify_vendor_error(vendor_exc)
-            if category is not None:
-                raise VendorPauseError(
-                    str(vendor_exc),
-                    original_error=vendor_exc,
-                    category=category,
-                ) from vendor_exc
-            # Defensive: if classify returns None, fall through to generic
-            logger.exception("Trial %s vendor error not classified", trial_id)
-            result = self._build_trial_error_result(
-                trial_id,
-                evaluation_config,
-                start_time,
-                lease,
-                progress_state,
-                optuna_trial_id,
-                vendor_exc,
-            )
-            record_trial_result(span, status="failed", error=str(vendor_exc))
-            end_time = time.time()
-            self._collect_workflow_span(trial_id, result, start_time, end_time)
-            return result
+            raise VendorPauseError(
+                str(vendor_exc),
+                original_error=vendor_exc,
+                category=category,
+            ) from vendor_exc
 
         except Exception as exc:
             logger.exception("Trial %s execution failed unexpectedly", trial_id)

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -192,21 +192,6 @@ class TrialLifecycle:
         if orchestrator.cost_enforcer is not None:
             permit = await orchestrator.cost_enforcer.acquire_permit_async()
             if not permit.is_granted:
-                # Interactive pause: let user raise the budget limit
-                prompt_adapter = getattr(orchestrator, "_prompt_adapter", None)
-                if prompt_adapter is not None:
-                    import asyncio
-
-                    decision = await asyncio.to_thread(
-                        prompt_adapter.prompt_budget_pause,
-                        orchestrator.cost_enforcer.get_status().accumulated_cost_usd,
-                        orchestrator.cost_enforcer.config.limit,
-                    )
-                    if decision.startswith("raise:"):
-                        new_limit = float(decision.split(":")[1])
-                        orchestrator.cost_enforcer.update_limit(new_limit)
-                        return trial_count, "continue"
-
                 logger.info(
                     "Sequential trial cancelled due to cost limit reached (config=%s)",
                     config_for_run,
@@ -464,7 +449,7 @@ class TrialLifecycle:
                 raise VendorPauseError(
                     str(vendor_exc),
                     original_error=vendor_exc,
-                    category=category.value,
+                    category=category,
                 ) from vendor_exc
             # Defensive: if classify returns None, fall through to generic
             logger.exception("Trial %s vendor error not classified", trial_id)

--- a/traigent/utils/exceptions.py
+++ b/traigent/utils/exceptions.py
@@ -314,14 +314,14 @@ class VendorPauseError(TraigentError):
 
     Attributes:
         original_error: The underlying vendor exception.
-        category: Classified vendor error category string.
+        category: The VendorErrorCategory enum value (or None).
     """
 
     def __init__(
         self,
         message: str,
         original_error: Exception | None = None,
-        category: str = "unknown",
+        category: Any = None,
     ) -> None:
         super().__init__(message)
         self.original_error = original_error

--- a/traigent/utils/exceptions.py
+++ b/traigent/utils/exceptions.py
@@ -306,6 +306,28 @@ class CostLimitExceeded(TraigentError):
         self.limit = limit
 
 
+class VendorPauseError(TraigentError):
+    """Raised when a vendor error is classified as pause-worthy.
+
+    Re-raised from TrialLifecycle._execute_trial_with_tracing to signal the
+    orchestrator that the user should be prompted before continuing.
+
+    Attributes:
+        original_error: The underlying vendor exception.
+        category: Classified vendor error category string.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        original_error: Exception | None = None,
+        category: str = "unknown",
+    ) -> None:
+        super().__init__(message)
+        self.original_error = original_error
+        self.category = category
+
+
 class NetworkError(RetryableError):
     """Network-related error."""
 


### PR DESCRIPTION
## Summary

Closes #433. Two UX improvements for the optimization loop:

- **Pause-on-error**: Vendor rate limits, quota exhaustion, and service unavailability errors trigger interactive prompts (resume or stop). Budget cost limits also prompt to raise the limit or stop. Non-interactive environments auto-stop. Parallel mode detects batch-wide vendor failures post-batch.
- **Default progress bar**: `ProgressBarCallback` auto-enabled in interactive terminals. `progress_bar=True` forces in non-interactive mode. `progress_bar=False` suppresses.

## Design

- Injectable `PausePromptAdapter` protocol for testability
- Vendor errors re-raised as `VendorPauseError` from `TrialLifecycle._execute_trial_with_tracing()` before generic catch
- Budget pause triggers only on `cost_limit` stop reason (not `max_trials`/`max_samples`)
- `asyncio.to_thread()` wraps blocking `input()` in async loop
- Uses existing `StopReason` literal `"vendor_error"` (not a custom string)
- Shared `_resolve_callbacks()` helper for `optimize()` / `optimize_sync()` parity
- `VendorPauseError` exported from `traigent/__init__.py`

## Files changed

| File | Change |
|------|--------|
| `traigent/core/exception_handler.py` | **NEW** - error classification, prompt adapter protocol, terminal prompt |
| `traigent/utils/exceptions.py` | Add `VendorPauseError` (category stores enum, not string) |
| `traigent/core/trial_lifecycle.py` | Re-raise vendor errors before generic catch |
| `traigent/core/orchestrator.py` | Prompt adapter, vendor/budget pause handlers, parallel batch vendor check |
| `traigent/core/optimized_function.py` | `_resolve_callbacks()`, `progress_bar` param, docstring updates |
| `traigent/__init__.py` | Export `VendorPauseError` |
| `README.md` | Add error resilience + live progress to features, `progress_bar` to quick reference |
| `tests/unit/core/test_exception_handler.py` | **NEW** - 19 tests |
| `tests/unit/core/test_pause_on_error.py` | **NEW** - 8 tests |
| `tests/unit/core/test_default_progress_bar.py` | **NEW** - 8 tests |

## Review fixes applied

All findings from Greptile and Codex reviews addressed:
- C2: VendorPauseError.category stores VendorErrorCategory enum, not string
- C3: Budget pause only on cost_limit, not max_trials/max_samples
- C1: Post-batch vendor error check for parallel mode
- I1/I4: Removed duplicate budget pause from trial_lifecycle
- I2: Hardened float() parse with try/except
- I3: progress_bar=True forces injection in non-interactive mode
- I5: VendorPauseError exported from __init__.py
- Greptile: Use valid StopReason literal "vendor_error" (not "vendor_error_user_stop")

## Test plan

- [x] 35 new unit tests pass
- [x] 150 existing core/decorator tests pass (no regressions)
- [x] make format clean
- [x] ruff check clean (remaining UP038 are pre-existing)
- [x] Secret scan clean
- [x] SonarCloud Quality Gate passed (80% coverage on new code)
- [ ] CI full suite