### PR TITLE
fix: restore venv creation step in Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Our mission: **Anything you can measure, we can improve.** Whether it's accuracy
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git && cd Traigent
-python3 -m venv .venv && source .venv/bin/activate
+python3 -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e ".[recommended]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Our mission: **Anything you can measure, we can improve.** Whether it's accuracy
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git && cd Traigent
+python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"
 ```
 


### PR DESCRIPTION
## Summary
- Restore `python3 -m venv .venv && source .venv/bin/activate` line in Quick Install that was accidentally dropped in #420

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)