### PR TITLE
feat: walkthrough page, hello_world rename, rich results table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install -e ".[recommended]"
 
 ```bash
 export TRAIGENT_MOCK_LLM=true
-python hello.py
+python hello_world.py
 ```
 
 **One decorator, two parameters, multi-objective optimization:**

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ def my_agent(question: str) -> str:
   <a href="https://portal.traigent.ai">Portal</a> &middot;
   <a href="docs/getting-started/GETTING_STARTED.md">Quickstart</a> &middot;
   <a href="examples/">Examples</a> &middot;
-  <a href="docs/agent-skill.md">Skill</a>
+  <a href="docs/agent-skill.md">Skill</a> &middot;
+  <a href="walkthrough/mock/">Walkthrough</a>
 </p>
 
 ---
@@ -309,4 +310,4 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-**[Get Started →](docs/getting-started/GETTING_STARTED.md)** | **[Examples →](examples/)** | **[Portal →](https://portal.traigent.ai)** | **[Skill →](docs/agent-skill.md)** | **[GitHub Issues](https://github.com/Traigent/Traigent/issues)** | **[Discussions](https://github.com/Traigent/Traigent/discussions)**
+**[Get Started →](docs/getting-started/GETTING_STARTED.md)** | **[Examples →](examples/)** | **[Portal →](https://portal.traigent.ai)** | **[Skill →](docs/agent-skill.md)** | **[Walkthrough →](walkthrough/mock/)** | **[GitHub Issues](https://github.com/Traigent/Traigent/issues)** | **[Discussions](https://github.com/Traigent/Traigent/discussions)**

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ def my_agent(question: str) -> str:
   <a href="docs/getting-started/GETTING_STARTED.md">Quickstart</a> &middot;
   <a href="examples/">Examples</a> &middot;
   <a href="docs/agent-skill.md">Skill</a> &middot;
-  <a href="walkthrough/mock/">Walkthrough</a>
+  <a href="docs/walkthrough.md">Walkthrough</a>
 </p>
 
 ---
@@ -310,4 +310,4 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 ---
 
-**[Get Started →](docs/getting-started/GETTING_STARTED.md)** | **[Examples →](examples/)** | **[Portal →](https://portal.traigent.ai)** | **[Skill →](docs/agent-skill.md)** | **[Walkthrough →](walkthrough/mock/)** | **[GitHub Issues](https://github.com/Traigent/Traigent/issues)** | **[Discussions](https://github.com/Traigent/Traigent/discussions)**
+**[Get Started →](docs/getting-started/GETTING_STARTED.md)** | **[Examples →](examples/)** | **[Portal →](https://portal.traigent.ai)** | **[Skill →](docs/agent-skill.md)** | **[Walkthrough →](docs/walkthrough.md)** | **[GitHub Issues](https://github.com/Traigent/Traigent/issues)** | **[Discussions](https://github.com/Traigent/Traigent/discussions)**

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,0 +1,32 @@
+# Walkthrough — 8 Runnable Examples
+
+Step through Traigent's features with 8 progressive examples. All run in mock mode — no API keys, no cost.
+
+## Setup
+
+```bash
+export TRAIGENT_MOCK_LLM=true
+```
+
+## Steps
+
+| # | Run | What you'll learn |
+|---|-----|-------------------|
+| 1 | `python walkthrough/mock/01_tuning_qa.py` | Basic model + temperature optimization |
+| 2 | `python walkthrough/mock/02_zero_code_change.py` | Seamless mode — zero code changes to existing code |
+| 3 | `python walkthrough/mock/03_parameter_mode.py` | Explicit config access via `traigent.get_config()` |
+| 4 | `python walkthrough/mock/04_multi_objective.py` | Balance accuracy, cost, and latency |
+| 5 | `python walkthrough/mock/05_rag_parallel.py` | RAG optimization with parallel evaluation |
+| 6 | `python walkthrough/mock/06_custom_evaluator.py` | Define your own success metrics |
+| 7 | `python walkthrough/mock/07_multi_provider.py` | Compare OpenAI, Anthropic, Google in one run |
+| 8 | `python walkthrough/mock/08_privacy_modes.py` | Local-only privacy-first execution |
+
+## What to expect
+
+Each script prints trial results to the console. In mock mode, scores are random — the point is to see the full pipeline run without errors.
+
+When you're ready for real optimization, remove `TRAIGENT_MOCK_LLM` and set your API keys.
+
+## Browse source
+
+[walkthrough/mock/](../walkthrough/mock/)

--- a/hello_world.py
+++ b/hello_world.py
@@ -1,18 +1,24 @@
 """Find the best model and temperature for your task — in one decorator."""
 import asyncio
+import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent / "walkthrough"))
+
 import traigent
+from utils.helpers import print_results_table
 
 DATASET = str(Path(__file__).parent / "examples" / "datasets" / "quickstart" / "qa_samples.jsonl")
+OBJECTIVES = ["accuracy"]
+CONFIG_SPACE = {
+    "model": ["gpt-4o-mini", "gpt-4o"],
+    "temperature": [0.0, 0.7, 1.0],
+}
 
 
 @traigent.optimize(
-    configuration_space={
-        "model": ["gpt-4o-mini", "gpt-4o"],
-        "temperature": [0.0, 0.7, 1.0],
-    },
-    objectives=["accuracy"],
+    configuration_space=CONFIG_SPACE,
+    objectives=OBJECTIVES,
     eval_dataset=DATASET,
     execution_mode="edge_analytics",
 )
@@ -27,5 +33,4 @@ def answer(question: str) -> str:
 
 if __name__ == "__main__":
     result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))
-    print(f"Best config: {result.best_config}")
-    print(f"Best score:  {result.best_score:.2%}")
+    print_results_table(result, CONFIG_SPACE, OBJECTIVES, is_mock=True)

--- a/hello_world.py
+++ b/hello_world.py
@@ -3,7 +3,7 @@ import asyncio
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent / "walkthrough"))
+sys.path.append(str(Path(__file__).parent / "walkthrough"))
 
 import traigent
 from utils.helpers import print_results_table


### PR DESCRIPTION
## Summary
- Add `docs/walkthrough.md` landing page explaining the 8-step walkthrough with run commands
- Add Walkthrough link to README nav bar and footer
- Rename `hello.py` → `hello_world.py` (industry convention)
- `hello_world.py` now displays rich trial results table via `walkthrough/utils/helpers.py`

Closes #438

## Test plan
- [ ] `TRAIGENT_MOCK_LLM=true python hello_world.py` displays table
- [ ] README links render correctly
- [ ] `docs/walkthrough.md` links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)