### PR TITLE
fix: address PR review issues from #466 rename (compat shim + backend fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ sections/
 # But keep example site sections tracked
 !examples/sections/
 !examples/sections/**
-optigen_schema/
+traigent_schema/
 # C extensions
 *.so
 

--- a/docs/traceability/taxonomy_reference.md
+++ b/docs/traceability/taxonomy_reference.md
@@ -38,7 +38,7 @@ Use **exactly one** `CONC-Layer-*` tag per file.
 | `CONC-Layer-Core` | Optimization orchestration, objectives, lifecycle controllers. | `traigent/core/orchestrator.py`, `traigent/core/optimized_function.py` | C4 Component responsible for domain logic. |
 | `CONC-Layer-Integration` | External adapters, plugins, telemetry bridges. | `traigent/integrations/*` | C4 Components that connect to other systems. |
 | `CONC-Layer-Infra` | Cloud/hybrid plumbing, storage backends, network clients. | `traigent/cloud/backend_client.py`, `traigent/storage/local_storage.py` | Maps to C4 deployment/process views. |
-| `CONC-Layer-Data` | Schemas, TVL specs, dataset loaders, DTOs. | `traigent/tvl/spec_loader.py`, `optigen_schema/*` | Aligns with TOGAF Data domain. |
+| `CONC-Layer-Data` | Schemas, TVL specs, dataset loaders, DTOs. | `traigent/tvl/spec_loader.py`, `traigent_schema/*` | Aligns with TOGAF Data domain. |
 | `CONC-Layer-Tooling` | Scripts, trace analyzers, dev automation. | `docs/traceability/scripts/*`, `tools/traceability/*` | Tracks supporting software not shipped to end users. |
 | ~~`CONC-Layer-CrossCutting`~~ | **DEPRECATED** — Migrate to Infra (plumbing), Core (domain logic), or Data (metadata). See `taxonomy.yaml`. | — | Use decision tree; avoid catch-all buckets. |
 | ~~`CONC-Layer-Test`~~ | **DEPRECATED** — Tests remain untagged by convention. | `tests/*` | Only tag if explicitly approved. |

--- a/scripts/code_analysis/__init__.py
+++ b/scripts/code_analysis/__init__.py
@@ -1,1 +1,1 @@
-"""Code analysis tooling for OptiGenBackend."""
+"""Code analysis tooling for TraigentBackend."""

--- a/scripts/db/migrate_optuna.py
+++ b/scripts/db/migrate_optuna.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Apply Optuna migration scripts to the OptiGen database."""
+"""Apply Optuna migration scripts to the Traigent database."""
 
 from __future__ import annotations
 
@@ -19,13 +19,13 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Apply Optuna database migrations")
     parser.add_argument(
         "--database-url",
-        default=os.getenv("OPTIGEN_DATABASE_URL", "sqlite:///:memory:"),
+        default=os.getenv("TRAIGENT_DATABASE_URL", "sqlite:///:memory:"),
         help="Database connection URL",
     )
     parser.add_argument(
         "--migrations-dir",
         type=Path,
-        default=Path("optigen_schema/optuna_migrations"),
+        default=Path("traigent_schema/optuna_migrations"),
         help="Directory containing migration SQL files",
     )
     parser.add_argument(

--- a/scripts/integration/test-local-integration.py
+++ b/scripts/integration/test-local-integration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Local Integration Test Script for Traigent + OptiGen.
+"""Local Integration Test Script for Traigent + Traigent.
 
-This script tests the integration between Traigent SDK and the local OptiGen
+This script tests the integration between Traigent SDK and the local Traigent
 backend environment. It validates the complete flow from SDK configuration
 to data storage and retrieval.
 """
@@ -30,7 +30,7 @@ def print_status(message: str, status: str = "INFO") -> None:
 
 
 def check_backend_health() -> bool:
-    """Check if the local OptiGen backend is healthy and responding."""
+    """Check if the local Traigent backend is healthy and responding."""
     backend_url = os.environ.get("TRAIGENT_BACKEND_URL", "http://localhost:5000")
     try:
         print_status("Checking backend health...")
@@ -251,7 +251,7 @@ def run_integration_test() -> bool:
 def main():
     """Run all integration tests."""
     print("=" * 60)
-    print("🧪 Traigent + OptiGen Local Integration Test")
+    print("🧪 Traigent + Traigent Local Integration Test")
     print("=" * 60)
     print()
 

--- a/scripts/smoke/smoke_real_api_measures.py
+++ b/scripts/smoke/smoke_real_api_measures.py
@@ -9,7 +9,7 @@ This script:
 Env vars you can set:
 - OPENAI_API_KEY: API key for OpenAI (required for real metrics)
 - TRAIGENT_API_URL: Backend base URL if not default (optional)
-- DB_URL: Postgres URL (e.g., postgresql://user:pass@host:5432/optigen)
+- DB_URL: Postgres URL (e.g., postgresql://user:pass@host:5432/traigent)
 
 Usage:
   python scripts/smoke/smoke_real_api_measures.py
@@ -106,7 +106,7 @@ async def _run_optimization():
 
 async def _query_db():
     db_url = os.environ.get(
-        "DB_URL", "postgresql://localhost:5432/optigen"
+        "DB_URL", "postgresql://localhost:5432/traigent"
     )
     if not _ensure_asyncpg():
         print("asyncpg not installed; attempting psql fallback...")

--- a/scripts/utilities/check_measures.py
+++ b/scripts/utilities/check_measures.py
@@ -18,7 +18,7 @@ except ImportError:
         try:
             cmd = [
                 "psql",
-                os.environ.get("DB_URL", "postgresql://localhost:5432/optigen"),
+                os.environ.get("DB_URL", "postgresql://localhost:5432/traigent"),
                 "-c",
                 "SELECT id, name, created_at FROM experiments ORDER BY created_at DESC LIMIT 5",
             ]
@@ -29,7 +29,7 @@ except ImportError:
             # Also check configuration runs
             cmd2 = [
                 "psql",
-                os.environ.get("DB_URL", "postgresql://localhost:5432/optigen"),
+                os.environ.get("DB_URL", "postgresql://localhost:5432/traigent"),
                 "-c",
                 "SELECT id, score, jsonb_array_length(measures) as measure_count FROM configuration_runs ORDER BY created_at DESC LIMIT 5",
             ]
@@ -44,7 +44,7 @@ except ImportError:
     sys.exit(0)
 
 # Database connection parameters
-DB_URL = os.environ.get("DB_URL", "postgresql://localhost:5432/optigen")
+DB_URL = os.environ.get("DB_URL", "postgresql://localhost:5432/traigent")
 
 
 async def check_measures():

--- a/tests/CURRENT_ISSUES.json
+++ b/tests/CURRENT_ISSUES.json
@@ -1,6 +1,6 @@
 [
   {
-    "file": "tests/unit/test_optigen_integration.py",
+    "file": "tests/unit/test_traigent_integration.py",
     "test_name": "test_optimize_saas_invalid_poll_interval",
     "line": 768,
     "issue_type": "IT-NA"

--- a/tests/cloud/test_sync_manager.py
+++ b/tests/cloud/test_sync_manager.py
@@ -218,7 +218,7 @@ class TestSyncManager:
             sync_manager._session.post = original_post
 
     def test_convert_trials_to_results(self):
-        """Test converting local trials to OptiGen configuration_run format."""
+        """Test converting local trials to Traigent configuration_run format."""
         self.test_session = self._create_test_session()
         trials = self.test_session.trials
         results = self.sync_manager._convert_trials_to_results(trials)

--- a/tests/integration/backend/test_backend_minimal.py
+++ b/tests/integration/backend/test_backend_minimal.py
@@ -46,8 +46,8 @@ async def test_backend_api():
         dataset_size=100,
     )
 
-    # Validate DTO (optional) - skip if optigen_schemas not installed
-    # The validate() method requires optigen_schemas package
+    # Validate DTO (optional) - skip if traigent_schemas not installed
+    # The validate() method requires traigent_schemas package
     # In strict mode (default), it raises DTOSerializationError when unavailable
     import os
 

--- a/tests/integration/backend/test_dtos_simple.py
+++ b/tests/integration/backend/test_dtos_simple.py
@@ -46,7 +46,7 @@ def test_dtos():
     print(f"     - model_parameters_id: {exp.model_parameters_id}")
     print(f"   - Metadata: {exp.metadata}")
 
-    # Validate (optional) - skip if optigen_schemas not installed
+    # Validate (optional) - skip if traigent_schemas not installed
     # Set non-strict mode to avoid exceptions when validator unavailable
     os.environ.setdefault("TRAIGENT_STRICT_VALIDATION", "false")
     if hasattr(exp, "validate"):

--- a/tests/integration/backend/test_integration_summary.py
+++ b/tests/integration/backend/test_integration_summary.py
@@ -16,7 +16,7 @@ def print_integration_summary():
 
     print("\n📋 IMPLEMENTATION OVERVIEW:")
     print("-" * 60)
-    print("✅ Created comprehensive DTOs based on optigen_schemas")
+    print("✅ Created comprehensive DTOs based on traigent_schemas")
     print("✅ Implemented privacy-preserving defaults for Edge Analytics mode")
     print("✅ Updated BackendIntegratedClient to use DTOs")
     print("✅ Added schema validation (optional, non-blocking)")
@@ -109,7 +109,7 @@ def print_integration_summary():
 
     print("\n✅ VALIDATION:")
     print("-" * 60)
-    print("- DTOs can optionally validate against optigen_schemas")
+    print("- DTOs can optionally validate against traigent_schemas")
     print("- Validation is non-blocking (logs warnings only)")
     print("- All DTOs are JSON serializable")
     print("- Privacy constraints are enforced at DTO creation")
@@ -117,8 +117,8 @@ def print_integration_summary():
     print("\n🎯 KEY ACHIEVEMENT:")
     print("-" * 60)
     print("Successfully implemented privacy-preserving backend integration")
-    print("that submits metadata to OptiGen backend while keeping all")
-    print("sensitive data local, using proper DTOs based on optigen_schemas.")
+    print("that submits metadata to Traigent backend while keeping all")
+    print("sensitive data local, using proper DTOs based on traigent_schemas.")
 
     print("\n" + "=" * 60)
 

--- a/tests/integration/test_backend_integration.py
+++ b/tests/integration/test_backend_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for Traigent SDK and OptiGen Backend integration."""
+"""Integration tests for Traigent SDK and Traigent Backend integration."""
 
 import time
 from copy import deepcopy

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -1062,7 +1062,7 @@ class TestUpdateConfigRunMeasuresSuccess:
 
     @pytest.mark.asyncio
     async def test_measures_update_with_all_standard_metrics(self):
-        """Test measures update with all standard OptiGen metrics."""
+        """Test measures update with all standard Traigent metrics."""
         mock_response = AsyncMock()
         mock_response.status = 200
 

--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -1,6 +1,6 @@
 """Comprehensive tests for traigent.cloud.dtos module.
 
-Tests cover all Data Transfer Objects (DTOs) for OptiGen Backend Integration
+Tests cover all Data Transfer Objects (DTOs) for Traigent Backend Integration
 with focus on schema compliance, serialization, and edge cases.
 """
 

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -339,7 +339,7 @@ class TestSyncManager:
     def test_convert_trials_to_results(
         self, sync_manager: SyncManager, sample_session: OptimizationSession
     ) -> None:
-        """Test conversion of trials to OptiGen results format."""
+        """Test conversion of trials to Traigent results format."""
         results = sync_manager._convert_trials_to_results(sample_session.trials)
 
         assert len(results) == 3

--- a/tests/unit/cloud/test_validators.py
+++ b/tests/unit/cloud/test_validators.py
@@ -1,6 +1,6 @@
 """Unit tests for cloud validation functions.
 
-Tests for OptiGen Backend integration validation according to schema specifications.
+Tests for Traigent Backend integration validation according to schema specifications.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID REQ-CLOUD-009 SYNC-CloudHybrid

--- a/tests/unit/integrations/test_init_imports.py
+++ b/tests/unit/integrations/test_init_imports.py
@@ -79,7 +79,7 @@ class TestIntegrationsAvailability:
         """Test workflow traces exports are always available."""
         from traigent.integrations import (
             OTEL_AVAILABLE,
-            OptiGenSpanExporter,
+            TraigentSpanExporter,
             SpanPayload,
             SpanStatus,
             SpanType,

--- a/tests/unit/plugins/test_plugin_architecture.py
+++ b/tests/unit/plugins/test_plugin_architecture.py
@@ -462,7 +462,7 @@ class TestLazyImportModules:
             "traigent.agents.specification_generator",
             "traigent.agents.platforms",
             "traigent.optimizers.interactive_optimizer",
-            "traigent.optigen_integration",
+            "traigent.traigent_integration",
         ],
     )
     def test_module_imports_without_cloud(self, module_path: str):
@@ -721,14 +721,14 @@ class TestFeatureNotAvailableErrorGuards:
         from traigent.utils.exceptions import FeatureNotAvailableError
 
         error = FeatureNotAvailableError(
-            "OptiGen cloud integration",
+            "Traigent cloud integration",
             plugin_name="traigent-cloud",
             install_hint="pip install traigent[cloud]",
         )
 
         message = str(error)
         # Should contain the feature name
-        assert "OptiGen cloud integration" in message
+        assert "Traigent cloud integration" in message
         # Should contain install instructions
         assert "pip install" in message
 

--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -81,7 +81,7 @@ class TestProductionMCPClientBasics:
 
         self.server_config = MCPServerConfig(
             server_path="python",
-            server_args=["-m", "optigen_backend.mcp.server"],
+            server_args=["-m", "traigent_backend.mcp.server"],
             timeout=30.0,
             max_retries=3,
         )

--- a/tests/unit/test_traigent_client.py
+++ b/tests/unit/test_traigent_client.py
@@ -215,13 +215,13 @@ class TestCheckPrivacyRequirements:
     @patch("traigent.config.backend_config.BackendConfig")
     @patch("os.path.exists", return_value=True)
     @patch.dict("os.environ", {}, clear=True)
-    def test_privacy_with_optigen_private_file(
+    def test_privacy_with_traigent_private_file(
         self,
         mock_exists: MagicMock,
         mock_backend_config: MagicMock,
         mock_backend_client: MagicMock,
     ) -> None:
-        """Test privacy requirement detection with .optigen-private file."""
+        """Test privacy requirement detection with .traigent-private file."""
         mock_backend_config.get_api_key.return_value = "key"
         mock_backend_config.get_backend_url.return_value = "https://url"
 

--- a/tests/unit/utils/test_exceptions.py
+++ b/tests/unit/utils/test_exceptions.py
@@ -386,9 +386,9 @@ class TestServiceError:
 
     def test_create_with_service_name(self):
         """Test ServiceError with service name."""
-        error = ServiceError("Failed", service_name="OptiGen Backend")
+        error = ServiceError("Failed", service_name="Traigent Backend")
 
-        assert error.service_name == "OptiGen Backend"
+        assert error.service_name == "Traigent Backend"
 
     def test_create_with_endpoint(self):
         """Test ServiceError with endpoint."""

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -43,14 +43,14 @@ def _warn_if_unknown_status(
         )
 
 
-# Try to import optigen_schemas for validation (optional)
+# Try to import traigent_schemas for validation (optional)
 try:
-    from optigen_schemas.validator import SchemaValidator
+    from traigent_schemas.validator import SchemaValidator
 
     VALIDATOR_AVAILABLE = True
 except ImportError:
     VALIDATOR_AVAILABLE = False
-    logger.debug("optigen_schemas not available, validation disabled")
+    logger.debug("traigent_schemas not available, validation disabled")
 
 
 class ExampleMeasure:
@@ -396,7 +396,7 @@ class ExperimentDTO:
         return result
 
     def validate(self) -> bool:
-        """Validate the DTO against optigen_schemas.
+        """Validate the DTO against traigent_schemas.
 
         By default, validation is strict - failures raise exceptions.
         Set TRAIGENT_STRICT_VALIDATION=false to make validation non-blocking.
@@ -416,7 +416,7 @@ class ExperimentDTO:
 
         if not VALIDATOR_AVAILABLE:
             error_msg = (
-                "Schema validator unavailable (optigen_schemas not installed). "
+                "Schema validator unavailable (traigent_schemas not installed). "
                 "Install with: pip install 'traigent[validation]'"
             )
             logger.error(error_msg)

--- a/traigent/cloud/integration_manager.py
+++ b/traigent/cloud/integration_manager.py
@@ -141,7 +141,7 @@ class IntegrationManager:
             if self.config.mcp_server_args is None:
                 self.config.mcp_server_args = [
                     "-m",
-                    "optigen_backend.mcp.server",
+                    "traigent_backend.mcp.server",
                     "--host",
                     "localhost",
                     "--port",

--- a/traigent/cloud/integration_manager.py
+++ b/traigent/cloud/integration_manager.py
@@ -139,9 +139,16 @@ class IntegrationManager:
 
             # Initialize MCP client
             if self.config.mcp_server_args is None:
+                # Prefer traigent_backend; fall back to optigen_backend during rename transition
+                import importlib.util
+                _backend_module = (
+                    "traigent_backend.mcp.server"
+                    if importlib.util.find_spec("traigent_backend") is not None
+                    else "optigen_backend.mcp.server"
+                )
                 self.config.mcp_server_args = [
                     "-m",
-                    "traigent_backend.mcp.server",
+                    _backend_module,
                     "--host",
                     "localhost",
                     "--port",

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -864,9 +864,16 @@ def get_production_mcp_client(
     if _production_client is None:
         # Default server args for Traigent Backend MCP
         if server_args is None:
+            # Prefer traigent_backend; fall back to optigen_backend during rename transition
+            import importlib.util
+            _backend_module = (
+                "traigent_backend.mcp.server"
+                if importlib.util.find_spec("traigent_backend") is not None
+                else "optigen_backend.mcp.server"
+            )
             server_args = [
                 "-m",
-                "traigent_backend.mcp.server",
+                _backend_module,
                 "--host",
                 "localhost",
                 "--port",

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -866,7 +866,7 @@ def get_production_mcp_client(
         if server_args is None:
             server_args = [
                 "-m",
-                "optigen_backend.mcp.server",
+                "traigent_backend.mcp.server",
                 "--host",
                 "localhost",
                 "--port",

--- a/traigent/integrations/__init__.py
+++ b/traigent/integrations/__init__.py
@@ -366,7 +366,7 @@ except ImportError:
 # Workflow traces integration (always available - graceful degradation for OTEL)
 from .observability.workflow_traces import (
     OTEL_AVAILABLE,
-    OptiGenSpanExporter,
+    TraigentSpanExporter,
     SpanPayload,
     SpanStatus,
     SpanType,
@@ -412,7 +412,7 @@ __all__.extend(
         "TraceIngestionRequest",
         "TraceIngestionResponse",
         "WorkflowTracesClient",
-        "OptiGenSpanExporter",
+        "TraigentSpanExporter",
         "WorkflowTracesTracker",
         "create_workflow_tracker",
         "setup_workflow_tracing",

--- a/traigent/integrations/observability/__init__.py
+++ b/traigent/integrations/observability/__init__.py
@@ -39,7 +39,7 @@ except ImportError:
 # Workflow traces integration
 from traigent.integrations.observability.workflow_traces import (
     OTEL_AVAILABLE,
-    OptiGenSpanExporter,
+    TraigentSpanExporter,
     SpanPayload,
     SpanStatus,
     SpanType,
@@ -87,7 +87,7 @@ __all__ = [
     "TraceIngestionRequest",
     "TraceIngestionResponse",
     "WorkflowTracesClient",
-    "OptiGenSpanExporter",
+    "TraigentSpanExporter",
     "WorkflowTracesTracker",
     "create_workflow_tracker",
     "setup_workflow_tracing",

--- a/traigent/integrations/observability/workflow_traces.py
+++ b/traigent/integrations/observability/workflow_traces.py
@@ -23,8 +23,8 @@ Usage:
         # Execute LangGraph workflow
         result = app.invoke(inputs)
 
-For OpenTelemetry integration, use OptiGenSpanExporter:
-    exporter = OptiGenSpanExporter(backend_url, auth_token)
+For OpenTelemetry integration, use TraigentSpanExporter:
+    exporter = TraigentSpanExporter(backend_url, auth_token)
     provider.add_span_processor(BatchSpanProcessor(exporter))
 """
 
@@ -887,7 +887,7 @@ class WorkflowTracesClient:
 
 if OTEL_AVAILABLE:
 
-    class OptiGenSpanExporter(SpanExporter):
+    class TraigentSpanExporter(SpanExporter):
         """OpenTelemetry span exporter that sends traces to the Traigent backend.
 
         This exporter integrates with the OpenTelemetry SDK to automatically
@@ -898,7 +898,7 @@ if OTEL_AVAILABLE:
             from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
             provider = TracerProvider()
-            exporter = OptiGenSpanExporter(
+            exporter = TraigentSpanExporter(
                 backend_url="http://backend:5000",
                 auth_token="your_token"
             )
@@ -912,7 +912,7 @@ if OTEL_AVAILABLE:
             auth_token: str | None = None,
             configuration_run_id_getter: Any | None = None,
         ) -> None:
-            """Initialize the OptiGen span exporter.
+            """Initialize the Traigent span exporter.
 
             Args:
                 backend_url: Base URL of the backend
@@ -1069,12 +1069,12 @@ if OTEL_AVAILABLE:
 
 else:
     # Stub class when OpenTelemetry is not available
-    class OptiGenSpanExporter:  # type: ignore[no-redef]
-        """Stub for OptiGenSpanExporter when OpenTelemetry is not available."""
+    class TraigentSpanExporter:  # type: ignore[no-redef]
+        """Stub for TraigentSpanExporter when OpenTelemetry is not available."""
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             raise ImportError(
-                "OpenTelemetry is required for OptiGenSpanExporter. "
+                "OpenTelemetry is required for TraigentSpanExporter. "
                 "Install with: pip install opentelemetry-sdk"
             )
 
@@ -1499,8 +1499,8 @@ def create_workflow_tracker(
 def setup_workflow_tracing(
     backend_url: str | None = None,
     auth_token: str | None = None,
-) -> OptiGenSpanExporter | None:
-    """Set up OpenTelemetry tracing with the OptiGen exporter.
+) -> TraigentSpanExporter | None:
+    """Set up OpenTelemetry tracing with the Traigent exporter.
 
     This function configures OpenTelemetry to automatically capture
     and export spans to the Traigent backend.
@@ -1510,7 +1510,7 @@ def setup_workflow_tracing(
         auth_token: Auth token (defaults to env var)
 
     Returns:
-        OptiGenSpanExporter instance if OTEL is available, None otherwise
+        TraigentSpanExporter instance if OTEL is available, None otherwise
     """
     if not OTEL_AVAILABLE:
         logger.warning(
@@ -1524,7 +1524,7 @@ def setup_workflow_tracing(
     resolved_url = backend_url or os.environ.get(
         "TRAIGENT_BACKEND_URL", "http://localhost:5000"
     )
-    exporter = OptiGenSpanExporter(
+    exporter = TraigentSpanExporter(
         backend_url=resolved_url,  # type: ignore[arg-type]
         auth_token=auth_token,
     )
@@ -1560,7 +1560,7 @@ __all__ = [
     # Client
     "WorkflowTracesClient",
     # OpenTelemetry
-    "OptiGenSpanExporter",
+    "TraigentSpanExporter",
     "OTEL_AVAILABLE",
     # High-Level API
     "WorkflowTracesTracker",

--- a/traigent/traigent_integration.py
+++ b/traigent/traigent_integration.py
@@ -2,21 +2,21 @@
 
 .. deprecated:: 2.0.0
     This module is deprecated. Use :mod:`traigent.traigent_client` instead.
-    The ``TraigentClient`` class has been renamed to ``TraigentClient``.
+    The ``OptiGenClient`` class has been renamed to ``TraigentClient``.
 """
 
 import warnings
 
 from traigent.traigent_client import TraigentClient
 
-# Backward compatibility alias
-TraigentClient = TraigentClient
+# Backward compatibility alias (OptiGenClient → TraigentClient)
+OptiGenClient = TraigentClient
 
 warnings.warn(
-    "traigent.traigent_integration is deprecated. "
-    "Use traigent.traigent_client and TraigentClient instead.",
+    "traigent.traigent_integration is a compatibility shim and is deprecated. "
+    "Import directly from traigent.traigent_client instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["TraigentClient", "TraigentClient"]
+__all__ = ["OptiGenClient", "TraigentClient"]

--- a/traigent/traigent_integration.py
+++ b/traigent/traigent_integration.py
@@ -2,7 +2,7 @@
 
 .. deprecated:: 2.0.0
     This module is deprecated. Use :mod:`traigent.traigent_client` instead.
-    The ``OptiGenClient`` class has been renamed to ``TraigentClient``.
+    The ``TraigentClient`` class has been renamed to ``TraigentClient``.
 """
 
 import warnings
@@ -10,13 +10,13 @@ import warnings
 from traigent.traigent_client import TraigentClient
 
 # Backward compatibility alias
-OptiGenClient = TraigentClient
+TraigentClient = TraigentClient
 
 warnings.warn(
-    "traigent.optigen_integration is deprecated. "
+    "traigent.traigent_integration is deprecated. "
     "Use traigent.traigent_client and TraigentClient instead.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["OptiGenClient", "TraigentClient"]
+__all__ = ["TraigentClient", "TraigentClient"]

--- a/walkthrough/mock/advanced/05_langgraph_multiagent_demo.py
+++ b/walkthrough/mock/advanced/05_langgraph_multiagent_demo.py
@@ -625,7 +625,7 @@ async def main() -> None:
             print(f"  Failed to send graph: {response.error}")
 
         # Note: Per-agent spans are automatically recorded via OpenTelemetry
-        # and exported to the Traigent backend by the OptiGenSpanExporter.
+        # and exported to the Traigent backend by the TraigentSpanExporter.
         # No manual span creation needed - OTEL handles it during workflow execution.
         print("\n" + "-" * 50)
         print("Note: Per-agent spans automatically recorded via OpenTelemetry")


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #466 (optigen → traigent rename), addressing Greptile P1/P2 review findings.

## Fixes

**`traigent/traigent_integration.py`** (compat shim was broken by the rename):
- Restored `OptiGenClient = TraigentClient` compat alias (was accidentally renamed to a no-op self-assignment)
- Fixed docstring: now correctly reads "OptiGenClient → TraigentClient"
- Fixed duplicate `__all__` — restored `["OptiGenClient", "TraigentClient"]`
- Clarified deprecation warning to point users to `traigent.traigent_client`

**`traigent/cloud/integration_manager.py` + `production_mcp_client.py`** (runtime safety):
- Added `importlib.util.find_spec` check: prefers `traigent_backend.mcp.server` when installed, falls back to `optigen_backend.mcp.server` during the backend rename transition window
- Prevents `ModuleNotFoundError` in environments where the backend hasn't been renamed yet

Closes review comments on #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)