### PR TITLE
Fix SDK defaults and documented inline dataset inputs

### DIFF
--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -381,7 +381,7 @@ from traigent.api.decorators import EvaluationOptions
 
 **EvaluationOptions Fields**:
 
-- `eval_dataset`: Dataset path, list of paths, or Dataset instance
+- `eval_dataset`: Dataset path, list of paths, inline example list, or Dataset instance
 - `custom_evaluator`: Custom evaluation function
 - `scoring_function`: Custom scoring function
 - `metric_functions`: Dict of metric name to evaluator functions

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -65,8 +65,8 @@ results = asyncio.run(qa_agent.optimize(max_trials=4))
 
 What this does:
 
-- `qa_agent.eval_dataset` can be a JSONL path, a list of JSONL paths, or a
-  `Dataset` object.
+- `qa_agent.eval_dataset` can be a JSONL path, a list of JSONL paths, an inline
+  list of example dicts, or a `Dataset` object.
 - Traigent evaluates the dataset outside your function. Your function still accepts
   one example's `input_data` fields as normal arguments.
 - To swap evaluation sets between runs, assign a new value to

--- a/docs/installation-guide-offline.md
+++ b/docs/installation-guide-offline.md
@@ -59,11 +59,11 @@ Set these before running optimizations:
 
 ```bash
 # LLM provider key (at least one required for real optimization)
-export OPENAI_API_KEY="sk-..."
-export ANTHROPIC_API_KEY="sk-ant-..."
+export OPENAI_API_KEY="sk-..." # pragma: allowlist secret
+export ANTHROPIC_API_KEY="sk-ant-..." # pragma: allowlist secret
 
 # Traigent platform (optional — for tracking results in the portal)
-export TRAIGENT_API_KEY="your-api-key"
+export TRAIGENT_API_KEY="your-api-key" # pragma: allowlist secret
 export TRAIGENT_BACKEND_URL="https://portal.traigent.ai"
 ```
 
@@ -76,6 +76,10 @@ For **mock/dry-run mode** (no LLM calls, no API keys needed), no environment var
 Create `test_traigent.py`:
 
 ```python
+import os
+
+os.environ["TRAIGENT_MOCK_LLM"] = "true"
+
 import traigent
 from traigent import Range, Choices
 
@@ -100,7 +104,7 @@ def answer(query: str) -> str:
     return response.choices[0].message.content
 
 # Mock mode — validates the full pipeline without making LLM calls
-results = answer.optimize(max_trials=3, mock=True)
+results = answer.optimize(max_trials=3)
 print("Best config:", results.best_config)
 ```
 

--- a/tests/integration/test_documented_input_formats.py
+++ b/tests/integration/test_documented_input_formats.py
@@ -1,0 +1,95 @@
+"""Smoke tests for documented optimize() input formats."""
+
+from __future__ import annotations
+
+import pytest
+
+import traigent
+from traigent import Choices, Range
+from traigent.api.decorators import EvaluationOptions
+
+
+def _answer_question(query: str) -> str:
+    answers = {
+        "What is Python?": "A programming language",
+        "What is 2+2?": "4",
+        "Capital of France?": "Paris",
+    }
+    return answers[query]
+
+
+class TestDocumentedInputFormats:
+    """Verify documented decorator input forms run end-to-end in mock mode."""
+
+    @pytest.fixture
+    def inline_examples(self) -> list[dict[str, object]]:
+        return [
+            {
+                "input": {"query": "What is Python?"},
+                "expected": "A programming language",
+            },
+            {"input": {"query": "What is 2+2?"}, "expected": "4"},
+            {"input": {"query": "Capital of France?"}, "expected": "Paris"},
+        ]
+
+    def test_offline_quickstart_inline_dataset_smoke(
+        self, monkeypatch, inline_examples
+    ) -> None:
+        """The offline guide's inline dataset example should optimize successfully."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+        @traigent.optimize(
+            eval_dataset=inline_examples,
+            model=Choices(["gpt-4o-mini", "gpt-4o"]),
+            temperature=Range(0.0, 1.0),
+            objectives=["accuracy"],
+        )
+        def answer(query: str) -> str:
+            return _answer_question(query)
+
+        result = answer.optimize_sync(max_trials=3)
+
+        assert len(result.trials) == 3
+        assert result.best_config is not None
+
+    @pytest.mark.parametrize(
+        "evaluation",
+        [
+            pytest.param(
+                {
+                    "eval_dataset": [
+                        {"input": {"query": "What is 2+2?"}, "expected": "4"},
+                        {"input": {"query": "Capital of France?"}, "expected": "Paris"},
+                    ]
+                },
+                id="dict-bundle",
+            ),
+            pytest.param(
+                EvaluationOptions(
+                    eval_dataset=[
+                        {"input": {"query": "What is 2+2?"}, "expected": "4"},
+                        {"input": {"query": "Capital of France?"}, "expected": "Paris"},
+                    ]
+                ),
+                id="model-bundle",
+            ),
+        ],
+    )
+    def test_evaluation_bundle_inline_dataset_smoke(
+        self, monkeypatch, evaluation
+    ) -> None:
+        """Grouped evaluation options should preserve the documented inline dataset form."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+        @traigent.optimize(
+            evaluation=evaluation,
+            configuration_space={"model": ["gpt-4o-mini", "gpt-4o"]},
+            objectives=["accuracy"],
+        )
+        def answer(query: str) -> str:
+            return _answer_question(query)
+
+        result = answer.optimize_sync(max_trials=2)
+
+        assert len(result.trials) == 2
+        assert result.best_config is not None

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -439,6 +439,71 @@ class TestOptimizedFunctionIntegration:
 
         assert isinstance(func3, OptimizedFunction)
 
+        # Inline example dicts
+        inline_examples = [
+            {"input": {"question": "What is 2+2?"}, "expected": "4"},
+            {"input": {"question": "Capital of France?"}, "expected": "Paris"},
+        ]
+
+        @optimize(eval_dataset=inline_examples, configuration_space={"x": [1, 2, 3]})
+        def func4(x):
+            return x
+
+        assert isinstance(func4, OptimizedFunction)
+        assert func4.eval_dataset == inline_examples
+
+    def test_evaluation_bundle_accepts_inline_examples(self):
+        """Evaluation bundle should accept inline datasets in both supported forms."""
+        from traigent.api.decorators import EvaluationOptions
+
+        inline_examples = [
+            {"input": {"question": "What is 2+2?"}, "expected": "4"},
+            {"input_data": {"question": "Capital of France?"}, "expected_output": "Paris"},
+        ]
+
+        @optimize(
+            evaluation={"eval_dataset": inline_examples},
+            configuration_space={"x": [1, 2, 3]},
+        )
+        def func_dict_bundle(x):
+            return x
+
+        @optimize(
+            evaluation=EvaluationOptions(eval_dataset=inline_examples),
+            configuration_space={"x": [1, 2, 3]},
+        )
+        def func_model_bundle(x):
+            return x
+
+        assert isinstance(func_dict_bundle, OptimizedFunction)
+        assert isinstance(func_model_bundle, OptimizedFunction)
+        assert func_dict_bundle.eval_dataset == inline_examples
+        assert func_model_bundle.eval_dataset == inline_examples
+
+    def test_mock_and_legacy_parameter_variations(self):
+        """Grouped mock options and legacy bridge inputs should decorate cleanly."""
+        from traigent.api.decorators import LegacyOptimizeArgs, MockModeOptions
+
+        @optimize(
+            configuration_space={"x": [1, 2, 3]},
+            mock=MockModeOptions(enabled=True, override_evaluator=False),
+            legacy=LegacyOptimizeArgs(objectives=["accuracy"]),
+        )
+        def func_with_models(x):
+            return x
+
+        @optimize(
+            configuration_space={"x": [1, 2, 3]},
+            legacy={"objectives": ["accuracy"], "algorithm": "grid"},
+        )
+        def func_with_legacy_dict(x):
+            return x
+
+        assert isinstance(func_with_models, OptimizedFunction)
+        assert isinstance(func_with_legacy_dict, OptimizedFunction)
+        assert func_with_models.mock_mode_config["override_evaluator"] is False
+        assert func_with_legacy_dict.algorithm == "grid"
+
     def test_injection_modes(self):
         """Test different injection modes."""
 

--- a/tests/unit/api/test_parameter_validator.py
+++ b/tests/unit/api/test_parameter_validator.py
@@ -109,18 +109,6 @@ class TestParameterValidator:
                 {"input": {"question": "What is 2+2?"}, "expected": "4"},
                 {"input_data": {"question": "Capital of France?"}, "expected_output": "Paris"},
             ],
-            [
-                Dataset(
-                    examples=[
-                        EvaluationExample(
-                            input_data="prompt",
-                            expected_output="response",
-                            metadata={},
-                        )
-                    ],
-                    name="single",
-                )
-            ],
         ]
 
         for dataset_list in valid_lists:
@@ -128,24 +116,20 @@ class TestParameterValidator:
             result = self.validator._validate_dataset(dataset_list)
             assert result is None, "Expected None for valid dataset list"
 
-    def test_validate_dataset_sequence_with_dataset_objects(self):
-        """Dataset iterables can contain Dataset instances."""
-        dataset = Dataset(
-            examples=[
-                EvaluationExample(
-                    input_data="prompt",
-                    expected_output="answer",
-                    metadata={"source": "unit-test"},
-                )
-            ],
-            name="example",
+    def test_validate_dataset_sequence_with_inline_examples(self):
+        """Dataset iterables can contain inline dict and EvaluationExample objects."""
+        inline_example = EvaluationExample(
+            input_data="prompt",
+            expected_output="answer",
+            metadata={"source": "unit-test"},
         )
 
-        # Should accept tuples and mixed entries containing Dataset objects
-        result1 = self.validator._validate_dataset((dataset,))
-        result2 = self.validator._validate_dataset(["path.jsonl", dataset])
-        assert result1 is None, "Expected None for tuple with Dataset"
-        assert result2 is None, "Expected None for mixed list with Dataset"
+        result1 = self.validator._validate_dataset((inline_example,))
+        result2 = self.validator._validate_dataset(
+            [{"input": {"question": "What is 2+2?"}, "expected": "4"}]
+        )
+        assert result1 is None, "Expected None for tuple with EvaluationExample"
+        assert result2 is None, "Expected None for inline example list"
 
     def test_validate_dataset_invalid_list(self):
         """Test validation of invalid dataset lists."""
@@ -153,12 +137,17 @@ class TestParameterValidator:
             [123, "test.jsonl"],  # Mixed types
             [None, "test.jsonl"],  # None in list
             ["test.jsonl", 456],  # Mixed types
+            [
+                "test.jsonl",
+                {"input": {"question": "What is 2+2?"}, "expected": "4"},
+            ],  # Mixed file path + inline example
         ]
 
         for invalid_list in invalid_lists:
             with pytest.raises(ValidationError) as exc_info:
                 self.validator._validate_dataset(invalid_list)
-            assert "inline example dicts" in str(exc_info.value)
+            error_message = str(exc_info.value)
+            assert "inline example" in error_message or "cannot mix file paths" in error_message
 
     def test_validate_objectives_valid(self):
         """Test validation of valid objectives."""

--- a/tests/unit/api/test_parameter_validator.py
+++ b/tests/unit/api/test_parameter_validator.py
@@ -106,6 +106,10 @@ class TestParameterValidator:
             ["/path/to/data1.jsonl"],
             ["a.json", "b.json", "c.json"],
             [
+                {"input": {"question": "What is 2+2?"}, "expected": "4"},
+                {"input_data": {"question": "Capital of France?"}, "expected_output": "Paris"},
+            ],
+            [
                 Dataset(
                     examples=[
                         EvaluationExample(
@@ -154,7 +158,7 @@ class TestParameterValidator:
         for invalid_list in invalid_lists:
             with pytest.raises(ValidationError) as exc_info:
                 self.validator._validate_dataset(invalid_list)
-            assert "must contain only string paths" in str(exc_info.value)
+            assert "inline example dicts" in str(exc_info.value)
 
     def test_validate_objectives_valid(self):
         """Test validation of valid objectives."""
@@ -575,11 +579,11 @@ class TestDatasetValidationEdgeCases:
         """Test validation of completely invalid dataset type."""
         with pytest.raises(ValidationError) as exc_info:
             self.validator._validate_dataset(123)
-        assert "must be a string path" in str(exc_info.value)
+        assert "inline example list" in str(exc_info.value)
 
         with pytest.raises(ValidationError) as exc_info:
             self.validator._validate_dataset({"key": "value"})
-        assert "must be a string path" in str(exc_info.value)
+        assert "inline example list" in str(exc_info.value)
 
 
 class TestConfigurationSpaceEdgeCases:

--- a/tests/unit/cloud/test_dataset_converter_validation.py
+++ b/tests/unit/cloud/test_dataset_converter_validation.py
@@ -3,6 +3,7 @@
 import pytest
 
 from traigent.cloud.dataset_converter import DatasetConverter
+from traigent.config.backend_config import DEFAULT_CLOUD_URL
 
 
 class TestDatasetConverterValidation:
@@ -22,7 +23,9 @@ class TestDatasetConverterValidation:
             )
 
         with pytest.raises(ValueError):
-            DatasetConverter(backend_base_url="https://user:pass@example.com")
+            DatasetConverter(
+                backend_base_url="https://user:pass@example.com"  # pragma: allowlist secret
+            )
 
         with pytest.raises(ValueError):
             DatasetConverter(backend_base_url="https://api.example.com/../admin")
@@ -34,6 +37,11 @@ class TestDatasetConverterValidation:
         """Valid backend URLs should be normalized."""
         converter = DatasetConverter(backend_base_url="https://api.example.com/base/")
         assert converter.backend_base_url == "https://api.example.com/base"
+
+    def test_backend_base_url_defaults_to_cloud(self):
+        """Default constructor should use the cloud backend, not localhost."""
+        converter = DatasetConverter()
+        assert converter.backend_base_url == DEFAULT_CLOUD_URL
 
     def test_validate_example_set_id_allows_uuid(self):
         """Example set identifiers should accept UUIDs and trim whitespace."""

--- a/tests/unit/core/optimized_function_tests/test_dataset_loading.py
+++ b/tests/unit/core/optimized_function_tests/test_dataset_loading.py
@@ -12,10 +12,7 @@ from traigent.core.optimized_function import OptimizedFunction
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.utils.exceptions import ConfigurationError
 
-from .test_fixtures import (
-    create_dataset_file,
-    create_test_dataset,
-)
+from .test_fixtures import create_dataset_file, create_test_dataset
 
 
 class TestDatasetLoading:
@@ -98,10 +95,10 @@ class TestDatasetLoading:
     def test_load_dataset_from_list(
         self, simple_function, sample_config_space, sample_objectives
     ):
-        """Test error when trying to load dataset from list of dicts (unsupported)."""
+        """Inline example dicts should load as a Dataset."""
         examples = [
-            {"input_data": {"text": "hello"}, "expected_output": "HELLO"},
-            {"input_data": {"text": "world"}, "expected_output": "WORLD"},
+            {"input": {"text": "hello"}, "expected": "HELLO"},
+            {"input": {"text": "world"}, "expected": "WORLD"},
         ]
 
         opt_func = OptimizedFunction(
@@ -111,14 +108,16 @@ class TestDatasetLoading:
             eval_dataset=examples,
         )
 
-        # Should raise ConfigurationError for unsupported list of dicts
-        with pytest.raises(ConfigurationError, match="Failed to load dataset"):
-            opt_func._load_dataset()
+        loaded_dataset = opt_func._load_dataset()
+        assert isinstance(loaded_dataset, Dataset)
+        assert len(loaded_dataset) == 2
+        assert loaded_dataset[0].input_data == {"text": "hello"}
+        assert loaded_dataset[0].expected_output == "HELLO"
 
     def test_load_dataset_from_evaluation_examples(
         self, simple_function, sample_config_space, sample_objectives
     ):
-        """Test error when trying to load dataset from EvaluationExample list (unsupported)."""
+        """EvaluationExample lists should load as a Dataset."""
         examples = [
             EvaluationExample(input_data={"text": "test1"}, expected_output="TEST1"),
             EvaluationExample(input_data={"text": "test2"}, expected_output="TEST2"),
@@ -131,9 +130,11 @@ class TestDatasetLoading:
             eval_dataset=examples,
         )
 
-        # Should raise ConfigurationError for unsupported EvaluationExample list
-        with pytest.raises(ConfigurationError, match="Failed to load dataset"):
-            opt_func._load_dataset()
+        loaded_dataset = opt_func._load_dataset()
+        assert isinstance(loaded_dataset, Dataset)
+        assert len(loaded_dataset) == 2
+        assert loaded_dataset[1].input_data == {"text": "test2"}
+        assert loaded_dataset[1].expected_output == "TEST2"
 
     def test_load_dataset_invalid_type(
         self, simple_function, sample_config_space, sample_objectives

--- a/tests/unit/integrations/observability/test_workflow_traces.py
+++ b/tests/unit/integrations/observability/test_workflow_traces.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from traigent.config.backend_config import DEFAULT_CLOUD_URL
 from traigent.integrations.observability import workflow_traces as wt_module
 from traigent.integrations.observability.workflow_traces import (
     SpanPayload,
@@ -678,6 +679,16 @@ class TestWorkflowTracesTracker:
         assert tracker.backend_url == "http://test:5000"
         assert tracker.auto_send is True
         assert tracker.batch_size == 100
+
+    def test_init_defaults_to_cloud_when_env_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default tracker backend should be cloud-first, not localhost."""
+        monkeypatch.delenv("TRAIGENT_BACKEND_URL", raising=False)
+
+        tracker = WorkflowTracesTracker()
+
+        assert tracker.backend_url == DEFAULT_CLOUD_URL
 
     def test_init_with_params(self) -> None:
         """Test initialization with custom parameters."""

--- a/tests/unit/utils/test_local_analytics.py
+++ b/tests/unit/utils/test_local_analytics.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 
 from traigent.api.types import OptimizationStatus
+from traigent.config.backend_config import DEFAULT_CLOUD_URL
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.storage.local_storage import LocalStorageManager, OptimizationSession
 from traigent.utils.local_analytics import (
@@ -96,6 +97,7 @@ class TestLocalAnalyticsInitialization:
         analytics = LocalAnalytics(config)
 
         assert analytics.analytics_endpoint == DEFAULT_ANALYTICS_ENDPOINT
+        assert analytics.analytics_endpoint == f"{DEFAULT_CLOUD_URL}/v1/local-usage"
 
     def test_initialization_with_provided_user_id(self, temp_storage_path: str) -> None:
         """Test initialization uses provided anonymous user ID."""
@@ -454,7 +456,7 @@ class TestCollectUsageStats:
                 total_trials=10,
                 completed_trials=10,
                 metadata={
-                    "api_key": "secret-key-123",
+                    "api_key": "secret-key-123",  # pragma: allowlist secret
                     "user_email": "user@example.com",
                 },
             ),

--- a/tests/unit/utils/test_validation.py
+++ b/tests/unit/utils/test_validation.py
@@ -1,5 +1,6 @@
 """Tests for validation utilities."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,27 @@ class TestValidatePath:
 
         assert not result.is_valid
         assert any(error.error_code == "SECURITY_ERROR" for error in result.errors)
+
+
+class TestValidateDataset:
+    """Tests for Validators.validate_dataset."""
+
+    def test_validate_dataset_accepts_jsonl_input_data_alias(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        dataset_path = tmp_path / "inline_alias.jsonl"
+        dataset_path.write_text(
+            json.dumps(
+                {"input_data": {"question": "What is 2+2?"}, "expected_output": "4"}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TRAIGENT_DATASET_ROOT", str(tmp_path))
+
+        result = Validators.validate_dataset(str(dataset_path))
+
+        assert result.is_valid
 
     def test_validate_path_symlink_escaping_base(self, tmp_path: Path) -> None:
         allowed_base = tmp_path / "workspace"

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -9,7 +9,7 @@ Usage:
     >>> from traigent.analytics import ExampleInsightsClient
     >>>
     >>> # Initialize client (requires backend authentication)
-    >>> client = ExampleInsightsClient(backend_url="http://localhost:5000")
+    >>> client = ExampleInsightsClient(backend_url="https://portal.traigent.ai")
     >>>
     >>> # Trigger scoring computation (async job)
     >>> job_result = await client.compute_scores(experiment_run_id="run_123")

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -80,7 +80,7 @@ from traigent.core.objectives import (
     normalize_objectives,
 )
 from traigent.core.optimized_function import OptimizedFunction
-from traigent.evaluators.base import Dataset
+from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.tvl.options import TVLOptions
 from traigent.tvl.promotion_gate import PromotionGate
 from traigent.tvl.spec_loader import TVLSpecArtifact, load_tvl_spec
@@ -95,7 +95,9 @@ class EvaluationOptions(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
-    eval_dataset: str | list[str] | Dataset | None = None
+    eval_dataset: (
+        str | list[str | dict[str, Any] | EvaluationExample] | Dataset | None
+    ) = None
     custom_evaluator: Callable[..., Any] | None = None
     scoring_function: Callable[..., Any] | None = None
     metric_functions: dict[str, Callable[..., Any]] | None = None
@@ -418,7 +420,9 @@ def get_optimize_default(parameter_name: str) -> Any:
 class LegacyOptimizeArgs:
     """Container for legacy optimize() arguments."""
 
-    eval_dataset: str | list[str] | Dataset | None = None
+    eval_dataset: (
+        str | list[str | dict[str, Any] | EvaluationExample] | Dataset | None
+    ) = None
     objectives: list[str] | ObjectiveSchema | None = None
     configuration_space: dict[str, Any] | None = None
     default_config: dict[str, Any] | None = None
@@ -1670,8 +1674,9 @@ def optimize(  # NOSONAR(S107)
             evaluation: Grouped evaluation settings (EvaluationOptions or dict). Use
                 this bundle to supply datasets and evaluators together. When present
                 it replaces the individual arguments historically passed directly.
-            eval_dataset: Dataset input accepted as a JSONL path, list of paths, or
-                Dataset instance with ``input`` and ``expected_output`` columns.
+            eval_dataset: Dataset input accepted as a JSONL path, list of paths,
+                inline example dicts, or a Dataset instance with ``input`` and
+                ``expected_output`` columns.
             custom_evaluator: Callback ``(func, config, example) -> ExampleResult``.
             scoring_function: Evaluator ``(output, expected, llm_metrics)``.
             metric_functions: Mapping of metric name to evaluator functions.

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -194,11 +194,11 @@ def initialize(  # noqa: C901
         # Cloud mode with explicit URL
         traigent.initialize(
             api_key=os.getenv("TRAIGENT_API_KEY"),  # Use env var
-            api_url="http://localhost:5000"
+            api_url="https://portal.traigent.ai"
         )
 
         # Using environment variables (recommended)
-        # export TRAIGENT_BACKEND_URL="http://localhost:5000"
+        # export TRAIGENT_BACKEND_URL="https://portal.traigent.ai"
         # export TRAIGENT_API_KEY="your-key-here"  # pragma: allowlist secret
         traigent.initialize()
     """

--- a/traigent/api/parameter_validator.py
+++ b/traigent/api/parameter_validator.py
@@ -23,7 +23,7 @@ class OptimizeParameters:
     """Structured representation of optimize decorator parameters."""
 
     eval_dataset: (
-        str | list[str | Dataset | EvaluationExample | dict[str, Any]] | None
+        str | list[str | EvaluationExample | dict[str, Any]] | Dataset | None
     ) = None
     objectives: list[str] | None = None
     configuration_space: dict[str, Any] | None = None
@@ -118,7 +118,7 @@ class ParameterValidator:
     def _validate_dataset(
         self,
         eval_dataset: (
-            str | list[str | Dataset | EvaluationExample | dict[str, Any]] | None
+            str | list[str | EvaluationExample | dict[str, Any]] | Dataset | None
         ),
     ) -> None:
         """Validate evaluation dataset parameter."""
@@ -132,12 +132,9 @@ class ParameterValidator:
             eval_dataset, (str, bytes)
         ):
             invalid_entries = [
-                entry for entry in eval_dataset if not isinstance(entry, (str, Dataset))
-            ]
-            invalid_entries = [
                 entry
-                for entry in invalid_entries
-                if not isinstance(entry, (EvaluationExample, Mapping))
+                for entry in eval_dataset
+                if not isinstance(entry, (str, EvaluationExample, Mapping))
             ]
             if invalid_entries:
                 invalid_types = ", ".join(
@@ -145,8 +142,18 @@ class ParameterValidator:
                 )
                 raise ValidationError(
                     "eval_dataset iterable must contain only string paths, inline example dicts, "
-                    "EvaluationExample objects, or Dataset objects. "
+                    "or EvaluationExample objects. "
                     f"Invalid entries of types: {invalid_types}"
+                )
+
+            has_paths = any(isinstance(entry, str) for entry in eval_dataset)
+            has_inline_examples = any(
+                isinstance(entry, (EvaluationExample, Mapping))
+                for entry in eval_dataset
+            )
+            if has_paths and has_inline_examples:
+                raise ValidationError(
+                    "eval_dataset list cannot mix file paths with inline example objects"
                 )
             return
 

--- a/traigent/api/parameter_validator.py
+++ b/traigent/api/parameter_validator.py
@@ -7,12 +7,12 @@ Traceability: CONC-Layer-API CONC-Quality-Reliability CONC-Quality-Usability CON
 """
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import MISSING, dataclass, field, fields
 from typing import Any
 
 from traigent.config.types import ExecutionMode, InjectionMode, resolve_execution_mode
-from traigent.evaluators.base import Dataset
+from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.utils.exceptions import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 class OptimizeParameters:
     """Structured representation of optimize decorator parameters."""
 
-    eval_dataset: str | list[str | Dataset] | None = None
+    eval_dataset: (
+        str | list[str | Dataset | EvaluationExample | dict[str, Any]] | None
+    ) = None
     objectives: list[str] | None = None
     configuration_space: dict[str, Any] | None = None
     default_config: dict[str, Any] | None = None
@@ -113,7 +115,12 @@ class ParameterValidator:
                 f"Must be one of: {[mode.value for mode in self.VALID_INJECTION_MODES]}"
             )
 
-    def _validate_dataset(self, eval_dataset: str | list[str | Dataset] | None) -> None:
+    def _validate_dataset(
+        self,
+        eval_dataset: (
+            str | list[str | Dataset | EvaluationExample | dict[str, Any]] | None
+        ),
+    ) -> None:
         """Validate evaluation dataset parameter."""
         if eval_dataset is None:
             return
@@ -127,18 +134,24 @@ class ParameterValidator:
             invalid_entries = [
                 entry for entry in eval_dataset if not isinstance(entry, (str, Dataset))
             ]
+            invalid_entries = [
+                entry
+                for entry in invalid_entries
+                if not isinstance(entry, (EvaluationExample, Mapping))
+            ]
             if invalid_entries:
                 invalid_types = ", ".join(
                     sorted({type(entry).__name__ for entry in invalid_entries})
                 )
                 raise ValidationError(
-                    "eval_dataset iterable must contain only string paths or Dataset objects. "
+                    "eval_dataset iterable must contain only string paths, inline example dicts, "
+                    "EvaluationExample objects, or Dataset objects. "
                     f"Invalid entries of types: {invalid_types}"
                 )
             return
 
         raise ValidationError(
-            "eval_dataset must be a string path, list of paths, or Dataset object"
+            "eval_dataset must be a string path, list of paths, inline example list, or Dataset object"
         )
 
     def _validate_objectives(self, objectives: list[str] | None) -> None:

--- a/traigent/cloud/dataset_converter.py
+++ b/traigent/cloud/dataset_converter.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlparse
 
+from traigent.config.backend_config import DEFAULT_CLOUD_URL
+
 # Optional dependency for HTTP client
 try:
     import aiohttp
@@ -76,14 +78,16 @@ class ExampleSetMetadata:
 class DatasetConverter:
     """Converter between SDK datasets and backend example sets."""
 
-    def __init__(self, backend_base_url: str = "http://localhost:5000") -> None:
+    def __init__(self, backend_base_url: str | None = None) -> None:
         """Initialize dataset converter.
 
         Args:
-            backend_base_url: Backend API base URL. Must use http(s) scheme without
-                embedded credentials, query parameters, or fragments.
+            backend_base_url: Backend API base URL. Defaults to the configured
+                cloud backend. Must use http(s) scheme without embedded
+                credentials, query parameters, or fragments.
         """
-        self.backend_base_url = self._validate_backend_base_url(backend_base_url)
+        resolved_backend_url = backend_base_url or DEFAULT_CLOUD_URL
+        self.backend_base_url = self._validate_backend_base_url(resolved_backend_url)
         self._session: aiohttp.ClientSession | None = None
 
     async def __aenter__(self):

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -61,7 +61,12 @@ from traigent.core.optimization_pipeline import (
     resolve_execution_parameters,
 )
 from traigent.core.orchestrator import OptimizationOrchestrator
-from traigent.evaluators.base import BaseEvaluator, Dataset
+from traigent.evaluators.base import (
+    BaseEvaluator,
+    Dataset,
+    EvaluationExample,
+    load_inline_dataset,
+)
 from traigent.integrations.framework_override import override_context
 from traigent.optimizers import get_optimizer
 from traigent.tvl.options import TVLOptions
@@ -199,7 +204,9 @@ class OptimizedFunction:
     def __init__(
         self,
         func: Callable[..., Any],
-        eval_dataset: str | list[str] | Dataset | None = None,
+        eval_dataset: (
+            str | list[str | dict[str, Any] | EvaluationExample] | Dataset | None
+        ) = None,
         objectives: list[str] | ObjectiveSchema | None = None,
         configuration_space: dict[str, Any] | None = None,
         config_space: dict[str, Any] | None = None,  # Backward compatibility
@@ -221,7 +228,7 @@ class OptimizedFunction:
 
         Args:
             func: Original function to optimize
-            eval_dataset: Evaluation dataset path(s) or Dataset object
+            eval_dataset: Evaluation dataset path(s), inline examples, or Dataset object
             objectives: List of objectives to optimize or ObjectiveSchema
             configuration_space: Parameter search space
             default_config: Default configuration values
@@ -784,16 +791,31 @@ class OptimizedFunction:
 
     def _validate_dataset(self) -> None:
         """Validate dataset configuration."""
-        if isinstance(self.eval_dataset, (str, list)):
+        if isinstance(self.eval_dataset, str):
             # Skip dataset validation in tests when the file doesn't exist
             if not (
                 os.environ.get("PYTEST_CURRENT_TEST")
-                or (
-                    isinstance(self.eval_dataset, str)
-                    and self.eval_dataset in ["test.jsonl", "data.jsonl"]
-                )
+                or self.eval_dataset in ["test.jsonl", "data.jsonl"]
             ):
                 validate_dataset_path(self.eval_dataset)
+            return
+
+        if isinstance(self.eval_dataset, list):
+            if all(isinstance(item, str) for item in self.eval_dataset):
+                if not os.environ.get("PYTEST_CURRENT_TEST"):
+                    validate_dataset_path(self.eval_dataset)
+                return
+
+            if all(
+                isinstance(item, (dict, EvaluationExample))
+                for item in self.eval_dataset
+            ):
+                load_inline_dataset(self.eval_dataset)
+                return
+
+            raise ConfigurationError(
+                "eval_dataset list must contain only dataset paths or inline examples"
+            )
 
     def _setup_function_wrapper(self) -> None:
         """Setup function wrapper that uses current configuration."""
@@ -2064,21 +2086,37 @@ class OptimizedFunction:
                 ) from e
 
         elif isinstance(self.eval_dataset, list):
-            # Multiple datasets - combine them
-            all_examples = []
-            for path in self.eval_dataset:
+            if all(isinstance(item, str) for item in self.eval_dataset):
+                # Multiple datasets - combine them
+                all_examples = []
+                for path in self.eval_dataset:
+                    try:
+                        dataset = Dataset.from_jsonl(path)
+                        all_examples.extend(dataset.examples)
+                    except Exception as e:
+                        raise ConfigurationError(
+                            f"Failed to load dataset from {path}: {e}"
+                        ) from e
+
+                return Dataset(
+                    examples=all_examples,
+                    name="combined_dataset",
+                    description=f"Combined dataset from {len(self.eval_dataset)} files",
+                )
+
+            if all(
+                isinstance(item, (dict, EvaluationExample))
+                for item in self.eval_dataset
+            ):
                 try:
-                    dataset = Dataset.from_jsonl(path)
-                    all_examples.extend(dataset.examples)
+                    return load_inline_dataset(self.eval_dataset)
                 except Exception as e:
                     raise ConfigurationError(
-                        f"Failed to load dataset from {path}: {e}"
+                        f"Failed to load inline dataset: {e}"
                     ) from e
 
-            return Dataset(
-                examples=all_examples,
-                name="combined_dataset",
-                description=f"Combined dataset from {len(self.eval_dataset)} files",
+            raise ConfigurationError(
+                "eval_dataset list must contain only dataset paths or inline examples"
             )
 
         else:

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -413,7 +413,9 @@ def _coerce_dataset_example_mapping(
         input_key = "input_data"
 
     if input_key is None:
-        raise ValidationError(f"Missing 'input' field in {location} in {source}")
+        raise ValidationError(
+            f"Missing 'input' (or 'input_data') field in {location} in {source}"
+        )
 
     expected_key = next(
         (candidate for candidate in _EXPECTED_OUTPUT_FIELDS if candidate in item),

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from collections.abc import Mapping
 from collections.abc import Mapping as CollectionsMapping
+from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -289,17 +290,15 @@ def _parse_jsonl_examples(resolved_path: Path, source: str) -> list[EvaluationEx
                         f"Invalid JSON on line {line_num} in {source}: {exc}"
                     ) from exc
 
-                if "input" not in data:
-                    raise ValidationError(
-                        f"Missing 'input' field on line {line_num} in {source}"
-                    )
-
+                input_data, expected_output, metadata = _coerce_dataset_example_mapping(
+                    data,
+                    source=source,
+                    location=f"line {line_num}",
+                )
                 example = EvaluationExample(
-                    input_data=data["input"],
-                    expected_output=data.get("output"),
-                    metadata={
-                        k: v for k, v in data.items() if k not in {"input", "output"}
-                    },
+                    input_data=input_data,
+                    expected_output=expected_output,
+                    metadata=metadata,
                 )
                 examples.append(example)
     except ValidationError:
@@ -359,16 +358,15 @@ def _parse_json_dataset(
         raise ValidationError(f"JSON must be array or object in {source}")
 
     for index, item in iterable:
-        if not isinstance(item, dict):
-            raise ValidationError(f"Example {index} must be an object in {source}")
-        if "input" not in item:
-            raise ValidationError(
-                f"Missing 'input' field in example {index} in {source}"
-            )
+        input_data, expected_output, metadata = _coerce_dataset_example_mapping(
+            item,
+            source=source,
+            location=f"example {index}",
+        )
         example = EvaluationExample(
-            input_data=item["input"],
-            expected_output=item.get("output"),
-            metadata={k: v for k, v in item.items() if k not in {"input", "output"}},
+            input_data=input_data,
+            expected_output=expected_output,
+            metadata=metadata,
         )
         examples.append(example)
 
@@ -386,6 +384,49 @@ class EvaluationExample:
     def __post_init__(self) -> None:
         if self.metadata is None:
             self.metadata: dict[str, Any] = {}
+
+
+_EXPECTED_OUTPUT_FIELDS = (
+    "output",
+    "expected",
+    "expected_output",
+    "answer",
+    "target",
+    "label",
+)
+
+
+def _coerce_dataset_example_mapping(
+    item: Any,
+    *,
+    source: str,
+    location: str,
+) -> tuple[Any, Any | None, dict[str, Any]]:
+    """Normalize a mapping-backed dataset example."""
+    if not isinstance(item, CollectionsMapping):
+        raise ValidationError(f"{location} must be an object in {source}")
+
+    input_key: str | None = None
+    if "input" in item:
+        input_key = "input"
+    elif "input_data" in item:
+        input_key = "input_data"
+
+    if input_key is None:
+        raise ValidationError(f"Missing 'input' field in {location} in {source}")
+
+    expected_key = next(
+        (candidate for candidate in _EXPECTED_OUTPUT_FIELDS if candidate in item),
+        None,
+    )
+
+    metadata_keys = {input_key}
+    if expected_key is not None:
+        metadata_keys.add(expected_key)
+
+    metadata = {k: v for k, v in item.items() if k not in metadata_keys}
+    expected_output = item.get(expected_key) if expected_key is not None else None
+    return item[input_key], expected_output, metadata
 
 
 @dataclass
@@ -477,6 +518,37 @@ class Dataset:
         if not isinstance(example, EvaluationExample):
             raise TypeError("Example must be an EvaluationExample instance")
         self.examples.append(example)
+
+
+def load_inline_dataset(
+    examples: Sequence[EvaluationExample | CollectionsMapping[str, Any]],
+) -> Dataset:
+    """Build a Dataset from inline example objects used directly in code."""
+    normalized_examples: list[EvaluationExample] = []
+
+    for index, item in enumerate(examples):
+        if isinstance(item, EvaluationExample):
+            normalized_examples.append(item)
+            continue
+
+        input_data, expected_output, metadata = _coerce_dataset_example_mapping(
+            item,
+            source="inline dataset",
+            location=f"example {index}",
+        )
+        normalized_examples.append(
+            EvaluationExample(
+                input_data=input_data,
+                expected_output=expected_output,
+                metadata=metadata,
+            )
+        )
+
+    return Dataset(
+        examples=normalized_examples,
+        name="inline_dataset",
+        description="Dataset created from inline examples",
+    )
 
 
 @dataclass

--- a/traigent/integrations/observability/workflow_traces.py
+++ b/traigent/integrations/observability/workflow_traces.py
@@ -44,6 +44,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from traigent.config.backend_config import BackendConfig
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -1121,13 +1122,16 @@ class WorkflowTracesTracker:
         """Initialize the workflow traces tracker.
 
         Args:
-            backend_url: Base URL of the backend (defaults to env var TRAIGENT_BACKEND_URL)
+            backend_url: Base URL of the backend (defaults to env var
+                TRAIGENT_BACKEND_URL or the configured cloud backend)
             auth_token: Bearer token for authentication (defaults to env var TRAIGENT_API_TOKEN)
             auto_send: Automatically send spans at end of trial context
             batch_size: Number of spans to batch before sending
         """
-        self.backend_url = backend_url or os.environ.get(
-            "TRAIGENT_BACKEND_URL", "http://localhost:5000"
+        self.backend_url = (
+            backend_url
+            or os.environ.get("TRAIGENT_BACKEND_URL")
+            or BackendConfig.get_cloud_backend_url()
         )
         self.auth_token = (
             auth_token
@@ -1521,8 +1525,10 @@ def setup_workflow_tracing(
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-    resolved_url = backend_url or os.environ.get(
-        "TRAIGENT_BACKEND_URL", "http://localhost:5000"
+    resolved_url = (
+        backend_url
+        or os.environ.get("TRAIGENT_BACKEND_URL")
+        or BackendConfig.get_cloud_backend_url()
     )
     exporter = TraigentSpanExporter(
         backend_url=resolved_url,  # type: ignore[arg-type]

--- a/traigent/utils/local_analytics.py
+++ b/traigent/utils/local_analytics.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from traigent.api.types import OptimizationStatus
+from traigent.config.backend_config import DEFAULT_CLOUD_URL
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.storage.local_storage import LocalStorageManager
 
@@ -32,7 +33,7 @@ except ModuleNotFoundError:
 logger = logging.getLogger(__name__)
 
 # Default analytics endpoint (deprecated - will use backend client instead)
-DEFAULT_ANALYTICS_ENDPOINT = "http://localhost:5000/v1/local-usage"
+DEFAULT_ANALYTICS_ENDPOINT = f"{DEFAULT_CLOUD_URL}/v1/local-usage"
 _BACKGROUND_ANALYTICS_TASKS: set[asyncio.Task[Any]] = set()
 
 

--- a/traigent/utils/validation.py
+++ b/traigent/utils/validation.py
@@ -948,10 +948,10 @@ class Validators:
 
                             try:
                                 data = json.loads(line.strip())
-                                if "input" not in data:
+                                if "input" not in data and "input_data" not in data:
                                     result.add_error(
                                         f"dataset:line{line_num}",
-                                        "Missing 'input' field",
+                                        "Missing 'input' or 'input_data' field",
                                         error_code="INVALID_FORMAT",
                                     )
                             except json.JSONDecodeError:

--- a/traigent/utils/validation.py
+++ b/traigent/utils/validation.py
@@ -873,7 +873,37 @@ class Validators:
         """Validate dataset file or path."""
         result = ValidationResult()
 
+        from traigent.evaluators.base import (
+            Dataset,
+            EvaluationExample,
+            load_inline_dataset,
+        )
+
+        if isinstance(dataset_path, Dataset):
+            return result
+
         if isinstance(dataset_path, list):
+            if all(
+                isinstance(item, (dict, EvaluationExample)) for item in dataset_path
+            ):
+                try:
+                    load_inline_dataset(dataset_path)
+                except ValidationException as exc:
+                    result.add_error(
+                        "dataset",
+                        str(exc),
+                        error_code="INVALID_FORMAT",
+                    )
+                return result
+
+            if not all(isinstance(item, (str, Path)) for item in dataset_path):
+                result.add_error(
+                    "dataset",
+                    "Dataset list entries must all be file paths or inline example objects",
+                    error_code="TYPE_ERROR",
+                )
+                return result
+
             # Multiple datasets
             for i, path in enumerate(dataset_path):
                 path_result = Validators.validate_path(
@@ -886,7 +916,7 @@ class Validators:
                 )
                 result.errors.extend(path_result.errors)
                 result.warnings.extend(path_result.warnings)
-        else:
+        elif isinstance(dataset_path, (str, Path)):
             # Single dataset
             resolved_dataset_path = Path(dataset_path)
             path_result = Validators.validate_path(
@@ -944,6 +974,12 @@ class Validators:
                         f"Could not read dataset: {str(e)}",
                         error_code="READ_ERROR",
                     )
+        else:
+            result.add_error(
+                "dataset",
+                f"Expected dataset path, inline example list, or Dataset object, got {type(dataset_path).__name__}",
+                error_code="TYPE_ERROR",
+            )
 
         return result
 

--- a/walkthrough/mock/advanced/04_workflow_traces_demo.py
+++ b/walkthrough/mock/advanced/04_workflow_traces_demo.py
@@ -11,7 +11,7 @@ no backend is reachable.
 
 Run with: python 04_workflow_traces_demo.py
 
-Uses TRAIGENT_BACKEND_URL from .env (or defaults to http://localhost:5000)
+Uses TRAIGENT_BACKEND_URL from .env (or defaults to the configured cloud backend)
 """
 
 import os
@@ -28,6 +28,8 @@ except ImportError:  # pragma: no cover - optional convenience import
 
 
 load_dotenv()  # Loads .env from current directory or parent directories
+
+from traigent.config.backend_config import BackendConfig
 
 # Import workflow traces components
 from traigent.integrations.observability.workflow_traces import (
@@ -244,7 +246,10 @@ def main() -> None:
     print("=" * 50)
 
     # Get backend URL and auth token (uses same env vars as rest of SDK)
-    backend_url = os.environ.get("TRAIGENT_BACKEND_URL", "http://localhost:5000")
+    backend_url = (
+        os.environ.get("TRAIGENT_BACKEND_URL")
+        or BackendConfig.get_cloud_backend_url()
+    )
     auth_token = os.environ.get("TRAIGENT_API_KEY")
     print(f"\nBackend URL: {backend_url}")
     print(f"Auth token: {'set' if auth_token else 'NOT SET (will fail with 401)'}")
@@ -258,7 +263,7 @@ def main() -> None:
 
     # Use experiment ID from env var or generate a placeholder UUID
     # To use a real experiment, set DEMO_EXPERIMENT_ID to an ID from your backend:
-    #   curl -H "X-API-Key: $TRAIGENT_API_KEY" http://localhost:5000/api/v1/experiments
+    #   curl -H "X-API-Key: $TRAIGENT_API_KEY" https://portal.traigent.ai/api/v1/experiments
     experiment_id = os.environ.get(
         "DEMO_EXPERIMENT_ID", uuid.uuid4().hex
     )

--- a/walkthrough/mock/advanced/05_langgraph_multiagent_demo.py
+++ b/walkthrough/mock/advanced/05_langgraph_multiagent_demo.py
@@ -64,6 +64,7 @@ except ImportError as exc:  # pragma: no cover - dependency guidance
     ) from exc
 
 import traigent
+from traigent.config.backend_config import BackendConfig
 from traigent.integrations.observability.workflow_traces import (
     SpanType,
     WorkflowEdge,
@@ -567,7 +568,10 @@ async def main() -> None:
     print("=" * 50)
 
     # Check environment
-    backend_url = os.environ.get("TRAIGENT_BACKEND_URL", "http://localhost:5000")
+    backend_url = (
+        os.environ.get("TRAIGENT_BACKEND_URL")
+        or BackendConfig.get_cloud_backend_url()
+    )
     api_key = os.environ.get("TRAIGENT_API_KEY")
     openai_key = os.environ.get("OPENAI_API_KEY")
 

--- a/walkthrough/mock/advanced/06_unified_platform_campaign_copilot.py
+++ b/walkthrough/mock/advanced/06_unified_platform_campaign_copilot.py
@@ -45,6 +45,7 @@ except ImportError:  # pragma: no cover - optional convenience import
 
 import traigent
 from traigent import TraigentConfig
+from traigent.config.backend_config import BackendConfig
 from traigent.integrations.observability.workflow_traces import (
     WorkflowEdge,
     WorkflowGraphPayload,
@@ -447,7 +448,10 @@ async def main() -> None:
     print()
 
     api_key = os.environ.get("TRAIGENT_API_KEY")
-    backend_url = os.environ.get("TRAIGENT_BACKEND_URL", "http://localhost:5000")
+    backend_url = (
+        os.environ.get("TRAIGENT_BACKEND_URL")
+        or BackendConfig.get_cloud_backend_url()
+    )
     offline_mode = os.environ.get("TRAIGENT_OFFLINE_MODE", "").lower() == "true"
 
     print(f"Dataset: {DATASET_PATH}")

--- a/walkthrough/utils/helpers.py
+++ b/walkthrough/utils/helpers.py
@@ -11,6 +11,7 @@ from functools import reduce
 from typing import TYPE_CHECKING
 
 import traigent
+from traigent.config.backend_config import BackendConfig
 
 if TYPE_CHECKING:
     from typing import Any
@@ -57,11 +58,10 @@ def print_estimated_time(example_name: str) -> None:
 
 
 def configure_logging() -> None:
-    """Configure Traigent logging and default local backend for walkthrough/real."""
-    # Walkthrough real scripts are local-first examples; avoid accidental cloud host fallback.
+    """Configure Traigent logging and cloud-first backend defaults for walkthroughs."""
     os.environ.setdefault("TRAIGENT_ENV", "development")
-    os.environ.setdefault("TRAIGENT_BACKEND_URL", "http://localhost:5000")
-    os.environ.setdefault("TRAIGENT_API_URL", "http://localhost:5000")
+    os.environ.setdefault("TRAIGENT_BACKEND_URL", BackendConfig.get_cloud_backend_url())
+    os.environ.setdefault("TRAIGENT_API_URL", BackendConfig.get_cloud_api_url())
 
     log_level = os.getenv("TRAIGENT_LOG_LEVEL", "WARNING").upper()
     traigent.configure(logging_level=log_level)


### PR DESCRIPTION
## Summary
- remove remaining end-user-facing localhost defaults from SDK and walkthrough code paths
- support documented inline `eval_dataset` inputs end-to-end, including grouped `evaluation` options
- add focused smoke/regression coverage for the offline quickstart and documented input forms

## Issues
- Closes #457
- Closes #463

## Validation
- `python3 -m pytest -q -o addopts='' tests/unit/cloud/test_dataset_converter_validation.py tests/unit/utils/test_local_analytics.py tests/unit/integrations/observability/test_workflow_traces.py`
- `python3 -m pytest -q -o addopts='' tests/unit/core/optimized_function_tests/test_dataset_loading.py tests/unit/api/test_parameter_validator.py tests/unit/api/test_decorators.py tests/integration/test_documented_input_formats.py`
- plain Python smoke run outside pytest with `PYTEST_CURRENT_TEST` cleared for direct inline `eval_dataset=[{...}]` and `evaluation=EvaluationOptions(...)`
