### PR TITLE
docs: add 'Using it in your own code' section separator in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ export TRAIGENT_MOCK_LLM=true
 python hello.py
 ```
 
+---
+
+## Using it in your own code
+
 **One decorator, two parameters, multi-objective optimization:**
 
 ```python


### PR DESCRIPTION
## Summary
- Adds a `---` horizontal rule and `## Using it in your own code` heading before the `@traigent.optimize` decorator example in the README
- Creates a clear visual break between the "run this to try it" quick-start and the "adapt it to your project" guidance

Closes #475

## Test plan
- [ ] Verify the README renders correctly on GitHub with the new separator and heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)