### PR TITLE
fix: remove keyring usage to prevent macOS Keychain prompts

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -297,11 +297,7 @@ withCredentials([string(credentialsId: 'traigent-api-key', variable: 'TRAIGENT_A
    - Never commit credentials to code
    - Use secure secret management
 
-4. **Enable Keyring When Possible**
-   - Provides OS-level security
-   - Better than file storage
-
-5. **Monitor Authentication Events**
+4. **Monitor Authentication Events**
    - Check audit logs for suspicious activity
    - Review failed authentication attempts
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -119,27 +119,21 @@ Unified authentication leverages the shared `CredentialManager` to look for cred
 
 The discovery order is:
 - System environment variable (`TRAIGENT_API_KEY`)
-- CLI-managed credentials saved via `traigent auth login` (keyring or encrypted file)
+- CLI-managed credentials saved via `traigent auth login` (local credentials file)
 - Development defaults only when explicit test flags are enabled
 
 If nothing is found, the CLI will prompt you during `traigent auth login`; the SDK expects explicit configuration or environment variables.
 
 ## Credential Storage
 
-Credentials are stored securely using multiple layers:
+Credentials are stored using file-based storage with restricted permissions:
 
-### 1. System Keyring (Most Secure)
-- Uses OS-native credential storage
-- macOS: Keychain
-- Windows: Credential Manager
-- Linux: Secret Service/KWallet
-
-### 2. Local File (Fallback)
+### 1. Local File
 - Location: `~/.traigent/credentials.json`
 - Permissions: 0600 (user read/write only)
-- Contents are JSON-encoded (no additional encryption)
+- Contents are JSON-encoded
 
-### 3. Environment Variables
+### 2. Environment Variables
 - `TRAIGENT_API_KEY`
 - Useful for CI/CD environments
 
@@ -253,16 +247,6 @@ traigent auth refresh
 Or switch to API keys (recommended):
 ```bash
 traigent auth login  # Generates API key automatically
-```
-
-### No Keyring Available
-
-If keyring is not available, credentials are stored in:
-- `~/.traigent/credentials.json` (with 0600 permissions)
-
-To install keyring support:
-```bash
-pip install keyring
 ```
 
 ## CI/CD Integration

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -142,7 +142,7 @@
     Provide secure credential storage, encryption utilities, JWT validation, rate limiting,
     audit logging, tenant isolation, and security headers suitable for enterprise use.
   acceptance_criteria:
-    - Credentials encrypted or stored in OS keyrings; secure comparison avoids leaks.
+    - Credentials stored in permission-restricted local files; secure comparison avoids leaks.
     - JWT validator enforces issuer/audience/expiry and derives defaults safely.
     - Rate limiters and audit loggers can be configured per deployment mode/tenant.
   tags: [security, auth, compliance]

--- a/docs/traceability/concepts/security.yml
+++ b/docs/traceability/concepts/security.yml
@@ -37,7 +37,7 @@ actions:
         fields:
           - name: location
             type: "str"
-    description: "Encrypt and store credentials in keyring or secure files; mask values in logs."
+    description: "Store credentials in secure files with restricted permissions; mask values in logs."
   - name: enforce_rate_limit
     inputs:
       - name: identity

--- a/docs/traceability/requirements.yml
+++ b/docs/traceability/requirements.yml
@@ -142,7 +142,7 @@
     Provide secure credential storage, encryption utilities, JWT validation, rate limiting,
     audit logging, tenant isolation, and security headers suitable for enterprise use.
   acceptance_criteria:
-    - Credentials encrypted or stored in OS keyrings; secure comparison avoids leaks.
+    - Credentials stored in permission-restricted local files; secure comparison avoids leaks.
     - JWT validator enforces issuer/audience/expiry and derives defaults safely.
     - Rate limiters and audit loggers can be configured per deployment mode/tenant.
   tags: [security, auth, compliance]

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -94,15 +94,11 @@ class TraigentAuthCLI:
             Storage location string if saved successfully, None if failed
         """
         try:
-            self.credentials_file.parent.mkdir(
-                mode=0o700, parents=True, exist_ok=True
-            )
+            self.credentials_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
             with open(self.credentials_file, "w") as f:
                 json.dump(credentials, f, indent=2)
             self.credentials_file.chmod(0o600)
-            logger.debug(
-                f"Credentials saved to {self.credentials_file}"
-            )
+            logger.debug(f"Credentials saved to {self.credentials_file}")
             return STORAGE_FILE
         except OSError as e:
             logger.error(f"Failed to save credentials: {e}")
@@ -516,27 +512,7 @@ class TraigentAuthCLI:
 
     def _display_storage_location(self, storage_location: str | None) -> None:
         """Display where credentials are stored."""
-        if storage_location == STORAGE_KEYRING:
-            console.print("\n[bold]Credentials stored in:[/bold] System Keyring")
-            import platform
-
-            system = platform.system()
-            if system == "Darwin":
-                console.print(
-                    "  [dim]View in: Keychain Access app → search 'traigent-sdk'[/dim]"
-                )
-                console.print(
-                    "  [dim]Or run:[/dim] [cyan]security find-generic-password -s traigent-sdk -a default -w | python -m json.tool[/cyan]"
-                )
-            elif system == "Windows":
-                console.print(
-                    "  [dim]View in: Control Panel → Credential Manager → 'traigent-sdk'[/dim]"
-                )
-            else:
-                console.print(
-                    "  [dim]View in: Seahorse/KWallet → search 'traigent-sdk'[/dim]"
-                )
-        elif storage_location == STORAGE_FILE:
+        if storage_location == STORAGE_FILE:
             console.print(
                 f"\n[bold]Credentials stored in:[/bold] [cyan]{self.credentials_file}[/cyan]"
             )
@@ -544,7 +520,7 @@ class TraigentAuthCLI:
                 f"  [dim]View with:[/dim] [cyan]cat {self.credentials_file}[/cyan]"
             )
         else:
-            console.print("\n[yellow]⚠️ Could not save credentials to storage[/yellow]")
+            console.print("\n[yellow]Could not save credentials to storage[/yellow]")
 
     def _offer_env_file_save(self, api_key: str, non_interactive: bool) -> None:
         """Offer to save API key to .env file."""
@@ -866,10 +842,7 @@ class TraigentAuthCLI:
             storage_location = self._save_credentials(credentials)
             if storage_location:
                 console.print("[green]✅ API key stored securely[/green]")
-                if storage_location == STORAGE_KEYRING:
-                    console.print("[dim]Location: System Keyring[/dim]\n")
-                else:
-                    console.print(f"[dim]Location: {self.credentials_file}[/dim]\n")
+                console.print(f"[dim]Location: {self.credentials_file}[/dim]\n")
             else:
                 console.print("[red]❌ Failed to store API key[/red]\n")
         else:

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -17,15 +17,6 @@ from typing import Any
 import click
 from rich.console import Console
 
-# Try to import keyring, but make it optional
-try:
-    import keyring
-
-    KEYRING_AVAILABLE = True
-except ImportError:
-    keyring = None
-    KEYRING_AVAILABLE = False
-
 # Try to import aiohttp for exception handling
 try:
     import aiohttp
@@ -53,12 +44,9 @@ logger = get_logger(__name__)
 # Constants
 TRAIGENT_CONFIG_DIR = Path.home() / ".traigent"
 CREDENTIALS_FILE = TRAIGENT_CONFIG_DIR / "credentials.json"
-KEYRING_SERVICE = "traigent-sdk"
-KEYRING_ACCOUNT = "default"
 BACKEND_RESPONSE_HEADER = "\n[red]--- Backend Response ---[/red]"
 
-# Storage location identifiers
-STORAGE_KEYRING = "keyring"
+# Storage location identifier
 STORAGE_FILE = "file"
 
 # Common user-facing messages (avoid duplication per SonarCloud S1192)
@@ -81,21 +69,11 @@ class TraigentAuthCLI:
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
 
     def _load_stored_credentials(self) -> dict[str, Any] | None:
-        """Load stored credentials from secure storage.
+        """Load stored credentials from local file.
 
         Returns:
             Stored credentials or None if not found
         """
-        # First try keyring (most secure) if available
-        if KEYRING_AVAILABLE and keyring is not None:
-            try:
-                stored_data = keyring.get_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
-                if stored_data:
-                    return dict(json.loads(stored_data))
-            except Exception as e:
-                logger.debug(f"Keyring access failed: {e}")
-
-        # Fallback to encrypted file
         if self.credentials_file.exists():
             try:
                 with open(self.credentials_file) as f:
@@ -107,7 +85,7 @@ class TraigentAuthCLI:
         return None
 
     def _save_credentials(self, credentials: dict[str, Any]) -> str | None:
-        """Save credentials securely.
+        """Save credentials to local file with restricted permissions.
 
         Args:
             credentials: Credentials to save
@@ -115,28 +93,16 @@ class TraigentAuthCLI:
         Returns:
             Storage location string if saved successfully, None if failed
         """
-        # Try keyring first (most secure) if available
-        if KEYRING_AVAILABLE and keyring is not None:
-            try:
-                keyring.set_password(
-                    KEYRING_SERVICE, KEYRING_ACCOUNT, json.dumps(credentials)
-                )
-                logger.debug("Credentials saved to keyring")
-                return STORAGE_KEYRING
-            except Exception as e:
-                logger.debug(f"Keyring save failed, using file: {e}")
-
-        # Fallback to file with restricted permissions
         try:
-            self.credentials_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-
-            # Write with restricted permissions
+            self.credentials_file.parent.mkdir(
+                mode=0o700, parents=True, exist_ok=True
+            )
             with open(self.credentials_file, "w") as f:
                 json.dump(credentials, f, indent=2)
-
-            # Ensure file has restricted permissions
             self.credentials_file.chmod(0o600)
-            logger.debug(f"Credentials saved to {self.credentials_file}")
+            logger.debug(
+                f"Credentials saved to {self.credentials_file}"
+            )
             return STORAGE_FILE
         except OSError as e:
             logger.error(f"Failed to save credentials: {e}")
@@ -276,17 +242,6 @@ class TraigentAuthCLI:
         """
         success = True
 
-        # Clear from keyring if available
-        if KEYRING_AVAILABLE and keyring is not None:
-            try:
-                keyring.delete_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
-                logger.debug("Cleared credentials from keyring")
-            except Exception as e:
-                logger.debug(
-                    f"Could not clear keyring credentials (may not exist): {e}"
-                )
-
-        # Clear file
         if self.credentials_file.exists():
             try:
                 self.credentials_file.unlink()

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -81,6 +81,13 @@ class TraigentAuthCLI:
                     return dict(data)
             except (json.JSONDecodeError, OSError) as e:
                 logger.debug(f"Failed to load credentials file: {e}")
+        elif self.config_dir.exists():
+            # Config dir exists but no credentials file - user may have
+            # authenticated when keyring was the primary store.
+            logger.info(
+                "No credentials file found. If you previously authenticated, "
+                "please run 'traigent auth login' again."
+            )
 
         return None
 
@@ -95,9 +102,15 @@ class TraigentAuthCLI:
         """
         try:
             self.credentials_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            with open(self.credentials_file, "w") as f:
+            # Use os.open with explicit mode to avoid a window where the
+            # file is world-readable between creation and chmod.
+            fd = os.open(
+                str(self.credentials_file),
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w") as f:
                 json.dump(credentials, f, indent=2)
-            self.credentials_file.chmod(0o600)
             logger.debug(f"Credentials saved to {self.credentials_file}")
             return STORAGE_FILE
         except OSError as e:

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -17,13 +17,6 @@ from typing import Any, cast
 
 from traigent.config.backend_config import BackendConfig
 
-# Try to import keyring, but make it optional
-try:
-    import keyring
-
-    KEYRING_AVAILABLE = True
-except ImportError:
-    KEYRING_AVAILABLE = False
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -31,8 +24,6 @@ logger = get_logger(__name__)
 # Constants matching CLI auth
 TRAIGENT_CONFIG_DIR = Path.home() / ".traigent"
 CREDENTIALS_FILE = TRAIGENT_CONFIG_DIR / "credentials.json"
-KEYRING_SERVICE = "traigent-sdk"
-KEYRING_ACCOUNT = "default"
 
 
 class CredentialManager:
@@ -111,19 +102,13 @@ class CredentialManager:
     def _load_cli_credentials(cls) -> dict[str, Any] | None:
         """Load credentials stored by CLI auth command.
 
+        Reads from the local credentials file only. Keyring is not used
+        by the SDK to avoid triggering OS credential prompts (e.g. macOS
+        Keychain) during normal library usage.
+
         Returns:
             Stored credentials or None
         """
-        # Try keyring first (most secure) if available
-        if KEYRING_AVAILABLE:
-            try:
-                stored_data = keyring.get_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
-                if stored_data:
-                    return cast(dict[str, Any], json.loads(stored_data))
-            except Exception as e:
-                logger.debug(f"Keyring access failed: {e}")
-
-        # Fallback to file
         if CREDENTIALS_FILE.exists():
             try:
                 with open(CREDENTIALS_FILE) as f:
@@ -213,16 +198,6 @@ class CredentialManager:
         """
         success = True
 
-        # Clear from keyring if available
-        if KEYRING_AVAILABLE:
-            try:
-                keyring.delete_password(KEYRING_SERVICE, KEYRING_ACCOUNT)
-            except Exception as e:
-                logger.debug(
-                    f"Could not clear keyring credentials (may not exist): {e}"
-                )
-
-        # Clear file
         if CREDENTIALS_FILE.exists():
             try:
                 CREDENTIALS_FILE.unlink()

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -95,7 +95,7 @@ class BackendSessionManager:
             BackendIntegratedClient if available, None otherwise
         """
         if is_backend_offline():
-            logger.debug("Offline mode — skipping backend client initialization")
+            logger.debug("Offline mode - skipping backend client initialization")
             return None
 
         # Try to import cloud module - may not be available if cloud plugin not installed

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -94,6 +94,12 @@ class BackendSessionManager:
         Returns:
             BackendIntegratedClient if available, None otherwise
         """
+        if is_backend_offline():
+            logger.debug(
+                "Offline mode — skipping backend client initialization"
+            )
+            return None
+
         # Try to import cloud module - may not be available if cloud plugin not installed
         try:
             from traigent.cloud.backend_client import (

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -95,9 +95,7 @@ class BackendSessionManager:
             BackendIntegratedClient if available, None otherwise
         """
         if is_backend_offline():
-            logger.debug(
-                "Offline mode — skipping backend client initialization"
-            )
+            logger.debug("Offline mode — skipping backend client initialization")
             return None
 
         # Try to import cloud module - may not be available if cloud plugin not installed
@@ -853,9 +851,9 @@ class BackendSessionManager:
             result.metadata.get("statistical_significance") if result.metadata else None
         )
         if stat_sig:
-            summary_stats_with_aggregation["metadata"][
-                "statistical_significance"
-            ] = stat_sig
+            summary_stats_with_aggregation["metadata"]["statistical_significance"] = (
+                stat_sig
+            )
 
         try:
             successful_trials = len([t for t in result.trials if t.is_successful])


### PR DESCRIPTION
## Summary

- Remove all `keyring` usage from the credential system (both SDK and CLI)
- Use `~/.traigent/credentials.json` with `0600` permissions as the sole credential store
- Skip backend client initialization when `TRAIGENT_OFFLINE_MODE` is set
- Update docs to reflect file-only credential storage

## Problem

On macOS, `keyring.get_password()` triggers a system-level Keychain password dialog even on fresh installs where no credentials are stored. This happens because macOS requires per-application authorization to access any Keychain item. First-time users running `hello_world.py` see a scary security prompt before their code even runs.

## Root Cause

`CredentialManager._load_cli_credentials` calls `keyring.get_password("traigent-sdk", "default")` during the optimization orchestrator's init path — not from any explicit auth operation. `keyring` is an optional imported dependency that activates when installed in the environment.

## Solution

Create a clean architectural boundary: the SDK never touches OS keychains. File-based credential storage with restricted permissions (`0600`) is the industry standard (AWS CLI uses the same pattern).

## Test plan

- [x] Secret scan: clean
- [x] Formatting: clean (pre-existing UP038 in unrelated line)
- [x] Unit tests: 1371 passed (cloud, config, CLI, backend session manager)
@Achi-Traigent Can you please do the test below?
- [ ] Manual: `python hello_world.py` on macOS — no Keychain prompt


🤖 Generated with [Claude Code](https://claude.com/claude-code)