### PR TITLE
docs: polish public SDK onboarding surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Our mission: **Anything you can measure, we can improve.** Whether it's accuracy
 **Quick Install:**
 
 ```bash
-git clone -b release/0.10.0-polish https://github.com/Traigent/Traigent.git && cd Traigent
+git clone https://github.com/Traigent/Traigent.git && cd Traigent
 python3 -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -e ".[recommended]"
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ Traigent is a **zero-code optimization platform** that automatically finds the b
 - **Zero Code Changes** - Works with existing functions
 - **Multi-Objective Optimization** - Balance accuracy, cost, and speed
 - **Framework Agnostic** - Works with OpenAI, Anthropic, LangChain, and more
-- **Production Ready** - Built for enterprise deployment
+- **Production Hardening Friendly** - Structured for release validation and production deployment work
 - **Real-time Analytics** - Monitor optimization progress live
 
 ## 🌐 Examples Navigator


### PR DESCRIPTION
## Summary
- remove the branch-specific quick install from the root README
- soften the Python SDK docs landing page release posture
- keep the public install/docs path aligned with the docs-only ACT pass

## Verification
- docs-only diff review
- docs-only ACT pass recorded in _release_program