### PR TITLE
refactor: make cloud exports optional in OSS builds

### DIFF
--- a/tests/unit/test_init_imports.py
+++ b/tests/unit/test_init_imports.py
@@ -9,6 +9,10 @@ flags accurately reflect installed dependencies.
 
 from __future__ import annotations
 
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 
@@ -99,6 +103,77 @@ class TestTraigentInit:
         # All items in __all__ should be accessible
         for name in traigent.__all__:
             assert hasattr(traigent, name), f"{name} in __all__ but not accessible"
+
+    def test_main_module_imports_without_optional_cloud_modules(self) -> None:
+        """Test that traigent still imports when cloud-only modules are absent."""
+        script = textwrap.dedent(
+            """
+            import builtins
+
+            real_import = builtins.__import__
+            blocked = {
+                "traigent.cloud.agent_dtos",
+                "traigent.cloud.dtos",
+                "traigent.optimizers.cloud_optimizer",
+                "traigent.optimizers.remote",
+            }
+
+            def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+                if name in blocked or any(
+                    name.startswith(f"{prefix}.") for prefix in blocked
+                ):
+                    exc = ModuleNotFoundError(f"No module named {name!r}")
+                    exc.name = name
+                    raise exc
+                return real_import(name, globals, locals, fromlist, level)
+
+            builtins.__import__ = blocked_import
+
+            import traigent
+            import traigent.optimizers as optimizers
+
+            assert hasattr(traigent, "optimize")
+            assert hasattr(optimizers, "GridSearchOptimizer")
+            assert "AgentCostBreakdown" not in traigent.__all__
+            assert "WorkflowCostSummary" not in traigent.__all__
+            assert "MeasuresDict" not in traigent.__all__
+            assert "CloudOptimizer" not in optimizers.__all__
+            assert "RemoteOptimizer" not in optimizers.__all__
+
+            for module, name, expected in [
+                (
+                    traigent,
+                    "AgentCostBreakdown",
+                    "Cloud workflow DTO exports are unavailable",
+                ),
+                (
+                    optimizers,
+                    "CloudOptimizer",
+                    "Cloud optimizer exports are unavailable",
+                ),
+                (
+                    optimizers,
+                    "RemoteOptimizer",
+                    "Remote optimizer exports are unavailable",
+                ),
+            ]:
+                try:
+                    getattr(module, name)
+                except AttributeError as exc:
+                    assert expected in str(exc)
+                else:
+                    raise AssertionError(f"{name} should be unavailable")
+            """
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
 
 
 class TestIntegrationsInit:

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -113,10 +113,6 @@ from traigent.api.validation_protocol import (
     ValidationResult as ConstraintValidationResult,
 )
 
-# Multi-agent workflow cost tracking (DTO hardening)
-from traigent.cloud.agent_dtos import AgentCostBreakdown, WorkflowCostSummary
-from traigent.cloud.dtos import MeasuresDict
-
 # Thread context helpers
 from traigent.config.context import copy_context_to_thread, get_trial_context
 
@@ -171,6 +167,44 @@ warnings.filterwarnings(
     "ignore", category=FutureWarning, module=r"instructor\.providers\.gemini"
 )
 
+
+def _is_missing_optional_module(
+    exc: ModuleNotFoundError, module_prefixes: tuple[str, ...]
+) -> bool:
+    missing_module = getattr(exc, "name", "")
+    return any(
+        missing_module == prefix or missing_module.startswith(f"{prefix}.")
+        for prefix in module_prefixes
+    )
+
+
+_OPTIONAL_EXPORT_ERRORS: dict[str, str] = {}
+
+try:
+    # Multi-agent workflow cost tracking (DTO hardening)
+    from traigent.cloud.agent_dtos import AgentCostBreakdown, WorkflowCostSummary
+    from traigent.cloud.dtos import MeasuresDict
+except ModuleNotFoundError as exc:
+    if not _is_missing_optional_module(exc, ("traigent.cloud",)):
+        raise
+
+    _OPTIONAL_EXPORT_ERRORS.update(
+        {
+            "AgentCostBreakdown": (
+                "module 'traigent' has no attribute 'AgentCostBreakdown'. "
+                "Cloud workflow DTO exports are unavailable in this build."
+            ),
+            "WorkflowCostSummary": (
+                "module 'traigent' has no attribute 'WorkflowCostSummary'. "
+                "Cloud workflow DTO exports are unavailable in this build."
+            ),
+            "MeasuresDict": (
+                "module 'traigent' has no attribute 'MeasuresDict'. "
+                "Cloud workflow DTO exports are unavailable in this build."
+            ),
+        }
+    )
+
 __all__ = [
     # Main decorator
     "optimize",
@@ -221,10 +255,6 @@ __all__ = [
     "OptimizationState",
     # Thread context helpers
     "copy_context_to_thread",
-    # Multi-agent workflow cost tracking (DTO hardening)
-    "AgentCostBreakdown",
-    "WorkflowCostSummary",
-    "MeasuresDict",
     "TraigentMetadata",
     "is_traigent_metadata",
     # Exceptions and warnings
@@ -268,6 +298,22 @@ __all__ = [
     "OptimizationStatus",
     "StrategyConfig",
 ]
+
+if "AgentCostBreakdown" in globals():
+    __all__.extend(
+        [
+            "AgentCostBreakdown",
+            "WorkflowCostSummary",
+            "MeasuresDict",
+        ]
+    )
+
+
+def __getattr__(name: str):
+    if name in _OPTIONAL_EXPORT_ERRORS:
+        raise AttributeError(_OPTIONAL_EXPORT_ERRORS[name])
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # NOTE: Legacy builtins injection removed in v0.9.0
 # Use explicit imports: `import traigent`

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -1053,10 +1053,10 @@ def with_usage(
             )
 
     Multi-Agent Workflows:
-        For multi-agent workflows with per-agent cost tracking, use the
-        AgentCostBreakdown and WorkflowCostSummary DTOs from traigent.cloud.agent_dtos:
+        If the optional cloud workflow DTOs are installed, you can use
+        AgentCostBreakdown and WorkflowCostSummary for per-agent cost tracking:
 
-        >>> from traigent import AgentCostBreakdown, WorkflowCostSummary
+        >>> from traigent.cloud.agent_dtos import AgentCostBreakdown, WorkflowCostSummary
         >>> agent1 = AgentCostBreakdown(
         ...     agent_id="researcher",
         ...     agent_name="Research Agent",
@@ -1075,6 +1075,9 @@ def with_usage(
         ...     input_tokens=workflow.total_input_tokens,
         ...     output_tokens=workflow.total_output_tokens
         ... )
+
+        In OSS-only builds, compute the aggregate totals directly and pass the
+        numeric values to ``with_usage()`` without importing cloud DTOs.
     """
     # Enforce string type
     if not isinstance(text, str):

--- a/traigent/optimizers/__init__.py
+++ b/traigent/optimizers/__init__.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from traigent.optimizers.base import BaseOptimizer
-from traigent.optimizers.cloud_optimizer import CloudOptimizer  # noqa: F401
 from traigent.optimizers.grid import GridSearchOptimizer
 from traigent.optimizers.optuna_adapter import OptunaAdapter
 from traigent.optimizers.optuna_coordinator import (
@@ -34,7 +33,47 @@ from traigent.optimizers.registry import (
     list_optimizers,
     register_optimizer,
 )
-from traigent.optimizers.remote import RemoteOptimizer  # noqa: F401
+
+
+def _is_missing_optional_module(
+    exc: ModuleNotFoundError, module_prefixes: tuple[str, ...]
+) -> bool:
+    missing_module = getattr(exc, "name", "")
+    return any(
+        missing_module == prefix or missing_module.startswith(f"{prefix}.")
+        for prefix in module_prefixes
+    )
+
+
+_OPTIONAL_EXPORT_ERRORS: dict[str, str] = {}
+
+try:
+    from traigent.optimizers.cloud_optimizer import CloudOptimizer  # noqa: F401
+except ModuleNotFoundError as exc:
+    if not _is_missing_optional_module(
+        exc,
+        (
+            "traigent.optimizers.cloud_optimizer",
+            "traigent.optimizers.remote_services",
+        ),
+    ):
+        raise
+
+    _OPTIONAL_EXPORT_ERRORS["CloudOptimizer"] = (
+        "module 'traigent.optimizers' has no attribute 'CloudOptimizer'. "
+        "Cloud optimizer exports are unavailable in this build."
+    )
+
+try:
+    from traigent.optimizers.remote import RemoteOptimizer  # noqa: F401
+except ModuleNotFoundError as exc:
+    if not _is_missing_optional_module(exc, ("traigent.optimizers.remote",)):
+        raise
+
+    _OPTIONAL_EXPORT_ERRORS["RemoteOptimizer"] = (
+        "module 'traigent.optimizers' has no attribute 'RemoteOptimizer'. "
+        "Remote optimizer exports are unavailable in this build."
+    )
 
 __all__ = [
     "BaseOptimizer",
@@ -54,11 +93,21 @@ __all__ = [
     "get_optimizer",
     "register_optimizer",
     "list_optimizers",
-    "RemoteOptimizer",
-    "CloudOptimizer",
     # Pruners for early stopping
     "CeilingPruner",
     "CeilingPrunerConfig",
     "StatisticalInferiorityPruner",
     "StatisticalInferiorityPrunerConfig",
 ]
+
+if "RemoteOptimizer" in globals():
+    __all__.append("RemoteOptimizer")
+
+if "CloudOptimizer" in globals():
+    __all__.append("CloudOptimizer")
+
+
+def __getattr__(name: str):
+    if name in _OPTIONAL_EXPORT_ERRORS:
+        raise AttributeError(_OPTIONAL_EXPORT_ERRORS[name])
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- make root package cloud DTO exports optional so `import traigent` still works in OSS-only builds
- make optimizer package cloud and remote optimizer exports optional instead of hard import requirements
- align `with_usage()` docs and add an import-regression test that simulates missing cloud-only modules

## Testing
- python3 -m pytest -o addopts= tests/unit/test_init_imports.py -q
- python3 -m pytest -o addopts= tests/unit/optimizers/test_remote_optimizer.py -q
- python3 - <<'PY'
import traigent
import traigent.optimizers as optimizers
print("import_ok", hasattr(traigent, "optimize") and hasattr(optimizers, "GridSearchOptimizer"))
PY