### PR TITLE
chore: ignore playground directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -466,6 +466,7 @@ coverage_observability_modules.xml
 RELIABILITY_SWEEP_*.md
 PR[0-9]*.md
 playground.py
+playground/
 test_redact*.py
 test_timeout*.py
 nvidia/


### PR DESCRIPTION
## Summary
- ignore the `playground/` directory alongside the existing local/dev-only playground ignores
- keep the sandbox local-only until it is intentionally rebuilt
- closes #509

## Testing
- not applicable (`.gitignore` change only)
