### PR TITLE
fix: replace localhost defaults with cloud URLs in docs and examples

### DIFF
--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -77,7 +77,7 @@ from traigent.cloud.client import TraigentCloudClient
 
 client = TraigentCloudClient(
     api_key="your-api-key",  # pragma: allowlist secret
-    base_url="http://localhost:5000"
+    base_url="https://api.traigent.ai"
 )
 ```
 

--- a/examples/experimental/hybrid_api_demo/run_demo.py
+++ b/examples/experimental/hybrid_api_demo/run_demo.py
@@ -11,7 +11,6 @@ Usage:
     python run_demo.py
 """
 
-import os
 import subprocess
 import sys
 import time
@@ -21,7 +20,7 @@ import requests
 
 # Get the directory containing this script
 SCRIPT_DIR = Path(__file__).parent.absolute()
-SERVER_URL = os.environ.get("HYBRID_SERVER_URL", "http://localhost:8080")
+SERVER_URL = "http://localhost:8080"
 STARTUP_TIMEOUT = 10  # seconds
 REQUEST_HEADERS = {"User-Agent": "Traigent-SDK/1.0"}
 

--- a/examples/experimental/hybrid_api_demo/run_demo.py
+++ b/examples/experimental/hybrid_api_demo/run_demo.py
@@ -11,6 +11,7 @@ Usage:
     python run_demo.py
 """
 
+import os
 import subprocess
 import sys
 import time
@@ -20,7 +21,7 @@ import requests
 
 # Get the directory containing this script
 SCRIPT_DIR = Path(__file__).parent.absolute()
-SERVER_URL = "http://localhost:8080"
+SERVER_URL = os.environ.get("HYBRID_SERVER_URL", "http://localhost:8080")
 STARTUP_TIMEOUT = 10  # seconds
 REQUEST_HEADERS = {"User-Agent": "Traigent-SDK/1.0"}
 

--- a/examples/experimental/hybrid_api_demo/run_optimization.py
+++ b/examples/experimental/hybrid_api_demo/run_optimization.py
@@ -36,7 +36,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from traigent.evaluators import HybridAPIEvaluator
 from traigent.evaluators.base import Dataset, EvaluationExample
 
-SERVER_URL = os.environ.get("HYBRID_SERVER_URL", "http://localhost:8080")
+SERVER_URL = "http://localhost:8080"
 STARTUP_TIMEOUT = 10
 REQUEST_HEADERS = {"User-Agent": "Traigent-SDK/1.0"}
 

--- a/examples/experimental/hybrid_api_demo/run_optimization.py
+++ b/examples/experimental/hybrid_api_demo/run_optimization.py
@@ -14,7 +14,7 @@ Usage:
 
 Environment variables:
     TRAIGENT_API_KEY - API key for Traigent backend (required for FE visibility)
-    TRAIGENT_API_URL - Backend URL (default: http://localhost:5000/api/v1)
+    TRAIGENT_API_URL - Backend URL (default: https://api.traigent.ai/api/v1)
 """
 
 import asyncio
@@ -36,7 +36,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from traigent.evaluators import HybridAPIEvaluator
 from traigent.evaluators.base import Dataset, EvaluationExample
 
-SERVER_URL = "http://localhost:8080"
+SERVER_URL = os.environ.get("HYBRID_SERVER_URL", "http://localhost:8080")
 STARTUP_TIMEOUT = 10
 REQUEST_HEADERS = {"User-Agent": "Traigent-SDK/1.0"}
 
@@ -235,7 +235,7 @@ async def run_optimization() -> None:
 
         # Step 6: Report backend status
         api_key = os.environ.get("TRAIGENT_API_KEY")
-        backend_url = os.environ.get("TRAIGENT_API_URL", "http://localhost:5000/api/v1")
+        backend_url = os.environ.get("TRAIGENT_API_URL", "https://api.traigent.ai/api/v1")
 
         if api_key:
             print("\n5. Backend Integration")
@@ -260,7 +260,7 @@ async def main() -> None:
     # Check for environment variables
     print("Environment:")
     api_key = os.environ.get("TRAIGENT_API_KEY")
-    backend_url = os.environ.get("TRAIGENT_API_URL", "http://localhost:5000/api/v1")
+    backend_url = os.environ.get("TRAIGENT_API_URL", "https://api.traigent.ai/api/v1")
     print(f"  TRAIGENT_API_URL: {backend_url}")
     print(f"  TRAIGENT_API_KEY: {'***' + api_key[-4:] if api_key else 'Not set'}")
 


### PR DESCRIPTION
## Summary

- Replace `http://localhost:5000` with `https://api.traigent.ai` in user-facing doc (`docs/user-guide/agent_optimization.md`)
- Replace hardcoded `localhost:5000` API URL fallbacks with cloud URL in `examples/experimental/hybrid_api_demo/run_optimization.py`
- Make `SERVER_URL` in demo scripts configurable via `HYBRID_SERVER_URL` env var (kept localhost default since these scripts start a local Flask server)

Part of Traigent/traigent-pricing-simulator#41 — safe batch of localhost removals across repos.

## Test plan

- [ ] `grep -r "localhost:5000" docs/user-guide/agent_optimization.md` — no matches
- [ ] `grep -r "localhost:5000" examples/experimental/hybrid_api_demo/run_optimization.py` — no matches
- [ ] Demo scripts still work locally (SERVER_URL defaults preserved for the local Flask server)


🤖 Generated with [Claude Code](https://claude.com/claude-code)