### PR TITLE
fix: quickstart uses real LLM when API key set; walkthrough dataset path resolution

### DIFF
--- a/examples/quickstart/01_simple_qa.py
+++ b/examples/quickstart/01_simple_qa.py
@@ -11,8 +11,9 @@ import os
 import sys
 from pathlib import Path
 
-# Ensure mock mode for testing without API keys
-os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+# Enable mock mode only when no API key is available
+if not os.environ.get("OPENAI_API_KEY"):
+    os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
 
 # Set results folder to local directory
 os.environ.setdefault(
@@ -54,21 +55,24 @@ def simple_qa_agent(question: str) -> str:
     """Simple Q&A agent with Tuned Variables.
 
     In mock mode, this returns a simulated response.
-    With real API keys, it would call the actual LLM.
+    With real API keys, it calls the actual LLM.
     """
-    # In real usage, you would use:
-    # from langchain_openai import ChatOpenAI
-    # llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7)
-    # response = llm.invoke(f"Question: {question}\nAnswer:")
-    # return response.content
+    if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
+        mock_answers = {
+            "What is the capital of France?": "Paris",
+            "What is 2 + 2?": "4",
+            "Who wrote Romeo and Juliet?": "William Shakespeare",
+        }
+        return mock_answers.get(question, "I don't know")
 
-    # For this demo, we return a mock response
-    mock_answers = {
-        "What is the capital of France?": "Paris",
-        "What is 2 + 2?": "4",
-        "Who wrote Romeo and Juliet?": "William Shakespeare",
-    }
-    return mock_answers.get(question, "I don't know")
+    from langchain_openai import ChatOpenAI
+    config = traigent.get_config()
+    llm = ChatOpenAI(
+        model=config.get("model", "gpt-3.5-turbo"),
+        temperature=config.get("temperature", 0.7),
+    )
+    response = llm.invoke(f"Question: {question}\nAnswer:")
+    return response.content
 
 
 async def main():

--- a/walkthrough/mock/01_tuning_qa.py
+++ b/walkthrough/mock/01_tuning_qa.py
@@ -12,7 +12,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from utils.helpers import print_optimization_config, print_results_table
 from utils.mock_answers import (
@@ -29,13 +29,16 @@ import traigent
 from traigent import TraigentConfig
 
 os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+os.environ.setdefault(
+    "TRAIGENT_DATASET_ROOT", str(Path(__file__).resolve().parent.parent)
+)
 
 traigent.initialize(
     config=TraigentConfig(execution_mode="edge_analytics", minimal_logging=True)
 )
 
 # Dataset path relative to this file
-DATASETS = Path(__file__).parent.parent / "datasets"
+DATASETS = Path(__file__).resolve().parent.parent / "datasets"
 SIMULATED_BEST = {"model": "gpt-4o", "temperature": 0.1, "accuracy": 0.80}
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],


### PR DESCRIPTION
## Summary

- **#520**: `examples/quickstart/01_simple_qa.py` was unconditionally setting `TRAIGENT_MOCK_LLM=true` via `setdefault`, overriding any `OPENAI_API_KEY` already in the environment. Mock mode is now only defaulted when no API key is present. The function body also now calls `ChatOpenAI` with the Traigent-injected config when not in mock mode.
- **#521**: `walkthrough/mock/01_tuning_qa.py` resolved paths relative to CWD. `test_all_examples.sh` `pushd`s into `walkthrough/mock/` before running each script, so a bare-filename `__file__` caused `Path().parent.parent` to remain at `.\ (the mock dir), pointing `DATASETS` at `walkthrough/mock/datasets/` (non-existent). Fixed with `Path(__file__).resolve()` on both `sys.path` and `DATASETS`, plus `TRAIGENT_DATASET_ROOT` set to `walkthrough/` so the framework security check accepts datasets from the shared `walkthrough/datasets/` folder.

## Test plan

- [x] Run `python examples/quickstart/01_simple_qa.py` with `OPENAI_API_KEY` set — should use real LLM, not mock
- [x] Run `python examples/quickstart/01_simple_qa.py` without `OPENAI_API_KEY` — should fall back to mock mode
- [x] `cd walkthrough/mock && python 01_tuning_qa.py` — should find dataset and complete successfully
- [x] `bash walkthrough/test_all_examples.sh --mock` — example 01 should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)