### PR TITLE
fix: suppress auth-rejected trace span warnings at DEBUG (#518)

### DIFF
--- a/traigent/core/workflow_trace_manager.py
+++ b/traigent/core/workflow_trace_manager.py
@@ -135,9 +135,15 @@ class WorkflowTraceManager:
                     if response.graph_id:
                         graph_id = response.graph_id
                 else:
-                    logger.warning(
-                        f"Failed to submit spans for config_run {config_run_id}: {response.error}"
-                    )
+                    # Auth rejections are expected in local/edge mode — log at DEBUG only
+                    if response.error and "Auth failed" in response.error:
+                        logger.debug(
+                            "Trace ingestion auth rejected for config_run %s", config_run_id
+                        )
+                    else:
+                        logger.warning(
+                            f"Failed to submit spans for config_run {config_run_id}: {response.error}"
+                        )
 
             if total_submitted > 0:
                 graph_msg = f", graph_id={graph_id}" if graph_id else ""


### PR DESCRIPTION
## Summary
- When the backend returns 401/403 for trace ingestion (expected in local/edge mode), `WorkflowTraceManager` was logging a `WARNING` per config_run
- `WorkflowTracesTracker` already returns `error="Auth failed (...)"` for these cases — this PR checks for that string and downgrades to `DEBUG`
- The rest of the 401 suppression chain (`api_operations.py`, `trial_operations.py`, `workflow_traces.py`) was already in place in this repo

## Test plan
- [ ] Run quickstart example with local backend (localhost:5000) responding with 401 — confirm no WARNING spam in stderr
- [ ] Run quickstart with no backend configured — confirm single "Backend tracking unavailable" notice, then clean output
- [ ] Run with valid API key and live backend — confirm spans are submitted normally and graph_id is logged

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)