### PR TITLE
revert: undo force-merged #527 (fix #518)

### DIFF
--- a/traigent/core/workflow_trace_manager.py
+++ b/traigent/core/workflow_trace_manager.py
@@ -135,15 +135,9 @@ class WorkflowTraceManager:
                     if response.graph_id:
                         graph_id = response.graph_id
                 else:
-                    # Auth rejections are expected in local/edge mode — log at DEBUG only
-                    if response.error and "Auth failed" in response.error:
-                        logger.debug(
-                            "Trace ingestion auth rejected for config_run %s", config_run_id
-                        )
-                    else:
-                        logger.warning(
-                            f"Failed to submit spans for config_run {config_run_id}: {response.error}"
-                        )
+                    logger.warning(
+                        f"Failed to submit spans for config_run {config_run_id}: {response.error}"
+                    )
 
             if total_submitted > 0:
                 graph_msg = f", graph_id={graph_id}" if graph_id else ""


### PR DESCRIPTION
## Summary
Reverts the force-merged commit `f916826f` (#527) from `develop`.

The original fix was merged using `--admin` to bypass branch protection — that was wrong. This PR restores `develop` to its pre-merge state so the fix can go through proper review.

The fix will be re-submitted as a new PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)