### PR TITLE
fix: suppress auth-rejected trace span warnings at DEBUG (#518)

### DIFF
--- a/tests/unit/core/test_workflow_trace_manager.py
+++ b/tests/unit/core/test_workflow_trace_manager.py
@@ -138,6 +138,26 @@ class TestSubmitTraces:
         assert mgr._collected_spans == []
 
     @pytest.mark.asyncio
+    async def test_auth_rejection_logs_at_debug_not_warning(self, caplog) -> None:
+        import logging
+
+        tracker = MagicMock()
+        tracker.ingest_traces_async = AsyncMock(
+            return_value=_FakeIngestResponse(success=False, error="Auth failed (401)")
+        )
+        mgr = _make_manager(tracker=tracker)
+        mgr._collected_spans = [_FakeSpan()]
+
+        with caplog.at_level(logging.DEBUG), patch(
+            "traigent.core.workflow_trace_manager.is_backend_offline",
+            return_value=False,
+        ):
+            await mgr.submit_traces(session_id="real-session")
+
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+        assert any("auth rejected" in r.message.lower() for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_handles_failed_ingestion(self) -> None:
         tracker = MagicMock()
         tracker.ingest_traces_async = AsyncMock(

--- a/traigent/core/workflow_trace_manager.py
+++ b/traigent/core/workflow_trace_manager.py
@@ -135,9 +135,15 @@ class WorkflowTraceManager:
                     if response.graph_id:
                         graph_id = response.graph_id
                 else:
-                    logger.warning(
-                        f"Failed to submit spans for config_run {config_run_id}: {response.error}"
-                    )
+                    # Auth rejections are expected in local/edge mode — log at DEBUG only
+                    if response.error and "Auth failed" in response.error:
+                        logger.debug(
+                            "Trace ingestion auth rejected for config_run %s", config_run_id
+                        )
+                    else:
+                        logger.warning(
+                            f"Failed to submit spans for config_run {config_run_id}: {response.error}"
+                        )
 
             if total_submitted > 0:
                 graph_msg = f", graph_id={graph_id}" if graph_id else ""

--- a/traigent/core/workflow_trace_manager.py
+++ b/traigent/core/workflow_trace_manager.py
@@ -138,7 +138,7 @@ class WorkflowTraceManager:
                     # Auth rejections are expected in local/edge mode — log at DEBUG only
                     if response.error and "Auth failed" in response.error:
                         logger.debug(
-                            "Trace ingestion auth rejected for config_run %s", config_run_id
+                            f"Trace ingestion auth rejected for config_run {config_run_id}"
                         )
                     else:
                         logger.warning(


### PR DESCRIPTION
## Summary
- When the backend returns 401/403 for trace ingestion (expected in local/edge mode), `WorkflowTraceManager` was logging a `WARNING` per config_run
- `WorkflowTracesTracker` already returns `error="Auth failed (...)"` for these cases — this PR checks for that string and downgrades to `DEBUG`
- The rest of the 401 suppression chain (`api_operations.py`, `trial_operations.py`, `workflow_traces.py`) was already in place in this repo

## Test plan
- [ ] Run quickstart with local backend (localhost:5000) responding with 401 — confirm no WARNING spam in stderr
- [ ] Run with no backend configured — confirm single "Backend tracking unavailable" notice, then clean output
- [ ] Run with valid API key and live backend — confirm spans are submitted normally

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)