### PR TITLE
Fallback walkthrough demos to mock when keys are missing

### DIFF
--- a/walkthrough/README.md
+++ b/walkthrough/README.md
@@ -31,11 +31,12 @@ This includes:
 # Mock examples - no API keys needed
 python walkthrough/mock/01_tuning_qa.py
 
-# Real examples - requires an LLM API key for LLM API calls
+# Real examples - use real LLM calls when a provider key is set;
+# otherwise they warn and fall back to the matching mock walkthrough
 export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
 python walkthrough/real/01_tuning_qa.py
 
-# Multi-provider example (any one key works)
+# Multi-provider example (any one key works; without keys it falls back to mock)
 export OPENAI_API_KEY="your-key"  # Or ANTHROPIC_API_KEY / GOOGLE_API_KEY  <!-- pragma: allowlist secret -->
 python walkthrough/real/07_multi_provider.py
 ```
@@ -48,7 +49,7 @@ Check your environment with `python walkthrough/utils/check_environment.py`.
 # Run all mock examples (no API keys needed)
 bash walkthrough/test_all_examples.sh --mock
 
-# Run all real examples (requires OpenAI API key; Example 07 can also use Anthropic/Gemini keys)
+# Run all real examples (uses provider keys when set, otherwise falls back to mock)
 export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
 bash walkthrough/test_all_examples.sh --real
 ```
@@ -60,7 +61,7 @@ walkthrough/
 ├── README.md              # This file
 ├── demo/                  # Optional demo/video support scripts
 ├── mock/                  # No API keys needed, instant results
-├── real/                  # Requires API keys, real LLM calls
+├── real/                  # Real LLM calls when keyed, mock fallback on first run
 ├── datasets/              # Pre-built evaluation datasets (20 examples each)
 ├── utils/                 # Shared utilities (scoring, helpers, mock answers)
 └── test_all_examples.sh   # Run all examples script
@@ -83,7 +84,7 @@ Eight hands-on examples that build on each other:
 
 Injection modes are explained in depth here: [Injection Modes Guide](../docs/user-guide/injection_modes.md).
 
-Each example has **mock** (no API keys) and **real** (actual LLM calls) variants.
+Each example has **mock** (no API keys) and **real** (actual LLM calls when keys are present, otherwise automatic mock fallback) variants.
 
 Note: Example 05 runs parallel evaluation by default. Pause-on-error prompts only
 appear in sequential mode (set `TRAIGENT_PARALLEL=0`).
@@ -192,8 +193,8 @@ In mock mode, Example 06 uses a lightweight heuristic scorer (function signature
 
 | Mock (`mock/`)        | Real (`real/`)           |
 |-----------------------|--------------------------|
-| No API keys           | Requires OPENAI_API_KEY  |
-| Instant results       | Real LLM calls           |
+| No API keys           | Uses provider keys when present |
+| Instant results       | Real LLM calls or mock fallback |
 | Simulated accuracy    | Actual model performance |
 | Simulated best config | Real best config per run |
 | Great for learning    | Production-ready         |

--- a/walkthrough/README.md
+++ b/walkthrough/README.md
@@ -52,6 +52,9 @@ bash walkthrough/test_all_examples.sh --mock
 # Run all real examples (uses provider keys when set, otherwise falls back to mock)
 export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
 bash walkthrough/test_all_examples.sh --real
+
+# Disable fallback and fail fast when keys are missing (useful for CI)
+export TRAIGENT_REQUIRE_REAL=1
 ```
 
 ## Structure
@@ -61,7 +64,7 @@ walkthrough/
 ├── README.md              # This file
 ├── demo/                  # Optional demo/video support scripts
 ├── mock/                  # No API keys needed, instant results
-├── real/                  # Real LLM calls when keyed, mock fallback on first run
+├── real/                  # Real LLM calls when keyed, mock fallback when keys are missing
 ├── datasets/              # Pre-built evaluation datasets (20 examples each)
 ├── utils/                 # Shared utilities (scoring, helpers, mock answers)
 └── test_all_examples.sh   # Run all examples script

--- a/walkthrough/real/01_tuning_qa.py
+++ b/walkthrough/real/01_tuning_qa.py
@@ -4,6 +4,9 @@
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/01_tuning_qa.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -13,6 +16,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
+
 from langchain_openai import ChatOpenAI
 from utils.helpers import (
     configure_logging,
@@ -20,7 +27,6 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
     sanitize_traigent_api_key,
     setup_example_logger,
 )
@@ -29,7 +35,6 @@ from utils.scoring import STOPWORDS, token_match_score, token_matches, tokenize
 import traigent
 from traigent import TraigentConfig
 
-require_openai_key("01_tuning_qa.py")
 sanitize_traigent_api_key()
 configure_logging()
 

--- a/walkthrough/real/02_zero_code_change.py
+++ b/walkthrough/real/02_zero_code_change.py
@@ -4,6 +4,9 @@
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/02_zero_code_change.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -13,6 +16,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
+
 from langchain_openai import ChatOpenAI
 from utils.helpers import (
     configure_logging,
@@ -20,14 +27,12 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
     sanitize_traigent_api_key,
 )
 from utils.scoring import token_match_score
 
 import traigent
 
-require_openai_key("02_zero_code_change.py")
 sanitize_traigent_api_key()
 configure_logging()
 

--- a/walkthrough/real/03_parameter_mode.py
+++ b/walkthrough/real/03_parameter_mode.py
@@ -4,6 +4,9 @@
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/03_parameter_mode.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -13,6 +16,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
+
 from langchain_openai import ChatOpenAI
 from utils.helpers import (
     configure_logging,
@@ -20,7 +27,6 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
     sanitize_traigent_api_key,
 )
 from utils.scoring import token_match_score
@@ -28,7 +34,6 @@ from utils.scoring import token_match_score
 import traigent
 from traigent import TraigentConfig
 
-require_openai_key("03_parameter_mode.py")
 sanitize_traigent_api_key()
 configure_logging()
 

--- a/walkthrough/real/04_multi_objective.py
+++ b/walkthrough/real/04_multi_objective.py
@@ -4,6 +4,9 @@
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/04_multi_objective.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -14,6 +17,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
+
 from langchain_openai import ChatOpenAI
 from utils.helpers import (
     configure_logging,
@@ -21,14 +28,12 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
     sanitize_traigent_api_key,
 )
 
 import traigent
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 
-require_openai_key("04_multi_objective.py")
 sanitize_traigent_api_key()
 configure_logging()
 

--- a/walkthrough/real/05_rag_parallel.py
+++ b/walkthrough/real/05_rag_parallel.py
@@ -4,6 +4,9 @@
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/05_rag_parallel.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -13,6 +16,10 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
 
 try:
     from langchain_community.vectorstores import FAISS
@@ -30,7 +37,6 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
     sanitize_traigent_api_key,
 )
 from utils.scoring import semantic_overlap_score
@@ -38,7 +44,6 @@ from utils.scoring import semantic_overlap_score
 import traigent
 from traigent.config.parallel import ParallelConfig
 
-require_openai_key("05_rag_parallel.py")
 sanitize_traigent_api_key()
 configure_logging()
 logging.getLogger("tokencost.costs").setLevel(logging.ERROR)

--- a/walkthrough/real/06_custom_evaluator.py
+++ b/walkthrough/real/06_custom_evaluator.py
@@ -7,6 +7,9 @@ The judge evaluates correctness, code quality, and documentation using a detaile
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/06_custom_evaluator.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -18,6 +21,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
+
 from langchain_openai import ChatOpenAI
 from utils.helpers import (
     configure_logging,
@@ -25,13 +32,11 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
     sanitize_traigent_api_key,
 )
 
 import traigent
 
-require_openai_key("06_custom_evaluator.py")
 sanitize_traigent_api_key()
 configure_logging()
 

--- a/walkthrough/real/07_multi_provider.py
+++ b/walkthrough/real/07_multi_provider.py
@@ -20,7 +20,8 @@ Usage (run from repo root):
     .venv/bin/python walkthrough/real/07_multi_provider.py
 
 Note: This example validates API keys using Traigent's core provider validation
-and skips any invalid providers.
+and skips any invalid providers. If no provider key is set, it shows a warning
+and runs the matching mock walkthrough instead.
 """
 
 import asyncio
@@ -32,6 +33,13 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(
+    __file__,
+    required_env_vars=("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"),
+)
 
 # Track errors per model to avoid spamming the console
 _error_counts: Counter[str] = Counter()

--- a/walkthrough/real/08_privacy_modes.py
+++ b/walkthrough/real/08_privacy_modes.py
@@ -4,6 +4,9 @@
 Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/08_privacy_modes.py
+
+If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
+mock walkthrough instead.
 """
 
 import asyncio
@@ -13,6 +16,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from utils.helpers import maybe_run_mock_example
+
+maybe_run_mock_example(__file__)
+
 from langchain_openai import ChatOpenAI
 from utils.helpers import (
     configure_logging,
@@ -20,14 +27,12 @@ from utils.helpers import (
     print_estimated_time,
     print_optimization_config,
     print_results_table,
-    require_openai_key,
 )
 from utils.scoring import token_match_score
 
 import traigent
 from traigent import TraigentConfig
 
-require_openai_key("08_privacy_modes.py")
 configure_logging()
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")

--- a/walkthrough/test_all_examples.sh
+++ b/walkthrough/test_all_examples.sh
@@ -184,7 +184,7 @@ case "$MODE" in
 
     --real)
         print_header "REAL"
-        echo "Real mode: makes actual API calls (requires OPENAI_API_KEY for these examples)"
+        echo "Real mode: uses provider API keys when set; otherwise examples fall back to mock"
         echo ""
 
         # Check for API key
@@ -195,21 +195,15 @@ case "$MODE" in
             set +a
         fi
 
-        if [ -z "${OPENAI_API_KEY:-}" ]; then
-            echo -e "${RED}ERROR: OPENAI_API_KEY not set${NC}"
+        if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${GOOGLE_API_KEY:-}" ]; then
+            echo -e "${YELLOW}WARNING: No provider API keys set${NC}"
             echo ""
-            echo "Set it via environment variable or create real/.env with:"
+            echo "Examples will print a warning and run their matching mock walkthroughs."
+            echo "Set provider keys to use real LLM calls:"
             echo "  OPENAI_API_KEY=your-key-here"
-            echo "  # Optional safety controls (not required to run):"
-            echo "  TRAIGENT_COST_APPROVED=true   # skips cost confirmation prompts"
-            echo "  TRAIGENT_RUN_COST_LIMIT=10    # soft spend cap in USD"
+            echo "  ANTHROPIC_API_KEY=your-key-here"
+            echo "  GOOGLE_API_KEY=your-key-here"
             echo ""
-            echo "If you're not using real/.env, export in your terminal:"
-            echo "  export OPENAI_API_KEY=your-key-here"
-            echo "  # Optional safety controls (not required to run):"
-            echo "  export TRAIGENT_COST_APPROVED=true   # skips cost confirmation prompts"
-            echo "  export TRAIGENT_RUN_COST_LIMIT=10    # soft spend cap in USD"
-            exit 1
         fi
 
         # Optional safety controls (skip prompts + set a soft spend cap)

--- a/walkthrough/test_all_examples.sh
+++ b/walkthrough/test_all_examples.sh
@@ -185,6 +185,7 @@ case "$MODE" in
     --real)
         print_header "REAL"
         echo "Real mode: uses provider API keys when set; otherwise examples fall back to mock"
+        echo "Set TRAIGENT_REQUIRE_REAL=1 to make missing provider keys a hard error."
         echo ""
 
         # Check for API key
@@ -196,14 +197,32 @@ case "$MODE" in
         fi
 
         if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${GOOGLE_API_KEY:-}" ]; then
-            echo -e "${YELLOW}WARNING: No provider API keys set${NC}"
-            echo ""
-            echo "Examples will print a warning and run their matching mock walkthroughs."
-            echo "Set provider keys to use real LLM calls:"
-            echo "  OPENAI_API_KEY=your-key-here"
-            echo "  ANTHROPIC_API_KEY=your-key-here"
-            echo "  GOOGLE_API_KEY=your-key-here"
-            echo ""
+            if [ "${TRAIGENT_REQUIRE_REAL:-}" = "1" ] || [ "${TRAIGENT_REQUIRE_REAL:-}" = "true" ]; then
+                echo -e "${RED}ERROR: TRAIGENT_REQUIRE_REAL=1 but no provider API keys are set${NC}"
+                echo ""
+                echo "Set provider keys to use real LLM calls:"
+                echo "  OPENAI_API_KEY=your-key-here"
+                echo "  ANTHROPIC_API_KEY=your-key-here"
+                echo "  GOOGLE_API_KEY=your-key-here"
+                echo ""
+                echo "Optional safety controls:"
+                echo "  TRAIGENT_COST_APPROVED=true   # skips cost confirmation prompts"
+                echo "  TRAIGENT_RUN_COST_LIMIT=10    # soft spend cap in USD"
+                exit 1
+            else
+                echo -e "${YELLOW}WARNING: No provider API keys set${NC}"
+                echo ""
+                echo "Examples will print a warning and run their matching mock walkthroughs."
+                echo "Set provider keys to use real LLM calls:"
+                echo "  OPENAI_API_KEY=your-key-here"
+                echo "  ANTHROPIC_API_KEY=your-key-here"
+                echo "  GOOGLE_API_KEY=your-key-here"
+                echo ""
+                echo "Optional safety controls when you do use real keys:"
+                echo "  TRAIGENT_COST_APPROVED=true   # skips cost confirmation prompts"
+                echo "  TRAIGENT_RUN_COST_LIMIT=10    # soft spend cap in USD"
+                echo ""
+            fi
         fi
 
         # Optional safety controls (skip prompts + set a soft spend cap)

--- a/walkthrough/utils/helpers.py
+++ b/walkthrough/utils/helpers.py
@@ -112,6 +112,32 @@ def _is_truthy_env(var_name: str) -> bool:
     return os.getenv(var_name, "").lower() in ("1", "true", "yes")
 
 
+def _find_repo_root(start_path: Path) -> Path:
+    """Walk upward until the repository root (identified by pyproject.toml)."""
+    for candidate in (start_path.parent, *start_path.parents):
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return start_path.parents[2]
+
+
+def _print_fallback_warning(reason: str, display_path: str) -> None:
+    """Print a prominent warning before delegating to a mock walkthrough."""
+    lines = [
+        f"WARNING: {reason}",
+        f"Falling back to {display_path}.",
+        "Set the required API key to use real LLM calls.",
+        "Set TRAIGENT_REQUIRE_REAL=1 to fail instead of falling back.",
+    ]
+    width = max(len(line) for line in lines)
+    border = "!" * (width + 4)
+    print()
+    print(border)
+    for line in lines:
+        print(f"! {line.ljust(width)} !")
+    print(border)
+    print()
+
+
 def maybe_run_mock_example(
     example_path: str,
     *,
@@ -129,8 +155,22 @@ def maybe_run_mock_example(
     Raises:
         SystemExit: After executing the matching mock example.
     """
+    require_real = _is_truthy_env("TRAIGENT_REQUIRE_REAL")
     should_force_mock = _is_truthy_env("TRAIGENT_MOCK_LLM")
     has_required_key = any(os.getenv(var_name) for var_name in required_env_vars)
+
+    if require_real:
+        if should_force_mock:
+            raise SystemExit(
+                "TRAIGENT_REQUIRE_REAL=1 is set, so TRAIGENT_MOCK_LLM cannot be used. "
+                "Unset TRAIGENT_MOCK_LLM or disable TRAIGENT_REQUIRE_REAL."
+            )
+        if not has_required_key:
+            raise SystemExit(
+                "TRAIGENT_REQUIRE_REAL=1 is set and no required provider key is available. "
+                f"Set one of: {', '.join(required_env_vars)}"
+            )
+        return
 
     if not should_force_mock and has_required_key:
         return
@@ -144,40 +184,27 @@ def maybe_run_mock_example(
             f"Set one of: {missing_keys}"
         )
 
-    repo_root = example_file.parents[2]
+    repo_root = _find_repo_root(example_file)
     display_path = mock_path.relative_to(repo_root).as_posix()
     if should_force_mock:
         reason = "TRAIGENT_MOCK_LLM is enabled"
     else:
         reason = f"Missing {' or '.join(required_env_vars)}"
 
-    print(
-        f"WARNING: {reason}. Running {display_path} instead. "
-        "Set the required API key to use real LLM calls."
-    )
+    _print_fallback_warning(reason, display_path)
 
     os.environ["TRAIGENT_MOCK_LLM"] = "true"
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
-    runpy.run_path(str(mock_path), run_name="__main__")
-    raise SystemExit(0)
-
-
-def require_openai_key(example_name: str) -> None:
-    """Exit with error if OPENAI_API_KEY is not set.
-
-    Args:
-        example_name: Name of the example file (used in error message)
-
-    Raises:
-        SystemExit: If OPENAI_API_KEY environment variable is not set
-    """
-    if not os.getenv("OPENAI_API_KEY"):
+    try:
+        runpy.run_path(str(mock_path), run_name="__main__")
+    except SystemExit:
+        raise
+    except Exception as exc:
         raise SystemExit(
-            "OPENAI_API_KEY not set. Export it to run real examples: "
-            'export OPENAI_API_KEY="your-key". '  # pragma: allowlist secret
-            f"To run without a key, use walkthrough/mock/{example_name}."
+            f"Mock fallback {display_path} failed: {type(exc).__name__}: {exc}"
         )
+    raise SystemExit(0)
 
 
 def setup_example_logger(name: str) -> logging.Logger:

--- a/walkthrough/utils/helpers.py
+++ b/walkthrough/utils/helpers.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import logging
 import os
+import runpy
 from functools import reduce
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import traigent
@@ -104,6 +106,61 @@ def sanitize_traigent_api_key() -> None:
             "Set a valid Traigent key to enable cloud features."
         )
         os.environ.pop("TRAIGENT_API_KEY", None)
+
+
+def _is_truthy_env(var_name: str) -> bool:
+    return os.getenv(var_name, "").lower() in ("1", "true", "yes")
+
+
+def maybe_run_mock_example(
+    example_path: str,
+    *,
+    required_env_vars: tuple[str, ...] = ("OPENAI_API_KEY",),
+) -> None:
+    """Run the matching mock walkthrough when required provider keys are missing.
+
+    This keeps first-run walkthrough usage seamless: the user can invoke a real
+    example directly, see a short warning, and still get a successful mock run.
+
+    Args:
+        example_path: Current script ``__file__`` path.
+        required_env_vars: Provider key env vars that enable real execution.
+
+    Raises:
+        SystemExit: After executing the matching mock example.
+    """
+    should_force_mock = _is_truthy_env("TRAIGENT_MOCK_LLM")
+    has_required_key = any(os.getenv(var_name) for var_name in required_env_vars)
+
+    if not should_force_mock and has_required_key:
+        return
+
+    example_file = Path(example_path).resolve()
+    mock_path = example_file.parent.parent / "mock" / example_file.name
+    if not mock_path.exists():
+        missing_keys = ", ".join(required_env_vars)
+        raise SystemExit(
+            f"No mock fallback exists for {example_file.name}. "
+            f"Set one of: {missing_keys}"
+        )
+
+    repo_root = example_file.parents[2]
+    display_path = mock_path.relative_to(repo_root).as_posix()
+    if should_force_mock:
+        reason = "TRAIGENT_MOCK_LLM is enabled"
+    else:
+        reason = f"Missing {' or '.join(required_env_vars)}"
+
+    print(
+        f"WARNING: {reason}. Running {display_path} instead. "
+        "Set the required API key to use real LLM calls."
+    )
+
+    os.environ["TRAIGENT_MOCK_LLM"] = "true"
+    os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
+    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+    runpy.run_path(str(mock_path), run_name="__main__")
+    raise SystemExit(0)
 
 
 def require_openai_key(example_name: str) -> None:


### PR DESCRIPTION
## Summary
- add a shared helper that reroutes real walkthroughs to their matching mock example when required provider keys are missing or mock mode is enabled
- use that helper in walkthrough real examples 01-08, including multi-provider fallback when no provider keys are set
- update walkthrough docs and the walkthrough runner to describe and support the seamless mock fallback path

## Verification
- .venv/bin/python -m py_compile walkthrough/utils/helpers.py walkthrough/real/01_tuning_qa.py walkthrough/real/02_zero_code_change.py walkthrough/real/03_parameter_mode.py walkthrough/real/04_multi_objective.py walkthrough/real/05_rag_parallel.py walkthrough/real/06_custom_evaluator.py walkthrough/real/07_multi_provider.py walkthrough/real/08_privacy_modes.py
- .venv/bin/python walkthrough/real/01_tuning_qa.py
- .venv/bin/python walkthrough/real/05_rag_parallel.py
- .venv/bin/python walkthrough/real/07_multi_provider.py
- .venv/bin/python walkthrough/real/08_privacy_modes.py