### PR TITLE
fix: make traigent-schema optional for public installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "aiohttp>=3.8.0",
     "requests>=2.28.0",  # Required by Langfuse integration sync fallback
     "jsonschema>=4.0.0",
-    "traigent-schema>=3.2.0",
+    # traigent-schema is optional — only needed for cloud schema validation.
+    # Install with: pip install -e ".[internal_schema]"
     "cryptography>=46.0.5",  # CVE-2026-26007 fix
     "backoff>=2.2.0",
     "litellm>=1.0.0",
@@ -50,8 +51,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Backward-compatible alias: TraigentSchema is now required at runtime.
-internal_schema = []
+# Internal-only schema validation contracts (cloud environments)
+internal_schema = [
+    "traigent-schema>=3.2.0",
+]
 
 # Analytics and intelligence features (Sprint 8)
 analytics = [


### PR DESCRIPTION
## Summary
- `traigent-schema>=3.2.0` was re-added as a hard dependency on `develop` but is not published to PyPI, blocking fresh `pip install` for any new user
- Both import sites (`cloud/dtos.py:49`, `reporting/example_map.py:93`) already have `try/except ImportError` fallbacks
- Moves the dep back to the `[internal_schema]` optional extra — mirrors the fix in e3e9a3ac

## Test plan
- [ ] `pip install -e ".[recommended]"` succeeds in a fresh venv without `traigent-schema` on PyPI
- [ ] `python hello_world.py` runs cleanly
- [ ] All 8 walkthrough steps pass (`walkthrough/mock/01..08`)
- [ ] Cloud/hybrid users can still install with `pip install -e ".[recommended,internal_schema]"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)