### PR TITLE
fix: add pydantic to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     # Required by core optimizer modules
     "optuna>=4.5.0",
     "psutil>=5.8.0",
+    # Required by API decorators and config validation
+    "pydantic>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Added `pydantic>=2.0.0` to core dependencies in pyproject.toml
- Fixes `ModuleNotFoundError: No module named 'pydantic'` when importing traigent

## Problem
`traigent/api/decorators.py` imports pydantic but it was not listed as a core dependency, causing import failures for fresh installs.

## Test plan
- [ ] Run `pip install -e .` and verify pydantic is installed
- [ ] Run `python hello_world.py` and verify no import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)