### PR TITLE
fix: downgrade token usage warning to debug level (#562)

### DIFF
--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -1047,7 +1047,7 @@ def _compute_cost(
                 metrics.cost.total_cost,
             )
     else:
-        logger.warning(
+        logger.debug(
             "No token usage extracted for model %s; "
             "falling back to deprecated text-based cost calculation",
             model_name,


### PR DESCRIPTION
## Summary
- Downgrade `logger.warning` → `logger.debug` for "No token usage extracted" message in `metrics_tracker.py`
- Eliminates noisy per-call warnings when LiteLLM doesn't populate token counts (e.g. gpt-3.5-turbo, gpt-4o, claude-haiku)
- Diagnostic info still available at debug log level

Closes #562

## Test plan
- [ ] Run any optimization with LiteLLM models — no warning should appear in output
- [ ] Set log level to DEBUG — warning should still appear for diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)