### PR TITLE
fix: pin litellm<1.82.7 due to compromised PyPI versions

### DIFF
--- a/examples/tvl/reusable_safety/requirements.txt
+++ b/examples/tvl/reusable_safety/requirements.txt
@@ -2,7 +2,7 @@
 # Install with: pip install -r requirements.txt
 
 # LiteLLM for unified LLM API (Groq, OpenAI, Anthropic, etc.)
-litellm>=1.30.0
+litellm>=1.30.0,<1.82.7
 
 # HuggingFace transformers for local toxicity classifier
 transformers>=4.35.0

--- a/plugins/traigent-ui/traigent_ui/requirements_streamlit.txt
+++ b/plugins/traigent-ui/traigent_ui/requirements_streamlit.txt
@@ -11,7 +11,7 @@ langchain>=0.1.0
 langchain-openai>=0.0.5
 openai>=1.0.0
 python-dotenv>=1.0.0
-litellm>=1.0.0
+litellm>=1.0.0,<1.82.7
 
 # Additional utilities
 aiofiles>=23.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # Install with: pip install -e ".[internal_schema]"
     "cryptography>=46.0.5",  # CVE-2026-26007 fix
     "backoff>=2.2.0",
-    "litellm>=1.0.0",
+    "litellm>=1.0.0,<1.82.7",
     "rank-bm25",
     # Required by core optimizer modules
     "optuna>=4.5.0",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,7 +10,7 @@ typing-extensions>=4.0.0; python_version<"3.11"
 claude-code-sdk>=0.0.14
 mcp>=1.23.0
 backoff>=2.2.0
-litellm>=1.0.0
+litellm>=1.0.0,<1.82.7
 rank-bm25
 optuna>=4.5.0
 psutil>=5.8.0


### PR DESCRIPTION
## Summary
- Pins litellm dependency to `<1.82.7` across all requirement files
- Versions 1.82.7 and 1.82.8 were compromised with malicious code on PyPI (supply chain attack)
- Protects the project from installing poisoned packages

## Files Changed
- `pyproject.toml`
- `requirements/requirements.txt`
- `plugins/traigent-ui/traigent_ui/requirements_streamlit.txt`
- `examples/tvl/reusable_safety/requirements.txt`

## Test plan
- [ ] Verify `pip install` resolves to a version < 1.82.7
- [ ] CI passes with the new constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)