### PR TITLE
chore: remove internal_schema extra from published package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ dependencies = [
     "aiohttp>=3.8.0",
     "requests>=2.28.0",  # Required by Langfuse integration sync fallback
     "jsonschema>=4.0.0",
-    # traigent-schema is optional — only needed for cloud schema validation.
-    # Install with: pip install -e ".[internal_schema]"
     "cryptography>=46.0.5",  # CVE-2026-26007 fix
     "backoff>=2.2.0",
     "litellm>=1.0.0",
@@ -53,11 +51,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Internal-only schema validation contracts (cloud environments)
-internal_schema = [
-    "traigent-schema>=3.2.0",
-]
-
 # Analytics and intelligence features (Sprint 8)
 analytics = [
     "numpy>=1.21.0",


### PR DESCRIPTION
## Summary
- Removes the `internal_schema` optional dependency extra (`traigent-schema>=3.2.0`) from `pyproject.toml`
- Removes the now-stale comment referencing it in core dependencies
- `traigent-schema` is a private repo not on PyPI, so `pip install traigent[internal_schema]` would fail for any user
- All SDK imports of `traigent_schema` are already lazy/guarded and degrade gracefully when absent
- Schema validation is handled server-side by TraigentBackend, not the SDK

## Test plan
- [ ] `pip install -e ".[recommended]"` still works
- [ ] SDK optimization runs work without `traigent-schema` installed (already confirmed by CEO)
- [ ] No import errors on `import traigent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)