### PR TITLE
fix: make real walkthroughs fail without provider keys

### DIFF
--- a/tests/unit/walkthrough/test_helpers.py
+++ b/tests/unit/walkthrough/test_helpers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from walkthrough.utils.helpers import maybe_run_mock_example
+
+
+def _create_example_tree(tmp_path: Path) -> Path:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    real_dir = tmp_path / "walkthrough" / "real"
+    mock_dir = tmp_path / "walkthrough" / "mock"
+    real_dir.mkdir(parents=True)
+    mock_dir.mkdir(parents=True)
+    example_path = real_dir / "01_tuning_qa.py"
+    example_path.write_text("print('real')\n")
+    (mock_dir / "01_tuning_qa.py").write_text("print('mock')\n")
+    return example_path
+
+
+def test_real_examples_fail_without_provider_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    example_path = _create_example_tree(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        maybe_run_mock_example(str(example_path))
+
+    message = str(exc_info.value)
+    assert "OPENAI_API_KEY environment variable is required" in message
+    assert "python walkthrough/real/01_tuning_qa.py" in message
+    assert "python walkthrough/mock/01_tuning_qa.py" in message
+
+
+def test_real_examples_reject_mock_fallback_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    example_path = _create_example_tree(tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+    with pytest.raises(SystemExit) as exc_info:
+        maybe_run_mock_example(str(example_path))
+
+    message = str(exc_info.value)
+    assert "do not fall back to mock mode" in message
+    assert "python walkthrough/mock/01_tuning_qa.py" in message
+
+
+def test_real_examples_continue_when_provider_key_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    example_path = _create_example_tree(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+
+    maybe_run_mock_example(str(example_path))

--- a/walkthrough/utils/helpers.py
+++ b/walkthrough/utils/helpers.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import os
-import runpy
 from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -107,11 +106,6 @@ def sanitize_traigent_api_key() -> None:
         )
         os.environ.pop("TRAIGENT_API_KEY", None)
 
-
-def _is_truthy_env(var_name: str) -> bool:
-    return os.getenv(var_name, "").lower() in ("1", "true", "yes")
-
-
 def _find_repo_root(start_path: Path) -> Path:
     """Walk upward until the repository root (identified by pyproject.toml)."""
     for candidate in (start_path.parent, *start_path.parents):
@@ -120,22 +114,26 @@ def _find_repo_root(start_path: Path) -> Path:
     return start_path.parents[2]
 
 
-def _print_fallback_warning(reason: str, display_path: str) -> None:
-    """Print a prominent warning before delegating to a mock walkthrough."""
-    lines = [
-        f"WARNING: {reason}",
-        f"Falling back to {display_path}.",
-        "Set the required API key to use real LLM calls.",
-        "Set TRAIGENT_REQUIRE_REAL=1 to fail instead of falling back.",
-    ]
-    width = max(len(line) for line in lines)
-    border = "!" * (width + 4)
-    print()
-    print(border)
-    for line in lines:
-        print(f"! {line.ljust(width)} !")
-    print(border)
-    print()
+def _required_real_example_message(
+    example_file: Path,
+    required_env_vars: tuple[str, ...],
+) -> str:
+    """Build a clear hard-failure message for real walkthrough examples."""
+    repo_root = _find_repo_root(example_file)
+    real_display_path = example_file.relative_to(repo_root).as_posix()
+    mock_display_path = (
+        example_file.parent.parent / "mock" / example_file.name
+    ).relative_to(repo_root).as_posix()
+    env_list = " or ".join(required_env_vars)
+    primary_env = required_env_vars[0]
+    return (
+        f"ERROR: {env_list} environment variable is required for real examples.\n\n"
+        "To run this example:\n"
+        f"  export {primary_env}=your-key-here\n"
+        f"  python {real_display_path}\n\n"
+        "For mock examples without API keys, use:\n"
+        f"  python {mock_display_path}"
+    )
 
 
 def maybe_run_mock_example(
@@ -143,68 +141,30 @@ def maybe_run_mock_example(
     *,
     required_env_vars: tuple[str, ...] = ("OPENAI_API_KEY",),
 ) -> None:
-    """Run the matching mock walkthrough when required provider keys are missing.
-
-    This keeps first-run walkthrough usage seamless: the user can invoke a real
-    example directly, see a short warning, and still get a successful mock run.
+    """Validate that real walkthroughs have the provider keys they require.
 
     Args:
         example_path: Current script ``__file__`` path.
         required_env_vars: Provider key env vars that enable real execution.
 
     Raises:
-        SystemExit: After executing the matching mock example.
+        SystemExit: When the real example should not proceed.
     """
-    require_real = _is_truthy_env("TRAIGENT_REQUIRE_REAL")
-    should_force_mock = _is_truthy_env("TRAIGENT_MOCK_LLM")
+    should_force_mock = os.getenv("TRAIGENT_MOCK_LLM", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     has_required_key = any(os.getenv(var_name) for var_name in required_env_vars)
-
-    if require_real:
-        if should_force_mock:
-            raise SystemExit(
-                "TRAIGENT_REQUIRE_REAL=1 is set, so TRAIGENT_MOCK_LLM cannot be used. "
-                "Unset TRAIGENT_MOCK_LLM or disable TRAIGENT_REQUIRE_REAL."
-            )
-        if not has_required_key:
-            raise SystemExit(
-                "TRAIGENT_REQUIRE_REAL=1 is set and no required provider key is available. "
-                f"Set one of: {', '.join(required_env_vars)}"
-            )
-        return
-
-    if not should_force_mock and has_required_key:
-        return
-
     example_file = Path(example_path).resolve()
-    mock_path = example_file.parent.parent / "mock" / example_file.name
-    if not mock_path.exists():
-        missing_keys = ", ".join(required_env_vars)
-        raise SystemExit(
-            f"No mock fallback exists for {example_file.name}. "
-            f"Set one of: {missing_keys}"
-        )
-
-    repo_root = _find_repo_root(example_file)
-    display_path = mock_path.relative_to(repo_root).as_posix()
     if should_force_mock:
-        reason = "TRAIGENT_MOCK_LLM is enabled"
-    else:
-        reason = f"Missing {' or '.join(required_env_vars)}"
-
-    _print_fallback_warning(reason, display_path)
-
-    os.environ["TRAIGENT_MOCK_LLM"] = "true"
-    os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
-    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
-    try:
-        runpy.run_path(str(mock_path), run_name="__main__")
-    except SystemExit:
-        raise
-    except Exception as exc:
         raise SystemExit(
-            f"Mock fallback {display_path} failed: {type(exc).__name__}: {exc}"
+            "ERROR: walkthrough/real examples do not fall back to mock mode. "
+            "Unset TRAIGENT_MOCK_LLM and provide the required API key, or run the "
+            f"mock example directly.\n\n{_required_real_example_message(example_file, required_env_vars)}"
         )
-    raise SystemExit(0)
+    if not has_required_key:
+        raise SystemExit(_required_real_example_message(example_file, required_env_vars))
 
 
 def setup_example_logger(name: str) -> logging.Logger:


### PR DESCRIPTION
## Summary
- stop `walkthrough/real/*` examples from silently falling back to mock mode
- fail fast with a clear provider-key error that points users to the matching real and mock commands
- add focused regression coverage for missing-key, forced-mock, and valid-key paths

## Validation
- `pytest -o addopts='' tests/unit/walkthrough/test_helpers.py`

Closes #539
