### PR TITLE
fix: remove duplicate results table from hello_world.py

### DIFF
--- a/hello_world.py
+++ b/hello_world.py
@@ -6,7 +6,6 @@ For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
 """
 import asyncio
 import os
-import sys
 from pathlib import Path
 
 # hello_world.py always runs in mock mode — no API keys needed.
@@ -15,11 +14,9 @@ os.environ["TRAIGENT_MOCK_LLM"] = "true"
 os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
 os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
-sys.path.append(str(Path(__file__).parent / "walkthrough"))
+from langchain_openai import ChatOpenAI
 
 import traigent
-from langchain_openai import ChatOpenAI
-from utils.helpers import print_results_table
 
 DATASET = str(Path(__file__).parent / "examples" / "datasets" / "quickstart" / "qa_samples.jsonl")
 OBJECTIVES = ["accuracy"]
@@ -44,5 +41,3 @@ def answer(question: str) -> str:
 
 if __name__ == "__main__":
     result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))
-    is_mock = os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes")
-    print_results_table(result, CONFIG_SPACE, OBJECTIVES, is_mock=is_mock)


### PR DESCRIPTION
## Summary
- Removed manual `print_results_table()` call from `hello_world.py` — the SDK callback system already renders it on optimization complete
- Removed `sys.path.append` hack and `utils.helpers` import that were only needed for the manual table call
- Cleaned up unused `sys` import

## Context
`hello_world.py` was rendering the results table twice in interactive terminals:
1. Once via `ProgressBarCallback.on_optimization_complete()` (SDK callback)
2. Once via the manual `print_results_table()` call at line 48

The SDK callback system (ProgressBarCallback for interactive, ResultsTableCallback for non-interactive) now owns all post-optimization output.

Lazy imports for faster cold start tracked separately in #587.

Closes #516

## Test plan
- [ ] Run `python hello_world.py` — verify results table appears exactly once
- [ ] Run in non-interactive mode (`echo | python hello_world.py`) — verify table still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)