### PR TITLE
docs: hide uv install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Our mission: **Anything you can measure, we can improve.** Whether it's accuracy
 
 > **Runs multiple LLM trials** — use `TRAIGENT_MOCK_LLM=true` to test without spending money, or set `TRAIGENT_RUN_COST_LIMIT=2.0` to cap spend. See [Cost Management](#cost-management).
 
-**Quick Install (`uv` recommended):**
+**Quick Install:**
 
 macOS / Linux:
 
@@ -27,12 +27,9 @@ macOS / Linux:
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 
-command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
-
-uv venv --python 3.12 .venv
+python3 -m venv .venv
 source .venv/bin/activate
-uv pip install -e ".[recommended]"
+pip install -e ".[recommended]"
 ```
 
 Windows PowerShell:
@@ -41,17 +38,12 @@ Windows PowerShell:
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-  irm https://astral.sh/uv/install.ps1 | iex
-}
-
-uv venv --python 3.12 .venv
+python -m venv .venv
 .venv\Scripts\Activate.ps1
-uv pip install -e ".[recommended]"
+pip install -e ".[recommended]"
 ```
 
-Prefer `uv` for new environments. If you need a `pip` fallback instead, see
-[Installation details](#installation).
+For more options, see [Installation details](#installation).
 
 **Try it now — no API keys needed** (requires the source checkout above):
 
@@ -251,19 +243,7 @@ Python 3.11+ on Linux, macOS, or Windows. For coordinated release validation, in
 
 **[Full installation guide →](docs/getting-started/installation.md)**
 
-Preferred source install with `uv`:
-
-```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
-command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
-uv venv --python 3.12 .venv
-source .venv/bin/activate
-uv pip install -e ".[recommended]"
-```
-
-Fallback source install with `pip`:
+Source install with `pip`:
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git
@@ -341,10 +321,10 @@ traigent --help                              # Full command reference
 
 | Problem | Fix |
 |---------|-----|
-| `ModuleNotFoundError` | `uv pip install -e ".[recommended]"` or check venv is activated |
+| `ModuleNotFoundError` | `pip install -e ".[recommended]"` or check venv is activated |
 | 0.0% accuracy | Set `TRAIGENT_MOCK_LLM=true`, or check dataset format |
 | Missing API keys | Copy `.env.example` to `.env`; or use mock mode |
-| Permission errors | Create a fresh `uv` venv and reinstall dependencies |
+| Permission errors | Create a fresh venv and reinstall dependencies |
 
 </details>
 
@@ -353,8 +333,8 @@ traigent --help                              # Full command reference
 ## 🛠️ Development
 
 ```bash
-uv venv --python 3.12 .venv && source .venv/bin/activate
-uv pip install -e ".[all,dev]"           # Install with dev dependencies
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[all,dev]"              # Install with dev dependencies
 TRAIGENT_MOCK_LLM=true pytest            # Run tests
 make format && make lint                 # Format and lint
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,15 +13,6 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"           # Recommended bundle: integrations, analytics, bayesian, visualization, hybrid, pydanticai
 ```
 
-### Faster path (uv)
-
-```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
-uv venv && source .venv/bin/activate
-uv pip install -e ".[recommended]"        # Same recommended bundle, faster resolver
-```
-
 ### PyPI vs source installs
 
 `0.10.0` release validation uses the source install from this repository. Use a published package only if your team separately validates that artifact for your environment.

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -10,11 +10,8 @@ This guide covers running tests in the Traigent SDK project.
 # Using pip
 pip install -e ".[test]"
 
-# Using uv (faster)
-uv pip install -e ".[test]"
-
 # Or install dev dependencies (includes test + linting tools)
-uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ### Run Tests
@@ -132,13 +129,13 @@ TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 
-# Create virtual environment with uv
-uv venv
+# Create virtual environment
+python3 -m venv .venv
 source .venv/bin/activate  # Linux/Mac
 # or: .venv\Scripts\activate  # Windows
 
 # Install dev dependencies (includes test)
-uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ### 2. Run Tests Before Committing
@@ -273,8 +270,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install uv
-        uv pip install -e ".[test]"
+        pip install -e ".[test]"
 
     - name: Run tests
       run: pytest --cov=traigent --cov-report=xml

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -28,24 +28,13 @@ pip install -r requirements/requirements.txt
 pip install -r requirements/requirements-dev.txt
 ```
 
-### Method 2: Using uv (Recommended - 10-100x faster)
+### Method 2: Using pyproject.toml extras (Recommended for development)
 
 ```bash
-# Core only
-uv pip install -r requirements/requirements.txt
-
-# Development (all features + dev tools)
-uv pip install -r requirements/requirements-dev.txt
-```
-
-### Method 3: Using pyproject.toml extras (Recommended for development)
-
-```bash
-# Using uv (faster)
-uv pip install -e ".[test,dev,integrations,analytics,bayesian,security]"
+pip install -e ".[test,dev,integrations,analytics,bayesian,security]"
 
 # Install everything
-uv pip install -e ".[all]"
+pip install -e ".[all]"
 ```
 
 ## Recent Changes (2024-10-14)

--- a/walkthrough/README.md
+++ b/walkthrough/README.md
@@ -20,7 +20,7 @@ install with the recommended extras:
 ```bash
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
-pip install -e ".[recommended]"   # or: uv pip install -e ".[recommended]"
+pip install -e ".[recommended]"
 ```
 
 The `recommended` extra includes LangChain, OpenAI, Anthropic, Google Gemini,


### PR DESCRIPTION
## Summary
- Replaced all `uv` install instructions with standard `pip` equivalents in README
- Removed uv-specific setup (auto-install scripts, `uv venv`, `uv pip`) from Quick Install, Installation details, Troubleshooting, and Development sections
- `pip` is now the only documented install method until uv support is validated

Closes #570

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no `uv` references remain in README
- [ ] Verify all install commands work with pip

🤖 Generated with [Claude Code](https://claude.com/claude-code)