### PR TITLE
fix: respect TRAIGENT_MOCK_LLM=false in hello_world.py

### DIFF
--- a/hello_world.py
+++ b/hello_world.py
@@ -8,11 +8,12 @@ import asyncio
 import os
 from pathlib import Path
 
-# hello_world.py always runs in mock mode — no API keys needed.
-# Hard-set so stale shell env vars don't silently break the quickstart.
-os.environ["TRAIGENT_MOCK_LLM"] = "true"
-os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
-os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+# Default to mock mode so the quickstart works without API keys.
+# Override with: TRAIGENT_MOCK_LLM=false python hello_world.py
+os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
+    os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
+    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
 from langchain_openai import ChatOpenAI
 


### PR DESCRIPTION
## Summary
- `hello_world.py` hard-coded `TRAIGENT_MOCK_LLM=true`, ignoring the user's shell env var
- Now uses `setdefault` so `TRAIGENT_MOCK_LLM=false python hello_world.py` works
- Dummy API key and offline mode are only injected when mock mode is active

## Test plan
- [ ] `python hello_world.py` — runs in mock mode (default, no keys needed)
- [ ] `TRAIGENT_MOCK_LLM=false python hello_world.py` — uses real LLM calls with user's API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)