### PR TITLE
ci: add tag-based auto-publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
 name: Publish to PyPI
 
 on:
+  # Auto-publish when a version tag is pushed (e.g. v0.10.0)
+  push:
+    tags:
+      - "v*"
+
+  # Keep manual dispatch as fallback (e.g. for TestPyPI)
   workflow_dispatch:
     inputs:
       environment:
@@ -20,8 +26,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.inputs.confirm_publish == 'true'
-    environment: ${{ github.event.inputs.environment || 'pypi' }}
+    # Run if: tag push OR manual dispatch with confirmation
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.confirm_publish == 'true'
+    environment: ${{ (github.event_name == 'push' && 'pypi') || github.event.inputs.environment || 'pypi' }}
     permissions:
       id-token: write  # For trusted publishing
       contents: read
@@ -50,6 +57,17 @@ jobs:
         if [ "$VERSION_PYPROJECT" != "$VERSION_INIT" ]; then
           echo "Error: Version mismatch between pyproject.toml and __init__.py"
           exit 1
+        fi
+
+        # If triggered by a tag, verify the tag matches the package version
+        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "Git tag version: $TAG_VERSION"
+          if [ "$TAG_VERSION" != "$VERSION_PYPROJECT" ]; then
+            echo "Error: Git tag v$TAG_VERSION does not match package version $VERSION_PYPROJECT"
+            exit 1
+          fi
+          echo "Tag v$TAG_VERSION matches package version $VERSION_PYPROJECT"
         fi
 
     - name: Run tests before publishing
@@ -87,17 +105,17 @@ jobs:
         pip install dist/*.whl
         python -c "import traigent; print(f'Package test: traigent v{traigent.__version__} imported successfully')"
 
-    # Publish to Test PyPI first for manual verification
+    # Publish to Test PyPI (manual dispatch only)
     - name: Publish to Test PyPI
-      if: github.event.inputs.environment == 'testpypi'
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
       with:
         repository-url: https://test.pypi.org/legacy/
         verbose: true
 
-    # Publish to production PyPI only by explicit manual dispatch
+    # Publish to production PyPI (automatic on tag push, or manual dispatch)
     - name: Publish to PyPI
-      if: github.event.inputs.environment == 'pypi'
+      if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'pypi')
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
       with:
         verbose: true
@@ -105,10 +123,12 @@ jobs:
     - name: Create deployment summary
       if: always()
       run: |
+        ENVIRONMENT="${{ (github.event_name == 'push' && 'pypi (auto from tag)') || github.event.inputs.environment || 'unknown' }}"
         echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
         echo "- **Version**: $(python -c "import traigent; print(traigent.__version__)")" >> $GITHUB_STEP_SUMMARY
-        echo "- **Environment**: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Environment**: ${ENVIRONMENT}" >> $GITHUB_STEP_SUMMARY
         echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Ref**: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
 
   verify-publication:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Our mission: **Anything you can measure, we can improve.** Whether it's accuracy
 
 > **Runs multiple LLM trials** — use `TRAIGENT_MOCK_LLM=true` to test without spending money, or set `TRAIGENT_RUN_COST_LIMIT=2.0` to cap spend. See [Cost Management](#cost-management).
 
-**Quick Install (`uv` recommended):**
+**Quick Install:**
 
 macOS / Linux:
 
@@ -27,12 +27,9 @@ macOS / Linux:
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 
-command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
-
-uv venv --python 3.12 .venv
+python3 -m venv .venv
 source .venv/bin/activate
-uv pip install -e ".[recommended]"
+pip install -e ".[recommended]"
 ```
 
 Windows PowerShell:
@@ -41,17 +38,12 @@ Windows PowerShell:
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-  irm https://astral.sh/uv/install.ps1 | iex
-}
-
-uv venv --python 3.12 .venv
+python -m venv .venv
 .venv\Scripts\Activate.ps1
-uv pip install -e ".[recommended]"
+pip install -e ".[recommended]"
 ```
 
-Prefer `uv` for new environments. If you need a `pip` fallback instead, see
-[Installation details](#installation).
+For more options, see [Installation details](#installation).
 
 **Try it now — no API keys needed** (requires the source checkout above):
 
@@ -251,19 +243,7 @@ Python 3.11+ on Linux, macOS, or Windows. For coordinated release validation, in
 
 **[Full installation guide →](docs/getting-started/installation.md)**
 
-Preferred source install with `uv`:
-
-```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
-command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
-uv venv --python 3.12 .venv
-source .venv/bin/activate
-uv pip install -e ".[recommended]"
-```
-
-Fallback source install with `pip`:
+Source install with `pip`:
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git
@@ -341,10 +321,10 @@ traigent --help                              # Full command reference
 
 | Problem | Fix |
 |---------|-----|
-| `ModuleNotFoundError` | `uv pip install -e ".[recommended]"` or check venv is activated |
+| `ModuleNotFoundError` | `pip install -e ".[recommended]"` or check venv is activated |
 | 0.0% accuracy | Set `TRAIGENT_MOCK_LLM=true`, or check dataset format |
 | Missing API keys | Copy `.env.example` to `.env`; or use mock mode |
-| Permission errors | Create a fresh `uv` venv and reinstall dependencies |
+| Permission errors | Create a fresh venv and reinstall dependencies |
 
 </details>
 
@@ -353,8 +333,8 @@ traigent --help                              # Full command reference
 ## 🛠️ Development
 
 ```bash
-uv venv --python 3.12 .venv && source .venv/bin/activate
-uv pip install -e ".[all,dev]"           # Install with dev dependencies
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[all,dev]"              # Install with dev dependencies
 TRAIGENT_MOCK_LLM=true pytest            # Run tests
 make format && make lint                 # Format and lint
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,15 +13,6 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"           # Recommended bundle: integrations, analytics, bayesian, visualization, hybrid, pydanticai
 ```
 
-### Faster path (uv)
-
-```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
-uv venv && source .venv/bin/activate
-uv pip install -e ".[recommended]"        # Same recommended bundle, faster resolver
-```
-
 ### PyPI vs source installs
 
 `0.10.0` release validation uses the source install from this repository. Use a published package only if your team separately validates that artifact for your environment.

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -10,11 +10,8 @@ This guide covers running tests in the Traigent SDK project.
 # Using pip
 pip install -e ".[test]"
 
-# Using uv (faster)
-uv pip install -e ".[test]"
-
 # Or install dev dependencies (includes test + linting tools)
-uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ### Run Tests
@@ -132,13 +129,13 @@ TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
 
-# Create virtual environment with uv
-uv venv
+# Create virtual environment
+python3 -m venv .venv
 source .venv/bin/activate  # Linux/Mac
 # or: .venv\Scripts\activate  # Windows
 
 # Install dev dependencies (includes test)
-uv pip install -e ".[dev]"
+pip install -e ".[dev]"
 ```
 
 ### 2. Run Tests Before Committing
@@ -273,8 +270,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install uv
-        uv pip install -e ".[test]"
+        pip install -e ".[test]"
 
     - name: Run tests
       run: pytest --cov=traigent --cov-report=xml

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+Text-to-SQL Query Generation - Optimize natural language to SQL conversion.
+
+Demonstrates how to use Traigent to tune a text-to-SQL pipeline over a
+telecom (Amdocs-style) database schema. Evaluates generated SQL using a
+normalized exact-match metric and a keyword-coverage fallback.
+
+Run without an API key (mock mode):
+    TRAIGENT_MOCK_LLM=true python examples/core/text-to-sql/run.py
+
+Run with a real LLM (requires ANTHROPIC_API_KEY):
+    python examples/core/text-to-sql/run.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import sys
+from pathlib import Path
+
+MOCK = str(os.getenv("TRAIGENT_MOCK_LLM", "")).lower() in {"1", "true", "yes", "y"}
+BASE = Path(__file__).parent
+if MOCK:
+    os.environ["HOME"] = str(BASE)
+    results_dir = BASE / ".traigent_local"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    os.environ["TRAIGENT_RESULTS_FOLDER"] = str(results_dir)
+
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
+
+try:
+    import traigent
+except ImportError:  # pragma: no cover
+    import importlib
+
+    module_path = Path(__file__).resolve()
+    for depth in (2, 3):
+        try:
+            sys.path.append(str(module_path.parents[depth]))
+        except IndexError:
+            continue
+    traigent = importlib.import_module("traigent")
+
+DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "text-to-sql"
+DATASET = str(DATA_ROOT / "evaluation_set.jsonl")
+SCHEMA = (BASE / "schema.sql").read_text()
+
+if MOCK:
+    try:
+        traigent.initialize(execution_mode="edge_analytics")
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Evaluation metric
+# ---------------------------------------------------------------------------
+
+def _normalize_sql(sql: str) -> str:
+    """Lowercase, collapse whitespace, strip trailing semicolon."""
+    sql = sql.strip().rstrip(";").lower()
+    return re.sub(r"\s+", " ", sql)
+
+
+def sql_accuracy(output: str, expected: str, **_: object) -> float:
+    """Score SQL output against expected query.
+
+    Returns 1.0 for a normalized exact match, 0.5 if all expected SQL
+    keywords and table names are present, otherwise 0.0.
+    """
+    norm_out = _normalize_sql(output)
+    norm_exp = _normalize_sql(expected)
+
+    if norm_out == norm_exp:
+        return 1.0
+
+    # Partial credit: check that key tokens from the expected query appear
+    sql_keywords = {"select", "from", "where", "join", "on", "group by",
+                    "order by", "having", "limit", "count", "sum", "avg",
+                    "max", "min", "distinct", "not in"}
+    exp_tokens = set(norm_exp.split())
+    out_tokens = set(norm_out.split())
+    # Table/column names are any word that is not a SQL keyword
+    stop = {"select", "from", "where", "join", "on", "by", "and", "or",
+            "not", "in", "as", "is", "null", "the", "a", "an", "*", ">",
+            "<", "=", ">=", "<=", "<>", "(", ")", ",", ".", "'", "1", "5"}
+    exp_names = {t for t in exp_tokens if t not in stop and not t.replace(".", "").isnumeric()}
+    matched = sum(1 for t in exp_names if t in out_tokens)
+    coverage = matched / len(exp_names) if exp_names else 0.0
+    return round(0.5 * coverage, 3)
+
+
+# ---------------------------------------------------------------------------
+# Mock responses (deterministic; no API key required)
+# ---------------------------------------------------------------------------
+
+_MOCK_ANSWERS: dict[str, str] = {
+    "show all active customers":
+        "SELECT * FROM customers WHERE status = 'active'",
+    "count how many customers are in new york":
+        "SELECT COUNT(*) FROM customers WHERE city = 'New York'",
+    "find customers with unpaid bills":
+        "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid'",
+    "get the total billing revenue":
+        "SELECT SUM(amount) FROM billing",
+    "list the top 5 customers by data usage":
+        "SELECT c.name, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_data DESC LIMIT 5",
+    "find all premium plan subscribers":
+        "SELECT * FROM subscriptions WHERE plan_name = 'premium'",
+    "get average monthly rate per plan":
+        "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name",
+    "count customers by city":
+        "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city ORDER BY customer_count DESC",
+    "find overdue unpaid bills":
+        "SELECT * FROM billing WHERE status = 'unpaid' AND due_date < CURRENT_DATE",
+    "show total call minutes by customer":
+        "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_minutes DESC",
+    "find customers with no network usage":
+        "SELECT name FROM customers WHERE customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)",
+    "list customers on the enterprise plan":
+        "SELECT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.plan_name = 'enterprise'",
+    "get the highest monthly billing amount":
+        "SELECT MAX(amount) FROM billing",
+    "show customers who have more than one subscription":
+        "SELECT customer_id, COUNT(*) AS sub_count FROM subscriptions GROUP BY customer_id HAVING COUNT(*) > 1",
+    "find the average data usage per customer":
+        "SELECT c.name, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
+}
+
+
+def _mock_generate_sql(question: str) -> str:
+    key = question.strip().lower()
+    return _MOCK_ANSWERS.get(key, f"SELECT * FROM customers -- unknown: {question}")
+
+
+# ---------------------------------------------------------------------------
+# Optimized function
+# ---------------------------------------------------------------------------
+
+@traigent.optimize(
+    eval_dataset=DATASET,
+    objectives=["sql_accuracy"],
+    configuration_space={
+        "model": ["claude-3-haiku-20240307", "claude-3-5-sonnet-20241022"],
+        "temperature": [0.0, 0.2],
+        "include_schema": ["true", "false"],
+    },
+    metric_functions={"sql_accuracy": sql_accuracy},
+    injection_mode="seamless",
+    execution_mode="edge_analytics",
+)
+def generate_sql(question: str) -> str:
+    """Convert a natural language question into a SQL query.
+
+    Args:
+        question: The natural language database question.
+
+    Returns:
+        A syntactically valid SQL query string.
+    """
+    if MOCK:
+        return _mock_generate_sql(question)
+
+    assert os.getenv("ANTHROPIC_API_KEY"), (
+        "Set ANTHROPIC_API_KEY or run with TRAIGENT_MOCK_LLM=true"
+    )
+
+    from langchain_anthropic import ChatAnthropic
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    config = traigent.get_config()
+    model = str(config.get("model", "claude-3-5-sonnet-20241022"))
+    temperature = float(config.get("temperature", 0.0))
+    include_schema = str(config.get("include_schema", "true")) == "true"
+
+    system_parts = [
+        "You are an expert SQL assistant. Convert the user's question into a valid SQL query.",
+        "Return ONLY the SQL query — no explanation, no markdown, no code fences.",
+    ]
+    if include_schema:
+        system_parts.append(f"\nDatabase schema:\n{SCHEMA}")
+
+    llm = ChatAnthropic(
+        model_name=model,
+        temperature=temperature,
+        timeout=None,
+        stop=None,
+    )
+    response = llm.invoke([
+        SystemMessage(content="\n".join(system_parts)),
+        HumanMessage(content=question),
+    ])
+    return str(response.content).strip()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    try:
+        print("=" * 60)
+        print("Text-to-SQL Optimization Example")
+        print("=" * 60)
+        print("Schema: Telecom customer database (customers, subscriptions,")
+        print("        billing, network_usage)")
+        print("Objective: sql_accuracy (normalize + exact-match scoring)")
+        print("Configuration space:")
+        print("  - model: claude-3-haiku, claude-3-5-sonnet")
+        print("  - temperature: 0.0, 0.2")
+        print("  - include_schema: true, false")
+        print(f"Mode: {'MOCK (no API key required)' if MOCK else 'REAL (requires ANTHROPIC_API_KEY)'}")
+        print("-" * 60)
+
+        async def main() -> None:
+            trials = 12  # covers all 8 config combos + oversampling
+            result = await generate_sql.optimize(algorithm="grid", max_trials=trials)
+
+            print("\n" + "=" * 60)
+            print("OPTIMIZATION COMPLETE")
+            print("=" * 60)
+            print(f"Best config : {result.best_config}")
+            print(f"Best score  : {result.best_score:.3f}")
+            print(f"Total trials: {len(result.trials)}")
+
+            df = result.to_aggregated_dataframe(primary_objective="sql_accuracy")
+            preferred = ["model", "temperature", "include_schema",
+                         "samples_count", "sql_accuracy", "cost", "duration"]
+            cols = [c for c in preferred if c in df.columns]
+            if cols:
+                df = df.sort_values("sql_accuracy", ascending=False)
+                print("\nAggregated results:")
+                print(df[cols].to_string(index=False))
+
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nCancelled by user.")
+        raise SystemExit(130) from None

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -46,7 +46,8 @@ except ImportError:  # pragma: no cover
 
 DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "text-to-sql"
 DATASET = str(DATA_ROOT / "evaluation_set.jsonl")
-SCHEMA = (BASE / "schema.sql").read_text()
+_schema_path = BASE / "schema.sql"
+SCHEMA = _schema_path.read_text() if _schema_path.exists() else ""
 
 if MOCK:
     try:

--- a/examples/core/text-to-sql/schema.sql
+++ b/examples/core/text-to-sql/schema.sql
@@ -1,0 +1,32 @@
+-- Telecom customer database schema (example for text-to-sql optimization)
+
+CREATE TABLE customers (
+    customer_id   INTEGER PRIMARY KEY,
+    name          TEXT NOT NULL,
+    city          TEXT,
+    status        TEXT DEFAULT 'active'
+);
+
+CREATE TABLE subscriptions (
+    subscription_id  INTEGER PRIMARY KEY,
+    customer_id      INTEGER REFERENCES customers(customer_id),
+    plan_name        TEXT NOT NULL,
+    monthly_rate     REAL,
+    start_date       DATE
+);
+
+CREATE TABLE billing (
+    billing_id    INTEGER PRIMARY KEY,
+    customer_id   INTEGER REFERENCES customers(customer_id),
+    amount        REAL NOT NULL,
+    status        TEXT DEFAULT 'paid',
+    due_date      DATE
+);
+
+CREATE TABLE network_usage (
+    usage_id      INTEGER PRIMARY KEY,
+    customer_id   INTEGER REFERENCES customers(customer_id),
+    call_minutes  REAL DEFAULT 0,
+    data_gb       REAL DEFAULT 0,
+    record_date   DATE
+);

--- a/examples/datasets/text-to-sql/evaluation_set.jsonl
+++ b/examples/datasets/text-to-sql/evaluation_set.jsonl
@@ -1,0 +1,15 @@
+{"question": "show all active customers", "expected": "SELECT * FROM customers WHERE status = 'active'"}
+{"question": "count how many customers are in new york", "expected": "SELECT COUNT(*) FROM customers WHERE city = 'New York'"}
+{"question": "find customers with unpaid bills", "expected": "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid'"}
+{"question": "get the total billing revenue", "expected": "SELECT SUM(amount) FROM billing"}
+{"question": "list the top 5 customers by data usage", "expected": "SELECT c.name, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_data DESC LIMIT 5"}
+{"question": "find all premium plan subscribers", "expected": "SELECT * FROM subscriptions WHERE plan_name = 'premium'"}
+{"question": "get average monthly rate per plan", "expected": "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name"}
+{"question": "count customers by city", "expected": "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city ORDER BY customer_count DESC"}
+{"question": "find overdue unpaid bills", "expected": "SELECT * FROM billing WHERE status = 'unpaid' AND due_date < CURRENT_DATE"}
+{"question": "show total call minutes by customer", "expected": "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_minutes DESC"}
+{"question": "find customers with no network usage", "expected": "SELECT name FROM customers WHERE customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)"}
+{"question": "list customers on the enterprise plan", "expected": "SELECT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.plan_name = 'enterprise'"}
+{"question": "get the highest monthly billing amount", "expected": "SELECT MAX(amount) FROM billing"}
+{"question": "show customers who have more than one subscription", "expected": "SELECT customer_id, COUNT(*) AS sub_count FROM subscriptions GROUP BY customer_id HAVING COUNT(*) > 1"}
+{"question": "find the average data usage per customer", "expected": "SELECT c.name, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name"}

--- a/hello_world.py
+++ b/hello_world.py
@@ -8,11 +8,12 @@ import asyncio
 import os
 from pathlib import Path
 
-# hello_world.py always runs in mock mode — no API keys needed.
-# Hard-set so stale shell env vars don't silently break the quickstart.
-os.environ["TRAIGENT_MOCK_LLM"] = "true"
-os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
-os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+# Default to mock mode so the quickstart works without API keys.
+# Override with: TRAIGENT_MOCK_LLM=false python hello_world.py
+os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
+    os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
+    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
 from langchain_openai import ChatOpenAI
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -28,24 +28,13 @@ pip install -r requirements/requirements.txt
 pip install -r requirements/requirements-dev.txt
 ```
 
-### Method 2: Using uv (Recommended - 10-100x faster)
+### Method 2: Using pyproject.toml extras (Recommended for development)
 
 ```bash
-# Core only
-uv pip install -r requirements/requirements.txt
-
-# Development (all features + dev tools)
-uv pip install -r requirements/requirements-dev.txt
-```
-
-### Method 3: Using pyproject.toml extras (Recommended for development)
-
-```bash
-# Using uv (faster)
-uv pip install -e ".[test,dev,integrations,analytics,bayesian,security]"
+pip install -e ".[test,dev,integrations,analytics,bayesian,security]"
 
 # Install everything
-uv pip install -e ".[all]"
+pip install -e ".[all]"
 ```
 
 ## Recent Changes (2024-10-14)

--- a/walkthrough/README.md
+++ b/walkthrough/README.md
@@ -20,7 +20,7 @@ install with the recommended extras:
 ```bash
 git clone https://github.com/Traigent/Traigent.git
 cd Traigent
-pip install -e ".[recommended]"   # or: uv pip install -e ".[recommended]"
+pip install -e ".[recommended]"
 ```
 
 The `recommended` extra includes LangChain, OpenAI, Anthropic, Google Gemini,

--- a/walkthrough/mock/07_multi_provider.py
+++ b/walkthrough/mock/07_multi_provider.py
@@ -36,11 +36,14 @@ from utils.mock_answers import (
 
 import traigent
 from traigent import TraigentConfig
+from traigent.integrations.providers import get_models_for_tier
+from traigent.providers import get_provider_for_model
 
 # -----------------------------------------------------------------------------
 # Environment Setup (Mock Mode)
 # -----------------------------------------------------------------------------
 os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
 traigent.initialize(
     config=TraigentConfig(execution_mode="edge_analytics", minimal_logging=True)
@@ -51,17 +54,14 @@ traigent.initialize(
 # -----------------------------------------------------------------------------
 DATASETS = Path(__file__).parent.parent / "datasets"
 
-# Models from three providers: OpenAI, Anthropic, and Google
-# In real mode, each requires its respective API key
+# Models from four providers — sourced from core (single source of truth).
+# In real mode, each provider requires its respective API key:
+#   OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY
+_PROVIDERS = ["openai", "anthropic", "google", "groq"]
 PROVIDER_MODELS = {
-    # OpenAI models (requires OPENAI_API_KEY)
-    "gpt-4o-mini": "openai",
-    "gpt-4o": "openai",
-    # Anthropic models (requires ANTHROPIC_API_KEY)
-    "claude-sonnet-4-20250514": "anthropic",
-    # Google Gemini models (requires GOOGLE_API_KEY)
-    "gemini-2.0-flash": "google",
-    "gemini-1.5-pro-latest": "google",
+    model: get_provider_for_model(model)
+    for provider in _PROVIDERS
+    for model in get_models_for_tier(provider=provider, tier="balanced")
 }
 
 OBJECTIVES = ["accuracy", "cost", "latency"]


### PR DESCRIPTION
## Summary
- Pushing a version tag (e.g. `v0.10.0`) now automatically triggers the publish workflow to PyPI
- Adds tag-version consistency validation — CI fails if the tag doesn't match `pyproject.toml` version
- Manual `workflow_dispatch` retained for TestPyPI and ad-hoc publishes

## How it works
1. Developer bumps version in `pyproject.toml` + `_version.py`, merges to main
2. Push tag: `git tag v0.11.0 && git push origin v0.11.0`
3. CI runs: version check → unit tests → example smoke → build → twine check → publish → verify

## Prerequisites
- [x] PyPI trusted publisher configured (Owner: Traigent, Repo: Traigent, Workflow: publish.yml, Env: pypi)

## Test plan
- [ ] Merge this PR
- [ ] Trigger first publish via manual dispatch (Actions → Publish to PyPI → Run workflow → environment: pypi, confirm: true)
- [ ] Verify `pip install traigent==0.10.0` works
- [ ] For next release: test tag-based auto-publish with `git tag v0.11.0 && git push origin v0.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)