### PR TITLE
docs: add real-token warning to quickstart README

### DIFF
--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -43,6 +43,8 @@ python examples/quickstart/03_custom_objectives.py
 
 Once you're ready to use real LLM APIs:
 
+> **Note:** Running with `TRAIGENT_MOCK_LLM=false` will make real API calls and consume tokens from your LLM provider account.
+
 ```bash
 # Set your API keys
 export OPENAI_API_KEY="your-key-here"


### PR DESCRIPTION
## Summary
- Adds a note in the quickstart README's "Running with Real APIs" section warning that `TRAIGENT_MOCK_LLM=false` will consume real tokens

Related: TraigentFrontend#269

## Test plan
- [ ] Verify the note renders correctly in the quickstart README

🤖 Generated with [Claude Code](https://claude.com/claude-code)