### PR TITLE
fix: address Greptile P2 findings from develop merge

### DIFF
--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -69,8 +69,8 @@ def _normalize_sql(sql: str) -> str:
 def sql_accuracy(output: str, expected: str, **_: object) -> float:
     """Score SQL output against expected query.
 
-    Returns 1.0 for a normalized exact match, 0.5 if all expected SQL
-    keywords and table names are present, otherwise 0.0.
+    Returns 1.0 for a normalized exact match, partial credit (up to 0.5)
+    based on coverage of expected table/column names, otherwise 0.0.
     """
     norm_out = _normalize_sql(output)
     norm_exp = _normalize_sql(expected)
@@ -79,9 +79,6 @@ def sql_accuracy(output: str, expected: str, **_: object) -> float:
         return 1.0
 
     # Partial credit: check that key tokens from the expected query appear
-    sql_keywords = {"select", "from", "where", "join", "on", "group by",
-                    "order by", "having", "limit", "count", "sum", "avg",
-                    "max", "min", "distinct", "not in"}
     exp_tokens = set(norm_exp.split())
     out_tokens = set(norm_out.split())
     # Table/column names are any word that is not a SQL keyword

--- a/walkthrough/mock/07_multi_provider.py
+++ b/walkthrough/mock/07_multi_provider.py
@@ -77,14 +77,14 @@ MOCK_MODE_CONFIG = {
 }
 
 
-def get_provider_for_model(model_name: str) -> str:
-    """Return the provider name for a given model.
+def _lookup_provider(model_name: str) -> str:
+    """Return the provider name for a given model from the local mapping.
 
     Args:
         model_name: The model identifier (e.g., 'gpt-4o-mini', 'claude-3-haiku')
 
     Returns:
-        Provider name: 'openai', 'anthropic', or 'google'
+        Provider name: 'openai', 'anthropic', 'google', or 'groq'
     """
     return PROVIDER_MODELS.get(model_name, "openai")
 
@@ -162,7 +162,7 @@ async def main() -> None:
 
     # Show best configuration with provider info
     best_model = results.best_config.get("model", DEFAULT_MOCK_MODEL)
-    best_provider = get_provider_for_model(best_model)
+    best_provider = _lookup_provider(best_model)
     best_temp = results.best_config.get("temperature")
 
     print("\nBest Configuration Found:")


### PR DESCRIPTION
## Summary
- Rename shadowed `get_provider_for_model` to `_lookup_provider` in `walkthrough/mock/07_multi_provider.py` — import was shadowed by local function
- Remove unused `sql_keywords` variable and fix stale docstring in `examples/core/text-to-sql/run.py`

Addresses Greptile findings from PR #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)