### PR TITLE
fix: single source of truth for version + publish workflow fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,20 +67,6 @@ jobs:
         VERSION_PYPROJECT=${{ steps.package_version.outputs.package_version }}
         echo "pyproject.toml version: $VERSION_PYPROJECT"
 
-        # Extract version from _version.py without importing (avoids dependency issues)
-        VERSION_CODE=$(python -c "
-        import re
-        text = open('traigent/_version.py').read()
-        # Find the hardcoded return value in get_version()
-        match = re.search(r'return \"(\d+\.\d+\.\d+)\"', text)
-        print(match.group(1) if match else 'UNKNOWN')
-        ")
-        echo "_version.py version: $VERSION_CODE"
-        if [ "$VERSION_PYPROJECT" != "$VERSION_CODE" ]; then
-          echo "Error: Version mismatch between pyproject.toml ($VERSION_PYPROJECT) and _version.py ($VERSION_CODE)"
-          exit 1
-        fi
-
         # If triggered by a tag, verify the tag matches the package version
         if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -43,6 +43,8 @@ python examples/quickstart/03_custom_objectives.py
 
 Once you're ready to use real LLM APIs:
 
+> **Note:** Running with `TRAIGENT_MOCK_LLM=false` will make real API calls and consume tokens from your LLM provider account.
+
 ```bash
 # Set your API keys
 export OPENAI_API_KEY="your-key-here"

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -8,30 +8,54 @@ import importlib.metadata
 import os
 from pathlib import Path
 
+_FALLBACK_VERSION = "0.10.0"
+
+
+def _read_pyproject_version() -> str | None:
+    """Read version from pyproject.toml without external dependencies."""
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except Exception:
+        return None
+    try:
+        with open(pyproject, "rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except Exception:
+        return None
+
 
 def get_version() -> str:
     """Get the current version of the Traigent SDK.
 
+    Resolution order:
+    1. TRAIGENT_FORCE_VERSION env var (override for testing)
+    2. pyproject.toml (development mode - single source of truth)
+    3. Installed package metadata (pip-installed mode)
+    4. Hardcoded fallback
+
     Returns:
-        Version string from package metadata or fallback version
+        Version string
     """
     if override := os.getenv("TRAIGENT_FORCE_VERSION"):
         return override
 
-    project_root = Path(__file__).resolve().parent.parent
-    if (project_root / "pyproject.toml").exists():
-        # In workspace/development mode we rely on the development version string
-        return "0.10.0"
+    # Development mode: read from pyproject.toml (single source of truth)
+    pyproject_version = _read_pyproject_version()
+    if pyproject_version:
+        return pyproject_version
 
-    if os.getenv("TRAIGENT_USE_PACKAGE_METADATA", "0") == "1":
-        try:
-            # Try to get version from installed package metadata
-            return importlib.metadata.version("traigent")
-        except importlib.metadata.PackageNotFoundError:
-            pass
+    # Installed package mode: read from package metadata
+    try:
+        return importlib.metadata.version("traigent")
+    except importlib.metadata.PackageNotFoundError:
+        pass
 
-    # Fallback to hardcoded version for development/testing
-    return "0.10.0"
+    return _FALLBACK_VERSION
 
 
 def get_version_info() -> dict[str, str]:


### PR DESCRIPTION
## Summary
- `_version.py` now reads version from `pyproject.toml` via `tomllib` - no more hardcoded duplicates
- **Only one place to update for releases: `pyproject.toml` line 7**
- Simplified publish workflow version check (removed regex hack)

## Release guide (for future releases)
1. Change version in `pyproject.toml` line 7
2. Merge to main
3. `git tag v0.11.0 && git push origin v0.11.0`
4. CI auto-publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)