### PR TITLE
fix: upgrade CI actions to Node 24 + retry verify-publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,12 +36,12 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Full history for version detection
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -146,10 +146,10 @@ jobs:
 
     steps:
     - name: Wait for package propagation
-      run: sleep 60
+      run: sleep 120
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
@@ -170,7 +170,10 @@ jobs:
         VERSION="$EXPECTED_VERSION"
         echo "Testing installation of traigent==$VERSION from $PACKAGE_LABEL"
 
-        curl -fsSL "$PACKAGE_API_URL" | python - "$VERSION" <<'PY'
+        # Retry API check up to 3 times (CDN propagation can be slow)
+        for attempt in 1 2 3; do
+          echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
+          if curl -fsSL "$PACKAGE_API_URL" | python - "$VERSION" <<'PY'
         import json
         import sys
 
@@ -181,6 +184,17 @@ jobs:
             raise SystemExit(f"Version {version} not found on package index")
         print(f"Verified version {version} exists on package index")
         PY
+          then
+            break
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Version not found yet, waiting 60s before retry..."
+            sleep 60
+          else
+            echo "Error: version $VERSION not found on $PACKAGE_LABEL after 3 attempts"
+            exit 1
+          fi
+        done
 
         # Create clean environment and test installation
         python -m venv test_env


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v4 -> v6 and `actions/setup-python` v5 -> v6 (fixes Node.js 20 deprecation warnings)
- Increase PyPI propagation wait from 60s to 120s
- Add 3-attempt retry loop for PyPI API version check (fixes CDN propagation delay that caused run #32 verify-publication failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)