### PR TITLE
feat: add TRAIGENT_SDK_PATH env var for demo scripts

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -270,6 +270,31 @@ export OPENAI_API_KEY="your-key-here" # pragma: allowlist secret
 python examples/core/multi-objective-tradeoff/run_anthropic.py
 ```
 
+### Running From Outside the Repo Tree
+
+If you want to run demo scripts from a different directory (e.g. your own project),
+set the `TRAIGENT_SDK_PATH` environment variable to the SDK repo root:
+
+```bash
+# Point demos at a local SDK clone
+export TRAIGENT_SDK_PATH=/path/to/Traigent
+
+# Now you can run any example from anywhere
+python /path/to/Traigent/examples/quickstart/01_simple_qa.py
+```
+
+This works for both local-dev and CI scenarios.  When `TRAIGENT_SDK_PATH` is not set,
+scripts automatically detect the SDK location relative to their own path — so running
+from inside the repo tree requires no extra setup.
+
+| Variable | Purpose |
+| -------- | ------- |
+| `TRAIGENT_SDK_PATH` | Absolute path to the SDK repo root (overrides auto-detection) |
+| `TRAIGENT_MOCK_LLM` | Set to `true` to run without real API keys |
+| `TRAIGENT_DATASET_ROOT` | Root directory for resolving dataset paths |
+| `TRAIGENT_RESULTS_FOLDER` | Custom directory for optimization results |
+| `TRAIGENT_COST_APPROVED` | Set to `true` to skip cost confirmation prompts |
+
 ### Recommended Learning Path
 
 1. **Quickstart:** `quickstart/01_simple_qa.py` (1 min) - README examples that just work
@@ -353,7 +378,7 @@ Follow these best practices when contributing new examples:
 
 | Problem | Solution |
 | ------- | -------- |
-| `ModuleNotFoundError: No module named 'traigent'` | Run `pip install -e .` from repository root |
+| `ModuleNotFoundError: No module named 'traigent'` | Run `pip install -e .` from repository root, or set `TRAIGENT_SDK_PATH` |
 | `API key not found` | Export your API key or use `TRAIGENT_MOCK_LLM=true` |
 | `Example doesn't run` | Check example's inline comments for prerequisites |
 | `0.0% accuracy` | Use mock mode or provide valid API keys |

--- a/examples/advanced/ai-engineering-tasks/p0_context_engineering/main.py
+++ b/examples/advanced/ai-engineering-tasks/p0_context_engineering/main.py
@@ -36,7 +36,7 @@ from typing import Any
 import numpy as np
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p0_few_shot_selection/main.py
+++ b/examples/advanced/ai-engineering-tasks/p0_few_shot_selection/main.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import numpy as np
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p0_structured_output/main.py
+++ b/examples/advanced/ai-engineering-tasks/p0_structured_output/main.py
@@ -27,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Mock mode for demo

--- a/examples/advanced/ai-engineering-tasks/p1_function_calling/main.py
+++ b/examples/advanced/ai-engineering-tasks/p1_function_calling/main.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p1_safety_guardrails/main.py
+++ b/examples/advanced/ai-engineering-tasks/p1_safety_guardrails/main.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p1_token_budget/main.py
+++ b/examples/advanced/ai-engineering-tasks/p1_token_budget/main.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/execution-modes/_archived/ex03-hybrid-basic/hybrid_basic.py
+++ b/examples/advanced/execution-modes/_archived/ex03-hybrid-basic/hybrid_basic.py
@@ -20,12 +20,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/_archived/ex04-hybrid-privacy/hybrid_privacy.py
+++ b/examples/advanced/execution-modes/_archived/ex04-hybrid-privacy/hybrid_privacy.py
@@ -20,12 +20,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/_archived/ex05-cloud-basic/cloud_basic.py
+++ b/examples/advanced/execution-modes/_archived/ex05-cloud-basic/cloud_basic.py
@@ -19,12 +19,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/cloud_limitations.py
+++ b/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/cloud_limitations.py
@@ -21,12 +21,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/ex01-local-basic/local_basic.py
+++ b/examples/advanced/execution-modes/ex01-local-basic/local_basic.py
@@ -19,12 +19,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/ex02-local-privacy/local_privacy.py
+++ b/examples/advanced/execution-modes/ex02-local-privacy/local_privacy.py
@@ -19,12 +19,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/ragas/basics/run.py
+++ b/examples/advanced/ragas/basics/run.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - allow running via python path
 except ImportError:  # pragma: no cover
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).resolve().parents[3])))
     import traigent
 
 from traigent.metrics import configure_ragas_defaults  # noqa: E402

--- a/examples/advanced/ragas/column_map/run.py
+++ b/examples/advanced/ragas/column_map/run.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - allow direct execution
 except ImportError:  # pragma: no cover
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).resolve().parents[3])))
     import traigent
 
 from traigent.metrics import configure_ragas_defaults  # noqa: E402

--- a/examples/advanced/ragas/with_llm/run.py
+++ b/examples/advanced/ragas/with_llm/run.py
@@ -13,7 +13,7 @@ try:  # pragma: no cover - allow direct execution
 except ImportError:  # pragma: no cover
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).resolve().parents[3])))
     import traigent
 
 from traigent.metrics import configure_ragas_defaults  # noqa: E402

--- a/examples/advanced/results-analysis/ex01-viewing-results/viewing_results.py
+++ b/examples/advanced/results-analysis/ex01-viewing-results/viewing_results.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/results-analysis/ex02-performance-metrics/performance_metrics.py
+++ b/examples/advanced/results-analysis/ex02-performance-metrics/performance_metrics.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/core/chunking-long-context/run.py
+++ b/examples/core/chunking-long-context/run.py
@@ -96,12 +96,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/error-handling/run.py
+++ b/examples/core/error-handling/run.py
@@ -38,12 +38,16 @@ try:
 except ImportError:
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # --- Configuration ---

--- a/examples/core/few-shot-classification/run.py
+++ b/examples/core/few-shot-classification/run.py
@@ -28,12 +28,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "few-shot-classification"

--- a/examples/core/multi-objective-tradeoff/run_anthropic.py
+++ b/examples/core/multi-objective-tradeoff/run_anthropic.py
@@ -36,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_many_providers.py
+++ b/examples/core/multi-objective-tradeoff/run_many_providers.py
@@ -72,12 +72,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_openai.py
+++ b/examples/core/multi-objective-tradeoff/run_openai.py
@@ -36,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna.py
@@ -39,12 +39,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
@@ -26,12 +26,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/production-deployment/run.py
+++ b/examples/core/production-deployment/run.py
@@ -38,12 +38,16 @@ try:
 except ImportError:
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # --- Configuration ---

--- a/examples/core/prompt-ab-test/run.py
+++ b/examples/core/prompt-ab-test/run.py
@@ -24,12 +24,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/prompt-style-optimization/run.py
+++ b/examples/core/prompt-style-optimization/run.py
@@ -32,12 +32,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/rag-optimization/run.py
+++ b/examples/core/rag-optimization/run.py
@@ -74,12 +74,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 from traigent.api.types import OptimizationResult  # noqa: E402
 from traigent.utils.error_handler import APIKeyError  # noqa: E402

--- a/examples/core/safety-guardrails/run.py
+++ b/examples/core/safety-guardrails/run.py
@@ -32,12 +32,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/simple-prompt/run.py
+++ b/examples/core/simple-prompt/run.py
@@ -36,15 +36,18 @@ if MOCK:
 try:
     import traigent
 except ImportError:
-    # Fallback for running directly from the repo without installation
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # --- Configuration ---

--- a/examples/core/structured-output-json/run.py
+++ b/examples/core/structured-output-json/run.py
@@ -33,12 +33,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -36,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "text-to-sql"

--- a/examples/core/token-budget-summarization/run.py
+++ b/examples/core/token-budget-summarization/run.py
@@ -24,12 +24,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/tool-use-calculator/run.py
+++ b/examples/core/tool-use-calculator/run.py
@@ -24,12 +24,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -8,17 +8,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
@@ -30,6 +35,9 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
     traigent = importlib.import_module("traigent")
 
 # Create dataset file path

--- a/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -38,6 +38,13 @@ except ImportError:  # pragma: no cover - support IDE execution paths
     _sdk = os.environ.get("TRAIGENT_SDK_PATH")
     if _sdk:
         sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3, 4, 5):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Create dataset file path

--- a/examples/gallery/page-inline/best-practices/ex01-small-space/small_space.py
+++ b/examples/gallery/page-inline/best-practices/ex01-small-space/small_space.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/best-practices/ex02-weighted-objectives/weighted_objectives.py
+++ b/examples/gallery/page-inline/best-practices/ex02-weighted-objectives/weighted_objectives.py
@@ -16,12 +16,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema  # noqa: E402

--- a/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
+++ b/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
+++ b/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
+++ b/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/by-goal/speed-latency/simple.py
+++ b/examples/gallery/page-inline/by-goal/speed-latency/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/common-tasks/p0-context-engineering/context_engineering.py
+++ b/examples/gallery/page-inline/common-tasks/p0-context-engineering/context_engineering.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/common-tasks/p0-few-shot-selection/few_shot_selection.py
+++ b/examples/gallery/page-inline/common-tasks/p0-few-shot-selection/few_shot_selection.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/common-tasks/p0-structured-output/structured_output.py
+++ b/examples/gallery/page-inline/common-tasks/p0-structured-output/structured_output.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 _DEFAULT_CONFIG: dict[str, Any] = {

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
@@ -9,17 +9,22 @@ from pathlib import Path
 from typing import Any, TypeVar, cast
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -27,12 +32,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 F = TypeVar("F")

--- a/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
+++ b/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 

--- a/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
+++ b/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 EVAL_DATASET: str = os.path.join(

--- a/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
+++ b/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Add optimization with custom parameter names

--- a/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
+++ b/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Add optimization with mixed parameter approach

--- a/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
+++ b/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Step 1: Run optimization and save the best configuration (MCQ format)

--- a/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
+++ b/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Debug mode to see exactly what Traigent is doing

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # How Traigent intercepts and modifies your LLM calls

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Define custom parameters to optimize

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Mix seamless injection with custom parameters

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Advanced seamless injection with multiple LLM instances

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Your existing function - no changes needed

--- a/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "code_review_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "conversation_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "multi_agent_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/research/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/research/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "research_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/support/advanced.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/advanced.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "support_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/support/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "support_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "tool_use_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/blog/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/blog/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "blog_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/creative/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/creative/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "creative_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/headlines/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/media/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/media/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "media_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "anomaly_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/bi/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/bi/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "bi_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "extraction_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/extraction/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/simple.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "extraction_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/trend/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/trend/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "trend_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
@@ -11,17 +11,22 @@ from collections import Counter
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")

--- a/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
+++ b/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Create dataset file

--- a/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
+++ b/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 try:
@@ -28,12 +33,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema  # noqa: E402

--- a/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
+++ b/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 try:
@@ -28,12 +33,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.evaluators.base import Dataset, EvaluationExample  # noqa: E402

--- a/examples/integrations/ci-cd/math-qa/math_qa.py
+++ b/examples/integrations/ci-cd/math-qa/math_qa.py
@@ -15,12 +15,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Dataset file path

--- a/examples/quickstart/01_simple_qa.py
+++ b/examples/quickstart/01_simple_qa.py
@@ -23,11 +23,12 @@ os.environ.setdefault(
 ROOT_DIR = Path(__file__).resolve().parents[2]
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", str(ROOT_DIR))
 
-# Allow running from repo root without installation
+# Allow running from anywhere: set TRAIGENT_SDK_PATH to the SDK repo root,
+# or run from within the repo tree for automatic detection.
 try:
     import traigent
 except ImportError:
-    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(ROOT_DIR)))
     import traigent
 
 from traigent.api.decorators import EvaluationOptions, ExecutionOptions  # noqa: E402

--- a/examples/quickstart/02_customer_support_rag.py
+++ b/examples/quickstart/02_customer_support_rag.py
@@ -25,11 +25,12 @@ os.environ.setdefault(
 ROOT_DIR = Path(__file__).resolve().parents[2]
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", str(ROOT_DIR))
 
-# Allow running from repo root without installation
+# Allow running from anywhere: set TRAIGENT_SDK_PATH to the SDK repo root,
+# or run from within the repo tree for automatic detection.
 try:
     import traigent
 except ImportError:
-    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(ROOT_DIR)))
     import traigent
 
 from traigent.api.decorators import EvaluationOptions, ExecutionOptions  # noqa: E402

--- a/examples/quickstart/03_custom_objectives.py
+++ b/examples/quickstart/03_custom_objectives.py
@@ -25,11 +25,12 @@ os.environ.setdefault(
 ROOT_DIR = Path(__file__).resolve().parents[2]
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", str(ROOT_DIR))
 
-# Allow running from repo root without installation
+# Allow running from anywhere: set TRAIGENT_SDK_PATH to the SDK repo root,
+# or run from within the repo tree for automatic detection.
 try:
     import traigent
 except ImportError:
-    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(ROOT_DIR)))
     import traigent
 
 from traigent.api.decorators import EvaluationOptions, ExecutionOptions  # noqa: E402

--- a/examples/templates/run_template.py
+++ b/examples/templates/run_template.py
@@ -21,8 +21,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-# Add parent directory to path to ensure traigent can be imported
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Add SDK root to path to ensure traigent can be imported.
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent)))
 
 from traigent.utils.logging import setup_logging  # noqa: E402
 

--- a/examples/utils/setup.py
+++ b/examples/utils/setup.py
@@ -36,10 +36,44 @@ def setup_mock_environment(base_path: Path) -> None:
     os.environ["TRAIGENT_RESULTS_FOLDER"] = str(results_dir)
 
 
-def setup_traigent_import() -> None:
+def resolve_sdk_path(caller_file: str | Path | None = None) -> str | None:
+    """Resolve the Traigent SDK root directory.
+
+    Resolution order:
+      1. ``TRAIGENT_SDK_PATH`` environment variable (explicit override)
+      2. Walk parent directories of *caller_file* looking for the package
+      3. Walk parent directories of *this* file as a last resort
+
+    Returns:
+        Absolute path to the SDK root, or ``None`` when the package is
+        probably pip-installed.
+    """
+    env_path = os.environ.get("TRAIGENT_SDK_PATH")
+    if env_path:
+        return str(Path(env_path).resolve())
+
+    anchors: list[Path] = []
+    if caller_file is not None:
+        anchors.append(Path(caller_file).resolve())
+    anchors.append(Path(__file__).resolve())
+
+    for anchor in anchors:
+        for depth in range(1, 7):
+            try:
+                parent = anchor.parents[depth]
+                if (parent / "traigent" / "__init__.py").exists():
+                    return str(parent)
+            except IndexError:
+                break
+    return None
+
+
+def setup_traigent_import(caller_file: str | Path | None = None) -> None:
     """Set up sys.path to allow importing traigent from the repo.
 
-    This is useful when running examples directly without installing traigent.
+    Checks ``TRAIGENT_SDK_PATH`` first, then falls back to parent-directory
+    detection.  Pass *caller_file* (``__file__``) from example scripts so the
+    walk starts from the correct location.
     """
     try:
         import traigent  # noqa: F401
@@ -48,16 +82,9 @@ def setup_traigent_import() -> None:
     except ImportError:
         pass
 
-    # Try to find the traigent package in parent directories
-    module_path = Path(__file__).resolve()
-    for depth in range(1, 5):
-        try:
-            parent = module_path.parents[depth]
-            if (parent / "traigent" / "__init__.py").exists():
-                sys.path.insert(0, str(parent))
-                return
-        except IndexError:
-            continue
+    sdk_root = resolve_sdk_path(caller_file)
+    if sdk_root and sdk_root not in sys.path:
+        sys.path.insert(0, sdk_root)
 
 
 def initialize_traigent(execution_mode: str = "edge_analytics") -> None:


### PR DESCRIPTION
## Summary
- Add `TRAIGENT_SDK_PATH` environment variable so demo scripts can locate and import the SDK from outside the repo tree
- Update `examples/utils/setup.py` with `resolve_sdk_path()` helper that checks the env var first, then falls back to parent-directory detection
- Update 92 example files across quickstart, core, advanced, gallery, integrations, and templates
- Document `TRAIGENT_SDK_PATH` and all environment variables in `examples/README.md`

Closes #572
Supersedes #601

## Test plan
- [ ] Run `TRAIGENT_MOCK_LLM=true python examples/quickstart/01_simple_qa.py` from repo root (existing path)
- [ ] Run the same from an external directory with `TRAIGENT_SDK_PATH` set
- [ ] Run `./examples/test_all_examples.sh quickstart` to validate quickstart suite
- [ ] Verify `pip install -e .` still works (no env var needed when installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)