### PR TITLE
fix(install): add langchain-openai to core deps for hello world

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -40,6 +40,13 @@ jobs:
       run: |
         python -c "import sys; sys.path.insert(0, 'examples'); import utils.base_example"
 
+    - name: Run hello world example
+      env:
+        TRAIGENT_MOCK_LLM: "true"
+        TRAIGENT_OFFLINE_MODE: "true"
+      run: |
+        python hello_world.py
+
     - name: Run quickstart example
       env:
         TRAIGENT_MOCK_LLM: "true"
@@ -115,6 +122,7 @@ jobs:
       run: |
         pip install -e ".[dev,integrations]"
         python -c "import traigent; print('Import works')"
+        python hello_world.py
         python examples/quickstart/01_simple_qa.py || true
         echo "Quick validation passed"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
     "psutil>=5.8.0",
     # Required by API decorators and config validation
     "pydantic>=2.0.0",
+    # Required by hello_world.py — the first-run quickstart example
+    "langchain-openai>=0.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Added `langchain-openai>=0.3.0` to core dependencies in `pyproject.toml` so `hello_world.py` works after a fresh `pip install traigent`
- Added `hello_world.py` to the `examples-smoke` CI workflow (both smoke-test and quick-validation jobs)

## Root cause
`hello_world.py` has a top-level `from langchain_openai import ChatOpenAI` (line 18), but `langchain-openai` was only in the optional `[integrations]` extras — not installed by default.

## Test plan
- [x] `TRAIGENT_MOCK_LLM=true python hello_world.py` runs successfully
- [x] Existing `test_readme_examples.py` tests still pass
- [ ] CI examples-smoke workflow runs hello_world.py

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)