### PR TITLE
docs: rewrite 'Use It in Your Own Code' examples without LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ def answer(question: str) -> str:
 
 ## Using it in your own code
 
+Add `@traigent.optimize()` to any function that calls an LLM — no framework required:
+
+```python
+import traigent
+import litellm                    # or openai, anthropic, requests …
+
+@traigent.optimize(
+    configuration_space={
+        "model": ["gpt-4o-mini", "gpt-4o"],
+        "temperature": [0.0, 0.7, 1.0],
+    },
+    objectives=["accuracy"],
+    eval_dataset="path/to/your_evals.jsonl",
+)
+def your_function(question: str) -> str:
+    cfg = traigent.get_config()
+    response = litellm.completion(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
+```
+
+Works with any LLM provider — [OpenAI](https://platform.openai.com/docs), [Anthropic](https://docs.anthropic.com), [LiteLLM](https://github.com/BerriAI/litellm) (100+ providers), or plain HTTP calls.
+
 <p align="center">
   <a href="https://portal.traigent.ai">Portal</a> &middot;
   <a href="docs/getting-started/GETTING_STARTED.md">Quickstart</a> &middot;

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@
 ## 🚀 Quick Start
 
 ```python
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     eval_dataset="examples/datasets/rag-optimization/evaluation_set.jsonl",
@@ -17,8 +17,12 @@ from langchain_openai import ChatOpenAI
 )
 def answer_question(question: str) -> str:
     cfg = traigent.get_config()  # Active trial/applied config
-    llm = ChatOpenAI(model=cfg.get("model"), temperature=cfg.get("temperature"))
-    return str(llm.invoke(question).content)
+    response = litellm.completion(
+        model=cfg.get("model"),
+        temperature=cfg.get("temperature"),
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
 
 # Async-safe in Traigent
 # results = await answer_question.optimize(max_trials=5)

--- a/docs/demos/DEMO_VIDEO_GUIDE.md
+++ b/docs/demos/DEMO_VIDEO_GUIDE.md
@@ -59,8 +59,8 @@ echo ""
 sleep 0.5
 
 cat << 'PYTHON'
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     # Define TUNED VARIABLES - parameters to optimize
@@ -78,11 +78,12 @@ from langchain_openai import ChatOpenAI
 )
 def qa_agent(question: str) -> str:
     """Q&A agent with tunable parameters"""
-    llm = ChatOpenAI(
+    response = litellm.completion(
         model="gpt-3.5-turbo",    # Traigent will tune this
-        temperature=0.7           # Traigent will tune this
+        temperature=0.7,          # Traigent will tune this
+        messages=[{"role": "user", "content": question}],
     )
-    return str(llm.invoke(question).content)
+    return response.choices[0].message.content
 PYTHON
 sleep 3
 

--- a/docs/demos/DEMO_VIDEO_GUIDE.md
+++ b/docs/demos/DEMO_VIDEO_GUIDE.md
@@ -78,9 +78,11 @@ import traigent
 )
 def qa_agent(question: str) -> str:
     """Q&A agent with tunable parameters"""
+    cfg = traigent.get_config()
     response = litellm.completion(
-        model="gpt-3.5-turbo",    # Traigent will tune this
-        temperature=0.7,          # Traigent will tune this
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        max_tokens=cfg["max_tokens"],
         messages=[{"role": "user", "content": question}],
     )
     return response.choices[0].message.content

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -107,7 +107,8 @@ from litellm import completion
     configuration_space={
         "model": ["gpt-4o-mini", "claude-3-haiku-20240307", "gemini/gemini-pro"],
     },
-    ...
+    objectives=["accuracy"],
+    eval_dataset="data/qa_samples.jsonl",
 )
 def my_agent(query: str) -> str:
     config = traigent.get_config()

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -18,8 +18,8 @@ python hello_world.py
 
 ```python
 import asyncio
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     configuration_space={
@@ -31,8 +31,12 @@ from langchain_openai import ChatOpenAI
 )
 def answer(question: str) -> str:
     cfg = traigent.get_config()
-    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
-    return llm.invoke(question).content
+    response = litellm.completion(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
 
 # Run optimization
 result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -80,16 +80,20 @@ What this does:
 - Great for natural language tasks where paraphrasing is fine.
 
 ```python
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     eval_dataset="data/qa_samples.jsonl",
     objectives=["accuracy", "cost"],
 )
 def qa_agent(question: str) -> str:
-    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
-    return str(llm.invoke(f"Question: {question}\nAnswer:").content)
+    response = litellm.completion(
+        model="gpt-4o-mini",
+        temperature=0.7,
+        messages=[{"role": "user", "content": f"Question: {question}\nAnswer:"}],
+    )
+    return response.choices[0].message.content
 ```
 
 ### 2) Custom scoring functions

--- a/docs/user-guide/evaluation_guide.md
+++ b/docs/user-guide/evaluation_guide.md
@@ -343,8 +343,8 @@ print(f"Best accuracy: {results.best_score:.2%}")
 ### Q&A System with Semantic Evaluation
 
 ```python
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     configuration_space={
@@ -356,15 +356,14 @@ from langchain_openai import ChatOpenAI
     max_trials=15
 )
 def qa_system(question, temperature=0.5, max_tokens=100):
-    llm = ChatOpenAI(
+    response = litellm.completion(
+        model="gpt-4o-mini",
         temperature=temperature,
-        max_tokens=max_tokens
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": f"Answer concisely: {question}"}],
     )
 
-    prompt = f"Answer concisely: {question}"
-    response = llm.invoke(prompt)
-
-    return str(response.content)
+    return response.choices[0].message.content
 
 # The default evaluator will use semantic similarity
 # to compare answers, allowing for paraphrasing


### PR DESCRIPTION
## Summary
- **Added a standalone code example** to the "Using it in your own code" section in the main README, using `litellm` instead of LangChain
- **Replaced all LangChain-based onboarding/quickstart code snippets** across 5 docs (`GETTING_STARTED.md`, `docs/README.md`, `evaluation.md`, `evaluation_guide.md`, `DEMO_VIDEO_GUIDE.md`) with `litellm.completion()` equivalents
- Examples now show the core Traigent pattern (`@traigent.optimize` + `traigent.get_config()`) without requiring a framework dependency
- **Fixed pre-existing issue** in `DEMO_VIDEO_GUIDE.md` where `qa_agent` used hardcoded values instead of `traigent.get_config()`
- **Fixed pre-existing syntax error** in `GETTING_STARTED.md` multi-provider snippet (bare `...` as positional arg after keyword args)

Closes #611

## Test plan
- [x] Verify the README "Using it in your own code" section renders correctly on GitHub
- [x] Verify GETTING_STARTED.md code snippet is syntactically correct
- [x] Confirm no remaining `langchain_openai` imports in quickstart/onboarding docs (except RELEASE_READINESS_TESTING.md which tests LangChain availability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)