### PR TITLE
Release v0.11.0: ship quickstart in pip package, fix mock mode, align docs

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m traigent.examples.quickstart
 
-    - name: Run hello world example
+    - name: Run hello world example (source checkout — not available from pip install)
       env:
         TRAIGENT_MOCK_LLM: "true"
         TRAIGENT_OFFLINE_MODE: "true"
@@ -130,7 +130,7 @@ jobs:
         pip install -e ".[dev,integrations]"
         python -c "import traigent; print('Import works')"
         python -m traigent.examples.quickstart
-        python hello_world.py
+        python hello_world.py  # source checkout only — not available from pip install
         python examples/quickstart/01_simple_qa.py || true
         echo "Quick validation passed"
 

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -40,6 +40,13 @@ jobs:
       run: |
         python -c "import sys; sys.path.insert(0, 'examples'); import utils.base_example"
 
+    - name: Run packaged quickstart module
+      env:
+        TRAIGENT_MOCK_LLM: "true"
+        TRAIGENT_OFFLINE_MODE: "true"
+      run: |
+        python -m traigent.examples.quickstart
+
     - name: Run hello world example
       env:
         TRAIGENT_MOCK_LLM: "true"
@@ -122,6 +129,7 @@ jobs:
       run: |
         pip install -e ".[dev,integrations]"
         python -c "import traigent; print('Import works')"
+        python -m traigent.examples.quickstart
         python hello_world.py
         python examples/quickstart/01_simple_qa.py || true
         echo "Quick validation passed"

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -40,6 +40,13 @@ jobs:
       run: |
         python -c "import sys; sys.path.insert(0, 'examples'); import utils.base_example"
 
+    - name: Run hello world example
+      env:
+        TRAIGENT_MOCK_LLM: "true"
+        TRAIGENT_OFFLINE_MODE: "true"
+      run: |
+        python hello_world.py
+
     - name: Run quickstart example
       env:
         TRAIGENT_MOCK_LLM: "true"
@@ -115,6 +122,7 @@ jobs:
       run: |
         pip install -e ".[dev,integrations]"
         python -c "import traigent; print('Import works')"
+        python hello_world.py
         python examples/quickstart/01_simple_qa.py || true
         echo "Quick validation passed"
 

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -82,3 +82,33 @@ jobs:
         run: |
           python -c "from importlib.metadata import version; import opentelemetry.sdk; print(f'opentelemetry-sdk {version(\"opentelemetry-sdk\")} OK')"
           python -c "import boto3; print(f'boto3 {boto3.__version__} OK')"
+
+  # Validates the pip-install user experience for the packaged quickstart.
+  # Runs in a temp directory (no repo checkout) to confirm the module works
+  # without hello_world.py or any other source-tree file present.
+  pip-install-quickstart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4  # needed to build the wheel
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir /tmp/dist
+
+      - name: Install from wheel in a clean temp directory
+        run: |
+          python -m pip install "/tmp/dist/$(ls /tmp/dist | grep .whl)" "langchain-openai"
+
+      - name: Run packaged quickstart from outside the repo (pip-install simulation)
+        env:
+          TRAIGENT_MOCK_LLM: "true"
+          TRAIGENT_OFFLINE_MODE: "true"
+        working-directory: /tmp
+        run: |
+          python -m traigent.examples.quickstart

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,16 @@ jobs:
       with:
         fetch-depth: 0  # Full history for version detection
 
+    - name: Verify tag is on main branch
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        git fetch origin main
+        if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+          echo "Error: tag ${{ github.ref_name }} is not on the main branch. Only tag from main."
+          exit 1
+        fi
+        echo "Tag ${{ github.ref_name }} is on main — proceeding."
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-03-30
+
 ### Added
 - **DeepEval metric integration** - `DeepEvalScorer` bridges DeepEval metrics into Traigent's `metric_functions` system
 - **Rich results table** - Formatted ASCII table with box-drawing characters for optimization output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dead methods removed from orchestrator (`_check_batch_vendor_failures`, `_maybe_pause_on_cost_limit`, `_handle_vendor_pause_in_loop`)
 
 ### Breaking Changes
-- `create_session()` return type changed from `str` to `SessionCreationResult` dataclass
+- `create_session()` return type changed from `str` to `SessionCreationResult` dataclass.
+  `SessionCreationResult.__str__` returns the session ID so most existing code continues
+  to work without changes, but explicit `isinstance(result, str)` checks will need updating.
+
+  **Before (v0.10.x):**
+  ```python
+  session_id: str = create_session()
+  ```
+  **After (v0.11.0+):**
+  ```python
+  result = create_session()
+  session_id: str = result.session_id   # explicit
+  # or: str(result)                      # via __str__
+  ```
 - `HybridExecuteRequest` and `HybridEvaluateRequest` no longer accept `benchmark_id` parameter
 - Default backend URL is now cloud instead of localhost
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,7 +20,7 @@ include pyproject.toml
 # Include package data
 recursive-include traigent *.py
 recursive-include traigent *.json
-recursive-include traigent/examples *.py *.jsonl
+recursive-include traigent/examples *.jsonl
 recursive-include traigent *.yaml
 include traigent/py.typed
 prune traigent/experimental

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,6 +20,7 @@ include pyproject.toml
 # Include package data
 recursive-include traigent *.py
 recursive-include traigent *.json
+recursive-include traigent/examples *.py *.jsonl
 recursive-include traigent *.yaml
 include traigent/py.typed
 prune traigent/experimental

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For more options, see [Installation details](#installation).
 **Try it now - no API keys needed:**
 
 ```bash
-pip install traigent
+pip install "traigent[integrations]"
 python -m traigent.examples.quickstart
 ```
 
@@ -61,10 +61,8 @@ python hello_world.py
 **Here's what the quickstart does - one decorator, automatic optimization:**
 
 ```python
-from openai import OpenAI
+from langchain_openai import ChatOpenAI
 import traigent
-
-DATASET = "examples/datasets/quickstart/qa_samples.jsonl"
 
 @traigent.optimize(
     configuration_space={
@@ -72,17 +70,12 @@ DATASET = "examples/datasets/quickstart/qa_samples.jsonl"
         "temperature": [0.0, 0.7, 1.0],
     },
     objectives=["accuracy"],
-    eval_dataset=DATASET,
+    eval_dataset="qa_samples.jsonl",
 )
 def answer(question: str) -> str:
     cfg = traigent.get_config()
-    client = OpenAI()
-    response = client.chat.completions.create(
-        model=cfg["model"],
-        temperature=cfg["temperature"],
-        messages=[{"role": "user", "content": question}],
-    )
-    return response.choices[0].message.content
+    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
+    return llm.invoke(question).content
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -45,13 +45,20 @@ pip install -e ".[recommended]"
 
 For more options, see [Installation details](#installation).
 
-**Try it now — no API keys needed** (requires the source checkout above):
+**Try it now - no API keys needed:**
+
+```bash
+pip install traigent
+python -m traigent.examples.quickstart
+```
+
+Or from a source checkout:
 
 ```bash
 python hello_world.py
 ```
 
-**Here's what `hello_world.py` does — one decorator, automatic optimization:**
+**Here's what the quickstart does - one decorator, automatic optimization:**
 
 ```python
 from openai import OpenAI

--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ def answer(question: str) -> str:
 
 ## Using it in your own code
 
+Add `@traigent.optimize()` to any function that calls an LLM — no framework required:
+
+```python
+import traigent
+import litellm                    # or openai, anthropic, requests …
+
+@traigent.optimize(
+    configuration_space={
+        "model": ["gpt-4o-mini", "gpt-4o"],
+        "temperature": [0.0, 0.7, 1.0],
+    },
+    objectives=["accuracy"],
+    eval_dataset="path/to/your_evals.jsonl",
+)
+def your_function(question: str) -> str:
+    cfg = traigent.get_config()
+    response = litellm.completion(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
+```
+
+Works with any LLM provider — [OpenAI](https://platform.openai.com/docs), [Anthropic](https://docs.anthropic.com), [LiteLLM](https://github.com/BerriAI/litellm) (100+ providers), or plain HTTP calls.
+
 <p align="center">
   <a href="https://portal.traigent.ai">Portal</a> &middot;
   <a href="docs/getting-started/GETTING_STARTED.md">Quickstart</a> &middot;

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ python hello_world.py
 **Here's what `hello_world.py` does — one decorator, automatic optimization:**
 
 ```python
+from openai import OpenAI
 import traigent
-from langchain_openai import ChatOpenAI
 
 DATASET = "examples/datasets/quickstart/qa_samples.jsonl"
 
@@ -69,8 +69,13 @@ DATASET = "examples/datasets/quickstart/qa_samples.jsonl"
 )
 def answer(question: str) -> str:
     cfg = traigent.get_config()
-    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
-    return llm.invoke(question).content
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@
 ## 🚀 Quick Start
 
 ```python
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     eval_dataset="examples/datasets/rag-optimization/evaluation_set.jsonl",
@@ -17,8 +17,12 @@ from langchain_openai import ChatOpenAI
 )
 def answer_question(question: str) -> str:
     cfg = traigent.get_config()  # Active trial/applied config
-    llm = ChatOpenAI(model=cfg.get("model"), temperature=cfg.get("temperature"))
-    return str(llm.invoke(question).content)
+    response = litellm.completion(
+        model=cfg.get("model"),
+        temperature=cfg.get("temperature"),
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
 
 # Async-safe in Traigent
 # results = await answer_question.optimize(max_trials=5)

--- a/docs/demos/DEMO_VIDEO_GUIDE.md
+++ b/docs/demos/DEMO_VIDEO_GUIDE.md
@@ -59,8 +59,8 @@ echo ""
 sleep 0.5
 
 cat << 'PYTHON'
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     # Define TUNED VARIABLES - parameters to optimize
@@ -78,11 +78,14 @@ from langchain_openai import ChatOpenAI
 )
 def qa_agent(question: str) -> str:
     """Q&A agent with tunable parameters"""
-    llm = ChatOpenAI(
-        model="gpt-3.5-turbo",    # Traigent will tune this
-        temperature=0.7           # Traigent will tune this
+    cfg = traigent.get_config()
+    response = litellm.completion(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        max_tokens=cfg["max_tokens"],
+        messages=[{"role": "user", "content": question}],
     )
-    return str(llm.invoke(question).content)
+    return response.choices[0].message.content
 PYTHON
 sleep 3
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -18,8 +18,8 @@ python hello_world.py
 
 ```python
 import asyncio
+from openai import OpenAI
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     configuration_space={
@@ -31,8 +31,13 @@ from langchain_openai import ChatOpenAI
 )
 def answer(question: str) -> str:
     cfg = traigent.get_config()
-    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
-    return llm.invoke(question).content
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
 
 # Run optimization
 result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -108,7 +108,8 @@ from litellm import completion
     configuration_space={
         "model": ["gpt-4o-mini", "claude-3-haiku-20240307", "gemini/gemini-pro"],
     },
-    ...
+    objectives=["accuracy"],
+    eval_dataset="data/qa_samples.jsonl",
 )
 def my_agent(query: str) -> str:
     config = traigent.get_config()

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -4,7 +4,14 @@ The fastest path to optimize an LLM workflow with **zero code changes**.
 
 ## 🚀 Quick Start
 
-1) Install and run — no API keys needed:
+1) Install and run - no API keys needed:
+
+```bash
+pip install traigent
+python -m traigent.examples.quickstart
+```
+
+Or from a source checkout:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
@@ -12,7 +19,7 @@ pip install -e ".[recommended]"
 python hello_world.py
 ```
 
-`hello_world.py` runs in mock mode by default — it simulates LLM calls so you can see the full optimization flow instantly.
+The quickstart runs in mock mode by default - it simulates LLM calls so you can see the full optimization flow instantly.
 
 2) Here's what it does — one decorator, automatic optimization:
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -7,7 +7,7 @@ The fastest path to optimize an LLM workflow with **zero code changes**.
 1) Install and run - no API keys needed:
 
 ```bash
-pip install traigent
+pip install "traigent[integrations]"
 python -m traigent.examples.quickstart
 ```
 
@@ -21,11 +21,11 @@ python hello_world.py
 
 The quickstart runs in mock mode by default - it simulates LLM calls so you can see the full optimization flow instantly.
 
-2) Here's what it does — one decorator, automatic optimization:
+2) Here's what it does - one decorator, automatic optimization:
 
 ```python
 import asyncio
-from openai import OpenAI
+from langchain_openai import ChatOpenAI
 import traigent
 
 @traigent.optimize(
@@ -34,17 +34,12 @@ import traigent
         "temperature": [0.0, 0.7, 1.0],
     },
     objectives=["accuracy"],
-    eval_dataset="examples/datasets/quickstart/qa_samples.jsonl",
+    eval_dataset="qa_samples.jsonl",
 )
 def answer(question: str) -> str:
     cfg = traigent.get_config()
-    client = OpenAI()
-    response = client.chat.completions.create(
-        model=cfg["model"],
-        temperature=cfg["temperature"],
-        messages=[{"role": "user", "content": question}],
-    )
-    return response.choices[0].message.content
+    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
+    return llm.invoke(question).content
 
 # Run optimization
 result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -80,16 +80,20 @@ What this does:
 - Great for natural language tasks where paraphrasing is fine.
 
 ```python
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     eval_dataset="data/qa_samples.jsonl",
     objectives=["accuracy", "cost"],
 )
 def qa_agent(question: str) -> str:
-    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.7)
-    return str(llm.invoke(f"Question: {question}\nAnswer:").content)
+    response = litellm.completion(
+        model="gpt-4o-mini",
+        temperature=0.7,
+        messages=[{"role": "user", "content": f"Question: {question}\nAnswer:"}],
+    )
+    return response.choices[0].message.content
 ```
 
 ### 2) Custom scoring functions

--- a/docs/user-guide/evaluation_guide.md
+++ b/docs/user-guide/evaluation_guide.md
@@ -343,8 +343,8 @@ print(f"Best accuracy: {results.best_score:.2%}")
 ### Q&A System with Semantic Evaluation
 
 ```python
+import litellm
 import traigent
-from langchain_openai import ChatOpenAI
 
 @traigent.optimize(
     configuration_space={
@@ -356,15 +356,14 @@ from langchain_openai import ChatOpenAI
     max_trials=15
 )
 def qa_system(question, temperature=0.5, max_tokens=100):
-    llm = ChatOpenAI(
+    response = litellm.completion(
+        model="gpt-4o-mini",
         temperature=temperature,
-        max_tokens=max_tokens
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": f"Answer concisely: {question}"}],
     )
 
-    prompt = f"Answer concisely: {question}"
-    response = llm.invoke(prompt)
-
-    return str(response.content)
+    return response.choices[0].message.content
 
 # The default evaluator will use semantic similarity
 # to compare answers, allowing for paraphrasing

--- a/examples/README.md
+++ b/examples/README.md
@@ -270,6 +270,31 @@ export OPENAI_API_KEY="your-key-here" # pragma: allowlist secret
 python examples/core/multi-objective-tradeoff/run_anthropic.py
 ```
 
+### Running From Outside the Repo Tree
+
+If you want to run demo scripts from a different directory (e.g. your own project),
+set the `TRAIGENT_SDK_PATH` environment variable to the SDK repo root:
+
+```bash
+# Point demos at a local SDK clone
+export TRAIGENT_SDK_PATH=/path/to/Traigent
+
+# Now you can run any example from anywhere
+python /path/to/Traigent/examples/quickstart/01_simple_qa.py
+```
+
+This works for both local-dev and CI scenarios.  When `TRAIGENT_SDK_PATH` is not set,
+scripts automatically detect the SDK location relative to their own path — so running
+from inside the repo tree requires no extra setup.
+
+| Variable | Purpose |
+| -------- | ------- |
+| `TRAIGENT_SDK_PATH` | Absolute path to the SDK repo root (overrides auto-detection) |
+| `TRAIGENT_MOCK_LLM` | Set to `true` to run without real API keys |
+| `TRAIGENT_DATASET_ROOT` | Root directory for resolving dataset paths |
+| `TRAIGENT_RESULTS_FOLDER` | Custom directory for optimization results |
+| `TRAIGENT_COST_APPROVED` | Set to `true` to skip cost confirmation prompts |
+
 ### Recommended Learning Path
 
 1. **Quickstart:** `quickstart/01_simple_qa.py` (1 min) - README examples that just work
@@ -353,7 +378,7 @@ Follow these best practices when contributing new examples:
 
 | Problem | Solution |
 | ------- | -------- |
-| `ModuleNotFoundError: No module named 'traigent'` | Run `pip install -e .` from repository root |
+| `ModuleNotFoundError: No module named 'traigent'` | Run `pip install -e .` from repository root, or set `TRAIGENT_SDK_PATH` |
 | `API key not found` | Export your API key or use `TRAIGENT_MOCK_LLM=true` |
 | `Example doesn't run` | Check example's inline comments for prerequisites |
 | `0.0% accuracy` | Use mock mode or provide valid API keys |

--- a/examples/advanced/ai-engineering-tasks/p0_context_engineering/main.py
+++ b/examples/advanced/ai-engineering-tasks/p0_context_engineering/main.py
@@ -36,7 +36,7 @@ from typing import Any
 import numpy as np
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p0_few_shot_selection/main.py
+++ b/examples/advanced/ai-engineering-tasks/p0_few_shot_selection/main.py
@@ -30,7 +30,7 @@ from pathlib import Path
 import numpy as np
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p0_structured_output/main.py
+++ b/examples/advanced/ai-engineering-tasks/p0_structured_output/main.py
@@ -27,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Mock mode for demo

--- a/examples/advanced/ai-engineering-tasks/p1_function_calling/main.py
+++ b/examples/advanced/ai-engineering-tasks/p1_function_calling/main.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p1_safety_guardrails/main.py
+++ b/examples/advanced/ai-engineering-tasks/p1_safety_guardrails/main.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/ai-engineering-tasks/p1_token_budget/main.py
+++ b/examples/advanced/ai-engineering-tasks/p1_token_budget/main.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 # Add project root to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent.parent.parent)))
 
 try:
     import traigent

--- a/examples/advanced/execution-modes/_archived/ex03-hybrid-basic/hybrid_basic.py
+++ b/examples/advanced/execution-modes/_archived/ex03-hybrid-basic/hybrid_basic.py
@@ -20,12 +20,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/_archived/ex04-hybrid-privacy/hybrid_privacy.py
+++ b/examples/advanced/execution-modes/_archived/ex04-hybrid-privacy/hybrid_privacy.py
@@ -20,12 +20,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/_archived/ex05-cloud-basic/cloud_basic.py
+++ b/examples/advanced/execution-modes/_archived/ex05-cloud-basic/cloud_basic.py
@@ -19,12 +19,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/cloud_limitations.py
+++ b/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/cloud_limitations.py
@@ -21,12 +21,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/ex01-local-basic/local_basic.py
+++ b/examples/advanced/execution-modes/ex01-local-basic/local_basic.py
@@ -19,12 +19,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/execution-modes/ex02-local-privacy/local_privacy.py
+++ b/examples/advanced/execution-modes/ex02-local-privacy/local_privacy.py
@@ -19,12 +19,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/ragas/basics/run.py
+++ b/examples/advanced/ragas/basics/run.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - allow running via python path
 except ImportError:  # pragma: no cover
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).resolve().parents[3])))
     import traigent
 
 from traigent.metrics import configure_ragas_defaults  # noqa: E402

--- a/examples/advanced/ragas/column_map/run.py
+++ b/examples/advanced/ragas/column_map/run.py
@@ -12,7 +12,7 @@ try:  # pragma: no cover - allow direct execution
 except ImportError:  # pragma: no cover
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).resolve().parents[3])))
     import traigent
 
 from traigent.metrics import configure_ragas_defaults  # noqa: E402

--- a/examples/advanced/ragas/with_llm/run.py
+++ b/examples/advanced/ragas/with_llm/run.py
@@ -13,7 +13,7 @@ try:  # pragma: no cover - allow direct execution
 except ImportError:  # pragma: no cover
     import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[3]))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).resolve().parents[3])))
     import traigent
 
 from traigent.metrics import configure_ragas_defaults  # noqa: E402

--- a/examples/advanced/results-analysis/ex01-viewing-results/viewing_results.py
+++ b/examples/advanced/results-analysis/ex01-viewing-results/viewing_results.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:  # Fallbacks if langchain packages are unavailable

--- a/examples/advanced/results-analysis/ex02-performance-metrics/performance_metrics.py
+++ b/examples/advanced/results-analysis/ex02-performance-metrics/performance_metrics.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/core/chunking-long-context/run.py
+++ b/examples/core/chunking-long-context/run.py
@@ -96,12 +96,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/error-handling/run.py
+++ b/examples/core/error-handling/run.py
@@ -38,12 +38,16 @@ try:
 except ImportError:
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # --- Configuration ---

--- a/examples/core/few-shot-classification/run.py
+++ b/examples/core/few-shot-classification/run.py
@@ -28,12 +28,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "few-shot-classification"

--- a/examples/core/multi-objective-tradeoff/run_anthropic.py
+++ b/examples/core/multi-objective-tradeoff/run_anthropic.py
@@ -36,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_many_providers.py
+++ b/examples/core/multi-objective-tradeoff/run_many_providers.py
@@ -72,12 +72,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_openai.py
+++ b/examples/core/multi-objective-tradeoff/run_openai.py
@@ -36,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna.py
@@ -39,12 +39,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
@@ -26,12 +26,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/production-deployment/run.py
+++ b/examples/core/production-deployment/run.py
@@ -38,12 +38,16 @@ try:
 except ImportError:
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # --- Configuration ---

--- a/examples/core/prompt-ab-test/run.py
+++ b/examples/core/prompt-ab-test/run.py
@@ -24,12 +24,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/prompt-style-optimization/run.py
+++ b/examples/core/prompt-style-optimization/run.py
@@ -32,12 +32,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/rag-optimization/run.py
+++ b/examples/core/rag-optimization/run.py
@@ -74,12 +74,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 from traigent.api.types import OptimizationResult  # noqa: E402
 from traigent.utils.error_handler import APIKeyError  # noqa: E402

--- a/examples/core/safety-guardrails/run.py
+++ b/examples/core/safety-guardrails/run.py
@@ -32,12 +32,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/simple-prompt/run.py
+++ b/examples/core/simple-prompt/run.py
@@ -36,15 +36,18 @@ if MOCK:
 try:
     import traigent
 except ImportError:
-    # Fallback for running directly from the repo without installation
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # --- Configuration ---

--- a/examples/core/structured-output-json/run.py
+++ b/examples/core/structured-output-json/run.py
@@ -33,12 +33,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -36,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "text-to-sql"

--- a/examples/core/token-budget-summarization/run.py
+++ b/examples/core/token-budget-summarization/run.py
@@ -24,12 +24,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/core/tool-use-calculator/run.py
+++ b/examples/core/tool-use-calculator/run.py
@@ -24,12 +24,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.api.types import OptimizationResult  # noqa: E402

--- a/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -37,7 +37,8 @@ except ImportError:  # pragma: no cover - support IDE execution paths
 
     _sdk = os.environ.get("TRAIGENT_SDK_PATH")
     if _sdk:
-        sys.path.insert(0, _sdk)
+        if _sdk not in sys.path:
+            sys.path.insert(0, _sdk)
     else:
         module_path = Path(__file__).resolve()
         for depth in (2, 3, 4, 5):

--- a/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -8,17 +8,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
@@ -30,6 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3, 4, 5):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Create dataset file path

--- a/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -25,7 +25,8 @@ else:
         except IndexError:
             continue
 
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/best-practices/ex01-small-space/small_space.py
+++ b/examples/gallery/page-inline/best-practices/ex01-small-space/small_space.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/best-practices/ex02-weighted-objectives/weighted_objectives.py
+++ b/examples/gallery/page-inline/best-practices/ex02-weighted-objectives/weighted_objectives.py
@@ -16,12 +16,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema  # noqa: E402

--- a/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
+++ b/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
+++ b/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
+++ b/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
+++ b/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
+++ b/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
+++ b/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/by-goal/speed-latency/simple.py
+++ b/examples/gallery/page-inline/by-goal/speed-latency/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/speed-latency/simple.py
+++ b/examples/gallery/page-inline/by-goal/speed-latency/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "calculator_eval.jsonl")

--- a/examples/gallery/page-inline/common-tasks/p0-context-engineering/context_engineering.py
+++ b/examples/gallery/page-inline/common-tasks/p0-context-engineering/context_engineering.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/common-tasks/p0-few-shot-selection/few_shot_selection.py
+++ b/examples/gallery/page-inline/common-tasks/p0-few-shot-selection/few_shot_selection.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/common-tasks/p0-structured-output/structured_output.py
+++ b/examples/gallery/page-inline/common-tasks/p0-structured-output/structured_output.py
@@ -17,12 +17,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 try:

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 _DEFAULT_CONFIG: dict[str, Any] = {

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
@@ -26,7 +26,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
@@ -25,7 +25,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
@@ -9,17 +9,22 @@ from pathlib import Path
 from typing import Any, TypeVar, cast
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -27,12 +32,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 F = TypeVar("F")

--- a/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
+++ b/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
@@ -26,7 +26,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
+++ b/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 

--- a/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
+++ b/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
@@ -26,7 +26,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
+++ b/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 EVAL_DATASET: str = os.path.join(

--- a/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
+++ b/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Add optimization with custom parameter names

--- a/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
+++ b/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
@@ -27,7 +27,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
+++ b/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Add optimization with mixed parameter approach

--- a/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
+++ b/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
@@ -27,7 +27,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
+++ b/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
+++ b/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Step 1: Run optimization and save the best configuration (MCQ format)

--- a/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
+++ b/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 

--- a/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
+++ b/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Debug mode to see exactly what Traigent is doing

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # How Traigent intercepts and modifies your LLM calls

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Define custom parameters to optimize

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Mix seamless injection with custom parameters

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Advanced seamless injection with multiple LLM instances

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
@@ -4,17 +4,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI
 
 try:
@@ -22,12 +27,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Your existing function - no changes needed

--- a/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "code_review_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -64,7 +65,7 @@ def review_code(snippet: str) -> str:
         "Respond with one label only: ok or issue.\n"
         f"Code:\n{snippet}"
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def should_escalate(utterance: str) -> str:
         "Return yes if this message requires human escalation (legal, threats, complex), else no.\n"
         f"Message: {utterance}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "conversation_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def route(task: str) -> str:
         "Classify who should handle the task: planner or executor.\n"
         f"Task: {task}\nReturn one label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "multi_agent_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/research/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/research/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "research_eval.jsonl")
 def answer(question: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.0)
     prompt = f"Answer concisely with one short phrase: {question}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/research/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/research/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "research_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/support/advanced.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/advanced.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -101,7 +102,7 @@ Message: {message}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "json":
         try:

--- a/examples/gallery/page-inline/cookbook-agents/support/advanced.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/advanced.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "support_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/support/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def support_intent(message: str) -> str:
         "Classify support intent as one of: billing, account, technical, general, cancellation.\n"
         f"Message: {message}\nReturn only the label."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/support/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "support_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def needs_tool(request: str) -> str:
         "Return needs_tool if the request requires a non-LLM action (API, calc), else no_tool.\n"
         f"Request: {request}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "tool_use_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/blog/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/blog/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "blog_eval.jsonl")
 def write_intro(topic: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     prompt = f"Write a 2-3 sentence blog introduction about: {topic}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/blog/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/blog/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "blog_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/creative/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/creative/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "creative_eval.jsonl")
 def write_poem(prompt: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.9)
     p = f"Write a 3-line poem about: {prompt}"
-    return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+    return llm.invoke([HumanMessage(content=p)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/creative/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/creative/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "creative_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -77,7 +78,7 @@ def generate_headline(topic: str) -> str:
         f"Write a {style_hint} headline about: {topic}\n"
         f"Max {int(cfg.get('max_words', 12))} words. One line only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/headlines/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")
 def generate_headline(topic: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     prompt = f"Write a concise, catchy headline about: {topic}\nOne line only."
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/headlines/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/media/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/media/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "media_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-content/media/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/media/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "media_eval.jsonl")
 def shotlist(topic: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     p = f"Create a 3-step shot list for a short video about: {topic}"
-    return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+    return llm.invoke([HumanMessage(content=p)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "anomaly_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def has_anomaly(series: str) -> str:
         "Given a numeric series, return yes if an outlier is present, else no.\n"
         f"Series: {series}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/bi/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/bi/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "bi_eval.jsonl")
 def summarize_kpis(kpis: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     prompt = f"Given KPI values, write 2-3 concise insights with trends and recommendations. KPIs: {kpis}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/bi/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/bi/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "bi_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -116,7 +117,7 @@ Text: {text}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "kv":
         # Normalize KV to JSON if needed for metric

--- a/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
@@ -10,17 +10,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -31,12 +36,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "extraction_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/extraction/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/simple.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "extraction_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/extraction/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/simple.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -84,7 +85,7 @@ def extract_fields(text: str) -> str:
         "Extract company and amount as JSON with keys 'company' and 'amount'."
         f"\nText: {text}\nReturn only JSON."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/trend/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/trend/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "trend_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-data/trend/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/trend/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def classify_trend(series: str) -> str:
         "Given a numeric series, classify overall trend: up, down, or flat.\n"
         f"Series: {series}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -110,7 +111,7 @@ Text: {text}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "json":
         try:

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
@@ -11,17 +11,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -86,7 +87,7 @@ Text: {text}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "json":
         try:

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")
 def sentiment_analysis(text: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7)
     prompt = f"Classify sentiment (positive/negative/neutral): {text}\nReturn one label only."
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -66,7 +67,7 @@ def summarize(document: str) -> str:
 
     def _sum(text: str) -> str:
         p = f"Summarize in 1-2 sentences:\n\n{text}"
-        return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+        return llm.invoke([HumanMessage(content=p)]).content.strip()
 
     words = document.split()
     cs = int(cfg.get("chunk_size", 240))

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
@@ -11,17 +11,22 @@ from collections import Counter
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -32,12 +37,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -79,7 +80,7 @@ def _summary_f1(output: str | None, expected: str | None, llm_metrics=None) -> f
 def summarize(document: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.0)
     p = f"Summarize in 1-2 sentences:\n\n{document}"
-    return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+    return llm.invoke([HumanMessage(content=p)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")
 def summarize(document: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7)
     prompt = f"Summarize in 1-2 sentences:\n\n{document}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")

--- a/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
+++ b/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
+++ b/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
@@ -9,17 +9,22 @@ import sys
 from pathlib import Path
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
@@ -30,12 +35,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Create dataset file

--- a/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
+++ b/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 try:
@@ -28,12 +33,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema  # noqa: E402

--- a/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
+++ b/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 try:
     import traigent

--- a/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
+++ b/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
@@ -10,17 +10,22 @@ from pathlib import Path
 from typing import Any
 
 # --- Setup for running from repo without installation ---
-# Add repo root to path so we can import examples.utils and traigent
-_module_path = Path(__file__).resolve()
-for _depth in range(1, 7):
-    try:
-        _repo_root = _module_path.parents[_depth]
-        if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
-            if str(_repo_root) not in sys.path:
-                sys.path.insert(0, str(_repo_root))
-            break
-    except IndexError:
-        continue
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+_sdk_override = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_override:
+    if _sdk_override not in sys.path:
+        sys.path.insert(0, _sdk_override)
+else:
+    _module_path = Path(__file__).resolve()
+    for _depth in range(1, 7):
+        try:
+            _repo_root = _module_path.parents[_depth]
+            if (_repo_root / "traigent").is_dir() and (_repo_root / "examples").is_dir():
+                if str(_repo_root) not in sys.path:
+                    sys.path.insert(0, str(_repo_root))
+                break
+        except IndexError:
+            continue
 from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
 
 try:
@@ -28,12 +33,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 from traigent.evaluators.base import Dataset, EvaluationExample  # noqa: E402

--- a/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
+++ b/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 try:
     import traigent

--- a/examples/integrations/ci-cd/math-qa/math_qa.py
+++ b/examples/integrations/ci-cd/math-qa/math_qa.py
@@ -15,12 +15,16 @@ try:
 except ImportError:  # pragma: no cover - support IDE execution paths
     import importlib
 
-    module_path = Path(__file__).resolve()
-    for depth in (2, 3):
-        try:
-            sys.path.append(str(module_path.parents[depth]))
-        except IndexError:
-            continue
+    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
+    if _sdk:
+        sys.path.insert(0, _sdk)
+    else:
+        module_path = Path(__file__).resolve()
+        for depth in (2, 3):
+            try:
+                sys.path.append(str(module_path.parents[depth]))
+            except IndexError:
+                continue
     traigent = importlib.import_module("traigent")
 
 # Dataset file path

--- a/examples/quickstart/01_simple_qa.py
+++ b/examples/quickstart/01_simple_qa.py
@@ -23,11 +23,12 @@ os.environ.setdefault(
 ROOT_DIR = Path(__file__).resolve().parents[2]
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", str(ROOT_DIR))
 
-# Allow running from repo root without installation
+# Allow running from anywhere: set TRAIGENT_SDK_PATH to the SDK repo root,
+# or run from within the repo tree for automatic detection.
 try:
     import traigent
 except ImportError:
-    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(ROOT_DIR)))
     import traigent
 
 from traigent.api.decorators import EvaluationOptions, ExecutionOptions  # noqa: E402

--- a/examples/quickstart/01_simple_qa.py
+++ b/examples/quickstart/01_simple_qa.py
@@ -42,6 +42,7 @@ DATASET_PATH = (
 )
 
 
+# Valid model names: https://models.litellm.ai/
 @traigent.optimize(
     configuration_space={
         "model": ["gpt-3.5-turbo", "gpt-4o-mini", "gpt-4o"],  # Tuned Variable #1

--- a/examples/quickstart/02_customer_support_rag.py
+++ b/examples/quickstart/02_customer_support_rag.py
@@ -83,6 +83,7 @@ def simple_retriever(query: str, k: int = 3) -> list[str]:
     return [doc for _, doc in scores[:k]]
 
 
+# Valid model names: https://models.litellm.ai/
 @traigent.optimize(
     configuration_space={
         "model": ["gpt-3.5-turbo", "gpt-4o-mini", "gpt-4o"],

--- a/examples/quickstart/02_customer_support_rag.py
+++ b/examples/quickstart/02_customer_support_rag.py
@@ -25,11 +25,12 @@ os.environ.setdefault(
 ROOT_DIR = Path(__file__).resolve().parents[2]
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", str(ROOT_DIR))
 
-# Allow running from repo root without installation
+# Allow running from anywhere: set TRAIGENT_SDK_PATH to the SDK repo root,
+# or run from within the repo tree for automatic detection.
 try:
     import traigent
 except ImportError:
-    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(ROOT_DIR)))
     import traigent
 
 from traigent.api.decorators import EvaluationOptions, ExecutionOptions  # noqa: E402

--- a/examples/quickstart/03_custom_objectives.py
+++ b/examples/quickstart/03_custom_objectives.py
@@ -53,6 +53,7 @@ custom_objectives = ObjectiveSchema.from_objectives(
 )
 
 
+# Valid model names: https://models.litellm.ai/
 @traigent.optimize(
     objectives=custom_objectives,
     configuration_space={

--- a/examples/quickstart/03_custom_objectives.py
+++ b/examples/quickstart/03_custom_objectives.py
@@ -25,11 +25,12 @@ os.environ.setdefault(
 ROOT_DIR = Path(__file__).resolve().parents[2]
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", str(ROOT_DIR))
 
-# Allow running from repo root without installation
+# Allow running from anywhere: set TRAIGENT_SDK_PATH to the SDK repo root,
+# or run from within the repo tree for automatic detection.
 try:
     import traigent
 except ImportError:
-    sys.path.insert(0, str(ROOT_DIR))
+    sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(ROOT_DIR)))
     import traigent
 
 from traigent.api.decorators import EvaluationOptions, ExecutionOptions  # noqa: E402

--- a/examples/templates/run_template.py
+++ b/examples/templates/run_template.py
@@ -21,8 +21,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-# Add parent directory to path to ensure traigent can be imported
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Add SDK root to path to ensure traigent can be imported.
+# Set TRAIGENT_SDK_PATH to override when running from outside the repo tree.
+sys.path.insert(0, os.environ.get("TRAIGENT_SDK_PATH", str(Path(__file__).parent.parent)))
 
 from traigent.utils.logging import setup_logging  # noqa: E402
 

--- a/examples/utils/setup.py
+++ b/examples/utils/setup.py
@@ -36,10 +36,44 @@ def setup_mock_environment(base_path: Path) -> None:
     os.environ["TRAIGENT_RESULTS_FOLDER"] = str(results_dir)
 
 
-def setup_traigent_import() -> None:
+def resolve_sdk_path(caller_file: str | Path | None = None) -> str | None:
+    """Resolve the Traigent SDK root directory.
+
+    Resolution order:
+      1. ``TRAIGENT_SDK_PATH`` environment variable (explicit override)
+      2. Walk parent directories of *caller_file* looking for the package
+      3. Walk parent directories of *this* file as a last resort
+
+    Returns:
+        Absolute path to the SDK root, or ``None`` when the package is
+        probably pip-installed.
+    """
+    env_path = os.environ.get("TRAIGENT_SDK_PATH")
+    if env_path:
+        return str(Path(env_path).resolve())
+
+    anchors: list[Path] = []
+    if caller_file is not None:
+        anchors.append(Path(caller_file).resolve())
+    anchors.append(Path(__file__).resolve())
+
+    for anchor in anchors:
+        for depth in range(1, 7):
+            try:
+                parent = anchor.parents[depth]
+                if (parent / "traigent" / "__init__.py").exists():
+                    return str(parent)
+            except IndexError:
+                break
+    return None
+
+
+def setup_traigent_import(caller_file: str | Path | None = None) -> None:
     """Set up sys.path to allow importing traigent from the repo.
 
-    This is useful when running examples directly without installing traigent.
+    Checks ``TRAIGENT_SDK_PATH`` first, then falls back to parent-directory
+    detection.  Pass *caller_file* (``__file__``) from example scripts so the
+    walk starts from the correct location.
     """
     try:
         import traigent  # noqa: F401
@@ -48,16 +82,9 @@ def setup_traigent_import() -> None:
     except ImportError:
         pass
 
-    # Try to find the traigent package in parent directories
-    module_path = Path(__file__).resolve()
-    for depth in range(1, 5):
-        try:
-            parent = module_path.parents[depth]
-            if (parent / "traigent" / "__init__.py").exists():
-                sys.path.insert(0, str(parent))
-                return
-        except IndexError:
-            continue
+    sdk_root = resolve_sdk_path(caller_file)
+    if sdk_root and sdk_root not in sys.path:
+        sys.path.insert(0, sdk_root)
 
 
 def initialize_traigent(execution_mode: str = "edge_analytics") -> None:

--- a/hello_world.py
+++ b/hello_world.py
@@ -15,7 +15,7 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
-from langchain_openai import ChatOpenAI
+from openai import OpenAI
 
 import traigent
 
@@ -36,8 +36,13 @@ CONFIG_SPACE = {
 def answer(question: str) -> str:
     """Call an LLM with the current trial's config."""
     cfg = traigent.get_config()
-    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
-    return llm.invoke(question).content
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
 
 
 if __name__ == "__main__":

--- a/hello_world.py
+++ b/hello_world.py
@@ -1,49 +1,8 @@
-"""Find the best model and temperature for your task — in one decorator.
+"""Convenience alias - runs the bundled quickstart example.
 
-No API keys needed — runs in mock mode and simulates LLM responses
-so you can see the optimization flow instantly.
-For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
+Equivalent to: python -m traigent.examples.quickstart
 """
-import asyncio
-import os
-from pathlib import Path
 
-# Default to mock mode so the quickstart works without API keys.
-# Override with: TRAIGENT_MOCK_LLM=false python hello_world.py
-os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
-if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
-    os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
-    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+import runpy
 
-from openai import OpenAI
-
-import traigent
-
-DATASET = str(Path(__file__).parent / "examples" / "datasets" / "quickstart" / "qa_samples.jsonl")
-OBJECTIVES = ["accuracy"]
-CONFIG_SPACE = {
-    "model": ["gpt-4o-mini", "gpt-4o"],
-    "temperature": [0.0, 0.7, 1.0],
-}
-
-
-@traigent.optimize(
-    configuration_space=CONFIG_SPACE,
-    objectives=OBJECTIVES,
-    eval_dataset=DATASET,
-    execution_mode="edge_analytics",
-)
-def answer(question: str) -> str:
-    """Call an LLM with the current trial's config."""
-    cfg = traigent.get_config()
-    client = OpenAI()
-    response = client.chat.completions.create(
-        model=cfg["model"],
-        temperature=cfg["temperature"],
-        messages=[{"role": "user", "content": question}],
-    )
-    return response.choices[0].message.content
-
-
-if __name__ == "__main__":
-    result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))
+runpy.run_module("traigent.examples.quickstart", run_name="__main__")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,7 @@ include = ["traigent*", "traigent_validation*"]
 exclude = ["tests*", "demos*", "docs*", "traigent.experimental*"]
 
 [tool.setuptools.package-data]
-traigent = ["py.typed"]
+traigent = ["py.typed", "examples/**/*.jsonl"]
 traigent_validation = ["py.typed"]
 
 [tool.black]

--- a/tests/unit/core/test_exception_handler.py
+++ b/tests/unit/core/test_exception_handler.py
@@ -10,6 +10,7 @@ from traigent.core.exception_handler import (
     classify_vendor_error,
 )
 from traigent.utils.exceptions import (
+    InsufficientFundsError,
     QuotaExceededError,
     RateLimitError,
     ServiceUnavailableError,
@@ -32,6 +33,22 @@ class TestClassifyVendorError:
     def test_service_unavailable_error(self):
         exc = ServiceUnavailableError("Service down")
         assert classify_vendor_error(exc) == VendorErrorCategory.SERVICE_UNAVAILABLE
+
+    def test_insufficient_funds_error(self):
+        exc = InsufficientFundsError("Insufficient funds")
+        assert classify_vendor_error(exc) == VendorErrorCategory.INSUFFICIENT_FUNDS
+
+    def test_generic_402_in_message(self):
+        exc = RuntimeError("HTTP status 402 Payment Required")
+        assert classify_vendor_error(exc) == VendorErrorCategory.INSUFFICIENT_FUNDS
+
+    def test_generic_insufficient_funds_in_message(self):
+        exc = RuntimeError("Error: insufficient funds on this account")
+        assert classify_vendor_error(exc) == VendorErrorCategory.INSUFFICIENT_FUNDS
+
+    def test_generic_billing_hard_limit_in_message(self):
+        exc = RuntimeError("You exceeded your current billing hard limit")
+        assert classify_vendor_error(exc) == VendorErrorCategory.INSUFFICIENT_FUNDS
 
     def test_generic_429_in_message(self):
         exc = RuntimeError("HTTP 429 Too Many Requests")
@@ -114,6 +131,16 @@ class TestTerminalPausePromptVendor:
             mock_stdin.isatty.return_value = True
             result = prompt.prompt_vendor_pause(
                 RuntimeError("rate limit"), VendorErrorCategory.RATE_LIMIT
+            )
+        assert result == "stop"
+
+    def test_insufficient_funds_auto_stops(self):
+        """Insufficient funds is non-recoverable — should auto-stop without prompting."""
+        prompt = TerminalPausePrompt()
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            result = prompt.prompt_vendor_pause(
+                RuntimeError("insufficient funds"), VendorErrorCategory.INSUFFICIENT_FUNDS
             )
         assert result == "stop"
 

--- a/traigent/core/exception_handler.py
+++ b/traigent/core/exception_handler.py
@@ -25,6 +25,7 @@ class VendorErrorCategory(Enum):
 
     RATE_LIMIT = "rate_limit"
     QUOTA_EXHAUSTED = "quota_exhausted"
+    INSUFFICIENT_FUNDS = "insufficient_funds"
     SERVICE_UNAVAILABLE = "service_unavailable"
 
 
@@ -53,6 +54,18 @@ _VENDOR_ERROR_PATTERNS: list[tuple[str, VendorErrorCategory]] = [
     ("error 429", VendorErrorCategory.RATE_LIMIT),
     ("429 too many", VendorErrorCategory.RATE_LIMIT),
     ("too many requests", VendorErrorCategory.RATE_LIMIT),
+    ("status 402", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("code: 402", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("code 402", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("http 402", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("error 402", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("402 payment required", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("insufficient_funds", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("insufficient funds", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("insufficient credits", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("billing hard limit", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("exceeded your current billing", VendorErrorCategory.INSUFFICIENT_FUNDS),
+    ("payment required", VendorErrorCategory.INSUFFICIENT_FUNDS),
     ("quota", VendorErrorCategory.QUOTA_EXHAUSTED),
     ("quota_exceeded", VendorErrorCategory.QUOTA_EXHAUSTED),
     ("insufficient_quota", VendorErrorCategory.QUOTA_EXHAUSTED),
@@ -81,6 +94,7 @@ def classify_vendor_error(exc: Exception) -> VendorErrorCategory | None:
         VendorErrorCategory if the error is vendor-pausable, None otherwise.
     """
     from traigent.utils.exceptions import (
+        InsufficientFundsError,
         QuotaExceededError,
         RateLimitError,
         ServiceUnavailableError,
@@ -88,6 +102,8 @@ def classify_vendor_error(exc: Exception) -> VendorErrorCategory | None:
 
     if isinstance(exc, RateLimitError):
         return VendorErrorCategory.RATE_LIMIT
+    if isinstance(exc, InsufficientFundsError):
+        return VendorErrorCategory.INSUFFICIENT_FUNDS
     if isinstance(exc, QuotaExceededError):
         return VendorErrorCategory.QUOTA_EXHAUSTED
     if isinstance(exc, ServiceUnavailableError):
@@ -110,6 +126,10 @@ _CATEGORY_DESCRIPTIONS: dict[VendorErrorCategory, str] = {
     VendorErrorCategory.QUOTA_EXHAUSTED: (
         "The LLM provider quota has been exhausted. "
         "Check your billing dashboard or wait for the quota to reset."
+    ),
+    VendorErrorCategory.INSUFFICIENT_FUNDS: (
+        "Your LLM provider API key has insufficient credits. "
+        "Please top up your account at your provider's billing page and retry."
     ),
     VendorErrorCategory.SERVICE_UNAVAILABLE: (
         "The LLM provider service is temporarily unavailable. "
@@ -148,6 +168,13 @@ class TerminalPausePrompt:
         print(f"\n⚠️  Vendor error: {category.value}")
         print(f"   {description}")
         print(f"   Error: {error}")
+
+        # Insufficient funds is non-recoverable — stop immediately
+        if category == VendorErrorCategory.INSUFFICIENT_FUNDS:
+            print()
+            print("Stopping optimization (insufficient funds cannot be resolved by retrying).")
+            return "stop"
+
         print()
         print("Options:")
         print("  [r] Resume optimization")

--- a/traigent/core/session_types.py
+++ b/traigent/core/session_types.py
@@ -27,6 +27,15 @@ class SessionCreationResult:
     failure_reason: SessionCreationFailureReason | None = None
     failure_detail: str | None = None
 
+    def __str__(self) -> str:
+        """Return the session ID string for backwards compatibility.
+
+        v0.10.x returned a plain str from create_session(); code that does
+        ``session_id = create_session()`` and passes the result as a string
+        argument will continue to work without changes.
+        """
+        return self.session_id
+
     def __post_init__(self) -> None:
         if not self.backend_connected and self.failure_reason is None:
             raise ValueError("failure_reason is required when backend_connected=False")

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -38,6 +38,7 @@ from traigent.core.types import TrialResult, TrialStatus
 from traigent.evaluators.base import Dataset
 from traigent.utils.error_handler import APIKeyError
 from traigent.utils.exceptions import (
+    InsufficientFundsError,
     OptimizationError,
     QuotaExceededError,
     RateLimitError,
@@ -433,6 +434,7 @@ class TrialLifecycle:
         except (
             RateLimitError,
             QuotaExceededError,
+            InsufficientFundsError,
             ServiceUnavailableError,
         ) as vendor_exc:
             # Re-raise as VendorPauseError so the orchestrator can prompt

--- a/traigent/examples/__init__.py
+++ b/traigent/examples/__init__.py
@@ -1,0 +1,1 @@
+# Bundled examples that ship with the pip package.

--- a/traigent/examples/quickstart/__init__.py
+++ b/traigent/examples/quickstart/__init__.py
@@ -1,1 +1,1 @@
-# Quickstart example — run with: python -m traigent.examples.quickstart
+# Quickstart example - run with: python -m traigent.examples.quickstart

--- a/traigent/examples/quickstart/__init__.py
+++ b/traigent/examples/quickstart/__init__.py
@@ -1,0 +1,1 @@
+# Quickstart example — run with: python -m traigent.examples.quickstart

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -7,6 +7,8 @@ For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
 
 import asyncio
 import os
+import shutil
+import tempfile
 from pathlib import Path
 
 # Default to mock mode so the quickstart works without API keys.
@@ -16,13 +18,24 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
-# Use LangChain's ChatOpenAI so Traigent's mock interceptor can bypass
-# real API calls when TRAIGENT_MOCK_LLM=true.
+# NOTE: This uses LangChain's ChatOpenAI rather than the litellm calls shown
+# in the documentation. That is intentional and temporary: Traigent's mock
+# interceptor (TRAIGENT_MOCK_LLM=true) only patches LangChain's ChatOpenAI at
+# this point — it does not yet intercept raw litellm/openai calls.
+# Once the interceptor adds raw litellm support this file will be updated to
+# match the litellm style shown in the docs.
 from langchain_openai import ChatOpenAI
 
 import traigent
 
-DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
+_DATASET_SRC = Path(__file__).parent / "qa_samples.jsonl"
+# The SDK requires dataset files to reside under the system temp directory.
+# When installed via pip the package data is in site-packages, so copy it.
+if str(_DATASET_SRC).startswith(tempfile.gettempdir()):
+    DATASET = str(_DATASET_SRC)
+else:
+    _tmp = Path(tempfile.mkdtemp())
+    DATASET = str(shutil.copy(_DATASET_SRC, _tmp / _DATASET_SRC.name))
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -16,7 +16,9 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
-from openai import OpenAI
+# Use LangChain's ChatOpenAI so Traigent's mock interceptor can bypass
+# real API calls when TRAIGENT_MOCK_LLM=true.
+from langchain_openai import ChatOpenAI
 
 import traigent
 
@@ -37,13 +39,8 @@ CONFIG_SPACE = {
 def answer(question: str) -> str:
     """Call an LLM with the current trial's config."""
     cfg = traigent.get_config()
-    client = OpenAI()
-    response = client.chat.completions.create(
-        model=cfg["model"],
-        temperature=cfg["temperature"],
-        messages=[{"role": "user", "content": question}],
-    )
-    return response.choices[0].message.content
+    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
+    return llm.invoke(question).content
 
 
 if __name__ == "__main__":

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -1,0 +1,49 @@
+"""Find the best model and temperature for your task — in one decorator.
+
+No API keys needed — runs in mock mode and simulates LLM responses
+so you can see the optimization flow instantly.
+For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
+"""
+import asyncio
+import os
+from pathlib import Path
+
+# Default to mock mode so the quickstart works without API keys.
+# Override with: TRAIGENT_MOCK_LLM=false python -m traigent.examples.quickstart
+os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
+    os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
+    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+
+from openai import OpenAI
+
+import traigent
+
+DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
+OBJECTIVES = ["accuracy"]
+CONFIG_SPACE = {
+    "model": ["gpt-4o-mini", "gpt-4o"],
+    "temperature": [0.0, 0.7, 1.0],
+}
+
+
+@traigent.optimize(
+    configuration_space=CONFIG_SPACE,
+    objectives=OBJECTIVES,
+    eval_dataset=DATASET,
+    execution_mode="edge_analytics",
+)
+def answer(question: str) -> str:
+    """Call an LLM with the current trial's config."""
+    cfg = traigent.get_config()
+    client = OpenAI()
+    response = client.chat.completions.create(
+        model=cfg["model"],
+        temperature=cfg["temperature"],
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
+
+
+if __name__ == "__main__":
+    result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -1,9 +1,10 @@
-"""Find the best model and temperature for your task — in one decorator.
+"""Find the best model and temperature for your task - in one decorator.
 
-No API keys needed — runs in mock mode and simulates LLM responses
+No API keys needed - runs in mock mode and simulates LLM responses
 so you can see the optimization flow instantly.
 For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
 """
+
 import asyncio
 import os
 from pathlib import Path

--- a/traigent/examples/quickstart/qa_samples.jsonl
+++ b/traigent/examples/quickstart/qa_samples.jsonl
@@ -1,0 +1,8 @@
+{"input": {"question": "What is the capital of France?"}, "output": "Paris"}
+{"input": {"question": "What is 2 + 2?"}, "output": "4"}
+{"input": {"question": "Who wrote Romeo and Juliet?"}, "output": "William Shakespeare"}
+{"input": {"question": "What is the largest planet in our solar system?"}, "output": "Jupiter"}
+{"input": {"question": "What year did World War II end?"}, "output": "1945"}
+{"input": {"question": "What is the chemical symbol for water?"}, "output": "H2O"}
+{"input": {"question": "Who painted the Mona Lisa?"}, "output": "Leonardo da Vinci"}
+{"input": {"question": "What is the speed of light?"}, "output": "299,792,458 meters per second"}

--- a/traigent/providers/validation.py
+++ b/traigent/providers/validation.py
@@ -44,6 +44,9 @@ _MSG_TRANSIENT_WARNING = (
 _MSG_AVAILABLE_UNVERIFIED = "Available (unverified: {error_type})"
 _MSG_VALIDATION_FAILED = "Validation failed ({error_type})"
 _MSG_AVAILABLE_CACHED = "Available (cached)"
+_MSG_INSUFFICIENT_FUNDS = (
+    "Insufficient funds — top up your {provider} account and retry"
+)
 
 # Provider detection patterns (model name -> provider)
 # Matches: gpt-*, o1-*, o3-* -> openai
@@ -197,6 +200,27 @@ def _is_transient_error(exc: Exception) -> bool:
         if parent.__name__ in _TRANSIENT_ERROR_TYPES:
             return True
     return False
+
+
+_INSUFFICIENT_FUNDS_KEYWORDS = (
+    "insufficient_funds",
+    "insufficient funds",
+    "insufficient credits",
+    "billing hard limit",
+    "exceeded your current billing",
+    "payment required",
+    "status 402",
+    "http 402",
+    "code: 402",
+    "error 402",
+    "402 payment",
+)
+
+
+def _is_insufficient_funds_error(exc: Exception) -> bool:
+    """Check if exception indicates insufficient funds / billing failure."""
+    msg = str(exc).lower()
+    return any(kw in msg for kw in _INSUFFICIENT_FUNDS_KEYWORDS)
 
 
 def _run_with_timeout(func: Callable[[], T], timeout: float, provider: str) -> T:
@@ -457,6 +481,13 @@ class ProviderValidator:
                     message=_MSG_INVALID_KEY.format(error_type=error_type),
                     error_type=error_type,
                 )
+            if _is_insufficient_funds_error(exc):
+                return ProviderStatus(
+                    provider="openai",
+                    valid=False,
+                    message=_MSG_INSUFFICIENT_FUNDS.format(provider="OpenAI"),
+                    error_type="InsufficientFunds",
+                )
             if _is_transient_error(exc):
                 # Transient error - key might be valid, warn but don't block
                 logger.warning(
@@ -526,6 +557,13 @@ class ProviderValidator:
                     valid=False,
                     message=_MSG_INVALID_KEY.format(error_type=error_type),
                     error_type=error_type,
+                )
+            if _is_insufficient_funds_error(exc):
+                return ProviderStatus(
+                    provider="anthropic",
+                    valid=False,
+                    message=_MSG_INSUFFICIENT_FUNDS.format(provider="Anthropic"),
+                    error_type="InsufficientFunds",
                 )
             if _is_transient_error(exc):
                 logger.warning(
@@ -597,6 +635,13 @@ class ProviderValidator:
                     message=_MSG_INVALID_KEY.format(error_type=error_type),
                     error_type=error_type,
                 )
+            if _is_insufficient_funds_error(exc):
+                return ProviderStatus(
+                    provider="google",
+                    valid=False,
+                    message=_MSG_INSUFFICIENT_FUNDS.format(provider="Google"),
+                    error_type="InsufficientFunds",
+                )
             if _is_transient_error(exc):
                 logger.warning(
                     _MSG_TRANSIENT_WARNING,
@@ -662,6 +707,13 @@ class ProviderValidator:
                     message=_MSG_INVALID_KEY.format(error_type=error_type),
                     error_type=error_type,
                 )
+            if _is_insufficient_funds_error(exc):
+                return ProviderStatus(
+                    provider="mistral",
+                    valid=False,
+                    message=_MSG_INSUFFICIENT_FUNDS.format(provider="Mistral"),
+                    error_type="InsufficientFunds",
+                )
             if _is_transient_error(exc):
                 logger.warning(
                     _MSG_TRANSIENT_WARNING,
@@ -726,6 +778,13 @@ class ProviderValidator:
                     valid=False,
                     message=_MSG_INVALID_KEY.format(error_type=error_type),
                     error_type=error_type,
+                )
+            if _is_insufficient_funds_error(exc):
+                return ProviderStatus(
+                    provider="cohere",
+                    valid=False,
+                    message=_MSG_INSUFFICIENT_FUNDS.format(provider="Cohere"),
+                    error_type="InsufficientFunds",
                 )
             if _is_transient_error(exc):
                 logger.warning(

--- a/traigent/utils/exceptions.py
+++ b/traigent/utils/exceptions.py
@@ -250,6 +250,14 @@ class QuotaExceededError(ServiceError):
     """Service quota or rate limit exceeded."""
 
 
+class InsufficientFundsError(ServiceError):
+    """LLM provider account has insufficient credits.
+
+    Raised on HTTP 402 / billing errors from providers.
+    This is non-retryable — the user must top up their account.
+    """
+
+
 class SessionError(TraigentError):
     """Error in session management."""
 

--- a/walkthrough/real/01_tuning_qa.py
+++ b/walkthrough/real/01_tuning_qa.py
@@ -5,8 +5,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/01_tuning_qa.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -66,6 +66,7 @@ DATASETS = Path(__file__).parent.parent / "datasets"
 DEBUG_EVAL = os.getenv("TRAIGENT_DEBUG_EVAL", "").lower() in ("1", "true", "yes")
 DEBUG_EVAL_PATH = os.getenv("TRAIGENT_DEBUG_EVAL_PATH")
 OBJECTIVES = ["accuracy", "cost"]
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini", "gpt-4o"],
     "temperature": [0.1, 0.7],

--- a/walkthrough/real/02_zero_code_change.py
+++ b/walkthrough/real/02_zero_code_change.py
@@ -5,8 +5,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/02_zero_code_change.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -43,6 +43,7 @@ traigent.initialize(execution_mode="edge_analytics")
 # Dataset path relative to this file
 DATASETS = Path(__file__).parent.parent / "datasets"
 OBJECTIVES = ["accuracy", "cost"]
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini", "gpt-4o"],
     "temperature": [0.1, 0.5, 0.9],

--- a/walkthrough/real/03_parameter_mode.py
+++ b/walkthrough/real/03_parameter_mode.py
@@ -5,8 +5,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/03_parameter_mode.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -44,6 +44,7 @@ traigent.initialize(execution_mode="edge_analytics")
 # Dataset path relative to this file
 DATASETS = Path(__file__).parent.parent / "datasets"
 OBJECTIVES = ["accuracy", "cost"]
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini"],
     "temperature": [0.0, 0.5, 1.0],

--- a/walkthrough/real/04_multi_objective.py
+++ b/walkthrough/real/04_multi_objective.py
@@ -5,8 +5,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/04_multi_objective.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -51,6 +51,7 @@ OBJECTIVES = ObjectiveSchema.from_objectives(
         ObjectiveDefinition("latency", orientation="minimize", weight=0.2),
     ]
 )
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": [
         "gpt-3.5-turbo",

--- a/walkthrough/real/05_rag_parallel.py
+++ b/walkthrough/real/05_rag_parallel.py
@@ -5,8 +5,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/05_rag_parallel.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -55,6 +55,7 @@ traigent.initialize(execution_mode="edge_analytics")
 # Dataset path relative to this file
 DATASETS = Path(__file__).parent.parent / "datasets"
 OBJECTIVES = ["accuracy", "cost"]
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini"],
     "temperature": [0.0, 0.3, 0.7],

--- a/walkthrough/real/06_custom_evaluator.py
+++ b/walkthrough/real/06_custom_evaluator.py
@@ -8,8 +8,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/06_custom_evaluator.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -47,6 +47,7 @@ traigent.initialize(execution_mode="edge_analytics")
 # Dataset path relative to this file
 DATASETS = Path(__file__).parent.parent / "datasets"
 OBJECTIVES = ["accuracy", "cost"]
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini"],
     "temperature": [0.0, 0.2, 0.5],

--- a/walkthrough/real/07_multi_provider.py
+++ b/walkthrough/real/07_multi_provider.py
@@ -20,8 +20,8 @@ Usage (run from repo root):
     .venv/bin/python walkthrough/real/07_multi_provider.py
 
 Note: This example validates API keys using Traigent's core provider validation
-and skips any invalid providers. If no provider key is set, it shows a warning
-and runs the matching mock walkthrough instead.
+and skips any invalid providers. If no provider key is set, the script exits
+with an error and suggests running the mock walkthrough instead.
 """
 
 import asyncio
@@ -78,7 +78,7 @@ traigent.initialize(
 # Uses Traigent core provider validation (traigent.providers.validation)
 # -----------------------------------------------------------------------------
 
-# Models organized by provider
+# Models organized by provider (valid model names: https://models.litellm.ai/)
 OPENAI_MODELS = ["gpt-4o-mini", "gpt-4o"]
 ANTHROPIC_MODELS = ["claude-sonnet-4-20250514"]
 GOOGLE_MODELS = ["gemini-2.0-flash", "gemini-1.5-pro-latest"]

--- a/walkthrough/real/08_privacy_modes.py
+++ b/walkthrough/real/08_privacy_modes.py
@@ -5,8 +5,8 @@ Usage (run in a terminal from repo root, works without activating venv):
     export OPENAI_API_KEY="your-key"  # pragma: allowlist secret
     .venv/bin/python walkthrough/real/08_privacy_modes.py
 
-If OPENAI_API_KEY is missing, this script shows a warning and runs the matching
-mock walkthrough instead.
+If OPENAI_API_KEY is missing, this script exits with an error and suggests
+running the mock walkthrough instead.
 """
 
 import asyncio
@@ -50,6 +50,7 @@ traigent.initialize(
 DATASETS = Path(__file__).parent.parent / "datasets"
 RESULTS_DIR = os.getenv("TRAIGENT_RESULTS_FOLDER", "./local_results")
 OBJECTIVES = ["accuracy"]
+# Valid model names: https://models.litellm.ai/
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini"],
     "temperature": [0.1, 0.5],


### PR DESCRIPTION
## Release v0.11.0

### Why this release
The QuickStart page tells users to run `python -m traigent.examples.quickstart` after `pip install`, but until now that module didn't exist in the published package. This release ships it, fixes the mock mode so it actually works without API keys, and aligns all docs to the new install path. Everything else is accumulated fixes and features from develop since v0.10.0 (2026-02-07).

### What's in it
238 files changed across 60+ commits. The full categorized list is in `CHANGELOG.md` under `[0.11.0] - 2026-03-30`. Key items:

**The reason for this release:**
- Quickstart bundled in pip package (`traigent/examples/quickstart/`) with dataset (#615, #617)
- Mock mode fixed to use ChatOpenAI so the interceptor works (#621)
- Install docs updated to `pip install "traigent[integrations]"` — temporary until mock interceptor supports raw `openai`/`litellm`
- `hello_world.py` made a thin shim to avoid duplicate source of truth

**Also shipping (accumulated since v0.10.0):**
- Langfuse observability bridge (Epic 1) (#560)
- Security: `litellm<1.82.7` pin for compromised PyPI versions
- Tag-based auto-publish CI workflow
- Breaking: `create_session()` return type, default backend URL, removed `experimental/`

### Breaking changes
See `CHANGELOG.md` — three breaking changes noted. Most users won't be affected (hybrid API consumers and localhost SDK devs).

### After merge
```bash
git checkout main && git pull
git tag v0.11.0
git push origin v0.11.0
```
CI auto-publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)