### PR TITLE
fix: use ChatOpenAI in quickstart so mock mode works

### DIFF
--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -16,7 +16,9 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
-from openai import OpenAI
+# Use LangChain's ChatOpenAI so Traigent's mock interceptor can bypass
+# real API calls when TRAIGENT_MOCK_LLM=true.
+from langchain_openai import ChatOpenAI
 
 import traigent
 
@@ -37,13 +39,8 @@ CONFIG_SPACE = {
 def answer(question: str) -> str:
     """Call an LLM with the current trial's config."""
     cfg = traigent.get_config()
-    client = OpenAI()
-    response = client.chat.completions.create(
-        model=cfg["model"],
-        temperature=cfg["temperature"],
-        messages=[{"role": "user", "content": question}],
-    )
-    return response.choices[0].message.content
+    llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
+    return llm.invoke(question).content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Switch `__main__.py` from raw `openai.OpenAI` to `langchain_openai.ChatOpenAI` so Traigent's mock interceptor can bypass real API calls when `TRAIGENT_MOCK_LLM=true`

## What happened
The `ChatOpenAI` fix was made locally during #617 but was lost in a stash when switching branches. The merged PR shipped with raw `openai`, which crashes with a 401 in mock mode (the default path for new users).

## Verified
- `python -m traigent.examples.quickstart` runs successfully in mock mode (6 trials, exit 0)
- `ruff check` and `ruff format` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)