### PR TITLE
fix: address PR #620 review findings before v0.11.0 merge

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m traigent.examples.quickstart
 
-    - name: Run hello world example
+    - name: Run hello world example (source checkout — not available from pip install)
       env:
         TRAIGENT_MOCK_LLM: "true"
         TRAIGENT_OFFLINE_MODE: "true"
@@ -130,7 +130,7 @@ jobs:
         pip install -e ".[dev,integrations]"
         python -c "import traigent; print('Import works')"
         python -m traigent.examples.quickstart
-        python hello_world.py
+        python hello_world.py  # source checkout only — not available from pip install
         python examples/quickstart/01_simple_qa.py || true
         echo "Quick validation passed"
 

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -82,3 +82,33 @@ jobs:
         run: |
           python -c "from importlib.metadata import version; import opentelemetry.sdk; print(f'opentelemetry-sdk {version(\"opentelemetry-sdk\")} OK')"
           python -c "import boto3; print(f'boto3 {boto3.__version__} OK')"
+
+  # Validates the pip-install user experience for the packaged quickstart.
+  # Runs in a temp directory (no repo checkout) to confirm the module works
+  # without hello_world.py or any other source-tree file present.
+  pip-install-quickstart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4  # needed to build the wheel
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir /tmp/dist
+
+      - name: Install from wheel in a clean temp directory
+        run: |
+          python -m pip install "/tmp/dist/$(ls /tmp/dist | grep .whl)" "langchain-openai"
+
+      - name: Run packaged quickstart from outside the repo (pip-install simulation)
+        env:
+          TRAIGENT_MOCK_LLM: "true"
+          TRAIGENT_OFFLINE_MODE: "true"
+        working-directory: /tmp
+        run: |
+          python -m traigent.examples.quickstart

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,16 @@ jobs:
       with:
         fetch-depth: 0  # Full history for version detection
 
+    - name: Verify tag is on main branch
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        git fetch origin main
+        if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+          echo "Error: tag ${{ github.ref_name }} is not on the main branch. Only tag from main."
+          exit 1
+        fi
+        echo "Tag ${{ github.ref_name }} is on main — proceeding."
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dead methods removed from orchestrator (`_check_batch_vendor_failures`, `_maybe_pause_on_cost_limit`, `_handle_vendor_pause_in_loop`)
 
 ### Breaking Changes
-- `create_session()` return type changed from `str` to `SessionCreationResult` dataclass
+- `create_session()` return type changed from `str` to `SessionCreationResult` dataclass.
+  `SessionCreationResult.__str__` returns the session ID so most existing code continues
+  to work without changes, but explicit `isinstance(result, str)` checks will need updating.
+
+  **Before (v0.10.x):**
+  ```python
+  session_id: str = create_session()
+  ```
+  **After (v0.11.0+):**
+  ```python
+  result = create_session()
+  session_id: str = result.session_id   # explicit
+  # or: str(result)                      # via __str__
+  ```
 - `HybridExecuteRequest` and `HybridEvaluateRequest` no longer accept `benchmark_id` parameter
 - Default backend URL is now cloud instead of localhost
 

--- a/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
+++ b/examples/gallery/page-inline/ai-agents/ex01-customer-support/customer_support.py
@@ -25,7 +25,8 @@ else:
         except IndexError:
             continue
 
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
+++ b/examples/gallery/page-inline/by-goal/accuracy-optimization/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
+++ b/examples/gallery/page-inline/by-goal/cost-reduction/simple.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
+++ b/examples/gallery/page-inline/by-goal/reliability-robustness/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/by-goal/speed-latency/simple.py
+++ b/examples/gallery/page-inline/by-goal/speed-latency/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-production.py
@@ -26,7 +26,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
+++ b/examples/gallery/page-inline/configuration-management/applying-configurations/apply-save.py
@@ -25,7 +25,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
+++ b/examples/gallery/page-inline/configuration-management/ex01-seamless-basic/seamless_basic.py
@@ -26,7 +26,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
+++ b/examples/gallery/page-inline/configuration-management/ex02-seamless-advanced/seamless_advanced.py
@@ -26,7 +26,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
+++ b/examples/gallery/page-inline/configuration-management/ex03-parameter-custom/parameter_custom.py
@@ -27,7 +27,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
+++ b/examples/gallery/page-inline/configuration-management/ex04-parameter-mixed/parameter_mixed.py
@@ -27,7 +27,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
+++ b/examples/gallery/page-inline/configuration-management/ex05-apply-saved/apply_saved.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
+++ b/examples/gallery/page-inline/configuration-management/ex06-apply-production/apply_production.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-debug.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
+++ b/examples/gallery/page-inline/configuration-management/injection-mechanism/inject-mechanism.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-custom.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
+++ b/examples/gallery/page-inline/configuration-management/parameter-injection/param-mixed.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-advanced.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
+++ b/examples/gallery/page-inline/configuration-management/seamless-injection/seamless-basic.py
@@ -20,7 +20,7 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI
+from langchain_openai import ChatOpenAI
 
 try:
     import traigent

--- a/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/code_review/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -64,7 +65,7 @@ def review_code(snippet: str) -> str:
         "Respond with one label only: ok or issue.\n"
         f"Code:\n{snippet}"
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/conversation/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def should_escalate(utterance: str) -> str:
         "Return yes if this message requires human escalation (legal, threats, complex), else no.\n"
         f"Message: {utterance}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/multi_agent/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def route(task: str) -> str:
         "Classify who should handle the task: planner or executor.\n"
         f"Task: {task}\nReturn one label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/research/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/research/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "research_eval.jsonl")
 def answer(question: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.0)
     prompt = f"Answer concisely with one short phrase: {question}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/support/advanced.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/advanced.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -101,7 +102,7 @@ Message: {message}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "json":
         try:

--- a/examples/gallery/page-inline/cookbook-agents/support/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/support/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def support_intent(message: str) -> str:
         "Classify support intent as one of: billing, account, technical, general, cancellation.\n"
         f"Message: {message}\nReturn only the label."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
+++ b/examples/gallery/page-inline/cookbook-agents/tool_use/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def needs_tool(request: str) -> str:
         "Return needs_tool if the request requires a non-LLM action (API, calc), else no_tool.\n"
         f"Request: {request}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/blog/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/blog/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "blog_eval.jsonl")
 def write_intro(topic: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     prompt = f"Write a 2-3 sentence blog introduction about: {topic}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/creative/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/creative/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "creative_eval.jsonl")
 def write_poem(prompt: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.9)
     p = f"Write a 3-line poem about: {prompt}"
-    return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+    return llm.invoke([HumanMessage(content=p)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/advanced.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -77,7 +78,7 @@ def generate_headline(topic: str) -> str:
         f"Write a {style_hint} headline about: {topic}\n"
         f"Max {int(cfg.get('max_words', 12))} words. One line only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/headlines/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/headlines/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "headlines_eval.jsonl")
 def generate_headline(topic: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     prompt = f"Write a concise, catchy headline about: {topic}\nOne line only."
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-content/media/simple.py
+++ b/examples/gallery/page-inline/cookbook-content/media/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "media_eval.jsonl")
 def shotlist(topic: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     p = f"Create a 3-step shot list for a short video about: {topic}"
-    return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+    return llm.invoke([HumanMessage(content=p)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/anomaly/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def has_anomaly(series: str) -> str:
         "Given a numeric series, return yes if an outlier is present, else no.\n"
         f"Series: {series}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/bi/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/bi/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "bi_eval.jsonl")
 def summarize_kpis(kpis: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.6)
     prompt = f"Given KPI values, write 2-3 concise insights with trends and recommendations. KPIs: {kpis}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/advanced.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -116,7 +117,7 @@ Text: {text}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "kv":
         # Normalize KV to JSON if needed for metric

--- a/examples/gallery/page-inline/cookbook-data/extraction/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/extraction/simple.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -84,7 +85,7 @@ def extract_fields(text: str) -> str:
         "Extract company and amount as JSON with keys 'company' and 'amount'."
         f"\nText: {text}\nReturn only JSON."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-data/trend/simple.py
+++ b/examples/gallery/page-inline/cookbook-data/trend/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -63,7 +64,7 @@ def classify_trend(series: str) -> str:
         "Given a numeric series, classify overall trend: up, down, or flat.\n"
         f"Series: {series}\nOne label only."
     )
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/advanced.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -110,7 +111,7 @@ Text: {text}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "json":
         try:

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/basic.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -86,7 +87,7 @@ Text: {text}
     llm = ChatOpenAI(
         model=cfg.get("model", "gpt-3.5-turbo"), temperature=cfg.get("temperature", 0.0)
     )
-    raw = extract_content(llm.invoke([HumanMessage(content=prompt)]))
+    raw = llm.invoke([HumanMessage(content=prompt)]).content
 
     if cfg.get("output_format") == "json":
         try:

--- a/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/sentiment/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "sentiment_eval.jsonl")
 def sentiment_analysis(text: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7)
     prompt = f"Classify sentiment (positive/negative/neutral): {text}\nReturn one label only."
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip().lower()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip().lower()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/context.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -66,7 +67,7 @@ def summarize(document: str) -> str:
 
     def _sum(text: str) -> str:
         p = f"Summarize in 1-2 sentences:\n\n{text}"
-        return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+        return llm.invoke([HumanMessage(content=p)]).content.strip()
 
     words = document.split()
     cs = int(cfg.get("chunk_size", 240))

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/quality.py
@@ -27,7 +27,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -79,7 +80,7 @@ def _summary_f1(output: str | None, expected: str | None, llm_metrics=None) -> f
 def summarize(document: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.0)
     p = f"Summarize in 1-2 sentences:\n\n{document}"
-    return extract_content(llm.invoke([HumanMessage(content=p)])).strip()
+    return llm.invoke([HumanMessage(content=p)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
+++ b/examples/gallery/page-inline/cookbook-nlp/summarization/simple.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage, extract_content
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
@@ -60,7 +61,7 @@ DATASET = os.path.join(os.path.dirname(__file__), "summarization_eval.jsonl")
 def summarize(document: str) -> str:
     llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.7)
     prompt = f"Summarize in 1-2 sentences:\n\n{document}"
-    return extract_content(llm.invoke([HumanMessage(content=prompt)])).strip()
+    return llm.invoke([HumanMessage(content=prompt)]).content.strip()
 
 
 if __name__ == "__main__":

--- a/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
+++ b/examples/gallery/page-inline/core-concepts/ex01-configuration-spaces/configuration_spaces.py
@@ -25,7 +25,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 

--- a/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
+++ b/examples/gallery/page-inline/core-concepts/ex02-objectives-metrics/objectives_metrics.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 try:
     import traigent

--- a/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
+++ b/examples/gallery/page-inline/core-concepts/ex03-evaluation-datasets/evaluation_datasets.py
@@ -26,7 +26,8 @@ else:
                 break
         except IndexError:
             continue
-from examples.utils.langchain_compat import ChatOpenAI, HumanMessage
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
 
 try:
     import traigent

--- a/traigent/core/session_types.py
+++ b/traigent/core/session_types.py
@@ -27,6 +27,15 @@ class SessionCreationResult:
     failure_reason: SessionCreationFailureReason | None = None
     failure_detail: str | None = None
 
+    def __str__(self) -> str:
+        """Return the session ID string for backwards compatibility.
+
+        v0.10.x returned a plain str from create_session(); code that does
+        ``session_id = create_session()`` and passes the result as a string
+        argument will continue to work without changes.
+        """
+        return self.session_id
+
     def __post_init__(self) -> None:
         if not self.backend_connected and self.failure_reason is None:
             raise ValueError("failure_reason is required when backend_connected=False")

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -16,8 +16,12 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
-# Use LangChain's ChatOpenAI so Traigent's mock interceptor can bypass
-# real API calls when TRAIGENT_MOCK_LLM=true.
+# NOTE: This uses LangChain's ChatOpenAI rather than the litellm calls shown
+# in the documentation. That is intentional and temporary: Traigent's mock
+# interceptor (TRAIGENT_MOCK_LLM=true) only patches LangChain's ChatOpenAI at
+# this point — it does not yet intercept raw litellm/openai calls.
+# Once the interceptor adds raw litellm support this file will be updated to
+# match the litellm style shown in the docs.
 from langchain_openai import ChatOpenAI
 
 import traigent

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -7,6 +7,8 @@ For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
 
 import asyncio
 import os
+import shutil
+import tempfile
 from pathlib import Path
 
 # Default to mock mode so the quickstart works without API keys.
@@ -26,7 +28,14 @@ from langchain_openai import ChatOpenAI
 
 import traigent
 
-DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
+_DATASET_SRC = Path(__file__).parent / "qa_samples.jsonl"
+# The SDK requires dataset files to reside under the system temp directory.
+# When installed via pip the package data is in site-packages, so copy it.
+if str(_DATASET_SRC).startswith(tempfile.gettempdir()):
+    DATASET = str(_DATASET_SRC)
+else:
+    _tmp = Path(tempfile.mkdtemp())
+    DATASET = str(shutil.copy(_DATASET_SRC, _tmp / _DATASET_SRC.name))
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],


### PR DESCRIPTION
Fixes the issues raised in the #623 review of PR #620 (Release v0.11.0). Tracked in #628.

## Changes

### C1 — `traigent/examples/quickstart/__main__.py`
Expanded the `ChatOpenAI` import comment to explain the docs/quickstart mismatch: mock interceptor only patches LangChain ChatOpenAI, not raw litellm. Noted it's temporary and will be updated when raw litellm support lands.

### C2 — `.github/workflows/publish.yml`
Added a "Verify tag is on main branch" step at the start of the publish job. Uses `git merge-base --is-ancestor` to confirm the tagged commit is reachable from `origin/main` before any build or publish step runs.

### S1 — `traigent/core/session_types.py` + `CHANGELOG.md`
Added `SessionCreationResult.__str__` returning `self.session_id` so existing code that treats `create_session()` as a string continues to work without changes. Added before/after migration snippet to CHANGELOG under Breaking Changes.

### S2 — `.github/workflows/examples-smoke.yml` + `install-smoke.yml`
- Renamed the `hello_world.py` smoke step to clarify it requires a source checkout and is not available from a pip install.
- Added `pip-install-quickstart` job to `install-smoke.yml`: builds a wheel, installs it in `/tmp` (outside the repo), and runs `python -m traigent.examples.quickstart` from there — validating the real pip-user experience.

### S3 — `examples/gallery/page-inline/**` (45 files)
Replaced `from examples.utils.langchain_compat import ...` with direct `langchain_openai` / `langchain_core.messages` imports in all 45 gallery page-inline files. Replaced `extract_content(expr)` call sites with `expr.content`. Removes the dependency on `examples/utils/` (not in the installed package).

## Test plan
- [ ] CI passes on this branch
- [ ] `python -m traigent.examples.quickstart` works with `TRAIGENT_MOCK_LLM=true`
- [ ] Push a test tag from a non-main branch → confirm publish.yml fails at the branch guard step
- [ ] Spot-check a gallery file: `python examples/gallery/page-inline/cookbook-data/trend/simple.py`

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)