### PR TITLE
fix: update fallback version and test assertion to 0.11.0

### DIFF
--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -85,7 +85,7 @@ def test_version_package_metadata_not_found():
                 importlib.reload(version_module)
                 result = version_module.get_version()
                 # Should fall back to hardcoded version
-                assert result == "0.10.0"
+                assert result == "0.11.0"
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -8,7 +8,7 @@ import importlib.metadata
 import os
 from pathlib import Path
 
-_FALLBACK_VERSION = "0.10.0"
+_FALLBACK_VERSION = "0.11.0"
 
 
 def _read_pyproject_version() -> str | None:


### PR DESCRIPTION
## Summary
- Update `_FALLBACK_VERSION` in `traigent/_version.py` from `0.10.0` to `0.11.0`
- Update test assertion in `tests/unit/test_coverage_improvements.py` to match

## What happened
The fix was committed to `chore/bump-v0.11.0` after PR #622 had already merged, so it was orphaned on a dead branch. This is the same class of issue as the ChatOpenAI stash loss from #621.

## After merge
This needs to land on main before tagging `v0.11.0`. Either merge develop -> main again, or cherry-pick directly to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)