### PR TITLE
fix: sync fallback version 0.11.0 to main

### DIFF
--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -85,7 +85,7 @@ def test_version_package_metadata_not_found():
                 importlib.reload(version_module)
                 result = version_module.get_version()
                 # Should fall back to hardcoded version
-                assert result == "0.10.0"
+                assert result == "0.11.0"
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -102,10 +102,12 @@ def test_get_version_info():
     assert "major" in info
     assert "minor" in info
     assert "patch" in info
-    # Version should be 0.11.0 format
-    assert info["major"] == "0"
-    assert info["minor"] == "11"
-    assert info["patch"] == "0"
+    # Verify version info is consistent with get_version()
+    from traigent._version import get_version
+    expected_parts = get_version().split(".")
+    assert info["major"] == expected_parts[0]
+    assert info["minor"] == expected_parts[1]
+    assert info["patch"] == expected_parts[2]
 
 
 # =============================================================================

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -102,9 +102,9 @@ def test_get_version_info():
     assert "major" in info
     assert "minor" in info
     assert "patch" in info
-    # Version should be 0.9.0 format
+    # Version should be 0.11.0 format
     assert info["major"] == "0"
-    assert info["minor"] == "10"
+    assert info["minor"] == "11"
     assert info["patch"] == "0"
 
 

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -8,7 +8,7 @@ import importlib.metadata
 import os
 from pathlib import Path
 
-_FALLBACK_VERSION = "0.10.0"
+_FALLBACK_VERSION = "0.11.0"
 
 
 def _read_pyproject_version() -> str | None:


### PR DESCRIPTION
Brings the fallback version fix (#631) to main. Two files:
- `traigent/_version.py` — `_FALLBACK_VERSION` 0.10.0 → 0.11.0
- `tests/unit/test_coverage_improvements.py` — test assertion updated

Must merge before tagging `v0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)