### PR TITLE
fix: update test_get_version_info minor assertion to 11

### DIFF
--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -102,10 +102,12 @@ def test_get_version_info():
     assert "major" in info
     assert "minor" in info
     assert "patch" in info
-    # Version should be 0.11.0 format
-    assert info["major"] == "0"
-    assert info["minor"] == "11"
-    assert info["patch"] == "0"
+    # Verify version info is consistent with get_version()
+    from traigent._version import get_version
+    expected_parts = get_version().split(".")
+    assert info["major"] == expected_parts[0]
+    assert info["minor"] == expected_parts[1]
+    assert info["patch"] == expected_parts[2]
 
 
 # =============================================================================

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -102,9 +102,9 @@ def test_get_version_info():
     assert "major" in info
     assert "minor" in info
     assert "patch" in info
-    # Version should be 0.9.0 format
+    # Version should be 0.11.0 format
     assert info["major"] == "0"
-    assert info["minor"] == "10"
+    assert info["minor"] == "11"
     assert info["patch"] == "0"
 
 


### PR DESCRIPTION
Greptile P1 on #632: `test_get_version_info` asserts `info["minor"] == "10"` but `get_version()` reads `pyproject.toml` which is `0.11.0`. CI would fail.

Also fixes stale comment (`0.9.0` → `0.11.0`).

Must merge before #632 (develop → main) and before tagging `v0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)