### PR TITLE
fix(ci): replace fragile curl pipe with file-based PyPI verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,7 +184,7 @@ jobs:
         for attempt in 1 2 3 4 5; do
           echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
           HTTP_CODE=$(curl -sL -w '%{http_code}' -o /tmp/pypi_response.json "$PACKAGE_API_URL" || echo "000")
-          if [ "$HTTP_CODE" = "200" ] && CHECK_VERSION="$VERSION" python3 -c "
+          if [ "$HTTP_CODE" = "200" ] && CHECK_VERSION="$VERSION" python -c "
         import json, os, sys
         with open('/tmp/pypi_response.json') as f:
             data = json.load(f)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,11 +184,11 @@ jobs:
         for attempt in 1 2 3 4 5; do
           echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
           HTTP_CODE=$(curl -sL -w '%{http_code}' -o /tmp/pypi_response.json "$PACKAGE_API_URL" || echo "000")
-          if [ "$HTTP_CODE" = "200" ] && python3 -c "
-        import json, sys
+          if [ "$HTTP_CODE" = "200" ] && CHECK_VERSION="$VERSION" python3 -c "
+        import json, os, sys
         with open('/tmp/pypi_response.json') as f:
             data = json.load(f)
-        version = '$VERSION'
+        version = os.environ['CHECK_VERSION']
         releases = data.get('releases', {})
         if version not in releases or not releases[version]:
             sys.exit(1)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,28 +180,28 @@ jobs:
         VERSION="$EXPECTED_VERSION"
         echo "Testing installation of traigent==$VERSION from $PACKAGE_LABEL"
 
-        # Retry API check up to 3 times (CDN propagation can be slow)
-        for attempt in 1 2 3; do
+        # Retry API check up to 5 times (CDN propagation can be slow)
+        for attempt in 1 2 3 4 5; do
           echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
-          if curl -fsSL "$PACKAGE_API_URL" | python - "$VERSION" <<'PY'
-        import json
-        import sys
-
-        data = json.load(sys.stdin)
-        version = sys.argv[1]
-        releases = data.get("releases", {})
+          HTTP_CODE=$(curl -sL -w '%{http_code}' -o /tmp/pypi_response.json "$PACKAGE_API_URL" || echo "000")
+          if [ "$HTTP_CODE" = "200" ] && python3 -c "
+        import json, sys
+        with open('/tmp/pypi_response.json') as f:
+            data = json.load(f)
+        version = '$VERSION'
+        releases = data.get('releases', {})
         if version not in releases or not releases[version]:
-            raise SystemExit(f"Version {version} not found on package index")
-        print(f"Verified version {version} exists on package index")
-        PY
+            sys.exit(1)
+        print(f'Verified version {version} exists on package index')
+        "
           then
             break
           fi
-          if [ "$attempt" -lt 3 ]; then
-            echo "Version not found yet, waiting 60s before retry..."
+          if [ "$attempt" -lt 5 ]; then
+            echo "Version not found yet (HTTP $HTTP_CODE), waiting 60s before retry..."
             sleep 60
           else
-            echo "Error: version $VERSION not found on $PACKAGE_LABEL after 3 attempts"
+            echo "Error: version $VERSION not found on $PACKAGE_LABEL after 5 attempts"
             exit 1
           fi
         done


### PR DESCRIPTION
## Problem
The `curl | python` pipe in the publish verification step broke during the v0.11.0 release. When curl fails or the CDN returns a non-JSON error page, the pipe delivers empty/garbage to python's stdin, causing `JSONDecodeError`.

## Fix
- Save curl response to `/tmp/pypi_response.json` instead of piping
- Check HTTP status code (`200`) before attempting to parse
- Read the file in python instead of stdin - no broken pipe possible
- Increased retries from 3 to 5 (CDN propagation was slow enough to exhaust 3)

Will land on main with the next develop -> main release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)