### PR TITLE
fix: set TRAIGENT_DATASET_ROOT so quickstart works from any directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,3 +425,4 @@ known-third-party = [
 "__init__.py" = ["F401"]
 "tests/*" = ["B011"]
 "examples/*" = ["E402"]  # Examples often set env vars before imports
+"traigent/examples/*" = ["E402"]  # Bundled examples set env vars before imports

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -32,7 +32,7 @@ from langchain_openai import ChatOpenAI
 
 import traigent
 
-DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
+DATASET = str(Path(__file__).resolve().parent / "qa_samples.jsonl")
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -7,8 +7,6 @@ For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
 
 import asyncio
 import os
-import shutil
-import tempfile
 from pathlib import Path
 
 # Default to mock mode so the quickstart works without API keys.
@@ -18,24 +16,23 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
+# The bundled dataset lives next to this file (inside the installed package).
+# Set TRAIGENT_DATASET_ROOT so the SDK's path validation accepts it regardless
+# of which directory the user runs from.
+_PACKAGE_DIR = str(Path(__file__).resolve().parent)
+os.environ.setdefault("TRAIGENT_DATASET_ROOT", _PACKAGE_DIR)
+
 # NOTE: This uses LangChain's ChatOpenAI rather than the litellm calls shown
 # in the documentation. That is intentional and temporary: Traigent's mock
 # interceptor (TRAIGENT_MOCK_LLM=true) only patches LangChain's ChatOpenAI at
-# this point — it does not yet intercept raw litellm/openai calls.
+# this point - it does not yet intercept raw litellm/openai calls.
 # Once the interceptor adds raw litellm support this file will be updated to
 # match the litellm style shown in the docs.
 from langchain_openai import ChatOpenAI
 
 import traigent
 
-_DATASET_SRC = Path(__file__).parent / "qa_samples.jsonl"
-# The SDK requires dataset files to reside under the system temp directory.
-# When installed via pip the package data is in site-packages, so copy it.
-if str(_DATASET_SRC).startswith(tempfile.gettempdir()):
-    DATASET = str(_DATASET_SRC)
-else:
-    _tmp = Path(tempfile.mkdtemp())
-    DATASET = str(shutil.copy(_DATASET_SRC, _tmp / _DATASET_SRC.name))
+DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],


### PR DESCRIPTION
## Problem
Running `python -m traigent.examples.quickstart` from any directory other than the project root fails with:
```
ConfigurationError: Dataset path must reside under /path/to/cwd: /tmp/.../qa_samples.jsonl
```
The SDK validates dataset paths are under CWD by default. The previous workaround (copying to /tmp) made it worse.

## Fix
- Set `TRAIGENT_DATASET_ROOT` to the package directory where `qa_samples.jsonl` lives
- Remove the broken tempdir copy workaround (`shutil`, `tempfile` imports)
- Add `traigent/examples/*` to ruff per-file-ignores for E402 (env vars must be set before imports)

## Verified
- `python -m traigent.examples.quickstart` works from project root (exit 0)
- `python -m traigent.examples.quickstart` works from `tests/` directory (exit 0, previously failed)
- ruff check and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)