### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-04-01
+
+### Fixed
+- Quickstart fails when run from any directory other than project root - set `TRAIGENT_DATASET_ROOT` to package directory (#636)
+- PyPI publish verification broken pipe - save curl response to file instead of piping (#635)
+- Consistent `resolve()` for dataset path in quickstart
+
 ## [0.11.0] - 2026-03-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -85,7 +85,7 @@ def test_version_package_metadata_not_found():
                 importlib.reload(version_module)
                 result = version_module.get_version()
                 # Should fall back to hardcoded version
-                assert result == "0.11.1"
+                assert result == version_module._FALLBACK_VERSION
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -85,7 +85,7 @@ def test_version_package_metadata_not_found():
                 importlib.reload(version_module)
                 result = version_module.get_version()
                 # Should fall back to hardcoded version
-                assert result == "0.11.0"
+                assert result == "0.11.1"
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -8,7 +8,7 @@ import importlib.metadata
 import os
 from pathlib import Path
 
-_FALLBACK_VERSION = "0.11.0"
+_FALLBACK_VERSION = "0.11.1"
 
 
 def _read_pyproject_version() -> str | None:


### PR DESCRIPTION
Patch release for quickstart dataset root fix.

Updates all 4 version-dependent files in one commit:
- `pyproject.toml`
- `traigent/_version.py` (`_FALLBACK_VERSION`)
- `CHANGELOG.md` (`[0.11.1] - 2026-04-01`)
- `tests/unit/test_coverage_improvements.py` (fallback assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)