### PR TITLE
Release v0.11.1: patch quickstart to work from any directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,7 +184,7 @@ jobs:
         for attempt in 1 2 3 4 5; do
           echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
           HTTP_CODE=$(curl -sL -w '%{http_code}' -o /tmp/pypi_response.json "$PACKAGE_API_URL" || echo "000")
-          if [ "$HTTP_CODE" = "200" ] && CHECK_VERSION="$VERSION" python3 -c "
+          if [ "$HTTP_CODE" = "200" ] && CHECK_VERSION="$VERSION" python -c "
         import json, os, sys
         with open('/tmp/pypi_response.json') as f:
             data = json.load(f)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,11 +184,11 @@ jobs:
         for attempt in 1 2 3 4 5; do
           echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
           HTTP_CODE=$(curl -sL -w '%{http_code}' -o /tmp/pypi_response.json "$PACKAGE_API_URL" || echo "000")
-          if [ "$HTTP_CODE" = "200" ] && python3 -c "
-        import json, sys
+          if [ "$HTTP_CODE" = "200" ] && CHECK_VERSION="$VERSION" python3 -c "
+        import json, os, sys
         with open('/tmp/pypi_response.json') as f:
             data = json.load(f)
-        version = '$VERSION'
+        version = os.environ['CHECK_VERSION']
         releases = data.get('releases', {})
         if version not in releases or not releases[version]:
             sys.exit(1)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -180,28 +180,28 @@ jobs:
         VERSION="$EXPECTED_VERSION"
         echo "Testing installation of traigent==$VERSION from $PACKAGE_LABEL"
 
-        # Retry API check up to 3 times (CDN propagation can be slow)
-        for attempt in 1 2 3; do
+        # Retry API check up to 5 times (CDN propagation can be slow)
+        for attempt in 1 2 3 4 5; do
           echo "Attempt $attempt: checking $PACKAGE_LABEL API for version $VERSION..."
-          if curl -fsSL "$PACKAGE_API_URL" | python - "$VERSION" <<'PY'
-        import json
-        import sys
-
-        data = json.load(sys.stdin)
-        version = sys.argv[1]
-        releases = data.get("releases", {})
+          HTTP_CODE=$(curl -sL -w '%{http_code}' -o /tmp/pypi_response.json "$PACKAGE_API_URL" || echo "000")
+          if [ "$HTTP_CODE" = "200" ] && python3 -c "
+        import json, sys
+        with open('/tmp/pypi_response.json') as f:
+            data = json.load(f)
+        version = '$VERSION'
+        releases = data.get('releases', {})
         if version not in releases or not releases[version]:
-            raise SystemExit(f"Version {version} not found on package index")
-        print(f"Verified version {version} exists on package index")
-        PY
+            sys.exit(1)
+        print(f'Verified version {version} exists on package index')
+        "
           then
             break
           fi
-          if [ "$attempt" -lt 3 ]; then
-            echo "Version not found yet, waiting 60s before retry..."
+          if [ "$attempt" -lt 5 ]; then
+            echo "Version not found yet (HTTP $HTTP_CODE), waiting 60s before retry..."
             sleep 60
           else
-            echo "Error: version $VERSION not found on $PACKAGE_LABEL after 3 attempts"
+            echo "Error: version $VERSION not found on $PACKAGE_LABEL after 5 attempts"
             exit 1
           fi
         done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-04-01
+
+### Fixed
+- Quickstart fails when run from any directory other than project root - set `TRAIGENT_DATASET_ROOT` to package directory (#636)
+- PyPI publish verification broken pipe - save curl response to file instead of piping (#635)
+- Consistent `resolve()` for dataset path in quickstart
+
 ## [0.11.0] - 2026-03-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.11.0"
+version = "0.11.1"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,3 +425,4 @@ known-third-party = [
 "__init__.py" = ["F401"]
 "tests/*" = ["B011"]
 "examples/*" = ["E402"]  # Examples often set env vars before imports
+"traigent/examples/*" = ["E402"]  # Bundled examples set env vars before imports

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -85,7 +85,7 @@ def test_version_package_metadata_not_found():
                 importlib.reload(version_module)
                 result = version_module.get_version()
                 # Should fall back to hardcoded version
-                assert result == "0.11.1"
+                assert result == version_module._FALLBACK_VERSION
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -85,7 +85,7 @@ def test_version_package_metadata_not_found():
                 importlib.reload(version_module)
                 result = version_module.get_version()
                 # Should fall back to hardcoded version
-                assert result == "0.11.0"
+                assert result == "0.11.1"
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -8,7 +8,7 @@ import importlib.metadata
 import os
 from pathlib import Path
 
-_FALLBACK_VERSION = "0.11.0"
+_FALLBACK_VERSION = "0.11.1"
 
 
 def _read_pyproject_version() -> str | None:

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -32,7 +32,7 @@ from langchain_openai import ChatOpenAI
 
 import traigent
 
-DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
+DATASET = str(Path(__file__).resolve().parent / "qa_samples.jsonl")
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -7,8 +7,6 @@ For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
 
 import asyncio
 import os
-import shutil
-import tempfile
 from pathlib import Path
 
 # Default to mock mode so the quickstart works without API keys.
@@ -18,24 +16,23 @@ if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
     os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
+# The bundled dataset lives next to this file (inside the installed package).
+# Set TRAIGENT_DATASET_ROOT so the SDK's path validation accepts it regardless
+# of which directory the user runs from.
+_PACKAGE_DIR = str(Path(__file__).resolve().parent)
+os.environ.setdefault("TRAIGENT_DATASET_ROOT", _PACKAGE_DIR)
+
 # NOTE: This uses LangChain's ChatOpenAI rather than the litellm calls shown
 # in the documentation. That is intentional and temporary: Traigent's mock
 # interceptor (TRAIGENT_MOCK_LLM=true) only patches LangChain's ChatOpenAI at
-# this point — it does not yet intercept raw litellm/openai calls.
+# this point - it does not yet intercept raw litellm/openai calls.
 # Once the interceptor adds raw litellm support this file will be updated to
 # match the litellm style shown in the docs.
 from langchain_openai import ChatOpenAI
 
 import traigent
 
-_DATASET_SRC = Path(__file__).parent / "qa_samples.jsonl"
-# The SDK requires dataset files to reside under the system temp directory.
-# When installed via pip the package data is in site-packages, so copy it.
-if str(_DATASET_SRC).startswith(tempfile.gettempdir()):
-    DATASET = str(_DATASET_SRC)
-else:
-    _tmp = Path(tempfile.mkdtemp())
-    DATASET = str(shutil.copy(_DATASET_SRC, _tmp / _DATASET_SRC.name))
+DATASET = str(Path(__file__).parent / "qa_samples.jsonl")
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],


### PR DESCRIPTION
## Release v0.11.1 (patch)

### Why this release
Users following the QuickStart guide (`pip install "traigent[integrations]"` then `python -m traigent.examples.quickstart`) hit a crash when running from any directory other than the Traigent repo root. The SDK validates that dataset files are under CWD, but the bundled dataset lives inside `site-packages/`. This blocks the primary onboarding path.

### What changed (6 files, 34 lines)

| File | Change | Why |
|------|--------|-----|
| `traigent/examples/quickstart/__main__.py` | Set `TRAIGENT_DATASET_ROOT` to package dir, remove broken tempdir workaround, use `resolve()` consistently | Fixes the crash (#636) |
| `.github/workflows/publish.yml` | Save curl response to file instead of piping, pass version via env var, increase retries 3->5 | v0.11.0 publish verification failed due to broken pipe (#635) |
| `pyproject.toml` | Version `0.11.0` -> `0.11.1`, add ruff E402 ignore for `traigent/examples/*` | Version bump + lint config for bundled examples |
| `traigent/_version.py` | `_FALLBACK_VERSION` `0.11.0` -> `0.11.1` | Keep fallback in sync |
| `CHANGELOG.md` | Add `[0.11.1]` section with 3 fixes | Release notes |
| `tests/unit/test_coverage_improvements.py` | Assert against `_FALLBACK_VERSION` instead of hardcoded string | No more manual test updates on version bumps (#637) |

### What to check during review
- `__main__.py` uses `os.environ.setdefault` so it won't override a user's explicit `TRAIGENT_DATASET_ROOT`
- `publish.yml` reads version from env var (`os.environ['CHECK_VERSION']`), not shell interpolation - previous version had a shell injection vector
- No new dependencies, no behavior changes outside quickstart and CI verification

### Verified
- `python -m traigent.examples.quickstart` from project root: exit 0
- `python -m traigent.examples.quickstart` from `~/` (arbitrary CWD): exit 0
- `python -m traigent.examples.quickstart` from `tests/` (previously crashed): exit 0
- `ruff check` and `ruff format`: pass
- Greptile: no findings on this PR (all addressed in source PRs)

### After merge
```bash
git checkout main && git pull
git tag v0.11.1
git push origin v0.11.1
```
CI auto-publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)