### PR TITLE
fix(ci): increase propagation wait and retry pip install in publish verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,7 @@ jobs:
 
     steps:
     - name: Wait for package propagation
-      run: sleep 120
+      run: sleep 300
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -211,8 +211,21 @@ jobs:
         source test_env/bin/activate
         pip install --upgrade pip
 
-        # Try to install the package
-        pip install "${INSTALL_ARGS[@]}" "traigent==$VERSION"
+        # Retry pip install up to 5 times (CDN propagation can lag behind the API)
+        for install_attempt in 1 2 3 4 5; do
+          echo "Install attempt $install_attempt: pip install traigent==$VERSION..."
+          if pip install "${INSTALL_ARGS[@]}" "traigent==$VERSION"; then
+            echo "Package installed successfully"
+            break
+          fi
+          if [ "$install_attempt" -lt 5 ]; then
+            echo "Install failed (CDN not ready), waiting 60s before retry..."
+            sleep 60
+          else
+            echo "Error: pip install traigent==$VERSION failed after 5 attempts"
+            exit 1
+          fi
+        done
 
         # Test basic import
         python -c "import traigent; print(f'Successfully installed and imported traigent v{traigent.__version__}')"


### PR DESCRIPTION
## Problem
v0.11.1 publish verification failed: the API check passed (version exists in metadata) but `pip install` failed because CDN hadn't propagated the download files yet. The 120s initial wait wasn't enough.

## Fix
- Initial wait: 120s -> 300s (5 min)
- `pip install` now retries up to 5 times with 60s between attempts
- Total worst case before failing: ~15 min (5min wait + 5min API retries + 5min install retries)

## Verified
Fresh venv test of v0.11.1: `pip install "traigent[integrations]"` then `python -m traigent.examples.quickstart` works end-to-end (exit 0, mock mode, 6 trials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)