### PR TITLE
fix: quickstart accuracy 0% with real LLMs

### DIFF
--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -28,29 +28,40 @@ os.environ.setdefault("TRAIGENT_DATASET_ROOT", _PACKAGE_DIR)
 # this point - it does not yet intercept raw litellm/openai calls.
 # Once the interceptor adds raw litellm support this file will be updated to
 # match the litellm style shown in the docs.
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 import traigent
+from traigent.api.decorators import EvaluationOptions
 
 DATASET = str(Path(__file__).resolve().parent / "qa_samples.jsonl")
-OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],
     "temperature": [0.0, 0.7, 1.0],
 }
 
+_SYSTEM_PROMPT = "Answer in as few words as possible. Give only the answer itself, nothing else."
+
+
+def contains_accuracy(output: str, expected: str) -> float:
+    """1.0 if the expected answer appears anywhere in the output (case-insensitive)."""
+    return 1.0 if expected.lower() in output.lower() else 0.0
+
 
 @traigent.optimize(
     configuration_space=CONFIG_SPACE,
-    objectives=OBJECTIVES,
-    eval_dataset=DATASET,
+    objectives=["accuracy"],
+    evaluation=EvaluationOptions(
+        eval_dataset=DATASET,
+        metric_functions={"accuracy": contains_accuracy},
+    ),
     execution_mode="edge_analytics",
 )
 def answer(question: str) -> str:
     """Call an LLM with the current trial's config."""
     cfg = traigent.get_config()
     llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
-    return llm.invoke(question).content
+    return llm.invoke([SystemMessage(_SYSTEM_PROMPT), HumanMessage(question)]).content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a system prompt to the quickstart LLM call (`"Answer in as few words as possible. Give only the answer itself, nothing else."`) so real LLMs return concise, matchable responses
- Replaces the built-in exact-match `accuracy` objective with a custom `contains_accuracy` metric function via `EvaluationOptions(metric_functions={"accuracy": contains_accuracy})` — case-insensitive substring match

## Test plan

- [ ] `TRAIGENT_MOCK_LLM=false python -m traigent.examples.quickstart` produces non-zero accuracy scores
- [ ] `python -m traigent.examples.quickstart` (mock mode, default) still works and completes without errors

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)