### PR TITLE
Release 0.11.1 — quickstart accuracy fix + CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,7 +156,7 @@ jobs:
 
     steps:
     - name: Wait for package propagation
-      run: sleep 120
+      run: sleep 300
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -211,8 +211,21 @@ jobs:
         source test_env/bin/activate
         pip install --upgrade pip
 
-        # Try to install the package
-        pip install "${INSTALL_ARGS[@]}" "traigent==$VERSION"
+        # Retry pip install up to 5 times (CDN propagation can lag behind the API)
+        for install_attempt in 1 2 3 4 5; do
+          echo "Install attempt $install_attempt: pip install traigent==$VERSION..."
+          if pip install "${INSTALL_ARGS[@]}" "traigent==$VERSION"; then
+            echo "Package installed successfully"
+            break
+          fi
+          if [ "$install_attempt" -lt 5 ]; then
+            echo "Install failed (CDN not ready), waiting 60s before retry..."
+            sleep 60
+          else
+            echo "Error: pip install traigent==$VERSION failed after 5 attempts"
+            exit 1
+          fi
+        done
 
         # Test basic import
         python -c "import traigent; print(f'Successfully installed and imported traigent v{traigent.__version__}')"

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -28,29 +28,40 @@ os.environ.setdefault("TRAIGENT_DATASET_ROOT", _PACKAGE_DIR)
 # this point - it does not yet intercept raw litellm/openai calls.
 # Once the interceptor adds raw litellm support this file will be updated to
 # match the litellm style shown in the docs.
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 import traigent
+from traigent.api.decorators import EvaluationOptions
 
 DATASET = str(Path(__file__).resolve().parent / "qa_samples.jsonl")
-OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-4o-mini", "gpt-4o"],
     "temperature": [0.0, 0.7, 1.0],
 }
 
+_SYSTEM_PROMPT = "Answer in as few words as possible. Give only the answer itself, nothing else."
+
+
+def contains_accuracy(output: str, expected: str) -> float:
+    """1.0 if the expected answer appears anywhere in the output (case-insensitive)."""
+    return 1.0 if expected.lower() in output.lower() else 0.0
+
 
 @traigent.optimize(
     configuration_space=CONFIG_SPACE,
-    objectives=OBJECTIVES,
-    eval_dataset=DATASET,
+    objectives=["accuracy"],
+    evaluation=EvaluationOptions(
+        eval_dataset=DATASET,
+        metric_functions={"accuracy": contains_accuracy},
+    ),
     execution_mode="edge_analytics",
 )
 def answer(question: str) -> str:
     """Call an LLM with the current trial's config."""
     cfg = traigent.get_config()
     llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
-    return llm.invoke(question).content
+    return llm.invoke([SystemMessage(_SYSTEM_PROMPT), HumanMessage(question)]).content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **fix**: quickstart accuracy always 0% with real LLMs — adds system prompt + contains-match evaluator (#641, #642)
- **fix(ci)**: increase propagation wait and retry pip install on publish verification (#640)

## Changes from develop → main

```
03ce9828 fix: quickstart accuracy 0% with real LLMs — contains match + system prompt (#642)
5a67619e Merge pull request #640 from Traigent/fix/publish-verification-install-retry
7e7a8b74 fix(ci): increase propagation wait and retry pip install
```

## Test plan

- [x] `TRAIGENT_MOCK_LLM=false python -m traigent.examples.quickstart` → gpt-4o 100%, gpt-4o-mini ~87.5%
- [ ] PyPI publish CI passes and `pip install traigent==0.11.1` includes `qa_samples.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)