### PR TITLE
fix(mock): custom metric_functions zeroes out mock accuracy

### DIFF
--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -515,7 +515,16 @@ class LocalEvaluator(BaseEvaluator):
             "response_time_ms": example_metric.response.response_time_ms,
         }
 
+        use_mock = is_mock_llm() and self.mock_mode_config.get(
+            "enabled", True
+        ) and self.mock_mode_config.get("override_evaluator", True)
+
         for metric_name, metric_func in self.metric_functions.items():
+            # In mock mode, skip custom functions for metrics that were already
+            # simulated by the mock engine (e.g. "accuracy") to avoid overwriting
+            # the simulated score with a real 0.0 from the mock LLM response.
+            if use_mock and metric_name in example_metric.custom_metrics:
+                continue
             value = self._invoke_metric_function(
                 metric_func,
                 metric_name,


### PR DESCRIPTION
## Summary

- `_apply_custom_metric_functions` was overwriting the mock-simulated accuracy score with the actual function result (always 0.0, since mock LLM responses don't contain expected answers)
- Fix: skip custom metric functions in mock mode for metrics already simulated by the mock engine

## Root cause

When `metric_functions={"accuracy": contains_accuracy}` is provided:
1. Mock engine correctly simulates `accuracy` → ~0.75
2. `_apply_custom_metric_functions` then calls `contains_accuracy(mock_response, expected)` → 0.0
3. Step 2 overwrites step 1

## Test plan

- [x] `TRAIGENT_MOCK_LLM=true python -m traigent.examples.quickstart` → non-zero accuracy (~75-86%)
- [x] `TRAIGENT_MOCK_LLM=false python -m traigent.examples.quickstart` → real accuracy unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)