### PR TITLE
fix(mock): quickstart 0% in mock mode with custom metric_functions

### DIFF
--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -515,16 +515,7 @@ class LocalEvaluator(BaseEvaluator):
             "response_time_ms": example_metric.response.response_time_ms,
         }
 
-        use_mock = is_mock_llm() and self.mock_mode_config.get(
-            "enabled", True
-        ) and self.mock_mode_config.get("override_evaluator", True)
-
         for metric_name, metric_func in self.metric_functions.items():
-            # In mock mode, skip custom functions for metrics that were already
-            # simulated by the mock engine (e.g. "accuracy") to avoid overwriting
-            # the simulated score with a real 0.0 from the mock LLM response.
-            if use_mock and metric_name in example_metric.custom_metrics:
-                continue
             value = self._invoke_metric_function(
                 metric_func,
                 metric_name,

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -42,6 +42,10 @@ CONFIG_SPACE = {
 
 _SYSTEM_PROMPT = "Answer in as few words as possible. Give only the answer itself, nothing else."
 
+# In mock mode the LLM returns a fixed placeholder string, so contains_accuracy
+# would always score 0.  Let the built-in mock simulation handle accuracy instead.
+_mock_mode = os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes")
+
 
 def contains_accuracy(output: str, expected: str) -> float:
     """1.0 if the expected answer appears anywhere in the output (case-insensitive)."""
@@ -53,7 +57,7 @@ def contains_accuracy(output: str, expected: str) -> float:
     objectives=["accuracy"],
     evaluation=EvaluationOptions(
         eval_dataset=DATASET,
-        metric_functions={"accuracy": contains_accuracy},
+        metric_functions=None if _mock_mode else {"accuracy": contains_accuracy},
     ),
     execution_mode="edge_analytics",
 )


### PR DESCRIPTION
## Summary

Reverts the `local.py` approach from #648 (which broke `test_scoring_function_overrides_exact_match`) and fixes the root cause properly: the quickstart now skips `metric_functions` when mock mode is active, letting the built-in mock simulation handle accuracy.

**Why the previous fix was wrong:** custom `scoring_function`/`metric_functions` are intentionally designed to override mock — there's an explicit test for this. The real problem was that `contains_accuracy(mock_placeholder, "Paris")` → 0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)