### PR TITLE
fix(quickstart): mock LLM mode no longer forces offline when API key is set

### DIFF
--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -14,7 +14,11 @@ from pathlib import Path
 os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
 if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
     os.environ.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
-    os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+    # Only fall back to offline mode if no Traigent API key is configured.
+    # When the user has set TRAIGENT_API_KEY, results should reach the portal
+    # even though the LLM calls themselves are mocked.
+    if not os.environ.get("TRAIGENT_API_KEY"):
+        os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
 
 # The bundled dataset lives next to this file (inside the installed package).
 # Set TRAIGENT_DATASET_ROOT so the SDK's path validation accepts it regardless


### PR DESCRIPTION
## Summary

- When `TRAIGENT_MOCK_LLM=true`, the quickstart unconditionally set `TRAIGENT_OFFLINE_MODE=true`, blocking all backend communication
- Users who followed the quickstart docs (set API key → run with mock LLM) saw no results in the portal
- Fix: only fall back to offline mode when `TRAIGENT_API_KEY` is not set — if the user has a key, results should reach the portal even in mock mode

## Test plan

- [ ] Set `TRAIGENT_API_KEY` and run `TRAIGENT_MOCK_LLM=true python -m traigent.examples.quickstart` — results should appear in the portal
- [ ] Without `TRAIGENT_API_KEY`, same command should still run offline (no regression)
- [ ] `TRAIGENT_OFFLINE_MODE=true python -m traigent.examples.quickstart` still respects explicit offline override

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)