### PR TITLE
feat(cli): add --env flag and document dev environment workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,13 @@ TRAIGENT_MOCK_LLM=true
 # Get your key from https://traigent.ai
 TRAIGENT_API_KEY=
 
-# Backend URLs (for local development)
+# Backend URLs
+# For local development:
 TRAIGENT_API_URL=http://localhost:5000/api/v1
 TRAIGENT_BACKEND_URL=http://localhost:5000
+# For dev environment (uncomment to target dev instead of prod):
+# TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
+# TRAIGENT_API_URL=https://api-dev.traigent.ai/api/v1
 
 # Local Results Storage
 # Default: ~/.traigent

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -39,6 +39,61 @@ traigent auth configure
 # Select option 2 and enter your API key
 ```
 
+## Targeting the Dev Environment
+
+By default, the SDK and CLI target **production** (`https://portal.traigent.ai`). To work against the dev environment instead, use one of the methods below.
+
+### Option 1: `--env` flag (recommended)
+
+```bash
+traigent auth login --env dev
+```
+
+This authenticates against `https://api-dev.traigent.ai` and stores the dev backend URL in your credentials so all subsequent SDK calls go to dev automatically.
+
+### Option 2: `--backend-url` flag
+
+```bash
+traigent auth login --backend-url https://api-dev.traigent.ai
+```
+
+### Option 3: Environment variable
+
+Set the backend URL before running any SDK code or CLI command:
+
+```bash
+export TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
+```
+
+Or in a `.env` file in your project root:
+
+```bash
+TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
+TRAIGENT_API_URL=https://api-dev.traigent.ai/api/v1
+```
+
+### Verifying your target environment
+
+```bash
+traigent auth status
+```
+
+The output includes a **Backend** row showing which URL your credentials are pointing to.
+
+### Switching back to production
+
+Log in again without `--env` or `--backend-url` to restore the default:
+
+```bash
+traigent auth login
+```
+
+Or explicitly:
+
+```bash
+traigent auth login --env prod
+```
+
 ## Authentication Commands
 
 ### Login
@@ -338,6 +393,8 @@ traigent auth whoami KEY   # Validate API key
 # Options
 --email EMAIL             # Specify email
 --non-interactive         # No prompts; use API keys for CI/CD
+--backend-url URL         # Target a specific backend URL
+--env {dev,prod}          # Named environment shortcut
 --help                   # Show help
 ```
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -127,6 +127,23 @@ Traigent executes your code locally. The default is `execution_mode="edge_analyt
 
 To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MODE=true`.
 
+## 🌐 Dev vs Prod Environment
+
+The SDK targets **production** by default. To send experiments to the **dev** environment instead:
+
+```bash
+# Authenticate against dev
+traigent auth login --env dev
+```
+
+Or set the environment variable:
+
+```bash
+export TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
+```
+
+See the [Authentication Guide](../features/authentication.md#targeting-the-dev-environment) for full details.
+
 ---
 
 Ready for more? Dive into the [examples](../../examples/) and the [API reference](../api-reference/complete-function-specification.md).

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -38,6 +38,12 @@ from traigent.cloud.auth import (
 from traigent.config.backend_config import SIGNUP_URL, BackendConfig
 from traigent.utils.logging import get_logger
 
+# Named environment shortcuts for --env flag
+NAMED_ENVIRONMENTS: dict[str, str] = {
+    "dev": "https://api-dev.traigent.ai",
+    "prod": "https://portal.traigent.ai",
+}
+
 console = Console()
 logger = get_logger(__name__)
 
@@ -57,13 +63,23 @@ MSG_RUN_LOGIN_AGAIN = "Please run [cyan]traigent auth login[/cyan] again.\n"
 class TraigentAuthCLI:
     """Modern CLI authentication manager for Traigent SDK."""
 
-    def __init__(self) -> None:
-        """Initialize the authentication CLI."""
+    def __init__(self, backend_url_override: str | None = None) -> None:
+        """Initialize the authentication CLI.
+
+        Args:
+            backend_url_override: If provided, use this backend URL instead of
+                the default. Useful for targeting specific environments (e.g. dev).
+        """
         self.config_dir = TRAIGENT_CONFIG_DIR
         self.credentials_file = CREDENTIALS_FILE
         self.auth_manager = AuthManager()
-        self.backend_url = BackendConfig.get_cloud_backend_url()
-        self.backend_api_url = BackendConfig.get_cloud_api_url()
+        if backend_url_override:
+            normalized = BackendConfig.normalize_backend_origin(backend_url_override)
+            self.backend_url = normalized or backend_url_override
+            self.backend_api_url = BackendConfig.build_api_base(self.backend_url)
+        else:
+            self.backend_url = BackendConfig.get_cloud_backend_url()
+            self.backend_api_url = BackendConfig.get_cloud_api_url()
 
         # Ensure config directory exists
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -890,7 +906,24 @@ def auth() -> None:
 @auth.command()
 @click.option("--email", "-e", help="Email address")
 @click.option("--non-interactive", is_flag=True, help="Non-interactive mode")
-def login(email: str | None, non_interactive: bool) -> None:
+@click.option(
+    "--backend-url",
+    default=None,
+    help="Backend URL to authenticate against (e.g. https://api-dev.traigent.ai)",
+)
+@click.option(
+    "--env",
+    "env_name",
+    default=None,
+    type=click.Choice(sorted(NAMED_ENVIRONMENTS), case_sensitive=False),
+    help="Named environment shortcut (dev, prod)",
+)
+def login(
+    email: str | None,
+    non_interactive: bool,
+    backend_url: str | None,
+    env_name: str | None,
+) -> None:
     """Authenticate with Traigent backend.
 
     This command will:
@@ -902,8 +935,13 @@ def login(email: str | None, non_interactive: bool) -> None:
     Examples:
         traigent auth login
         traigent auth login --email user@example.com
+        traigent auth login --env dev
+        traigent auth login --backend-url https://api-dev.traigent.ai
     """
-    cli = TraigentAuthCLI()
+    if backend_url and env_name:
+        raise click.UsageError("Cannot specify both --backend-url and --env")
+    url_override = backend_url or (NAMED_ENVIRONMENTS.get(env_name) if env_name else None)
+    cli = TraigentAuthCLI(backend_url_override=url_override)
     success = asyncio.run(cli.login(email, non_interactive))
     sys.exit(0 if success else 1)
 


### PR DESCRIPTION
## Summary

- Add `--env {dev,prod}` and `--backend-url` flags to `traigent auth login` so users can target the dev environment with a single command (`traigent auth login --env dev`)
- Add "Targeting the Dev Environment" section to the authentication guide with three options (flag, URL, env var)
- Add dev vs prod note to Getting Started guide
- Add commented-out dev URL examples to `.env.example`

Closes #682

## Test plan

- [x] `python -c "from traigent.cli.auth_commands import ..."` — imports succeed
- [x] `TraigentAuthCLI(backend_url_override=...)` — correctly overrides backend URL and API URL
- [x] `traigent auth login --help` — shows new `--env` and `--backend-url` flags
- [x] Existing auth CLI unit tests pass (11/11)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)