### PR TITLE
fix: remove dev URLs and --env flag from published SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,9 @@ TRAIGENT_MOCK_LLM=true
 # Get your key from https://traigent.ai
 TRAIGENT_API_KEY=
 
-# Backend URLs
-# For local development:
+# Backend URLs (for local development)
 TRAIGENT_API_URL=http://localhost:5000/api/v1
 TRAIGENT_BACKEND_URL=http://localhost:5000
-# For dev environment (uncomment to target dev instead of prod):
-# TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
-# TRAIGENT_API_URL=https://api-dev.traigent.ai/api/v1
 
 # Local Results Storage
 # Default: ~/.traigent

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -39,59 +39,26 @@ traigent auth configure
 # Select option 2 and enter your API key
 ```
 
-## Targeting the Dev Environment
+## Custom Backend URL
 
-By default, the SDK and CLI target **production** (`https://portal.traigent.ai`). To work against the dev environment instead, use one of the methods below.
-
-### Option 1: `--env` flag (recommended)
+By default the SDK and CLI target `https://portal.traigent.ai`. To authenticate against a different backend, use `--backend-url`:
 
 ```bash
-traigent auth login --env dev
+traigent auth login --backend-url https://your-backend.example.com
 ```
 
-This authenticates against `https://api-dev.traigent.ai` and stores the dev backend URL in your credentials so all subsequent SDK calls go to dev automatically.
+The URL is stored in your credentials so subsequent SDK calls use it automatically.
 
-### Option 2: `--backend-url` flag
+You can also set the backend via environment variables:
 
 ```bash
-traigent auth login --backend-url https://api-dev.traigent.ai
+export TRAIGENT_BACKEND_URL=https://your-backend.example.com
 ```
 
-### Option 3: Environment variable
-
-Set the backend URL before running any SDK code or CLI command:
-
-```bash
-export TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
-```
-
-Or in a `.env` file in your project root:
-
-```bash
-TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
-TRAIGENT_API_URL=https://api-dev.traigent.ai/api/v1
-```
-
-### Verifying your target environment
+Verify which backend you're pointing to with:
 
 ```bash
 traigent auth status
-```
-
-The output includes a **Backend** row showing which URL your credentials are pointing to.
-
-### Switching back to production
-
-Log in again without `--env` or `--backend-url` to restore the default:
-
-```bash
-traigent auth login
-```
-
-Or explicitly:
-
-```bash
-traigent auth login --env prod
 ```
 
 ## Authentication Commands
@@ -394,7 +361,6 @@ traigent auth whoami KEY   # Validate API key
 --email EMAIL             # Specify email
 --non-interactive         # No prompts; use API keys for CI/CD
 --backend-url URL         # Target a specific backend URL
---env {dev,prod}          # Named environment shortcut
 --help                   # Show help
 ```
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -127,23 +127,6 @@ Traigent executes your code locally. The default is `execution_mode="edge_analyt
 
 To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MODE=true`.
 
-## 🌐 Dev vs Prod Environment
-
-The SDK targets **production** by default. To send experiments to the **dev** environment instead:
-
-```bash
-# Authenticate against dev
-traigent auth login --env dev
-```
-
-Or set the environment variable:
-
-```bash
-export TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
-```
-
-See the [Authentication Guide](../features/authentication.md#targeting-the-dev-environment) for full details.
-
 ---
 
 Ready for more? Dive into the [examples](../../examples/) and the [API reference](../api-reference/complete-function-specification.md).

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -38,12 +38,6 @@ from traigent.cloud.auth import (
 from traigent.config.backend_config import SIGNUP_URL, BackendConfig
 from traigent.utils.logging import get_logger
 
-# Named environment shortcuts for --env flag
-NAMED_ENVIRONMENTS: dict[str, str] = {
-    "dev": "https://api-dev.traigent.ai",
-    "prod": "https://portal.traigent.ai",
-}
-
 console = Console()
 logger = get_logger(__name__)
 
@@ -909,20 +903,12 @@ def auth() -> None:
 @click.option(
     "--backend-url",
     default=None,
-    help="Backend URL to authenticate against (e.g. https://api-dev.traigent.ai)",
-)
-@click.option(
-    "--env",
-    "env_name",
-    default=None,
-    type=click.Choice(sorted(NAMED_ENVIRONMENTS), case_sensitive=False),
-    help="Named environment shortcut (dev, prod)",
+    help="Backend URL to authenticate against",
 )
 def login(
     email: str | None,
     non_interactive: bool,
     backend_url: str | None,
-    env_name: str | None,
 ) -> None:
     """Authenticate with Traigent backend.
 
@@ -935,13 +921,9 @@ def login(
     Examples:
         traigent auth login
         traigent auth login --email user@example.com
-        traigent auth login --env dev
-        traigent auth login --backend-url https://api-dev.traigent.ai
+        traigent auth login --backend-url https://your-backend.example.com
     """
-    if backend_url and env_name:
-        raise click.UsageError("Cannot specify both --backend-url and --env")
-    url_override = backend_url or (NAMED_ENVIRONMENTS.get(env_name) if env_name else None)
-    cli = TraigentAuthCLI(backend_url_override=url_override)
+    cli = TraigentAuthCLI(backend_url_override=backend_url)
     success = asyncio.run(cli.login(email, non_interactive))
     sys.exit(0 if success else 1)
 


### PR DESCRIPTION
## Summary

- Remove `--env {dev,prod}` flag and `NAMED_ENVIRONMENTS` mapping from CLI (hardcoded `api-dev.traigent.ai`)
- Replace dev-specific "Targeting the Dev Environment" docs section with generic "Custom Backend URL" section
- Remove dev URL examples from `.env.example`
- Keep `--backend-url` flag — generic, no internal URLs leaked

The full dev environment workflow guide has been moved to `Traigent/internal-docs`.

Follow-up to #684. Closes #682.

## Test plan

- [ ] `traigent auth login --help` shows `--backend-url` but no `--env`
- [ ] No references to `api-dev.traigent.ai` in `traigent/` or `docs/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)