### PR TITLE
hotfix: resolve input_id mapping in HybridAPIEvaluator

### DIFF
--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -1333,6 +1333,72 @@ class TestExecuteBatch:
         results = await ev._execute_batch(mock_transport, caps, {}, batch)
         assert results[0].example_id == "custom_id"
 
+    @pytest.mark.asyncio
+    async def test_uses_input_id_from_input_data(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """Falls back to input_id when example_id is absent in input_data."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id="cap",
+            keep_alive=False,
+        )
+        ev._benchmark_id = "test-bench"
+        exec_response = _make_execute_response(
+            outputs=[{"input_id": "consultant-fridge", "output": "out"}],
+            quality_metrics=None,
+        )
+        mock_transport.execute = AsyncMock(return_value=exec_response)
+        caps = _default_capabilities(supports_evaluate=False)
+
+        example = EvaluationExample(
+            input_data={"input_id": "consultant-fridge"}
+        )
+        dataset = Dataset(examples=[example], name="test")
+        batch = list(dataset)
+
+        results = await ev._execute_batch(mock_transport, caps, {}, batch)
+        assert results[0].example_id == "consultant-fridge"
+
+    @pytest.mark.asyncio
+    async def test_two_phase_input_id_matching(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """Two-phase mode matches evaluate results keyed by input_id."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id="cap",
+            keep_alive=False,
+        )
+        exec_response = _make_execute_response(
+            outputs=[
+                {"input_id": "consultant-fridge", "output": "result_0", "output_id": "out_0"},
+            ],
+            operational_metrics={"cost_usd": 0.01, "latency_ms": 100.0},
+        )
+        eval_response = _make_evaluate_response(
+            results=[
+                {"input_id": "consultant-fridge", "metrics": {"tool_accuracy": 1.0}},
+            ]
+        )
+        mock_transport.evaluate = AsyncMock(return_value=eval_response)
+
+        example = EvaluationExample(
+            input_data={"input_id": "consultant-fridge"},
+            expected_output="expected",
+        )
+        dataset = Dataset(examples=[example], name="test")
+        batch = list(dataset)
+        inputs = [{"example_id": "consultant-fridge", "data": {"input_id": "consultant-fridge"}}]
+
+        results = await ev._evaluate_outputs(
+            mock_transport, {}, batch, inputs, exec_response
+        )
+
+        assert len(results) == 1
+        assert results[0].metrics["tool_accuracy"] == 1.0
+        assert results[0].example_id == "consultant-fridge"
+
 
 # ---------------------------------------------------------------------------
 # _evaluate_outputs tests

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -741,7 +741,11 @@ class HybridAPIEvaluator(BaseEvaluator):
         inputs = []
         for i, example in enumerate(batch):
             input_data = self._extract_input(example)
-            example_id = input_data.get("example_id", f"ex_{i}")
+            example_id = (
+                input_data.get("example_id")
+                or input_data.get("input_id")
+                or f"ex_{i}"
+            )
             inputs.append(
                 {
                     "example_id": example_id,


### PR DESCRIPTION
## Summary
Cherry-pick of #716 from develop → main for immediate release.

Fixes HybridAPIEvaluator dropping `input_id` from datasets, causing empty evaluate metrics and broken portal sync for hybrid mode customers (Bazak).

## Changes
- `hybrid_api.py`: fall through `example_id` → `input_id` → `ex_{i}` (1-line fix)
- 2 new tests: execute-only + two-phase `input_id` matching

## Why hotfix
Bazak client package (traigent-api#67) ships with `pip install traigent` — needs this fix on PyPI before they can use it.

## Test plan
- [x] 105 unit tests pass (full hybrid evaluator suite)
- [x] End-to-end validated against live `ai.bazak.ai`
- [x] Already merged to develop via #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)