### PR TITLE
chore(ci): unblock release-gate code-quality + documentation-quality (closes #718, #719)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
         from pathlib import Path
 
         SKIP_DIRS = {".archive", "_archived", ".release_review", ".post_release_recommendation_fixes",
-                     "node_modules", ".git", "venv", ".venv", "configs", ".claude", "local"}
+                     "node_modules", ".git", "venv", ".venv", "configs", ".claude", "local", "_bmad"}
 
         errors = []
         for md_file in Path(".").rglob("*.md"):

--- a/traigent/core/exception_handler.py
+++ b/traigent/core/exception_handler.py
@@ -172,7 +172,9 @@ class TerminalPausePrompt:
         # Insufficient funds is non-recoverable — stop immediately
         if category == VendorErrorCategory.INSUFFICIENT_FUNDS:
             print()
-            print("Stopping optimization (insufficient funds cannot be resolved by retrying).")
+            print(
+                "Stopping optimization (insufficient funds cannot be resolved by retrying)."
+            )
             return "stop"
 
         print()

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -994,9 +994,8 @@ def _calculate_cost_for_metrics(
 
         # Log when cost ends up at zero despite having tokens — this is the
         # most actionable diagnostic for the "$0 cost" issue (#325).
-        if (
-            metrics.cost.total_cost == 0.0
-            and (metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0)
+        if metrics.cost.total_cost == 0.0 and (
+            metrics.tokens.input_tokens > 0 or metrics.tokens.output_tokens > 0
         ):
             logger.warning(
                 "Cost is $0.00 despite non-zero tokens for model %r "
@@ -1007,8 +1006,7 @@ def _calculate_cost_for_metrics(
             )
     except Exception as e:
         logger.error(
-            "Cost calculation failed for model %s: %s "
-            "(tokens: in=%d, out=%d)",
+            "Cost calculation failed for model %s: %s " "(tokens: in=%d, out=%d)",
             model_name,
             e,
             metrics.tokens.input_tokens,


### PR DESCRIPTION
## Summary

Clears the last two required-gate failures on the develop → main promote path, identified while running the release-gate PR check suite locally against #664.

- **#718 (code-quality / black)** — apply black to two pre-existing drift sites:
  - `traigent/evaluators/metrics_tracker.py` (two reflow deltas)
  - `traigent/core/exception_handler.py` (one long-line split)
  Pure formatting, no behaviour change.
- **#719 (documentation-quality)** — add `"_bmad"` to `SKIP_DIRS` in `.github/workflows/documentation.yml`. The `_bmad/` directory contains BMAD workflow templates with intentional placeholder links like `./path/to/file.ts` and `{{relative_path}}` that the broken-link checker was flagging as 44 false positives. `quality.yml`'s separate inline link check does not fail on errors (no `sys.exit(1)`), so no change needed there.

## Verification

- `black --check traigent/ traigent_validation/` → 393 files clean
- Inline doc-link script with `_bmad` skipped → no broken links

## Why now

With #664 merged and #720 merged, the three pre-existing promote-gate blockers identified earlier were #652 (litellm CVEs, now fixed), #677 (aiohttp CVEs, now fixed), and these two. After this lands, the release-gate check on the next develop → main promote will have a clean record.

## Closes

- #718 — black drift in metrics_tracker.py
- #719 — documentation-quality gate failing on _bmad templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)