### PR TITLE
robustness: cherry-pick three fixes from vendor trial-progress patch

### DIFF
--- a/tests/unit/core/test_robustness_cherrypicks.py
+++ b/tests/unit/core/test_robustness_cherrypicks.py
@@ -1,0 +1,248 @@
+"""Tests for the three robustness cherry-picks from the trial-progress patch.
+
+Covers:
+
+1. ``BackendSessionManager._started_trials`` — idempotent
+   ``register_trial_start`` so retries of ``submit_trial`` don't re-hit the
+   backend registration endpoint.
+2. ``SessionOperations.finalize_session`` — session-mapping recovery
+   from active-session metadata when the in-memory bridge entry is lost.
+3. ``CustomEvaluatorWrapper`` — blocking custom evaluators are executed via
+   ``asyncio.to_thread`` so backend progress updates / heartbeats running on
+   the main event loop are not starved.
+
+The three fixes were lifted from a larger feature patch; the tests here
+intentionally exercise only the robustness surface, not the live-progress
+streaming feature that the patch also introduced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from traigent.api.types import OptimizationStatus, TrialResult, TrialStatus
+from traigent.config.types import TraigentConfig
+from traigent.core.backend_session_manager import BackendSessionManager
+from traigent.core.objectives import create_default_objectives
+
+
+@pytest.fixture
+def mock_backend_client() -> MagicMock:
+    client = MagicMock()
+    client.register_trial_start = AsyncMock(return_value=True)
+    client._submit_trial_result_via_session = AsyncMock(return_value=True)
+    client.get_session_mapping = Mock(
+        return_value=MagicMock(experiment_run_id="run_test_123")
+    )
+    auth_manager = Mock()
+    auth_manager.has_api_key = Mock(return_value=True)
+    client.auth_manager = auth_manager
+    return client
+
+
+@pytest.fixture
+def traigent_config() -> TraigentConfig:
+    config = TraigentConfig()
+    config.execution_mode = "edge_analytics"
+    return config
+
+
+@pytest.fixture
+def objective_schema():
+    return create_default_objectives(
+        objective_names=["accuracy"],
+        orientations={"accuracy": "maximize"},
+    )
+
+
+@pytest.fixture
+def mock_optimizer() -> MagicMock:
+    optimizer = MagicMock()
+    optimizer.objectives = ["accuracy"]
+    optimizer.config_space = {"model": ["gpt-4o-mini"]}
+    return optimizer
+
+
+@pytest.fixture
+def manager(
+    mock_backend_client: MagicMock,
+    traigent_config: TraigentConfig,
+    objective_schema,
+    mock_optimizer: MagicMock,
+) -> BackendSessionManager:
+    return BackendSessionManager(
+        backend_client=mock_backend_client,
+        traigent_config=traigent_config,
+        objectives=["accuracy"],
+        objective_schema=objective_schema,
+        optimizer=mock_optimizer,
+        optimization_id="opt-1",
+        optimization_status=OptimizationStatus.RUNNING,
+    )
+
+
+def _trial_result(trial_id: str = "trial-1") -> TrialResult:
+    return TrialResult(
+        trial_id=trial_id,
+        config={"model": "gpt-4o-mini"},
+        metrics={"accuracy": 0.9},
+        status=TrialStatus.COMPLETED,
+        duration=0.1,
+        timestamp=datetime.now(UTC),
+    )
+
+
+class TestStartedTrialsIdempotency:
+    """Second submit_trial call for the same (session, trial) pair must not
+    re-register the trial start with the backend."""
+
+    @pytest.mark.asyncio
+    async def test_register_trial_start_runs_once_across_retries(
+        self, manager: BackendSessionManager, mock_backend_client: MagicMock
+    ) -> None:
+        session_id = "sess-1"
+        tr = _trial_result()
+
+        with patch.object(
+            manager, "_should_suppress_backend_warnings", return_value=False
+        ):
+            await manager.submit_trial(tr, session_id)
+            await manager.submit_trial(tr, session_id)
+
+        assert mock_backend_client.register_trial_start.await_count == 1
+        assert (session_id, tr.trial_id) in manager._started_trials
+
+    @pytest.mark.asyncio
+    async def test_failed_registration_not_marked_as_started(
+        self, manager: BackendSessionManager, mock_backend_client: MagicMock
+    ) -> None:
+        mock_backend_client.register_trial_start = AsyncMock(return_value=False)
+
+        session_id = "sess-2"
+        tr = _trial_result("trial-2")
+
+        with patch.object(
+            manager, "_should_suppress_backend_warnings", return_value=False
+        ):
+            await manager.submit_trial(tr, session_id)
+            await manager.submit_trial(tr, session_id)
+
+        assert mock_backend_client.register_trial_start.await_count == 2
+        assert (session_id, tr.trial_id) not in manager._started_trials
+
+
+class TestSessionMappingRecovery:
+    """finalize_session must try to rebuild a session mapping from the
+    active-session metadata before giving up on remote finalization."""
+
+    @pytest.mark.asyncio
+    async def test_recovers_mapping_from_active_session_metadata(self) -> None:
+        from traigent.cloud.backend_client import BackendIntegratedClient
+
+        with patch("traigent.cloud.backend_client.AIOHTTP_AVAILABLE", True):
+            client = BackendIntegratedClient(
+                api_key="test-key",  # pragma: allowlist secret
+                base_url="http://localhost:5000",
+            )
+
+        session_id = "sess-recovery"
+        active_session = MagicMock()
+        active_session.metadata = {
+            "experiment_id": "exp-42",
+            "experiment_run_id": "run-42",
+        }
+        active_session.function_name = "my_fn"
+        active_session.configuration_space = {"model": ["gpt-4o"]}
+        active_session.objectives = ["accuracy"]
+
+        with client._active_sessions_lock:
+            client._active_sessions[session_id] = active_session
+
+        client._session_ops._finalize_session_via_api = AsyncMock(return_value=True)
+
+        assert client.session_bridge.get_session_mapping(session_id) is None
+
+        await client._session_ops.finalize_session(session_id)
+
+        mapping = client.session_bridge.get_session_mapping(session_id)
+        assert mapping is not None
+        assert mapping.experiment_id == "exp-42"
+        assert mapping.experiment_run_id == "run-42"
+        client._session_ops._finalize_session_via_api.assert_awaited_once_with(
+            session_id, "run-42"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_recovery_when_active_session_metadata_incomplete(self) -> None:
+        from traigent.cloud.backend_client import BackendIntegratedClient
+
+        with patch("traigent.cloud.backend_client.AIOHTTP_AVAILABLE", True):
+            client = BackendIntegratedClient(
+                api_key="test-key",  # pragma: allowlist secret
+                base_url="http://localhost:5000",
+            )
+
+        session_id = "sess-no-meta"
+        active_session = MagicMock()
+        active_session.metadata = {}
+
+        with client._active_sessions_lock:
+            client._active_sessions[session_id] = active_session
+
+        client._session_ops._finalize_session_via_api = AsyncMock(return_value=True)
+
+        await client._session_ops.finalize_session(session_id)
+
+        assert client.session_bridge.get_session_mapping(session_id) is None
+        client._session_ops._finalize_session_via_api.assert_not_called()
+
+
+class TestBlockingEvaluatorOffloading:
+    """Blocking custom evaluators must run via asyncio.to_thread so concurrent
+    async work (heartbeats, progress callbacks) is not starved."""
+
+    @pytest.mark.asyncio
+    async def test_to_thread_does_not_block_event_loop(self) -> None:
+        """A 200ms blocking call must overlap a parallel 50ms-cadence
+        heartbeat without delaying its ticks. If run inline on the event
+        loop, heartbeats would bunch at the end."""
+        heartbeats: list[float] = []
+
+        async def heartbeat() -> None:
+            for _ in range(5):
+                heartbeats.append(time.monotonic())
+                await asyncio.sleep(0.05)
+
+        def blocking_work() -> str:
+            time.sleep(0.2)
+            return "done"
+
+        async def offloaded_call() -> str:
+            return await asyncio.to_thread(blocking_work)
+
+        start = time.monotonic()
+        _, result = await asyncio.gather(heartbeat(), offloaded_call())
+        elapsed = time.monotonic() - start
+
+        assert result == "done"
+        assert len(heartbeats) == 5
+        # Sequential would be ~0.45s (0.2 blocking + 0.25 heartbeat). With
+        # to_thread they overlap and total ~0.25-0.3s.
+        assert elapsed < 0.4, f"elapsed={elapsed:.3f}s suggests event-loop starvation"
+
+    def test_evaluator_wrapper_wraps_blocking_evaluator_in_to_thread(self) -> None:
+        """Source-level guard against accidental regression: the wrapper's
+        sync-evaluator branch must stay on asyncio.to_thread."""
+        from traigent.core import evaluator_wrapper
+
+        source = inspect.getsource(evaluator_wrapper.CustomEvaluatorWrapper)
+        assert "asyncio.to_thread(" in source, (
+            "CustomEvaluatorWrapper must use asyncio.to_thread to run blocking "
+            "custom evaluators off the main event loop"
+        )

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -707,8 +707,39 @@ class SessionOperations:
         self._validate_non_empty_string(session_id, "session_id")
         logger.info(f"Finalizing optimization session {session_id}")
 
-        # Get session mapping for experiment_run_id
+        # Get session mapping for experiment_run_id, or reconstruct it from the
+        # active-session metadata if live tracking had succeeded but the in-memory
+        # bridge entry was lost (e.g. after a partial restart or lost-reference
+        # race). Finalization is a one-shot remote call — losing it silently on
+        # a recoverable-metadata path would leave the session flagged as never
+        # finalized.
         mapping = self.client.session_bridge.get_session_mapping(session_id)
+        if mapping is None:
+            with self.client._active_sessions_lock:
+                active_session = self.client._active_sessions.get(session_id)
+            if active_session is not None:
+                metadata = dict(getattr(active_session, "metadata", {}) or {})
+                experiment_id = metadata.get("experiment_id")
+                experiment_run_id = metadata.get("experiment_run_id")
+                if experiment_id and experiment_run_id:
+                    mapping = self.client.session_bridge.create_session_mapping(
+                        session_id=session_id,
+                        experiment_id=str(experiment_id),
+                        experiment_run_id=str(experiment_run_id),
+                        function_name=str(
+                            getattr(active_session, "function_name", "unknown_function")
+                        ),
+                        configuration_space=dict(
+                            getattr(active_session, "configuration_space", {}) or {}
+                        ),
+                        objectives=list(
+                            getattr(active_session, "objectives", []) or []
+                        ),
+                    )
+                    logger.info(
+                        "Recovered session mapping for %s from active session metadata",
+                        session_id,
+                    )
 
         # Try to finalize via backend API endpoint (POST /sessions/{id}/finalize)
         finalized_via_api = False

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -82,6 +82,11 @@ class BackendSessionManager:
         self._backend_tracking_enabled: bool = True
         self._backend_disabled_reason: SessionCreationFailureReason | None = None
 
+        # Tracks (session_id, trial_id) pairs that have already been registered
+        # with the backend, so retries of submit_trial don't re-register and
+        # trip "already started" errors on the backend side.
+        self._started_trials: set[tuple[str, str]] = set()
+
     @property
     def backend_tracking_enabled(self) -> bool:
         """Whether remote backend tracking is active for this run."""
@@ -603,21 +608,28 @@ class BackendSessionManager:
         status = status_mapping.get(trial_result.status, "FAILED")
 
         try:
-            try:
-                start_result = self._backend_client.register_trial_start(
-                    session_id=session_id,
-                    trial_id=trial_result.trial_id,
-                    config=trial_result.config,
-                )
-                if inspect.isawaitable(start_result):
-                    await start_result
-            except Exception as exc:
-                logger.debug(
-                    "Trial start registration failed for session %s trial %s: %s",
-                    session_id,
-                    trial_result.trial_id,
-                    exc,
-                )
+            trial_key = (session_id, trial_result.trial_id)
+            if trial_key not in self._started_trials:
+                try:
+                    start_call = self._backend_client.register_trial_start(
+                        session_id=session_id,
+                        trial_id=trial_result.trial_id,
+                        config=trial_result.config,
+                    )
+                    start_ok: Any = (
+                        await start_call
+                        if inspect.isawaitable(start_call)
+                        else start_call
+                    )
+                    if start_ok:
+                        self._started_trials.add(trial_key)
+                except Exception as exc:
+                    logger.debug(
+                        "Trial start registration failed for session %s trial %s: %s",
+                        session_id,
+                        trial_result.trial_id,
+                        exc,
+                    )
 
             submitted_result = self._backend_client._submit_trial_result_via_session(
                 session_id=session_id,

--- a/traigent/core/evaluator_wrapper.py
+++ b/traigent/core/evaluator_wrapper.py
@@ -428,8 +428,14 @@ class CustomEvaluatorWrapper(BaseEvaluator):
                                 func, config, example
                             )
                         else:
-                            example_result = self.custom_evaluator(
-                                func, config, example
+                            # Run blocking custom evaluators off the main event loop so
+                            # concurrent async tasks (progress callbacks, heartbeats)
+                            # are not starved while long-running per-example work runs.
+                            example_result = await asyncio.to_thread(
+                                self.custom_evaluator,
+                                func,
+                                config,
+                                example,
                             )
                         per_example_duration = time.time() - per_example_start
 


### PR DESCRIPTION
## Summary

Three self-contained robustness improvements lifted from the larger feature patch in \`_archive/vendor_traigent_dirty_20260421.patch\`. The feature portion (live trial-progress streaming) is **intentionally left out** — review flagged unresolved issues (no rate limiting on per-example progress submits, hardcoded \`sdk_version=\"2.0.0\"\`, arithmetic-mean aggregation of cost metrics that should sum instead) that need to be addressed separately.

## What lands

### 1. \`BackendSessionManager\`: idempotent \`register_trial_start\`
Adds \`_started_trials: set[(session_id, trial_id)]\` so retries of \`submit_trial\` don't re-register the same trial and trip \"already started\" errors on the backend side. The dedup is conditional on the registration actually succeeding — failures do not mark the trial as started, so a later retry can recover.

### 2. \`SessionOperations.finalize_session\`: recover lost session mapping
If the in-memory \`session_bridge\` mapping is missing at finalize time (e.g. after a partial restart or lost reference), falls back to reconstructing it from \`active_session.metadata\`'s \`experiment_id\` + \`experiment_run_id\`. Finalization is a one-shot remote call; silently losing it leaves the session flagged as never finalized.

### 3. \`CustomEvaluatorWrapper\`: off-load blocking custom evaluators
Wraps the synchronous-evaluator branch with \`asyncio.to_thread\` so blocking per-example work doesn't starve the main event loop. Other async tasks (progress callbacks, auth refresh, heartbeats) now get scheduling time while long-running evaluators are in flight.

## Why the feature piece is excluded

Reviewing the full 679-line patch flagged these issues in the streaming feature:

| Concern | Severity |
|---|---|
| No rate limiting on per-example progress submits — 1000-example trial fires 1000 HTTP calls | 🔴 blocker |
| \`sdk_version: \"2.0.0\"\` hardcoded in 3 places (actual version is 0.11.x) | 🟡 P1 |
| Cost metric aggregation uses arithmetic mean; should sum for cost | 🟡 P1 |
| Config-run custom-metric validation removed — NaN/Inf now silently flow through \`summary_stats\` | 🟡 P1 |
| \`session_mapping is None\` no longer short-circuits submission — can cause backend 400s | 🟡 P1 |

These are all fixable but not in scope for a \"security/robustness only\" pass. File a follow-up ticket when the feature is back on the roadmap.

## Tests

- New: \`tests/unit/core/test_robustness_cherrypicks.py\` (**6 tests, all pass**)
  - Idempotency on success + on failure-of-registration
  - Session-mapping recovery when metadata present + when incomplete
  - Event-loop-starvation guard: 200ms blocking work must overlap a 50ms-cadence heartbeat
  - Source-level regression guard on the \`asyncio.to_thread\` call site
- Regression sweep on touched files: \`test_backend_session_manager\` + \`test_session_finalization\` + \`test_client_stateful\` → **55 pass, 0 regress**

🤖 Generated with [Claude Code](https://claude.com/claude-code)