### PR TITLE
chore(dependabot): address Greptile P2 follow-up on PR #739

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,7 +70,6 @@ updates:
       api-framework:
         patterns:
           - "pydantic*"
-          - "pydantic-settings*"
           - "aiohttp*"
           - "httpx*"
           - "requests*"
@@ -125,19 +124,18 @@ updates:
       - dependency-name: "anthropic"
         update-types: ["version-update:semver-major"]
       # LangChain has shipped minor-version breaking changes (1.x → 2.x);
-      # hold both major and minor for manual review.
-      - dependency-name: "langchain"
+      # hold both major and minor for manual review. Wildcards cover
+      # langchain-openai, langchain-anthropic, langchain-text-splitters,
+      # langchain-google-genai, etc. langsmith is bundled with langchain
+      # in the group pattern, so it gets the same hold.
+      - dependency-name: "langchain*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "langchain-core"
+      - dependency-name: "langsmith*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      - dependency-name: "langchain-community"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # OpenTelemetry: historically non-semver-compatible jumps.
+      # OpenTelemetry: historically non-semver-compatible jumps. The wildcard
+      # covers opentelemetry-api, opentelemetry-sdk, and every instrumentation
+      # package in one rule.
       - dependency-name: "opentelemetry-*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "opentelemetry-api"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "opentelemetry-sdk"
         update-types: ["version-update:semver-major"]
 
   # GitHub Actions — monthly, majors held for manual audit.


### PR DESCRIPTION
## Summary

Three style/completeness cleanups flagged by Greptile on [PR #739](https://github.com/Traigent/Traigent/pull/739) (already merged) — addressing them here as a follow-up.

## Findings addressed

### 1. Widen LangChain ignore to `langchain*` + `langsmith*`
The \`langchain\` group pattern is \`langchain*\`, which matches:
- \`langsmith\`
- \`langchain-openai\`, \`langchain-anthropic\`
- \`langchain-text-splitters\`, \`langchain-google-genai\`
- ...and any other \`langchain-*\` package we add later

But the \`ignore\` list only named three: \`langchain\`, \`langchain-core\`, \`langchain-community\`. Dependabot could still open standalone minor PRs for the rest. Switched to wildcards so every \`langchain-*\` + \`langsmith*\` package gets the same hold.

### 2. Drop redundant \`pydantic-settings*\` pattern
\`pydantic*\` already glob-matches \`pydantic-settings\` and \`pydantic-settings-*\`. Harmless but removed for clarity.

### 3. Drop redundant OTel entries under the wildcard
\`opentelemetry-*\` wildcard already covered \`opentelemetry-api\` + \`opentelemetry-sdk\`. The two explicit entries were unreachable.

## Impact

- **#1**: widens hold to ~5 more LangChain packages. Security updates (CVE-triggered) still flow via the separate Dependabot Security Updates path. No behaviour change for routine cadence.
- **#2, #3**: pure cleanup, zero change.

## Diff

\`+9 / -11\` — config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)