### PR TITLE
feat: bind SDK auth keys to tenant context

### DIFF
--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -265,6 +265,27 @@ class TestCliAuthPayload:
     """CLI _authenticate_with_backend() should send write permissions and User-Agent."""
 
     @pytest.mark.asyncio
+    async def test_key_creation_requires_explicit_tenant_id(self):
+        """CLI auth must not silently create API keys against a server-default tenant."""
+        from traigent.cli.auth_commands import TraigentAuthCLI
+        from traigent.cloud.auth import AuthenticationError
+
+        with (
+            patch.dict(
+                "os.environ", {"TRAIGENT_PROJECT_ID": "project_alpha"}, clear=True
+            ),
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            cli = object.__new__(TraigentAuthCLI)
+            cli.backend_api_url = "http://test/api/v1"
+            cli.backend_url = "http://test"
+
+            with pytest.raises(AuthenticationError, match="TRAIGENT_TENANT_ID"):
+                await cli._authenticate_with_backend("a@b.com", "pass123")
+
+        mock_session.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_key_creation_includes_write_permissions_and_user_agent(self):
         """POST /keys payload must include write scopes; both requests need User-Agent."""
         from traigent.cli.auth_commands import TraigentAuthCLI
@@ -316,6 +337,14 @@ class TestCliAuthPayload:
                 pass
 
         with (
+            patch.dict(
+                "os.environ",
+                {
+                    "TRAIGENT_TENANT_ID": "tenant_acme",
+                    "TRAIGENT_PROJECT_ID": "project_alpha",
+                },
+                clear=True,
+            ),
             patch("aiohttp.ClientSession", return_value=FakeSession()),
             patch.object(
                 TraigentAuthCLI,
@@ -332,12 +361,15 @@ class TestCliAuthPayload:
         # Verify login request (first POST) has User-Agent
         login_call = post_calls[0]
         assert login_call["headers"]["User-Agent"] == "Traigent-SDK-CLI/1.0"
+        assert login_call["headers"]["X-Tenant-Id"] == "tenant_acme"
 
-        # Verify key creation request (second POST) has User-Agent + write permissions
+        # Verify key creation request has User-Agent, tenant context, and write permissions.
         key_call = post_calls[1]
         assert key_call["headers"]["User-Agent"] == "Traigent-SDK-CLI/1.0"
+        assert key_call["headers"]["X-Tenant-Id"] == "tenant_acme"
 
         payload = key_call["json"]
+        assert payload["project_id"] == "project_alpha"
         assert "permissions" in payload
         perms = payload["permissions"]
         assert "experiment.write" in perms
@@ -398,6 +430,6 @@ class TestCentralizedCredentialHints:
         ):
             BackendConfig.get_api_key()
 
-        assert any(
-            SIGNUP_URL in msg for msg in caplog.messages
-        ), f"Expected {SIGNUP_URL!r} in warning messages: {caplog.messages}"
+        assert any(SIGNUP_URL in msg for msg in caplog.messages), (
+            f"Expected {SIGNUP_URL!r} in warning messages: {caplog.messages}"
+        )

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -36,6 +36,8 @@ from traigent.cloud.auth import (
     InvalidCredentialsError,
 )
 from traigent.config.backend_config import SIGNUP_URL, BackendConfig
+from traigent.config.project import PROJECT_ENV_VAR, read_optional_project_env
+from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
 from traigent.utils.logging import get_logger
 
 console = Console()
@@ -291,16 +293,30 @@ class TraigentAuthCLI:
 
         # Step 1: Direct login call for better error visibility
         login_url = f"{self.backend_api_url}/auth/login"
+        tenant_id = read_optional_env(TENANT_ENV_VAR)
+        project_id = read_optional_project_env()
+        if not tenant_id:
+            message = (
+                f"{TENANT_ENV_VAR} is required for org-bound SDK authentication. "
+                "Set it to the organization id before running `traigent auth login`."
+            )
+            if project_id:
+                message += f" {PROJECT_ENV_VAR} is set, but project-bound keys also require a tenant."
+            raise AuthenticationError(message)
+        login_headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "Traigent-SDK-CLI/1.0",
+        }
+        if tenant_id:
+            login_headers[TENANT_HEADER_NAME] = tenant_id
+
         console.print(f"[dim]POST {login_url}[/dim]")
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 login_url,
                 json={"email": email, "password": password},
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": "Traigent-SDK-CLI/1.0",
-                },
+                headers=login_headers,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as response:
                 response_text = await response.text()
@@ -364,6 +380,26 @@ class TraigentAuthCLI:
         hostname = platform.node() or "unknown"
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         key_name = f"Traigent SDK CLI ({hostname[:20]} {timestamp})"
+        key_payload = {
+            "key_name": key_name,
+            "permissions": [
+                "read",
+                "write",
+                "experiment.read",
+                "experiment.write",
+                "session.read",
+                "session.write",
+            ],
+        }
+        if project_id:
+            key_payload["project_id"] = project_id
+        key_headers = {
+            "Authorization": f"Bearer {jwt_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "Traigent-SDK-CLI/1.0",
+        }
+        if tenant_id:
+            key_headers[TENANT_HEADER_NAME] = tenant_id
 
         console.print(f"\n[dim]POST {api_key_url}[/dim]")
         console.print(f"[dim]Creating API key: {key_name}[/dim]")
@@ -371,22 +407,8 @@ class TraigentAuthCLI:
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 api_key_url,
-                json={
-                    "key_name": key_name,
-                    "permissions": [
-                        "read",
-                        "write",
-                        "experiment.read",
-                        "experiment.write",
-                        "session.read",
-                        "session.write",
-                    ],
-                },
-                headers={
-                    "Authorization": f"Bearer {jwt_token}",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Traigent-SDK-CLI/1.0",
-                },
+                json=key_payload,
+                headers=key_headers,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as response:
                 response_text = await response.text()


### PR DESCRIPTION
## Summary\n- send X-Tenant-Id during CLI login and API-key creation\n- include project_id in API-key creation when TRAIGENT_PROJECT_ID is set\n- require TRAIGENT_TENANT_ID before org-bound SDK auth to avoid silent default-tenant binding\n\n## Stack\n- Base branch: security/aikido-wave1\n- Merge after the SDK security PR.\n\n## Tests\n- ruff check traigent/cli/auth_commands.py tests/unit/config/test_backend_config_stored_creds.py\n- ruff format --check traigent/cli/auth_commands.py tests/unit/config/test_backend_config_stored_creds.py\n- pytest -q tests/unit/config/test_backend_config_stored_creds.py