### PR TITLE
[codex] Align SDK Black pre-commit floor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
 
   # Python code formatting
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.3.1
     hooks:
       - id: black
         language_version: python3.12


### PR DESCRIPTION
## Summary
- Aligns the Black pre-commit hook revision with the 26.3.1 dependency floor already enforced by requirements and pyproject.toml.

## Validation
- python3 scripts/ci/check_dep_floor_drift.py
- pre-commit hooks during git commit
