### PR TITLE
[codex] Require tenant for org-bound SDK auth

### DIFF
--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -36,7 +36,7 @@ class TestBackendConfigStoredApiKey:
         with (
             patch.dict(
                 "os.environ",
-                {"TRAIGENT_API_KEY": "tg_env_key"},
+                {"TRAIGENT_API_KEY": "tg_env_key"},  # pragma: allowlist secret
                 clear=True,
             ),
             patch(
@@ -126,6 +126,27 @@ class TestCliAuthPayload:
     """CLI _authenticate_with_backend() should send write permissions and User-Agent."""
 
     @pytest.mark.asyncio
+    async def test_key_creation_requires_explicit_tenant_id(self):
+        """CLI auth must not silently create API keys against a server-default tenant."""
+        from traigent.cli.auth_commands import TraigentAuthCLI
+        from traigent.cloud.auth import AuthenticationError
+
+        with (
+            patch.dict(
+                "os.environ", {"TRAIGENT_PROJECT_ID": "project_alpha"}, clear=True
+            ),
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            cli = object.__new__(TraigentAuthCLI)
+            cli.backend_api_url = "http://test/api/v1"
+            cli.backend_url = "http://test"
+
+            with pytest.raises(AuthenticationError, match="TRAIGENT_TENANT_ID"):
+                await cli._authenticate_with_backend("a@b.com", "pass123")
+
+        mock_session.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_key_creation_includes_write_permissions_and_user_agent(self):
         """POST /keys payload must include write scopes; both requests need User-Agent."""
         from traigent.cli.auth_commands import TraigentAuthCLI
@@ -177,6 +198,14 @@ class TestCliAuthPayload:
                 pass
 
         with (
+            patch.dict(
+                "os.environ",
+                {
+                    "TRAIGENT_TENANT_ID": "tenant_acme",
+                    "TRAIGENT_PROJECT_ID": "project_alpha",
+                },
+                clear=True,
+            ),
             patch("aiohttp.ClientSession", return_value=FakeSession()),
             patch.object(
                 TraigentAuthCLI,
@@ -193,12 +222,15 @@ class TestCliAuthPayload:
         # Verify login request (first POST) has User-Agent
         login_call = post_calls[0]
         assert login_call["headers"]["User-Agent"] == "Traigent-SDK-CLI/1.0"
+        assert login_call["headers"]["X-Tenant-Id"] == "tenant_acme"
 
-        # Verify key creation request (second POST) has User-Agent + write permissions
+        # Verify key creation request has User-Agent, tenant context, and write permissions.
         key_call = post_calls[1]
         assert key_call["headers"]["User-Agent"] == "Traigent-SDK-CLI/1.0"
+        assert key_call["headers"]["X-Tenant-Id"] == "tenant_acme"
 
         payload = key_call["json"]
+        assert payload["project_id"] == "project_alpha"
         assert "permissions" in payload
         perms = payload["permissions"]
         assert "experiment.write" in perms
@@ -206,4 +238,4 @@ class TestCliAuthPayload:
         assert "write" in perms
 
         # Verify result
-        assert result["api_key"] == "tg_created_key"
+        assert result["api_key"] == "tg_created_key"  # pragma: allowlist secret

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -315,9 +315,8 @@ class TraigentAuthCLI:
         login_headers = {
             "Content-Type": "application/json",
             "User-Agent": "Traigent-SDK-CLI/1.0",
+            TENANT_HEADER_NAME: tenant_id,
         }
-        if tenant_id:
-            login_headers[TENANT_HEADER_NAME] = tenant_id
 
         console.print(f"[dim]POST {login_url}[/dim]")
 
@@ -406,9 +405,8 @@ class TraigentAuthCLI:
             "Authorization": f"Bearer {jwt_token}",
             "Content-Type": "application/json",
             "User-Agent": "Traigent-SDK-CLI/1.0",
+            TENANT_HEADER_NAME: tenant_id,
         }
-        if tenant_id:
-            key_headers[TENANT_HEADER_NAME] = tenant_id
 
         console.print(f"\n[dim]POST {api_key_url}[/dim]")
         console.print(f"[dim]Creating API key: {key_name}[/dim]")

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -45,6 +45,8 @@ from traigent.cloud.auth import (
     InvalidCredentialsError,
 )
 from traigent.config.backend_config import BackendConfig
+from traigent.config.project import PROJECT_ENV_VAR, read_optional_project_env
+from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
 from traigent.utils.logging import get_logger
 
 console = Console()
@@ -300,16 +302,30 @@ class TraigentAuthCLI:
 
         # Step 1: Direct login call for better error visibility
         login_url = f"{self.backend_api_url}/auth/login"
+        tenant_id = read_optional_env(TENANT_ENV_VAR)
+        project_id = read_optional_project_env()
+        if not tenant_id:
+            message = (
+                f"{TENANT_ENV_VAR} is required for org-bound SDK authentication. "
+                "Set it to the organization id before running `traigent auth login`."
+            )
+            if project_id:
+                message += f" {PROJECT_ENV_VAR} is set, but project-bound keys also require a tenant."
+            raise AuthenticationError(message)
+        login_headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "Traigent-SDK-CLI/1.0",
+        }
+        if tenant_id:
+            login_headers[TENANT_HEADER_NAME] = tenant_id
+
         console.print(f"[dim]POST {login_url}[/dim]")
 
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 login_url,
                 json={"email": email, "password": password},
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": "Traigent-SDK-CLI/1.0",
-                },
+                headers=login_headers,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as response:
                 response_text = await response.text()
@@ -373,6 +389,26 @@ class TraigentAuthCLI:
         hostname = platform.node() or "unknown"
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         key_name = f"Traigent SDK CLI ({hostname[:20]} {timestamp})"
+        key_payload = {
+            "key_name": key_name,
+            "permissions": [
+                "read",
+                "write",
+                "experiment.read",
+                "experiment.write",
+                "session.read",
+                "session.write",
+            ],
+        }
+        if project_id:
+            key_payload["project_id"] = project_id
+        key_headers = {
+            "Authorization": f"Bearer {jwt_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "Traigent-SDK-CLI/1.0",
+        }
+        if tenant_id:
+            key_headers[TENANT_HEADER_NAME] = tenant_id
 
         console.print(f"\n[dim]POST {api_key_url}[/dim]")
         console.print(f"[dim]Creating API key: {key_name}[/dim]")
@@ -380,22 +416,8 @@ class TraigentAuthCLI:
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 api_key_url,
-                json={
-                    "key_name": key_name,
-                    "permissions": [
-                        "read",
-                        "write",
-                        "experiment.read",
-                        "experiment.write",
-                        "session.read",
-                        "session.write",
-                    ],
-                },
-                headers={
-                    "Authorization": f"Bearer {jwt_token}",
-                    "Content-Type": "application/json",
-                    "User-Agent": "Traigent-SDK-CLI/1.0",
-                },
+                json=key_payload,
+                headers=key_headers,
                 timeout=aiohttp.ClientTimeout(total=30),
             ) as response:
                 response_text = await response.text()


### PR DESCRIPTION
## Summary
- require TRAIGENT_TENANT_ID before SDK auth creates an org-bound API key
- keep project binding as optional but reject project-only auth without a tenant
- send X-Tenant-Id on login and key creation requests
- cover the missing-tenant failure path and tenant/project key payloads

## Tests
- pre-commit hooks during cherry-pick: isort, black, ruff, detect-secrets, bandit, mypy, guardrail checks
- uv run --with ruff ruff check traigent/cli/auth_commands.py tests/unit/config/test_backend_config_stored_creds.py
- uv run --with black black --check traigent/cli/auth_commands.py tests/unit/config/test_backend_config_stored_creds.py
- uv run --with pytest-xdist --with pytest-asyncio pytest tests/unit/config/test_backend_config_stored_creds.py -q