### PR TITLE
fix(security): close template-injection surface in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,13 +42,16 @@ jobs:
 
     - name: Verify tag is on main branch
       if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GIT_SHA: ${{ github.sha }}
+        GIT_REF_NAME: ${{ github.ref_name }}
       run: |
         git fetch origin main
-        if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
-          echo "Error: tag ${{ github.ref_name }} is not on the main branch. Only tag from main."
+        if ! git merge-base --is-ancestor "$GIT_SHA" origin/main; then
+          echo "Error: tag $GIT_REF_NAME is not on the main branch. Only tag from main."
           exit 1
         fi
-        echo "Tag ${{ github.ref_name }} is on main — proceeding."
+        echo "Tag $GIT_REF_NAME is on main — proceeding."
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -73,8 +76,9 @@ jobs:
         echo "package_version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Verify version consistency
+      env:
+        VERSION_PYPROJECT: ${{ steps.package_version.outputs.package_version }}
       run: |
-        VERSION_PYPROJECT=${{ steps.package_version.outputs.package_version }}
         echo "pyproject.toml version: $VERSION_PYPROJECT"
 
         # If triggered by a tag, verify the tag matches the package version
@@ -140,14 +144,18 @@ jobs:
 
     - name: Create deployment summary
       if: always()
+      env:
+        ENVIRONMENT: ${{ (github.event_name == 'push' && 'pypi (auto from tag)') || github.event.inputs.environment || 'unknown' }}
+        TRIGGER: ${{ github.event_name }}
+        REF: ${{ github.ref }}
+        JOB_STATUS: ${{ job.status }}
       run: |
-        ENVIRONMENT="${{ (github.event_name == 'push' && 'pypi (auto from tag)') || github.event.inputs.environment || 'unknown' }}"
-        echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
-        echo "- **Version**: $(python -c "import traigent; print(traigent.__version__)")" >> $GITHUB_STEP_SUMMARY
-        echo "- **Environment**: ${ENVIRONMENT}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Ref**: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+        echo "## Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Version**: $(python -c "import traigent; print(traigent.__version__)")" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Environment**: $ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Trigger**: $TRIGGER" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Ref**: $REF" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Status**: $JOB_STATUS" >> "$GITHUB_STEP_SUMMARY"
 
   verify-publication:
     needs: publish
@@ -166,8 +174,9 @@ jobs:
     - name: Test installation from PyPI
       env:
         EXPECTED_VERSION: ${{ needs.publish.outputs.package_version }}
+        PUBLISH_ENVIRONMENT: ${{ github.event.inputs.environment }}
       run: |
-        if [ "${{ github.event.inputs.environment }}" = "testpypi" ]; then
+        if [ "$PUBLISH_ENVIRONMENT" = "testpypi" ]; then
           PACKAGE_LABEL="TestPyPI"
           PACKAGE_API_URL="https://test.pypi.org/pypi/traigent/json"
           INSTALL_ARGS=(--index-url "https://test.pypi.org/simple/" --extra-index-url "https://pypi.org/simple/")


### PR DESCRIPTION
## Summary

Addresses the Aikido SAST finding **Template Injection in GitHub Workflows Action** (High, downgraded to "somewhat hard to exploit") at `.github/workflows/publish.yml:169-232`.

The flagged step's condition `if [ "${{ github.event.inputs.environment }}" = "testpypi" ]` interpolated a GitHub context value directly into a shell command. The input is `type: choice` with a fixed `testpypi`/`pypi` option list, so the *practical* risk is low — but the pattern is what SAST flags, and scope creep on the input (or a subtle upstream change) would open a real injection.

## Fix

Moved every `${{ ... }}` expression that was being expanded inside a `run:` block in this file into `env:` blocks. GitHub Actions passes `env:` values through the shell's environment (quoted at assignment), so they are never string-substituted into the script before bash parses it.

**Steps touched (all in `publish.yml`):**

1. **Test installation from PyPI** — the specific step Aikido flagged. `github.event.inputs.environment` → `PUBLISH_ENVIRONMENT`.
2. **Verify tag is on main branch** — `github.sha` / `github.ref_name` → `GIT_SHA` / `GIT_REF_NAME`. Same pattern, preempts re-flag.
3. **Verify version consistency** — `steps.package_version.outputs.package_version` → `VERSION_PYPROJECT` (moved from inline assignment to `env:`).
4. **Create deployment summary** — `github.event_name`, `github.ref`, `job.status`, and the environment expression → env vars; also quoted `"$GITHUB_STEP_SUMMARY"` for robustness.

No behavior change — only the expansion mechanism changed. YAML still parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Test plan

- [ ] Aikido rescan no longer flags the Template Injection finding on publish.yml
- [ ] Next `v*` tag push or manual `workflow_dispatch` publish run behaves identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)