### PR TITLE
fix(security): close template-injection in auto-tune example workflows

### DIFF
--- a/.github/workflows/example-auto-tune-secure.yml
+++ b/.github/workflows/example-auto-tune-secure.yml
@@ -146,17 +146,19 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Validate budget limits
+        env:
+          INPUT_BUDGET: ${{ github.event.inputs.budget || '5.0' }}
         run: |
           python -c "
-          import yaml
+          import os, yaml
           with open('examples/ci-pipeline/params.yaml') as f:
               params = yaml.safe_load(f)
 
-          budget = float('${{ github.event.inputs.budget || 5.0 }}')
+          budget = float(os.environ['INPUT_BUDGET'])
           if budget > 25:
-              print(f'❌ Budget ${budget} exceeds maximum allowed ($25)')
+              print(f'❌ Budget \${budget} exceeds maximum allowed (\$25)')
               exit(1)
-          print(f'✅ Budget ${budget} is within limits')
+          print(f'✅ Budget \${budget} is within limits')
           "
 
   auto-tune:
@@ -219,34 +221,38 @@ jobs:
 
       - name: Set environment
         id: env
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
-          echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          echo "environment=$INPUT_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set tuning parameters
         id: params
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          INPUT_MAX_TRIALS: ${{ github.event.inputs.max_trials }}
+          INPUT_BUDGET: ${{ github.event.inputs.budget }}
         run: |
-          ENV="${{ steps.env.outputs.environment }}"
-
           # Set defaults based on environment with strict limits
-          if [[ "$ENV" == "production" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '50' }}"
-            BUDGET="${{ github.event.inputs.budget || '25.0' }}"
-          elif [[ "$ENV" == "staging" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '20' }}"
-            BUDGET="${{ github.event.inputs.budget || '10.0' }}"
+          if [[ "$STEP_ENV_OUTPUT" == "production" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-50}"
+            BUDGET="${INPUT_BUDGET:-25.0}"
+          elif [[ "$STEP_ENV_OUTPUT" == "staging" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-20}"
+            BUDGET="${INPUT_BUDGET:-10.0}"
           else
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '10' }}"
-            BUDGET="${{ github.event.inputs.budget || '5.0' }}"
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-10}"
+            BUDGET="${INPUT_BUDGET:-5.0}"
           fi
 
           # Enforce maximum limits
           if (( $(echo "$BUDGET > 25" | bc -l) )); then
-            echo "⚠️ Budget exceeds maximum, capping at $25"
+            echo "⚠️ Budget exceeds maximum, capping at \$25"
             BUDGET="25.0"
           fi
 
-          echo "max_trials=$MAX_TRIALS" >> $GITHUB_OUTPUT
-          echo "budget=$BUDGET" >> $GITHUB_OUTPUT
+          echo "max_trials=$MAX_TRIALS" >> "$GITHUB_OUTPUT"
+          echo "budget=$BUDGET" >> "$GITHUB_OUTPUT"
 
       - name: Run pre-optimization tests
         run: |
@@ -263,14 +269,16 @@ jobs:
           TRAIGENT_MOCK_LLM: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
           TRAIGENT_OFFLINE_MODE: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
           MAX_BUDGET: ${{ steps.params.outputs.budget }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Update DVC params
           python -c "
-          import yaml
+          import os, yaml
           with open('params.yaml', 'r') as f:
               params = yaml.safe_load(f)
-          params['optimize']['max_trials'] = ${{ steps.params.outputs.max_trials }}
-          params['optimize']['budget'] = ${{ steps.params.outputs.budget }}
+          params['optimize']['max_trials'] = int(os.environ['STEP_PARAMS_MAX_TRIALS'])
+          params['optimize']['budget'] = float(os.environ['STEP_PARAMS_BUDGET'])
           with open('params.yaml', 'w') as f:
               yaml.dump(params, f)
           "
@@ -283,13 +291,17 @@ jobs:
 
       - name: Generate CML report
         if: always()
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Create performance report
           echo "## 🤖 Secure Auto-Tuning Results" > report.md
           echo "" >> report.md
-          echo "**Environment:** ${{ steps.env.outputs.environment }}" >> report.md
-          echo "**Max Trials:** ${{ steps.params.outputs.max_trials }}" >> report.md
-          echo "**Budget:** \$${{ steps.params.outputs.budget }}" >> report.md
+          echo "**Environment:** $STEP_ENV_OUTPUT" >> report.md
+          echo "**Max Trials:** $STEP_PARAMS_MAX_TRIALS" >> report.md
+          echo "**Budget:** \$$STEP_PARAMS_BUDGET" >> report.md
           echo "" >> report.md
 
           # Add security scan results

--- a/.github/workflows/example-auto-tune.yml
+++ b/.github/workflows/example-auto-tune.yml
@@ -87,28 +87,32 @@ jobs:
 
       - name: Determine environment
         id: env
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
-          echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          echo "environment=$INPUT_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set tuning parameters
         id: params
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          INPUT_MAX_TRIALS: ${{ github.event.inputs.max_trials }}
+          INPUT_BUDGET: ${{ github.event.inputs.budget }}
         run: |
-          ENV="${{ steps.env.outputs.environment }}"
-
           # Set defaults based on environment
-          if [[ "$ENV" == "production" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '50' }}"
-            BUDGET="${{ github.event.inputs.budget || '25.0' }}"
-          elif [[ "$ENV" == "staging" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '20' }}"
-            BUDGET="${{ github.event.inputs.budget || '10.0' }}"
+          if [[ "$STEP_ENV_OUTPUT" == "production" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-50}"
+            BUDGET="${INPUT_BUDGET:-25.0}"
+          elif [[ "$STEP_ENV_OUTPUT" == "staging" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-20}"
+            BUDGET="${INPUT_BUDGET:-10.0}"
           else
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '10' }}"
-            BUDGET="${{ github.event.inputs.budget || '5.0' }}"
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-10}"
+            BUDGET="${INPUT_BUDGET:-5.0}"
           fi
 
-          echo "max_trials=$MAX_TRIALS" >> $GITHUB_OUTPUT
-          echo "budget=$BUDGET" >> $GITHUB_OUTPUT
+          echo "max_trials=$MAX_TRIALS" >> "$GITHUB_OUTPUT"
+          echo "budget=$BUDGET" >> "$GITHUB_OUTPUT"
 
       - name: Run auto-tuning pipeline
         env:
@@ -116,14 +120,16 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TRAIGENT_MOCK_LLM: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
           TRAIGENT_OFFLINE_MODE: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Update DVC params with current settings
           python -c "
-          import yaml
+          import os, yaml
           with open('params.yaml', 'r') as f:
               params = yaml.safe_load(f)
-          params['optimize']['max_trials'] = ${{ steps.params.outputs.max_trials }}
-          params['optimize']['budget'] = ${{ steps.params.outputs.budget }}
+          params['optimize']['max_trials'] = int(os.environ['STEP_PARAMS_MAX_TRIALS'])
+          params['optimize']['budget'] = float(os.environ['STEP_PARAMS_BUDGET'])
           with open('params.yaml', 'w') as f:
               yaml.dump(params, f)
           "
@@ -133,13 +139,17 @@ jobs:
 
       - name: Generate CML report
         if: always()
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Create performance report
           echo "## 🤖 Auto-Tuning Results" > report.md
           echo "" >> report.md
-          echo "**Environment:** ${{ steps.env.outputs.environment }}" >> report.md
-          echo "**Max Trials:** ${{ steps.params.outputs.max_trials }}" >> report.md
-          echo "**Budget:** \$${{ steps.params.outputs.budget }}" >> report.md
+          echo "**Environment:** $STEP_ENV_OUTPUT" >> report.md
+          echo "**Max Trials:** $STEP_PARAMS_MAX_TRIALS" >> report.md
+          echo "**Budget:** \$$STEP_PARAMS_BUDGET" >> report.md
           echo "" >> report.md
 
           # Add metrics


### PR DESCRIPTION
## Summary

Addresses two **Critical** Aikido SAST findings (`Template Injection in GitHub Workflows Action`):
- `.github/workflows/example-auto-tune-secure.yml:222-224`
- `.github/workflows/example-auto-tune.yml:90-92`

Same fix pattern as PR #770 (publish.yml). Every `${{ github.event.inputs.* }}` and `${{ steps.*.outputs.* }}` expression that was being expanded inside a `run:` block (or a `python -c` heredoc inside a run block) has been moved into `env:` blocks, so the value is passed through the shell's environment (quoted at assignment time) rather than string-substituted into the script before bash parses it.

## Steps touched (both files)

1. **Determine / Set environment** — `github.event.inputs.environment` → `$INPUT_ENVIRONMENT`.
2. **Set tuning parameters** — `github.event.inputs.{max_trials,budget}` → env vars; the per-environment defaults (50/25, 20/10, 10/5) are preserved using bash `${INPUT_MAX_TRIALS:-50}` parameter expansion, which is functionally identical to the previous `${{ ... || '50' }}` pattern.
3. **Run auto-tuning pipeline** — `steps.params.outputs.{max_trials,budget}` → env vars; the inline python heredoc now reads `os.environ['STEP_PARAMS_*']` instead of having values string-substituted.
4. **Generate CML report** — `steps.env.outputs.environment` and `steps.params.outputs.{max_trials,budget}` → env vars; subsequent `echo` writes use `\$VAR` shell expansion.

`example-auto-tune-secure.yml` additionally fixes the earlier **Validate budget limits** step that interpolated `github.event.inputs.budget` into a python literal.

No behavior change. Per-environment defaults, conditional logic, and DVC pipeline calls all preserved. The `if:` expressions on later steps (which reference `steps.env.outputs.environment` for conditional skips) are GitHub Actions expression contexts — not vulnerable to shell injection — and were left as-is. Likewise, `with: body:`, `with: token:`, `with: branch:`, `concurrency.group`, `secrets.*` in `env:`, and `vars.AWS_ROLE_TO_ASSUME` are all action-input or YAML-config positions, not shell.

The commit looks like a 326-line diff because `pre-commit` normalized pre-existing trailing whitespace across both files; the **substantive** diff (`git diff -w`) is ~90 lines.

## Test plan

- [ ] Aikido rescan no longer flags Template Injection on these two workflows
- [ ] Manual `workflow_dispatch` of either workflow runs identically (per-env defaults, budget cap, DVC params update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)