### PR TITLE
fix(security): close Aikido SAST path-traversal + SSRF findings

### DIFF
--- a/.aikidoignore
+++ b/.aikidoignore
@@ -8,3 +8,33 @@ tests/**/*.py:assert
 # Ignore test credential patterns in test files
 # These are intentionally fake credentials for testing purposes
 tests/**/*.py:generic-api-key
+
+# ----------------------------------------------------------------------------
+# Path-traversal false-positives — see inline `# nosec` comments at each call
+# site for the per-instance rationale. All listed paths are scripts whose
+# `path` argument is either a developer-provided CLI flag (and therefore not
+# attacker-controllable in the threat model), or an internal helper called
+# only with paths the module itself constructs from validated/fixed roots.
+# ----------------------------------------------------------------------------
+
+# Internal docs-audit helpers (write_json / asset markdown writer): `path` is
+# main()-supplied under args.output_dir.
+scripts/documentation/audit_docs_consistency.py:path-traversal
+
+# Developer-facing CLI for duplicate detection; --output is the user's choice.
+scripts/analysis/duplicate_detector.py:path-traversal
+
+# Auto-tune helper that already calls validate_path() before writing.
+scripts/auto_tune/security_utils.py:path-traversal
+
+# CLI tool for TVL spec validation; intentionally reads the user's file argument.
+traigent/tvl/__main__.py:path-traversal
+
+# generate-config CLI; safe_source is constrained to TRAIGENT_CONFIG_BASE_DIR.
+traigent/cli/generate_config_command.py:path-traversal
+
+# Local storage lock file path is computed by the storage module itself.
+traigent/storage/local_storage.py:path-traversal
+
+# wandb integration: trial filename derived from int(trial_number).
+traigent/integrations/observability/wandb.py:path-traversal

--- a/scripts/analysis/duplicate_detector.py
+++ b/scripts/analysis/duplicate_detector.py
@@ -186,6 +186,8 @@ def generate_report(
     report_content = "\n".join(report_lines)
 
     if output_file:
+        # nosec - developer-facing CLI; output_file is the user's --output arg
+        # and they own the destination by definition.
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(report_content)
         print(f"Report saved to {output_file}")

--- a/scripts/auto_tune/security_utils.py
+++ b/scripts/auto_tune/security_utils.py
@@ -446,6 +446,8 @@ def safe_file_write(path: Union[Path, str], content: str, backup: bool = True):
     # Write with atomic operation
     temp_path = path.with_suffix(f"{path.suffix}.tmp")
     try:
+        # nosec - path is validated above (line 438) via validate_path();
+        # temp_path is derived from the validated path.
         with open(temp_path, "w") as f:
             f.write(content)
         temp_path.rename(path)

--- a/scripts/documentation/audit_docs_consistency.py
+++ b/scripts/documentation/audit_docs_consistency.py
@@ -409,6 +409,8 @@ def build_records() -> tuple[list[DocRecord], list[dict], list[CommandRecord]]:
 
 
 def write_json(path: Path, payload: object) -> None:
+    # nosec - internal docs-audit helper; path is set by main() to a fixed
+    # output filename under args.output_dir, never user-controlled.
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
@@ -506,6 +508,8 @@ def write_tracking(
         lines.append(
             f"| `{asset['path']}` | `{asset['suffix']}` | {asset['size_bytes']} |"
         )
+    # nosec - internal docs-audit helper; path is set by main() to a fixed
+    # output filename under args.output_dir, never user-controlled.
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/traigent/cli/generate_config_command.py
+++ b/traigent/cli/generate_config_command.py
@@ -243,6 +243,8 @@ def _output_tvl(result, path: Path):
 
     spec = result.to_tvl_spec(module_name=safe_source.stem)
     tvl_path = safe_source.with_suffix(".tvl.yml")
+    # nosec - safe_source is constrained to TRAIGENT_CONFIG_BASE_DIR above
+    # (line 238); tvl_path is derived via with_suffix on a validated path.
     tvl_path.write_text(yaml.dump(spec, default_flow_style=False, sort_keys=False))
     click.echo(f"TVL spec written to: {tvl_path}")
 

--- a/traigent/integrations/observability/wandb.py
+++ b/traigent/integrations/observability/wandb.py
@@ -281,10 +281,12 @@ class TraigentWandBTracker:
 
         # Save trial as JSON artifact. Coerce trial_number through int() so
         # the formatted filename can never carry path-traversal segments even
-        # if a caller violates the int type contract.
-        trial_file = f"trial_{int(trial_number)}.json"
+        # if a caller violates the int type contract. The coercion is inside
+        # the try block so a bad caller falls into the same graceful-failure
+        # path as I/O / serialisation errors instead of crashing log_trial().
         artifact_written = False
         try:
+            trial_file = f"trial_{int(trial_number)}.json"
             with open(trial_file, "w", encoding="utf-8") as f:
                 json.dump(trial_artifact_data, f, indent=2)
                 artifact_written = True

--- a/traigent/integrations/observability/wandb.py
+++ b/traigent/integrations/observability/wandb.py
@@ -279,8 +279,10 @@ class TraigentWandBTracker:
             "timestamp": timestamp_iso,
         }
 
-        # Save trial as JSON artifact
-        trial_file = f"trial_{trial_number}.json"
+        # Save trial as JSON artifact. Coerce trial_number through int() so
+        # the formatted filename can never carry path-traversal segments even
+        # if a caller violates the int type contract.
+        trial_file = f"trial_{int(trial_number)}.json"
         artifact_written = False
         try:
             with open(trial_file, "w", encoding="utf-8") as f:

--- a/traigent/projects/client.py
+++ b/traigent/projects/client.py
@@ -171,7 +171,7 @@ class ProjectManagementClient:
         try:
             with request.urlopen(
                 http_request, timeout=self.config.request_timeout
-            ) as response:  # nosec B310
+            ) as response:  # nosec B310 - backend_origin is caller-configured API endpoint
                 status_code = getattr(response, "status", 200)
                 body = response.read().decode("utf-8") if response else ""
                 parsed = json.loads(body) if body else {}

--- a/traigent/storage/local_storage.py
+++ b/traigent/storage/local_storage.py
@@ -143,6 +143,8 @@ class LocalStorageManager:
     def _read_lock_pid(self, lock_path: Path) -> int | None:
         """Read owning PID from lock file, if present."""
         try:
+            # nosec - lock_path is computed internally by LocalStorage from
+            # self.storage_path and a fixed lock filename; never user-controlled.
             with open(lock_path, encoding="utf-8") as lock_file:
                 raw_value = lock_file.read().strip()
         except OSError:

--- a/traigent/tvl/__main__.py
+++ b/traigent/tvl/__main__.py
@@ -56,7 +56,8 @@ def validate_tvl_files(
             # First validate schema (early validation)
             import yaml
 
-            # Security: CLI tool intentionally reads user-specified files for validation
+            # nosec - CLI tool intentionally reads user-specified files for
+            # TVL validation; resolved_path is the user-provided argument.
             with open(resolved_path, encoding="utf-8") as f:
                 raw_data = yaml.safe_load(f)
 

--- a/traigent/utils/optimization_logger.py
+++ b/traigent/utils/optimization_logger.py
@@ -23,6 +23,7 @@ from traigent.config.types import ExecutionMode, resolve_execution_mode
 from traigent.core.objectives import ObjectiveSchema, normalize_objectives
 from traigent.utils.file_versioning import FileVersionManager, RunVersionInfo
 from traigent.utils.logging import get_logger
+from traigent.utils.secure_path import PathTraversalError, validate_path
 
 logger = get_logger(__name__)
 
@@ -314,6 +315,8 @@ class OptimizationLogger:
         temp_path = file_path.with_suffix(f"{file_path.suffix}.tmp.{os.getpid()}")
         sanitized = sanitize_for_logging(data)
         try:
+            # nosec - temp_path derives from caller-supplied file_path which the
+            # logger already constrains to its own run/experiment directory.
             with open(temp_path, "w", encoding="utf-8") as handle:
                 json.dump(sanitized, handle, indent=2, default=str, ensure_ascii=False)
             temp_path.replace(file_path)
@@ -803,7 +806,18 @@ class OptimizationLogger:
         with open(latest_file) as handle:
             latest_data = json.load(handle)
 
-        checkpoint_file = run_path / "checkpoints" / latest_data["checkpoint_file"]
+        # Constrain the checkpoint reference to the run's checkpoints directory.
+        # The filename comes from latest.json on disk; a tampered manifest
+        # could otherwise traverse out of run_path via "../" segments.
+        checkpoints_dir = run_path / "checkpoints"
+        try:
+            checkpoint_file = validate_path(
+                latest_data["checkpoint_file"], checkpoints_dir, must_exist=True
+            )
+        except PathTraversalError as exc:
+            raise ValueError(
+                f"Invalid checkpoint reference in {latest_file}: {exc}"
+            ) from exc
         with open(checkpoint_file) as handle:
             checkpoint_data = json.load(handle)
 


### PR DESCRIPTION
## Summary

Addresses **11 open Aikido SAST findings** on develop — 10 path-traversal hits across CLI scripts/internal helpers, plus 1 SSRF advisory on the projects client.

## Two postures

### 1) Real fix — one site

`traigent/utils/optimization_logger.py:807` — `load_checkpoint()` reads `latest_data["checkpoint_file"]` from a JSON manifest on disk and joins it onto `run_path / "checkpoints" / …`. A tampered manifest could otherwise traverse out of `run_path` via `..`. Now validated through the existing `traigent.utils.secure_path.validate_path()` helper against the checkpoints dir; a `PathTraversalError` is converted to a clean `ValueError` for the caller.

This is the only Aikido finding where the path argument comes from external data crossing our process trust boundary.

### 2) Documented suppression — everywhere else

The other nine path-traversal sites are CLI scripts whose `path` argument is either:
- a developer-provided CLI flag (the user owns their `--output` destination),
- already validated upstream within the same module (e.g. `safe_source.relative_to(base_dir)` checks before deriving sibling paths), or
- constructed from fixed module-internal roots (lock files, temp files derived via `path.with_suffix`).

Each call site now carries an inline `# nosec` comment giving its per-instance rationale; `.aikidoignore` is updated with file-level entries matching the existing `tests/**/*.py:assert` pattern.

| Site | Why suppressed |
|---|---|
| `scripts/documentation/audit_docs_consistency.py` (write_json, asset md writer) | `path` set by `main()` to a fixed name under `args.output_dir` |
| `scripts/analysis/duplicate_detector.py:189` | `--output` CLI arg; user owns destination |
| `scripts/auto_tune/security_utils.py:449` | `validate_path(path)` already called immediately above the write |
| `traigent/utils/optimization_logger.py:317` (`_atomic_write`) | `temp_path` derives from caller-supplied `file_path`, which the logger constrains to its own run dir |
| `traigent/integrations/observability/wandb.py:286` | filename now built via `f"trial_{int(trial_number)}.json"` — coerces through `int()` so a bad caller can't sneak path segments |
| `traigent/cli/generate_config_command.py:246` | `safe_source` is checked against `TRAIGENT_CONFIG_BASE_DIR` (line 238) before `with_suffix` |
| `traigent/storage/local_storage.py:146` | `lock_path` is computed by `LocalStorage` from `self.storage_path` + a fixed name |
| `traigent/tvl/__main__.py:60` | CLI tool's stated purpose is to validate user-specified TVL files |

### SSRF: `traigent/projects/client.py:174`

Already had a terse `# nosec B310`. Expanded it to match the rationale-bearing form already used in the sibling clients (`prompts/client.py`, `observability/client.py`, `evaluation/client.py`): `# nosec B310 - backend_origin is caller-configured API endpoint`. Behavior unchanged.

## Test plan

- [ ] Aikido rescan no longer flags the 11 SAST findings (path-traversal × 10 + SSRF × 1)
- [ ] Unit tests for `optimization_logger.load_checkpoint` still pass; new `PathTraversalError` path can be covered by a follow-up if desired
- [ ] Pre-commit hooks pass (already verified locally — bandit/mypy/black/isort all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)