### PR TITLE
fix(security): address SDK high-critical Aikido findings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -242,5 +242,5 @@ jobs:
     - name: Notify on success
       if: success()
       run: |
-        echo "✅ Package successfully published and verified on PyPI!" >> $GITHUB_STEP_SUMMARY
-        echo "Users can now install with: \`pip install traigent\`" >> $GITHUB_STEP_SUMMARY
+        echo "✅ Package successfully published and verified on PyPI!" >> "$GITHUB_STEP_SUMMARY"
+        echo "Users can now install with: \`pip install traigent\`" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/contributing/aikido_triage.md
+++ b/docs/contributing/aikido_triage.md
@@ -1,0 +1,31 @@
+# Aikido Triage Notes
+
+This file records repository-local triage decisions for Aikido findings that
+cannot be safely fixed by code changes alone.
+
+## 2026-04-25 SDK License Finding
+
+- Aikido issue: `235535549`
+- Aikido issue group: `27772214`
+- Type: `license`
+- Severity: `critical`
+- Affected package: `traigent@0.11.4`
+- Affected file: `uv.lock`
+- Related license: `AGPL-3.0-only`
+- Disposition: intentional project license, requires Aikido issue ignore
+
+The finding is for the SDK root package's declared license, not for a
+third-party dependency license drift. The repository consistently declares
+`AGPL-3.0-only` in `pyproject.toml`, includes the AGPL license text in
+`LICENSE`, and documents separate commercial licensing in
+`COMMERCIAL-LICENSING.md` and `CONTRIBUTOR-LICENSING.md`.
+
+Do not resolve this by excluding `uv.lock` from Aikido scanning. That would
+also suppress dependency, malware, and future license findings from the lockfile.
+
+Do not change the SDK license as a scanner remediation without explicit legal
+and business approval. If Aikido comments on a PR for this finding, reply:
+
+```text
+@AikidoSec ignore: Intentional SDK project license. Traigent open-source releases are AGPL-3.0-only and separate commercial licenses are documented in COMMERCIAL-LICENSING.md and CONTRIBUTOR-LICENSING.md. This is the root package license, not a third-party dependency license drift.
+```


### PR DESCRIPTION
## Summary
- confirms the three SDK GitHub Actions template-injection findings are already fixed on current develop via PRs #770/#771
- closes the remaining Greptile publish workflow nit by quoting GITHUB_STEP_SUMMARY
- documents the critical SDK AGPL license finding as an intentional root-package license triage without excluding uv.lock from scanning

## Verification
- python -c "import yaml; [yaml.safe_load(open(p)) for p in ['.github/workflows/example-auto-tune-secure.yml','.github/workflows/example-auto-tune.yml','.github/workflows/publish.yml']]; print('yaml-ok')"
- uv run pytest -q tests/auto_tune/test_security_utils.py

## Notes
- Attempted Aikido issue-level ignore for issue 235535549 with the configured local AIKIDO_TOKEN/AIKIDO_API_KEY, but Aikido returned 401 invalid token signature. If Aikido comments on this PR, docs/contributing/aikido_triage.md includes the exact @AikidoSec ignore response to apply.