### PR TITLE
[codex] stabilize SDK preprod schema checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,11 @@ hybrid = [
     "mcp>=1.27.0",  # CVE-2025-66416, AIKIDO-2026-10472 fix (claude-code-sdk dependency)
 ]
 
+# Internal schema validation support for DTO strict-validation paths.
+internal_schema = [
+    "traigent-schema @ git+https://github.com/Traigent/TraigentSchema.git@96c30d3c6f4f0ab32748093357bbedfab89b80a5",
+]
+
 # Testing dependencies
 test = [
     "pytest>=9.0.3",

--- a/scripts/ci/install_sdk_requirements.sh
+++ b/scripts/ci/install_sdk_requirements.sh
@@ -5,11 +5,24 @@ python -m pip install --upgrade pip
 
 private_deps_token="${TRAIGENT_PRIVATE_DEPS_TOKEN:-${TRAIGENT_SCHEMA_TOKEN:-${TRAIGENT_SCHEMAS_PAT:-}}}"
 schema_ref="${TRAIGENT_SCHEMA_REF:-7d8539f45e978c5148e4335e8250843f097e3b67}"
+install_schema="${TRAIGENT_INSTALL_SCHEMA:-}"
+
+for arg in "$@"; do
+  case "$arg" in
+    *internal_schema*) install_schema="1" ;;
+  esac
+done
 
 if [ -n "$private_deps_token" ]; then
-  python -m pip install "traigent-schema @ git+https://x-access-token:${private_deps_token}@github.com/Traigent/TraigentSchema.git@${schema_ref}"
-else
-  python -m pip install "traigent-schema>=3.2.0"
+  git config --global url."https://x-access-token:${private_deps_token}@github.com/Traigent/".insteadOf "https://github.com/Traigent/"
+fi
+
+if [ "$install_schema" = "1" ]; then
+  if [ -n "$private_deps_token" ]; then
+    python -m pip install "traigent-schema @ git+https://x-access-token:${private_deps_token}@github.com/Traigent/TraigentSchema.git@${schema_ref}"
+  else
+    python -m pip install "traigent-schema>=3.2.0"
+  fi
 fi
 
 if [ "$#" -gt 0 ]; then

--- a/scripts/ci/install_sdk_requirements.sh
+++ b/scripts/ci/install_sdk_requirements.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 python -m pip install --upgrade pip
 
 private_deps_token="${TRAIGENT_PRIVATE_DEPS_TOKEN:-${TRAIGENT_SCHEMA_TOKEN:-${TRAIGENT_SCHEMAS_PAT:-}}}"
-schema_ref="${TRAIGENT_SCHEMA_REF:-7d8539f45e978c5148e4335e8250843f097e3b67}"
+schema_ref="${TRAIGENT_SCHEMA_REF:-96c30d3c6f4f0ab32748093357bbedfab89b80a5}"
 install_schema="${TRAIGENT_INSTALL_SCHEMA:-}"
 
 for arg in "$@"; do

--- a/tests/unit/test_import_side_effects.py
+++ b/tests/unit/test_import_side_effects.py
@@ -46,9 +46,12 @@ def test_local_evaluator_patches_langchain_lazily_once(monkeypatch):
         calls.append("patched")
         return False
 
-    monkeypatch.setattr(local_module, "_LANGCHAIN_PATCH_ATTEMPTED", False)
+    monkeypatch.setattr(local_module, "_METADATA_PATCHES_ATTEMPTED", False)
     monkeypatch.setattr(
         local_module, "patch_langchain_for_metadata_capture", fake_patch
+    )
+    monkeypatch.setattr(
+        local_module, "patch_litellm_for_metadata_capture", lambda: True
     )
 
     local_module.LocalEvaluator(metrics=["accuracy"])

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -34,6 +34,7 @@ if env_file.exists() and os.environ.get("TRAIGENT_SKIP_DOTENV", "").lower() not 
     "1",
     "true",
     "yes",
+    "on",
 ):
     load_dotenv(env_file)
 

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -30,7 +30,11 @@ if os.environ.get("TRAIGENT_MOCK_MODE"):
 
 # Load environment variables from .env file if it exists
 env_file = Path(__file__).parent.parent.parent / ".env"
-if env_file.exists():
+if env_file.exists() and os.environ.get("TRAIGENT_SKIP_DOTENV", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+):
     load_dotenv(env_file)
 
 _MIN_JWT_SECRET_LENGTH = 32

--- a/uv.lock
+++ b/uv.lock
@@ -6188,6 +6188,9 @@ integrations = [
     { name = "rank-bm25" },
     { name = "wandb" },
 ]
+internal-schema = [
+    { name = "traigent-schema" },
+]
 ml = [
     { name = "matplotlib" },
     { name = "numpy" },
@@ -6354,13 +6357,24 @@ requires-dist = [
     { name = "traigent", extras = ["bayesian", "analytics"], marker = "extra == 'ml'" },
     { name = "traigent", extras = ["integrations", "analytics", "bayesian", "visualization", "hybrid", "pydanticai"], marker = "extra == 'recommended'" },
     { name = "traigent", extras = ["security"], marker = "extra == 'cloud'" },
+    { name = "traigent-schema", marker = "extra == 'internal-schema'", git = "https://github.com/Traigent/TraigentSchema.git?rev=96c30d3c6f4f0ab32748093357bbedfab89b80a5" },
     { name = "types-bleach", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "uvicorn", marker = "extra == 'security'", specifier = ">=0.18.0" },
     { name = "wandb", marker = "extra == 'integrations'", specifier = ">=0.15.0" },
 ]
-provides-extras = ["analytics", "bayesian", "integrations", "dspy", "pydanticai", "security", "visualization", "hybrid", "test", "tracing", "dev", "docs", "ml", "deepeval", "cloud", "recommended", "all", "enterprise"]
+provides-extras = ["analytics", "bayesian", "integrations", "dspy", "pydanticai", "security", "visualization", "hybrid", "internal-schema", "test", "tracing", "dev", "docs", "ml", "deepeval", "cloud", "recommended", "all", "enterprise"]
+
+[[package]]
+name = "traigent-schema"
+version = "4.0.0"
+source = { git = "https://github.com/Traigent/TraigentSchema.git?rev=96c30d3c6f4f0ab32748093357bbedfab89b80a5#96c30d3c6f4f0ab32748093357bbedfab89b80a5" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
 
 [[package]]
 name = "typer"


### PR DESCRIPTION
## Summary
- add the SDK internal_schema extra used by DTO strict-validation paths
- update uv.lock for the schema extra
- allow pre-prod/unit runs to skip repo .env loading via TRAIGENT_SKIP_DOTENV
- update the lazy metadata patch unit test for the current private flag names

## Why
The post-merge pre-prod harness found SDK G1/G2 failures around the missing internal schema extra, local .env leakage into unit tests, and a stale import side-effect test.

## Validation
- Full pre-prod harness: READY, 31 pass / 0 fail / 3 skip / 0 P0 failures / 0 P1 failures
- Commit hooks passed: isort, black, ruff, detect-secrets, mypy, dep-floor drift, cost guardrails

## Notes
The remaining skipped gates are environment-dependent checks, not failures.