### PR TITLE
security: close SDK release blockers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
         exclude: .*\.lock$|package-lock\.json$|pnpm-lock\.yaml$|.*\.example$|\.secrets\.baseline$|\.venv/
 
   # General file checks

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -152,15 +152,6 @@
         "line_number": 205
       }
     ],
-    "configs/env-templates/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "configs/env-templates/README.md",
-        "hashed_secret": "33f220dd67f717cc949db63e21c90e130a6137da",
-        "is_verified": false,
-        "line_number": 65
-      }
-    ],
     "docs/architecture/plugin_architecture.md": [
       {
         "type": "Secret Keyword",
@@ -176,30 +167,7 @@
         "filename": "docs/features/authentication.md",
         "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
         "is_verified": false,
-        "line_number": 371
-      }
-    ],
-    "docs/installation-guide-offline.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/installation-guide-offline.md",
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_verified": false,
-        "line_number": 62
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/installation-guide-offline.md",
-        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
-        "is_verified": false,
-        "line_number": 63
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/installation-guide-offline.md",
-        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
-        "is_verified": false,
-        "line_number": 66
+        "line_number": 374
       }
     ],
     "docs/tvl/tvl-website/pnpm-lock.yaml": [
@@ -208,5019 +176,5229 @@
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "121a3385c5e28b32a26d3cad7c90a29496d9747f",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 17
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69ae37e0133456d2c3fbfd903c273bf1372267e0",
         "is_verified": false,
-        "line_number": 244
+        "line_number": 248
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "24bcacef3fb203d046d58405e8207a5342669fe2",
         "is_verified": false,
-        "line_number": 247
+        "line_number": 251
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d4eac0bf704336f38e69fd6832e6f021ded39602",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dc4d28f9890d4fa2dfd62af6dad92301d743197b",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 258
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5d38e92aeafa91e0b0d9dca469391b9cdfe9dcfd",
         "is_verified": false,
-        "line_number": 258
+        "line_number": 262
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4a9ae62604ff3094a86888165571aedf55bb29b1",
         "is_verified": false,
-        "line_number": 262
+        "line_number": 266
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "91ef8efb1f1a9f7b957debc2f9382278a11e9e91",
         "is_verified": false,
-        "line_number": 266
+        "line_number": 270
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5cb278a68156ae376bea48fb0f872cbc5dfd0a63",
         "is_verified": false,
-        "line_number": 270
+        "line_number": 274
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1ebe57ea46fba7d746cb222ee21b5cd413c80ff1",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1fc27c75818896b4e84d7e8ca98e0e8c00118bb7",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 282
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e844f3c78344b978e74bc22b6c2736d4b0c393e1",
         "is_verified": false,
-        "line_number": 284
+        "line_number": 288
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8319864fae2ce720a9588f890930b4dd3f736a4f",
         "is_verified": false,
-        "line_number": 288
+        "line_number": 292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e2a4d1a24c1c4aac8dc6ee6056c8a135c8db64a",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 296
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6302a9750ba626bf9d98ea2b93c8044c2c13dd03",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 300
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "aab5f636e7355b605c94009444540cb86f20a48d",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 304
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8570cc5660ba5cb0957e273be0100cce91506931",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 308
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "210797f986e8839f4aa71c2e7fa465944644b42f",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 313
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "07c2a515b8ce991183b3b5cbfc018668baa54ac6",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 319
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "adc1d52f38ba77308117df559dea25e43eb9f263",
         "is_verified": false,
-        "line_number": 321
+        "line_number": 325
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "67428c90207cc195acaf62942754b6a6861c8b90",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 329
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "de045e2ed3223c2ab40b541eb6a518fd1a3ad0f2",
         "is_verified": false,
-        "line_number": 329
+        "line_number": 333
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "73b60e42d9313eca080440873f8fa1fcb5310f29",
         "is_verified": false,
-        "line_number": 333
+        "line_number": 337
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3942b0ee3200c0c70746db896347c9f1c86795ee",
         "is_verified": false,
-        "line_number": 337
+        "line_number": 341
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2765cac86159f5017e7511a57adb410bf0540193",
         "is_verified": false,
-        "line_number": 340
+        "line_number": 344
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e7272e163bbc139a72d39a9cd8d521c3daef962d",
         "is_verified": false,
-        "line_number": 343
+        "line_number": 347
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f14ba07acf972f2b7095f1814fc1596e605878a4",
         "is_verified": false,
-        "line_number": 348
+        "line_number": 352
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4d2a9fe8166ba36c28dbe2172304f097713f9f4b",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 355
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f97e027840e6148350273c88efef7e8b5d1cf5bc",
         "is_verified": false,
-        "line_number": 354
+        "line_number": 358
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69a078d0c8d430cbbb7fc4c42f598e5e98ee5c5d",
         "is_verified": false,
-        "line_number": 357
+        "line_number": 361
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "854ad107863bc6fe3bfc0508180a26191b1c0a2d",
         "is_verified": false,
-        "line_number": 360
+        "line_number": 364
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a8e4627e40f4bf3903759a298bc646332f041250",
         "is_verified": false,
-        "line_number": 363
+        "line_number": 367
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ba92041b8b57e5f3f7cfda01eca4eb5f863d8230",
         "is_verified": false,
-        "line_number": 366
+        "line_number": 370
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ec1989ae36181cb6d116871a04bd886e8aa7680a",
         "is_verified": false,
-        "line_number": 372
+        "line_number": 376
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4fc407ff3fa666522e784402874b39ccaa9b9084",
+        "is_verified": false,
+        "line_number": 382
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7543ee65aa0a02783414e8a1dbd3d18c0c3123cc",
         "is_verified": false,
-        "line_number": 378
+        "line_number": 388
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d8fa482cdfbba9269e34d191ace0e402c5cb45c3",
         "is_verified": false,
-        "line_number": 384
+        "line_number": 394
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6e53b1d7147a431758aded05223f60a6cf8404b6",
+        "is_verified": false,
+        "line_number": 400
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5cab2cbf14962ddc1d6ed2bfe25898fe4c36dec1",
         "is_verified": false,
-        "line_number": 390
+        "line_number": 406
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9d1eaaf504742620f3f5b102a4f02d28d4f919ce",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 412
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "21094ab4fc5b3c4b172a28c6e96d474b60d8f176",
+        "is_verified": false,
+        "line_number": 418
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b3ffc344491402f73ea16b1b8718e18833050114",
         "is_verified": false,
-        "line_number": 402
+        "line_number": 424
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e427dd2b428dd4241dd1b8355c3b92fd85839376",
         "is_verified": false,
-        "line_number": 408
+        "line_number": 430
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "57902bee1f6a5e12ed03dd3b3281ab07318ff81f",
+        "is_verified": false,
+        "line_number": 436
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "06c952d11f13461da10c7bba057d78cc5fa5e6fb",
         "is_verified": false,
-        "line_number": 414
+        "line_number": 442
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "771db604fdb79532e77b7128227a745a3ec9ec0a",
         "is_verified": false,
-        "line_number": 420
+        "line_number": 448
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3cfe66e44a47be9aa1a2b2570d4e6ca4fe8646d6",
+        "is_verified": false,
+        "line_number": 454
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c2ea7b0b8f40b08e1b89209f677ff5d6a719b60a",
         "is_verified": false,
-        "line_number": 426
+        "line_number": 460
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2b63c304518691010aeed935b51f86afcc24ede1",
         "is_verified": false,
-        "line_number": 432
+        "line_number": 466
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6e9116d6ceb830c0e81b752f03b594c04b867404",
+        "is_verified": false,
+        "line_number": 472
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8816a15bd9ad8879b3f1823b94fb7c46dd643f17",
         "is_verified": false,
-        "line_number": 438
+        "line_number": 478
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e1c65275ad0b487c12c5a2f2ca5541ad0ebe811",
         "is_verified": false,
-        "line_number": 444
+        "line_number": 484
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "92eb7bfdfe82cc5019dea1ead34c876de720e71f",
+        "is_verified": false,
+        "line_number": 490
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9836b23edc498bf0925d3e560f0684f6ec75bb9a",
         "is_verified": false,
-        "line_number": 450
+        "line_number": 496
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "19506ba5fec5de7d878352659f9a362ada89bb75",
         "is_verified": false,
-        "line_number": 456
+        "line_number": 502
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f83beff54841a17222f2c5d542077e07f0a640ce",
+        "is_verified": false,
+        "line_number": 508
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f42b2f70ce99e343a262e45315a2c4d27daba270",
         "is_verified": false,
-        "line_number": 462
+        "line_number": 514
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "de04d845fc3903d04f8604ae162d8a4cb95f86ba",
         "is_verified": false,
-        "line_number": 468
+        "line_number": 520
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "de1558a98424f61bb30fd681ab33ebe9ac162b93",
+        "is_verified": false,
+        "line_number": 526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e9fc60c601cab29ea7878a0c9688fb6ee925cf9",
         "is_verified": false,
-        "line_number": 474
+        "line_number": 532
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6c8a21c9366b66bd16b8848cd8ef2f10233ad5ef",
         "is_verified": false,
-        "line_number": 480
+        "line_number": 538
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0609a7c3993cb0b98d835bd299b5e78674c1c4e6",
+        "is_verified": false,
+        "line_number": 544
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6b1f54e31a53e3667a97cf3af18a66d1cedec7b8",
         "is_verified": false,
-        "line_number": 486
+        "line_number": 550
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "05a957e570c3e4e61ba9f99a19db326dcd2417c2",
         "is_verified": false,
-        "line_number": 492
+        "line_number": 556
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7cd72661910d8f1eae72b0783a01c7dcdb990036",
+        "is_verified": false,
+        "line_number": 562
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "efbe56870cd191d53ef1e6ac6d40ed5eb4cd01c0",
         "is_verified": false,
-        "line_number": 498
+        "line_number": 568
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "24594f4581212d856fe125c6864f7fed1b8a4b65",
         "is_verified": false,
-        "line_number": 504
+        "line_number": 574
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c5b024f5526693865d3af7324ab65fc3ab1605fa",
+        "is_verified": false,
+        "line_number": 580
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fefbbc2958b5d0546d6507d1aad9bead9ef7e9eb",
         "is_verified": false,
-        "line_number": 510
+        "line_number": 586
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5020d98c493f4c60e4e9faa360aee83831e8b060",
         "is_verified": false,
-        "line_number": 516
+        "line_number": 592
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7ea3a0d38529d3159199bb46bcf538993729a4ca",
+        "is_verified": false,
+        "line_number": 598
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "489f7d6ea770d41978c763f306e573aa9c086e3b",
         "is_verified": false,
-        "line_number": 522
+        "line_number": 604
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3bcaf9ab39f602b74d65d903898d40b60bc49e8d",
         "is_verified": false,
-        "line_number": 528
+        "line_number": 610
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "abac0dd92435eb969522a0ad244a7d5d3bcf9c90",
+        "is_verified": false,
+        "line_number": 616
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "84e33cad738a516642e9e4e00c9910ada2755eb8",
         "is_verified": false,
-        "line_number": 534
+        "line_number": 622
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0c232b00899ac5c6c72c50d675fba58be657bb51",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 628
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "039980936156bd5bc0de9e386f1e385a9bbabcf0",
+        "is_verified": false,
+        "line_number": 634
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0329358e1442ae9c1dd0cfa7884c4cc51c123c7d",
         "is_verified": false,
-        "line_number": 546
+        "line_number": 640
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "45d7376b39d308f58d92366f89fd5897f34937df",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 646
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ff2f515b75e908a3a079d6b0cf692f65bec13192",
+        "is_verified": false,
+        "line_number": 652
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5520077e071061b96b1bd30a351f2bb3a52cac50",
         "is_verified": false,
-        "line_number": 558
+        "line_number": 658
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a28c69b673bfe25255ddea617830f4a227450bed",
         "is_verified": false,
-        "line_number": 564
+        "line_number": 664
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "43b4d7cc77f29c50ebc0ae65cdd5ae53c4610b89",
+        "is_verified": false,
+        "line_number": 670
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "87b1f5328d5448d368f3d6f42f966bf553d4bf3c",
         "is_verified": false,
-        "line_number": 570
+        "line_number": 676
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4080ae8ed6a6391c581edbf27618aa0806118784",
+        "is_verified": false,
+        "line_number": 682
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5fd94d7bc55b700838f7232aa04cd14ce8883702",
         "is_verified": false,
-        "line_number": 576
+        "line_number": 688
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "01860ebaf2a9445d78d11a9db89fecb64710265a",
         "is_verified": false,
-        "line_number": 582
+        "line_number": 694
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e24f346b7ed723f027041976b3d2e7b555ebd90",
+        "is_verified": false,
+        "line_number": 700
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c3d73f1f8439f4e9e5ad0a8febe880d627dddabc",
         "is_verified": false,
-        "line_number": 588
+        "line_number": 706
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2b88177306d91942e3df15d0361c1fd5125db60a",
+        "is_verified": false,
+        "line_number": 712
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8c94dfd0dbadd0e968f0e9e175bf5bb4fd2594c0",
         "is_verified": false,
-        "line_number": 594
+        "line_number": 718
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cbe73cdb542e52cf85fdae96db4078baf3f81b92",
         "is_verified": false,
-        "line_number": 600
+        "line_number": 724
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "68d8df9678250f3f17e3c6e65e8e29e1007cd5ba",
+        "is_verified": false,
+        "line_number": 730
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ed301ff805587fb9a77f80f5d0fdda6c08a58b87",
         "is_verified": false,
-        "line_number": 606
+        "line_number": 736
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a1d2a1836521ff0216663ecd5526c0a53ce86a4d",
+        "is_verified": false,
+        "line_number": 742
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "38e7a2d417fe20d4760873aa7ad041fa74821645",
         "is_verified": false,
-        "line_number": 612
+        "line_number": 748
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "467ae1b8eba0bb5ed7382100073d14fbb509e77d",
         "is_verified": false,
-        "line_number": 618
+        "line_number": 754
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b1265b06c14c30da47639c2ed791f50c8d80227f",
+        "is_verified": false,
+        "line_number": 760
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2a46cf814514d8cf3a189ce88b22d30c24baf70a",
         "is_verified": false,
-        "line_number": 624
+        "line_number": 766
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "59d87dd0fe7239a69d11c22fbefefe60c35d99fb",
         "is_verified": false,
-        "line_number": 630
+        "line_number": 772
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f13e357a26f9e2972019db90dd8ceb867b494f9c",
-        "is_verified": false,
-        "line_number": 636
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f218898e24af5e5ed6a427f4ab4a68014281779f",
-        "is_verified": false,
-        "line_number": 642
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "35ecb49473bd3c2a84f86fcae2c69e255bdcd843",
-        "is_verified": false,
-        "line_number": 648
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "669e09509d438d5cd9e616a3c27c19d501a6a931",
-        "is_verified": false,
-        "line_number": 654
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5a933a1d9e284cd13a250c28ac430627f1764b3a",
-        "is_verified": false,
-        "line_number": 660
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5db841f4dee4c0a298106f6d56f32851515d99b2",
-        "is_verified": false,
-        "line_number": 663
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b013f3dad4ce2fde647e14586ce596cca9a8c39f",
-        "is_verified": false,
-        "line_number": 666
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dd1db68c43067371d00db59c7f10d0d3ad598841",
-        "is_verified": false,
-        "line_number": 672
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e0d5107e832ed2eed26116dafb2f5c5f977e1341",
-        "is_verified": false,
-        "line_number": 675
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "85caec8d352770d092317299afa348764d129ed5",
-        "is_verified": false,
-        "line_number": 678
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "12de1cdad03b08d04f2c666eb0cb5f1234b496e5",
-        "is_verified": false,
-        "line_number": 681
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
-        "is_verified": false,
-        "line_number": 685
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3e3522c83d724aa4133ee6bb6d627e4390be31a5",
-        "is_verified": false,
-        "line_number": 688
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
-        "is_verified": false,
-        "line_number": 691
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
-        "is_verified": false,
-        "line_number": 695
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
-        "is_verified": false,
-        "line_number": 698
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b02f181ddfb118185d3fc0be3cac545e7bec4ce5",
-        "is_verified": false,
-        "line_number": 701
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8936283936d833d3fcbc796b612c493f0fc5a2a4",
-        "is_verified": false,
-        "line_number": 704
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5bace6024c7051eb7a1cb1e37f7b9985e533a42e",
-        "is_verified": false,
-        "line_number": 707
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
-        "is_verified": false,
-        "line_number": 710
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9966b38a797edc23680e66fcde5a3aa022979a2a",
-        "is_verified": false,
-        "line_number": 713
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6ff531666abb24912d9fae3b91bcd05a49330c9f",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
-        "is_verified": false,
-        "line_number": 739
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bf694b5dac75776f7b55aa5663e0d0cef3fb1812",
-        "is_verified": false,
-        "line_number": 752
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8d4a8977dae9d6867dfcdbeb6417d6ab8461534a",
-        "is_verified": false,
-        "line_number": 765
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "eea334ce67d119e127ca2448c8fd8cb9328a5664",
+        "hashed_secret": "17e8e3b6a6567490ad87c92962f2fe73df1a95e3",
         "is_verified": false,
         "line_number": 778
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "693ab2239e3a31d3b1052c6976a8429dd406e7ea",
+        "hashed_secret": "f13e357a26f9e2972019db90dd8ceb867b494f9c",
         "is_verified": false,
-        "line_number": 791
+        "line_number": 784
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "09b6aade4800e313c2bbed96548c4f2dce507168",
+        "hashed_secret": "f218898e24af5e5ed6a427f4ab4a68014281779f",
         "is_verified": false,
-        "line_number": 804
+        "line_number": 790
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e9d53eedf607b11c3ef44b8c6ff18958ad146340",
+        "hashed_secret": "b9ed31d4313f86c359571fc1caeced011e1549c8",
         "is_verified": false,
-        "line_number": 817
+        "line_number": 796
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d918d00bcbccaae92cf19b1396e6a7513de61bed",
+        "hashed_secret": "35ecb49473bd3c2a84f86fcae2c69e255bdcd843",
+        "is_verified": false,
+        "line_number": 802
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "669e09509d438d5cd9e616a3c27c19d501a6a931",
+        "is_verified": false,
+        "line_number": 808
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9234d6da8ceb8786f9a95485ab027085c326afee",
+        "is_verified": false,
+        "line_number": 814
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5a933a1d9e284cd13a250c28ac430627f1764b3a",
+        "is_verified": false,
+        "line_number": 820
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5db841f4dee4c0a298106f6d56f32851515d99b2",
+        "is_verified": false,
+        "line_number": 823
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b013f3dad4ce2fde647e14586ce596cca9a8c39f",
         "is_verified": false,
         "line_number": 826
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "32322bcf00299724296af3309bc033b969f83bf6",
+        "hashed_secret": "dd1db68c43067371d00db59c7f10d0d3ad598841",
         "is_verified": false,
-        "line_number": 839
+        "line_number": 832
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "76bb59906af53dcb878b807d5817d5edb7ae390f",
+        "hashed_secret": "e0d5107e832ed2eed26116dafb2f5c5f977e1341",
+        "is_verified": false,
+        "line_number": 835
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "85caec8d352770d092317299afa348764d129ed5",
+        "is_verified": false,
+        "line_number": 838
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "12de1cdad03b08d04f2c666eb0cb5f1234b496e5",
+        "is_verified": false,
+        "line_number": 841
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
+        "is_verified": false,
+        "line_number": 845
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3e3522c83d724aa4133ee6bb6d627e4390be31a5",
         "is_verified": false,
         "line_number": 848
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ebfd0dc170295e67df4d796db25987963ca97e61",
+        "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
+        "is_verified": false,
+        "line_number": 851
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
+        "is_verified": false,
+        "line_number": 855
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
+        "is_verified": false,
+        "line_number": 858
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b02f181ddfb118185d3fc0be3cac545e7bec4ce5",
         "is_verified": false,
         "line_number": 861
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d146f31752027f19751d396a49a62010d97f6b80",
+        "hashed_secret": "8936283936d833d3fcbc796b612c493f0fc5a2a4",
+        "is_verified": false,
+        "line_number": 864
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "5bace6024c7051eb7a1cb1e37f7b9985e533a42e",
+        "is_verified": false,
+        "line_number": 867
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
         "is_verified": false,
         "line_number": 870
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9966b38a797edc23680e66fcde5a3aa022979a2a",
+        "is_verified": false,
+        "line_number": 873
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6ff531666abb24912d9fae3b91bcd05a49330c9f",
+        "is_verified": false,
+        "line_number": 886
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
+        "is_verified": false,
+        "line_number": 899
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bf694b5dac75776f7b55aa5663e0d0cef3fb1812",
+        "is_verified": false,
+        "line_number": 912
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8d4a8977dae9d6867dfcdbeb6417d6ab8461534a",
+        "is_verified": false,
+        "line_number": 925
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "eea334ce67d119e127ca2448c8fd8cb9328a5664",
+        "is_verified": false,
+        "line_number": 938
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "693ab2239e3a31d3b1052c6976a8429dd406e7ea",
+        "is_verified": false,
+        "line_number": 951
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "09b6aade4800e313c2bbed96548c4f2dce507168",
+        "is_verified": false,
+        "line_number": 964
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e9d53eedf607b11c3ef44b8c6ff18958ad146340",
+        "is_verified": false,
+        "line_number": 977
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d918d00bcbccaae92cf19b1396e6a7513de61bed",
+        "is_verified": false,
+        "line_number": 986
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "32322bcf00299724296af3309bc033b969f83bf6",
+        "is_verified": false,
+        "line_number": 999
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "76bb59906af53dcb878b807d5817d5edb7ae390f",
+        "is_verified": false,
+        "line_number": 1008
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ebfd0dc170295e67df4d796db25987963ca97e61",
+        "is_verified": false,
+        "line_number": 1021
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d146f31752027f19751d396a49a62010d97f6b80",
+        "is_verified": false,
+        "line_number": 1030
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cfe0bd31a00a41920823c76d517fe7d062e5337c",
         "is_verified": false,
-        "line_number": 883
+        "line_number": 1043
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b16b457c3af8581fda0aad82df8a4d25d56b72f5",
         "is_verified": false,
-        "line_number": 896
+        "line_number": 1056
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "28f0a338a11c78c8b77f06940e97fd7242579d23",
         "is_verified": false,
-        "line_number": 905
+        "line_number": 1065
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c33800ed8ec5106a1d053238f1a22ffad0f7efb9",
         "is_verified": false,
-        "line_number": 918
+        "line_number": 1078
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bfb1d8f7fcfdc3951f2a407606332dd0561ea889",
         "is_verified": false,
-        "line_number": 931
+        "line_number": 1091
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "34ad22b7134e6220790e6f8cb7f7325b72b0ac78",
         "is_verified": false,
-        "line_number": 940
+        "line_number": 1100
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "380016634dca8718e45627a3e887a33cfdbf9583",
         "is_verified": false,
-        "line_number": 953
+        "line_number": 1113
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e12e619cf0949f9f48db809f6ba8abe6d9c49b47",
         "is_verified": false,
-        "line_number": 966
+        "line_number": 1126
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "afb54bbdc2c452025423e4b999636e1168c9e9c8",
         "is_verified": false,
-        "line_number": 979
+        "line_number": 1139
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d5af9fbde70bf119125bc5280e31def9cfc5d2e4",
         "is_verified": false,
-        "line_number": 992
+        "line_number": 1152
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c93cfee749f39a6731bd90e3b8bfc1c2f39dd0bb",
         "is_verified": false,
-        "line_number": 1005
+        "line_number": 1165
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "384119563704c0a0c154cfa3a7fb2f1b6e403e4d",
         "is_verified": false,
-        "line_number": 1018
+        "line_number": 1178
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a9799e49f2382f864dab19d97df038fbcc760f79",
         "is_verified": false,
-        "line_number": 1031
+        "line_number": 1191
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "237858a86350af1517b45ec07878dc64d875b973",
         "is_verified": false,
-        "line_number": 1044
+        "line_number": 1204
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8016aea1098ddd8ebc4bfdebfe91e36d1f038306",
         "is_verified": false,
-        "line_number": 1057
+        "line_number": 1217
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ebafd7b99e26904ea5a3ba20abd17c2d7b913663",
         "is_verified": false,
-        "line_number": 1070
+        "line_number": 1230
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "938a7b1d49a0c2692666797b3a00b607ba1912d4",
         "is_verified": false,
-        "line_number": 1083
+        "line_number": 1243
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5cdcee5a29292be13235b5cbddc6aa392d2b23f1",
         "is_verified": false,
-        "line_number": 1096
+        "line_number": 1256
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d157cd2020faa83a1b672bfd2233a417b17e42d8",
         "is_verified": false,
-        "line_number": 1109
+        "line_number": 1269
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7de62fb92f302a3b6974835f839eb53033647499",
         "is_verified": false,
-        "line_number": 1122
+        "line_number": 1282
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "929a3372bee6ce841a9f65cc9edebf68210e5fd7",
         "is_verified": false,
-        "line_number": 1135
+        "line_number": 1295
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c8400bcab54bbc669cbe44b013fd300ec181ae04",
         "is_verified": false,
-        "line_number": 1148
+        "line_number": 1308
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4ca19d51441ee1c7bae4a9ed5f5d5e5befcbbb2e",
         "is_verified": false,
-        "line_number": 1157
+        "line_number": 1317
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "249cc7d6ea282d76f5efff9fb4ed6ed5d3058d08",
         "is_verified": false,
-        "line_number": 1170
+        "line_number": 1330
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "324131826dfbc742fce8c6746a676f16efc315cd",
         "is_verified": false,
-        "line_number": 1183
+        "line_number": 1343
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2b0f34d995e245b329cd153a0eeee34dfc4266c7",
         "is_verified": false,
-        "line_number": 1196
+        "line_number": 1356
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "446546bba84a6355c159d0562c57c670fea13d34",
         "is_verified": false,
-        "line_number": 1209
+        "line_number": 1369
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7d3f1b8d6e4eca6f79dbaf3cdfbca069ab37a6e8",
         "is_verified": false,
-        "line_number": 1222
+        "line_number": 1382
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1cfc669b4a91926a20a0c195e64a33fddfc28636",
         "is_verified": false,
-        "line_number": 1231
+        "line_number": 1391
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "089409fd943a2fb3a5a50b4725a4c96a16bc5d19",
         "is_verified": false,
-        "line_number": 1240
+        "line_number": 1400
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ccf9afc9b093a34274214374a841c68216c23105",
         "is_verified": false,
-        "line_number": 1249
+        "line_number": 1409
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "29094c26e288b5cebbc5262a1996e29057328f1f",
         "is_verified": false,
-        "line_number": 1258
+        "line_number": 1418
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "95362ad9b076707c159a81577f1695dea0ed2eb3",
         "is_verified": false,
-        "line_number": 1267
+        "line_number": 1427
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8cd02e410a9ff591baae8fb0b142f31b91ef9ec0",
         "is_verified": false,
-        "line_number": 1276
+        "line_number": 1436
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9dfea0993e072e2f30d0a2cac0b7bda5f6e7f980",
         "is_verified": false,
-        "line_number": 1285
+        "line_number": 1445
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "15432d91ade7f228054c5d23ceac8d48711a5853",
         "is_verified": false,
-        "line_number": 1294
+        "line_number": 1454
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69ae791ca6d7814550c0af06cc57217e4e1388ea",
         "is_verified": false,
-        "line_number": 1303
+        "line_number": 1463
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "647690124fbe1ff7811211b1ec8ec14c9800de35",
         "is_verified": false,
-        "line_number": 1316
+        "line_number": 1476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "74e24729da4c61e671c60aba5212f1641cba2b44",
         "is_verified": false,
-        "line_number": 1319
+        "line_number": 1479
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c27db3e7ad28966571d6aaab4221024adc120e28",
+        "hashed_secret": "80baf094c85a8b814390721f28df4426791950e2",
         "is_verified": false,
-        "line_number": 1322
+        "line_number": 1482
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cb81edbb9a250cdf42587eda7d50adffe56a7716",
+        "hashed_secret": "19c871b99cc8a8066f7c372cc935250508cdbf7e",
         "is_verified": false,
-        "line_number": 1327
+        "line_number": 1487
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f9f4f9a8a71949a267f7074f07957384044256e0",
-        "is_verified": false,
-        "line_number": 1332
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a0ac680a8a2a9c7fcd76e3eeec5a56dab25d4a75",
-        "is_verified": false,
-        "line_number": 1337
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2d95d1eb2675da08784f1d264e8062451750e573",
-        "is_verified": false,
-        "line_number": 1342
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cbcf851cc0fc469cc6cff29b7bda4823770c2b24",
-        "is_verified": false,
-        "line_number": 1347
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2d76c5b618e06f5060b1251c229bd66068993d79",
-        "is_verified": false,
-        "line_number": 1352
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "082cca8a1791200f5bd827df1a5af92478fff517",
-        "is_verified": false,
-        "line_number": 1357
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b6d5ddb597b029ec693970060b7472ba0087d057",
-        "is_verified": false,
-        "line_number": 1362
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "873d6e91bd90150ae8600b7982720e47b7f7726d",
-        "is_verified": false,
-        "line_number": 1367
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6f1d9b493a63d420310b699d2006de1511097c5f",
-        "is_verified": false,
-        "line_number": 1372
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "600319d21b284b959a238f481057f93ad9ace156",
-        "is_verified": false,
-        "line_number": 1377
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "78de47b110ddd28c06f356dd9fe919eea04f695c",
-        "is_verified": false,
-        "line_number": 1382
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "641123fc06f217d65b231317ec413f3d82eb2c82",
-        "is_verified": false,
-        "line_number": 1387
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0e5b7b2230b86973ef30c42ca73f8c2f1866c66f",
-        "is_verified": false,
-        "line_number": 1392
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7b234ae165a5fb9ee72ebe505cb033dd78cb1427",
-        "is_verified": false,
-        "line_number": 1397
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e15d714dc0e3fadc34fa31dd2f93530b7527c224",
-        "is_verified": false,
-        "line_number": 1402
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ef4ebf89aac434354ef0e549b6562a590b38c1ef",
-        "is_verified": false,
-        "line_number": 1407
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "847a90be5433925b78d97121266c6f28d10cad46",
-        "is_verified": false,
-        "line_number": 1412
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "efd91b12240e7d0966f7683a6632b899efb02060",
-        "is_verified": false,
-        "line_number": 1417
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "eabb7b1469793615d2e481374e7fa0bf1b797331",
-        "is_verified": false,
-        "line_number": 1422
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "98e39cf276637483701c7f4ad34f04b82b23db00",
-        "is_verified": false,
-        "line_number": 1427
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6d8b4508131713ab295b7a5d54bf9f650ea7de3a",
-        "is_verified": false,
-        "line_number": 1432
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "94a6793bad904a80d0d830ad166c5e110ef0e0ce",
-        "is_verified": false,
-        "line_number": 1435
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3d1f976e7e48c3331bf146ef86537fa84641cfc9",
-        "is_verified": false,
-        "line_number": 1438
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0fa45a368d9cb3af91d18980d7bf1359cf6906ec",
-        "is_verified": false,
-        "line_number": 1441
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6ef4e98430a48ebe9da892571cc9116aa215d65a",
-        "is_verified": false,
-        "line_number": 1444
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d6f51dd81a5a11e1838c695ca672e145b4b574a3",
-        "is_verified": false,
-        "line_number": 1447
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "883ffddc90f7adb0b2e567704e0e2e7c9ce772e7",
-        "is_verified": false,
-        "line_number": 1450
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d2f4b057fca06c6c685b9e0d0d347ae4b62d81d0",
-        "is_verified": false,
-        "line_number": 1453
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6ddcd40970d7a4c79ad7d97ba287276315fbecf8",
-        "is_verified": false,
-        "line_number": 1456
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8189f85216ce53283b06100728bfbdb6ba39349b",
-        "is_verified": false,
-        "line_number": 1462
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a9ee872ba47547763ea96bf68935b1ca511b1eea",
-        "is_verified": false,
-        "line_number": 1468
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3c54a53db895c2d2db105419004c4ca9c0669b9b",
-        "is_verified": false,
-        "line_number": 1474
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "73eabe01b3849af9f5b7d09fd682e29988078e03",
-        "is_verified": false,
-        "line_number": 1480
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ed4a714216e6fb3df582608436c971c64d16eb21",
-        "is_verified": false,
-        "line_number": 1486
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e32262f842014867b6d05de1e8b54be38c774f41",
+        "hashed_secret": "66eb29da9a96876a8e1b7fefb901f6b582e14b33",
         "is_verified": false,
         "line_number": 1492
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "07938cb535ebe7164be475b659157d8722bf6cd8",
+        "hashed_secret": "5ce412f8142bfcc2b11a375e1c91a3a54ca8c0ae",
         "is_verified": false,
-        "line_number": 1498
+        "line_number": 1497
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ed8125bef66b019626fce657625f4dc098ce2d5b",
+        "hashed_secret": "3e47d4fda361e2553fee0d1f059b0b135fcce98f",
         "is_verified": false,
-        "line_number": 1504
+        "line_number": 1502
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "efc4995969632bacd704a7dcaaae920f586c0ebd",
+        "hashed_secret": "7ce2d9200e0e41b2ee19b821089b6a95a39bc509",
         "is_verified": false,
-        "line_number": 1510
+        "line_number": 1507
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "91280ce4aa21694239d39cbf79a7ec38c75b6241",
+        "hashed_secret": "b68b16505cf49c5f3cb98af1b54893a1a79565a5",
+        "is_verified": false,
+        "line_number": 1512
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b41be781eb3b0c4750e39d09dcdd6a3494f1f357",
+        "is_verified": false,
+        "line_number": 1517
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f99a49bc745631a8b7085149e82a79811d9bac8c",
         "is_verified": false,
         "line_number": 1522
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "108599ae85386bc9ebd90603fc1fa7332c44ab2a",
+        "hashed_secret": "edeb02a82bcc0b255ba89f276f37e4091792f4fe",
         "is_verified": false,
-        "line_number": 1528
+        "line_number": 1527
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e92548ca579280bcf908b3e719e347cad2f3b34e",
+        "hashed_secret": "7691f9054b1626b357caca8a9f8e83eb8ac84def",
         "is_verified": false,
-        "line_number": 1534
+        "line_number": 1532
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9c93b5a77413b84c8aab30d61269c5d5af893e84",
+        "hashed_secret": "b77dfdeb5ffee23aff3b2f97ff640802ad415a3c",
         "is_verified": false,
-        "line_number": 1538
+        "line_number": 1537
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0e6b9c5945acf85ec45d0577171ab4adaf465f3c",
+        "hashed_secret": "94297c922da678a24c4fc963af0da51d961d8fe5",
         "is_verified": false,
-        "line_number": 1543
+        "line_number": 1542
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4e6b6006b2f7a6f7794756349cd40cce5e779432",
+        "hashed_secret": "1f0eb8fb4434346c68f359042c9fc254c1c46be6",
         "is_verified": false,
-        "line_number": 1548
+        "line_number": 1547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "be64cf9169891b8b4bef36e06bd7defef6a1ec7a",
+        "hashed_secret": "5d67ae5d1c2f8a622e078f0d8d16670619aa561e",
         "is_verified": false,
-        "line_number": 1551
+        "line_number": 1552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "50a0bc6ed4bd15cd54a9ef3e744d9e367b1ee0b2",
+        "hashed_secret": "fee3efd07b8abcb9d734d6f324253508f7501156",
         "is_verified": false,
-        "line_number": 1563
+        "line_number": 1557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f161e2b04f8faa8a514998b846300c0e52e3dde4",
+        "hashed_secret": "1380cb2734346cc00e41eb54cdd94860f4859e2c",
         "is_verified": false,
-        "line_number": 1566
+        "line_number": 1562
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "21a255bacab0430cf0dd455985ab2ac363136cdb",
+        "hashed_secret": "5aea3dce81939048d287d7761e40642490194d09",
         "is_verified": false,
-        "line_number": 1569
+        "line_number": 1567
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "146791ae0b950340d17de1ffbda27158f3e8be1c",
+        "hashed_secret": "11487ba85b40245c0bb0e34846085b8714439652",
         "is_verified": false,
         "line_number": 1572
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f0223109c42a9c75ee9a859c7897c6ab5c6eec49",
+        "hashed_secret": "9f2824e8182be80a655c1164a0c7d043abe0b2e8",
         "is_verified": false,
-        "line_number": 1575
+        "line_number": 1577
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7fa226273d5a0d1b9abf45e18909943d7007d1b2",
+        "hashed_secret": "87bb0e1e3669074c5cda58de04798789e0eda61d",
         "is_verified": false,
-        "line_number": 1578
+        "line_number": 1582
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a4fa4a2da187e1f35991b7e3c5bb8c58b148ca09",
-        "is_verified": false,
-        "line_number": 1581
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9ed4ec5e13d0127aa4390ca0ea6bb0c58955813c",
-        "is_verified": false,
-        "line_number": 1584
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "11c08054a654f517144d206c95a7ef3d1d1d8a10",
+        "hashed_secret": "5423261b835b9649ae476fc59e957f6cb03b2369",
         "is_verified": false,
         "line_number": 1587
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "202814e7e7561774522a76c66bc453965f59e0be",
+        "hashed_secret": "c62e701dc37732b77d24e97d4676d597a1e1ce41",
         "is_verified": false,
-        "line_number": 1590
+        "line_number": 1592
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "82e45680d983d798b7eb9ff070d2f4a2ed1a6aca",
+        "hashed_secret": "58a0c6f04ab904bada0f96e79f61f7633b8e8554",
         "is_verified": false,
-        "line_number": 1593
+        "line_number": 1597
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b5e25bc274fcd2e0765d9719b5778385a09cd417",
-        "is_verified": false,
-        "line_number": 1596
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8da85cbce59e3d1311b8d83fca1c8e3d0e67fa36",
-        "is_verified": false,
-        "line_number": 1599
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "681fe2f819d566ee80576d71374fbe2ea25e9856",
+        "hashed_secret": "5ac63bbb4857e2c672bef90951ed012b5e1a3099",
         "is_verified": false,
         "line_number": 1602
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8e2775553add62306a4a60d9730357d20cc8eca4",
+        "hashed_secret": "6d8b4508131713ab295b7a5d54bf9f650ea7de3a",
         "is_verified": false,
-        "line_number": 1605
+        "line_number": 1607
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "13451c46d267093367a4021d60ecfd01b589453b",
+        "hashed_secret": "94a6793bad904a80d0d830ad166c5e110ef0e0ce",
         "is_verified": false,
-        "line_number": 1608
+        "line_number": 1610
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f10d8e7fd0a2d47dd1c517aee23443ac47c8d8f1",
+        "hashed_secret": "3d1f976e7e48c3331bf146ef86537fa84641cfc9",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1613
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7ad8f7855e91cd8b06becd442f47ac889e45b05c",
+        "hashed_secret": "0fa45a368d9cb3af91d18980d7bf1359cf6906ec",
         "is_verified": false,
-        "line_number": 1614
+        "line_number": 1616
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "709ec0fb00ecef1e145c61d0227084baf41695ee",
+        "hashed_secret": "6ef4e98430a48ebe9da892571cc9116aa215d65a",
         "is_verified": false,
-        "line_number": 1617
+        "line_number": 1619
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "679c86b8b8102c4f59f082861f7153bbff1c302f",
+        "hashed_secret": "d6f51dd81a5a11e1838c695ca672e145b4b574a3",
         "is_verified": false,
-        "line_number": 1620
+        "line_number": 1622
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4edd46fe0024d509c40f64891b8de2c1b8648486",
+        "hashed_secret": "883ffddc90f7adb0b2e567704e0e2e7c9ce772e7",
         "is_verified": false,
-        "line_number": 1623
+        "line_number": 1625
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fdaf5cc2f4c70e89a63da173c9094c23a2bdb447",
+        "hashed_secret": "d2f4b057fca06c6c685b9e0d0d347ae4b62d81d0",
         "is_verified": false,
-        "line_number": 1626
+        "line_number": 1628
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "085598568dc4c356ab7aa2d37615bf3e5ac9a276",
+        "hashed_secret": "6ddcd40970d7a4c79ad7d97ba287276315fbecf8",
         "is_verified": false,
-        "line_number": 1629
+        "line_number": 1631
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "accccbc920e9b8894c9e249476a9d23a102dc51d",
+        "hashed_secret": "8189f85216ce53283b06100728bfbdb6ba39349b",
         "is_verified": false,
-        "line_number": 1632
+        "line_number": 1637
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7863f0eb9ee850d4cf1b3ba4790af627e46e8bf5",
+        "hashed_secret": "a9ee872ba47547763ea96bf68935b1ca511b1eea",
         "is_verified": false,
-        "line_number": 1635
+        "line_number": 1643
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "19026bc85cda2b7c02ab2100543274cdfc87e235",
+        "hashed_secret": "3c54a53db895c2d2db105419004c4ca9c0669b9b",
         "is_verified": false,
-        "line_number": 1638
+        "line_number": 1649
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ba993e097570d247c652bcc7a4a09a1433017c7f",
+        "hashed_secret": "73eabe01b3849af9f5b7d09fd682e29988078e03",
         "is_verified": false,
-        "line_number": 1641
+        "line_number": 1655
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7cfe93f5ecad2c99e18b38dc4eac2dd238115509",
+        "hashed_secret": "ed4a714216e6fb3df582608436c971c64d16eb21",
         "is_verified": false,
-        "line_number": 1644
+        "line_number": 1661
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8f7078b941b0c422ed7d2b71a8eeec584b26c85d",
+        "hashed_secret": "e32262f842014867b6d05de1e8b54be38c774f41",
         "is_verified": false,
-        "line_number": 1647
+        "line_number": 1667
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b70e5de9bb948e7b610f4630c08929d8c6de5a7c",
+        "hashed_secret": "07938cb535ebe7164be475b659157d8722bf6cd8",
         "is_verified": false,
-        "line_number": 1650
+        "line_number": 1673
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0e06cd30bd4605847a6bd20556de8927f1aca0e9",
+        "hashed_secret": "ed8125bef66b019626fce657625f4dc098ce2d5b",
         "is_verified": false,
-        "line_number": 1653
+        "line_number": 1679
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8736366f5f93c2407716a62c93c8cd885c50f08d",
+        "hashed_secret": "efc4995969632bacd704a7dcaaae920f586c0ebd",
         "is_verified": false,
-        "line_number": 1656
+        "line_number": 1685
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ee467c04a4f38d68d8a5a5fc367c934838e079da",
+        "hashed_secret": "91280ce4aa21694239d39cbf79a7ec38c75b6241",
         "is_verified": false,
-        "line_number": 1659
+        "line_number": 1697
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8e1c627ad3f1025cf9f784e000700389c751dc4b",
+        "hashed_secret": "108599ae85386bc9ebd90603fc1fa7332c44ab2a",
         "is_verified": false,
-        "line_number": 1662
+        "line_number": 1703
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9cae8ddf51d712b423a6341beaac3b89acffbaa5",
+        "hashed_secret": "e92548ca579280bcf908b3e719e347cad2f3b34e",
         "is_verified": false,
-        "line_number": 1665
+        "line_number": 1709
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1c5d9085d8ef508b7ecd2db78f089e94de0c9d02",
-        "is_verified": false,
-        "line_number": 1668
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "04c5e75f80231932968bcbf67513faeb9e5b9420",
-        "is_verified": false,
-        "line_number": 1671
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6b919cede0677aa776671ba3483c972767adbe2c",
-        "is_verified": false,
-        "line_number": 1674
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "20bd9f1e82cc3f128d819fa043e4d8be985394dc",
-        "is_verified": false,
-        "line_number": 1677
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
-        "is_verified": false,
-        "line_number": 1680
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "690f1d4ee2519d4f62cc3a3f62d6fef48b892c39",
-        "is_verified": false,
-        "line_number": 1683
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4b612bba8446c6122505b596782ba4ce168218fb",
-        "is_verified": false,
-        "line_number": 1686
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d4df5977f20f1c07ccc57574a509a2adc7ec8088",
-        "is_verified": false,
-        "line_number": 1689
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0c6d336e7fe34021c50d0363181bd912cbcd9078",
-        "is_verified": false,
-        "line_number": 1692
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c554198dff4b9d03e4fed41f9f60ab0f15c68690",
-        "is_verified": false,
-        "line_number": 1695
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7820059c8d2e0898ad244e8da132f1db709cf138",
-        "is_verified": false,
-        "line_number": 1698
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fc6d3459aaf555ec080d434621b4841e09a28e49",
-        "is_verified": false,
-        "line_number": 1701
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7a734bb2b865c8090c992da81fb88b47856d04e3",
-        "is_verified": false,
-        "line_number": 1704
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "63b336193044808bbd0e235fac5f6aeadb612a52",
-        "is_verified": false,
-        "line_number": 1707
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7101ee1815ba5a49e02c80e26cd1a18095cf9e33",
-        "is_verified": false,
-        "line_number": 1710
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d1939c5f12b77cb2d3825f0a77efbaf342eda9f1",
+        "hashed_secret": "9c93b5a77413b84c8aab30d61269c5d5af893e84",
         "is_verified": false,
         "line_number": 1713
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6fe0c1d94e5bf7af28db976667694b068fbbcfa9",
+        "hashed_secret": "0e6b9c5945acf85ec45d0577171ab4adaf465f3c",
         "is_verified": false,
-        "line_number": 1716
+        "line_number": 1718
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "edad7a64109ca056f9c0c36e70e45ff24f5942b9",
+        "hashed_secret": "4e6b6006b2f7a6f7794756349cd40cce5e779432",
         "is_verified": false,
-        "line_number": 1719
+        "line_number": 1723
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5fbe6af214ff086a2f24d714dc93bbd14cfaf2c6",
+        "hashed_secret": "be64cf9169891b8b4bef36e06bd7defef6a1ec7a",
         "is_verified": false,
-        "line_number": 1722
+        "line_number": 1726
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1c61cb6e4dfe89ea9932b7b0c795158b3609ea90",
+        "hashed_secret": "50a0bc6ed4bd15cd54a9ef3e744d9e367b1ee0b2",
         "is_verified": false,
-        "line_number": 1727
+        "line_number": 1738
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2dba792b1970249e25fea7bd4bef1339031bb5c9",
+        "hashed_secret": "f161e2b04f8faa8a514998b846300c0e52e3dde4",
         "is_verified": false,
-        "line_number": 1730
+        "line_number": 1741
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9474365f899688921c3d377f365fcbbc1c136978",
+        "hashed_secret": "21a255bacab0430cf0dd455985ab2ac363136cdb",
         "is_verified": false,
-        "line_number": 1733
+        "line_number": 1744
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "33cf77c3b3f57d57c513ec1e83df5d7af1f35099",
+        "hashed_secret": "146791ae0b950340d17de1ffbda27158f3e8be1c",
         "is_verified": false,
-        "line_number": 1736
+        "line_number": 1747
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5f411c7e6073b67aca1c9043e3e952322dc21d46",
+        "hashed_secret": "f0223109c42a9c75ee9a859c7897c6ab5c6eec49",
         "is_verified": false,
-        "line_number": 1739
+        "line_number": 1750
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "82e9b248cdbed101133fcd9229632ccd3e00d416",
+        "hashed_secret": "7fa226273d5a0d1b9abf45e18909943d7007d1b2",
         "is_verified": false,
-        "line_number": 1742
+        "line_number": 1753
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3b3fdad4fa80ae8473e0304fe52e0cd272ef2a11",
+        "hashed_secret": "a4fa4a2da187e1f35991b7e3c5bb8c58b148ca09",
         "is_verified": false,
-        "line_number": 1745
+        "line_number": 1756
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d9ea4a68b988aca799b7049c045c05d7f5eb839a",
+        "hashed_secret": "9ed4ec5e13d0127aa4390ca0ea6bb0c58955813c",
         "is_verified": false,
-        "line_number": 1748
+        "line_number": 1759
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2ed50d4e930408285a9712d6c970fd7e8c46fb69",
+        "hashed_secret": "11c08054a654f517144d206c95a7ef3d1d1d8a10",
         "is_verified": false,
-        "line_number": 1751
+        "line_number": 1762
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "91e7edf530f3d2c573744a030a47764481de24a7",
+        "hashed_secret": "202814e7e7561774522a76c66bc453965f59e0be",
         "is_verified": false,
-        "line_number": 1757
+        "line_number": 1765
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9ca427b833d97f9025e7605a3a2dd0d081aaa0ee",
+        "hashed_secret": "82e45680d983d798b7eb9ff070d2f4a2ed1a6aca",
         "is_verified": false,
-        "line_number": 1760
+        "line_number": 1768
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "75d6aaa3b4dd6c53985c9f5ffabf6cfdb6a426dc",
+        "hashed_secret": "b5e25bc274fcd2e0765d9719b5778385a09cd417",
         "is_verified": false,
         "line_number": 1771
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d71cf22228db367a0643e25b4aaf35bda34fa9bb",
+        "hashed_secret": "8da85cbce59e3d1311b8d83fca1c8e3d0e67fa36",
         "is_verified": false,
         "line_number": 1774
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e82ef1986dfaf305bd0539f0c8413683c0b20ff1",
+        "hashed_secret": "681fe2f819d566ee80576d71374fbe2ea25e9856",
         "is_verified": false,
         "line_number": 1777
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0414462c3828bc4fc16caaed47eeda948fe9cee7",
+        "hashed_secret": "8e2775553add62306a4a60d9730357d20cc8eca4",
         "is_verified": false,
         "line_number": 1780
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "538f066bf5a6b310644be407205a05e28a8dc8fd",
+        "hashed_secret": "13451c46d267093367a4021d60ecfd01b589453b",
         "is_verified": false,
         "line_number": 1783
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "89c31fa0d6838019bc29341b448d189aa712045b",
+        "hashed_secret": "f10d8e7fd0a2d47dd1c517aee23443ac47c8d8f1",
         "is_verified": false,
         "line_number": 1786
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "30dff6e111c0a18b53cc71da853bac87f73a816c",
+        "hashed_secret": "7ad8f7855e91cd8b06becd442f47ac889e45b05c",
         "is_verified": false,
-        "line_number": 1790
+        "line_number": 1789
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2b3802837ce1f8f46c325534f20f111ce94b7862",
+        "hashed_secret": "709ec0fb00ecef1e145c61d0227084baf41695ee",
+        "is_verified": false,
+        "line_number": 1792
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "679c86b8b8102c4f59f082861f7153bbff1c302f",
         "is_verified": false,
         "line_number": 1795
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f3b53a220b75e239a29648a2022162f032abbc8d",
+        "hashed_secret": "4edd46fe0024d509c40f64891b8de2c1b8648486",
         "is_verified": false,
         "line_number": 1798
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "93aa782c4df17b6541e0e372240cf197066bab69",
+        "hashed_secret": "fdaf5cc2f4c70e89a63da173c9094c23a2bdb447",
         "is_verified": false,
-        "line_number": 1802
+        "line_number": 1801
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
+        "hashed_secret": "085598568dc4c356ab7aa2d37615bf3e5ac9a276",
         "is_verified": false,
-        "line_number": 1805
+        "line_number": 1804
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "599395997c127ee79a03df8cbc9c57d9c5c4b39b",
+        "hashed_secret": "accccbc920e9b8894c9e249476a9d23a102dc51d",
         "is_verified": false,
-        "line_number": 1809
+        "line_number": 1807
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4f9ca841aeb6fd5f8e147135c04c7351eda0145e",
+        "hashed_secret": "7863f0eb9ee850d4cf1b3ba4790af627e46e8bf5",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1810
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "08123a72eda5582ac678d0f7a9c55d7ab9ed22fd",
+        "hashed_secret": "19026bc85cda2b7c02ab2100543274cdfc87e235",
+        "is_verified": false,
+        "line_number": 1813
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ba993e097570d247c652bcc7a4a09a1433017c7f",
+        "is_verified": false,
+        "line_number": 1816
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7cfe93f5ecad2c99e18b38dc4eac2dd238115509",
         "is_verified": false,
         "line_number": 1819
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ce4084b9c766db59d8efac9df450a2ec42ca3639",
+        "hashed_secret": "8f7078b941b0c422ed7d2b71a8eeec584b26c85d",
         "is_verified": false,
         "line_number": 1822
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "eb1c10c194ba834a6b271d11ed0e87417a434c06",
+        "hashed_secret": "b70e5de9bb948e7b610f4630c08929d8c6de5a7c",
         "is_verified": false,
         "line_number": 1825
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3165aeec45a531bca4274a9a152b2091b99bf960",
+        "hashed_secret": "0e06cd30bd4605847a6bd20556de8927f1aca0e9",
         "is_verified": false,
-        "line_number": 1829
+        "line_number": 1828
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e0c6298d33fd17530dfd7b996b7f0c0f67bc7f08",
+        "hashed_secret": "8736366f5f93c2407716a62c93c8cd885c50f08d",
         "is_verified": false,
-        "line_number": 1833
+        "line_number": 1831
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c61921cb03b0d17c9d180fa6d2d765269458f5e9",
+        "hashed_secret": "ee467c04a4f38d68d8a5a5fc367c934838e079da",
         "is_verified": false,
-        "line_number": 1838
+        "line_number": 1834
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c56c76bc828483f5553df346fb2eaa6e3e6c4bba",
+        "hashed_secret": "8e1c627ad3f1025cf9f784e000700389c751dc4b",
         "is_verified": false,
-        "line_number": 1842
+        "line_number": 1837
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "09ce1f68022d542bd4b111b2e648b4261e7ea537",
+        "hashed_secret": "9cae8ddf51d712b423a6341beaac3b89acffbaa5",
+        "is_verified": false,
+        "line_number": 1840
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1c5d9085d8ef508b7ecd2db78f089e94de0c9d02",
+        "is_verified": false,
+        "line_number": 1843
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "04c5e75f80231932968bcbf67513faeb9e5b9420",
         "is_verified": false,
         "line_number": 1846
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f4713ff6d6ebe4c91eabb4abaa4fff79252287e2",
+        "hashed_secret": "6b919cede0677aa776671ba3483c972767adbe2c",
         "is_verified": false,
-        "line_number": 1850
+        "line_number": 1849
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bb4753386dbead02652a11ec39d51f531400f795",
+        "hashed_secret": "20bd9f1e82cc3f128d819fa043e4d8be985394dc",
         "is_verified": false,
-        "line_number": 1854
+        "line_number": 1852
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "76ee5d005d74b14bfcf949a0b24859a1ad611560",
+        "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
         "is_verified": false,
-        "line_number": 1857
+        "line_number": 1855
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5620b727309eb0585715c051b3f1ad6560879967",
+        "hashed_secret": "690f1d4ee2519d4f62cc3a3f62d6fef48b892c39",
         "is_verified": false,
-        "line_number": 1860
+        "line_number": 1858
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "838860fad35a9938ad0c45978737609b9acf2e86",
+        "hashed_secret": "4b612bba8446c6122505b596782ba4ce168218fb",
+        "is_verified": false,
+        "line_number": 1861
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d4df5977f20f1c07ccc57574a509a2adc7ec8088",
         "is_verified": false,
         "line_number": 1864
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a3c954fbcfcb5b1c2087ff1e1a592601ebd0d7f0",
+        "hashed_secret": "0c6d336e7fe34021c50d0363181bd912cbcd9078",
         "is_verified": false,
         "line_number": 1867
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "40b0aef4115b2c0ecffb2e2c74e6e67d01b84997",
+        "hashed_secret": "c554198dff4b9d03e4fed41f9f60ab0f15c68690",
         "is_verified": false,
         "line_number": 1870
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ed1668ceb8dc6aaabcb871317d585a5edf44c0bf",
+        "hashed_secret": "7820059c8d2e0898ad244e8da132f1db709cf138",
         "is_verified": false,
         "line_number": 1873
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "198c12bf7d9e91116c7bf79acfb5d26023bddca6",
+        "hashed_secret": "fc6d3459aaf555ec080d434621b4841e09a28e49",
         "is_verified": false,
         "line_number": 1876
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c6132446174fb42fadfe75a8183f305a65574678",
+        "hashed_secret": "7a734bb2b865c8090c992da81fb88b47856d04e3",
         "is_verified": false,
-        "line_number": 1880
+        "line_number": 1879
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2e168b2e58d3797e1b488abbf415e9b90b3149b9",
+        "hashed_secret": "63b336193044808bbd0e235fac5f6aeadb612a52",
+        "is_verified": false,
+        "line_number": 1882
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7101ee1815ba5a49e02c80e26cd1a18095cf9e33",
         "is_verified": false,
         "line_number": 1885
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d2e1dec5724740f83adc172b07e15342b3eac984",
+        "hashed_secret": "d1939c5f12b77cb2d3825f0a77efbaf342eda9f1",
         "is_verified": false,
         "line_number": 1888
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ed8dee19a6f2946f9f7ee7c5f7d9652daa9064bb",
+        "hashed_secret": "6fe0c1d94e5bf7af28db976667694b068fbbcfa9",
         "is_verified": false,
-        "line_number": 1892
+        "line_number": 1891
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5974b42acc3c558a08c734a45a10785534b5d382",
+        "hashed_secret": "edad7a64109ca056f9c0c36e70e45ff24f5942b9",
         "is_verified": false,
-        "line_number": 1895
+        "line_number": 1894
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "91384b25fae910b4fb3847c70b40b3f56f68346d",
+        "hashed_secret": "5fbe6af214ff086a2f24d714dc93bbd14cfaf2c6",
         "is_verified": false,
-        "line_number": 1899
+        "line_number": 1897
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "83307cb75a4a44ba528f4a0aefcec2a8018dc6d8",
+        "hashed_secret": "1c61cb6e4dfe89ea9932b7b0c795158b3609ea90",
+        "is_verified": false,
+        "line_number": 1902
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2dba792b1970249e25fea7bd4bef1339031bb5c9",
         "is_verified": false,
         "line_number": 1905
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "67df7123f1b2c84bf066bc3e6fb4834aa022e20b",
+        "hashed_secret": "9474365f899688921c3d377f365fcbbc1c136978",
         "is_verified": false,
-        "line_number": 1909
+        "line_number": 1908
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9e4bcb8df7a5f802322234f792347caa3c9240fa",
+        "hashed_secret": "33cf77c3b3f57d57c513ec1e83df5d7af1f35099",
         "is_verified": false,
-        "line_number": 1912
+        "line_number": 1911
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4e737227d8a4ff0c87704616f4c0c457fa6bf550",
+        "hashed_secret": "5f411c7e6073b67aca1c9043e3e952322dc21d46",
         "is_verified": false,
-        "line_number": 1916
+        "line_number": 1914
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f4c8d4909804be929ee867133fe4b0810002c8a4",
+        "hashed_secret": "82e9b248cdbed101133fcd9229632ccd3e00d416",
+        "is_verified": false,
+        "line_number": 1917
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3b3fdad4fa80ae8473e0304fe52e0cd272ef2a11",
         "is_verified": false,
         "line_number": 1920
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "272e5b30f1b718ab85c40a90f9022aea7f6a506f",
+        "hashed_secret": "d9ea4a68b988aca799b7049c045c05d7f5eb839a",
         "is_verified": false,
         "line_number": 1923
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f52956fa7c317746fde250d0f4e54d6115252cd4",
+        "hashed_secret": "2ed50d4e930408285a9712d6c970fd7e8c46fb69",
         "is_verified": false,
         "line_number": 1926
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7f104c1c37e525afe159a7b26fe2782992e9c896",
+        "hashed_secret": "91e7edf530f3d2c573744a030a47764481de24a7",
         "is_verified": false,
-        "line_number": 1930
+        "line_number": 1932
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
+        "hashed_secret": "9ca427b833d97f9025e7605a3a2dd0d081aaa0ee",
         "is_verified": false,
-        "line_number": 1934
+        "line_number": 1935
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0126e1c37886a7ddcb7c64bbaeba26fbc7350779",
+        "hashed_secret": "75d6aaa3b4dd6c53985c9f5ffabf6cfdb6a426dc",
         "is_verified": false,
-        "line_number": 1937
+        "line_number": 1946
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5c41822f05c632ab0ea5a83c2153196107e7e48a",
+        "hashed_secret": "d71cf22228db367a0643e25b4aaf35bda34fa9bb",
         "is_verified": false,
-        "line_number": 1940
+        "line_number": 1949
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a31efbdaf429353b1a681cdf75f1c3b091709994",
+        "hashed_secret": "e82ef1986dfaf305bd0539f0c8413683c0b20ff1",
         "is_verified": false,
-        "line_number": 1944
+        "line_number": 1952
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e42422d60a4e1b1bb29b9f097fa9e00cca9e310d",
-        "is_verified": false,
-        "line_number": 1947
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "99cb01a94916f4b1a4cd94d7c866029a9e3734ee",
-        "is_verified": false,
-        "line_number": 1950
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8b6e3d167f9d34dcb4fb60d814fdfd4b8f850b7b",
+        "hashed_secret": "0414462c3828bc4fc16caaed47eeda948fe9cee7",
         "is_verified": false,
         "line_number": 1955
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "031e74c3988d3aa3530d827ec994228035f76b24",
+        "hashed_secret": "538f066bf5a6b310644be407205a05e28a8dc8fd",
         "is_verified": false,
         "line_number": 1958
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "79380c4284060f6d92599b5075ab5dff98980365",
+        "hashed_secret": "89c31fa0d6838019bc29341b448d189aa712045b",
         "is_verified": false,
-        "line_number": 1963
+        "line_number": 1961
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c3882e02b815ece615eb89b61d2d0f1f1fb1a13f",
+        "hashed_secret": "30dff6e111c0a18b53cc71da853bac87f73a816c",
         "is_verified": false,
-        "line_number": 1968
+        "line_number": 1965
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "33717c29c8aea5e30d94507cde08e926103815fd",
+        "hashed_secret": "2b3802837ce1f8f46c325534f20f111ce94b7862",
         "is_verified": false,
-        "line_number": 1972
+        "line_number": 1970
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cb160c0fa67ad1904f0157c03f6acdc648e14c29",
+        "hashed_secret": "f3b53a220b75e239a29648a2022162f032abbc8d",
         "is_verified": false,
-        "line_number": 1975
+        "line_number": 1973
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0ec2f9ddae6f2c51a32b569bfa0990b62144a32f",
+        "hashed_secret": "93aa782c4df17b6541e0e372240cf197066bab69",
         "is_verified": false,
-        "line_number": 1979
+        "line_number": 1977
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "63031c941f273d524122c445b6cc52855ba4d80a",
+        "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
         "is_verified": false,
-        "line_number": 1983
+        "line_number": 1980
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8ffcdf73a059a511bd1a984ff94a6ec26a450da6",
+        "hashed_secret": "599395997c127ee79a03df8cbc9c57d9c5c4b39b",
+        "is_verified": false,
+        "line_number": 1984
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4f9ca841aeb6fd5f8e147135c04c7351eda0145e",
         "is_verified": false,
         "line_number": 1987
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d7df03c04920f03f01f8b40c877fc25a56a9ee19",
+        "hashed_secret": "8cbe1e980a8cbfc595a57726c1596e3338554dd1",
         "is_verified": false,
-        "line_number": 1991
+        "line_number": 1994
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "475f81349c63a4a4aa6ee2b034a6670b65d2605d",
+        "hashed_secret": "ce4084b9c766db59d8efac9df450a2ec42ca3639",
         "is_verified": false,
-        "line_number": 1995
+        "line_number": 1997
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3e5ccf3a7d5ed1538ce0524b55a6faf09287516d",
+        "hashed_secret": "eb1c10c194ba834a6b271d11ed0e87417a434c06",
         "is_verified": false,
-        "line_number": 1999
+        "line_number": 2000
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "981618e70764ccff965f43b2608479f4b38c4b6b",
+        "hashed_secret": "3165aeec45a531bca4274a9a152b2091b99bf960",
         "is_verified": false,
-        "line_number": 2003
+        "line_number": 2004
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "79fe65c8553fd143f3323cfe6925f719b6ef230a",
+        "hashed_secret": "e0c6298d33fd17530dfd7b996b7f0c0f67bc7f08",
         "is_verified": false,
-        "line_number": 2007
+        "line_number": 2008
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1258c27ec2d20bcd3b0691e4a621c6167bf14166",
+        "hashed_secret": "c61921cb03b0d17c9d180fa6d2d765269458f5e9",
         "is_verified": false,
-        "line_number": 2011
+        "line_number": 2013
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fb3a4cac7ed22b602c677b19d442df41415484d9",
+        "hashed_secret": "c56c76bc828483f5553df346fb2eaa6e3e6c4bba",
         "is_verified": false,
-        "line_number": 2016
+        "line_number": 2017
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7584292a0d73867cf2a975ae71b7a6b4b7a18fd3",
+        "hashed_secret": "09ce1f68022d542bd4b111b2e648b4261e7ea537",
         "is_verified": false,
-        "line_number": 2020
+        "line_number": 2021
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bfee3969cf314fd46a4a98c127c6e88dbe47a7d7",
+        "hashed_secret": "f4713ff6d6ebe4c91eabb4abaa4fff79252287e2",
         "is_verified": false,
-        "line_number": 2024
+        "line_number": 2025
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0648eae8d4fb533908b8beb9eace610b07c305e3",
+        "hashed_secret": "bb4753386dbead02652a11ec39d51f531400f795",
         "is_verified": false,
-        "line_number": 2028
+        "line_number": 2029
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a810ae8365e0609794326708e32a66311accf6d9",
+        "hashed_secret": "76ee5d005d74b14bfcf949a0b24859a1ad611560",
         "is_verified": false,
         "line_number": 2032
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "84dc5f27bdddf193db7112ded0e6e62aae32c563",
+        "hashed_secret": "5620b727309eb0585715c051b3f1ad6560879967",
         "is_verified": false,
-        "line_number": 2036
+        "line_number": 2035
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "91f1d14f5c42035f88d9326dba1ab34a390de763",
+        "hashed_secret": "838860fad35a9938ad0c45978737609b9acf2e86",
         "is_verified": false,
-        "line_number": 2040
+        "line_number": 2039
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9b88197199e0708719546e337507aa489f482035",
+        "hashed_secret": "a3c954fbcfcb5b1c2087ff1e1a592601ebd0d7f0",
         "is_verified": false,
-        "line_number": 2044
+        "line_number": 2042
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e646475e64142c1d1d386b89728a88e637d76ffd",
+        "hashed_secret": "40b0aef4115b2c0ecffb2e2c74e6e67d01b84997",
         "is_verified": false,
-        "line_number": 2047
+        "line_number": 2045
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e4a8eca0bfd89c5c73b1d9b70d7fdc1d63a742c3",
+        "hashed_secret": "ed1668ceb8dc6aaabcb871317d585a5edf44c0bf",
+        "is_verified": false,
+        "line_number": 2048
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "198c12bf7d9e91116c7bf79acfb5d26023bddca6",
         "is_verified": false,
         "line_number": 2051
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9c2024aeeebab8de7dbec46172c80d3c0977b9fd",
+        "hashed_secret": "c6132446174fb42fadfe75a8183f305a65574678",
         "is_verified": false,
         "line_number": 2055
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d3110b2f096c13b4a05286099f37adb93dc0d98b",
+        "hashed_secret": "2e168b2e58d3797e1b488abbf415e9b90b3149b9",
         "is_verified": false,
-        "line_number": 2059
+        "line_number": 2060
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "26abf1dd2ca59fe7be9eaa38dca3da206ea420ac",
+        "hashed_secret": "d2e1dec5724740f83adc172b07e15342b3eac984",
         "is_verified": false,
         "line_number": 2063
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "20691e3175c231d4ed0a46b007016f11088622ce",
+        "hashed_secret": "ed8dee19a6f2946f9f7ee7c5f7d9652daa9064bb",
         "is_verified": false,
-        "line_number": 2066
+        "line_number": 2067
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bf1d6785d64c573898e6f002e2118df315a3fe8c",
+        "hashed_secret": "5974b42acc3c558a08c734a45a10785534b5d382",
         "is_verified": false,
         "line_number": 2070
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "615111c758dde1f8cbc15fe1e655610e0da5a417",
+        "hashed_secret": "91384b25fae910b4fb3847c70b40b3f56f68346d",
         "is_verified": false,
         "line_number": 2074
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b839d6cce2e9faca3fe3db9e2571dabe23cf4987",
+        "hashed_secret": "83307cb75a4a44ba528f4a0aefcec2a8018dc6d8",
         "is_verified": false,
-        "line_number": 2078
+        "line_number": 2080
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4f6023e8bc49fa69a236a0745192387ee698473f",
+        "hashed_secret": "67df7123f1b2c84bf066bc3e6fb4834aa022e20b",
         "is_verified": false,
-        "line_number": 2081
+        "line_number": 2084
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "20a2abce8debc1b0a34db8be8bdec759c03470a5",
+        "hashed_secret": "9e4bcb8df7a5f802322234f792347caa3c9240fa",
         "is_verified": false,
-        "line_number": 2085
+        "line_number": 2087
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "64a1e3b17b6fe4e477f67655772adfb9a8f0685b",
+        "hashed_secret": "4e737227d8a4ff0c87704616f4c0c457fa6bf550",
         "is_verified": false,
-        "line_number": 2089
+        "line_number": 2091
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5d5ad5db83b23a384f6c1d4cd98ff642d93831a2",
+        "hashed_secret": "f4c8d4909804be929ee867133fe4b0810002c8a4",
         "is_verified": false,
-        "line_number": 2093
+        "line_number": 2095
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2cc8a665f17064b10ab9135e29345f537879c7e0",
+        "hashed_secret": "272e5b30f1b718ab85c40a90f9022aea7f6a506f",
         "is_verified": false,
-        "line_number": 2097
+        "line_number": 2098
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "080264b10431d7bffd7d0bf2c2e0d27edc640ff4",
+        "hashed_secret": "f52956fa7c317746fde250d0f4e54d6115252cd4",
         "is_verified": false,
-        "line_number": 2103
+        "line_number": 2101
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "131593dcab4a460dbebcff8d0a12d821b3edd402",
+        "hashed_secret": "7f104c1c37e525afe159a7b26fe2782992e9c896",
         "is_verified": false,
-        "line_number": 2107
+        "line_number": 2105
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d961319d454caee7b7f6e7790a39f87e1719f043",
+        "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
         "is_verified": false,
-        "line_number": 2111
+        "line_number": 2109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7f3dc3eeca35d4b8f640fea69abdb9249637616d",
+        "hashed_secret": "0126e1c37886a7ddcb7c64bbaeba26fbc7350779",
         "is_verified": false,
-        "line_number": 2114
+        "line_number": 2112
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f5f75498bedb2fb320a0c96529ed808e8032ab29",
+        "hashed_secret": "5c41822f05c632ab0ea5a83c2153196107e7e48a",
         "is_verified": false,
-        "line_number": 2117
+        "line_number": 2115
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b579cc9cf455d76457ba6922c763d7fcc554f34f",
+        "hashed_secret": "a31efbdaf429353b1a681cdf75f1c3b091709994",
         "is_verified": false,
-        "line_number": 2120
+        "line_number": 2119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
+        "hashed_secret": "e42422d60a4e1b1bb29b9f097fa9e00cca9e310d",
         "is_verified": false,
-        "line_number": 2123
+        "line_number": 2122
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
+        "hashed_secret": "99cb01a94916f4b1a4cd94d7c866029a9e3734ee",
         "is_verified": false,
-        "line_number": 2131
+        "line_number": 2125
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "62823fccad763959e8805be597bbafe575f4809e",
+        "hashed_secret": "8b6e3d167f9d34dcb4fb60d814fdfd4b8f850b7b",
         "is_verified": false,
-        "line_number": 2140
+        "line_number": 2130
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4907d411dbbc15d87a3134352a52127406248740",
+        "hashed_secret": "031e74c3988d3aa3530d827ec994228035f76b24",
+        "is_verified": false,
+        "line_number": 2133
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "79380c4284060f6d92599b5075ab5dff98980365",
+        "is_verified": false,
+        "line_number": 2138
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c3882e02b815ece615eb89b61d2d0f1f1fb1a13f",
         "is_verified": false,
         "line_number": 2143
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b4a9257558064dbd957e726d9d25d81b97837009",
+        "hashed_secret": "33717c29c8aea5e30d94507cde08e926103815fd",
         "is_verified": false,
-        "line_number": 2146
+        "line_number": 2147
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "30032b6b21b6761f545cb3a442477208db30131f",
+        "hashed_secret": "cb160c0fa67ad1904f0157c03f6acdc648e14c29",
         "is_verified": false,
         "line_number": 2150
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6263b491d8e05bc0d6bc8b232c3a06044db2232c",
+        "hashed_secret": "0ec2f9ddae6f2c51a32b569bfa0990b62144a32f",
         "is_verified": false,
-        "line_number": 2153
+        "line_number": 2154
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c5deff9c59d0e0419952da44431546620804d70e",
+        "hashed_secret": "63031c941f273d524122c445b6cc52855ba4d80a",
         "is_verified": false,
-        "line_number": 2157
+        "line_number": 2158
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
+        "hashed_secret": "8ffcdf73a059a511bd1a984ff94a6ec26a450da6",
         "is_verified": false,
-        "line_number": 2161
+        "line_number": 2162
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "572b5e5253ab86ef535e76d891766cc1a17ee6a5",
+        "hashed_secret": "d7df03c04920f03f01f8b40c877fc25a56a9ee19",
         "is_verified": false,
-        "line_number": 2165
+        "line_number": 2166
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
+        "hashed_secret": "475f81349c63a4a4aa6ee2b034a6670b65d2605d",
         "is_verified": false,
-        "line_number": 2169
+        "line_number": 2170
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6cfffbcd76530450de1b86aa6a25cf6232ba9dc8",
+        "hashed_secret": "3e5ccf3a7d5ed1538ce0524b55a6faf09287516d",
         "is_verified": false,
-        "line_number": 2173
+        "line_number": 2174
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dbaf8941e1df2a6cc0af186ab8c288162c591d75",
+        "hashed_secret": "981618e70764ccff965f43b2608479f4b38c4b6b",
         "is_verified": false,
-        "line_number": 2176
+        "line_number": 2178
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4f8baa628528be69e02276f95e83eed38d79feaa",
-        "is_verified": false,
-        "line_number": 2179
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4283f0269f12ac2e491ed22c9d47171a9d48fd48",
+        "hashed_secret": "79fe65c8553fd143f3323cfe6925f719b6ef230a",
         "is_verified": false,
         "line_number": 2182
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "79119667cecad09809c34832b1f2b650b5ccded7",
+        "hashed_secret": "1258c27ec2d20bcd3b0691e4a621c6167bf14166",
         "is_verified": false,
-        "line_number": 2185
+        "line_number": 2186
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4d50b55900617c8d08097c03af9667c135c1fc24",
+        "hashed_secret": "fb3a4cac7ed22b602c677b19d442df41415484d9",
         "is_verified": false,
-        "line_number": 2189
+        "line_number": 2191
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7e0a63b607dc49438c5ff4a0db3931dbc0285dbc",
-        "is_verified": false,
-        "line_number": 2192
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2d3b72d498880ee7aac85ecfde3d52435c5ab00b",
+        "hashed_secret": "7584292a0d73867cf2a975ae71b7a6b4b7a18fd3",
         "is_verified": false,
         "line_number": 2195
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1f1fa592047caa0501169ce68034b590a04e268c",
+        "hashed_secret": "bfee3969cf314fd46a4a98c127c6e88dbe47a7d7",
         "is_verified": false,
-        "line_number": 2200
+        "line_number": 2199
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "140d86931cb07f9ba23e4b7ef112f5304e16aab1",
+        "hashed_secret": "0648eae8d4fb533908b8beb9eace610b07c305e3",
         "is_verified": false,
-        "line_number": 2205
+        "line_number": 2203
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "21194e556cc6a23d3903b12189b0b9cd1050f2e5",
+        "hashed_secret": "a810ae8365e0609794326708e32a66311accf6d9",
         "is_verified": false,
-        "line_number": 2208
+        "line_number": 2207
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2a0c5c01be780688ae4faf4a3e1cb6e48c50dc23",
+        "hashed_secret": "84dc5f27bdddf193db7112ded0e6e62aae32c563",
         "is_verified": false,
-        "line_number": 2212
+        "line_number": 2211
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ff8047908af26a3f03fd3ac26aaa2f5d7ae75e5a",
+        "hashed_secret": "91f1d14f5c42035f88d9326dba1ab34a390de763",
         "is_verified": false,
-        "line_number": 2216
+        "line_number": 2215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b32dc7581438839b3baa8cbb9dafcc80017588ea",
+        "hashed_secret": "9b88197199e0708719546e337507aa489f482035",
         "is_verified": false,
-        "line_number": 2220
+        "line_number": 2219
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6d1db030d72c8b03fd95eaeb0266255402f70df5",
+        "hashed_secret": "e646475e64142c1d1d386b89728a88e637d76ffd",
         "is_verified": false,
-        "line_number": 2224
+        "line_number": 2222
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cf75ddffbc923b32123e91e069fbcb97ac39c4d9",
+        "hashed_secret": "e4a8eca0bfd89c5c73b1d9b70d7fdc1d63a742c3",
         "is_verified": false,
-        "line_number": 2228
+        "line_number": 2226
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d076e5a9f2245bcedf234f70abb7fa41d4d9f0dc",
+        "hashed_secret": "9c2024aeeebab8de7dbec46172c80d3c0977b9fd",
         "is_verified": false,
-        "line_number": 2232
+        "line_number": 2230
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "417a00b911e0b72a50a597cb7c4c70885c55516e",
+        "hashed_secret": "d3110b2f096c13b4a05286099f37adb93dc0d98b",
         "is_verified": false,
-        "line_number": 2235
+        "line_number": 2234
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e28508e3ee2cfadee43ef9cfb9bb3b5d5d8ef5af",
+        "hashed_secret": "26abf1dd2ca59fe7be9eaa38dca3da206ea420ac",
         "is_verified": false,
-        "line_number": 2239
+        "line_number": 2238
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "508e13818451655db815826a00fe15a68b7481b7",
+        "hashed_secret": "20691e3175c231d4ed0a46b007016f11088622ce",
         "is_verified": false,
-        "line_number": 2243
+        "line_number": 2241
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0a78ed1531f1e89e2dde49c07aee4199c0837078",
+        "hashed_secret": "bf1d6785d64c573898e6f002e2118df315a3fe8c",
         "is_verified": false,
-        "line_number": 2248
+        "line_number": 2245
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3cb8e7a708267691af8530db673cae1ad0578392",
+        "hashed_secret": "615111c758dde1f8cbc15fe1e655610e0da5a417",
+        "is_verified": false,
+        "line_number": 2249
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "b839d6cce2e9faca3fe3db9e2571dabe23cf4987",
         "is_verified": false,
         "line_number": 2253
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cc0394ae9ff7278ac1f8ba8305e06627798ae34b",
+        "hashed_secret": "4f6023e8bc49fa69a236a0745192387ee698473f",
         "is_verified": false,
-        "line_number": 2257
+        "line_number": 2256
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9282693a1a1e5f8fadcc1617db1f7a097db8429b",
+        "hashed_secret": "20a2abce8debc1b0a34db8be8bdec759c03470a5",
         "is_verified": false,
         "line_number": 2260
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "aabf9f3ccb818057fe7b956cb56b9c011e002839",
+        "hashed_secret": "64a1e3b17b6fe4e477f67655772adfb9a8f0685b",
         "is_verified": false,
         "line_number": 2264
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8ab0d03e8d34c76769e2494c72290c441ebcc749",
+        "hashed_secret": "5d5ad5db83b23a384f6c1d4cd98ff642d93831a2",
         "is_verified": false,
-        "line_number": 2267
+        "line_number": 2268
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
+        "hashed_secret": "2cc8a665f17064b10ab9135e29345f537879c7e0",
         "is_verified": false,
-        "line_number": 2270
+        "line_number": 2272
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3b9b4f0e0dc452a1ab51ff9a7e649171b0b54a70",
+        "hashed_secret": "080264b10431d7bffd7d0bf2c2e0d27edc640ff4",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "03d6fb388dd1b185129b14221f7127715822ece6",
+        "hashed_secret": "131593dcab4a460dbebcff8d0a12d821b3edd402",
         "is_verified": false,
-        "line_number": 2277
+        "line_number": 2282
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "72e5393170ee8c03f5ebad63e044422989818b95",
+        "hashed_secret": "d961319d454caee7b7f6e7790a39f87e1719f043",
         "is_verified": false,
-        "line_number": 2280
+        "line_number": 2286
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "030fd33a7a056f197ef34c37cfcb73f470df0612",
+        "hashed_secret": "7f3dc3eeca35d4b8f640fea69abdb9249637616d",
         "is_verified": false,
-        "line_number": 2284
+        "line_number": 2289
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "12ecf39948e93968cea583a27ce0f918a02e3878",
+        "hashed_secret": "f5f75498bedb2fb320a0c96529ed808e8032ab29",
         "is_verified": false,
-        "line_number": 2288
+        "line_number": 2292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
+        "hashed_secret": "b579cc9cf455d76457ba6922c763d7fcc554f34f",
         "is_verified": false,
-        "line_number": 2291
+        "line_number": 2295
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4a0c4d36aaf8c5cea9b9087156ac34f7da104dc4",
-        "is_verified": false,
-        "line_number": 2294
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
+        "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
         "is_verified": false,
         "line_number": 2298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "608a2b22745aedb3dff3a03315104b03db3bc18a",
+        "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
         "is_verified": false,
-        "line_number": 2307
+        "line_number": 2306
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "40e7076fc8fd248af67cfc317346eafeafa8f7a9",
+        "hashed_secret": "62823fccad763959e8805be597bbafe575f4809e",
         "is_verified": false,
-        "line_number": 2311
+        "line_number": 2315
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8880036dd8f74c6cd85075c896ff8851627a0919",
+        "hashed_secret": "4907d411dbbc15d87a3134352a52127406248740",
         "is_verified": false,
-        "line_number": 2320
+        "line_number": 2318
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dc9a2ba629796d6ef3323496eb952461f964e115",
+        "hashed_secret": "b4a9257558064dbd957e726d9d25d81b97837009",
         "is_verified": false,
-        "line_number": 2324
+        "line_number": 2321
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c53a12e9d025e4a06da4523b43f6538eedd9d04f",
+        "hashed_secret": "30032b6b21b6761f545cb3a442477208db30131f",
+        "is_verified": false,
+        "line_number": 2325
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6263b491d8e05bc0d6bc8b232c3a06044db2232c",
         "is_verified": false,
         "line_number": 2328
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "154f11f3be7925e9dfc95d61ccd19f9d367bd090",
+        "hashed_secret": "c5deff9c59d0e0419952da44431546620804d70e",
         "is_verified": false,
-        "line_number": 2331
+        "line_number": 2332
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "67e1630eef767c17f165bed8793abff78d5d53ac",
+        "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
         "is_verified": false,
-        "line_number": 2345
+        "line_number": 2336
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
+        "hashed_secret": "572b5e5253ab86ef535e76d891766cc1a17ee6a5",
         "is_verified": false,
-        "line_number": 2349
+        "line_number": 2340
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e7f54899a1654525fbfb1d8c3ac44d632f655af1",
+        "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
+        "is_verified": false,
+        "line_number": 2344
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6cfffbcd76530450de1b86aa6a25cf6232ba9dc8",
+        "is_verified": false,
+        "line_number": 2348
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "dbaf8941e1df2a6cc0af186ab8c288162c591d75",
+        "is_verified": false,
+        "line_number": 2351
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4f8baa628528be69e02276f95e83eed38d79feaa",
         "is_verified": false,
         "line_number": 2354
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
+        "hashed_secret": "09a4d7d429043289e839863c3ba9cafda1e09192",
         "is_verified": false,
         "line_number": 2357
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "70239f714086644424a812bb19cd8af853b4fe93",
+        "hashed_secret": "79119667cecad09809c34832b1f2b650b5ccded7",
         "is_verified": false,
-        "line_number": 2361
+        "line_number": 2360
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4cd3a1b109eb67acf1557141e83880899d18eaea",
+        "hashed_secret": "4d50b55900617c8d08097c03af9667c135c1fc24",
         "is_verified": false,
-        "line_number": 2365
+        "line_number": 2364
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
+        "hashed_secret": "7e0a63b607dc49438c5ff4a0db3931dbc0285dbc",
         "is_verified": false,
-        "line_number": 2369
+        "line_number": 2367
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5a4d96497ba98531c9c36ced1d043fbd8c535eff",
+        "hashed_secret": "2d3b72d498880ee7aac85ecfde3d52435c5ab00b",
         "is_verified": false,
-        "line_number": 2373
+        "line_number": 2370
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ae324c1d6b29cddd2062229ca65d08baecc7789a",
+        "hashed_secret": "1f1fa592047caa0501169ce68034b590a04e268c",
         "is_verified": false,
-        "line_number": 2377
+        "line_number": 2375
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4d0e714a0f6a740c6b6b047cf9b513bf8ff4c898",
+        "hashed_secret": "140d86931cb07f9ba23e4b7ef112f5304e16aab1",
         "is_verified": false,
         "line_number": 2380
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "979e2a14e4576c62a9748d7466bfa7f4f3a0620d",
+        "hashed_secret": "21194e556cc6a23d3903b12189b0b9cd1050f2e5",
         "is_verified": false,
-        "line_number": 2384
+        "line_number": 2383
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
+        "hashed_secret": "2a0c5c01be780688ae4faf4a3e1cb6e48c50dc23",
         "is_verified": false,
-        "line_number": 2388
+        "line_number": 2387
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4bc048ef798be5bb613b48cf7e4602803fb1b709",
+        "hashed_secret": "ff8047908af26a3f03fd3ac26aaa2f5d7ae75e5a",
         "is_verified": false,
         "line_number": 2391
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0d97c7fe1c124e07eb8bba42a86419c083ba0591",
+        "hashed_secret": "b32dc7581438839b3baa8cbb9dafcc80017588ea",
         "is_verified": false,
-        "line_number": 2394
+        "line_number": 2395
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e07f2c68e0fe6abfac19da4e9dd0c81669de7078",
+        "hashed_secret": "6d1db030d72c8b03fd95eaeb0266255402f70df5",
         "is_verified": false,
-        "line_number": 2398
+        "line_number": 2399
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f52c08f63289414b8da2ea1271f68c9e1d6338ea",
+        "hashed_secret": "cf75ddffbc923b32123e91e069fbcb97ac39c4d9",
         "is_verified": false,
-        "line_number": 2402
+        "line_number": 2403
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9ac633e9766159806b447d7be2d84067548764f4",
+        "hashed_secret": "d076e5a9f2245bcedf234f70abb7fa41d4d9f0dc",
         "is_verified": false,
-        "line_number": 2406
+        "line_number": 2407
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fffff370595b6f4803e610b7519dbb1bb9923c8a",
+        "hashed_secret": "417a00b911e0b72a50a597cb7c4c70885c55516e",
         "is_verified": false,
-        "line_number": 2409
+        "line_number": 2410
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3300960d885e191e93efbb20d444a625bddcfe90",
+        "hashed_secret": "e28508e3ee2cfadee43ef9cfb9bb3b5d5d8ef5af",
         "is_verified": false,
-        "line_number": 2412
+        "line_number": 2414
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a0540a26c42e0189fb536e1a42e879429302f9a8",
-        "is_verified": false,
-        "line_number": 2415
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
+        "hashed_secret": "508e13818451655db815826a00fe15a68b7481b7",
         "is_verified": false,
         "line_number": 2418
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c73d5fe546a436b30bdec90b571803faa29161c0",
+        "hashed_secret": "0a78ed1531f1e89e2dde49c07aee4199c0837078",
         "is_verified": false,
-        "line_number": 2421
+        "line_number": 2423
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ecf82334d7607ee319ed50d5c868b73e18e07f8c",
+        "hashed_secret": "cab616f3cdb6eb3c372039eeae16f83314439923",
         "is_verified": false,
-        "line_number": 2424
+        "line_number": 2428
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6b480f88105d1d6f58deb5c93ce778e95daab763",
-        "is_verified": false,
-        "line_number": 2427
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
-        "is_verified": false,
-        "line_number": 2430
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "886470e65dd1f05934c64b6cefaf846f674a70e9",
+        "hashed_secret": "3cb8e7a708267691af8530db673cae1ad0578392",
         "is_verified": false,
         "line_number": 2433
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
+        "hashed_secret": "cc0394ae9ff7278ac1f8ba8305e06627798ae34b",
         "is_verified": false,
-        "line_number": 2436
+        "line_number": 2437
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
+        "hashed_secret": "9282693a1a1e5f8fadcc1617db1f7a097db8429b",
         "is_verified": false,
-        "line_number": 2439
+        "line_number": 2440
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4032d4dd08dc516a97cd96b4d161fd0dccb8b592",
+        "hashed_secret": "aabf9f3ccb818057fe7b956cb56b9c011e002839",
         "is_verified": false,
-        "line_number": 2442
+        "line_number": 2444
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d3063fb8878cd870d06706fb7de1fbf791b78dd8",
+        "hashed_secret": "8ab0d03e8d34c76769e2494c72290c441ebcc749",
         "is_verified": false,
-        "line_number": 2446
+        "line_number": 2447
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
+        "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
         "is_verified": false,
-        "line_number": 2449
+        "line_number": 2450
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "395c2fd7dd96691ca2f110afa91b51ffc6f26d97",
+        "hashed_secret": "3b9b4f0e0dc452a1ab51ff9a7e649171b0b54a70",
         "is_verified": false,
-        "line_number": 2452
+        "line_number": 2453
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ebf396301cd5f2bffdd5e7e25066a15ea189798d",
+        "hashed_secret": "03d6fb388dd1b185129b14221f7127715822ece6",
         "is_verified": false,
-        "line_number": 2455
+        "line_number": 2457
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3e6c18abd5b90c63da0bd8b4c0d3a142e3d5a83d",
+        "hashed_secret": "72e5393170ee8c03f5ebad63e044422989818b95",
         "is_verified": false,
-        "line_number": 2459
+        "line_number": 2460
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9cfd1c9ff642dd3f9093c2e68fda7b9daba943ca",
+        "hashed_secret": "030fd33a7a056f197ef34c37cfcb73f470df0612",
         "is_verified": false,
-        "line_number": 2463
+        "line_number": 2464
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
+        "hashed_secret": "12ecf39948e93968cea583a27ce0f918a02e3878",
         "is_verified": false,
-        "line_number": 2467
+        "line_number": 2468
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6c0b4cfc433a0c4567ffa56f081ab35a7e8b0bb5",
+        "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
         "is_verified": false,
-        "line_number": 2470
+        "line_number": 2471
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b339256107c4edc00f4a15bc9e8524893981ede2",
+        "hashed_secret": "4a0c4d36aaf8c5cea9b9087156ac34f7da104dc4",
         "is_verified": false,
-        "line_number": 2473
+        "line_number": 2474
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a0b8be6c9c901fe0b497f749b90ea1a7228d5621",
+        "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
         "is_verified": false,
-        "line_number": 2479
+        "line_number": 2478
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
+        "hashed_secret": "608a2b22745aedb3dff3a03315104b03db3bc18a",
         "is_verified": false,
-        "line_number": 2482
+        "line_number": 2487
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "89b283ab50bf537dfbd64a59830fb7dda89eb546",
+        "hashed_secret": "7c5e3c6fa20471b4957071b973791e5b70877322",
         "is_verified": false,
-        "line_number": 2486
+        "line_number": 2491
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
+        "hashed_secret": "6afa15e8edc16b7f6767c97ca8892b8602a2adfe",
         "is_verified": false,
-        "line_number": 2490
+        "line_number": 2500
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
+        "hashed_secret": "dc9a2ba629796d6ef3323496eb952461f964e115",
         "is_verified": false,
-        "line_number": 2493
+        "line_number": 2504
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
+        "hashed_secret": "c53a12e9d025e4a06da4523b43f6538eedd9d04f",
         "is_verified": false,
-        "line_number": 2496
+        "line_number": 2508
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
+        "hashed_secret": "154f11f3be7925e9dfc95d61ccd19f9d367bd090",
         "is_verified": false,
-        "line_number": 2499
+        "line_number": 2511
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
+        "hashed_secret": "67e1630eef767c17f165bed8793abff78d5d53ac",
         "is_verified": false,
-        "line_number": 2502
+        "line_number": 2525
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
+        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
         "is_verified": false,
-        "line_number": 2506
+        "line_number": 2529
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
+        "hashed_secret": "e7f54899a1654525fbfb1d8c3ac44d632f655af1",
         "is_verified": false,
-        "line_number": 2510
+        "line_number": 2534
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
-        "is_verified": false,
-        "line_number": 2513
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
-        "is_verified": false,
-        "line_number": 2518
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8de81592addca35790ac4952804d8bf7e97825a2",
-        "is_verified": false,
-        "line_number": 2523
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ea988cbd3d8b5e867a1b9205a31c22a0e677cc07",
-        "is_verified": false,
-        "line_number": 2527
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8271215bc0f8f3c777e34a26e08ac6f4b0643b46",
-        "is_verified": false,
-        "line_number": 2530
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e3aa848f78699e8fd784dde75cb72e3d31d89d0b",
-        "is_verified": false,
-        "line_number": 2533
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "424c32eeac514fcbcd69f564d4633bf29df3584c",
+        "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
         "is_verified": false,
         "line_number": 2537
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "55e984b8442729280aba3a65202556f31aa7ee2b",
+        "hashed_secret": "70239f714086644424a812bb19cd8af853b4fe93",
         "is_verified": false,
-        "line_number": 2540
+        "line_number": 2541
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "234449837ea82897a022123e9cef8c60b5700beb",
+        "hashed_secret": "4cd3a1b109eb67acf1557141e83880899d18eaea",
         "is_verified": false,
-        "line_number": 2543
+        "line_number": 2545
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "64cdfb16d3cf2dee4aec7722977bbcfd7f125dd1",
+        "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
         "is_verified": false,
         "line_number": 2549
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "24652ad480f103f15bb57964ecd71d5bb6e3cdc0",
+        "hashed_secret": "5a4d96497ba98531c9c36ced1d043fbd8c535eff",
         "is_verified": false,
-        "line_number": 2555
+        "line_number": 2553
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8f62546695ef43015b84686167d3cb5a959c5d56",
+        "hashed_secret": "ae324c1d6b29cddd2062229ca65d08baecc7789a",
         "is_verified": false,
-        "line_number": 2561
+        "line_number": 2557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d961d5c083c668941a0fc005f4f494117c275692",
+        "hashed_secret": "4d0e714a0f6a740c6b6b047cf9b513bf8ff4c898",
         "is_verified": false,
-        "line_number": 2567
+        "line_number": 2560
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1d3b7b58e55dda6205d88c114f2c7bd54c3a88b5",
+        "hashed_secret": "979e2a14e4576c62a9748d7466bfa7f4f3a0620d",
         "is_verified": false,
-        "line_number": 2573
+        "line_number": 2564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e49ff6eff7e9fef5776e75b90b4fe817511e3e21",
+        "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
         "is_verified": false,
-        "line_number": 2579
+        "line_number": 2568
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "06252eb36883aef1fa36bf426225f6b836e660da",
+        "hashed_secret": "4bc048ef798be5bb613b48cf7e4602803fb1b709",
         "is_verified": false,
-        "line_number": 2585
+        "line_number": 2571
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ced599fa36c18f07d6cd42c35691b91b1fbe428e",
+        "hashed_secret": "0d97c7fe1c124e07eb8bba42a86419c083ba0591",
         "is_verified": false,
-        "line_number": 2591
+        "line_number": 2574
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f3f7ebf5b129836f221b766a549bd87000295f12",
+        "hashed_secret": "e07f2c68e0fe6abfac19da4e9dd0c81669de7078",
         "is_verified": false,
-        "line_number": 2597
+        "line_number": 2578
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "25190a22b603f9ec8147fb0841a1388bf16a2f10",
+        "hashed_secret": "a171d831e5bb8b8dd823212d122109b84af8a0d9",
         "is_verified": false,
-        "line_number": 2603
+        "line_number": 2582
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8fd18f737f7036fe9e4886ce31dcacf15ffbb58d",
+        "hashed_secret": "9ac633e9766159806b447d7be2d84067548764f4",
+        "is_verified": false,
+        "line_number": 2586
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fffff370595b6f4803e610b7519dbb1bb9923c8a",
+        "is_verified": false,
+        "line_number": 2589
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3300960d885e191e93efbb20d444a625bddcfe90",
+        "is_verified": false,
+        "line_number": 2592
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a0540a26c42e0189fb536e1a42e879429302f9a8",
+        "is_verified": false,
+        "line_number": 2595
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
+        "is_verified": false,
+        "line_number": 2598
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c73d5fe546a436b30bdec90b571803faa29161c0",
+        "is_verified": false,
+        "line_number": 2601
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ecf82334d7607ee319ed50d5c868b73e18e07f8c",
+        "is_verified": false,
+        "line_number": 2604
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6b480f88105d1d6f58deb5c93ce778e95daab763",
         "is_verified": false,
         "line_number": 2607
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5cc20a5b047f98c3bdfc84b87d743bfb60f2947a",
+        "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
         "is_verified": false,
-        "line_number": 2611
+        "line_number": 2610
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e9fdc3025cd10bd8aa4508611e6b7b7a9d650a2c",
+        "hashed_secret": "886470e65dd1f05934c64b6cefaf846f674a70e9",
         "is_verified": false,
-        "line_number": 2614
+        "line_number": 2613
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
+        "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
         "is_verified": false,
-        "line_number": 2617
+        "line_number": 2616
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
+        "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
         "is_verified": false,
-        "line_number": 2620
+        "line_number": 2619
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "73bc28172456bad6166fd9a576eb52082dc4dd3c",
+        "hashed_secret": "4032d4dd08dc516a97cd96b4d161fd0dccb8b592",
         "is_verified": false,
-        "line_number": 2624
+        "line_number": 2622
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
+        "hashed_secret": "d3063fb8878cd870d06706fb7de1fbf791b78dd8",
         "is_verified": false,
-        "line_number": 2627
+        "line_number": 2626
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "13e23943c1cb3acb333b79f031e253eba14e19b0",
+        "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
         "is_verified": false,
-        "line_number": 2630
+        "line_number": 2629
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "93d26aba3b02b6b4cfc7f49abe2ae9c07fef0566",
+        "hashed_secret": "395c2fd7dd96691ca2f110afa91b51ffc6f26d97",
+        "is_verified": false,
+        "line_number": 2632
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ebf396301cd5f2bffdd5e7e25066a15ea189798d",
         "is_verified": false,
         "line_number": 2635
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cb5bf77fc0e159831c9d3ff288109c30f9a0f5e6",
+        "hashed_secret": "3e6c18abd5b90c63da0bd8b4c0d3a142e3d5a83d",
         "is_verified": false,
-        "line_number": 2640
+        "line_number": 2639
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
+        "hashed_secret": "9cfd1c9ff642dd3f9093c2e68fda7b9daba943ca",
         "is_verified": false,
         "line_number": 2643
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "89ef487bec97886dd937d3802746b4a6a7b18ebf",
+        "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
         "is_verified": false,
-        "line_number": 2646
+        "line_number": 2647
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "87ae5db459dbd9fe4157473b016ae5ff5ef0f4ed",
+        "hashed_secret": "6c0b4cfc433a0c4567ffa56f081ab35a7e8b0bb5",
         "is_verified": false,
-        "line_number": 2651
+        "line_number": 2650
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
+        "hashed_secret": "b339256107c4edc00f4a15bc9e8524893981ede2",
         "is_verified": false,
-        "line_number": 2655
+        "line_number": 2653
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bd6b0d8b6b1f3c582851ca1e5596cbb670883e54",
+        "hashed_secret": "a0b8be6c9c901fe0b497f749b90ea1a7228d5621",
         "is_verified": false,
-        "line_number": 2658
+        "line_number": 2659
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
+        "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
         "is_verified": false,
-        "line_number": 2661
+        "line_number": 2662
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
+        "hashed_secret": "89b283ab50bf537dfbd64a59830fb7dda89eb546",
         "is_verified": false,
-        "line_number": 2664
+        "line_number": 2666
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
-        "is_verified": false,
-        "line_number": 2667
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
+        "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
         "is_verified": false,
         "line_number": 2670
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
+        "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
         "is_verified": false,
         "line_number": 2673
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
+        "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
         "is_verified": false,
         "line_number": 2676
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3b13d0031f0062532c2653885b097a9721c95a86",
+        "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
         "is_verified": false,
         "line_number": 2679
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
+        "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
         "is_verified": false,
         "line_number": 2682
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
+        "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
         "is_verified": false,
-        "line_number": 2685
+        "line_number": 2686
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
+        "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
         "is_verified": false,
-        "line_number": 2688
+        "line_number": 2690
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
+        "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
         "is_verified": false,
-        "line_number": 2691
+        "line_number": 2693
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b9381a68b32516410cee735432800123389658cd",
+        "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
         "is_verified": false,
-        "line_number": 2694
+        "line_number": 2698
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
-        "is_verified": false,
-        "line_number": 2697
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
-        "is_verified": false,
-        "line_number": 2700
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d7c39664c403d1fecb3d1e330ad65a00bab67629",
+        "hashed_secret": "8de81592addca35790ac4952804d8bf7e97825a2",
         "is_verified": false,
         "line_number": 2703
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "33424d6062b147852810a1b4e7d5cd675caa3231",
+        "hashed_secret": "ea988cbd3d8b5e867a1b9205a31c22a0e677cc07",
         "is_verified": false,
         "line_number": 2707
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0661a6284527e94d3ac8b52324e219703276485b",
+        "hashed_secret": "8271215bc0f8f3c777e34a26e08ac6f4b0643b46",
         "is_verified": false,
         "line_number": 2710
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "22f475d09df2c53aa6332a6d7aa6ac7e2cc09481",
+        "hashed_secret": "e3aa848f78699e8fd784dde75cb72e3d31d89d0b",
         "is_verified": false,
         "line_number": 2713
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
+        "hashed_secret": "424c32eeac514fcbcd69f564d4633bf29df3584c",
         "is_verified": false,
         "line_number": 2717
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c42c0f2b427e93ec72f707573c0fcb5e4e191af4",
+        "hashed_secret": "55e984b8442729280aba3a65202556f31aa7ee2b",
         "is_verified": false,
         "line_number": 2720
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2883c8b2e73c93ec9c28c8a8e3077279894a3bcd",
+        "hashed_secret": "234449837ea82897a022123e9cef8c60b5700beb",
         "is_verified": false,
-        "line_number": 2730
+        "line_number": 2723
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2f6768b77ca0db905e677336b7ed115432d94d69",
+        "hashed_secret": "64cdfb16d3cf2dee4aec7722977bbcfd7f125dd1",
         "is_verified": false,
-        "line_number": 2739
+        "line_number": 2729
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
+        "hashed_secret": "24652ad480f103f15bb57964ecd71d5bb6e3cdc0",
         "is_verified": false,
-        "line_number": 2749
+        "line_number": 2735
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
+        "hashed_secret": "8f62546695ef43015b84686167d3cb5a959c5d56",
         "is_verified": false,
-        "line_number": 2752
+        "line_number": 2741
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
+        "hashed_secret": "d961d5c083c668941a0fc005f4f494117c275692",
         "is_verified": false,
-        "line_number": 2755
+        "line_number": 2747
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
+        "hashed_secret": "1d3b7b58e55dda6205d88c114f2c7bd54c3a88b5",
         "is_verified": false,
-        "line_number": 2758
+        "line_number": 2753
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
+        "hashed_secret": "e49ff6eff7e9fef5776e75b90b4fe817511e3e21",
         "is_verified": false,
-        "line_number": 2761
+        "line_number": 2759
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
+        "hashed_secret": "06252eb36883aef1fa36bf426225f6b836e660da",
         "is_verified": false,
-        "line_number": 2764
+        "line_number": 2765
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
+        "hashed_secret": "ced599fa36c18f07d6cd42c35691b91b1fbe428e",
         "is_verified": false,
-        "line_number": 2767
+        "line_number": 2771
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e3b8bd39c0d74b5489473733b30f2ff0c21beb55",
+        "hashed_secret": "f3f7ebf5b129836f221b766a549bd87000295f12",
         "is_verified": false,
-        "line_number": 2770
+        "line_number": 2777
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
+        "hashed_secret": "25190a22b603f9ec8147fb0841a1388bf16a2f10",
         "is_verified": false,
-        "line_number": 2773
+        "line_number": 2783
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
+        "hashed_secret": "8fd18f737f7036fe9e4886ce31dcacf15ffbb58d",
         "is_verified": false,
-        "line_number": 2776
+        "line_number": 2787
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
-        "is_verified": false,
-        "line_number": 2779
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
-        "is_verified": false,
-        "line_number": 2782
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
-        "is_verified": false,
-        "line_number": 2785
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
-        "is_verified": false,
-        "line_number": 2788
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
+        "hashed_secret": "af1761dddd338a777dabd8eb8f1ae8955205a116",
         "is_verified": false,
         "line_number": 2791
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
+        "hashed_secret": "2cb277435cb97d4859d0d0ae4d891a9f3cd17bef",
         "is_verified": false,
         "line_number": 2794
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
+        "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
         "is_verified": false,
         "line_number": 2797
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
+        "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
         "is_verified": false,
         "line_number": 2800
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
+        "hashed_secret": "73bc28172456bad6166fd9a576eb52082dc4dd3c",
         "is_verified": false,
-        "line_number": 2803
+        "line_number": 2804
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
+        "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
         "is_verified": false,
-        "line_number": 2806
+        "line_number": 2807
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
+        "hashed_secret": "13e23943c1cb3acb333b79f031e253eba14e19b0",
         "is_verified": false,
-        "line_number": 2809
+        "line_number": 2810
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
-        "is_verified": false,
-        "line_number": 2812
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
+        "hashed_secret": "93d26aba3b02b6b4cfc7f49abe2ae9c07fef0566",
         "is_verified": false,
         "line_number": 2815
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
+        "hashed_secret": "cb5bf77fc0e159831c9d3ff288109c30f9a0f5e6",
         "is_verified": false,
-        "line_number": 2818
+        "line_number": 2820
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
+        "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
         "is_verified": false,
-        "line_number": 2821
+        "line_number": 2823
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
+        "hashed_secret": "89ef487bec97886dd937d3802746b4a6a7b18ebf",
         "is_verified": false,
-        "line_number": 2824
+        "line_number": 2826
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
+        "hashed_secret": "87ae5db459dbd9fe4157473b016ae5ff5ef0f4ed",
         "is_verified": false,
-        "line_number": 2827
+        "line_number": 2831
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
+        "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
         "is_verified": false,
-        "line_number": 2830
+        "line_number": 2835
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "838abb1331a160bdd441c25a2a2d44332ee8694b",
+        "hashed_secret": "bd6b0d8b6b1f3c582851ca1e5596cbb670883e54",
         "is_verified": false,
-        "line_number": 2833
+        "line_number": 2838
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e6525dbd438fc8858b0d56c59d164f403792ba1e",
-        "is_verified": false,
-        "line_number": 2837
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5c270f653b2fcd5b7c700b53f8543df4147a4aba",
+        "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
         "is_verified": false,
         "line_number": 2841
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0430ef838f88b8c253f36d7c2c5e9da6b30310b7",
+        "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
         "is_verified": false,
-        "line_number": 2846
+        "line_number": 2844
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1560a9e5a2cb0315745d4a4936af7518beb680e7",
+        "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
+        "is_verified": false,
+        "line_number": 2847
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
         "is_verified": false,
         "line_number": 2850
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "143743528e3b9b96aaf60f7aec6c318be5e54a99",
+        "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
         "is_verified": false,
-        "line_number": 2854
+        "line_number": 2853
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "90de41bb645eb912a3dcfbf357a4d329707ba620",
+        "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
         "is_verified": false,
-        "line_number": 2857
+        "line_number": 2856
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2718c296599ffc1e7d35452180a0ca84429f3565",
+        "hashed_secret": "3b13d0031f0062532c2653885b097a9721c95a86",
         "is_verified": false,
-        "line_number": 2860
+        "line_number": 2859
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d1538c9c6f5e959070b379c89558393edcf64c0d",
+        "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
         "is_verified": false,
-        "line_number": 2863
+        "line_number": 2862
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9a2e9779fa026f10b01762c6db4beb39bbf28531",
+        "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
         "is_verified": false,
-        "line_number": 2866
+        "line_number": 2865
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "612b70ad4343adbb09a9cacc2fd28d7a2eae9313",
+        "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
         "is_verified": false,
-        "line_number": 2869
+        "line_number": 2868
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
+        "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
         "is_verified": false,
-        "line_number": 2872
+        "line_number": 2871
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
+        "hashed_secret": "a43d82b1bb02a76982f03708a4c77d9717f5f5c1",
         "is_verified": false,
-        "line_number": 2875
+        "line_number": 2874
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f58d2ed9acfa2afd285ebd603ede04ea158f9767",
+        "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
+        "is_verified": false,
+        "line_number": 2877
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
         "is_verified": false,
         "line_number": 2880
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4882a3f560bc1bf6d57e2e0d1bf68d2568e76dae",
+        "hashed_secret": "d7c39664c403d1fecb3d1e330ad65a00bab67629",
         "is_verified": false,
-        "line_number": 2885
+        "line_number": 2883
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "57850ae994dc8800eef664d4c7e35bbc69515b6e",
+        "hashed_secret": "33424d6062b147852810a1b4e7d5cd675caa3231",
         "is_verified": false,
-        "line_number": 2889
+        "line_number": 2887
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "75e87bd654e00a58569f2f4964d6ac76c962f0b8",
+        "hashed_secret": "0661a6284527e94d3ac8b52324e219703276485b",
         "is_verified": false,
-        "line_number": 2895
+        "line_number": 2890
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7de59f662d7b267325ed23d6f2e9237530304d27",
+        "hashed_secret": "22f475d09df2c53aa6332a6d7aa6ac7e2cc09481",
         "is_verified": false,
-        "line_number": 2898
+        "line_number": 2893
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
+        "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
         "is_verified": false,
-        "line_number": 2902
+        "line_number": 2897
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0817713c3585298fbb156482ffc6787018397167",
+        "hashed_secret": "c42c0f2b427e93ec72f707573c0fcb5e4e191af4",
         "is_verified": false,
-        "line_number": 2906
+        "line_number": 2900
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1fd960f79ff7ccd39310bfdf81fba2b2663b71d0",
+        "hashed_secret": "2883c8b2e73c93ec9c28c8a8e3077279894a3bcd",
         "is_verified": false,
         "line_number": 2910
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "872f644ca44ce177f63803aa24fcb778566ecf1f",
+        "hashed_secret": "2f6768b77ca0db905e677336b7ed115432d94d69",
         "is_verified": false,
-        "line_number": 2914
+        "line_number": 2919
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2962f0a9f971f12844f66fddcaec41e8f889ad1c",
-        "is_verified": false,
-        "line_number": 2917
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bd243db4547725d4f90f654639e2fc2cea47e9ca",
-        "is_verified": false,
-        "line_number": 2920
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
-        "is_verified": false,
-        "line_number": 2923
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d25f38e564eeda6402f558b3ad020bd05220df32",
-        "is_verified": false,
-        "line_number": 2926
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ae745d719f97b3ddb9791348b1f29ff8208c0c5c",
+        "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
         "is_verified": false,
         "line_number": 2929
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cdb8646d4a7ff41822fd7db480ce191ce8d0adcb",
+        "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
         "is_verified": false,
-        "line_number": 2933
+        "line_number": 2932
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "78cac34debb068504165d4e64975947b641f5da8",
+        "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
         "is_verified": false,
-        "line_number": 2936
+        "line_number": 2935
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "976e08d754318ea78969397d0d99157a6e8813a3",
+        "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
         "is_verified": false,
-        "line_number": 2939
+        "line_number": 2938
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
+        "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
         "is_verified": false,
-        "line_number": 2942
+        "line_number": 2941
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "406d7e234572008768bde7f31b176a7a0f8da4f0",
+        "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
         "is_verified": false,
-        "line_number": 2945
+        "line_number": 2944
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
+        "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
         "is_verified": false,
-        "line_number": 2949
+        "line_number": 2947
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "06477f13a769300ebac81ebe76739fb78432f564",
+        "hashed_secret": "e3b8bd39c0d74b5489473733b30f2ff0c21beb55",
         "is_verified": false,
-        "line_number": 2952
+        "line_number": 2950
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "18320432c7c3515f682ce9a5def8785bf11de5fd",
+        "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
+        "is_verified": false,
+        "line_number": 2953
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
         "is_verified": false,
         "line_number": 2956
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2aaf078a06eded23d8751c4e0aad33ec11c447fd",
+        "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
         "is_verified": false,
         "line_number": 2959
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e2d1a2a5929d1167344a4844e1292d456c714bec",
+        "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
         "is_verified": false,
         "line_number": 2962
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8d24ba248862a0cdc267a56eaa97c4667069409d",
+        "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
         "is_verified": false,
-        "line_number": 2967
+        "line_number": 2965
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "295c5d969535881e04800821e0a1bc48bd5761f2",
+        "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
         "is_verified": false,
-        "line_number": 2970
+        "line_number": 2968
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
+        "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
         "is_verified": false,
-        "line_number": 2973
+        "line_number": 2971
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "157e5b0c4ac544ad1a995d6414e4dd539af39aa3",
+        "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
+        "is_verified": false,
+        "line_number": 2974
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
         "is_verified": false,
         "line_number": 2977
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e4d0457c3771bd19a2db30ce4295cc025189392e",
+        "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
         "is_verified": false,
         "line_number": 2980
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e5b68dc212c35983909130bf6b5106e3a462ecbc",
+        "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
         "is_verified": false,
-        "line_number": 2984
+        "line_number": 2983
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
+        "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
+        "is_verified": false,
+        "line_number": 2986
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
         "is_verified": false,
         "line_number": 2989
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9f48be0a09794d087d8615cbce47e062b9984fd6",
+        "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
         "is_verified": false,
         "line_number": 2992
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
+        "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
         "is_verified": false,
         "line_number": 2995
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2a416cdbfc3b4651a6d04d447938ace3ff9c7b6a",
+        "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
         "is_verified": false,
         "line_number": 2998
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "60edf9357ab126e077a488706704a2f658e19087",
+        "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
         "is_verified": false,
-        "line_number": 3002
+        "line_number": 3001
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9366bc8779ea1bd895e15b0f9f3257a488db6397",
+        "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
         "is_verified": false,
-        "line_number": 3005
+        "line_number": 3004
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f4184df080a8edb44024dca429a59f60a1d5308d",
+        "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
         "is_verified": false,
-        "line_number": 3009
+        "line_number": 3007
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8287678ab8009ae16b02930c9e260d1f28578fbe",
+        "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
         "is_verified": false,
-        "line_number": 3012
+        "line_number": 3010
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1233ad875b4ae7f0bab0b28dbae2127a4f9f738a",
+        "hashed_secret": "838abb1331a160bdd441c25a2a2d44332ee8694b",
         "is_verified": false,
-        "line_number": 3016
+        "line_number": 3013
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d270708a32c532655e0c3b6fd4bbc7475c182e50",
+        "hashed_secret": "e6525dbd438fc8858b0d56c59d164f403792ba1e",
         "is_verified": false,
-        "line_number": 3020
+        "line_number": 3017
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "62066f5078abd3f1c707b12b69fcb8d5c45f69ff",
+        "hashed_secret": "5c270f653b2fcd5b7c700b53f8543df4147a4aba",
+        "is_verified": false,
+        "line_number": 3021
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "0430ef838f88b8c253f36d7c2c5e9da6b30310b7",
         "is_verified": false,
         "line_number": 3026
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "175f769aab57cbd6962a4b89661ca9b22cd9a0eb",
+        "hashed_secret": "1560a9e5a2cb0315745d4a4936af7518beb680e7",
         "is_verified": false,
-        "line_number": 3031
+        "line_number": 3030
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dbc1ca0fc1f62c784dd9e4abae5b29195843b7fc",
+        "hashed_secret": "143743528e3b9b96aaf60f7aec6c318be5e54a99",
         "is_verified": false,
-        "line_number": 3036
+        "line_number": 3034
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
+        "hashed_secret": "90de41bb645eb912a3dcfbf357a4d329707ba620",
         "is_verified": false,
-        "line_number": 3042
+        "line_number": 3037
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5a233e343e439f5c0b7dad5b0bb3aac587600408",
+        "hashed_secret": "2718c296599ffc1e7d35452180a0ca84429f3565",
         "is_verified": false,
-        "line_number": 3045
+        "line_number": 3040
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fdc540c809ae88d0d77093f757f4a36ce9bdb89b",
+        "hashed_secret": "d1538c9c6f5e959070b379c89558393edcf64c0d",
         "is_verified": false,
-        "line_number": 3048
+        "line_number": 3043
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
+        "hashed_secret": "9a2e9779fa026f10b01762c6db4beb39bbf28531",
+        "is_verified": false,
+        "line_number": 3046
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "612b70ad4343adbb09a9cacc2fd28d7a2eae9313",
+        "is_verified": false,
+        "line_number": 3049
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
         "is_verified": false,
         "line_number": 3052
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c9e32f7e9605822ec5eecb8e000538cd32106217",
+        "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
         "is_verified": false,
-        "line_number": 3062
+        "line_number": 3055
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e48b8a44b97dad18efd583c058b08a57ae0b81b4",
+        "hashed_secret": "f58d2ed9acfa2afd285ebd603ede04ea158f9767",
         "is_verified": false,
-        "line_number": 3072
+        "line_number": 3060
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6b0e00a52b430695aac66bffdeca87b13dce5782",
+        "hashed_secret": "4882a3f560bc1bf6d57e2e0d1bf68d2568e76dae",
+        "is_verified": false,
+        "line_number": 3065
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "57850ae994dc8800eef664d4c7e35bbc69515b6e",
+        "is_verified": false,
+        "line_number": 3069
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "75e87bd654e00a58569f2f4964d6ac76c962f0b8",
+        "is_verified": false,
+        "line_number": 3075
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7de59f662d7b267325ed23d6f2e9237530304d27",
         "is_verified": false,
         "line_number": 3078
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
+        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
         "is_verified": false,
-        "line_number": 3084
+        "line_number": 3082
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1b44c0e3cc4aa423d96cf80ea9a08cf21225dc4e",
+        "hashed_secret": "0817713c3585298fbb156482ffc6787018397167",
+        "is_verified": false,
+        "line_number": 3086
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1fd960f79ff7ccd39310bfdf81fba2b2663b71d0",
+        "is_verified": false,
+        "line_number": 3090
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "872f644ca44ce177f63803aa24fcb778566ecf1f",
         "is_verified": false,
         "line_number": 3094
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4f171d08ea6de5b94bad0eff32e65a96a10ac15a",
+        "hashed_secret": "2962f0a9f971f12844f66fddcaec41e8f889ad1c",
+        "is_verified": false,
+        "line_number": 3097
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bd243db4547725d4f90f654639e2fc2cea47e9ca",
         "is_verified": false,
         "line_number": 3100
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c4dd7584b90374c3719d5069681d2c7cd05f06da",
+        "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
         "is_verified": false,
-        "line_number": 3104
+        "line_number": 3103
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dbe8cad574fbb7dbb938da01c0c4aff2dffdd029",
+        "hashed_secret": "d25f38e564eeda6402f558b3ad020bd05220df32",
         "is_verified": false,
-        "line_number": 3108
+        "line_number": 3106
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0f8e84e87aa0422f0c3445b79cbbe528d508dce3",
+        "hashed_secret": "ae745d719f97b3ddb9791348b1f29ff8208c0c5c",
         "is_verified": false,
-        "line_number": 3111
+        "line_number": 3109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8fd098a872474859bcce3e25efacdaf7d273a6e0",
+        "hashed_secret": "cdb8646d4a7ff41822fd7db480ce191ce8d0adcb",
         "is_verified": false,
-        "line_number": 3118
+        "line_number": 3113
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4e416a02c571be91e08682290d440c7879f08dc5",
+        "hashed_secret": "78cac34debb068504165d4e64975947b641f5da8",
         "is_verified": false,
-        "line_number": 3121
+        "line_number": 3116
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3843fe8bfabd5162ea792aad489b0bc2e774535e",
+        "hashed_secret": "976e08d754318ea78969397d0d99157a6e8813a3",
         "is_verified": false,
-        "line_number": 3124
+        "line_number": 3119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "68aeb7ec9fab680d80cbce2a624ccf642f3339cd",
+        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
         "is_verified": false,
-        "line_number": 3127
+        "line_number": 3122
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "10313a72df8760e8ec47c3e5a516858781be83cc",
+        "hashed_secret": "406d7e234572008768bde7f31b176a7a0f8da4f0",
         "is_verified": false,
-        "line_number": 3131
+        "line_number": 3125
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d253be4a7c019ad20bcb9cf5a4073ef85ce70854",
+        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
         "is_verified": false,
-        "line_number": 3134
+        "line_number": 3129
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f6cd0a74446935fab1bca4e983a1b0b98eeabc53",
+        "hashed_secret": "84cbfec871cf2b178ab90fcc1f442fa369e99a02",
         "is_verified": false,
-        "line_number": 3137
+        "line_number": 3132
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b2a129c0faee8294286099a63244e8811707a015",
+        "hashed_secret": "18320432c7c3515f682ce9a5def8785bf11de5fd",
         "is_verified": false,
-        "line_number": 3140
+        "line_number": 3136
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "69f812c17419570caedae0a2606890b87f7fa599",
+        "hashed_secret": "2aaf078a06eded23d8751c4e0aad33ec11c447fd",
+        "is_verified": false,
+        "line_number": 3139
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e2d1a2a5929d1167344a4844e1292d456c714bec",
+        "is_verified": false,
+        "line_number": 3142
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8d24ba248862a0cdc267a56eaa97c4667069409d",
+        "is_verified": false,
+        "line_number": 3147
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "295c5d969535881e04800821e0a1bc48bd5761f2",
         "is_verified": false,
         "line_number": 3150
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
+        "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
+        "is_verified": false,
+        "line_number": 3153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "157e5b0c4ac544ad1a995d6414e4dd539af39aa3",
+        "is_verified": false,
+        "line_number": 3157
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e4d0457c3771bd19a2db30ce4295cc025189392e",
         "is_verified": false,
         "line_number": 3160
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1a39ece38101be692eca60b18570d82d9b78a26e",
+        "hashed_secret": "e5b68dc212c35983909130bf6b5106e3a462ecbc",
         "is_verified": false,
-        "line_number": 3163
+        "line_number": 3164
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
-        "is_verified": false,
-        "line_number": 3166
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
+        "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
         "is_verified": false,
         "line_number": 3169
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
+        "hashed_secret": "9f48be0a09794d087d8615cbce47e062b9984fd6",
         "is_verified": false,
         "line_number": 3172
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5a333bc370c115c8b9d2fa6689eaa1dc37b696ad",
+        "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
         "is_verified": false,
         "line_number": 3175
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "17df0cf1bffb39d85a2aea45c887f1998ffc48a8",
+        "hashed_secret": "2a416cdbfc3b4651a6d04d447938ace3ff9c7b6a",
         "is_verified": false,
         "line_number": 3178
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "47e9d02523f2192439c8ebc19f11d491f61874f6",
+        "hashed_secret": "17c4dfcbb00dec5ffbc9dcd18a6a9d4da6973b3c",
         "is_verified": false,
-        "line_number": 3181
+        "line_number": 3182
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9a0dfdcc6623d8d2996e396f5e08840914c241a0",
+        "hashed_secret": "3708af066f7b1edc1ba2d5e1da654cf995375b64",
         "is_verified": false,
-        "line_number": 3184
+        "line_number": 3186
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "12c75bf14fc9e7d25cb8b6d66ea81decab2f32aa",
+        "hashed_secret": "f4184df080a8edb44024dca429a59f60a1d5308d",
         "is_verified": false,
-        "line_number": 3189
+        "line_number": 3190
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4ec2ff08ee70f4f3ed104cf914130dc8b4af02db",
+        "hashed_secret": "8287678ab8009ae16b02930c9e260d1f28578fbe",
         "is_verified": false,
-        "line_number": 3192
+        "line_number": 3193
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
+        "hashed_secret": "1233ad875b4ae7f0bab0b28dbae2127a4f9f738a",
         "is_verified": false,
-        "line_number": 3195
+        "line_number": 3197
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
-        "is_verified": false,
-        "line_number": 3198
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2e9e26d0fd5a69fc56b781ec5b24890dfb4976fe",
+        "hashed_secret": "d270708a32c532655e0c3b6fd4bbc7475c182e50",
         "is_verified": false,
         "line_number": 3201
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
-        "is_verified": false,
-        "line_number": 3204
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
+        "hashed_secret": "62066f5078abd3f1c707b12b69fcb8d5c45f69ff",
         "is_verified": false,
         "line_number": 3207
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "edb81778ed5fee48cae4e8a8b8d1793b9e9e7663",
+        "hashed_secret": "175f769aab57cbd6962a4b89661ca9b22cd9a0eb",
         "is_verified": false,
-        "line_number": 3211
+        "line_number": 3212
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ca9671a0948519aefcd2ec2428e9a187e79113e3",
+        "hashed_secret": "dbc1ca0fc1f62c784dd9e4abae5b29195843b7fc",
         "is_verified": false,
-        "line_number": 3215
+        "line_number": 3217
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bae67d3ce231086fba18abc7365c94878f900c14",
+        "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
         "is_verified": false,
-        "line_number": 3219
+        "line_number": 3223
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9a53482ec2c9de9f382f9c30f308986d167d2d86",
+        "hashed_secret": "5a233e343e439f5c0b7dad5b0bb3aac587600408",
         "is_verified": false,
-        "line_number": 3222
+        "line_number": 3226
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a1785e76071823a09f23d2c2b64db80b223c5411",
-        "is_verified": false,
-        "line_number": 3225
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7cdaa4e52326d9a81d36d211cd26c2d7a9fc69e1",
+        "hashed_secret": "fdc540c809ae88d0d77093f757f4a36ce9bdb89b",
         "is_verified": false,
         "line_number": 3229
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6a66a6ffc1f1c2f31ec1c5c694938bedbae39c02",
+        "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
         "is_verified": false,
         "line_number": 3233
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "05b9deaec8f504ac476e1af49d6dd6c7c79f6b36",
+        "hashed_secret": "c9e32f7e9605822ec5eecb8e000538cd32106217",
         "is_verified": false,
-        "line_number": 3237
+        "line_number": 3243
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
+        "hashed_secret": "e48b8a44b97dad18efd583c058b08a57ae0b81b4",
         "is_verified": false,
-        "line_number": 3241
+        "line_number": 3253
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a3e455e610a2599c21af6806a2d0bcfa38dd3e0e",
+        "hashed_secret": "6b0e00a52b430695aac66bffdeca87b13dce5782",
         "is_verified": false,
-        "line_number": 3244
+        "line_number": 3259
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
+        "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
         "is_verified": false,
-        "line_number": 3250
+        "line_number": 3265
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
-        "is_verified": false,
-        "line_number": 3254
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
-        "is_verified": false,
-        "line_number": 3257
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6057a244d926cc3fac60c38cc276e3a75c45e178",
-        "is_verified": false,
-        "line_number": 3260
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "859f0bf5b150aedf3fe7c8ed5719bb865f543231",
-        "is_verified": false,
-        "line_number": 3264
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "06ea5a63927e269d49312b5c9e8bea03616f842e",
-        "is_verified": false,
-        "line_number": 3267
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
-        "is_verified": false,
-        "line_number": 3272
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d4e08224926a563394787a12a3b195c3d73d224e",
+        "hashed_secret": "1b44c0e3cc4aa423d96cf80ea9a08cf21225dc4e",
         "is_verified": false,
         "line_number": 3275
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e7dd0f768f7d4107192416f4ceec8e68f6e019c7",
-        "is_verified": false,
-        "line_number": 3278
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7821aab8b32fe85984d087e74a64d274074fd5ff",
+        "hashed_secret": "4f171d08ea6de5b94bad0eff32e65a96a10ac15a",
         "is_verified": false,
         "line_number": 3281
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e828f62944b52bb12d3005ea71fc3a8af14ebb31",
+        "hashed_secret": "c4dd7584b90374c3719d5069681d2c7cd05f06da",
         "is_verified": false,
-        "line_number": 3284
+        "line_number": 3285
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f5cde8151f6ac3de1ce731aa99fec04b98fca09f",
+        "hashed_secret": "dbe8cad574fbb7dbb938da01c0c4aff2dffdd029",
         "is_verified": false,
-        "line_number": 3287
+        "line_number": 3289
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a48b8ac8fd33d3bfc89ac437ee1c3274e7006629",
+        "hashed_secret": "0f8e84e87aa0422f0c3445b79cbbe528d508dce3",
         "is_verified": false,
         "line_number": 3292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c349366fbe16160ca9910d83a1de29924246c04d",
-        "is_verified": false,
-        "line_number": 3295
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "533c0ebb91e72493384d8beda7994d2fb902cce2",
+        "hashed_secret": "8fd098a872474859bcce3e25efacdaf7d273a6e0",
         "is_verified": false,
         "line_number": 3299
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "315bcdd30c6b9c9705234a5dbc10279315e7611b",
+        "hashed_secret": "4e416a02c571be91e08682290d440c7879f08dc5",
         "is_verified": false,
-        "line_number": 3303
+        "line_number": 3302
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
+        "hashed_secret": "3843fe8bfabd5162ea792aad489b0bc2e774535e",
         "is_verified": false,
-        "line_number": 3306
+        "line_number": 3305
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a664083cd7ea977f953eb398c15a7391521e8c88",
+        "hashed_secret": "68aeb7ec9fab680d80cbce2a624ccf642f3339cd",
         "is_verified": false,
-        "line_number": 3309
+        "line_number": 3308
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e11dc6504f1442c6e5b78658db9c245708c24690",
+        "hashed_secret": "10313a72df8760e8ec47c3e5a516858781be83cc",
         "is_verified": false,
         "line_number": 3312
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3bea92b9f6fb799774c52db9b38668949e60a65f",
+        "hashed_secret": "d253be4a7c019ad20bcb9cf5a4073ef85ce70854",
         "is_verified": false,
         "line_number": 3315
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "66022833f4701f45cff007311050911fe571487c",
+        "hashed_secret": "f6cd0a74446935fab1bca4e983a1b0b98eeabc53",
         "is_verified": false,
-        "line_number": 3319
+        "line_number": 3318
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "295370934921eb088b38a5591b27ef4c3feeabda",
+        "hashed_secret": "b2a129c0faee8294286099a63244e8811707a015",
         "is_verified": false,
-        "line_number": 3323
+        "line_number": 3321
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "48ab61adf0ee0771b3002628be653baccb9af277",
-        "is_verified": false,
-        "line_number": 3327
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a6d813aa7164341218d80a2b625ff1b254fa10c3",
+        "hashed_secret": "69f812c17419570caedae0a2606890b87f7fa599",
         "is_verified": false,
         "line_number": 3331
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
-        "is_verified": false,
-        "line_number": 3335
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
-        "is_verified": false,
-        "line_number": 3338
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1e68acc8ad653691b250fb20aefebd10afacfb1c",
+        "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
         "is_verified": false,
         "line_number": 3341
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
+        "hashed_secret": "1a39ece38101be692eca60b18570d82d9b78a26e",
         "is_verified": false,
-        "line_number": 3345
+        "line_number": 3344
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1f97ba54d48d51a2ed9bef23e8100e44b5863113",
+        "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
         "is_verified": false,
-        "line_number": 3348
+        "line_number": 3347
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "760287f140e56c5274845b0b4c48fb3f1c6f5cbf",
+        "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
+        "is_verified": false,
+        "line_number": 3350
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
         "is_verified": false,
         "line_number": 3353
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "955d2d24c472b4eb0b4488f935a0f65e38001df8",
+        "hashed_secret": "5a333bc370c115c8b9d2fa6689eaa1dc37b696ad",
         "is_verified": false,
         "line_number": 3356
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "60bbb117f59dfb9ea6273375f335852852518f21",
+        "hashed_secret": "17df0cf1bffb39d85a2aea45c887f1998ffc48a8",
         "is_verified": false,
-        "line_number": 3360
+        "line_number": 3359
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b0cc5db4f99fc0fb773b7006064bd925ae04e9b5",
+        "hashed_secret": "47e9d02523f2192439c8ebc19f11d491f61874f6",
+        "is_verified": false,
+        "line_number": 3362
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4a92c1257b67845f12260b454ba353a5919dec29",
         "is_verified": false,
         "line_number": 3365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3643f874367db545d17373925c62a1ef98b4e8eb",
+        "hashed_secret": "12c75bf14fc9e7d25cb8b6d66ea81decab2f32aa",
         "is_verified": false,
-        "line_number": 3368
+        "line_number": 3370
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
+        "hashed_secret": "4ec2ff08ee70f4f3ed104cf914130dc8b4af02db",
         "is_verified": false,
-        "line_number": 3371
+        "line_number": 3373
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
+        "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
         "is_verified": false,
-        "line_number": 3374
+        "line_number": 3376
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
+        "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
         "is_verified": false,
-        "line_number": 3377
+        "line_number": 3379
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
+        "hashed_secret": "2e9e26d0fd5a69fc56b781ec5b24890dfb4976fe",
         "is_verified": false,
-        "line_number": 3380
+        "line_number": 3382
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "96274955a46e3f4a4cf02b179edba026678799c5",
+        "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
         "is_verified": false,
-        "line_number": 3383
+        "line_number": 3385
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
+        "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
         "is_verified": false,
-        "line_number": 3386
+        "line_number": 3388
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
-        "is_verified": false,
-        "line_number": 3389
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "235983a96e805984ce05975bd175dfaaae62ec0a",
+        "hashed_secret": "edb81778ed5fee48cae4e8a8b8d1793b9e9e7663",
         "is_verified": false,
         "line_number": 3392
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "292b56ccb1313ea50f4d1bf0efc7f2b04670fe73",
+        "hashed_secret": "ca9671a0948519aefcd2ec2428e9a187e79113e3",
         "is_verified": false,
-        "line_number": 3395
+        "line_number": 3396
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9eaf006db1f782b8da68c3ae97eae05f36c62973",
+        "hashed_secret": "bae67d3ce231086fba18abc7365c94878f900c14",
         "is_verified": false,
-        "line_number": 3399
+        "line_number": 3400
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
+        "hashed_secret": "9a53482ec2c9de9f382f9c30f308986d167d2d86",
         "is_verified": false,
-        "line_number": 3405
+        "line_number": 3403
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
+        "hashed_secret": "a1785e76071823a09f23d2c2b64db80b223c5411",
         "is_verified": false,
-        "line_number": 3415
+        "line_number": 3406
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
+        "hashed_secret": "7cdaa4e52326d9a81d36d211cd26c2d7a9fc69e1",
+        "is_verified": false,
+        "line_number": 3410
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6a66a6ffc1f1c2f31ec1c5c694938bedbae39c02",
+        "is_verified": false,
+        "line_number": 3414
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "05b9deaec8f504ac476e1af49d6dd6c7c79f6b36",
+        "is_verified": false,
+        "line_number": 3418
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
+        "is_verified": false,
+        "line_number": 3422
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a3e455e610a2599c21af6806a2d0bcfa38dd3e0e",
         "is_verified": false,
         "line_number": 3425
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
+        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
         "is_verified": false,
-        "line_number": 3430
+        "line_number": 3431
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4885a73ae27294938a483e855613b49825a795e8",
+        "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
         "is_verified": false,
-        "line_number": 3433
+        "line_number": 3435
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "e9929bd50a5523f3ee0cf35a8fd80c06bc43cc50",
+        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
         "is_verified": false,
-        "line_number": 3437
+        "line_number": 3438
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f436e5e80e3407aed61c6a5d0463a46e0da536d8",
+        "hashed_secret": "6057a244d926cc3fac60c38cc276e3a75c45e178",
         "is_verified": false,
         "line_number": 3441
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "44e465ae72a1040308940ab81352dfbacbe7e364",
+        "hashed_secret": "859f0bf5b150aedf3fe7c8ed5719bb865f543231",
         "is_verified": false,
         "line_number": 3445
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8dde1ebef344011f9e6ac282be903ab5cc8cdcdf",
+        "hashed_secret": "06ea5a63927e269d49312b5c9e8bea03616f842e",
         "is_verified": false,
-        "line_number": 3451
+        "line_number": 3448
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
+        "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
         "is_verified": false,
-        "line_number": 3454
+        "line_number": 3453
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
+        "hashed_secret": "d4e08224926a563394787a12a3b195c3d73d224e",
         "is_verified": false,
-        "line_number": 3457
+        "line_number": 3456
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "aee6e2f94569251fe1d62eafb1e922c0c9da7310",
+        "hashed_secret": "e7dd0f768f7d4107192416f4ceec8e68f6e019c7",
         "is_verified": false,
-        "line_number": 3460
+        "line_number": 3459
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "d4993485565eb1018819491e8a7ee52a1594e101",
+        "hashed_secret": "7821aab8b32fe85984d087e74a64d274074fd5ff",
         "is_verified": false,
-        "line_number": 3463
+        "line_number": 3462
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "db1d5fe158aaf084a72a2dfa5555e5d63cc4236c",
+        "hashed_secret": "e828f62944b52bb12d3005ea71fc3a8af14ebb31",
+        "is_verified": false,
+        "line_number": 3465
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f5cde8151f6ac3de1ce731aa99fec04b98fca09f",
         "is_verified": false,
         "line_number": 3468
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7e30ca914cc2ed38e1a330be94a26824867b5934",
+        "hashed_secret": "a48b8ac8fd33d3bfc89ac437ee1c3274e7006629",
         "is_verified": false,
-        "line_number": 3471
+        "line_number": 3473
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3885943ec38bd72b75dd793c8064f5b82b7986df",
+        "hashed_secret": "c349366fbe16160ca9910d83a1de29924246c04d",
         "is_verified": false,
-        "line_number": 3502
+        "line_number": 3476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "09eef298f78df698d8ecb1d9a58fa11e5d9f4e99",
+        "hashed_secret": "533c0ebb91e72493384d8beda7994d2fb902cce2",
+        "is_verified": false,
+        "line_number": 3480
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "315bcdd30c6b9c9705234a5dbc10279315e7611b",
+        "is_verified": false,
+        "line_number": 3485
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
+        "is_verified": false,
+        "line_number": 3488
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a664083cd7ea977f953eb398c15a7391521e8c88",
+        "is_verified": false,
+        "line_number": 3491
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e11dc6504f1442c6e5b78658db9c245708c24690",
+        "is_verified": false,
+        "line_number": 3494
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "bcc923e3a3bbb5c5c7c2f2b5e17bda91f8076652",
+        "is_verified": false,
+        "line_number": 3497
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "66022833f4701f45cff007311050911fe571487c",
+        "is_verified": false,
+        "line_number": 3501
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "295370934921eb088b38a5591b27ef4c3feeabda",
+        "is_verified": false,
+        "line_number": 3505
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "48ab61adf0ee0771b3002628be653baccb9af277",
+        "is_verified": false,
+        "line_number": 3509
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "a6d813aa7164341218d80a2b625ff1b254fa10c3",
+        "is_verified": false,
+        "line_number": 3513
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
+        "is_verified": false,
+        "line_number": 3517
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
+        "is_verified": false,
+        "line_number": 3520
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1e68acc8ad653691b250fb20aefebd10afacfb1c",
+        "is_verified": false,
+        "line_number": 3523
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
+        "is_verified": false,
+        "line_number": 3527
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "1f97ba54d48d51a2ed9bef23e8100e44b5863113",
+        "is_verified": false,
+        "line_number": 3530
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "760287f140e56c5274845b0b4c48fb3f1c6f5cbf",
+        "is_verified": false,
+        "line_number": 3535
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "955d2d24c472b4eb0b4488f935a0f65e38001df8",
+        "is_verified": false,
+        "line_number": 3538
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "60bbb117f59dfb9ea6273375f335852852518f21",
         "is_verified": false,
         "line_number": 3542
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c85b08c4b0d082d8ef795d3feb33248d653a86dd",
+        "hashed_secret": "b0cc5db4f99fc0fb773b7006064bd925ae04e9b5",
         "is_verified": false,
-        "line_number": 3567
+        "line_number": 3547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "646545163be60fa7b4864dabc97dc921b6217a3f",
+        "hashed_secret": "3643f874367db545d17373925c62a1ef98b4e8eb",
+        "is_verified": false,
+        "line_number": 3550
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
+        "is_verified": false,
+        "line_number": 3553
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
+        "is_verified": false,
+        "line_number": 3556
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
+        "is_verified": false,
+        "line_number": 3559
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
+        "is_verified": false,
+        "line_number": 3562
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "96274955a46e3f4a4cf02b179edba026678799c5",
+        "is_verified": false,
+        "line_number": 3565
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
+        "is_verified": false,
+        "line_number": 3568
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
         "is_verified": false,
         "line_number": 3571
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7c0f26e555ee262ed308b5e9a40f3ed4fdaacaa9",
+        "hashed_secret": "235983a96e805984ce05975bd175dfaaae62ec0a",
         "is_verified": false,
         "line_number": 3574
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fbab298b8cf4892db7d5b25fa56f64db70c02191",
+        "hashed_secret": "292b56ccb1313ea50f4d1bf0efc7f2b04670fe73",
         "is_verified": false,
         "line_number": 3577
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c404e90db76532488af93bd2a7001a73ec20db70",
+        "hashed_secret": "9eaf006db1f782b8da68c3ae97eae05f36c62973",
         "is_verified": false,
-        "line_number": 3580
+        "line_number": 3581
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9a7f758ccbe3c1a33e64125ee88909ceb0f2b9ad",
-        "is_verified": false,
-        "line_number": 3584
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ee4887dad945f60487dbcadc8e688259e0f670ae",
+        "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
         "is_verified": false,
         "line_number": 3587
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
+        "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
         "is_verified": false,
-        "line_number": 3590
+        "line_number": 3597
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c34d43e9581b3e233d1d2cdc667a3ce110c60491",
-        "is_verified": false,
-        "line_number": 3595
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
-        "is_verified": false,
-        "line_number": 3600
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6961f61ab86a0461464a49ee3080e16851cf964e",
-        "is_verified": false,
-        "line_number": 3603
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "543c98d315431cc1616876ddf1cdc5fd13349a9b",
+        "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
         "is_verified": false,
         "line_number": 3607
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
+        "is_verified": false,
+        "line_number": 3612
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "4885a73ae27294938a483e855613b49825a795e8",
+        "is_verified": false,
+        "line_number": 3615
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "e9929bd50a5523f3ee0cf35a8fd80c06bc43cc50",
+        "is_verified": false,
+        "line_number": 3619
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "f436e5e80e3407aed61c6a5d0463a46e0da536d8",
+        "is_verified": false,
+        "line_number": 3623
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "44e465ae72a1040308940ab81352dfbacbe7e364",
+        "is_verified": false,
+        "line_number": 3627
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "8dde1ebef344011f9e6ac282be903ab5cc8cdcdf",
+        "is_verified": false,
+        "line_number": 3633
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
+        "is_verified": false,
+        "line_number": 3636
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
+        "is_verified": false,
+        "line_number": 3639
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "aee6e2f94569251fe1d62eafb1e922c0c9da7310",
+        "is_verified": false,
+        "line_number": 3642
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "d4993485565eb1018819491e8a7ee52a1594e101",
+        "is_verified": false,
+        "line_number": 3645
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "db1d5fe158aaf084a72a2dfa5555e5d63cc4236c",
+        "is_verified": false,
+        "line_number": 3650
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "2f73770c4b2c405b9f25e2bc5b5e42d82aa859dd",
+        "is_verified": false,
+        "line_number": 3653
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "10268f6f4f68752aa603c74f237e00cf940909a4",
+        "is_verified": false,
+        "line_number": 3684
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "09eef298f78df698d8ecb1d9a58fa11e5d9f4e99",
+        "is_verified": false,
+        "line_number": 3724
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c85b08c4b0d082d8ef795d3feb33248d653a86dd",
+        "is_verified": false,
+        "line_number": 3749
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "646545163be60fa7b4864dabc97dc921b6217a3f",
+        "is_verified": false,
+        "line_number": 3753
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "7c0f26e555ee262ed308b5e9a40f3ed4fdaacaa9",
+        "is_verified": false,
+        "line_number": 3756
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "fbab298b8cf4892db7d5b25fa56f64db70c02191",
+        "is_verified": false,
+        "line_number": 3759
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c404e90db76532488af93bd2a7001a73ec20db70",
+        "is_verified": false,
+        "line_number": 3762
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "9a7f758ccbe3c1a33e64125ee88909ceb0f2b9ad",
+        "is_verified": false,
+        "line_number": 3766
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "ee4887dad945f60487dbcadc8e688259e0f670ae",
+        "is_verified": false,
+        "line_number": 3769
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
+        "is_verified": false,
+        "line_number": 3772
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c34d43e9581b3e233d1d2cdc667a3ce110c60491",
+        "is_verified": false,
+        "line_number": 3777
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
+        "is_verified": false,
+        "line_number": 3782
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "6961f61ab86a0461464a49ee3080e16851cf964e",
+        "is_verified": false,
+        "line_number": 3785
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
+        "hashed_secret": "543c98d315431cc1616876ddf1cdc5fd13349a9b",
+        "is_verified": false,
+        "line_number": 3789
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3c2d8491c2232a61643d57a3622f9e4c284b24f2",
         "is_verified": false,
-        "line_number": 3610
+        "line_number": 3792
       }
     ],
     "docs/user-guide/optuna_integration.md": [
@@ -5274,16 +5452,7 @@
         "filename": "examples/quickstart/README.md",
         "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
         "is_verified": false,
-        "line_number": 48
-      }
-    ],
-    "my_llm_project/rag_agent.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "my_llm_project/rag_agent.py",
-        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
-        "is_verified": false,
-        "line_number": 5
+        "line_number": 50
       }
     ],
     "plugins/traigent-ui/traigent_ui/STREAMLIT_README.md": [
@@ -5293,22 +5462,6 @@
         "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
         "is_verified": false,
         "line_number": 19
-      }
-    ],
-    "scripts/release/build_offline_zip.sh": [
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/release/build_offline_zip.sh",
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_verified": false,
-        "line_number": 180
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/release/build_offline_zip.sh",
-        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
-        "is_verified": false,
-        "line_number": 181
       }
     ],
     "scripts/smoke/smoke_real_api_measures.py": [
@@ -5422,15 +5575,6 @@
         "hashed_secret": "f5ef767f75e3447133504f094ac9a57a6bf9a5c6",
         "is_verified": false,
         "line_number": 28
-      }
-    ],
-    "tests/integration/test_privacy_integration.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/integration/test_privacy_integration.py",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 22
       }
     ],
     "tests/integration/test_traigent_decorator_cloud_integration.py": [
@@ -5578,15 +5722,6 @@
         "line_number": 390
       }
     ],
-    "tests/test_cli_auth_integration.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_cli_auth_integration.py",
-        "hashed_secret": "34ad4531592cb8f09eb6fdd15229ed5140ee45c0",
-        "is_verified": false,
-        "line_number": 91
-      }
-    ],
     "tests/unit/adapters/test_execution_adapter.py": [
       {
         "type": "Secret Keyword",
@@ -5632,28 +5767,28 @@
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 88
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "c44b91d6672bb1d7c51e050ababb0146efa84380",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 88
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 88
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 201
       }
     ],
     "tests/unit/cloud/test_auth_data_classes.py": [
@@ -5699,21 +5834,21 @@
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "25b5a7e454ccbe4974ee239749935c9e32b887e1",
         "is_verified": false,
-        "line_number": 301
+        "line_number": 317
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "b3215fe1d22a64a131c0f9c09718c5b8860911ad",
         "is_verified": false,
-        "line_number": 334
+        "line_number": 350
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "495289ab973afae18fc84235f33dadc07a9608c4",
         "is_verified": false,
-        "line_number": 365
+        "line_number": 381
       }
     ],
     "tests/unit/cloud/test_backend_bridges_security.py": [
@@ -5738,84 +5873,84 @@
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
         "is_verified": false,
-        "line_number": 237
+        "line_number": 288
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44c08d71fbe20d2cf9c5842af590dda096bee6f9",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 302
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "801f9bf378fc57a61f95a66e2465a02ed3092d7e",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 303
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "c6e454d960df4845f9d69eb11377c8b23882715b",
         "is_verified": false,
-        "line_number": 273
+        "line_number": 324
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
         "is_verified": false,
-        "line_number": 484
+        "line_number": 540
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 514
+        "line_number": 570
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "827ba56f5549ed55e91dc9fb84327b0148c01a5e",
         "is_verified": false,
-        "line_number": 575
+        "line_number": 631
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 681
+        "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
         "is_verified": false,
-        "line_number": 1008
+        "line_number": 1102
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ad6ed643d097938d8f82b0945077efdc93928614",
         "is_verified": false,
-        "line_number": 1017
+        "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 1119
+        "line_number": 1213
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
-        "line_number": 1189
+        "line_number": 1283
       }
     ],
     "tests/unit/cloud/test_cloud_client_validation.py": [
@@ -5859,15 +5994,6 @@
         "line_number": 294
       }
     ],
-    "tests/unit/cloud/test_dataset_converter_validation.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/unit/cloud/test_dataset_converter_validation.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 25
-      }
-    ],
     "tests/unit/cloud/test_session_finalization.py": [
       {
         "type": "Secret Keyword",
@@ -5884,15 +6010,6 @@
         "hashed_secret": "d244bdec6e3b588fa5a9d63a735bc527d57ae878",
         "is_verified": false,
         "line_number": 29
-      }
-    ],
-    "tests/unit/cloud/test_sync_manager.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/cloud/test_sync_manager.py",
-        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
-        "is_verified": false,
-        "line_number": 106
       }
     ],
     "tests/unit/config/test_api_keys.py": [
@@ -6171,15 +6288,6 @@
         "line_number": 43
       }
     ],
-    "tests/unit/utils/test_local_analytics.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/utils/test_local_analytics.py",
-        "hashed_secret": "035bf17d591b5967aafe1700f7e7d0bf0f7d6bf3",
-        "is_verified": false,
-        "line_number": 457
-      }
-    ],
     "tests/unit/utils/test_reproducibility.py": [
       {
         "type": "Hex High Entropy String",
@@ -6187,15 +6295,6 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
         "line_number": 166
-      }
-    ],
-    "traigent/integrations/langfuse/__init__.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "traigent/integrations/langfuse/__init__.py",
-        "hashed_secret": "bfc5221616fd29387d7413aeb41401391dceefa8",
-        "is_verified": false,
-        "line_number": 27
       }
     ],
     "traigent/integrations/langfuse/tracker.py": [
@@ -6244,6 +6343,15 @@
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
         "line_number": 103
+      }
+    ],
+    "traigent/integrations/llms/litellm_plugin.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/llms/litellm_plugin.py",
+        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
+        "is_verified": false,
+        "line_number": 58
       }
     ],
     "traigent/integrations/llms/llamaindex_plugin.py": [
@@ -6322,5 +6430,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-19T20:20:57Z"
+  "generated_at": "2026-04-27T21:43:31Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,7 +167,30 @@
         "filename": "docs/features/authentication.md",
         "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
         "is_verified": false,
-        "line_number": 374
+        "line_number": 371
+      }
+    ],
+    "docs/installation-guide-offline.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/installation-guide-offline.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/installation-guide-offline.md",
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/installation-guide-offline.md",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 66
       }
     ],
     "docs/tvl/tvl-website/pnpm-lock.yaml": [
@@ -176,5229 +199,5019 @@
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "121a3385c5e28b32a26d3cad7c90a29496d9747f",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 13
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69ae37e0133456d2c3fbfd903c273bf1372267e0",
         "is_verified": false,
-        "line_number": 248
+        "line_number": 244
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "24bcacef3fb203d046d58405e8207a5342669fe2",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 247
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d4eac0bf704336f38e69fd6832e6f021ded39602",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dc4d28f9890d4fa2dfd62af6dad92301d743197b",
         "is_verified": false,
-        "line_number": 258
+        "line_number": 254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5d38e92aeafa91e0b0d9dca469391b9cdfe9dcfd",
         "is_verified": false,
-        "line_number": 262
+        "line_number": 258
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4a9ae62604ff3094a86888165571aedf55bb29b1",
         "is_verified": false,
-        "line_number": 266
+        "line_number": 262
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "91ef8efb1f1a9f7b957debc2f9382278a11e9e91",
         "is_verified": false,
-        "line_number": 270
+        "line_number": 266
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5cb278a68156ae376bea48fb0f872cbc5dfd0a63",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 270
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1ebe57ea46fba7d746cb222ee21b5cd413c80ff1",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 274
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1fc27c75818896b4e84d7e8ca98e0e8c00118bb7",
         "is_verified": false,
-        "line_number": 282
+        "line_number": 278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e844f3c78344b978e74bc22b6c2736d4b0c393e1",
         "is_verified": false,
-        "line_number": 288
+        "line_number": 284
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8319864fae2ce720a9588f890930b4dd3f736a4f",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 288
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e2a4d1a24c1c4aac8dc6ee6056c8a135c8db64a",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6302a9750ba626bf9d98ea2b93c8044c2c13dd03",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 296
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "aab5f636e7355b605c94009444540cb86f20a48d",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 300
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8570cc5660ba5cb0957e273be0100cce91506931",
         "is_verified": false,
-        "line_number": 308
+        "line_number": 304
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "210797f986e8839f4aa71c2e7fa465944644b42f",
         "is_verified": false,
-        "line_number": 313
+        "line_number": 309
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "07c2a515b8ce991183b3b5cbfc018668baa54ac6",
         "is_verified": false,
-        "line_number": 319
+        "line_number": 315
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "adc1d52f38ba77308117df559dea25e43eb9f263",
         "is_verified": false,
-        "line_number": 325
+        "line_number": 321
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "67428c90207cc195acaf62942754b6a6861c8b90",
         "is_verified": false,
-        "line_number": 329
+        "line_number": 325
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "de045e2ed3223c2ab40b541eb6a518fd1a3ad0f2",
         "is_verified": false,
-        "line_number": 333
+        "line_number": 329
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "73b60e42d9313eca080440873f8fa1fcb5310f29",
         "is_verified": false,
-        "line_number": 337
+        "line_number": 333
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3942b0ee3200c0c70746db896347c9f1c86795ee",
         "is_verified": false,
-        "line_number": 341
+        "line_number": 337
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2765cac86159f5017e7511a57adb410bf0540193",
         "is_verified": false,
-        "line_number": 344
+        "line_number": 340
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e7272e163bbc139a72d39a9cd8d521c3daef962d",
         "is_verified": false,
-        "line_number": 347
+        "line_number": 343
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f14ba07acf972f2b7095f1814fc1596e605878a4",
         "is_verified": false,
-        "line_number": 352
+        "line_number": 348
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4d2a9fe8166ba36c28dbe2172304f097713f9f4b",
         "is_verified": false,
-        "line_number": 355
+        "line_number": 351
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f97e027840e6148350273c88efef7e8b5d1cf5bc",
         "is_verified": false,
-        "line_number": 358
+        "line_number": 354
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69a078d0c8d430cbbb7fc4c42f598e5e98ee5c5d",
         "is_verified": false,
-        "line_number": 361
+        "line_number": 357
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "854ad107863bc6fe3bfc0508180a26191b1c0a2d",
         "is_verified": false,
-        "line_number": 364
+        "line_number": 360
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a8e4627e40f4bf3903759a298bc646332f041250",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 363
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ba92041b8b57e5f3f7cfda01eca4eb5f863d8230",
         "is_verified": false,
-        "line_number": 370
+        "line_number": 366
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ec1989ae36181cb6d116871a04bd886e8aa7680a",
         "is_verified": false,
-        "line_number": 376
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4fc407ff3fa666522e784402874b39ccaa9b9084",
-        "is_verified": false,
-        "line_number": 382
+        "line_number": 372
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7543ee65aa0a02783414e8a1dbd3d18c0c3123cc",
         "is_verified": false,
-        "line_number": 388
+        "line_number": 378
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d8fa482cdfbba9269e34d191ace0e402c5cb45c3",
         "is_verified": false,
-        "line_number": 394
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6e53b1d7147a431758aded05223f60a6cf8404b6",
-        "is_verified": false,
-        "line_number": 400
+        "line_number": 384
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5cab2cbf14962ddc1d6ed2bfe25898fe4c36dec1",
         "is_verified": false,
-        "line_number": 406
+        "line_number": 390
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9d1eaaf504742620f3f5b102a4f02d28d4f919ce",
         "is_verified": false,
-        "line_number": 412
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "21094ab4fc5b3c4b172a28c6e96d474b60d8f176",
-        "is_verified": false,
-        "line_number": 418
+        "line_number": 396
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b3ffc344491402f73ea16b1b8718e18833050114",
         "is_verified": false,
-        "line_number": 424
+        "line_number": 402
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e427dd2b428dd4241dd1b8355c3b92fd85839376",
         "is_verified": false,
-        "line_number": 430
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "57902bee1f6a5e12ed03dd3b3281ab07318ff81f",
-        "is_verified": false,
-        "line_number": 436
+        "line_number": 408
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "06c952d11f13461da10c7bba057d78cc5fa5e6fb",
         "is_verified": false,
-        "line_number": 442
+        "line_number": 414
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "771db604fdb79532e77b7128227a745a3ec9ec0a",
         "is_verified": false,
-        "line_number": 448
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3cfe66e44a47be9aa1a2b2570d4e6ca4fe8646d6",
-        "is_verified": false,
-        "line_number": 454
+        "line_number": 420
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c2ea7b0b8f40b08e1b89209f677ff5d6a719b60a",
         "is_verified": false,
-        "line_number": 460
+        "line_number": 426
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2b63c304518691010aeed935b51f86afcc24ede1",
         "is_verified": false,
-        "line_number": 466
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6e9116d6ceb830c0e81b752f03b594c04b867404",
-        "is_verified": false,
-        "line_number": 472
+        "line_number": 432
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8816a15bd9ad8879b3f1823b94fb7c46dd643f17",
         "is_verified": false,
-        "line_number": 478
+        "line_number": 438
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e1c65275ad0b487c12c5a2f2ca5541ad0ebe811",
         "is_verified": false,
-        "line_number": 484
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "92eb7bfdfe82cc5019dea1ead34c876de720e71f",
-        "is_verified": false,
-        "line_number": 490
+        "line_number": 444
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9836b23edc498bf0925d3e560f0684f6ec75bb9a",
         "is_verified": false,
-        "line_number": 496
+        "line_number": 450
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "19506ba5fec5de7d878352659f9a362ada89bb75",
         "is_verified": false,
-        "line_number": 502
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f83beff54841a17222f2c5d542077e07f0a640ce",
-        "is_verified": false,
-        "line_number": 508
+        "line_number": 456
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f42b2f70ce99e343a262e45315a2c4d27daba270",
         "is_verified": false,
-        "line_number": 514
+        "line_number": 462
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "de04d845fc3903d04f8604ae162d8a4cb95f86ba",
         "is_verified": false,
-        "line_number": 520
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "de1558a98424f61bb30fd681ab33ebe9ac162b93",
-        "is_verified": false,
-        "line_number": 526
+        "line_number": 468
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e9fc60c601cab29ea7878a0c9688fb6ee925cf9",
         "is_verified": false,
-        "line_number": 532
+        "line_number": 474
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6c8a21c9366b66bd16b8848cd8ef2f10233ad5ef",
         "is_verified": false,
-        "line_number": 538
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "0609a7c3993cb0b98d835bd299b5e78674c1c4e6",
-        "is_verified": false,
-        "line_number": 544
+        "line_number": 480
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6b1f54e31a53e3667a97cf3af18a66d1cedec7b8",
         "is_verified": false,
-        "line_number": 550
+        "line_number": 486
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "05a957e570c3e4e61ba9f99a19db326dcd2417c2",
         "is_verified": false,
-        "line_number": 556
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7cd72661910d8f1eae72b0783a01c7dcdb990036",
-        "is_verified": false,
-        "line_number": 562
+        "line_number": 492
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "efbe56870cd191d53ef1e6ac6d40ed5eb4cd01c0",
         "is_verified": false,
-        "line_number": 568
+        "line_number": 498
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "24594f4581212d856fe125c6864f7fed1b8a4b65",
         "is_verified": false,
-        "line_number": 574
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c5b024f5526693865d3af7324ab65fc3ab1605fa",
-        "is_verified": false,
-        "line_number": 580
+        "line_number": 504
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fefbbc2958b5d0546d6507d1aad9bead9ef7e9eb",
         "is_verified": false,
-        "line_number": 586
+        "line_number": 510
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5020d98c493f4c60e4e9faa360aee83831e8b060",
         "is_verified": false,
-        "line_number": 592
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7ea3a0d38529d3159199bb46bcf538993729a4ca",
-        "is_verified": false,
-        "line_number": 598
+        "line_number": 516
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "489f7d6ea770d41978c763f306e573aa9c086e3b",
         "is_verified": false,
-        "line_number": 604
+        "line_number": 522
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3bcaf9ab39f602b74d65d903898d40b60bc49e8d",
         "is_verified": false,
-        "line_number": 610
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "abac0dd92435eb969522a0ad244a7d5d3bcf9c90",
-        "is_verified": false,
-        "line_number": 616
+        "line_number": 528
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "84e33cad738a516642e9e4e00c9910ada2755eb8",
         "is_verified": false,
-        "line_number": 622
+        "line_number": 534
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0c232b00899ac5c6c72c50d675fba58be657bb51",
         "is_verified": false,
-        "line_number": 628
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "039980936156bd5bc0de9e386f1e385a9bbabcf0",
-        "is_verified": false,
-        "line_number": 634
+        "line_number": 540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0329358e1442ae9c1dd0cfa7884c4cc51c123c7d",
         "is_verified": false,
-        "line_number": 640
+        "line_number": 546
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "45d7376b39d308f58d92366f89fd5897f34937df",
         "is_verified": false,
-        "line_number": 646
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "ff2f515b75e908a3a079d6b0cf692f65bec13192",
-        "is_verified": false,
-        "line_number": 652
+        "line_number": 552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5520077e071061b96b1bd30a351f2bb3a52cac50",
         "is_verified": false,
-        "line_number": 658
+        "line_number": 558
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a28c69b673bfe25255ddea617830f4a227450bed",
         "is_verified": false,
-        "line_number": 664
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "43b4d7cc77f29c50ebc0ae65cdd5ae53c4610b89",
-        "is_verified": false,
-        "line_number": 670
+        "line_number": 564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "87b1f5328d5448d368f3d6f42f966bf553d4bf3c",
         "is_verified": false,
-        "line_number": 676
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4080ae8ed6a6391c581edbf27618aa0806118784",
-        "is_verified": false,
-        "line_number": 682
+        "line_number": 570
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5fd94d7bc55b700838f7232aa04cd14ce8883702",
         "is_verified": false,
-        "line_number": 688
+        "line_number": 576
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "01860ebaf2a9445d78d11a9db89fecb64710265a",
         "is_verified": false,
-        "line_number": 694
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3e24f346b7ed723f027041976b3d2e7b555ebd90",
-        "is_verified": false,
-        "line_number": 700
+        "line_number": 582
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c3d73f1f8439f4e9e5ad0a8febe880d627dddabc",
         "is_verified": false,
-        "line_number": 706
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2b88177306d91942e3df15d0361c1fd5125db60a",
-        "is_verified": false,
-        "line_number": 712
+        "line_number": 588
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8c94dfd0dbadd0e968f0e9e175bf5bb4fd2594c0",
         "is_verified": false,
-        "line_number": 718
+        "line_number": 594
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cbe73cdb542e52cf85fdae96db4078baf3f81b92",
         "is_verified": false,
-        "line_number": 724
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "68d8df9678250f3f17e3c6e65e8e29e1007cd5ba",
-        "is_verified": false,
-        "line_number": 730
+        "line_number": 600
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ed301ff805587fb9a77f80f5d0fdda6c08a58b87",
         "is_verified": false,
-        "line_number": 736
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a1d2a1836521ff0216663ecd5526c0a53ce86a4d",
-        "is_verified": false,
-        "line_number": 742
+        "line_number": 606
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "38e7a2d417fe20d4760873aa7ad041fa74821645",
         "is_verified": false,
-        "line_number": 748
+        "line_number": 612
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "467ae1b8eba0bb5ed7382100073d14fbb509e77d",
         "is_verified": false,
-        "line_number": 754
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b1265b06c14c30da47639c2ed791f50c8d80227f",
-        "is_verified": false,
-        "line_number": 760
+        "line_number": 618
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2a46cf814514d8cf3a189ce88b22d30c24baf70a",
         "is_verified": false,
-        "line_number": 766
+        "line_number": 624
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "59d87dd0fe7239a69d11c22fbefefe60c35d99fb",
         "is_verified": false,
-        "line_number": 772
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "17e8e3b6a6567490ad87c92962f2fe73df1a95e3",
-        "is_verified": false,
-        "line_number": 778
+        "line_number": 630
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f13e357a26f9e2972019db90dd8ceb867b494f9c",
         "is_verified": false,
-        "line_number": 784
+        "line_number": 636
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f218898e24af5e5ed6a427f4ab4a68014281779f",
         "is_verified": false,
-        "line_number": 790
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b9ed31d4313f86c359571fc1caeced011e1549c8",
-        "is_verified": false,
-        "line_number": 796
+        "line_number": 642
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "35ecb49473bd3c2a84f86fcae2c69e255bdcd843",
         "is_verified": false,
-        "line_number": 802
+        "line_number": 648
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "669e09509d438d5cd9e616a3c27c19d501a6a931",
         "is_verified": false,
-        "line_number": 808
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9234d6da8ceb8786f9a95485ab027085c326afee",
-        "is_verified": false,
-        "line_number": 814
+        "line_number": 654
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5a933a1d9e284cd13a250c28ac430627f1764b3a",
         "is_verified": false,
-        "line_number": 820
+        "line_number": 660
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5db841f4dee4c0a298106f6d56f32851515d99b2",
         "is_verified": false,
-        "line_number": 823
+        "line_number": 663
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b013f3dad4ce2fde647e14586ce596cca9a8c39f",
         "is_verified": false,
-        "line_number": 826
+        "line_number": 666
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dd1db68c43067371d00db59c7f10d0d3ad598841",
         "is_verified": false,
-        "line_number": 832
+        "line_number": 672
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e0d5107e832ed2eed26116dafb2f5c5f977e1341",
         "is_verified": false,
-        "line_number": 835
+        "line_number": 675
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "85caec8d352770d092317299afa348764d129ed5",
         "is_verified": false,
-        "line_number": 838
+        "line_number": 678
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "12de1cdad03b08d04f2c666eb0cb5f1234b496e5",
         "is_verified": false,
-        "line_number": 841
+        "line_number": 681
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8733ba82d33885a92ca3009eb6ba61e505a1ee9a",
         "is_verified": false,
-        "line_number": 845
+        "line_number": 685
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e3522c83d724aa4133ee6bb6d627e4390be31a5",
         "is_verified": false,
-        "line_number": 848
+        "line_number": 688
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9d1b9dbec9f048e048f4dd38591947ca7deff5dd",
         "is_verified": false,
-        "line_number": 851
+        "line_number": 691
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
         "is_verified": false,
-        "line_number": 855
+        "line_number": 695
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b0e9cbf320ebe74507bcdaae3f0b40740459a092",
         "is_verified": false,
-        "line_number": 858
+        "line_number": 698
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b02f181ddfb118185d3fc0be3cac545e7bec4ce5",
         "is_verified": false,
-        "line_number": 861
+        "line_number": 701
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8936283936d833d3fcbc796b612c493f0fc5a2a4",
         "is_verified": false,
-        "line_number": 864
+        "line_number": 704
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5bace6024c7051eb7a1cb1e37f7b9985e533a42e",
         "is_verified": false,
-        "line_number": 867
+        "line_number": 707
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cab18f47244b512a9bb13971e95ba235db151253",
         "is_verified": false,
-        "line_number": 870
+        "line_number": 710
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9966b38a797edc23680e66fcde5a3aa022979a2a",
         "is_verified": false,
-        "line_number": 873
+        "line_number": 713
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6ff531666abb24912d9fae3b91bcd05a49330c9f",
         "is_verified": false,
-        "line_number": 886
+        "line_number": 726
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "be3c56e37593a4a92b74d53e8cb3762e714497b0",
         "is_verified": false,
-        "line_number": 899
+        "line_number": 739
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bf694b5dac75776f7b55aa5663e0d0cef3fb1812",
         "is_verified": false,
-        "line_number": 912
+        "line_number": 752
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8d4a8977dae9d6867dfcdbeb6417d6ab8461534a",
         "is_verified": false,
-        "line_number": 925
+        "line_number": 765
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "eea334ce67d119e127ca2448c8fd8cb9328a5664",
         "is_verified": false,
-        "line_number": 938
+        "line_number": 778
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "693ab2239e3a31d3b1052c6976a8429dd406e7ea",
         "is_verified": false,
-        "line_number": 951
+        "line_number": 791
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "09b6aade4800e313c2bbed96548c4f2dce507168",
         "is_verified": false,
-        "line_number": 964
+        "line_number": 804
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e9d53eedf607b11c3ef44b8c6ff18958ad146340",
         "is_verified": false,
-        "line_number": 977
+        "line_number": 817
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d918d00bcbccaae92cf19b1396e6a7513de61bed",
         "is_verified": false,
-        "line_number": 986
+        "line_number": 826
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "32322bcf00299724296af3309bc033b969f83bf6",
         "is_verified": false,
-        "line_number": 999
+        "line_number": 839
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "76bb59906af53dcb878b807d5817d5edb7ae390f",
         "is_verified": false,
-        "line_number": 1008
+        "line_number": 848
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ebfd0dc170295e67df4d796db25987963ca97e61",
         "is_verified": false,
-        "line_number": 1021
+        "line_number": 861
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d146f31752027f19751d396a49a62010d97f6b80",
         "is_verified": false,
-        "line_number": 1030
+        "line_number": 870
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cfe0bd31a00a41920823c76d517fe7d062e5337c",
         "is_verified": false,
-        "line_number": 1043
+        "line_number": 883
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b16b457c3af8581fda0aad82df8a4d25d56b72f5",
         "is_verified": false,
-        "line_number": 1056
+        "line_number": 896
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "28f0a338a11c78c8b77f06940e97fd7242579d23",
         "is_verified": false,
-        "line_number": 1065
+        "line_number": 905
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c33800ed8ec5106a1d053238f1a22ffad0f7efb9",
         "is_verified": false,
-        "line_number": 1078
+        "line_number": 918
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bfb1d8f7fcfdc3951f2a407606332dd0561ea889",
         "is_verified": false,
-        "line_number": 1091
+        "line_number": 931
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "34ad22b7134e6220790e6f8cb7f7325b72b0ac78",
         "is_verified": false,
-        "line_number": 1100
+        "line_number": 940
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "380016634dca8718e45627a3e887a33cfdbf9583",
         "is_verified": false,
-        "line_number": 1113
+        "line_number": 953
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e12e619cf0949f9f48db809f6ba8abe6d9c49b47",
         "is_verified": false,
-        "line_number": 1126
+        "line_number": 966
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "afb54bbdc2c452025423e4b999636e1168c9e9c8",
         "is_verified": false,
-        "line_number": 1139
+        "line_number": 979
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d5af9fbde70bf119125bc5280e31def9cfc5d2e4",
         "is_verified": false,
-        "line_number": 1152
+        "line_number": 992
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c93cfee749f39a6731bd90e3b8bfc1c2f39dd0bb",
         "is_verified": false,
-        "line_number": 1165
+        "line_number": 1005
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "384119563704c0a0c154cfa3a7fb2f1b6e403e4d",
         "is_verified": false,
-        "line_number": 1178
+        "line_number": 1018
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a9799e49f2382f864dab19d97df038fbcc760f79",
         "is_verified": false,
-        "line_number": 1191
+        "line_number": 1031
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "237858a86350af1517b45ec07878dc64d875b973",
         "is_verified": false,
-        "line_number": 1204
+        "line_number": 1044
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8016aea1098ddd8ebc4bfdebfe91e36d1f038306",
         "is_verified": false,
-        "line_number": 1217
+        "line_number": 1057
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ebafd7b99e26904ea5a3ba20abd17c2d7b913663",
         "is_verified": false,
-        "line_number": 1230
+        "line_number": 1070
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "938a7b1d49a0c2692666797b3a00b607ba1912d4",
         "is_verified": false,
-        "line_number": 1243
+        "line_number": 1083
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5cdcee5a29292be13235b5cbddc6aa392d2b23f1",
         "is_verified": false,
-        "line_number": 1256
+        "line_number": 1096
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d157cd2020faa83a1b672bfd2233a417b17e42d8",
         "is_verified": false,
-        "line_number": 1269
+        "line_number": 1109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7de62fb92f302a3b6974835f839eb53033647499",
         "is_verified": false,
-        "line_number": 1282
+        "line_number": 1122
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "929a3372bee6ce841a9f65cc9edebf68210e5fd7",
         "is_verified": false,
-        "line_number": 1295
+        "line_number": 1135
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c8400bcab54bbc669cbe44b013fd300ec181ae04",
         "is_verified": false,
-        "line_number": 1308
+        "line_number": 1148
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4ca19d51441ee1c7bae4a9ed5f5d5e5befcbbb2e",
         "is_verified": false,
-        "line_number": 1317
+        "line_number": 1157
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "249cc7d6ea282d76f5efff9fb4ed6ed5d3058d08",
         "is_verified": false,
-        "line_number": 1330
+        "line_number": 1170
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "324131826dfbc742fce8c6746a676f16efc315cd",
         "is_verified": false,
-        "line_number": 1343
+        "line_number": 1183
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2b0f34d995e245b329cd153a0eeee34dfc4266c7",
         "is_verified": false,
-        "line_number": 1356
+        "line_number": 1196
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "446546bba84a6355c159d0562c57c670fea13d34",
         "is_verified": false,
-        "line_number": 1369
+        "line_number": 1209
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7d3f1b8d6e4eca6f79dbaf3cdfbca069ab37a6e8",
         "is_verified": false,
-        "line_number": 1382
+        "line_number": 1222
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1cfc669b4a91926a20a0c195e64a33fddfc28636",
         "is_verified": false,
-        "line_number": 1391
+        "line_number": 1231
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "089409fd943a2fb3a5a50b4725a4c96a16bc5d19",
         "is_verified": false,
-        "line_number": 1400
+        "line_number": 1240
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ccf9afc9b093a34274214374a841c68216c23105",
         "is_verified": false,
-        "line_number": 1409
+        "line_number": 1249
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "29094c26e288b5cebbc5262a1996e29057328f1f",
         "is_verified": false,
-        "line_number": 1418
+        "line_number": 1258
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "95362ad9b076707c159a81577f1695dea0ed2eb3",
         "is_verified": false,
-        "line_number": 1427
+        "line_number": 1267
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8cd02e410a9ff591baae8fb0b142f31b91ef9ec0",
         "is_verified": false,
-        "line_number": 1436
+        "line_number": 1276
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9dfea0993e072e2f30d0a2cac0b7bda5f6e7f980",
         "is_verified": false,
-        "line_number": 1445
+        "line_number": 1285
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "15432d91ade7f228054c5d23ceac8d48711a5853",
         "is_verified": false,
-        "line_number": 1454
+        "line_number": 1294
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69ae791ca6d7814550c0af06cc57217e4e1388ea",
         "is_verified": false,
-        "line_number": 1463
+        "line_number": 1303
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "647690124fbe1ff7811211b1ec8ec14c9800de35",
         "is_verified": false,
-        "line_number": 1476
+        "line_number": 1316
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "74e24729da4c61e671c60aba5212f1641cba2b44",
         "is_verified": false,
-        "line_number": 1479
+        "line_number": 1319
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "80baf094c85a8b814390721f28df4426791950e2",
+        "hashed_secret": "c27db3e7ad28966571d6aaab4221024adc120e28",
         "is_verified": false,
-        "line_number": 1482
+        "line_number": 1322
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "19c871b99cc8a8066f7c372cc935250508cdbf7e",
+        "hashed_secret": "cb81edbb9a250cdf42587eda7d50adffe56a7716",
         "is_verified": false,
-        "line_number": 1487
+        "line_number": 1327
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "66eb29da9a96876a8e1b7fefb901f6b582e14b33",
+        "hashed_secret": "f9f4f9a8a71949a267f7074f07957384044256e0",
         "is_verified": false,
-        "line_number": 1492
+        "line_number": 1332
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5ce412f8142bfcc2b11a375e1c91a3a54ca8c0ae",
+        "hashed_secret": "a0ac680a8a2a9c7fcd76e3eeec5a56dab25d4a75",
         "is_verified": false,
-        "line_number": 1497
+        "line_number": 1337
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3e47d4fda361e2553fee0d1f059b0b135fcce98f",
+        "hashed_secret": "2d95d1eb2675da08784f1d264e8062451750e573",
         "is_verified": false,
-        "line_number": 1502
+        "line_number": 1342
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7ce2d9200e0e41b2ee19b821089b6a95a39bc509",
+        "hashed_secret": "cbcf851cc0fc469cc6cff29b7bda4823770c2b24",
         "is_verified": false,
-        "line_number": 1507
+        "line_number": 1347
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b68b16505cf49c5f3cb98af1b54893a1a79565a5",
+        "hashed_secret": "2d76c5b618e06f5060b1251c229bd66068993d79",
         "is_verified": false,
-        "line_number": 1512
+        "line_number": 1352
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b41be781eb3b0c4750e39d09dcdd6a3494f1f357",
+        "hashed_secret": "082cca8a1791200f5bd827df1a5af92478fff517",
         "is_verified": false,
-        "line_number": 1517
+        "line_number": 1357
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "f99a49bc745631a8b7085149e82a79811d9bac8c",
+        "hashed_secret": "b6d5ddb597b029ec693970060b7472ba0087d057",
         "is_verified": false,
-        "line_number": 1522
+        "line_number": 1362
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "edeb02a82bcc0b255ba89f276f37e4091792f4fe",
+        "hashed_secret": "873d6e91bd90150ae8600b7982720e47b7f7726d",
         "is_verified": false,
-        "line_number": 1527
+        "line_number": 1367
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7691f9054b1626b357caca8a9f8e83eb8ac84def",
+        "hashed_secret": "6f1d9b493a63d420310b699d2006de1511097c5f",
         "is_verified": false,
-        "line_number": 1532
+        "line_number": 1372
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "b77dfdeb5ffee23aff3b2f97ff640802ad415a3c",
+        "hashed_secret": "600319d21b284b959a238f481057f93ad9ace156",
         "is_verified": false,
-        "line_number": 1537
+        "line_number": 1377
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "94297c922da678a24c4fc963af0da51d961d8fe5",
+        "hashed_secret": "78de47b110ddd28c06f356dd9fe919eea04f695c",
         "is_verified": false,
-        "line_number": 1542
+        "line_number": 1382
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1f0eb8fb4434346c68f359042c9fc254c1c46be6",
+        "hashed_secret": "641123fc06f217d65b231317ec413f3d82eb2c82",
         "is_verified": false,
-        "line_number": 1547
+        "line_number": 1387
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5d67ae5d1c2f8a622e078f0d8d16670619aa561e",
+        "hashed_secret": "0e5b7b2230b86973ef30c42ca73f8c2f1866c66f",
         "is_verified": false,
-        "line_number": 1552
+        "line_number": 1392
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "fee3efd07b8abcb9d734d6f324253508f7501156",
+        "hashed_secret": "7b234ae165a5fb9ee72ebe505cb033dd78cb1427",
         "is_verified": false,
-        "line_number": 1557
+        "line_number": 1397
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "1380cb2734346cc00e41eb54cdd94860f4859e2c",
+        "hashed_secret": "e15d714dc0e3fadc34fa31dd2f93530b7527c224",
         "is_verified": false,
-        "line_number": 1562
+        "line_number": 1402
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5aea3dce81939048d287d7761e40642490194d09",
+        "hashed_secret": "ef4ebf89aac434354ef0e549b6562a590b38c1ef",
         "is_verified": false,
-        "line_number": 1567
+        "line_number": 1407
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "11487ba85b40245c0bb0e34846085b8714439652",
+        "hashed_secret": "847a90be5433925b78d97121266c6f28d10cad46",
         "is_verified": false,
-        "line_number": 1572
+        "line_number": 1412
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "9f2824e8182be80a655c1164a0c7d043abe0b2e8",
+        "hashed_secret": "efd91b12240e7d0966f7683a6632b899efb02060",
         "is_verified": false,
-        "line_number": 1577
+        "line_number": 1417
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "87bb0e1e3669074c5cda58de04798789e0eda61d",
+        "hashed_secret": "eabb7b1469793615d2e481374e7fa0bf1b797331",
         "is_verified": false,
-        "line_number": 1582
+        "line_number": 1422
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5423261b835b9649ae476fc59e957f6cb03b2369",
+        "hashed_secret": "98e39cf276637483701c7f4ad34f04b82b23db00",
         "is_verified": false,
-        "line_number": 1587
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "c62e701dc37732b77d24e97d4676d597a1e1ce41",
-        "is_verified": false,
-        "line_number": 1592
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "58a0c6f04ab904bada0f96e79f61f7633b8e8554",
-        "is_verified": false,
-        "line_number": 1597
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "5ac63bbb4857e2c672bef90951ed012b5e1a3099",
-        "is_verified": false,
-        "line_number": 1602
+        "line_number": 1427
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6d8b4508131713ab295b7a5d54bf9f650ea7de3a",
         "is_verified": false,
-        "line_number": 1607
+        "line_number": 1432
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "94a6793bad904a80d0d830ad166c5e110ef0e0ce",
         "is_verified": false,
-        "line_number": 1610
+        "line_number": 1435
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3d1f976e7e48c3331bf146ef86537fa84641cfc9",
         "is_verified": false,
-        "line_number": 1613
+        "line_number": 1438
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0fa45a368d9cb3af91d18980d7bf1359cf6906ec",
         "is_verified": false,
-        "line_number": 1616
+        "line_number": 1441
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6ef4e98430a48ebe9da892571cc9116aa215d65a",
         "is_verified": false,
-        "line_number": 1619
+        "line_number": 1444
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d6f51dd81a5a11e1838c695ca672e145b4b574a3",
         "is_verified": false,
-        "line_number": 1622
+        "line_number": 1447
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "883ffddc90f7adb0b2e567704e0e2e7c9ce772e7",
         "is_verified": false,
-        "line_number": 1625
+        "line_number": 1450
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d2f4b057fca06c6c685b9e0d0d347ae4b62d81d0",
         "is_verified": false,
-        "line_number": 1628
+        "line_number": 1453
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6ddcd40970d7a4c79ad7d97ba287276315fbecf8",
         "is_verified": false,
-        "line_number": 1631
+        "line_number": 1456
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8189f85216ce53283b06100728bfbdb6ba39349b",
         "is_verified": false,
-        "line_number": 1637
+        "line_number": 1462
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a9ee872ba47547763ea96bf68935b1ca511b1eea",
         "is_verified": false,
-        "line_number": 1643
+        "line_number": 1468
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3c54a53db895c2d2db105419004c4ca9c0669b9b",
         "is_verified": false,
-        "line_number": 1649
+        "line_number": 1474
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "73eabe01b3849af9f5b7d09fd682e29988078e03",
         "is_verified": false,
-        "line_number": 1655
+        "line_number": 1480
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ed4a714216e6fb3df582608436c971c64d16eb21",
         "is_verified": false,
-        "line_number": 1661
+        "line_number": 1486
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e32262f842014867b6d05de1e8b54be38c774f41",
         "is_verified": false,
-        "line_number": 1667
+        "line_number": 1492
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "07938cb535ebe7164be475b659157d8722bf6cd8",
         "is_verified": false,
-        "line_number": 1673
+        "line_number": 1498
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ed8125bef66b019626fce657625f4dc098ce2d5b",
         "is_verified": false,
-        "line_number": 1679
+        "line_number": 1504
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "efc4995969632bacd704a7dcaaae920f586c0ebd",
         "is_verified": false,
-        "line_number": 1685
+        "line_number": 1510
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "91280ce4aa21694239d39cbf79a7ec38c75b6241",
         "is_verified": false,
-        "line_number": 1697
+        "line_number": 1522
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "108599ae85386bc9ebd90603fc1fa7332c44ab2a",
         "is_verified": false,
-        "line_number": 1703
+        "line_number": 1528
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e92548ca579280bcf908b3e719e347cad2f3b34e",
         "is_verified": false,
-        "line_number": 1709
+        "line_number": 1534
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9c93b5a77413b84c8aab30d61269c5d5af893e84",
         "is_verified": false,
-        "line_number": 1713
+        "line_number": 1538
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0e6b9c5945acf85ec45d0577171ab4adaf465f3c",
         "is_verified": false,
-        "line_number": 1718
+        "line_number": 1543
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4e6b6006b2f7a6f7794756349cd40cce5e779432",
         "is_verified": false,
-        "line_number": 1723
+        "line_number": 1548
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "be64cf9169891b8b4bef36e06bd7defef6a1ec7a",
         "is_verified": false,
-        "line_number": 1726
+        "line_number": 1551
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "50a0bc6ed4bd15cd54a9ef3e744d9e367b1ee0b2",
         "is_verified": false,
-        "line_number": 1738
+        "line_number": 1563
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f161e2b04f8faa8a514998b846300c0e52e3dde4",
         "is_verified": false,
-        "line_number": 1741
+        "line_number": 1566
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "21a255bacab0430cf0dd455985ab2ac363136cdb",
         "is_verified": false,
-        "line_number": 1744
+        "line_number": 1569
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "146791ae0b950340d17de1ffbda27158f3e8be1c",
         "is_verified": false,
-        "line_number": 1747
+        "line_number": 1572
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f0223109c42a9c75ee9a859c7897c6ab5c6eec49",
         "is_verified": false,
-        "line_number": 1750
+        "line_number": 1575
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7fa226273d5a0d1b9abf45e18909943d7007d1b2",
         "is_verified": false,
-        "line_number": 1753
+        "line_number": 1578
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a4fa4a2da187e1f35991b7e3c5bb8c58b148ca09",
         "is_verified": false,
-        "line_number": 1756
+        "line_number": 1581
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9ed4ec5e13d0127aa4390ca0ea6bb0c58955813c",
         "is_verified": false,
-        "line_number": 1759
+        "line_number": 1584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "11c08054a654f517144d206c95a7ef3d1d1d8a10",
         "is_verified": false,
-        "line_number": 1762
+        "line_number": 1587
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "202814e7e7561774522a76c66bc453965f59e0be",
         "is_verified": false,
-        "line_number": 1765
+        "line_number": 1590
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "82e45680d983d798b7eb9ff070d2f4a2ed1a6aca",
         "is_verified": false,
-        "line_number": 1768
+        "line_number": 1593
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b5e25bc274fcd2e0765d9719b5778385a09cd417",
         "is_verified": false,
-        "line_number": 1771
+        "line_number": 1596
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8da85cbce59e3d1311b8d83fca1c8e3d0e67fa36",
         "is_verified": false,
-        "line_number": 1774
+        "line_number": 1599
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "681fe2f819d566ee80576d71374fbe2ea25e9856",
         "is_verified": false,
-        "line_number": 1777
+        "line_number": 1602
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8e2775553add62306a4a60d9730357d20cc8eca4",
         "is_verified": false,
-        "line_number": 1780
+        "line_number": 1605
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "13451c46d267093367a4021d60ecfd01b589453b",
         "is_verified": false,
-        "line_number": 1783
+        "line_number": 1608
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f10d8e7fd0a2d47dd1c517aee23443ac47c8d8f1",
         "is_verified": false,
-        "line_number": 1786
+        "line_number": 1611
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7ad8f7855e91cd8b06becd442f47ac889e45b05c",
         "is_verified": false,
-        "line_number": 1789
+        "line_number": 1614
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "709ec0fb00ecef1e145c61d0227084baf41695ee",
         "is_verified": false,
-        "line_number": 1792
+        "line_number": 1617
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "679c86b8b8102c4f59f082861f7153bbff1c302f",
         "is_verified": false,
-        "line_number": 1795
+        "line_number": 1620
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4edd46fe0024d509c40f64891b8de2c1b8648486",
         "is_verified": false,
-        "line_number": 1798
+        "line_number": 1623
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fdaf5cc2f4c70e89a63da173c9094c23a2bdb447",
         "is_verified": false,
-        "line_number": 1801
+        "line_number": 1626
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "085598568dc4c356ab7aa2d37615bf3e5ac9a276",
         "is_verified": false,
-        "line_number": 1804
+        "line_number": 1629
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "accccbc920e9b8894c9e249476a9d23a102dc51d",
         "is_verified": false,
-        "line_number": 1807
+        "line_number": 1632
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7863f0eb9ee850d4cf1b3ba4790af627e46e8bf5",
         "is_verified": false,
-        "line_number": 1810
+        "line_number": 1635
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "19026bc85cda2b7c02ab2100543274cdfc87e235",
         "is_verified": false,
-        "line_number": 1813
+        "line_number": 1638
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ba993e097570d247c652bcc7a4a09a1433017c7f",
         "is_verified": false,
-        "line_number": 1816
+        "line_number": 1641
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7cfe93f5ecad2c99e18b38dc4eac2dd238115509",
         "is_verified": false,
-        "line_number": 1819
+        "line_number": 1644
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8f7078b941b0c422ed7d2b71a8eeec584b26c85d",
         "is_verified": false,
-        "line_number": 1822
+        "line_number": 1647
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b70e5de9bb948e7b610f4630c08929d8c6de5a7c",
         "is_verified": false,
-        "line_number": 1825
+        "line_number": 1650
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0e06cd30bd4605847a6bd20556de8927f1aca0e9",
         "is_verified": false,
-        "line_number": 1828
+        "line_number": 1653
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8736366f5f93c2407716a62c93c8cd885c50f08d",
         "is_verified": false,
-        "line_number": 1831
+        "line_number": 1656
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ee467c04a4f38d68d8a5a5fc367c934838e079da",
         "is_verified": false,
-        "line_number": 1834
+        "line_number": 1659
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8e1c627ad3f1025cf9f784e000700389c751dc4b",
         "is_verified": false,
-        "line_number": 1837
+        "line_number": 1662
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9cae8ddf51d712b423a6341beaac3b89acffbaa5",
         "is_verified": false,
-        "line_number": 1840
+        "line_number": 1665
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1c5d9085d8ef508b7ecd2db78f089e94de0c9d02",
         "is_verified": false,
-        "line_number": 1843
+        "line_number": 1668
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "04c5e75f80231932968bcbf67513faeb9e5b9420",
         "is_verified": false,
-        "line_number": 1846
+        "line_number": 1671
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6b919cede0677aa776671ba3483c972767adbe2c",
         "is_verified": false,
-        "line_number": 1849
+        "line_number": 1674
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "20bd9f1e82cc3f128d819fa043e4d8be985394dc",
         "is_verified": false,
-        "line_number": 1852
+        "line_number": 1677
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
         "is_verified": false,
-        "line_number": 1855
+        "line_number": 1680
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "690f1d4ee2519d4f62cc3a3f62d6fef48b892c39",
         "is_verified": false,
-        "line_number": 1858
+        "line_number": 1683
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4b612bba8446c6122505b596782ba4ce168218fb",
         "is_verified": false,
-        "line_number": 1861
+        "line_number": 1686
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d4df5977f20f1c07ccc57574a509a2adc7ec8088",
         "is_verified": false,
-        "line_number": 1864
+        "line_number": 1689
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0c6d336e7fe34021c50d0363181bd912cbcd9078",
         "is_verified": false,
-        "line_number": 1867
+        "line_number": 1692
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c554198dff4b9d03e4fed41f9f60ab0f15c68690",
         "is_verified": false,
-        "line_number": 1870
+        "line_number": 1695
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7820059c8d2e0898ad244e8da132f1db709cf138",
         "is_verified": false,
-        "line_number": 1873
+        "line_number": 1698
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fc6d3459aaf555ec080d434621b4841e09a28e49",
         "is_verified": false,
-        "line_number": 1876
+        "line_number": 1701
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7a734bb2b865c8090c992da81fb88b47856d04e3",
         "is_verified": false,
-        "line_number": 1879
+        "line_number": 1704
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "63b336193044808bbd0e235fac5f6aeadb612a52",
         "is_verified": false,
-        "line_number": 1882
+        "line_number": 1707
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7101ee1815ba5a49e02c80e26cd1a18095cf9e33",
         "is_verified": false,
-        "line_number": 1885
+        "line_number": 1710
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d1939c5f12b77cb2d3825f0a77efbaf342eda9f1",
         "is_verified": false,
-        "line_number": 1888
+        "line_number": 1713
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6fe0c1d94e5bf7af28db976667694b068fbbcfa9",
         "is_verified": false,
-        "line_number": 1891
+        "line_number": 1716
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "edad7a64109ca056f9c0c36e70e45ff24f5942b9",
         "is_verified": false,
-        "line_number": 1894
+        "line_number": 1719
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5fbe6af214ff086a2f24d714dc93bbd14cfaf2c6",
         "is_verified": false,
-        "line_number": 1897
+        "line_number": 1722
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1c61cb6e4dfe89ea9932b7b0c795158b3609ea90",
         "is_verified": false,
-        "line_number": 1902
+        "line_number": 1727
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2dba792b1970249e25fea7bd4bef1339031bb5c9",
         "is_verified": false,
-        "line_number": 1905
+        "line_number": 1730
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9474365f899688921c3d377f365fcbbc1c136978",
         "is_verified": false,
-        "line_number": 1908
+        "line_number": 1733
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "33cf77c3b3f57d57c513ec1e83df5d7af1f35099",
         "is_verified": false,
-        "line_number": 1911
+        "line_number": 1736
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5f411c7e6073b67aca1c9043e3e952322dc21d46",
         "is_verified": false,
-        "line_number": 1914
+        "line_number": 1739
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "82e9b248cdbed101133fcd9229632ccd3e00d416",
         "is_verified": false,
-        "line_number": 1917
+        "line_number": 1742
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3b3fdad4fa80ae8473e0304fe52e0cd272ef2a11",
         "is_verified": false,
-        "line_number": 1920
+        "line_number": 1745
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d9ea4a68b988aca799b7049c045c05d7f5eb839a",
         "is_verified": false,
-        "line_number": 1923
+        "line_number": 1748
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2ed50d4e930408285a9712d6c970fd7e8c46fb69",
         "is_verified": false,
-        "line_number": 1926
+        "line_number": 1751
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "91e7edf530f3d2c573744a030a47764481de24a7",
         "is_verified": false,
-        "line_number": 1932
+        "line_number": 1757
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9ca427b833d97f9025e7605a3a2dd0d081aaa0ee",
         "is_verified": false,
-        "line_number": 1935
+        "line_number": 1760
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "75d6aaa3b4dd6c53985c9f5ffabf6cfdb6a426dc",
         "is_verified": false,
-        "line_number": 1946
+        "line_number": 1771
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d71cf22228db367a0643e25b4aaf35bda34fa9bb",
         "is_verified": false,
-        "line_number": 1949
+        "line_number": 1774
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e82ef1986dfaf305bd0539f0c8413683c0b20ff1",
         "is_verified": false,
-        "line_number": 1952
+        "line_number": 1777
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0414462c3828bc4fc16caaed47eeda948fe9cee7",
         "is_verified": false,
-        "line_number": 1955
+        "line_number": 1780
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "538f066bf5a6b310644be407205a05e28a8dc8fd",
         "is_verified": false,
-        "line_number": 1958
+        "line_number": 1783
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "89c31fa0d6838019bc29341b448d189aa712045b",
         "is_verified": false,
-        "line_number": 1961
+        "line_number": 1786
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "30dff6e111c0a18b53cc71da853bac87f73a816c",
         "is_verified": false,
-        "line_number": 1965
+        "line_number": 1790
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2b3802837ce1f8f46c325534f20f111ce94b7862",
         "is_verified": false,
-        "line_number": 1970
+        "line_number": 1795
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f3b53a220b75e239a29648a2022162f032abbc8d",
         "is_verified": false,
-        "line_number": 1973
+        "line_number": 1798
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "93aa782c4df17b6541e0e372240cf197066bab69",
         "is_verified": false,
-        "line_number": 1977
+        "line_number": 1802
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1c504c77e2b9f1ea0e1770e65673fd7f8b3f4c8f",
         "is_verified": false,
-        "line_number": 1980
+        "line_number": 1805
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "599395997c127ee79a03df8cbc9c57d9c5c4b39b",
         "is_verified": false,
-        "line_number": 1984
+        "line_number": 1809
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4f9ca841aeb6fd5f8e147135c04c7351eda0145e",
         "is_verified": false,
-        "line_number": 1987
+        "line_number": 1812
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "8cbe1e980a8cbfc595a57726c1596e3338554dd1",
+        "hashed_secret": "08123a72eda5582ac678d0f7a9c55d7ab9ed22fd",
         "is_verified": false,
-        "line_number": 1994
+        "line_number": 1819
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ce4084b9c766db59d8efac9df450a2ec42ca3639",
         "is_verified": false,
-        "line_number": 1997
+        "line_number": 1822
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "eb1c10c194ba834a6b271d11ed0e87417a434c06",
         "is_verified": false,
-        "line_number": 2000
+        "line_number": 1825
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3165aeec45a531bca4274a9a152b2091b99bf960",
         "is_verified": false,
-        "line_number": 2004
+        "line_number": 1829
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e0c6298d33fd17530dfd7b996b7f0c0f67bc7f08",
         "is_verified": false,
-        "line_number": 2008
+        "line_number": 1833
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c61921cb03b0d17c9d180fa6d2d765269458f5e9",
         "is_verified": false,
-        "line_number": 2013
+        "line_number": 1838
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c56c76bc828483f5553df346fb2eaa6e3e6c4bba",
         "is_verified": false,
-        "line_number": 2017
+        "line_number": 1842
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "09ce1f68022d542bd4b111b2e648b4261e7ea537",
         "is_verified": false,
-        "line_number": 2021
+        "line_number": 1846
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f4713ff6d6ebe4c91eabb4abaa4fff79252287e2",
         "is_verified": false,
-        "line_number": 2025
+        "line_number": 1850
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bb4753386dbead02652a11ec39d51f531400f795",
         "is_verified": false,
-        "line_number": 2029
+        "line_number": 1854
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "76ee5d005d74b14bfcf949a0b24859a1ad611560",
         "is_verified": false,
-        "line_number": 2032
+        "line_number": 1857
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5620b727309eb0585715c051b3f1ad6560879967",
         "is_verified": false,
-        "line_number": 2035
+        "line_number": 1860
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "838860fad35a9938ad0c45978737609b9acf2e86",
         "is_verified": false,
-        "line_number": 2039
+        "line_number": 1864
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a3c954fbcfcb5b1c2087ff1e1a592601ebd0d7f0",
         "is_verified": false,
-        "line_number": 2042
+        "line_number": 1867
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "40b0aef4115b2c0ecffb2e2c74e6e67d01b84997",
         "is_verified": false,
-        "line_number": 2045
+        "line_number": 1870
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ed1668ceb8dc6aaabcb871317d585a5edf44c0bf",
         "is_verified": false,
-        "line_number": 2048
+        "line_number": 1873
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "198c12bf7d9e91116c7bf79acfb5d26023bddca6",
         "is_verified": false,
-        "line_number": 2051
+        "line_number": 1876
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c6132446174fb42fadfe75a8183f305a65574678",
         "is_verified": false,
-        "line_number": 2055
+        "line_number": 1880
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2e168b2e58d3797e1b488abbf415e9b90b3149b9",
         "is_verified": false,
-        "line_number": 2060
+        "line_number": 1885
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d2e1dec5724740f83adc172b07e15342b3eac984",
         "is_verified": false,
-        "line_number": 2063
+        "line_number": 1888
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ed8dee19a6f2946f9f7ee7c5f7d9652daa9064bb",
         "is_verified": false,
-        "line_number": 2067
+        "line_number": 1892
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5974b42acc3c558a08c734a45a10785534b5d382",
         "is_verified": false,
-        "line_number": 2070
+        "line_number": 1895
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "91384b25fae910b4fb3847c70b40b3f56f68346d",
         "is_verified": false,
-        "line_number": 2074
+        "line_number": 1899
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "83307cb75a4a44ba528f4a0aefcec2a8018dc6d8",
         "is_verified": false,
-        "line_number": 2080
+        "line_number": 1905
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "67df7123f1b2c84bf066bc3e6fb4834aa022e20b",
         "is_verified": false,
-        "line_number": 2084
+        "line_number": 1909
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9e4bcb8df7a5f802322234f792347caa3c9240fa",
         "is_verified": false,
-        "line_number": 2087
+        "line_number": 1912
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4e737227d8a4ff0c87704616f4c0c457fa6bf550",
         "is_verified": false,
-        "line_number": 2091
+        "line_number": 1916
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f4c8d4909804be929ee867133fe4b0810002c8a4",
         "is_verified": false,
-        "line_number": 2095
+        "line_number": 1920
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "272e5b30f1b718ab85c40a90f9022aea7f6a506f",
         "is_verified": false,
-        "line_number": 2098
+        "line_number": 1923
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f52956fa7c317746fde250d0f4e54d6115252cd4",
         "is_verified": false,
-        "line_number": 2101
+        "line_number": 1926
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7f104c1c37e525afe159a7b26fe2782992e9c896",
         "is_verified": false,
-        "line_number": 2105
+        "line_number": 1930
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "08c8ee0987f57add8cd4071488caef8ec431336a",
         "is_verified": false,
-        "line_number": 2109
+        "line_number": 1934
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0126e1c37886a7ddcb7c64bbaeba26fbc7350779",
         "is_verified": false,
-        "line_number": 2112
+        "line_number": 1937
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5c41822f05c632ab0ea5a83c2153196107e7e48a",
         "is_verified": false,
-        "line_number": 2115
+        "line_number": 1940
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a31efbdaf429353b1a681cdf75f1c3b091709994",
         "is_verified": false,
-        "line_number": 2119
+        "line_number": 1944
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e42422d60a4e1b1bb29b9f097fa9e00cca9e310d",
         "is_verified": false,
-        "line_number": 2122
+        "line_number": 1947
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "99cb01a94916f4b1a4cd94d7c866029a9e3734ee",
         "is_verified": false,
-        "line_number": 2125
+        "line_number": 1950
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8b6e3d167f9d34dcb4fb60d814fdfd4b8f850b7b",
         "is_verified": false,
-        "line_number": 2130
+        "line_number": 1955
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "031e74c3988d3aa3530d827ec994228035f76b24",
         "is_verified": false,
-        "line_number": 2133
+        "line_number": 1958
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "79380c4284060f6d92599b5075ab5dff98980365",
         "is_verified": false,
-        "line_number": 2138
+        "line_number": 1963
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c3882e02b815ece615eb89b61d2d0f1f1fb1a13f",
         "is_verified": false,
-        "line_number": 2143
+        "line_number": 1968
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "33717c29c8aea5e30d94507cde08e926103815fd",
         "is_verified": false,
-        "line_number": 2147
+        "line_number": 1972
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cb160c0fa67ad1904f0157c03f6acdc648e14c29",
         "is_verified": false,
-        "line_number": 2150
+        "line_number": 1975
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0ec2f9ddae6f2c51a32b569bfa0990b62144a32f",
         "is_verified": false,
-        "line_number": 2154
+        "line_number": 1979
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "63031c941f273d524122c445b6cc52855ba4d80a",
         "is_verified": false,
-        "line_number": 2158
+        "line_number": 1983
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8ffcdf73a059a511bd1a984ff94a6ec26a450da6",
         "is_verified": false,
-        "line_number": 2162
+        "line_number": 1987
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d7df03c04920f03f01f8b40c877fc25a56a9ee19",
         "is_verified": false,
-        "line_number": 2166
+        "line_number": 1991
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "475f81349c63a4a4aa6ee2b034a6670b65d2605d",
         "is_verified": false,
-        "line_number": 2170
+        "line_number": 1995
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e5ccf3a7d5ed1538ce0524b55a6faf09287516d",
         "is_verified": false,
-        "line_number": 2174
+        "line_number": 1999
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "981618e70764ccff965f43b2608479f4b38c4b6b",
         "is_verified": false,
-        "line_number": 2178
+        "line_number": 2003
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "79fe65c8553fd143f3323cfe6925f719b6ef230a",
         "is_verified": false,
-        "line_number": 2182
+        "line_number": 2007
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1258c27ec2d20bcd3b0691e4a621c6167bf14166",
         "is_verified": false,
-        "line_number": 2186
+        "line_number": 2011
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fb3a4cac7ed22b602c677b19d442df41415484d9",
         "is_verified": false,
-        "line_number": 2191
+        "line_number": 2016
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7584292a0d73867cf2a975ae71b7a6b4b7a18fd3",
         "is_verified": false,
-        "line_number": 2195
+        "line_number": 2020
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bfee3969cf314fd46a4a98c127c6e88dbe47a7d7",
         "is_verified": false,
-        "line_number": 2199
+        "line_number": 2024
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0648eae8d4fb533908b8beb9eace610b07c305e3",
         "is_verified": false,
-        "line_number": 2203
+        "line_number": 2028
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a810ae8365e0609794326708e32a66311accf6d9",
         "is_verified": false,
-        "line_number": 2207
+        "line_number": 2032
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "84dc5f27bdddf193db7112ded0e6e62aae32c563",
         "is_verified": false,
-        "line_number": 2211
+        "line_number": 2036
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "91f1d14f5c42035f88d9326dba1ab34a390de763",
         "is_verified": false,
-        "line_number": 2215
+        "line_number": 2040
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9b88197199e0708719546e337507aa489f482035",
         "is_verified": false,
-        "line_number": 2219
+        "line_number": 2044
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e646475e64142c1d1d386b89728a88e637d76ffd",
         "is_verified": false,
-        "line_number": 2222
+        "line_number": 2047
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e4a8eca0bfd89c5c73b1d9b70d7fdc1d63a742c3",
         "is_verified": false,
-        "line_number": 2226
+        "line_number": 2051
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9c2024aeeebab8de7dbec46172c80d3c0977b9fd",
         "is_verified": false,
-        "line_number": 2230
+        "line_number": 2055
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d3110b2f096c13b4a05286099f37adb93dc0d98b",
         "is_verified": false,
-        "line_number": 2234
+        "line_number": 2059
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "26abf1dd2ca59fe7be9eaa38dca3da206ea420ac",
         "is_verified": false,
-        "line_number": 2238
+        "line_number": 2063
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "20691e3175c231d4ed0a46b007016f11088622ce",
         "is_verified": false,
-        "line_number": 2241
+        "line_number": 2066
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bf1d6785d64c573898e6f002e2118df315a3fe8c",
         "is_verified": false,
-        "line_number": 2245
+        "line_number": 2070
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "615111c758dde1f8cbc15fe1e655610e0da5a417",
         "is_verified": false,
-        "line_number": 2249
+        "line_number": 2074
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b839d6cce2e9faca3fe3db9e2571dabe23cf4987",
         "is_verified": false,
-        "line_number": 2253
+        "line_number": 2078
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4f6023e8bc49fa69a236a0745192387ee698473f",
         "is_verified": false,
-        "line_number": 2256
+        "line_number": 2081
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "20a2abce8debc1b0a34db8be8bdec759c03470a5",
         "is_verified": false,
-        "line_number": 2260
+        "line_number": 2085
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "64a1e3b17b6fe4e477f67655772adfb9a8f0685b",
         "is_verified": false,
-        "line_number": 2264
+        "line_number": 2089
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5d5ad5db83b23a384f6c1d4cd98ff642d93831a2",
         "is_verified": false,
-        "line_number": 2268
+        "line_number": 2093
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2cc8a665f17064b10ab9135e29345f537879c7e0",
         "is_verified": false,
-        "line_number": 2272
+        "line_number": 2097
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "080264b10431d7bffd7d0bf2c2e0d27edc640ff4",
         "is_verified": false,
-        "line_number": 2278
+        "line_number": 2103
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "131593dcab4a460dbebcff8d0a12d821b3edd402",
         "is_verified": false,
-        "line_number": 2282
+        "line_number": 2107
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d961319d454caee7b7f6e7790a39f87e1719f043",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2111
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7f3dc3eeca35d4b8f640fea69abdb9249637616d",
         "is_verified": false,
-        "line_number": 2289
+        "line_number": 2114
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f5f75498bedb2fb320a0c96529ed808e8032ab29",
         "is_verified": false,
-        "line_number": 2292
+        "line_number": 2117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b579cc9cf455d76457ba6922c763d7fcc554f34f",
         "is_verified": false,
-        "line_number": 2295
+        "line_number": 2120
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
         "is_verified": false,
-        "line_number": 2298
+        "line_number": 2123
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
         "is_verified": false,
-        "line_number": 2306
+        "line_number": 2131
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "62823fccad763959e8805be597bbafe575f4809e",
         "is_verified": false,
-        "line_number": 2315
+        "line_number": 2140
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4907d411dbbc15d87a3134352a52127406248740",
         "is_verified": false,
-        "line_number": 2318
+        "line_number": 2143
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b4a9257558064dbd957e726d9d25d81b97837009",
         "is_verified": false,
-        "line_number": 2321
+        "line_number": 2146
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "30032b6b21b6761f545cb3a442477208db30131f",
         "is_verified": false,
-        "line_number": 2325
+        "line_number": 2150
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6263b491d8e05bc0d6bc8b232c3a06044db2232c",
         "is_verified": false,
-        "line_number": 2328
+        "line_number": 2153
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c5deff9c59d0e0419952da44431546620804d70e",
         "is_verified": false,
-        "line_number": 2332
+        "line_number": 2157
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d031e18cc14e54a719197084af4cd6b2372fd005",
         "is_verified": false,
-        "line_number": 2336
+        "line_number": 2161
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "572b5e5253ab86ef535e76d891766cc1a17ee6a5",
         "is_verified": false,
-        "line_number": 2340
+        "line_number": 2165
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bef68af5091abf3bd912b28fd2f8b438426dd79d",
         "is_verified": false,
-        "line_number": 2344
+        "line_number": 2169
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6cfffbcd76530450de1b86aa6a25cf6232ba9dc8",
         "is_verified": false,
-        "line_number": 2348
+        "line_number": 2173
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dbaf8941e1df2a6cc0af186ab8c288162c591d75",
         "is_verified": false,
-        "line_number": 2351
+        "line_number": 2176
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4f8baa628528be69e02276f95e83eed38d79feaa",
         "is_verified": false,
-        "line_number": 2354
+        "line_number": 2179
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "09a4d7d429043289e839863c3ba9cafda1e09192",
+        "hashed_secret": "4283f0269f12ac2e491ed22c9d47171a9d48fd48",
         "is_verified": false,
-        "line_number": 2357
+        "line_number": 2182
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "79119667cecad09809c34832b1f2b650b5ccded7",
         "is_verified": false,
-        "line_number": 2360
+        "line_number": 2185
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4d50b55900617c8d08097c03af9667c135c1fc24",
         "is_verified": false,
-        "line_number": 2364
+        "line_number": 2189
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7e0a63b607dc49438c5ff4a0db3931dbc0285dbc",
         "is_verified": false,
-        "line_number": 2367
+        "line_number": 2192
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2d3b72d498880ee7aac85ecfde3d52435c5ab00b",
         "is_verified": false,
-        "line_number": 2370
+        "line_number": 2195
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1f1fa592047caa0501169ce68034b590a04e268c",
         "is_verified": false,
-        "line_number": 2375
+        "line_number": 2200
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "140d86931cb07f9ba23e4b7ef112f5304e16aab1",
         "is_verified": false,
-        "line_number": 2380
+        "line_number": 2205
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "21194e556cc6a23d3903b12189b0b9cd1050f2e5",
         "is_verified": false,
-        "line_number": 2383
+        "line_number": 2208
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2a0c5c01be780688ae4faf4a3e1cb6e48c50dc23",
         "is_verified": false,
-        "line_number": 2387
+        "line_number": 2212
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ff8047908af26a3f03fd3ac26aaa2f5d7ae75e5a",
         "is_verified": false,
-        "line_number": 2391
+        "line_number": 2216
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b32dc7581438839b3baa8cbb9dafcc80017588ea",
         "is_verified": false,
-        "line_number": 2395
+        "line_number": 2220
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6d1db030d72c8b03fd95eaeb0266255402f70df5",
         "is_verified": false,
-        "line_number": 2399
+        "line_number": 2224
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cf75ddffbc923b32123e91e069fbcb97ac39c4d9",
         "is_verified": false,
-        "line_number": 2403
+        "line_number": 2228
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d076e5a9f2245bcedf234f70abb7fa41d4d9f0dc",
         "is_verified": false,
-        "line_number": 2407
+        "line_number": 2232
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "417a00b911e0b72a50a597cb7c4c70885c55516e",
         "is_verified": false,
-        "line_number": 2410
+        "line_number": 2235
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e28508e3ee2cfadee43ef9cfb9bb3b5d5d8ef5af",
         "is_verified": false,
-        "line_number": 2414
+        "line_number": 2239
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "508e13818451655db815826a00fe15a68b7481b7",
         "is_verified": false,
-        "line_number": 2418
+        "line_number": 2243
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0a78ed1531f1e89e2dde49c07aee4199c0837078",
         "is_verified": false,
-        "line_number": 2423
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "cab616f3cdb6eb3c372039eeae16f83314439923",
-        "is_verified": false,
-        "line_number": 2428
+        "line_number": 2248
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3cb8e7a708267691af8530db673cae1ad0578392",
         "is_verified": false,
-        "line_number": 2433
+        "line_number": 2253
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cc0394ae9ff7278ac1f8ba8305e06627798ae34b",
         "is_verified": false,
-        "line_number": 2437
+        "line_number": 2257
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9282693a1a1e5f8fadcc1617db1f7a097db8429b",
         "is_verified": false,
-        "line_number": 2440
+        "line_number": 2260
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "aabf9f3ccb818057fe7b956cb56b9c011e002839",
         "is_verified": false,
-        "line_number": 2444
+        "line_number": 2264
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8ab0d03e8d34c76769e2494c72290c441ebcc749",
         "is_verified": false,
-        "line_number": 2447
+        "line_number": 2267
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
         "is_verified": false,
-        "line_number": 2450
+        "line_number": 2270
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3b9b4f0e0dc452a1ab51ff9a7e649171b0b54a70",
         "is_verified": false,
-        "line_number": 2453
+        "line_number": 2273
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "03d6fb388dd1b185129b14221f7127715822ece6",
         "is_verified": false,
-        "line_number": 2457
+        "line_number": 2277
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "72e5393170ee8c03f5ebad63e044422989818b95",
         "is_verified": false,
-        "line_number": 2460
+        "line_number": 2280
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "030fd33a7a056f197ef34c37cfcb73f470df0612",
         "is_verified": false,
-        "line_number": 2464
+        "line_number": 2284
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "12ecf39948e93968cea583a27ce0f918a02e3878",
         "is_verified": false,
-        "line_number": 2468
+        "line_number": 2288
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "acce4ef8d841ffa646256da3af7b79ad5cb78158",
         "is_verified": false,
-        "line_number": 2471
+        "line_number": 2291
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4a0c4d36aaf8c5cea9b9087156ac34f7da104dc4",
         "is_verified": false,
-        "line_number": 2474
+        "line_number": 2294
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "16fa3bfaeef78e32910c87baf9060e51490d09ad",
         "is_verified": false,
-        "line_number": 2478
+        "line_number": 2298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "608a2b22745aedb3dff3a03315104b03db3bc18a",
         "is_verified": false,
-        "line_number": 2487
+        "line_number": 2307
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "7c5e3c6fa20471b4957071b973791e5b70877322",
+        "hashed_secret": "40e7076fc8fd248af67cfc317346eafeafa8f7a9",
         "is_verified": false,
-        "line_number": 2491
+        "line_number": 2311
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "6afa15e8edc16b7f6767c97ca8892b8602a2adfe",
+        "hashed_secret": "8880036dd8f74c6cd85075c896ff8851627a0919",
         "is_verified": false,
-        "line_number": 2500
+        "line_number": 2320
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dc9a2ba629796d6ef3323496eb952461f964e115",
         "is_verified": false,
-        "line_number": 2504
+        "line_number": 2324
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c53a12e9d025e4a06da4523b43f6538eedd9d04f",
         "is_verified": false,
-        "line_number": 2508
+        "line_number": 2328
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "154f11f3be7925e9dfc95d61ccd19f9d367bd090",
         "is_verified": false,
-        "line_number": 2511
+        "line_number": 2331
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "67e1630eef767c17f165bed8793abff78d5d53ac",
         "is_verified": false,
-        "line_number": 2525
+        "line_number": 2345
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
         "is_verified": false,
-        "line_number": 2529
+        "line_number": 2349
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e7f54899a1654525fbfb1d8c3ac44d632f655af1",
         "is_verified": false,
-        "line_number": 2534
+        "line_number": 2354
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f5e09813aa79c07abdd4edd0469c3fad0a4ec10d",
         "is_verified": false,
-        "line_number": 2537
+        "line_number": 2357
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "70239f714086644424a812bb19cd8af853b4fe93",
         "is_verified": false,
-        "line_number": 2541
+        "line_number": 2361
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4cd3a1b109eb67acf1557141e83880899d18eaea",
         "is_verified": false,
-        "line_number": 2545
+        "line_number": 2365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c80b43d625c11b70d6408c9e01348f73adb7c10e",
         "is_verified": false,
-        "line_number": 2549
+        "line_number": 2369
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5a4d96497ba98531c9c36ced1d043fbd8c535eff",
         "is_verified": false,
-        "line_number": 2553
+        "line_number": 2373
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ae324c1d6b29cddd2062229ca65d08baecc7789a",
         "is_verified": false,
-        "line_number": 2557
+        "line_number": 2377
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4d0e714a0f6a740c6b6b047cf9b513bf8ff4c898",
         "is_verified": false,
-        "line_number": 2560
+        "line_number": 2380
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "979e2a14e4576c62a9748d7466bfa7f4f3a0620d",
         "is_verified": false,
-        "line_number": 2564
+        "line_number": 2384
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1e074256695d27dc0bea46d8da0b7d078ac360b9",
         "is_verified": false,
-        "line_number": 2568
+        "line_number": 2388
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4bc048ef798be5bb613b48cf7e4602803fb1b709",
         "is_verified": false,
-        "line_number": 2571
+        "line_number": 2391
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0d97c7fe1c124e07eb8bba42a86419c083ba0591",
         "is_verified": false,
-        "line_number": 2574
+        "line_number": 2394
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e07f2c68e0fe6abfac19da4e9dd0c81669de7078",
         "is_verified": false,
-        "line_number": 2578
+        "line_number": 2398
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a171d831e5bb8b8dd823212d122109b84af8a0d9",
+        "hashed_secret": "f52c08f63289414b8da2ea1271f68c9e1d6338ea",
         "is_verified": false,
-        "line_number": 2582
+        "line_number": 2402
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9ac633e9766159806b447d7be2d84067548764f4",
         "is_verified": false,
-        "line_number": 2586
+        "line_number": 2406
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fffff370595b6f4803e610b7519dbb1bb9923c8a",
         "is_verified": false,
-        "line_number": 2589
+        "line_number": 2409
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3300960d885e191e93efbb20d444a625bddcfe90",
         "is_verified": false,
-        "line_number": 2592
+        "line_number": 2412
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a0540a26c42e0189fb536e1a42e879429302f9a8",
         "is_verified": false,
-        "line_number": 2595
+        "line_number": 2415
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4a5f8dde591a608cfa2336a8892bd84faf3f6fa6",
         "is_verified": false,
-        "line_number": 2598
+        "line_number": 2418
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c73d5fe546a436b30bdec90b571803faa29161c0",
         "is_verified": false,
-        "line_number": 2601
+        "line_number": 2421
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ecf82334d7607ee319ed50d5c868b73e18e07f8c",
         "is_verified": false,
-        "line_number": 2604
+        "line_number": 2424
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6b480f88105d1d6f58deb5c93ce778e95daab763",
         "is_verified": false,
-        "line_number": 2607
+        "line_number": 2427
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b128899a573a4719880fc1d714ef898c2cd0bbf4",
         "is_verified": false,
-        "line_number": 2610
+        "line_number": 2430
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "886470e65dd1f05934c64b6cefaf846f674a70e9",
         "is_verified": false,
-        "line_number": 2613
+        "line_number": 2433
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c13019d9b575d1a10e507a546e858569e335b12e",
         "is_verified": false,
-        "line_number": 2616
+        "line_number": 2436
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2d4c99fda7bfa97703c58c10a3f406dffea5b103",
         "is_verified": false,
-        "line_number": 2619
+        "line_number": 2439
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4032d4dd08dc516a97cd96b4d161fd0dccb8b592",
         "is_verified": false,
-        "line_number": 2622
+        "line_number": 2442
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d3063fb8878cd870d06706fb7de1fbf791b78dd8",
         "is_verified": false,
-        "line_number": 2626
+        "line_number": 2446
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a93b7cbad36674f1587bbaaf17a4c35cb121288f",
         "is_verified": false,
-        "line_number": 2629
+        "line_number": 2449
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "395c2fd7dd96691ca2f110afa91b51ffc6f26d97",
         "is_verified": false,
-        "line_number": 2632
+        "line_number": 2452
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ebf396301cd5f2bffdd5e7e25066a15ea189798d",
         "is_verified": false,
-        "line_number": 2635
+        "line_number": 2455
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3e6c18abd5b90c63da0bd8b4c0d3a142e3d5a83d",
         "is_verified": false,
-        "line_number": 2639
+        "line_number": 2459
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9cfd1c9ff642dd3f9093c2e68fda7b9daba943ca",
         "is_verified": false,
-        "line_number": 2643
+        "line_number": 2463
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
         "is_verified": false,
-        "line_number": 2647
+        "line_number": 2467
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6c0b4cfc433a0c4567ffa56f081ab35a7e8b0bb5",
         "is_verified": false,
-        "line_number": 2650
+        "line_number": 2470
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b339256107c4edc00f4a15bc9e8524893981ede2",
         "is_verified": false,
-        "line_number": 2653
+        "line_number": 2473
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a0b8be6c9c901fe0b497f749b90ea1a7228d5621",
         "is_verified": false,
-        "line_number": 2659
+        "line_number": 2479
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "16eded55a99600a3cf9b11d791983819c7846ba1",
         "is_verified": false,
-        "line_number": 2662
+        "line_number": 2482
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "89b283ab50bf537dfbd64a59830fb7dda89eb546",
         "is_verified": false,
-        "line_number": 2666
+        "line_number": 2486
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1e8b8a60def9fb8f8c82d1e179ce58c72153919f",
         "is_verified": false,
-        "line_number": 2670
+        "line_number": 2490
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "80ff4b9ea3008303d30330c97e58802255dc7593",
         "is_verified": false,
-        "line_number": 2673
+        "line_number": 2493
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9cec1315b7372e1295e71f729deec833d65722fb",
         "is_verified": false,
-        "line_number": 2676
+        "line_number": 2496
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "43dc656bfd918cc743c84a579f03cb2d5b90b3dd",
         "is_verified": false,
-        "line_number": 2679
+        "line_number": 2499
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "523696dbce7fa1ba78c3e9e7ced068a037d0e6a1",
         "is_verified": false,
-        "line_number": 2682
+        "line_number": 2502
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "347211552fbc738f276a998116b5ef0f8750cb92",
         "is_verified": false,
-        "line_number": 2686
+        "line_number": 2506
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5856bd4cb3a23981807d6e537408344c13ffaada",
         "is_verified": false,
-        "line_number": 2690
+        "line_number": 2510
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3773d33c5207f8939a7a42e355daa3e28619cab1",
         "is_verified": false,
-        "line_number": 2693
+        "line_number": 2513
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "88d5de50147c0a55cf86a9c79b0002573f21febe",
         "is_verified": false,
-        "line_number": 2698
+        "line_number": 2518
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8de81592addca35790ac4952804d8bf7e97825a2",
         "is_verified": false,
-        "line_number": 2703
+        "line_number": 2523
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ea988cbd3d8b5e867a1b9205a31c22a0e677cc07",
         "is_verified": false,
-        "line_number": 2707
+        "line_number": 2527
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8271215bc0f8f3c777e34a26e08ac6f4b0643b46",
         "is_verified": false,
-        "line_number": 2710
+        "line_number": 2530
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e3aa848f78699e8fd784dde75cb72e3d31d89d0b",
         "is_verified": false,
-        "line_number": 2713
+        "line_number": 2533
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "424c32eeac514fcbcd69f564d4633bf29df3584c",
         "is_verified": false,
-        "line_number": 2717
+        "line_number": 2537
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "55e984b8442729280aba3a65202556f31aa7ee2b",
         "is_verified": false,
-        "line_number": 2720
+        "line_number": 2540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "234449837ea82897a022123e9cef8c60b5700beb",
         "is_verified": false,
-        "line_number": 2723
+        "line_number": 2543
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "64cdfb16d3cf2dee4aec7722977bbcfd7f125dd1",
         "is_verified": false,
-        "line_number": 2729
+        "line_number": 2549
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "24652ad480f103f15bb57964ecd71d5bb6e3cdc0",
         "is_verified": false,
-        "line_number": 2735
+        "line_number": 2555
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8f62546695ef43015b84686167d3cb5a959c5d56",
         "is_verified": false,
-        "line_number": 2741
+        "line_number": 2561
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d961d5c083c668941a0fc005f4f494117c275692",
         "is_verified": false,
-        "line_number": 2747
+        "line_number": 2567
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1d3b7b58e55dda6205d88c114f2c7bd54c3a88b5",
         "is_verified": false,
-        "line_number": 2753
+        "line_number": 2573
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e49ff6eff7e9fef5776e75b90b4fe817511e3e21",
         "is_verified": false,
-        "line_number": 2759
+        "line_number": 2579
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "06252eb36883aef1fa36bf426225f6b836e660da",
         "is_verified": false,
-        "line_number": 2765
+        "line_number": 2585
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ced599fa36c18f07d6cd42c35691b91b1fbe428e",
         "is_verified": false,
-        "line_number": 2771
+        "line_number": 2591
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f3f7ebf5b129836f221b766a549bd87000295f12",
         "is_verified": false,
-        "line_number": 2777
+        "line_number": 2597
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "25190a22b603f9ec8147fb0841a1388bf16a2f10",
         "is_verified": false,
-        "line_number": 2783
+        "line_number": 2603
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8fd18f737f7036fe9e4886ce31dcacf15ffbb58d",
         "is_verified": false,
-        "line_number": 2787
+        "line_number": 2607
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "af1761dddd338a777dabd8eb8f1ae8955205a116",
+        "hashed_secret": "5cc20a5b047f98c3bdfc84b87d743bfb60f2947a",
         "is_verified": false,
-        "line_number": 2791
+        "line_number": 2611
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2cb277435cb97d4859d0d0ae4d891a9f3cd17bef",
+        "hashed_secret": "e9fdc3025cd10bd8aa4508611e6b7b7a9d650a2c",
         "is_verified": false,
-        "line_number": 2794
+        "line_number": 2614
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c4de6f94f8f7a0f08c01a965f6a643d1c57f5c61",
         "is_verified": false,
-        "line_number": 2797
+        "line_number": 2617
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fb9c7a703400fb200bda1edab8099ecde48d9af7",
         "is_verified": false,
-        "line_number": 2800
+        "line_number": 2620
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "73bc28172456bad6166fd9a576eb52082dc4dd3c",
         "is_verified": false,
-        "line_number": 2804
+        "line_number": 2624
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7ed5906c17ddd4e8330c8475dac722175e5e67c4",
         "is_verified": false,
-        "line_number": 2807
+        "line_number": 2627
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "13e23943c1cb3acb333b79f031e253eba14e19b0",
         "is_verified": false,
-        "line_number": 2810
+        "line_number": 2630
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "93d26aba3b02b6b4cfc7f49abe2ae9c07fef0566",
         "is_verified": false,
-        "line_number": 2815
+        "line_number": 2635
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cb5bf77fc0e159831c9d3ff288109c30f9a0f5e6",
         "is_verified": false,
-        "line_number": 2820
+        "line_number": 2640
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a407d06722bf11a6fd9dbf73f64de844545bf571",
         "is_verified": false,
-        "line_number": 2823
+        "line_number": 2643
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "89ef487bec97886dd937d3802746b4a6a7b18ebf",
         "is_verified": false,
-        "line_number": 2826
+        "line_number": 2646
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "87ae5db459dbd9fe4157473b016ae5ff5ef0f4ed",
         "is_verified": false,
-        "line_number": 2831
+        "line_number": 2651
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b7f0ec14ead4ce3ec5a28b652101064505ca5153",
         "is_verified": false,
-        "line_number": 2835
+        "line_number": 2655
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bd6b0d8b6b1f3c582851ca1e5596cbb670883e54",
         "is_verified": false,
-        "line_number": 2838
+        "line_number": 2658
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4936a580bf9308ae4bb0c0ad363825b99f5a3acf",
         "is_verified": false,
-        "line_number": 2841
+        "line_number": 2661
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e90d3992248e1597937943ae623ad2c0e243cc9c",
         "is_verified": false,
-        "line_number": 2844
+        "line_number": 2664
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "21c00ccd7d3f52c23ad0a792501a222ec6d30194",
         "is_verified": false,
-        "line_number": 2847
+        "line_number": 2667
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d58ffd4a136f1e28323e9986114c5e98b9cb3137",
         "is_verified": false,
-        "line_number": 2850
+        "line_number": 2670
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fa960b6bc3050364365c412b7d57e30ae5b83eb7",
         "is_verified": false,
-        "line_number": 2853
+        "line_number": 2673
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "897e0533ac8d299571dbc275eba1bbfebba3883b",
         "is_verified": false,
-        "line_number": 2856
+        "line_number": 2676
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3b13d0031f0062532c2653885b097a9721c95a86",
         "is_verified": false,
-        "line_number": 2859
+        "line_number": 2679
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ab8c0dcb0826b3d7e70fc36102f23c6041b3ca82",
         "is_verified": false,
-        "line_number": 2862
+        "line_number": 2682
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8e326c53cdef19ea5189fb18b64262fdacbad1c3",
         "is_verified": false,
-        "line_number": 2865
+        "line_number": 2685
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "65dfebe42f609ad9e8d4175351c56d70c69414ae",
         "is_verified": false,
-        "line_number": 2868
+        "line_number": 2688
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d3972dcaca2a5c591cb7a09776b0dc338f544820",
         "is_verified": false,
-        "line_number": 2871
+        "line_number": 2691
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "a43d82b1bb02a76982f03708a4c77d9717f5f5c1",
+        "hashed_secret": "b9381a68b32516410cee735432800123389658cd",
         "is_verified": false,
-        "line_number": 2874
+        "line_number": 2694
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5c6fd1ad37e6f3656e527822c052f74a1bcd4b42",
         "is_verified": false,
-        "line_number": 2877
+        "line_number": 2697
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f88647a1b4c22c3707f1fac4105d45bb98c5bc64",
         "is_verified": false,
-        "line_number": 2880
+        "line_number": 2700
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d7c39664c403d1fecb3d1e330ad65a00bab67629",
         "is_verified": false,
-        "line_number": 2883
+        "line_number": 2703
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "33424d6062b147852810a1b4e7d5cd675caa3231",
         "is_verified": false,
-        "line_number": 2887
+        "line_number": 2707
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0661a6284527e94d3ac8b52324e219703276485b",
         "is_verified": false,
-        "line_number": 2890
+        "line_number": 2710
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "22f475d09df2c53aa6332a6d7aa6ac7e2cc09481",
         "is_verified": false,
-        "line_number": 2893
+        "line_number": 2713
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "79530a702b5cdd581150cc6ad6a7d16b50bab092",
         "is_verified": false,
-        "line_number": 2897
+        "line_number": 2717
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c42c0f2b427e93ec72f707573c0fcb5e4e191af4",
         "is_verified": false,
-        "line_number": 2900
+        "line_number": 2720
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2883c8b2e73c93ec9c28c8a8e3077279894a3bcd",
         "is_verified": false,
-        "line_number": 2910
+        "line_number": 2730
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2f6768b77ca0db905e677336b7ed115432d94d69",
         "is_verified": false,
-        "line_number": 2919
+        "line_number": 2739
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "952be565343ea5ad6f02977ec8af33008e8aa335",
         "is_verified": false,
-        "line_number": 2929
+        "line_number": 2749
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1ccbfc906b119ecfd9f397b40fad4208826a6673",
         "is_verified": false,
-        "line_number": 2932
+        "line_number": 2752
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1ad7ea9a5e284e9f11d87268b24bb07d6293a834",
         "is_verified": false,
-        "line_number": 2935
+        "line_number": 2755
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "694e2bae57d97eb1561652c96877824df97b6a39",
         "is_verified": false,
-        "line_number": 2938
+        "line_number": 2758
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fe9d0a2d35157bf60abbe436a0e8d4adcdc094f7",
         "is_verified": false,
-        "line_number": 2941
+        "line_number": 2761
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f6be95794c456d6f70e9bf783774e43930f5d61f",
         "is_verified": false,
-        "line_number": 2944
+        "line_number": 2764
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "75c53f5e8c084076e3594ea55e597bc21394d4cd",
         "is_verified": false,
-        "line_number": 2947
+        "line_number": 2767
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e3b8bd39c0d74b5489473733b30f2ff0c21beb55",
         "is_verified": false,
-        "line_number": 2950
+        "line_number": 2770
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8efeb0ea3d48a3a2b2a090a7c8010755a2915fc0",
         "is_verified": false,
-        "line_number": 2953
+        "line_number": 2773
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "37da2eab0a1a2eb5aca7e20ec5a339dbe92c65d2",
         "is_verified": false,
-        "line_number": 2956
+        "line_number": 2776
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2c51dc6c745842f8fbf71a2c28e780f1533f8fe7",
         "is_verified": false,
-        "line_number": 2959
+        "line_number": 2779
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "414e5b40034f7acb7f416a296ca1c2345f280da0",
         "is_verified": false,
-        "line_number": 2962
+        "line_number": 2782
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b0669b6ec44009fc2ce9b137b86ecb0dce0e67fd",
         "is_verified": false,
-        "line_number": 2965
+        "line_number": 2785
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "792a1156c3600bde64fe6afdb70027451714a505",
         "is_verified": false,
-        "line_number": 2968
+        "line_number": 2788
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "af7df54d476b7e073039dbc773c624f8f97629b8",
         "is_verified": false,
-        "line_number": 2971
+        "line_number": 2791
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "feb32ba7caba22bc1bfc8fa40d3aab70d80c3711",
         "is_verified": false,
-        "line_number": 2974
+        "line_number": 2794
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "265f0d4504aecf5901e39e1a846b464af8f548a1",
         "is_verified": false,
-        "line_number": 2977
+        "line_number": 2797
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0643e1dd5e6fa6e7bf26a459decc1c8bf9eb0d01",
         "is_verified": false,
-        "line_number": 2980
+        "line_number": 2800
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9dd8c628f27bb52398e48ddbcb3458495642f294",
         "is_verified": false,
-        "line_number": 2983
+        "line_number": 2803
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "109cd598436e4dbd5c935b071213eb93a9708f76",
         "is_verified": false,
-        "line_number": 2986
+        "line_number": 2806
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d640cd5c7ce3473bcecf0c2a20aa4af797104959",
         "is_verified": false,
-        "line_number": 2989
+        "line_number": 2809
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4efd847a5850eeae332676e2b684fafdcdec75af",
         "is_verified": false,
-        "line_number": 2992
+        "line_number": 2812
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "eaf09abc5e0c47680c2e017deb2f21c42aa080df",
         "is_verified": false,
-        "line_number": 2995
+        "line_number": 2815
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "884dbfc05c081ec180a4161939d88eeac20e5069",
         "is_verified": false,
-        "line_number": 2998
+        "line_number": 2818
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "541dfcea68a9f74d492a6578e75b29b6c76b6eb7",
         "is_verified": false,
-        "line_number": 3001
+        "line_number": 2821
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1cbcaee55711fa79b8e31ea01993e469b1e7a103",
         "is_verified": false,
-        "line_number": 3004
+        "line_number": 2824
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7a3ba83c9e664a7e4ca91d47bddf0368f196635d",
         "is_verified": false,
-        "line_number": 3007
+        "line_number": 2827
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0272672e07bf95193ae1149d4fe8e21c2e057326",
         "is_verified": false,
-        "line_number": 3010
+        "line_number": 2830
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "838abb1331a160bdd441c25a2a2d44332ee8694b",
         "is_verified": false,
-        "line_number": 3013
+        "line_number": 2833
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e6525dbd438fc8858b0d56c59d164f403792ba1e",
         "is_verified": false,
-        "line_number": 3017
+        "line_number": 2837
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5c270f653b2fcd5b7c700b53f8543df4147a4aba",
         "is_verified": false,
-        "line_number": 3021
+        "line_number": 2841
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0430ef838f88b8c253f36d7c2c5e9da6b30310b7",
         "is_verified": false,
-        "line_number": 3026
+        "line_number": 2846
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1560a9e5a2cb0315745d4a4936af7518beb680e7",
         "is_verified": false,
-        "line_number": 3030
+        "line_number": 2850
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "143743528e3b9b96aaf60f7aec6c318be5e54a99",
         "is_verified": false,
-        "line_number": 3034
+        "line_number": 2854
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "90de41bb645eb912a3dcfbf357a4d329707ba620",
         "is_verified": false,
-        "line_number": 3037
+        "line_number": 2857
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2718c296599ffc1e7d35452180a0ca84429f3565",
         "is_verified": false,
-        "line_number": 3040
+        "line_number": 2860
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d1538c9c6f5e959070b379c89558393edcf64c0d",
         "is_verified": false,
-        "line_number": 3043
+        "line_number": 2863
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9a2e9779fa026f10b01762c6db4beb39bbf28531",
         "is_verified": false,
-        "line_number": 3046
+        "line_number": 2866
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "612b70ad4343adbb09a9cacc2fd28d7a2eae9313",
         "is_verified": false,
-        "line_number": 3049
+        "line_number": 2869
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
         "is_verified": false,
-        "line_number": 3052
+        "line_number": 2872
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
         "is_verified": false,
-        "line_number": 3055
+        "line_number": 2875
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f58d2ed9acfa2afd285ebd603ede04ea158f9767",
         "is_verified": false,
-        "line_number": 3060
+        "line_number": 2880
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4882a3f560bc1bf6d57e2e0d1bf68d2568e76dae",
         "is_verified": false,
-        "line_number": 3065
+        "line_number": 2885
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "57850ae994dc8800eef664d4c7e35bbc69515b6e",
         "is_verified": false,
-        "line_number": 3069
+        "line_number": 2889
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "75e87bd654e00a58569f2f4964d6ac76c962f0b8",
         "is_verified": false,
-        "line_number": 3075
+        "line_number": 2895
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7de59f662d7b267325ed23d6f2e9237530304d27",
         "is_verified": false,
-        "line_number": 3078
+        "line_number": 2898
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
         "is_verified": false,
-        "line_number": 3082
+        "line_number": 2902
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0817713c3585298fbb156482ffc6787018397167",
         "is_verified": false,
-        "line_number": 3086
+        "line_number": 2906
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1fd960f79ff7ccd39310bfdf81fba2b2663b71d0",
         "is_verified": false,
-        "line_number": 3090
+        "line_number": 2910
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "872f644ca44ce177f63803aa24fcb778566ecf1f",
         "is_verified": false,
-        "line_number": 3094
+        "line_number": 2914
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2962f0a9f971f12844f66fddcaec41e8f889ad1c",
         "is_verified": false,
-        "line_number": 3097
+        "line_number": 2917
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bd243db4547725d4f90f654639e2fc2cea47e9ca",
         "is_verified": false,
-        "line_number": 3100
+        "line_number": 2920
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ab840a50bf838c62ac16ef5ef0bd5249bbb945e0",
         "is_verified": false,
-        "line_number": 3103
+        "line_number": 2923
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d25f38e564eeda6402f558b3ad020bd05220df32",
         "is_verified": false,
-        "line_number": 3106
+        "line_number": 2926
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ae745d719f97b3ddb9791348b1f29ff8208c0c5c",
         "is_verified": false,
-        "line_number": 3109
+        "line_number": 2929
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cdb8646d4a7ff41822fd7db480ce191ce8d0adcb",
         "is_verified": false,
-        "line_number": 3113
+        "line_number": 2933
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "78cac34debb068504165d4e64975947b641f5da8",
         "is_verified": false,
-        "line_number": 3116
+        "line_number": 2936
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "976e08d754318ea78969397d0d99157a6e8813a3",
         "is_verified": false,
-        "line_number": 3119
+        "line_number": 2939
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
         "is_verified": false,
-        "line_number": 3122
+        "line_number": 2942
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "406d7e234572008768bde7f31b176a7a0f8da4f0",
         "is_verified": false,
-        "line_number": 3125
+        "line_number": 2945
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
         "is_verified": false,
-        "line_number": 3129
+        "line_number": 2949
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "84cbfec871cf2b178ab90fcc1f442fa369e99a02",
+        "hashed_secret": "06477f13a769300ebac81ebe76739fb78432f564",
         "is_verified": false,
-        "line_number": 3132
+        "line_number": 2952
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "18320432c7c3515f682ce9a5def8785bf11de5fd",
         "is_verified": false,
-        "line_number": 3136
+        "line_number": 2956
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2aaf078a06eded23d8751c4e0aad33ec11c447fd",
         "is_verified": false,
-        "line_number": 3139
+        "line_number": 2959
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e2d1a2a5929d1167344a4844e1292d456c714bec",
         "is_verified": false,
-        "line_number": 3142
+        "line_number": 2962
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8d24ba248862a0cdc267a56eaa97c4667069409d",
         "is_verified": false,
-        "line_number": 3147
+        "line_number": 2967
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "295c5d969535881e04800821e0a1bc48bd5761f2",
         "is_verified": false,
-        "line_number": 3150
+        "line_number": 2970
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5b189a85028bdd8e9efea153b06dc2bf302ba6e0",
         "is_verified": false,
-        "line_number": 3153
+        "line_number": 2973
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "157e5b0c4ac544ad1a995d6414e4dd539af39aa3",
         "is_verified": false,
-        "line_number": 3157
+        "line_number": 2977
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e4d0457c3771bd19a2db30ce4295cc025189392e",
         "is_verified": false,
-        "line_number": 3160
+        "line_number": 2980
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e5b68dc212c35983909130bf6b5106e3a462ecbc",
         "is_verified": false,
-        "line_number": 3164
+        "line_number": 2984
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a44086439a402b1cfa18ba35abf41235c616d5a5",
         "is_verified": false,
-        "line_number": 3169
+        "line_number": 2989
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9f48be0a09794d087d8615cbce47e062b9984fd6",
         "is_verified": false,
-        "line_number": 3172
+        "line_number": 2992
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c15d96d7e81cc1f40282e204d55b5832f5117f3f",
         "is_verified": false,
-        "line_number": 3175
+        "line_number": 2995
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2a416cdbfc3b4651a6d04d447938ace3ff9c7b6a",
         "is_verified": false,
-        "line_number": 3178
+        "line_number": 2998
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "17c4dfcbb00dec5ffbc9dcd18a6a9d4da6973b3c",
+        "hashed_secret": "60edf9357ab126e077a488706704a2f658e19087",
         "is_verified": false,
-        "line_number": 3182
+        "line_number": 3002
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "3708af066f7b1edc1ba2d5e1da654cf995375b64",
+        "hashed_secret": "9366bc8779ea1bd895e15b0f9f3257a488db6397",
         "is_verified": false,
-        "line_number": 3186
+        "line_number": 3005
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f4184df080a8edb44024dca429a59f60a1d5308d",
         "is_verified": false,
-        "line_number": 3190
+        "line_number": 3009
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8287678ab8009ae16b02930c9e260d1f28578fbe",
         "is_verified": false,
-        "line_number": 3193
+        "line_number": 3012
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1233ad875b4ae7f0bab0b28dbae2127a4f9f738a",
         "is_verified": false,
-        "line_number": 3197
+        "line_number": 3016
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d270708a32c532655e0c3b6fd4bbc7475c182e50",
         "is_verified": false,
-        "line_number": 3201
+        "line_number": 3020
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "62066f5078abd3f1c707b12b69fcb8d5c45f69ff",
         "is_verified": false,
-        "line_number": 3207
+        "line_number": 3026
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "175f769aab57cbd6962a4b89661ca9b22cd9a0eb",
         "is_verified": false,
-        "line_number": 3212
+        "line_number": 3031
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dbc1ca0fc1f62c784dd9e4abae5b29195843b7fc",
         "is_verified": false,
-        "line_number": 3217
+        "line_number": 3036
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2b4fcd00bc9e2b4aeb9e0675196f5058318a5a5e",
         "is_verified": false,
-        "line_number": 3223
+        "line_number": 3042
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5a233e343e439f5c0b7dad5b0bb3aac587600408",
         "is_verified": false,
-        "line_number": 3226
+        "line_number": 3045
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fdc540c809ae88d0d77093f757f4a36ce9bdb89b",
         "is_verified": false,
-        "line_number": 3229
+        "line_number": 3048
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9e2f4835a3c6149aa8c2f449cc4b4654d36a24e4",
         "is_verified": false,
-        "line_number": 3233
+        "line_number": 3052
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c9e32f7e9605822ec5eecb8e000538cd32106217",
         "is_verified": false,
-        "line_number": 3243
+        "line_number": 3062
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e48b8a44b97dad18efd583c058b08a57ae0b81b4",
         "is_verified": false,
-        "line_number": 3253
+        "line_number": 3072
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6b0e00a52b430695aac66bffdeca87b13dce5782",
         "is_verified": false,
-        "line_number": 3259
+        "line_number": 3078
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "47d3a36693956435bfb86f052ce1c48d7cc61595",
         "is_verified": false,
-        "line_number": 3265
+        "line_number": 3084
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1b44c0e3cc4aa423d96cf80ea9a08cf21225dc4e",
         "is_verified": false,
-        "line_number": 3275
+        "line_number": 3094
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4f171d08ea6de5b94bad0eff32e65a96a10ac15a",
         "is_verified": false,
-        "line_number": 3281
+        "line_number": 3100
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c4dd7584b90374c3719d5069681d2c7cd05f06da",
         "is_verified": false,
-        "line_number": 3285
+        "line_number": 3104
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dbe8cad574fbb7dbb938da01c0c4aff2dffdd029",
         "is_verified": false,
-        "line_number": 3289
+        "line_number": 3108
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0f8e84e87aa0422f0c3445b79cbbe528d508dce3",
         "is_verified": false,
-        "line_number": 3292
+        "line_number": 3111
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8fd098a872474859bcce3e25efacdaf7d273a6e0",
         "is_verified": false,
-        "line_number": 3299
+        "line_number": 3118
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4e416a02c571be91e08682290d440c7879f08dc5",
         "is_verified": false,
-        "line_number": 3302
+        "line_number": 3121
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3843fe8bfabd5162ea792aad489b0bc2e774535e",
         "is_verified": false,
-        "line_number": 3305
+        "line_number": 3124
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "68aeb7ec9fab680d80cbce2a624ccf642f3339cd",
         "is_verified": false,
-        "line_number": 3308
+        "line_number": 3127
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "10313a72df8760e8ec47c3e5a516858781be83cc",
         "is_verified": false,
-        "line_number": 3312
+        "line_number": 3131
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d253be4a7c019ad20bcb9cf5a4073ef85ce70854",
         "is_verified": false,
-        "line_number": 3315
+        "line_number": 3134
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f6cd0a74446935fab1bca4e983a1b0b98eeabc53",
         "is_verified": false,
-        "line_number": 3318
+        "line_number": 3137
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b2a129c0faee8294286099a63244e8811707a015",
         "is_verified": false,
-        "line_number": 3321
+        "line_number": 3140
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "69f812c17419570caedae0a2606890b87f7fa599",
         "is_verified": false,
-        "line_number": 3331
+        "line_number": 3150
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9568c98dea59c3c571547a22b9c930355bd1cdeb",
         "is_verified": false,
-        "line_number": 3341
+        "line_number": 3160
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1a39ece38101be692eca60b18570d82d9b78a26e",
         "is_verified": false,
-        "line_number": 3344
+        "line_number": 3163
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c0700c89b2779175df0e9d38ff12256ffc09a372",
         "is_verified": false,
-        "line_number": 3347
+        "line_number": 3166
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "0e1b8602e786eb5190cfe11e2c9c4058d4771f88",
         "is_verified": false,
-        "line_number": 3350
+        "line_number": 3169
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "331ef1b30a600da758056bf5f9a416209254c207",
         "is_verified": false,
-        "line_number": 3353
+        "line_number": 3172
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "5a333bc370c115c8b9d2fa6689eaa1dc37b696ad",
         "is_verified": false,
-        "line_number": 3356
+        "line_number": 3175
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "17df0cf1bffb39d85a2aea45c887f1998ffc48a8",
         "is_verified": false,
-        "line_number": 3359
+        "line_number": 3178
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "47e9d02523f2192439c8ebc19f11d491f61874f6",
         "is_verified": false,
-        "line_number": 3362
+        "line_number": 3181
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "4a92c1257b67845f12260b454ba353a5919dec29",
+        "hashed_secret": "9a0dfdcc6623d8d2996e396f5e08840914c241a0",
         "is_verified": false,
-        "line_number": 3365
+        "line_number": 3184
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "12c75bf14fc9e7d25cb8b6d66ea81decab2f32aa",
         "is_verified": false,
-        "line_number": 3370
+        "line_number": 3189
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4ec2ff08ee70f4f3ed104cf914130dc8b4af02db",
         "is_verified": false,
-        "line_number": 3373
+        "line_number": 3192
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
         "is_verified": false,
-        "line_number": 3376
+        "line_number": 3195
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
         "is_verified": false,
-        "line_number": 3379
+        "line_number": 3198
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2e9e26d0fd5a69fc56b781ec5b24890dfb4976fe",
         "is_verified": false,
-        "line_number": 3382
+        "line_number": 3201
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e624c5279b887bafa9e8e6373349bdb9138708b8",
         "is_verified": false,
-        "line_number": 3385
+        "line_number": 3204
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "dc84bd66761f714927258320c0bb8dae84587827",
         "is_verified": false,
-        "line_number": 3388
+        "line_number": 3207
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "edb81778ed5fee48cae4e8a8b8d1793b9e9e7663",
         "is_verified": false,
-        "line_number": 3392
+        "line_number": 3211
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ca9671a0948519aefcd2ec2428e9a187e79113e3",
         "is_verified": false,
-        "line_number": 3396
+        "line_number": 3215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "bae67d3ce231086fba18abc7365c94878f900c14",
         "is_verified": false,
-        "line_number": 3400
+        "line_number": 3219
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9a53482ec2c9de9f382f9c30f308986d167d2d86",
         "is_verified": false,
-        "line_number": 3403
+        "line_number": 3222
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a1785e76071823a09f23d2c2b64db80b223c5411",
         "is_verified": false,
-        "line_number": 3406
+        "line_number": 3225
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7cdaa4e52326d9a81d36d211cd26c2d7a9fc69e1",
         "is_verified": false,
-        "line_number": 3410
+        "line_number": 3229
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6a66a6ffc1f1c2f31ec1c5c694938bedbae39c02",
         "is_verified": false,
-        "line_number": 3414
+        "line_number": 3233
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "05b9deaec8f504ac476e1af49d6dd6c7c79f6b36",
         "is_verified": false,
-        "line_number": 3418
+        "line_number": 3237
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
         "is_verified": false,
-        "line_number": 3422
+        "line_number": 3241
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a3e455e610a2599c21af6806a2d0bcfa38dd3e0e",
         "is_verified": false,
-        "line_number": 3425
+        "line_number": 3244
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
         "is_verified": false,
-        "line_number": 3431
+        "line_number": 3250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7aa114aa9a7bfd188312ad99782db3d5355eda95",
         "is_verified": false,
-        "line_number": 3435
+        "line_number": 3254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
         "is_verified": false,
-        "line_number": 3438
+        "line_number": 3257
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6057a244d926cc3fac60c38cc276e3a75c45e178",
         "is_verified": false,
-        "line_number": 3441
+        "line_number": 3260
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "859f0bf5b150aedf3fe7c8ed5719bb865f543231",
         "is_verified": false,
-        "line_number": 3445
+        "line_number": 3264
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "06ea5a63927e269d49312b5c9e8bea03616f842e",
         "is_verified": false,
-        "line_number": 3448
+        "line_number": 3267
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2558599ab14e11c4e61eb6c940041453b8dbb70d",
         "is_verified": false,
-        "line_number": 3453
+        "line_number": 3272
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d4e08224926a563394787a12a3b195c3d73d224e",
         "is_verified": false,
-        "line_number": 3456
+        "line_number": 3275
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e7dd0f768f7d4107192416f4ceec8e68f6e019c7",
         "is_verified": false,
-        "line_number": 3459
+        "line_number": 3278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7821aab8b32fe85984d087e74a64d274074fd5ff",
         "is_verified": false,
-        "line_number": 3462
+        "line_number": 3281
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e828f62944b52bb12d3005ea71fc3a8af14ebb31",
         "is_verified": false,
-        "line_number": 3465
+        "line_number": 3284
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f5cde8151f6ac3de1ce731aa99fec04b98fca09f",
         "is_verified": false,
-        "line_number": 3468
+        "line_number": 3287
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a48b8ac8fd33d3bfc89ac437ee1c3274e7006629",
         "is_verified": false,
-        "line_number": 3473
+        "line_number": 3292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c349366fbe16160ca9910d83a1de29924246c04d",
         "is_verified": false,
-        "line_number": 3476
+        "line_number": 3295
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "533c0ebb91e72493384d8beda7994d2fb902cce2",
         "is_verified": false,
-        "line_number": 3480
+        "line_number": 3299
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "315bcdd30c6b9c9705234a5dbc10279315e7611b",
         "is_verified": false,
-        "line_number": 3485
+        "line_number": 3303
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
         "is_verified": false,
-        "line_number": 3488
+        "line_number": 3306
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a664083cd7ea977f953eb398c15a7391521e8c88",
         "is_verified": false,
-        "line_number": 3491
+        "line_number": 3309
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e11dc6504f1442c6e5b78658db9c245708c24690",
         "is_verified": false,
-        "line_number": 3494
+        "line_number": 3312
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "bcc923e3a3bbb5c5c7c2f2b5e17bda91f8076652",
+        "hashed_secret": "3bea92b9f6fb799774c52db9b38668949e60a65f",
         "is_verified": false,
-        "line_number": 3497
+        "line_number": 3315
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "66022833f4701f45cff007311050911fe571487c",
         "is_verified": false,
-        "line_number": 3501
+        "line_number": 3319
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "295370934921eb088b38a5591b27ef4c3feeabda",
         "is_verified": false,
-        "line_number": 3505
+        "line_number": 3323
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "48ab61adf0ee0771b3002628be653baccb9af277",
         "is_verified": false,
-        "line_number": 3509
+        "line_number": 3327
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "a6d813aa7164341218d80a2b625ff1b254fa10c3",
         "is_verified": false,
-        "line_number": 3513
+        "line_number": 3331
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c8ac07caa8b70b9e60a7cc5785840065a9d2eff1",
         "is_verified": false,
-        "line_number": 3517
+        "line_number": 3335
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "cd2e12140e63538d725bf39d6bcd7da6976c19bc",
         "is_verified": false,
-        "line_number": 3520
+        "line_number": 3338
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1e68acc8ad653691b250fb20aefebd10afacfb1c",
         "is_verified": false,
-        "line_number": 3523
+        "line_number": 3341
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9bf200e3147a1d837839d6bf5b649716c1537cbb",
         "is_verified": false,
-        "line_number": 3527
+        "line_number": 3345
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1f97ba54d48d51a2ed9bef23e8100e44b5863113",
         "is_verified": false,
-        "line_number": 3530
+        "line_number": 3348
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "760287f140e56c5274845b0b4c48fb3f1c6f5cbf",
         "is_verified": false,
-        "line_number": 3535
+        "line_number": 3353
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "955d2d24c472b4eb0b4488f935a0f65e38001df8",
         "is_verified": false,
-        "line_number": 3538
+        "line_number": 3356
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "60bbb117f59dfb9ea6273375f335852852518f21",
         "is_verified": false,
-        "line_number": 3542
+        "line_number": 3360
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "b0cc5db4f99fc0fb773b7006064bd925ae04e9b5",
         "is_verified": false,
-        "line_number": 3547
+        "line_number": 3365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3643f874367db545d17373925c62a1ef98b4e8eb",
         "is_verified": false,
-        "line_number": 3550
+        "line_number": 3368
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3ea284f94ec920b901878d173bcca0b98514b672",
         "is_verified": false,
-        "line_number": 3553
+        "line_number": 3371
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "aa9e8d6464b9142712e4096491699ba46c641acc",
         "is_verified": false,
-        "line_number": 3556
+        "line_number": 3374
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f602e09f0678d8dd41830125dc283eb47750a893",
         "is_verified": false,
-        "line_number": 3559
+        "line_number": 3377
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9a9c48cdcf1e676cd67b5a518e3179bbb5c45945",
         "is_verified": false,
-        "line_number": 3562
+        "line_number": 3380
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "96274955a46e3f4a4cf02b179edba026678799c5",
         "is_verified": false,
-        "line_number": 3565
+        "line_number": 3383
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "62e729afe8b83c39fe12240d3009701ceae77e8d",
         "is_verified": false,
-        "line_number": 3568
+        "line_number": 3386
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f4e6a8d0fa33a7dfe3e654a159c5510de82f2d91",
         "is_verified": false,
-        "line_number": 3571
+        "line_number": 3389
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "235983a96e805984ce05975bd175dfaaae62ec0a",
         "is_verified": false,
-        "line_number": 3574
+        "line_number": 3392
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "292b56ccb1313ea50f4d1bf0efc7f2b04670fe73",
         "is_verified": false,
-        "line_number": 3577
+        "line_number": 3395
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9eaf006db1f782b8da68c3ae97eae05f36c62973",
         "is_verified": false,
-        "line_number": 3581
+        "line_number": 3399
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "acc27d538c903c3097a9fe198c0a1d9f8ad7efcc",
         "is_verified": false,
-        "line_number": 3587
+        "line_number": 3405
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "1ea125887e03dda4c31037928eddc57d4541b64b",
         "is_verified": false,
-        "line_number": 3597
+        "line_number": 3415
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e7c3737f5f4c36f748bb4164b81197d326a70d22",
         "is_verified": false,
-        "line_number": 3607
+        "line_number": 3425
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "735bd20202e59e618bfe941a5941731da477e7b6",
         "is_verified": false,
-        "line_number": 3612
+        "line_number": 3430
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "4885a73ae27294938a483e855613b49825a795e8",
         "is_verified": false,
-        "line_number": 3615
+        "line_number": 3433
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "e9929bd50a5523f3ee0cf35a8fd80c06bc43cc50",
         "is_verified": false,
-        "line_number": 3619
+        "line_number": 3437
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "f436e5e80e3407aed61c6a5d0463a46e0da536d8",
         "is_verified": false,
-        "line_number": 3623
+        "line_number": 3441
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "44e465ae72a1040308940ab81352dfbacbe7e364",
         "is_verified": false,
-        "line_number": 3627
+        "line_number": 3445
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "8dde1ebef344011f9e6ac282be903ab5cc8cdcdf",
         "is_verified": false,
-        "line_number": 3633
+        "line_number": 3451
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "10af1db589c7ec869e82074e6bb65cc5a4a6f3d7",
         "is_verified": false,
-        "line_number": 3636
+        "line_number": 3454
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "24cac35b603c4f62f26c8d890617e134c1746183",
         "is_verified": false,
-        "line_number": 3639
+        "line_number": 3457
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "aee6e2f94569251fe1d62eafb1e922c0c9da7310",
         "is_verified": false,
-        "line_number": 3642
+        "line_number": 3460
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "d4993485565eb1018819491e8a7ee52a1594e101",
         "is_verified": false,
-        "line_number": 3645
+        "line_number": 3463
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "db1d5fe158aaf084a72a2dfa5555e5d63cc4236c",
         "is_verified": false,
-        "line_number": 3650
+        "line_number": 3468
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "2f73770c4b2c405b9f25e2bc5b5e42d82aa859dd",
+        "hashed_secret": "7e30ca914cc2ed38e1a330be94a26824867b5934",
         "is_verified": false,
-        "line_number": 3653
+        "line_number": 3471
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
-        "hashed_secret": "10268f6f4f68752aa603c74f237e00cf940909a4",
+        "hashed_secret": "3885943ec38bd72b75dd793c8064f5b82b7986df",
         "is_verified": false,
-        "line_number": 3684
+        "line_number": 3502
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "09eef298f78df698d8ecb1d9a58fa11e5d9f4e99",
         "is_verified": false,
-        "line_number": 3724
+        "line_number": 3542
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c85b08c4b0d082d8ef795d3feb33248d653a86dd",
         "is_verified": false,
-        "line_number": 3749
+        "line_number": 3567
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "646545163be60fa7b4864dabc97dc921b6217a3f",
         "is_verified": false,
-        "line_number": 3753
+        "line_number": 3571
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "7c0f26e555ee262ed308b5e9a40f3ed4fdaacaa9",
         "is_verified": false,
-        "line_number": 3756
+        "line_number": 3574
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "fbab298b8cf4892db7d5b25fa56f64db70c02191",
         "is_verified": false,
-        "line_number": 3759
+        "line_number": 3577
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c404e90db76532488af93bd2a7001a73ec20db70",
         "is_verified": false,
-        "line_number": 3762
+        "line_number": 3580
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "9a7f758ccbe3c1a33e64125ee88909ceb0f2b9ad",
         "is_verified": false,
-        "line_number": 3766
+        "line_number": 3584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "ee4887dad945f60487dbcadc8e688259e0f670ae",
         "is_verified": false,
-        "line_number": 3769
+        "line_number": 3587
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
         "is_verified": false,
-        "line_number": 3772
+        "line_number": 3590
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c34d43e9581b3e233d1d2cdc667a3ce110c60491",
         "is_verified": false,
-        "line_number": 3777
+        "line_number": 3595
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "c0665d268ee6985b4ce98c67b9c6c7502af11a25",
         "is_verified": false,
-        "line_number": 3782
+        "line_number": 3600
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "6961f61ab86a0461464a49ee3080e16851cf964e",
         "is_verified": false,
-        "line_number": 3785
+        "line_number": 3603
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "543c98d315431cc1616876ddf1cdc5fd13349a9b",
         "is_verified": false,
-        "line_number": 3789
+        "line_number": 3607
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/tvl/tvl-website/pnpm-lock.yaml",
         "hashed_secret": "3c2d8491c2232a61643d57a3622f9e4c284b24f2",
         "is_verified": false,
-        "line_number": 3792
+        "line_number": 3610
       }
     ],
     "docs/user-guide/optuna_integration.md": [
@@ -5452,7 +5265,16 @@
         "filename": "examples/quickstart/README.md",
         "hashed_secret": "a8253456364f1bfc7da7ae4a1db5b45d106317a5",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 48
+      }
+    ],
+    "my_llm_project/rag_agent.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "my_llm_project/rag_agent.py",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 5
       }
     ],
     "plugins/traigent-ui/traigent_ui/STREAMLIT_README.md": [
@@ -5462,6 +5284,22 @@
         "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
         "is_verified": false,
         "line_number": 19
+      }
+    ],
+    "scripts/release/build_offline_zip.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/release/build_offline_zip.sh",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/release/build_offline_zip.sh",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 181
       }
     ],
     "scripts/smoke/smoke_real_api_measures.py": [
@@ -5575,6 +5413,15 @@
         "hashed_secret": "f5ef767f75e3447133504f094ac9a57a6bf9a5c6",
         "is_verified": false,
         "line_number": 28
+      }
+    ],
+    "tests/integration/test_privacy_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/integration/test_privacy_integration.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 22
       }
     ],
     "tests/integration/test_traigent_decorator_cloud_integration.py": [
@@ -6288,6 +6135,15 @@
         "line_number": 43
       }
     ],
+    "tests/unit/utils/test_local_analytics.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/unit/utils/test_local_analytics.py",
+        "hashed_secret": "035bf17d591b5967aafe1700f7e7d0bf0f7d6bf3",
+        "is_verified": false,
+        "line_number": 457
+      }
+    ],
     "tests/unit/utils/test_reproducibility.py": [
       {
         "type": "Hex High Entropy String",
@@ -6295,6 +6151,15 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_verified": false,
         "line_number": 166
+      }
+    ],
+    "traigent/integrations/langfuse/__init__.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "traigent/integrations/langfuse/__init__.py",
+        "hashed_secret": "bfc5221616fd29387d7413aeb41401391dceefa8",
+        "is_verified": false,
+        "line_number": 27
       }
     ],
     "traigent/integrations/langfuse/tracker.py": [
@@ -6343,15 +6208,6 @@
         "hashed_secret": "3bc4a7fe761cff21ea09e3d718f510f637996afb",
         "is_verified": false,
         "line_number": 103
-      }
-    ],
-    "traigent/integrations/llms/litellm_plugin.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "traigent/integrations/llms/litellm_plugin.py",
-        "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
-        "is_verified": false,
-        "line_number": 58
       }
     ],
     "traigent/integrations/llms/llamaindex_plugin.py": [
@@ -6430,5 +6286,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-27T21:43:31Z"
+  "generated_at": "2026-04-27T22:35:24Z"
 }

--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -91,7 +91,7 @@ def my_agent(question: str) -> str:
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `execution_mode` | `str` | `"edge_analytics"` | `"edge_analytics"` is supported today; `"cloud"`, `"hybrid"`, `"standard"` are reserved for managed backends. `"privacy"` is accepted as a legacy alias for `"hybrid"` and sets `privacy_enabled=True`. |
+| `execution_mode` | `str` | `"edge_analytics"` | `"edge_analytics"` runs locally. `"hybrid"` runs trials locally and submits sessions/trial metrics to the backend for portal tracking. `"cloud"` is reserved for future remote execution and fails closed with guidance to use `"hybrid"`. `"privacy"` is accepted as a legacy alias for `"hybrid"` and sets `privacy_enabled=True`. |
 | `local_storage_path` | `str \| None` | `None` | Custom directory for persisted results. Falls back to `TRAIGENT_RESULTS_FOLDER` or `~/.traigent/`. |
 | `minimal_logging` | `bool` | `True` | Suppresses verbose logs in privacy-sensitive modes. |
 | `parallel_config` | `ParallelConfig \| dict \| None` | `None` | Unified concurrency configuration. |
@@ -108,11 +108,11 @@ def my_agent(question: str) -> str:
 
 **Usage Notes**
 
-- The default execution mode is `"edge_analytics"` and is the only supported mode in the open-source build. Other modes are present for forward compatibility but require a managed backend.
+- The default execution mode is `"edge_analytics"`. Use `"hybrid"` for portal-tracked optimization with local trial execution.
 - Prefer the grouped option classes (`EvaluationOptions`, `InjectionOptions`, `ExecutionOptions`, `MockModeOptions`) when you need to adjust several related knobs. Import them from `traigent.api.decorators` and pass either instances or plain dicts.
 - `parallel_config=ParallelConfig(...)` remains the primary way to control concurrency. Set global defaults via `traigent.configure(parallel_config=...)`, override them in the decorator, and fine-tune per `.optimize()` call. Later scopes override earlier ones field-by-field.
 - `ParallelConfig` lives in `traigent.config.parallel`. You can pass either an instance or a simple `dict` with the same keys.
-- `privacy_enabled=True` applies in local/edge contexts; cloud/hybrid execution is not available yet in OSS builds.
+- `privacy_enabled=True` applies in local and hybrid contexts. `cloud` remote execution is not available yet.
 - `config_param` is required whenever you choose `injection_mode="parameter"`; forgetting it leaves your function without injected configs.
 - Provide plain lists for quick starts; Traigent infers orientations (maximize for accuracy-like metrics, minimize for cost/latency) and assigns equal weights. Use an `ObjectiveSchema` when you need explicit control over orientations, weights, or metric metadata.
 - Inline tuned-variable definitions accept `Range`, `IntRange`, `LogRange`, `Choices`, or numeric `(low, high)` tuples. Inline lists are not recognized; use `Choices([...])` instead.

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -469,7 +469,7 @@ from traigent.config.parallel import ParallelConfig
 
 **ExecutionOptions Fields**:
 
-- `execution_mode`: "edge_analytics" (only supported mode in OSS)
+- `execution_mode`: "edge_analytics" for local-only runs; "hybrid" for local execution with backend/portal tracking; "cloud" is reserved for future remote execution.
 - `local_storage_path`: Custom storage directory
 - `minimal_logging`: Reduce log verbosity
 - `parallel_config`: Concurrency configuration

--- a/docs/fake-completion-tracking.md
+++ b/docs/fake-completion-tracking.md
@@ -1,0 +1,37 @@
+# Fake Completion Tracking
+
+Last updated: 2026-04-28
+
+## Scope
+
+Track cleanup work for paths that can report fake success, fake completion,
+synthetic cloud IDs, or mock remote execution results in production-facing SDK
+flows.
+
+## Completed
+
+- Clarified SDK modes:
+  - `edge_analytics`: local-only execution.
+  - `hybrid`: local trial execution plus backend/portal session tracking.
+  - `cloud`: reserved for future remote execution.
+- Preserved hybrid session creation and trial result submission through the
+  backend session endpoints.
+- Made unimplemented cloud remote execution fail closed with guidance to use
+  hybrid for portal-tracked optimization.
+- Removed production mock cloud session/trial/agent responses from cloud API
+  operation paths.
+- Added regression coverage for hybrid session/result endpoints and cloud
+  fail-closed behavior.
+
+## Active Queue
+
+1. Inspect repository and GitHub issues for remaining fake-completion/fake-success
+   paths.
+2. Fix remaining production paths in priority order.
+3. Commit and push after each completed issue slice.
+
+## Notes
+
+- Leave explicit offline/local mock IDs intact where they are gated by
+  `TRAIGENT_OFFLINE_MODE=true` or test-only paths.
+- Do not treat `hybrid` portal tracking as fake cloud execution.

--- a/docs/fake-completion-tracking.md
+++ b/docs/fake-completion-tracking.md
@@ -5,33 +5,65 @@ Last updated: 2026-04-28
 ## Scope
 
 Track cleanup work for paths that can report fake success, fake completion,
-synthetic cloud IDs, or mock remote execution results in production-facing SDK
-flows.
+synthetic IDs, mock remote execution results, or mock production data across
+the SDK, backend, and frontend fake-completion audit.
 
 ## Completed
 
-- Clarified SDK modes:
-  - `edge_analytics`: local-only execution.
-  - `hybrid`: local trial execution plus backend/portal session tracking.
-  - `cloud`: reserved for future remote execution.
-- Preserved hybrid session creation and trial result submission through the
-  backend session endpoints.
-- Made unimplemented cloud remote execution fail closed with guidance to use
-  hybrid for portal-tracked optimization.
-- Removed production mock cloud session/trial/agent responses from cloud API
-  operation paths.
-- Added regression coverage for hybrid session/result endpoints and cloud
-  fail-closed behavior.
+- SDK commit `c4e8ef97` on
+  `security/preprod-schema-extra-20260425`:
+  - Clarified SDK modes:
+    - `edge_analytics`: local-only execution.
+    - `hybrid`: local trial execution plus backend/portal session tracking.
+    - `cloud`: reserved for future remote execution.
+  - Preserved hybrid session creation and trial result submission through the
+    backend session endpoints.
+  - Made unimplemented cloud remote execution fail closed with guidance to use
+    hybrid for portal-tracked optimization.
+  - Removed production mock cloud session/trial/agent responses from cloud API
+    operation paths.
+  - Added regression coverage for hybrid session/result endpoints and cloud
+    fail-closed behavior.
+- Backend branch `codex/fake-completion-backend-guards`:
+  - `d33642c`: failed closed for evaluator execution, retrieval config tests,
+    cost compatibility routes, MCP evaluation fallback, rate-limit
+    compatibility health/status, and monitoring security alerts.
+  - `7735a98`: removed leftover mock-behavior wording from the unavailable
+    security alerts response.
+- Frontend branch `codex/fake-completion-frontend-guards`:
+  - `e846ccc`: removed example-generation success on missing status tracking,
+    deterministic API-key trend generation, and Planner interim mock content.
+- Closed follow-up-only backend findings:
+  - FC-013: no production route/service call path found to the stub evaluation
+    orchestrator on the reviewed local `develop` tree.
+  - FC-014: no production route/service call path found to the placeholder
+    storage saga delete/backup path on the reviewed local `develop` tree.
 
-## Active Queue
+## Verification
 
-1. Inspect repository and GitHub issues for remaining fake-completion/fake-success
-   paths.
-2. Fix remaining production paths in priority order.
-3. Commit and push after each completed issue slice.
+- SDK: focused unit/integration pytest suites passed with repo `addopts`
+  disabled because local xdist is unavailable; ruff and `git diff --check`
+  passed.
+- Backend: ruff, compileall, and `git diff --check` passed for touched files.
+  Local pytest collection is still blocked by missing environment dependencies
+  including `flask_sqlalchemy` and `bcrypt`.
+- Frontend: `npm ci` completed, `npm run type-check` passed, and targeted
+  eslint passed with warnings only.
+- Final targeted sweeps found none of the removed fake-completion strings in
+  the production files changed for the audit findings.
+
+## Remaining Queue
+
+- No open fake-completion audit findings remain in the implemented scope.
+- Backend and frontend branches have been pushed for review/PR creation:
+  - `TraigentBackend`: `codex/fake-completion-backend-guards`
+  - `TraigentFrontend`: `codex/fake-completion-frontend-guards`
 
 ## Notes
 
 - Leave explicit offline/local mock IDs intact where they are gated by
   `TRAIGENT_OFFLINE_MODE=true` or test-only paths.
 - Do not treat `hybrid` portal tracking as fake cloud execution.
+- The unused frontend `GenerateExamplesModalSimple` still has a normal
+  synchronous success toast after an authoritative POST response. It is not
+  imported by the app and was not part of the confirmed audit findings.

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -123,7 +123,9 @@ def my_agent(query: str) -> str:
 
 Traigent executes your code locally. The default is `execution_mode="edge_analytics"` (local).
 
-`execution_mode="cloud"` and `execution_mode="hybrid"` are reserved for Traigent Cloud and are not yet supported in this build; they will raise `NotYetSupported` when optimization runs.
+`execution_mode="hybrid"` runs trials locally while sending session and trial metrics to the backend so results appear in the Traigent portal.
+
+`execution_mode="cloud"` is reserved for future remote execution. It is not available yet and fails with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.”
 
 To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MODE=true`.
 

--- a/docs/guides/execution-modes.md
+++ b/docs/guides/execution-modes.md
@@ -1,10 +1,10 @@
 # Traigent Execution Modes Guide
 
-> **Current status:** Traigent executes your code locally. The default is `execution_mode="edge_analytics"` (local). `execution_mode="cloud"` and `execution_mode="hybrid"` are reserved for Traigent Cloud and are not yet supported in this build; they will raise `NotYetSupported` when optimization runs.
+> **Current status:** Traigent executes trials locally. The default is `execution_mode="edge_analytics"` (local-only). Use `execution_mode="hybrid"` when you want local execution plus backend/portal tracking. `execution_mode="cloud"` is reserved for future remote execution and fails with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.”
 
 ## Overview
 
-Use `edge_analytics` (default) to run locally. Use `cloud` or `hybrid` only when Traigent Cloud is available for your build/deployment.
+Use `edge_analytics` (default) to run locally. Use `hybrid` for website-visible results while keeping trials on your machine. Do not use `cloud` yet; remote agent execution is not implemented.
 
 To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MODE=true`.
 
@@ -12,9 +12,9 @@ To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MO
 
 | Mode | OSS availability | Status | Notes |
 | --- | --- | --- | --- |
-| `edge_analytics` | ✅ Available | ✅ Supported | Local execution |
-| `hybrid` | ✅ Available | 🚧 Not yet supported | Raises `NotYetSupported` when optimization runs |
-| `cloud` | ✅ Available | 🚧 Not yet supported | Raises `NotYetSupported` when optimization runs |
+| `edge_analytics` | Available | Supported | Local execution and local results |
+| `hybrid` | Available | Supported | Local execution plus backend session/trial tracking |
+| `cloud` | Reserved | Not implemented | Remote execution path fails closed |
 
 ## Local Mode (`edge_analytics`)
 
@@ -60,9 +60,15 @@ def my_agent(query: str) -> str:
 - CI smoke tests and demos (`TRAIGENT_MOCK_LLM=true`)
 - Budget-conscious experiments
 
-## Roadmap Notes
+## Hybrid Mode
 
-Some fully managed backend capabilities (for example, cloud-executed trials / agent optimization) require a provisioned backend and may not be available in OSS builds yet. In this build, only `execution_mode="edge_analytics"` is supported.
+Hybrid mode is the production path for portal-tracked SDK runs today. The SDK creates a backend session through `/api/v1/sessions`, runs each trial locally, and submits trial metrics through `/api/v1/sessions/{session_id}/results`.
+
+Use `hybrid` when you want results to appear in the Traigent website. Use `edge_analytics` when you want fully local runs with no backend dependency.
+
+## Cloud Roadmap
+
+Fully managed remote execution, including cloud-executed trials and remote agent optimization, is reserved for `execution_mode="cloud"`. That path is not implemented yet and must not return synthetic session IDs, trial suggestions, agent outputs, or completed statuses.
 
 ## Privacy-Safe Analytics
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,9 +160,33 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_slow)
 
 
+# Tests that need the metrics_tracker mock-mode token-estimation path.
+# S2-B Round 3 narrowed the scope of TRAIGENT_GENERATE_MOCKS=true so it is
+# only set for tests that actually exercise the mocked cost-estimation path
+# in metrics_tracker._calculate_cost_for_metrics. Setting it autouse for the
+# whole suite leaked into unrelated paths (e.g. credential_manager's
+# _is_development_mode), causing test pollution.
+_GENERATE_MOCKS_TEST_PATHS: tuple[str, ...] = (
+    "tests/unit/evaluators/test_metrics_tracker",
+    "tests/unit/evaluators/test_metrics.py",
+    "tests/unit/evaluators/test_local_evaluator_builtin_metrics",
+    "tests/integration/test_ctd_coverage_from_csv",
+    "tests/integration/test_ctd_execution_modes",
+)
+
+
+def _test_needs_generate_mocks(node) -> bool:
+    """Return True if the test's path matches a known cost-fixture-recording test."""
+    try:
+        path_str = str(node.fspath).replace(os.sep, "/")
+    except Exception:  # noqa: BLE001 — defensive; pytest internals vary by version
+        return False
+    return any(marker in path_str for marker in _GENERATE_MOCKS_TEST_PATHS)
+
+
 # Set JWT validation to development mode for all tests
 @pytest.fixture(autouse=True)
-def jwt_development_mode(monkeypatch):
+def jwt_development_mode(monkeypatch, request):
     """Set JWT validator to development mode for all tests."""
     monkeypatch.setenv("TRAIGENT_ENVIRONMENT", "development")
     # Ensure mock LLM mode to avoid real LLM API calls during tests
@@ -170,6 +194,18 @@ def jwt_development_mode(monkeypatch):
     # Ensure offline mode to avoid real backend calls during tests
     monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
     monkeypatch.setenv("MOCK_MODE", "true")
+    # TRAIGENT_GENERATE_MOCKS is an internal fixture-recording knob (NOT a
+    # user-facing mock-LLM toggle). Setting it globally leaked into unrelated
+    # paths such as credential_manager._is_development_mode, so it is now
+    # only applied to the specific tests that need the metrics_tracker
+    # mock-mode token-estimation path. Tests can still set it themselves
+    # via monkeypatch when needed.
+    if _test_needs_generate_mocks(request.node):
+        monkeypatch.setenv("TRAIGENT_GENERATE_MOCKS", "true")
+    else:
+        # Defensive: ensure the var is not inherited from the parent shell
+        # for tests that don't opt in.
+        monkeypatch.delenv("TRAIGENT_GENERATE_MOCKS", raising=False)
 
 
 # Global State Reset Fixture - Critical for test isolation

--- a/tests/integration/test_cost_enforcement_sequential.py
+++ b/tests/integration/test_cost_enforcement_sequential.py
@@ -442,49 +442,47 @@ class TestBudgetScenarios:
 
 
 class TestMockModeIntegration:
-    """Tests for mock mode integration."""
+    """Tests pinning that TRAIGENT_MOCK_LLM no longer bypasses cost enforcement.
 
-    def test_mock_mode_bypasses_tracking(self) -> None:
-        """Verify mock mode bypasses all cost tracking."""
+    S2-B Round 3 removed the mock-mode bypass from CostEnforcer because a
+    leaked env var in production could silently disable cost limits and
+    billing accounting. Cost enforcement now always runs.
+    """
+
+    def test_mock_mode_does_not_bypass_tracking(self) -> None:
+        """TRAIGENT_MOCK_LLM=true must not bypass tracking or limits."""
         os.environ["TRAIGENT_MOCK_LLM"] = "true"
 
         try:
             enforcer = CostEnforcer(
                 CostEnforcerConfig(
-                    limit=0.01,  # Very low limit
+                    limit=1.0,
                     estimated_cost_per_trial=0.10,
                 )
             )
 
-            # In mock mode, should always get permit (id=0)
-            for _ in range(100):  # Would far exceed limit normally
-                permit = enforcer.acquire_permit()
-                assert permit.is_granted
-                assert permit.id == 0  # Mock permit ID
-                enforcer.track_cost(1.0, permit=permit)  # High cost
+            # Real permit IDs (>=1), real accounting.
+            permit = enforcer.acquire_permit()
+            assert permit.is_granted
+            assert permit.id != 0, "Mock-mode bypass must not return id=0 permits"
 
-            # Nothing was actually tracked in mock mode
-            assert abs(enforcer._accumulated_cost) < FLOAT_TOLERANCE
+            enforcer.track_cost(0.25, permit=permit)
+            assert abs(enforcer._accumulated_cost - 0.25) < FLOAT_TOLERANCE
             assert enforcer._in_flight_count == 0
         finally:
             os.environ["TRAIGENT_MOCK_LLM"] = "false"
 
-    def test_mock_mode_cached_at_init(self) -> None:
-        """Verify mock mode is cached at init time."""
-        os.environ["TRAIGENT_MOCK_LLM"] = "false"
-
-        enforcer = CostEnforcer(CostEnforcerConfig(limit=0.10))
-
-        # Change env var after init
+    def test_mock_mode_env_var_is_ignored_at_init(self) -> None:
+        """Setting TRAIGENT_MOCK_LLM at init must not change behavior."""
         os.environ["TRAIGENT_MOCK_LLM"] = "true"
+        try:
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=0.10))
 
-        # Should still use real tracking (cached at init)
-        permit = enforcer.acquire_permit()
-        assert permit.id != 0  # Not mock permit ID
-        assert enforcer._in_flight_count == 1
+            permit = enforcer.acquire_permit()
+            assert permit.id != 0  # Real permit, not bypass id=0
+            assert enforcer._in_flight_count == 1
 
-        enforcer.track_cost(0.05, permit=permit)
-        assert abs(enforcer._accumulated_cost - 0.05) < FLOAT_TOLERANCE
-
-        # Cleanup
-        os.environ["TRAIGENT_MOCK_LLM"] = "false"
+            enforcer.track_cost(0.05, permit=permit)
+            assert abs(enforcer._accumulated_cost - 0.05) < FLOAT_TOLERANCE
+        finally:
+            os.environ["TRAIGENT_MOCK_LLM"] = "false"

--- a/tests/integration/test_ctd_execution_modes.py
+++ b/tests/integration/test_ctd_execution_modes.py
@@ -206,9 +206,8 @@ def _generate_covering_combos(
 
 
 def _expected_mode(combo: dict[str, Any]) -> ExecutionMode:
-    # Note: cloud/hybrid raise ConfigurationError (not yet supported)
-    # standard/privacy have been removed from the enum
-    # All paths now lead to edge_analytics (only supported mode)
+    # CTD auto-detection cases still resolve to local execution; explicit
+    # hybrid/backend tracking is covered by dedicated execution-mode tests.
     return ExecutionMode.EDGE_ANALYTICS
 
 

--- a/tests/integration/test_execution_modes.py
+++ b/tests/integration/test_execution_modes.py
@@ -117,32 +117,33 @@ class TestExecutionModes:
                 api_key="test_key",
             )
 
-    def test_hybrid_mode_raises_configuration_error(self, mock_agent_builder):
-        """Test that 'hybrid' mode (not yet supported) raises ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="'hybrid' not yet supported"):
-            TraigentClient(
+    def test_hybrid_mode_initializes_backend_tracking(self, mock_agent_builder):
+        """Test that 'hybrid' mode is supported for portal-tracked local runs."""
+        with patch("traigent.traigent_client.BackendIntegratedClient"):
+            client = TraigentClient(
                 execution_mode="hybrid",
                 agent_builder=mock_agent_builder,
                 api_key="test_key",
             )
 
+        assert client.execution_mode == ExecutionMode.HYBRID
+
     def test_cloud_mode_raises_configuration_error(self):
         """Test that 'cloud' mode (not yet supported) raises ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="'cloud' not yet supported"):
+        with pytest.raises(ConfigurationError, match="Cloud remote execution"):
             TraigentClient(execution_mode="cloud", api_key="test_key")
 
     def test_execution_mode_auto_detection(self):
         """Test automatic execution mode detection.
 
         In the current SDK, 'auto' always resolves to edge_analytics since
-        cloud/hybrid modes are not yet supported.
+        cloud mode is not yet supported.
         """
         # With or without API key, auto defaults to edge_analytics
         client = TraigentClient(execution_mode="auto")
         assert client.execution_mode == ExecutionMode.EDGE_ANALYTICS
 
-        # Even with API key, auto mode defaults to edge_analytics
-        # (cloud/hybrid modes not yet supported)
+        # Even with API key, auto mode defaults to edge_analytics.
         client = TraigentClient(execution_mode="auto", api_key="test_key")
         assert client.execution_mode == ExecutionMode.EDGE_ANALYTICS
 

--- a/tests/integration/test_summary_stats_integration.py
+++ b/tests/integration/test_summary_stats_integration.py
@@ -1,7 +1,7 @@
 """Integration tests for summary_stats mode in privacy/local execution."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -142,22 +142,30 @@ class TestSummaryStatsIntegration:
             backend_base_url="http://localhost:5000", enable_session_sync=True
         )
         backend_client = BackendIntegratedClient(
-            api_key="test_key",  # pragma: allowlist secret
+            api_key="tg_" + ("a" * 61),  # pragma: allowlist secret
             backend_config=backend_config,
             enable_fallback=True,
         )
+        backend_client.auth_manager.augment_headers = AsyncMock(return_value={})
 
         # Mock the aiohttp session
         with patch(
-            "traigent.cloud.backend_client.aiohttp.ClientSession"
+            "traigent.cloud.trial_operations.aiohttp.ClientSession"
         ) as mock_session_class:
-            mock_session = MagicMock()
-            mock_response = MagicMock()
+            mock_response = AsyncMock()
             mock_response.status = 200
-            mock_response.__aenter__.return_value = mock_response
-            mock_session.post.return_value = mock_response
-            mock_session.__aenter__.return_value = mock_session
-            mock_session_class.return_value = mock_session
+
+            mock_post_context = AsyncMock()
+            mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_post_context.__aexit__ = AsyncMock(return_value=False)
+
+            mock_session = AsyncMock()
+            mock_session.post = MagicMock(return_value=mock_post_context)
+
+            mock_session_context = AsyncMock()
+            mock_session_context.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_context.__aexit__ = AsyncMock(return_value=False)
+            mock_session_class.return_value = mock_session_context
 
             # Create summary_stats data
             summary_stats = {
@@ -207,7 +215,7 @@ class TestSummaryStatsIntegration:
             backend_base_url="http://localhost:5000", enable_session_sync=True
         )
         backend_client = BackendIntegratedClient(
-            api_key="test_key",  # pragma: allowlist secret
+            api_key="tg_" + ("a" * 61),  # pragma: allowlist secret
             backend_config=backend_config,
             enable_fallback=True,
         )
@@ -287,9 +295,10 @@ class TestExecutionModeHandling:
         # validate_execution_mode provides strict validation
         from traigent.config.types import validate_execution_mode
 
-        for mode in ["cloud", "hybrid"]:
-            with pytest.raises(ConfigurationError, match="not yet supported"):
-                validate_execution_mode(mode)
+        with pytest.raises(ConfigurationError, match="Cloud remote execution"):
+            validate_execution_mode("cloud")
+
+        assert validate_execution_mode("hybrid").value == "hybrid"
 
         for mode in ["privacy", "standard"]:
             with pytest.raises(ConfigurationError, match="No such mode"):

--- a/tests/unit/api/test_parameter_validator.py
+++ b/tests/unit/api/test_parameter_validator.py
@@ -42,13 +42,13 @@ class TestParameterValidator:
     def test_validate_execution_mode_valid(self):
         """Test validation of valid execution modes.
 
-        Only edge_analytics is currently supported. cloud/hybrid raise
-        ConfigurationError (not yet supported), privacy/standard raise
-        ConfigurationError (removed).
+        Edge analytics and hybrid are supported mode strings at decorator
+        validation time; cloud remains a recognized future mode whose remote
+        execution path fails at runtime.
         """
-        # Only edge_analytics is valid
         result = self.validator._validate_execution_mode("edge_analytics")
         assert result is None, "Expected None for valid mode edge_analytics"
+        assert self.validator._validate_execution_mode("hybrid") is None
 
     def test_validate_execution_mode_invalid(self):
         """Test validation of invalid execution modes."""

--- a/tests/unit/bridges/conftest.py
+++ b/tests/unit/bridges/conftest.py
@@ -1,70 +1,13 @@
 """Conftest for JS bridge tests.
 
-CRITICAL: These tests spawn Node.js processes that can crash VSCode terminals
-and cause system instability. They MUST run via test_bridge_wrapper.py subprocess.
+Bridge unit tests mock subprocess creation, while integration paths can spawn
+real Node.js runners. The bridge now isolates spawned runners in their own
+process group on POSIX systems and terminates that group during cleanup.
 
-DO NOT run directly:
-    pytest tests/unit/bridges/ -v  # WILL CRASH YOUR SYSTEM!
-
-Safe way:
+The wrapper remains useful for captured-output runs:
     pytest tests/unit/test_bridge_wrapper.py -v
 """
 
 import os
-import sys
 
-import pytest
-
-# Environment variable set by test_bridge_wrapper.py when running via subprocess
-_SUBPROCESS_ENV_VAR = "TRAIGENT_JS_TEST_SUBPROCESS"
-
-
-def pytest_configure(config):
-    """HARD FAIL if JS bridge tests are run directly (not via subprocess wrapper).
-
-    This runs BEFORE test collection, preventing any JS bridge code from executing.
-    """
-    if os.environ.get(_SUBPROCESS_ENV_VAR) == "1":
-        # Running via wrapper subprocess - allow tests
-        return
-
-    # Check if we're collecting tests in this directory
-    # pytest_configure runs for ALL conftest.py files, so we need to check
-    # if this specific directory's tests are being targeted
-    args = config.args if hasattr(config, "args") else []
-    invocation_dir = (
-        str(config.invocation_params.dir)
-        if hasattr(config, "invocation_params")
-        else ""
-    )
-
-    # Detect if bridges tests are being run directly
-    is_bridges_targeted = (
-        any("bridges" in str(arg) for arg in args) or "bridges" in invocation_dir
-    )
-
-    if is_bridges_targeted:
-        print("\n" + "=" * 70, file=sys.stderr)
-        print("FATAL: JS bridge tests cannot be run directly!", file=sys.stderr)
-        print("=" * 70, file=sys.stderr)
-        print(
-            "\nThese tests spawn Node.js processes that WILL CRASH your terminal.",
-            file=sys.stderr,
-        )
-        print("\nSafe way to run JS tests:", file=sys.stderr)
-        print("    pytest tests/unit/test_bridge_wrapper.py -v", file=sys.stderr)
-        print("\n" + "=" * 70 + "\n", file=sys.stderr)
-        pytest.exit("JS bridge tests must run via test_bridge_wrapper.py", returncode=1)
-
-
-def pytest_collection_modifyitems(config, items):
-    """Additional safety: skip any JS bridge tests that slip through."""
-    if os.environ.get(_SUBPROCESS_ENV_VAR) == "1":
-        return
-
-    for item in items:
-        if "/bridges/" in str(item.fspath):
-            # Hard fail instead of skip - this should never happen if pytest_configure works
-            item.add_marker(
-                pytest.mark.skip(reason="BLOCKED: Run via test_bridge_wrapper.py only")
-            )
+os.environ.setdefault("TRAIGENT_JS_TEST_SUBPROCESS", "1")

--- a/tests/unit/bridges/test_js_bridge.py
+++ b/tests/unit/bridges/test_js_bridge.py
@@ -531,6 +531,7 @@ def mock_subprocess():
     """Create a basic mock subprocess."""
     mock = AsyncMock()
     mock.returncode = None
+    mock.pid = 12345
     mock.stdin = MagicMock()
     mock.stdin.write = MagicMock()
     mock.stdin.drain = AsyncMock()
@@ -558,6 +559,7 @@ def mock_subprocess_factory():
     ):
         mock_process = MagicMock()
         mock_process.returncode = None
+        mock_process.pid = 12345
         mock_process.wait = AsyncMock(return_value=0)
         mock_process.terminate = MagicMock()
         mock_process.kill = MagicMock()

--- a/tests/unit/cloud/test_agent_client.py
+++ b/tests/unit/cloud/test_agent_client.py
@@ -1,9 +1,10 @@
 """Unit tests for agent support in cloud client."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from traigent.cloud.auth import AuthManager
 from traigent.cloud.client import CloudServiceError, TraigentCloudClient
 from traigent.cloud.models import (
     AgentExecutionRequest,
@@ -15,6 +16,25 @@ from traigent.cloud.models import (
     OptimizationSessionStatus,
 )
 from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+async def _stub_validate(self, api_key):  # noqa: ARG001
+    """Bypass backend API key validation for offline tests."""
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _patch_backend_validate_autouse():
+    """Auto-applied: keep B4 backend validation offline for all tests in this module.
+
+    B4 round 3 made ``get_auth_headers()`` fail closed, so any test exercising
+    a code path that builds auth headers needs the backend validation hook
+    stubbed when no real backend is available.
+    """
+    with patch.object(
+        AuthManager, "_validate_api_key_with_backend", new=_stub_validate
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -54,7 +54,7 @@ class _FakeSession:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    def post(self, url, headers=None):  # noqa: ARG002
+    def post(self, url, headers=None, allow_redirects=None):  # noqa: ARG002
         return _FakeResponse(self._payload)
 
 
@@ -130,3 +130,17 @@ async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
 
     assert reason is None
     post.assert_called_once()
+    assert post.call_args.kwargs["allow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_invalid_backend_validation_url():
+    """Backend key validation must not send credentials to unsupported URL schemes."""
+    manager = AuthManager()
+    manager.config.backend_base_url = "ftp://backend.example"
+
+    with patch("requests.post") as post:
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason == "backend validation URL is invalid"
+    post.assert_not_called()

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -77,10 +77,17 @@ class _RequestsResponse:
         return json.loads(self._body.decode("utf-8"))
 
 
+def _auth_manager_with_public_backend() -> AuthManager:
+    """Create an auth manager whose validation URL is not localhost-derived."""
+    manager = AuthManager()
+    manager.config.backend_base_url = "https://backend.example.test"
+    return manager
+
+
 @pytest.mark.asyncio
 async def test_validate_rejects_string_false_payload():
     """A backend returning ``{"valid": "false"}`` must NOT authenticate."""
-    manager = AuthManager()
+    manager = _auth_manager_with_public_backend()
 
     with _patch_aiohttp({"valid": "false"}):
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
@@ -94,7 +101,7 @@ async def test_validate_rejects_string_false_payload():
 @pytest.mark.asyncio
 async def test_validate_rejects_truthy_int_payload():
     """A backend returning ``{"valid": 1}`` must NOT authenticate (strict bool)."""
-    manager = AuthManager()
+    manager = _auth_manager_with_public_backend()
 
     with _patch_aiohttp({"valid": 1}):
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
@@ -106,7 +113,7 @@ async def test_validate_rejects_truthy_int_payload():
 @pytest.mark.asyncio
 async def test_validate_accepts_strict_true_payload():
     """A backend returning the literal ``{"valid": True}`` is the only success."""
-    manager = AuthManager()
+    manager = _auth_manager_with_public_backend()
 
     with _patch_aiohttp({"valid": True}):
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
@@ -117,7 +124,7 @@ async def test_validate_accepts_strict_true_payload():
 @pytest.mark.asyncio
 async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
     """Missing aiohttp must not block API-key validation when the stdlib can call backend."""
-    manager = AuthManager()
+    manager = _auth_manager_with_public_backend()
 
     with (
         patch("traigent.cloud.auth.AIOHTTP_AVAILABLE", False),
@@ -136,7 +143,7 @@ async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
 @pytest.mark.asyncio
 async def test_validate_fails_closed_when_requests_fallback_missing():
     """Missing aiohttp and requests must return a validation failure reason."""
-    manager = AuthManager()
+    manager = _auth_manager_with_public_backend()
 
     with (
         patch("traigent.cloud.auth.AIOHTTP_AVAILABLE", False),
@@ -161,4 +168,29 @@ async def test_validate_rejects_invalid_backend_validation_url():
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
 
     assert reason == "backend validation URL is invalid"
+    post.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "backend_url",
+    [
+        "http://169.254.169.254/latest/meta-data",
+        "https://10.0.0.1",
+        "http://127.0.0.1:5000",
+        "http://localhost:5000",
+    ],
+)
+async def test_validate_rejects_non_global_backend_validation_hosts(backend_url):
+    """Backend key validation must not POST credentials to internal hosts."""
+    manager = AuthManager()
+    manager.config.backend_base_url = backend_url
+
+    with (
+        patch("traigent.cloud.auth.AIOHTTP_AVAILABLE", False),
+        patch("requests.post") as post,
+    ):
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason == "backend validation URL host is not allowed"
     post.assert_not_called()

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -134,6 +134,24 @@ async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
 
 
 @pytest.mark.asyncio
+async def test_validate_fails_closed_when_requests_fallback_missing():
+    """Missing aiohttp and requests must return a validation failure reason."""
+    manager = AuthManager()
+
+    with (
+        patch("traigent.cloud.auth.AIOHTTP_AVAILABLE", False),
+        patch.object(
+            manager,
+            "_validate_api_key_with_backend_sync",
+            side_effect=ImportError("requests missing"),
+        ),
+    ):
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason == "requests library not available for backend validation"
+
+
+@pytest.mark.asyncio
 async def test_validate_rejects_invalid_backend_validation_url():
     """Backend key validation must not send credentials to unsupported URL schemes."""
     manager = AuthManager()

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -17,6 +17,7 @@ non-empty string ``"false"`` is truthy in Python. The fix tightens this to
 """
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -65,6 +66,17 @@ def _patch_aiohttp(payload):
     return patch("traigent.cloud.auth.aiohttp", fake_aiohttp)
 
 
+class _RequestsResponse:
+    """Minimal requests response stub for the no-aiohttp fallback path."""
+
+    def __init__(self, status: int, body: bytes):
+        self.status_code = status
+        self._body = body
+
+    def json(self):
+        return json.loads(self._body.decode("utf-8"))
+
+
 @pytest.mark.asyncio
 async def test_validate_rejects_string_false_payload():
     """A backend returning ``{"valid": "false"}`` must NOT authenticate."""
@@ -100,3 +112,21 @@ async def test_validate_accepts_strict_true_payload():
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
 
     assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
+    """Missing aiohttp must not block API-key validation when the stdlib can call backend."""
+    manager = AuthManager()
+
+    with (
+        patch("traigent.cloud.auth.AIOHTTP_AVAILABLE", False),
+        patch(
+            "requests.post",
+            return_value=_RequestsResponse(200, b'{"valid": true}'),
+        ) as post,
+    ):
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason is None
+    post.assert_called_once()

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -1,0 +1,102 @@
+"""Strict-bool regression test for ``_validate_api_key_with_backend``.
+
+The backend response body must be parsed strictly: only the literal boolean
+``True`` for the ``valid`` key indicates a successful validation. Truthy
+non-boolean values (e.g. the string ``"false"``, the int ``1``) MUST be
+treated as a rejection so a misconfigured or hostile backend cannot smuggle
+a fake-pass through the SDK.
+
+Repro for the prior weakness:
+
+    if isinstance(data, dict) and data.get("valid"):  # truthy check
+        return None
+
+A response of ``{"valid": "false"}`` would silently authenticate because the
+non-empty string ``"false"`` is truthy in Python. The fix tightens this to
+``data.get("valid") is True``.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from traigent.cloud.auth import AuthManager
+
+
+class _FakeResponse:
+    """Minimal aiohttp response stub for the success-status path."""
+
+    def __init__(self, payload):
+        self.status = 200
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self, content_type=None):  # noqa: ARG002
+        return self._payload
+
+
+class _FakeSession:
+    """Stub aiohttp.ClientSession returning a configurable JSON payload."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, headers=None):  # noqa: ARG002
+        return _FakeResponse(self._payload)
+
+
+def _patch_aiohttp(payload):
+    """Patch the aiohttp surface used by ``_validate_api_key_with_backend``."""
+    fake_aiohttp = MagicMock()
+    fake_aiohttp.ClientSession = MagicMock(return_value=_FakeSession(payload))
+    fake_aiohttp.ClientTimeout = MagicMock()
+    return patch("traigent.cloud.auth.aiohttp", fake_aiohttp)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_string_false_payload():
+    """A backend returning ``{"valid": "false"}`` must NOT authenticate."""
+    manager = AuthManager()
+
+    with _patch_aiohttp({"valid": "false"}):
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason is not None, (
+        "String 'false' was treated as truthy — strict ``is True`` check missing"
+    )
+    assert "invalid" in reason.lower() or "reported" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_truthy_int_payload():
+    """A backend returning ``{"valid": 1}`` must NOT authenticate (strict bool)."""
+    manager = AuthManager()
+
+    with _patch_aiohttp({"valid": 1}):
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason is not None
+    assert "invalid" in reason.lower() or "reported" in reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_strict_true_payload():
+    """A backend returning the literal ``{"valid": True}`` is the only success."""
+    manager = AuthManager()
+
+    with _patch_aiohttp({"valid": True}):
+        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+
+    assert reason is None

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -9,7 +9,10 @@ from traigent.cloud.api_operations import (
     AIOHTTP_AVAILABLE,
     ApiOperations,
 )
-from traigent.cloud.client import CloudServiceError
+from traigent.cloud.client import (
+    CloudRemoteExecutionUnavailableError,
+    CloudServiceError,
+)
 from traigent.cloud.models import (
     AgentExecutionRequest,
     AgentOptimizationRequest,
@@ -526,7 +529,7 @@ class TestCreateCloudSession:
             max_trials=10,
             billing_tier="standard",
         )
-        with pytest.raises(CloudServiceError, match="use hybrid"):
+        with pytest.raises(CloudRemoteExecutionUnavailableError, match="use hybrid"):
             await self.ops.create_cloud_session(request)
 
 

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -517,8 +517,8 @@ class TestCreateCloudSession:
         self.ops = ApiOperations(mock_client)
 
     @pytest.mark.asyncio
-    async def test_returns_session_response(self):
-        """Test returns valid session response."""
+    async def test_raises_not_implemented(self):
+        """Test remote cloud session creation fails closed."""
         request = SessionCreationRequest(
             function_name="test_func",
             configuration_space={"param": [1, 2, 3]},
@@ -526,9 +526,8 @@ class TestCreateCloudSession:
             max_trials=10,
             billing_tier="standard",
         )
-        response = await self.ops.create_cloud_session(request)
-        assert "cloud_session_" in response.session_id
-        assert response.metadata["billing_tier"] == "standard"
+        with pytest.raises(CloudServiceError, match="use hybrid"):
+            await self.ops.create_cloud_session(request)
 
 
 class TestGetCloudTrialSuggestion:
@@ -540,16 +539,14 @@ class TestGetCloudTrialSuggestion:
         self.ops = ApiOperations(mock_client)
 
     @pytest.mark.asyncio
-    async def test_returns_trial_suggestion(self):
-        """Test returns valid trial suggestion."""
+    async def test_raises_not_implemented(self):
+        """Test remote cloud trial suggestions fail closed."""
         request = NextTrialRequest(
             session_id="session_123",
             previous_results=None,
         )
-        response = await self.ops.get_cloud_trial_suggestion(request)
-        assert response.suggestion is not None
-        assert "trial_" in response.suggestion.trial_id
-        assert response.should_continue is True
+        with pytest.raises(CloudServiceError, match="use hybrid"):
+            await self.ops.get_cloud_trial_suggestion(request)
 
 
 class TestSubmitCloudTrialResults:
@@ -561,8 +558,8 @@ class TestSubmitCloudTrialResults:
         self.ops = ApiOperations(mock_client)
 
     @pytest.mark.asyncio
-    async def test_submits_without_error(self):
-        """Test submits without raising errors."""
+    async def test_raises_not_implemented(self):
+        """Test remote cloud trial submission fails closed."""
         from traigent.cloud.models import TrialStatus
 
         submission = TrialResultSubmission(
@@ -572,8 +569,8 @@ class TestSubmitCloudTrialResults:
             duration=1.5,
             status=TrialStatus.COMPLETED,
         )
-        # Should not raise
-        await self.ops.submit_cloud_trial_results(submission)
+        with pytest.raises(CloudServiceError, match="use hybrid"):
+            await self.ops.submit_cloud_trial_results(submission)
 
 
 class TestSubmitAgentOptimization:
@@ -585,8 +582,8 @@ class TestSubmitAgentOptimization:
         self.ops = ApiOperations(mock_client)
 
     @pytest.mark.asyncio
-    async def test_returns_optimization_response(self):
-        """Test returns valid optimization response."""
+    async def test_raises_not_implemented(self):
+        """Test remote agent optimization fails closed."""
         agent_spec = Mock()
         agent_spec.name = "test_agent"
         request = AgentOptimizationRequest(
@@ -596,10 +593,8 @@ class TestSubmitAgentOptimization:
             objectives=["maximize"],
             max_trials=10,
         )
-        response = await self.ops.submit_agent_optimization(request)
-        assert "agent_session_" in response.session_id
-        assert "opt_" in response.optimization_id
-        assert response.status == "started"
+        with pytest.raises(CloudServiceError, match="use hybrid"):
+            await self.ops.submit_agent_optimization(request)
 
 
 class TestExecuteCloudAgent:
@@ -611,8 +606,8 @@ class TestExecuteCloudAgent:
         self.ops = ApiOperations(mock_client)
 
     @pytest.mark.asyncio
-    async def test_returns_execution_response(self):
-        """Test returns valid execution response."""
+    async def test_raises_not_implemented(self):
+        """Test remote agent execution fails closed."""
         agent_spec = Mock()
         agent_spec.name = "test_agent"
         agent_spec.id = "agent_123"
@@ -620,10 +615,8 @@ class TestExecuteCloudAgent:
             agent_spec=agent_spec,
             input_data={"query": "test"},
         )
-        response = await self.ops.execute_cloud_agent(request)
-        assert response.output == "Mock agent response"
-        assert abs(response.duration - 1.5) < 0.01  # Avoid floating point comparison
-        assert response.tokens_used == 50
+        with pytest.raises(CloudServiceError, match="use hybrid"):
+            await self.ops.execute_cloud_agent(request)
 
 
 class TestDeprecatedMethods:
@@ -696,8 +689,8 @@ class TestAiohttpNotAvailable:
         self.ops = ApiOperations(mock_client)
 
     @pytest.mark.asyncio
-    async def test_create_session_without_aiohttp_returns_fallback_ids(self):
-        """Test session creation returns fallback IDs when aiohttp not available."""
+    async def test_create_session_without_aiohttp_fails_closed(self):
+        """Test session creation fails closed when aiohttp is unavailable."""
         with (
             patch("traigent.cloud.api_operations.AIOHTTP_AVAILABLE", False),
             patch(
@@ -710,12 +703,8 @@ class TestAiohttpNotAvailable:
                 objectives=["maximize"],
                 max_trials=10,
             )
-            session_id, exp_id, run_id = await self.ops.create_traigent_session_via_api(
-                request
-            )
-            assert "session_" in session_id
-            assert "exp_" in exp_id
-            assert "run_" in run_id
+            with pytest.raises(CloudServiceError, match="aiohttp is required"):
+                await self.ops.create_traigent_session_via_api(request)
 
 
 class TestHandleConnectorError:
@@ -801,6 +790,10 @@ class TestPostSessionCreation:
             assert session_id == "session_123"
             assert exp_id == "exp_123"
             assert run_id == "run_123"
+            assert (
+                mock_session.post.call_args.args[0]
+                == "https://api.example.com/sessions"
+            )
 
 
 class TestParseSessionResponse:
@@ -1237,8 +1230,8 @@ class TestUpdateExperimentRunStatusSuccess:
             )
 
     @pytest.mark.asyncio
-    async def test_invalid_status_uses_completed_default(self):
-        """Test invalid status defaults to COMPLETED."""
+    async def test_invalid_status_uses_failed_default(self):
+        """Test invalid status defaults to FAILED, not completed."""
         mock_response = AsyncMock()
         mock_response.status = 200
 
@@ -1261,6 +1254,7 @@ class TestUpdateExperimentRunStatusSuccess:
             await self.ops.update_experiment_run_status_on_completion(
                 "run_123", "unknown_status"
             )
+            assert mock_session.put.call_args.kwargs["json"]["status"] == "FAILED"
 
     @pytest.mark.asyncio
     async def test_failed_update_logs_warning(self):

--- a/tests/unit/cloud/test_authentication_concurrency.py
+++ b/tests/unit/cloud/test_authentication_concurrency.py
@@ -381,7 +381,16 @@ class TestBackendClientConcurrency:
 
     @pytest.mark.asyncio
     async def test_backend_client_auth_fallback_race_condition(self):
-        """Test that auth fallback in BackendIntegratedClient is thread-safe."""
+        """B4 ROUND 4: Concurrent auth-failure callers all fail closed.
+
+        Pre-round-4, auth failures during ``_ensure_session`` silently
+        rebuilt headers from the raw stored API key. This regression
+        test originally asserted that behavior. After round 4, every
+        concurrent caller must observe the auth failure (as
+        ``CloudServiceError`` for generic exceptions) and no session
+        with raw-key headers may be created.
+        """
+        from traigent.cloud.client import CloudServiceError
 
         config = BackendClientConfig(backend_base_url="http://test.com")
 
@@ -421,17 +430,23 @@ class TestBackendClientConcurrency:
                         )
                         client.auth = mock_auth_instance
 
-                        # Launch concurrent calls - all should fallback to API key
+                        # Launch concurrent calls - every caller must see
+                        # the auth failure surfaced as CloudServiceError.
                         tasks = [client._ensure_session() for _ in range(5)]
-                        await asyncio.gather(*tasks)
+                        results = await asyncio.gather(
+                            *tasks, return_exceptions=True
+                        )
 
-                        # Verify only one session was created
-                        assert len(session_creations) == 1
+                        # All concurrent attempts must have failed closed.
+                        assert len(results) == 5
+                        for r in results:
+                            assert isinstance(r, CloudServiceError), r
 
-                        # Verify fallback headers were used
-                        headers = session_creations[0]
-                        assert "X-API-Key" in headers
-                        assert headers["X-API-Key"] == "fallback-api-key"
+                        # No session should have been created with the raw
+                        # fallback key as auth headers.
+                        for headers in session_creations:
+                            assert "X-API-Key" not in headers
+                            assert "Authorization" not in headers
 
 
 class TestSessionLifecycleConcurrency:

--- a/tests/unit/cloud/test_authentication_headers.py
+++ b/tests/unit/cloud/test_authentication_headers.py
@@ -9,8 +9,19 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from traigent.cloud.auth import AuthManager
 from traigent.cloud.backend_client import BackendClientConfig, BackendIntegratedClient
 from traigent.cloud.client import CloudServiceError, TraigentCloudClient
+
+
+async def _stub_validate(self, api_key):  # noqa: ARG001
+    """Bypass backend API key validation for header-only tests."""
+    return None
+
+
+def _patch_backend_validate():
+    """Convenience patcher to keep auth offline in header tests."""
+    return patch.object(AuthManager, "_validate_api_key_with_backend", new=_stub_validate)
 
 
 @pytest.fixture
@@ -101,7 +112,9 @@ class TestTraigentCloudClientCore:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test _ensure_session creates session with authentication headers."""
-        with patch("traigent.cloud.client.aiohttp.ClientSession") as mock_cs:
+        with _patch_backend_validate(), patch(
+            "traigent.cloud.client.aiohttp.ClientSession"
+        ) as mock_cs:
             mock_session = Mock()
             mock_cs.return_value = mock_session
 
@@ -181,7 +194,9 @@ class TestTraigentCloudClientCore:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test context manager creates session with authentication headers."""
-        with patch("traigent.cloud.client.aiohttp.ClientSession") as mock_cs:
+        with _patch_backend_validate(), patch(
+            "traigent.cloud.client.aiohttp.ClientSession"
+        ) as mock_cs:
             mock_session = Mock()
             mock_session.close = AsyncMock()  # Mock close method as async
             mock_cs.return_value = mock_session
@@ -202,25 +217,26 @@ class TestTraigentCloudClientCore:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test execute_agent method includes authentication headers."""
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        # Create agent execution request
-        from traigent.cloud.models import AgentExecutionRequest, AgentSpecification
+            # Create agent execution request
+            from traigent.cloud.models import AgentExecutionRequest, AgentSpecification
 
-        agent_spec = AgentSpecification(
-            name="test_agent",
-            agent_platform="langchain",
-            model_parameters={"model": "gpt-4"},
-        )
+            agent_spec = AgentSpecification(
+                name="test_agent",
+                agent_platform="langchain",
+                model_parameters={"model": "gpt-4"},
+            )
 
-        request = AgentExecutionRequest(
-            agent_spec=agent_spec,
-            input_data={"query": "test query"},
-            config_overrides={"temperature": 0.5},
-        )
+            request = AgentExecutionRequest(
+                agent_spec=agent_spec,
+                input_data={"query": "test query"},
+                config_overrides={"temperature": 0.5},
+            )
 
-        # Execute agent
-        await client.execute_agent(request)
+            # Execute agent
+            await client.execute_agent(request)
 
         # Verify headers were included in the POST request
         mock_aiohttp_session.post.assert_called()
@@ -234,11 +250,12 @@ class TestTraigentCloudClientCore:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test get_agent_optimization_status includes authentication headers."""
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        # Get optimization status
-        optimization_id = "opt-test-123"
-        await client.get_agent_optimization_status(optimization_id)
+            # Get optimization status
+            optimization_id = "opt-test-123"
+            await client.get_agent_optimization_status(optimization_id)
 
         # Verify headers were included in the GET request
         mock_aiohttp_session.get.assert_called()
@@ -252,11 +269,12 @@ class TestTraigentCloudClientCore:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test cancel_agent_optimization includes authentication headers."""
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        # Cancel optimization
-        optimization_id = "opt-test-456"
-        await client.cancel_agent_optimization(optimization_id)
+            # Cancel optimization
+            optimization_id = "opt-test-456"
+            await client.cancel_agent_optimization(optimization_id)
 
         # Verify headers were included in the POST request
         mock_aiohttp_session.post.assert_called()
@@ -270,30 +288,33 @@ class TestTraigentCloudClientCore:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test optimize_agent (alias for agent_optimize) includes headers."""
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        from traigent.cloud.models import AgentSpecification
+            from traigent.cloud.models import AgentSpecification
 
-        agent_spec = AgentSpecification(
-            name="optimizer_test",
-            agent_platform="openai",
-            model_parameters={"model": "gpt-3.5-turbo"},
-        )
+            agent_spec = AgentSpecification(
+                name="optimizer_test",
+                agent_platform="openai",
+                model_parameters={"model": "gpt-3.5-turbo"},
+            )
 
-        # Call optimize_agent
-        from traigent.evaluators.base import Dataset, EvaluationExample
+            # Call optimize_agent
+            from traigent.evaluators.base import Dataset, EvaluationExample
 
-        examples = [
-            EvaluationExample(input_data={"input": "test"}, expected_output="output")
-        ]
-        dataset = Dataset(examples)
+            examples = [
+                EvaluationExample(
+                    input_data={"input": "test"}, expected_output="output"
+                )
+            ]
+            dataset = Dataset(examples)
 
-        await client.optimize_agent(
-            agent_spec=agent_spec,
-            dataset=dataset,
-            configuration_space={"temperature": [0.1, 0.9]},
-            objectives=["accuracy", "cost"],
-        )
+            await client.optimize_agent(
+                agent_spec=agent_spec,
+                dataset=dataset,
+                configuration_space={"temperature": [0.1, 0.9]},
+                objectives=["accuracy", "cost"],
+            )
 
         # Verify headers in request
         mock_aiohttp_session.post.assert_called()
@@ -473,8 +494,19 @@ class TestBackendIntegratedClientCore:
             )
 
     @pytest.mark.asyncio
-    async def test_backend_client_ensure_session_with_fallback(self):
-        """Test BackendIntegratedClient _ensure_session handles auth failures gracefully."""
+    async def test_backend_client_ensure_session_fails_closed_on_auth_error(self):
+        """B4 ROUND 4: ``_ensure_session`` must fail closed on auth errors.
+
+        Previously this test asserted that ``_ensure_session`` silently
+        rebuilt headers (Content-Type only, no auth) when ``get_headers``
+        raised -- and worse, when auth raised it would also splice in
+        raw-key headers via ``_build_session_fallback_headers``. After
+        round 4, that fail-open path is removed: any unexpected exception
+        from ``get_headers`` is surfaced as ``CloudServiceError`` (and
+        ``AuthenticationError`` propagates unchanged).
+        """
+        from traigent.cloud.client import CloudServiceError
+
         config = BackendClientConfig(
             backend_base_url="http://test.backend.com",
         )
@@ -500,14 +532,12 @@ class TestBackendIntegratedClientCore:
                     # Properly mock the nested structure: auth_manager.auth
                     client.auth_manager.auth = mock_auth_instance
 
-                    # Call _ensure_session - should fallback to api_key
-                    await client._ensure_session()
+                    # Generic exceptions become CloudServiceError; no
+                    # session is built with fallback headers.
+                    with pytest.raises(CloudServiceError):
+                        await client._ensure_session()
 
-                    # Verify session was created with fallback headers
-                    mock_session_class.assert_called_once()
-                    call_kwargs = mock_session_class.call_args[1]
-                    assert "headers" in call_kwargs
-                    assert call_kwargs["headers"]["Content-Type"] == "application/json"
+                    mock_session_class.assert_not_called()
 
 
 class TestHTTPMethodCoverage:
@@ -518,6 +548,14 @@ class TestHTTPMethodCoverage:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Ensure every HTTP method in TraigentCloudClient includes headers."""
+        with _patch_backend_validate():
+            await self._run_all_client_http_methods_covered(
+                valid_api_key, mock_aiohttp_session
+            )
+
+    async def _run_all_client_http_methods_covered(
+        self, valid_api_key, mock_aiohttp_session
+    ):
         client = TraigentCloudClient(api_key=valid_api_key)
 
         # List of all methods that make HTTP calls
@@ -575,50 +613,53 @@ class TestHTTPMethodCoverage:
         self, valid_api_key, mock_aiohttp_session
     ):
         """Test methods that use AgentSpecification objects."""
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        from traigent.cloud.models import AgentExecutionRequest, AgentSpecification
+            from traigent.cloud.models import AgentExecutionRequest, AgentSpecification
 
-        agent_spec = AgentSpecification(
-            name="comprehensive_test",
-            agent_platform="custom",
-            model_parameters={"model": "test-model", "params": {"key": "value"}},
-            metadata={"version": "1.0"},
-        )
+            agent_spec = AgentSpecification(
+                name="comprehensive_test",
+                agent_platform="custom",
+                model_parameters={"model": "test-model", "params": {"key": "value"}},
+                metadata={"version": "1.0"},
+            )
 
-        # Test optimize_agent (full optimization)
-        from traigent.evaluators.base import Dataset, EvaluationExample
+            # Test optimize_agent (full optimization)
+            from traigent.evaluators.base import Dataset, EvaluationExample
 
-        examples = [EvaluationExample(input_data={"input": "q1"}, expected_output="a1")]
-        dataset = Dataset(examples)
+            examples = [
+                EvaluationExample(input_data={"input": "q1"}, expected_output="a1")
+            ]
+            dataset = Dataset(examples)
 
-        await client.optimize_agent(
-            agent_spec=agent_spec,
-            dataset=dataset,
-            configuration_space={"temperature": [0.1, 1.0]},
-            objectives=["accuracy", "latency"],
-            max_trials=5,
-        )
+            await client.optimize_agent(
+                agent_spec=agent_spec,
+                dataset=dataset,
+                configuration_space={"temperature": [0.1, 1.0]},
+                objectives=["accuracy", "latency"],
+                max_trials=5,
+            )
 
-        # Verify POST with headers
-        assert mock_aiohttp_session.post.called
-        call_kwargs = mock_aiohttp_session.post.call_args[1]
-        assert "headers" in call_kwargs
-        headers = call_kwargs["headers"]
-        assert "X-API-Key" in headers or "Authorization" in headers
+            # Verify POST with headers
+            assert mock_aiohttp_session.post.called
+            call_kwargs = mock_aiohttp_session.post.call_args[1]
+            assert "headers" in call_kwargs
+            headers = call_kwargs["headers"]
+            assert "X-API-Key" in headers or "Authorization" in headers
 
-        # Reset
-        mock_aiohttp_session.post.reset_mock()
+            # Reset
+            mock_aiohttp_session.post.reset_mock()
 
-        # Test execute_agent with AgentExecutionRequest
-        exec_request = AgentExecutionRequest(
-            agent_spec=agent_spec,
-            input_data={"prompt": "test prompt"},
-            config_overrides={"max_tokens": 100},
-            execution_context={"user": "test-user"},
-        )
+            # Test execute_agent with AgentExecutionRequest
+            exec_request = AgentExecutionRequest(
+                agent_spec=agent_spec,
+                input_data={"prompt": "test prompt"},
+                config_overrides={"max_tokens": 100},
+                execution_context={"user": "test-user"},
+            )
 
-        await client.execute_agent(exec_request)
+            await client.execute_agent(exec_request)
 
         # Verify POST with headers
         assert mock_aiohttp_session.post.called
@@ -758,7 +799,9 @@ class TestEdgeCasesAndErrorHandling:
     @pytest.mark.asyncio
     async def test_no_aiohttp_raises_error(self, valid_api_key):
         """Test that missing aiohttp raises appropriate error."""
-        with patch("traigent.cloud.client.AIOHTTP_AVAILABLE", False):
+        with _patch_backend_validate(), patch(
+            "traigent.cloud.client.AIOHTTP_AVAILABLE", False
+        ):
             client = TraigentCloudClient(api_key=valid_api_key)
 
             with pytest.raises(CloudServiceError) as exc_info:
@@ -858,25 +901,26 @@ class TestIntegrationScenarios:
 
         mock_aiohttp_session.post = Mock(side_effect=mock_post)
 
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        # Simulate a full optimization flow
-        await client.create_optimization_session(
-            "test_function",  # request_or_function_name as first positional arg
-            configuration_space={"param": [1, 2, 3]},
-            objectives=["accuracy"],
-        )
+            # Simulate a full optimization flow
+            await client.create_optimization_session(
+                "test_function",  # request_or_function_name as first positional arg
+                configuration_space={"param": [1, 2, 3]},
+                objectives=["accuracy"],
+            )
 
-        await client.get_next_trial(session_id="test-session")
+            await client.get_next_trial(session_id="test-session")
 
-        await client.submit_trial_result(
-            session_id="test-session",
-            trial_id="test-trial",
-            metrics={"accuracy": 0.95},
-            duration=1.5,
-        )
+            await client.submit_trial_result(
+                session_id="test-session",
+                trial_id="test-trial",
+                metrics={"accuracy": 0.95},
+                duration=1.5,
+            )
 
-        await client.finalize_optimization(session_id="test-session")
+            await client.finalize_optimization(session_id="test-session")
 
         # Verify all calls included headers
         assert mock_aiohttp_session.post.call_count == 4
@@ -890,20 +934,21 @@ class TestIntegrationScenarios:
     async def test_manual_session_creation_deprecated(self, valid_api_key):
         """Test that manually setting _session still works but with headers."""
         # This test verifies backward compatibility while ensuring headers are included
-        client = TraigentCloudClient(api_key=valid_api_key)
+        with _patch_backend_validate():
+            client = TraigentCloudClient(api_key=valid_api_key)
 
-        # Manually create a mock session (simulating old test pattern)
-        mock_session = AsyncMock()
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.json = AsyncMock(return_value={"status": "ok"})
-        mock_session.get.return_value.__aenter__.return_value = mock_response
+            # Manually create a mock session (simulating old test pattern)
+            mock_session = AsyncMock()
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value={"status": "ok"})
+            mock_session.get.return_value.__aenter__.return_value = mock_response
 
-        # Set session manually (deprecated pattern)
-        client._session = mock_session
+            # Set session manually (deprecated pattern)
+            client._session = mock_session
 
-        # Even with manual session, methods should add headers
-        await client.check_service_status()
+            # Even with manual session, methods should add headers
+            await client.check_service_status()
 
         # Verify headers were still added
         mock_session.get.assert_called_once()

--- a/tests/unit/cloud/test_authentication_lifecycle.py
+++ b/tests/unit/cloud/test_authentication_lifecycle.py
@@ -11,8 +11,18 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from traigent.cloud.auth import AuthManager
 from traigent.cloud.backend_client import BackendClientConfig, BackendIntegratedClient
 from traigent.cloud.client import CloudServiceError, TraigentCloudClient
+
+
+async def _stub_validate(self, api_key):  # noqa: ARG001
+    """Bypass backend API key validation for offline lifecycle tests."""
+    return None
+
+
+def _patch_backend_validate():
+    return patch.object(AuthManager, "_validate_api_key_with_backend", new=_stub_validate)
 
 
 def require(condition: bool, message: str = "Assertion failed") -> None:
@@ -49,7 +59,9 @@ class TestSessionExpiryAndRefresh:
             session.close = AsyncMock()
             return session
 
-        with patch("traigent.cloud.client.AIOHTTP_AVAILABLE", True):
+        with _patch_backend_validate(), patch(
+            "traigent.cloud.client.AIOHTTP_AVAILABLE", True
+        ):
             with patch(
                 "traigent.cloud.client.aiohttp.ClientSession",
                 side_effect=mock_session_constructor,
@@ -734,22 +746,28 @@ class TestBackendClientAuthLifecycle:
                         task_1 = client_1.create_hybrid_session("problem 1", {}, {})
                         task_2 = client_2.create_hybrid_session("problem 2", {}, {})
 
-                        await asyncio.gather(task_1, task_2, return_exceptions=True)
+                        results = await asyncio.gather(
+                            task_1, task_2, return_exceptions=True
+                        )
 
-                        # Verify both clients handled auth appropriately
-                        require(len(session_data) == 2)
+                        # B4 ROUND 4: client 2 must fail closed instead of
+                        # falling back to raw-key headers. Only client 1
+                        # builds a session with auth headers.
+                        require(len(session_data) == 1)
 
-                        # Client 1 should have primary auth
                         headers_1 = session_data[0]["headers"]
                         require("Authorization" in headers_1)
                         require("Bearer client-1-token" in headers_1["Authorization"])
 
-                        # Client 2 should fall back to the explicit API key when
-                        # auth header generation fails.
-                        headers_2 = session_data[1]["headers"]
-                        require("Content-Type" in headers_2)
-                        require(headers_2.get("X-API-Key") == "key-2")
-                        require(headers_2.get("Authorization") == "Bearer key-2")
+                        # The raw fallback key MUST NOT appear in any session.
+                        for entry in session_data:
+                            require(entry["headers"].get("X-API-Key") != "key-2")
+                            require(entry["headers"].get("Authorization")
+                                    != "Bearer key-2")
+
+                        # Client 2's task must have raised, not silently
+                        # produced a session.
+                        require(isinstance(results[1], Exception))
 
                         # Verify appropriate auth calls were made
                         require("client_1_auth" in auth_calls)

--- a/tests/unit/cloud/test_authentication_security.py
+++ b/tests/unit/cloud/test_authentication_security.py
@@ -34,6 +34,23 @@ def _fake_api_key(length: int = 61) -> str:
     )
 
 
+_DEV_TOKEN = "test-security-dev-token"
+
+
+def _dev_env():
+    """Set TRAIGENT_DEV_AUTH_TOKEN for development-mode flow tests."""
+    return patch.dict(
+        "os.environ", {"TRAIGENT_DEV_AUTH_TOKEN": _DEV_TOKEN}, clear=False
+    )
+
+
+def _dev_credentials(**metadata) -> AuthCredentials:
+    """Build a DEVELOPMENT-mode credential carrying the shared dev token."""
+    md = {"dev_token": _DEV_TOKEN}
+    md.update(metadata)
+    return AuthCredentials(mode=AuthMode.DEVELOPMENT, metadata=md)
+
+
 class TestCredentialSecurity:
     """Test credential storage and handling security."""
 
@@ -250,22 +267,21 @@ class TestCredentialSecurity:
         # An attacker provides a session ID, then tries to use it
 
         # First, authenticate normally
-        credentials = AuthCredentials(
-            mode=AuthMode.DEVELOPMENT, metadata={"dev_user": "legitimate_user"}
-        )
+        credentials = _dev_credentials(dev_user="legitimate_user")
 
-        result1 = asyncio.run(auth_manager.authenticate(credentials))
-        assert result1.success
+        with _dev_env():
+            result1 = asyncio.run(auth_manager.authenticate(credentials))
+            assert result1.success
 
-        # Get initial headers
-        headers1 = asyncio.run(auth_manager.get_auth_headers())
+            # Get initial headers
+            headers1 = asyncio.run(auth_manager.get_auth_headers())
 
-        # Simulate logout and re-authentication
-        asyncio.run(auth_manager.logout())
+            # Simulate logout and re-authentication
+            asyncio.run(auth_manager.logout())
 
-        # Re-authenticate - should get different session context
-        result2 = asyncio.run(auth_manager.authenticate(credentials))
-        assert result2.success
+            # Re-authenticate - should get different session context
+            result2 = asyncio.run(auth_manager.authenticate(credentials))
+            assert result2.success
 
         headers2 = asyncio.run(auth_manager.get_auth_headers())
 
@@ -379,20 +395,19 @@ class TestAuthenticationFlows:
         config = UnifiedAuthConfig()
         auth_manager = AuthManager(config)
 
-        credentials = AuthCredentials(
-            mode=AuthMode.DEVELOPMENT, metadata={"dev_user": "concurrent_test"}
-        )
+        credentials = _dev_credentials(dev_user="concurrent_test")
 
-        # Perform multiple concurrent authentication attempts
-        tasks = [auth_manager.authenticate(credentials) for _ in range(10)]
-        results = await asyncio.gather(*tasks)
+        with _dev_env():
+            # Perform multiple concurrent authentication attempts
+            tasks = [auth_manager.authenticate(credentials) for _ in range(10)]
+            results = await asyncio.gather(*tasks)
 
-        # All should succeed
-        assert all(result.success for result in results)
+            # All should succeed
+            assert all(result.success for result in results)
 
-        # Should be consistently authenticated
-        is_authenticated = await auth_manager.is_authenticated()
-        assert is_authenticated
+            # Should be consistently authenticated
+            is_authenticated = await auth_manager.is_authenticated()
+            assert is_authenticated
 
     @pytest.mark.asyncio
     async def test_token_refresh_security(self):
@@ -401,12 +416,11 @@ class TestAuthenticationFlows:
         auth_manager = AuthManager(config)
 
         # Use development mode for simpler testing
-        credentials = AuthCredentials(
-            mode=AuthMode.DEVELOPMENT, metadata={"dev_user": "test_user_for_refresh"}
-        )
+        credentials = _dev_credentials(dev_user="test_user_for_refresh")
 
         # Authenticate first
-        result = await auth_manager.authenticate(credentials)
+        with _dev_env():
+            result = await auth_manager.authenticate(credentials)
         assert result.success
 
         # Force token refresh (may not be implemented in current version)
@@ -654,13 +668,11 @@ class TestEnvironmentSecurity:
 
     def test_development_mode_security_warnings(self):
         """Test that development mode provides appropriate security warnings."""
-        with patch("traigent.cloud.auth.logger") as mock_logger:
+        with patch("traigent.cloud.auth.logger") as mock_logger, _dev_env():
             config = UnifiedAuthConfig(default_mode=AuthMode.DEVELOPMENT)
             auth_manager = AuthManager(config)
 
-            credentials = AuthCredentials(
-                mode=AuthMode.DEVELOPMENT, metadata={"dev_user": "test_developer"}
-            )
+            credentials = _dev_credentials(dev_user="test_developer")
 
             result = asyncio.run(auth_manager.authenticate(credentials))
             assert result.success

--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -188,15 +188,26 @@ class TestBackendIntegratedClient:
             assert client is not None
 
     def test_async_context_manager(self, backend_client):
-        """Test async context manager functionality."""
+        """Test async context manager functionality.
+
+        B4 ROUND 4: ``__aenter__`` now propagates ``AuthenticationError``
+        instead of silently swallowing it. Mock the backend-side API-key
+        validation so the auth path completes successfully and the
+        context manager mechanics can be exercised.
+        """
+        from traigent.cloud.auth import AuthManager
+
+        async def _ok(self, api_key):  # noqa: ARG001
+            return None
 
         async def run_test():
-            async with backend_client as client:
-                assert client is backend_client
-                # Session initialization is mocked, so we can't test actual session
+            with patch.object(AuthManager, "_validate_api_key_with_backend", new=_ok):
+                async with backend_client as client:
+                    assert client is backend_client
+                    # Session initialization is mocked, so we can't test actual session
 
-            # Session should be None after exit (if it was created)
-            assert backend_client._session is None
+                # Session should be None after exit (if it was created)
+                assert backend_client._session is None
 
         import asyncio
 

--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -334,14 +334,14 @@ class TestPrivacyFirstOptimization:
                 assert exp_id == "exp_456"
                 assert run_id == "run_789"
 
-                # Verify session creation call
-                mock_cloud.assert_called_once()
-                session_request = mock_cloud.call_args[0][0]
-                assert session_request.function_name == "test_function"
-                assert session_request.billing_tier == "privacy"
+                # Cloud remote execution is not used for hybrid/backend tracking.
+                mock_cloud.assert_not_called()
 
                 # Verify session API call
                 mock_session_api.assert_called_once()
+                session_request = mock_session_api.call_args[0][0]
+                assert session_request.function_name == "test_function"
+                assert session_request.billing_tier == "privacy"
 
                 # Verify session mapping creation
                 mock_bridge.create_session_mapping.assert_called_once()
@@ -362,7 +362,7 @@ class TestPrivacyFirstOptimization:
         async def run_test():
             with patch.object(
                 backend_client,
-                "_create_cloud_session",
+                "_create_traigent_session_via_api",
                 side_effect=Exception("Network error"),
             ):
                 with pytest.raises(CloudServiceError, match="Failed to create session"):
@@ -512,7 +512,6 @@ class TestPrivacyFirstOptimization:
                 ) as mock_session,
                 patch("traigent.cloud.backend_client.bridge") as mock_bridge,
             ):
-                mock_cloud.return_value = True  # Mock cloud submission success
                 mock_session.return_value = True  # Mock session submission success
                 mock_bridge.get_trial_mapping.return_value = "config_789"
 
@@ -526,14 +525,8 @@ class TestPrivacyFirstOptimization:
 
                 assert success is True
 
-                # Verify cloud submission
-                mock_cloud.assert_called_once()
-                submission = mock_cloud.call_args[0][0]
-                assert submission.session_id == session_id
-                assert submission.trial_id == trial_id
-                assert submission.metrics == {"accuracy": 0.85, "latency": 1.2}
-                assert submission.duration == 30.5
-                assert submission.status == TrialStatus.COMPLETED
+                # Cloud remote submission is not used for hybrid/backend tracking.
+                mock_cloud.assert_not_called()
 
                 # Verify session submission
                 mock_session.assert_called_once()
@@ -566,7 +559,6 @@ class TestPrivacyFirstOptimization:
                 ) as mock_session,
                 patch("traigent.cloud.backend_client.bridge") as mock_bridge,
             ):
-                mock_cloud.return_value = True  # Mock cloud submission success
                 mock_session.return_value = True  # Mock session submission success
                 mock_bridge.get_trial_mapping.return_value = "config_789"
 
@@ -581,10 +573,8 @@ class TestPrivacyFirstOptimization:
 
                 assert success is True
 
-                # Verify error status
-                submission = mock_cloud.call_args[0][0]
-                assert submission.status == TrialStatus.FAILED
-                assert submission.error_message == "Execution failed"
+                # Cloud remote submission is not used for hybrid/backend tracking.
+                mock_cloud.assert_not_called()
 
                 # Verify session submission with error
                 session_args = mock_session.call_args[0]
@@ -601,7 +591,7 @@ class TestPrivacyFirstOptimization:
         async def run_test():
             with patch.object(
                 backend_client,
-                "_submit_cloud_trial_results",
+                "_submit_trial_result_via_session",
                 side_effect=Exception("Network error"),
             ):
                 success = await backend_client.submit_privacy_trial_results(
@@ -624,7 +614,7 @@ class TestCloudSaaSOptimization:
     def test_start_agent_optimization(
         self, backend_client, agent_specification, sample_dataset
     ):
-        """Test starting agent optimization."""
+        """Test cloud agent optimization fails closed."""
 
         async def run_test():
             with (
@@ -636,41 +626,19 @@ class TestCloudSaaSOptimization:
                 ) as mock_cloud,
                 patch("traigent.cloud.backend_client.bridge") as mock_bridge,
             ):
-                # Mock responses
-                mock_backend.return_value = ("exp_123", "run_456")
-                mock_cloud.return_value = MagicMock(
-                    session_id="agent_session_789",
-                    optimization_id="opt_123",
-                    status="started",
-                )
+                with pytest.raises(CloudServiceError, match="use hybrid"):
+                    await backend_client.start_agent_optimization(
+                        agent_spec=agent_specification,
+                        dataset=sample_dataset,
+                        configuration_space={"temperature": [0.3, 0.7, 1.0]},
+                        objectives=["accuracy", "cost"],
+                        max_trials=30,
+                        user_id="test_user",
+                    )
 
-                response = await backend_client.start_agent_optimization(
-                    agent_spec=agent_specification,
-                    dataset=sample_dataset,
-                    configuration_space={"temperature": [0.3, 0.7, 1.0]},
-                    objectives=["accuracy", "cost"],
-                    max_trials=30,
-                    user_id="test_user",
-                )
-
-                assert response.session_id == "agent_session_789"
-                assert response.optimization_id == "opt_123"
-                assert response.status == "started"
-
-                # Verify backend experiment creation
-                mock_backend.assert_called_once()
-                backend_args = mock_backend.call_args[0]
-                assert backend_args[0] == agent_specification
-                assert backend_args[1] == sample_dataset
-
-                # Verify cloud submission
-                mock_cloud.assert_called_once()
-                cloud_request = mock_cloud.call_args[0][0]
-                assert cloud_request.agent_spec == agent_specification
-                assert cloud_request.billing_tier == "cloud"
-
-                # Verify session mapping
-                mock_bridge.create_session_mapping.assert_called_once()
+                mock_backend.assert_not_called()
+                mock_cloud.assert_not_called()
+                mock_bridge.create_session_mapping.assert_not_called()
 
         import asyncio
 
@@ -679,7 +647,7 @@ class TestCloudSaaSOptimization:
     def test_start_agent_optimization_error_handling(
         self, backend_client, agent_specification, sample_dataset
     ):
-        """Test error handling in agent optimization."""
+        """Test cloud not-implemented guidance in agent optimization."""
 
         async def run_test():
             with patch.object(
@@ -687,9 +655,7 @@ class TestCloudSaaSOptimization:
                 "_create_backend_agent_experiment",
                 side_effect=Exception("Backend error"),
             ):
-                with pytest.raises(
-                    CloudServiceError, match="Failed to start optimization"
-                ):
+                with pytest.raises(CloudServiceError, match="use hybrid"):
                     await backend_client.start_agent_optimization(
                         agent_spec=agent_specification,
                         dataset=sample_dataset,
@@ -702,49 +668,37 @@ class TestCloudSaaSOptimization:
         asyncio.run(run_test())
 
     def test_execute_agent(self, backend_client, agent_specification):
-        """Test agent execution."""
+        """Test cloud agent execution fails closed."""
 
         async def run_test():
             with patch.object(backend_client, "_execute_cloud_agent") as mock_execute:
-                mock_execute.return_value = MagicMock(
-                    output="Test response", duration=2.5, tokens_used=75, cost=0.002
-                )
+                with pytest.raises(CloudServiceError, match="use hybrid"):
+                    await backend_client.execute_agent(
+                        agent_spec=agent_specification,
+                        input_data={"query": "What is AI?"},
+                        config_overrides={"temperature": 0.8},
+                    )
 
-                response = await backend_client.execute_agent(
-                    agent_spec=agent_specification,
-                    input_data={"query": "What is AI?"},
-                    config_overrides={"temperature": 0.8},
-                )
-
-                assert response.output == "Test response"
-                assert response.duration == 2.5
-                assert response.tokens_used == 75
-                assert response.cost == 0.002
-
-                # Verify execution request
-                mock_execute.assert_called_once()
-                execution_request = mock_execute.call_args[0][0]
-                assert execution_request.agent_spec == agent_specification
-                assert execution_request.input_data == {"query": "What is AI?"}
-                assert execution_request.config_overrides == {"temperature": 0.8}
+                mock_execute.assert_not_called()
 
         import asyncio
 
         asyncio.run(run_test())
 
     def test_execute_agent_error_handling(self, backend_client, agent_specification):
-        """Test error handling in agent execution."""
+        """Test cloud agent execution does not reach legacy error path."""
 
         async def run_test():
             with patch.object(
                 backend_client,
                 "_execute_cloud_agent",
                 side_effect=Exception("Execution error"),
-            ):
-                with pytest.raises(CloudServiceError, match="Failed to execute agent"):
+            ) as mock_execute:
+                with pytest.raises(CloudServiceError, match="use hybrid"):
                     await backend_client.execute_agent(
                         agent_spec=agent_specification, input_data={"query": "test"}
                     )
+                mock_execute.assert_not_called()
 
         import asyncio
 
@@ -856,10 +810,10 @@ class TestBackendAPIIntegration:
 
 
 class TestCloudServiceIntegration:
-    """Test cloud service integration placeholder methods."""
+    """Test cloud service integration remote methods."""
 
-    def test_cloud_service_placeholders(self, backend_client):
-        """Test cloud service placeholder methods."""
+    def test_cloud_service_methods_fail_closed(self, backend_client):
+        """Test cloud remote methods do not return synthetic success."""
 
         async def run_test():
             # Test session creation
@@ -869,21 +823,15 @@ class TestCloudServiceIntegration:
                 objectives=["accuracy"],
                 dataset_metadata={},
             )
-            session_response = await backend_client._create_cloud_session(
-                session_request
-            )
-            assert "session_" in session_response.session_id
-            assert session_response.status == OptimizationSessionStatus.CREATED
+            with pytest.raises(CloudServiceError, match="use hybrid"):
+                await backend_client._create_cloud_session(session_request)
 
             # Test trial suggestion
             from traigent.cloud.models import NextTrialRequest
 
             trial_request = NextTrialRequest(session_id="session_123")
-            trial_response = await backend_client._get_cloud_trial_suggestion(
-                trial_request
-            )
-            assert trial_response.suggestion is not None
-            assert trial_response.should_continue is True
+            with pytest.raises(CloudServiceError, match="use hybrid"):
+                await backend_client._get_cloud_trial_suggestion(trial_request)
 
             # Test trial results submission
             trial_submission = TrialResultSubmission(
@@ -893,7 +841,8 @@ class TestCloudServiceIntegration:
                 duration=30.0,
                 status=TrialStatus.COMPLETED,
             )
-            await backend_client._submit_cloud_trial_results(trial_submission)
+            with pytest.raises(CloudServiceError, match="use hybrid"):
+                await backend_client._submit_cloud_trial_results(trial_submission)
 
             # Test agent optimization submission
             from traigent.cloud.models import AgentOptimizationRequest
@@ -904,11 +853,8 @@ class TestCloudServiceIntegration:
                 configuration_space={},
                 objectives=["accuracy"],
             )
-            agent_response = await backend_client._submit_agent_optimization(
-                agent_request
-            )
-            assert "agent_session_" in agent_response.session_id
-            assert agent_response.status == "started"
+            with pytest.raises(CloudServiceError, match="use hybrid"):
+                await backend_client._submit_agent_optimization(agent_request)
 
             # Test agent execution
             from traigent.cloud.models import AgentExecutionRequest
@@ -916,9 +862,8 @@ class TestCloudServiceIntegration:
             exec_request = AgentExecutionRequest(
                 agent_spec=MagicMock(), input_data={"query": "test"}
             )
-            exec_response = await backend_client._execute_cloud_agent(exec_request)
-            assert exec_response.output == "Mock agent response"
-            assert exec_response.duration == 1.5
+            with pytest.raises(CloudServiceError, match="use hybrid"):
+                await backend_client._execute_cloud_agent(exec_request)
 
         import asyncio
 
@@ -1167,7 +1112,7 @@ class TestEdgeCases:
         asyncio.run(run_test())
 
     def test_empty_dataset_handling(self, backend_client, agent_specification):
-        """Test handling of empty datasets."""
+        """Test agent optimization fails before legacy backend/cloud setup."""
 
         async def run_test():
             empty_dataset = Dataset(examples=[], name="empty")
@@ -1183,18 +1128,16 @@ class TestEdgeCases:
                 mock_backend.return_value = ("exp_123", "run_456")
                 mock_cloud.return_value = MagicMock(session_id="session_123")
 
-                response = await backend_client.start_agent_optimization(
-                    agent_spec=agent_specification,
-                    dataset=empty_dataset,
-                    configuration_space={"temperature": [0.7]},
-                    objectives=["accuracy"],
-                )
+                with pytest.raises(CloudServiceError, match="use hybrid"):
+                    await backend_client.start_agent_optimization(
+                        agent_spec=agent_specification,
+                        dataset=empty_dataset,
+                        configuration_space={"temperature": [0.7]},
+                        objectives=["accuracy"],
+                    )
 
-                assert response.session_id == "session_123"
-
-                # Verify empty dataset was passed
-                backend_args = mock_backend.call_args[0]
-                assert len(backend_args[1].examples) == 0
+                mock_backend.assert_not_called()
+                mock_cloud.assert_not_called()
 
         import asyncio
 

--- a/tests/unit/cloud/test_backend_client_fail_closed.py
+++ b/tests/unit/cloud/test_backend_client_fail_closed.py
@@ -22,7 +22,7 @@ After the round-4 fix:
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -32,6 +32,8 @@ from traigent.cloud.auth import (
     InvalidCredentialsError,
 )
 from traigent.cloud.backend_client import BackendIntegratedClient
+from traigent.cloud.backend_components import BackendAuthManager
+from traigent.cloud.client import CloudServiceError
 
 _VALID_LOOKING_KEY = "tg_" + "x" * 61
 
@@ -119,6 +121,26 @@ async def test_no_session_fallback_helper_remains():
         assert not hasattr(client, "_build_session_fallback_headers")
     finally:
         await client.close()
+
+
+@pytest.mark.asyncio
+async def test_backend_auth_manager_propagates_auth_errors():
+    """``augment_headers`` must not swallow backend-rejected credentials."""
+    manager = BackendAuthManager(api_key=_VALID_LOOKING_KEY)
+    manager.auth.get_headers = AsyncMock(side_effect=AuthenticationError("rejected"))
+
+    with pytest.raises(AuthenticationError):
+        await manager.augment_headers({"X-Request-ID": "req"})
+
+
+@pytest.mark.asyncio
+async def test_backend_auth_manager_wraps_unexpected_errors():
+    """Unexpected auth helper errors fail closed as cloud service errors."""
+    manager = BackendAuthManager(api_key=_VALID_LOOKING_KEY)
+    manager.auth.get_headers = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(CloudServiceError, match="Failed to augment backend auth headers"):
+        await manager.augment_headers({"X-Request-ID": "req"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cloud/test_backend_client_fail_closed.py
+++ b/tests/unit/cloud/test_backend_client_fail_closed.py
@@ -1,0 +1,147 @@
+"""B4 ROUND 4 regression tests: ``BackendIntegratedClient`` must fail closed.
+
+Codex's external review identified a parallel fail-open path in
+``traigent/cloud/backend_client.py`` that defeated the round-3 fix to
+``AuthManager.get_auth_headers()``:
+
+* ``_ensure_session()`` caught ``Exception`` from ``get_headers()`` and
+  fell back to ``_build_session_fallback_headers()`` -- which in turn
+  used ``_get_api_key_headers()`` and ultimately the raw stored
+  ``_api_key_fallback`` to mint ``X-API-Key`` / ``Authorization``
+  headers, even after the backend rejected the key.
+
+After the round-4 fix:
+
+* ``AuthenticationError`` (and its ``InvalidCredentialsError`` subclass)
+  raised by ``get_headers()`` must propagate from ``_ensure_session``
+  and ``__aenter__``.
+* No raw-key fallback path may build auth headers.
+* ``_build_session_fallback_headers()`` is removed entirely so it cannot
+  be reached by any code path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from traigent.cloud.auth import (
+    AuthenticationError,
+    AuthManager,
+    InvalidCredentialsError,
+)
+from traigent.cloud.backend_client import BackendIntegratedClient
+
+_VALID_LOOKING_KEY = "tg_" + "x" * 61
+
+
+def _force_backend_reject():
+    """Force ``AuthManager._validate_api_key_with_backend`` to fail."""
+
+    async def _fail(self, api_key):  # noqa: ARG001
+        return "backend-rejected"
+
+    return patch.object(
+        AuthManager,
+        "_validate_api_key_with_backend",
+        new=_fail,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_raises_when_backend_rejects_key():
+    """``_ensure_session`` must surface auth failure, not silently mint headers.
+
+    This is the core regression. Prior to round 4, ``_ensure_session``
+    caught the ``InvalidCredentialsError`` raised by round-3
+    ``get_auth_headers()`` and rebuilt the session with raw-key headers
+    via ``_build_session_fallback_headers``.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        with _force_backend_reject():
+            with pytest.raises(AuthenticationError):
+                await client._ensure_session()
+        # The session must NOT have been created with rejected-key headers.
+        assert client._session is None
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_raises_invalid_credentials_subclass():
+    """The specific ``InvalidCredentialsError`` raised by auth must propagate."""
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        with _force_backend_reject():
+            with pytest.raises(InvalidCredentialsError):
+                await client._ensure_session()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_aenter_raises_when_backend_rejects_key():
+    """The async context manager entry must also fail closed.
+
+    Previously ``__aenter__`` swallowed every exception from
+    ``get_headers()`` and built a session with empty auth headers. While
+    that did not directly leak the raw key, it produced a usable session
+    whose later requests could be paired with the rejected key elsewhere
+    in the stack. After round 4, ``AuthenticationError`` must propagate.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        with _force_backend_reject():
+            with pytest.raises(AuthenticationError):
+                await client.__aenter__()
+        assert client._session is None
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_no_session_fallback_helper_remains():
+    """The unsafe helper must not exist on the class any more.
+
+    ``_build_session_fallback_headers`` was the entry point that turned a
+    rejected key into ``X-API-Key`` / ``Authorization`` headers. Round 4
+    removes it outright so no future regression can re-introduce a fail-
+    open call site.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        assert not hasattr(client, "_build_session_fallback_headers")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_session_does_not_emit_raw_key_headers():
+    """Direct guard: even on partial failure paths, no raw-key headers leak.
+
+    Inspect ``client._session`` after a forced rejection: it must not
+    exist, and (defensively) if it somehow does, its default headers must
+    not contain the raw API key.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        with _force_backend_reject():
+            try:
+                await client._ensure_session()
+            except AuthenticationError:
+                pass
+
+        session = client._session
+        if session is not None:  # pragma: no cover - defensive
+            default_headers = dict(getattr(session, "_default_headers", {}) or {})
+            assert _VALID_LOOKING_KEY not in default_headers.get("X-API-Key", "")
+            assert _VALID_LOOKING_KEY not in default_headers.get("Authorization", "")
+    finally:
+        await client.close()

--- a/tests/unit/cloud/test_backend_client_sync_auth_fail_closed.py
+++ b/tests/unit/cloud/test_backend_client_sync_auth_fail_closed.py
@@ -1,0 +1,216 @@
+"""B4 ROUND 5 regression: ``_get_sync_auth_headers`` must fail closed.
+
+Codex's external review identified the last remaining fail-open path in
+the SDK auth chain:
+
+* ``BackendIntegratedClient._get_sync_auth_headers()`` previously caught
+  every exception from ``auth.get_headers()`` (including the
+  ``AuthenticationError`` raised by the round-3 fail-closed check in
+  ``AuthManager.get_auth_headers()``) and returned bare default headers
+  containing only ``Content-Type`` and ``User-Agent``.
+* ``upload_example_features()`` then proceeded to call ``requests.post``
+  with those default headers -- shipping an UNAUTHENTICATED request to
+  the backend after the key had already been rejected.
+
+After round 5:
+
+* ``_get_sync_auth_headers`` re-raises ``AuthenticationError`` and
+  surfaces other failures as ``CloudServiceError`` instead of silently
+  returning default headers.
+* ``upload_example_features`` catches both, logs, and returns ``False``
+  WITHOUT calling ``requests.post`` -- so no unauthenticated POST ever
+  reaches the network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from traigent.cloud.auth import AuthenticationError, AuthManager
+from traigent.cloud.backend_client import BackendIntegratedClient
+from traigent.cloud.client import CloudServiceError
+
+_VALID_LOOKING_KEY = "tg_" + "x" * 61
+
+
+def _force_backend_reject():
+    """Force ``AuthManager._validate_api_key_with_backend`` to fail.
+
+    Mirrors the helper used by ``test_backend_client_fail_closed.py``:
+    returning a non-None reason from the validation hook causes the
+    auth manager to raise ``InvalidCredentialsError`` (a subclass of
+    ``AuthenticationError``) the next time headers are requested.
+    """
+
+    async def _fail(self, api_key):  # noqa: ARG001
+        return "backend-rejected"
+
+    return patch.object(
+        AuthManager,
+        "_validate_api_key_with_backend",
+        new=_fail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core regression: no unauthenticated POST after backend rejection.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_example_features_does_not_post_when_backend_rejects():
+    """KEY ASSERTION: ``requests.post`` must NOT be called.
+
+    Pre-round-5 behavior: ``_get_sync_auth_headers`` swallowed the auth
+    rejection and returned ``{"Content-Type": ..., "User-Agent": ...}``,
+    after which ``upload_example_features`` happily POSTed to the
+    backend with NO authentication. Round 5 closes that hole.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+    fake_post = MagicMock()
+
+    try:
+        with _force_backend_reject(), patch(
+            "requests.post", new=fake_post
+        ):
+            result = client.upload_example_features(
+                experiment_run_id="run-123",
+                feature_kind="task_complexity",
+                features=[{"example_id": "ex1", "value": 0.5}],
+            )
+
+        # The upload must have short-circuited (False), and crucially the
+        # POST must NEVER have been issued.
+        assert result is False
+        fake_post.assert_not_called()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sync_auth_headers_raises_authentication_error_on_reject():
+    """``_get_sync_auth_headers`` itself must propagate the auth failure.
+
+    Direct guard against re-introducing a fail-open catch in the helper.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        with _force_backend_reject():
+            with pytest.raises(AuthenticationError):
+                client._get_sync_auth_headers(target="backend")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sync_auth_headers_does_not_return_default_on_reject():
+    """Defensive: confirm the rejection path never produces bare defaults.
+
+    If a future regression catches ``AuthenticationError`` and returns
+    ``{"Content-Type": ..., "User-Agent": ...}`` it would slip past the
+    assertions above only if the test stopped raising. Pin the
+    behavior explicitly: header generation must NOT silently produce
+    a 2-key default dict in the rejection path.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        with _force_backend_reject():
+            captured: dict[str, str] | None = None
+            try:
+                captured = client._get_sync_auth_headers(target="backend")
+            except AuthenticationError:
+                captured = None
+
+        # Either we raised (captured is None) or, defensively, we did
+        # NOT return a bare defaults-only dict.
+        if captured is not None:  # pragma: no cover - defensive guard
+            assert set(captured.keys()) != {"Content-Type", "User-Agent"}
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# Unexpected failures must also fail closed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_sync_auth_headers_raises_cloud_service_error_on_unexpected():
+    """Non-auth failures must surface as ``CloudServiceError``.
+
+    If ``auth.get_headers`` raises a generic ``RuntimeError`` (e.g. a
+    transient programming bug), the helper must NOT swallow it into
+    default headers. It must raise ``CloudServiceError`` so the caller
+    cannot mistake "header generation blew up" for "everything's fine".
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    async def _boom(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("simulated header failure")
+
+    try:
+        with patch.object(
+            client.auth_manager.auth, "get_headers", new=_boom
+        ):
+            with pytest.raises(CloudServiceError):
+                client._get_sync_auth_headers(target="backend")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_sync_auth_headers_raises_when_auth_manager_auth_missing():
+    """B4 ROUND 6: auth_manager present but ``.auth`` missing must fail closed.
+
+    Codex found that the previous fix still returned bare ``default_headers``
+    when ``auth_manager.auth`` was None or lacked ``get_headers``. That path
+    is an internal-bug indicator -- not a license to send an unauthenticated
+    request. The helper must now raise ``CloudServiceError``.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+
+    try:
+        # Case 1: auth_manager.auth is None
+        with patch.object(client.auth_manager, "auth", new=None):
+            with pytest.raises(CloudServiceError):
+                client._get_sync_auth_headers(target="backend")
+
+        # Case 2: auth_manager.auth lacks ``get_headers``
+        broken_auth = object()  # plain object, no ``get_headers`` attr
+        with patch.object(client.auth_manager, "auth", new=broken_auth):
+            with pytest.raises(CloudServiceError):
+                client._get_sync_auth_headers(target="backend")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_example_features_skips_post_on_unexpected_failure():
+    """``upload_example_features`` must skip the POST on ``CloudServiceError`` too.
+
+    Same fail-closed guarantee, different failure mode.
+    """
+    client = BackendIntegratedClient(api_key=_VALID_LOOKING_KEY)
+    fake_post = MagicMock()
+
+    async def _boom(*args, **kwargs):  # noqa: ARG001
+        raise RuntimeError("simulated header failure")
+
+    try:
+        with patch.object(
+            client.auth_manager.auth, "get_headers", new=_boom
+        ), patch("requests.post", new=fake_post):
+            result = client.upload_example_features(
+                experiment_run_id="run-456",
+                feature_kind="task_complexity",
+                features=[{"example_id": "ex1", "value": 0.5}],
+            )
+
+        assert result is False
+        fake_post.assert_not_called()
+    finally:
+        await client.close()

--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -18,6 +18,38 @@ from traigent.cloud.auth import (
 )
 
 
+def _mock_backend_validate(success: bool = True):
+    """Patch ``AuthManager._validate_api_key_with_backend`` for offline tests.
+
+    Returns a context manager. Use ``with _mock_backend_validate():`` around
+    code that exercises ``_authenticate_api_key`` so tests do not require a
+    live backend. ``success=False`` simulates a backend rejection.
+    """
+
+    async def _ok(self, api_key):  # noqa: ARG001
+        return None
+
+    async def _fail(self, api_key):  # noqa: ARG001
+        return "mocked-failure"
+
+    return patch.object(
+        AuthManager,
+        "_validate_api_key_with_backend",
+        new=_ok if success else _fail,
+    )
+
+
+# Shared dev-token used by tests exercising AuthMode.DEVELOPMENT.
+_DEV_TOKEN = "test-dev-token-shared-secret"
+
+
+def _dev_env():
+    """Set TRAIGENT_DEV_AUTH_TOKEN for the duration of a test."""
+    return patch.dict(
+        "os.environ", {"TRAIGENT_DEV_AUTH_TOKEN": _DEV_TOKEN}, clear=False
+    )
+
+
 class TestAPIKey:
     """Test cases for APIKey dataclass."""
 
@@ -128,7 +160,8 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_authenticate_success(self):
         manager = AuthManager(api_key="tg_" + "x" * 61)
-        result = await manager.authenticate()
+        with _mock_backend_validate():
+            result = await manager.authenticate()
 
         assert result.success is True
         assert manager._authenticated is True
@@ -154,25 +187,43 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_is_authenticated(self):
         manager = AuthManager(api_key="tg_" + "x" * 61)
-        await manager.authenticate()
+        with _mock_backend_validate():
+            await manager.authenticate()
 
         assert await manager.is_authenticated() is True
 
     @pytest.mark.asyncio
     async def test_get_headers_success(self):
         manager = AuthManager(api_key="tg_" + "x" * 61)
-        await manager.authenticate()
+        with _mock_backend_validate():
+            auth_result = await manager.authenticate()
+            # Explicitly assert authentication succeeded BEFORE asking for headers.
+            assert auth_result.success is True
+            assert await manager.is_authenticated() is True
 
-        headers = await manager.get_auth_headers()
+            headers = await manager.get_auth_headers()
         # API key may be in X-API-Key or Authorization header
         assert "X-API-Key" in headers or "Authorization" in headers
+
+    @pytest.mark.asyncio
+    async def test_get_headers_raises_on_auth_failure(self):
+        """B4: get_auth_headers must fail closed when authenticate() fails.
+
+        Previously, a backend-rejected key still produced X-API-Key /
+        Authorization headers via a fallback path. The fallback was removed,
+        so an AuthenticationError must be raised instead.
+        """
+        manager = AuthManager(api_key="tg_" + "x" * 61)
+        with _mock_backend_validate(success=False):
+            with pytest.raises(AuthenticationError):
+                await manager.get_auth_headers()
 
     @pytest.mark.asyncio
     async def test_get_headers_without_credentials(self):
         with patch.dict("os.environ", {}, clear=True):
             manager = AuthManager()
-            headers = await manager.get_auth_headers()
-            assert headers == {}
+            with pytest.raises(AuthenticationError):
+                await manager.get_auth_headers()
 
     @pytest.mark.asyncio
     async def test_refresh_authentication_without_token(self):
@@ -321,7 +372,8 @@ class TestDemoAuthManager:
     @pytest.mark.asyncio
     async def test_demo_auth_manager_initialization(self):
         manager = AuthManager(api_key=self.DEMO_KEY)
-        result = await manager.authenticate()
+        with _mock_backend_validate():
+            result = await manager.authenticate()
 
         assert result.success is True
         assert manager.has_api_key()
@@ -330,20 +382,23 @@ class TestDemoAuthManager:
     @pytest.mark.asyncio
     async def test_demo_authenticate_always_succeeds(self):
         manager = AuthManager(api_key=self.DEMO_KEY)
-        result = await manager.authenticate()
+        with _mock_backend_validate():
+            result = await manager.authenticate()
         assert result.success is True
 
     @pytest.mark.asyncio
     async def test_demo_auth_permissions(self):
         manager = AuthManager(api_key=self.DEMO_KEY)
-        await manager.authenticate()
+        with _mock_backend_validate():
+            await manager.authenticate()
         assert manager._api_key is not None
         assert manager._api_key.has_permission("optimize") is True
 
     @pytest.mark.asyncio
     async def test_demo_auth_headers(self):
         manager = AuthManager(api_key=self.DEMO_KEY)
-        await manager.authenticate()
+        with _mock_backend_validate():
+            await manager.authenticate()
         headers = await manager.get_auth_headers()
         # API key may be in X-API-Key or Authorization header
         assert "X-API-Key" in headers or "Authorization" in headers
@@ -372,7 +427,8 @@ class TestAuthenticationModes:
             mode=AuthMode.API_KEY,
             api_key="tg_" + "x" * 61,
         )
-        result = await manager._authenticate_by_mode(credentials)
+        with _mock_backend_validate():
+            result = await manager._authenticate_by_mode(credentials)
 
         assert result.success is True
         assert result.status == AuthStatus.AUTHENTICATED
@@ -601,14 +657,15 @@ class TestAuthenticationModes:
 
     @pytest.mark.asyncio
     async def test_authenticate_development_success(self):
-        """Test development mode authentication always succeeds."""
+        """Test development mode auth succeeds when env token + creds match."""
         manager = AuthManager()
         credentials = AuthCredentials(
             mode=AuthMode.DEVELOPMENT,
-            metadata={"dev_user": "test_developer"},
+            metadata={"dev_user": "test_developer", "dev_token": _DEV_TOKEN},
         )
 
-        result = await manager._authenticate_development(credentials)
+        with _dev_env():
+            result = await manager._authenticate_development(credentials)
 
         assert result.success is True
         assert result.status == AuthStatus.AUTHENTICATED
@@ -621,13 +678,48 @@ class TestAuthenticationModes:
         manager = AuthManager()
         credentials = AuthCredentials(
             mode=AuthMode.DEVELOPMENT,
-            metadata={},  # No dev_user specified
+            metadata={"dev_token": _DEV_TOKEN},  # No dev_user specified
         )
 
-        result = await manager._authenticate_development(credentials)
+        with _dev_env():
+            result = await manager._authenticate_development(credentials)
 
         assert result.success is True
         assert result.headers["X-Dev-User"] == "developer"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_development_rejects_without_env(self):
+        """Development mode must reject when TRAIGENT_DEV_AUTH_TOKEN is unset."""
+        manager = AuthManager()
+        credentials = AuthCredentials(
+            mode=AuthMode.DEVELOPMENT,
+            metadata={"dev_token": "anything"},
+        )
+
+        with patch.dict("os.environ", {}, clear=False) as _:
+            import os as _os
+
+            _os.environ.pop("TRAIGENT_DEV_AUTH_TOKEN", None)
+            result = await manager._authenticate_development(credentials)
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
+        assert "TRAIGENT_DEV_AUTH_TOKEN" in (result.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_authenticate_development_rejects_token_mismatch(self):
+        """Development mode rejects when supplied token does not match env."""
+        manager = AuthManager()
+        credentials = AuthCredentials(
+            mode=AuthMode.DEVELOPMENT,
+            metadata={"dev_token": "wrong-token"},
+        )
+
+        with _dev_env():
+            result = await manager._authenticate_development(credentials)
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
 
     @pytest.mark.asyncio
     async def test_authenticate_by_mode_jwt_dispatch(self):
@@ -665,9 +757,11 @@ class TestAuthenticationModes:
         manager = AuthManager()
         credentials = AuthCredentials(
             mode=AuthMode.DEVELOPMENT,
+            metadata={"dev_token": _DEV_TOKEN},
         )
 
-        result = await manager._authenticate_by_mode(credentials)
+        with _dev_env():
+            result = await manager._authenticate_by_mode(credentials)
 
         assert result.success is True
         assert result.headers["X-Development-Mode"] == "true"

--- a/tests/unit/cloud/test_get_auth_headers_fail_closed.py
+++ b/tests/unit/cloud/test_get_auth_headers_fail_closed.py
@@ -1,0 +1,98 @@
+"""B4 ROUND 3 + ROUND 7 regression tests: get_auth_headers() must fail closed.
+
+Codex's external review identified that ``AuthManager.get_auth_headers()``
+defeated the purpose of B4 backend validation: when ``authenticate()``
+returned an unsuccessful ``AuthResult``, the method silently fell back to
+``_get_api_key_headers()`` -- emitting ``X-API-Key`` / ``Authorization``
+headers built from the rejected raw key.
+
+After the fix, ``get_auth_headers()`` must raise ``AuthenticationError``
+(``InvalidCredentialsError``) instead of returning fallback headers when
+the underlying authentication fails.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from traigent.cloud.auth import (
+    AuthenticationError,
+    AuthManager,
+    InvalidCredentialsError,
+)
+
+
+def _force_backend_reject():
+    """Force ``_validate_api_key_with_backend`` to report a failure."""
+
+    async def _fail(self, api_key):  # noqa: ARG001
+        return "backend-rejected"
+
+    return patch.object(
+        AuthManager,
+        "_validate_api_key_with_backend",
+        new=_fail,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_auth_headers_raises_when_backend_rejects_key():
+    """Backend-rejected keys must NOT yield headers, even silently.
+
+    This is the core regression: prior to the fix, the code would fall back
+    to ``_get_api_key_headers()`` and ship the raw rejected key as
+    ``X-API-Key`` / ``Authorization``.
+    """
+    manager = AuthManager(api_key="tg_" + "x" * 61)
+
+    with _force_backend_reject():
+        with pytest.raises(AuthenticationError):
+            await manager.get_auth_headers()
+
+
+@pytest.mark.asyncio
+async def test_get_auth_headers_raises_invalid_credentials_subclass():
+    """Confirm we raise the more specific ``InvalidCredentialsError``."""
+    manager = AuthManager(api_key="tg_" + "x" * 61)
+
+    with _force_backend_reject():
+        with pytest.raises(InvalidCredentialsError):
+            await manager.get_auth_headers()
+
+
+@pytest.mark.asyncio
+async def test_get_auth_headers_does_not_emit_api_key_on_failure():
+    """Even via try/except, the raw key must never reach the headers dict."""
+    manager = AuthManager(api_key="tg_" + "x" * 61)
+
+    captured: dict[str, str] | None = None
+    with _force_backend_reject():
+        try:
+            captured = await manager.get_auth_headers()
+        except AuthenticationError:
+            captured = None
+
+    # If anything was returned, ensure no auth header carries the raw key.
+    if captured is not None:  # pragma: no cover - defensive
+        assert "X-API-Key" not in captured
+        assert "Authorization" not in captured
+
+
+@pytest.mark.asyncio
+async def test_get_auth_headers_raises_when_credentials_none_after_auth():
+    """B4 ROUND 7: _credentials=None while is_authenticated()=True must fail closed.
+
+    Codex found that the post-authentication branch (line 898) returned {}
+    when _credentials was None but _current_token existed -- yielding empty
+    headers without an exception. That path is an internal inconsistency
+    and must now raise InvalidCredentialsError.
+    """
+    manager = AuthManager(api_key="tg_" + "x" * 61)
+
+    # Force is_authenticated() to return True while _credentials is None
+    with patch.object(manager, "is_authenticated", return_value=True):
+        manager._credentials = None  # simulate inconsistent state
+        with pytest.raises(InvalidCredentialsError):
+            await manager.get_auth_headers()

--- a/tests/unit/cloud/test_traigent_cloud_client.py
+++ b/tests/unit/cloud/test_traigent_cloud_client.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from traigent.cloud.auth import AuthManager
 from traigent.cloud.client import (
     CloudOptimizationResult,
     CloudServiceError,
@@ -12,6 +13,24 @@ from traigent.cloud.client import (
 )
 from traigent.config.backend_config import BackendConfig
 from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+async def _stub_validate(self, api_key):  # noqa: ARG001
+    """Bypass backend API key validation for offline tests."""
+    return None
+
+
+def _patch_backend_validate():
+    """Patch ``AuthManager._validate_api_key_with_backend`` for offline tests.
+
+    B4 round 3 made ``get_auth_headers()`` fail closed when authentication
+    fails, so any test that calls a method which builds auth headers must
+    either authenticate against a working backend or stub the backend
+    validation hook.
+    """
+    return patch.object(
+        AuthManager, "_validate_api_key_with_backend", new=_stub_validate
+    )
 
 
 @pytest.fixture
@@ -87,11 +106,12 @@ class TestTraigentCloudClient:
         """Test async context manager functionality."""
 
         async def run_test():
-            async with mock_cloud_client as client:
-                assert client._session is not None
+            with _patch_backend_validate():
+                async with mock_cloud_client as client:
+                    assert client._session is not None
 
-            # Session should be closed after exit
-            assert mock_cloud_client._session is None
+                # Session should be closed after exit
+                assert mock_cloud_client._session is None
 
         asyncio.run(run_test())
 
@@ -297,14 +317,15 @@ class TestTraigentCloudClient:
             mock_session.post.return_value.__aenter__.return_value = mock_response
             mock_cloud_client._session = mock_session
 
-            result = await mock_cloud_client._submit_optimization(
-                {
-                    "function_name": "test",
-                    "dataset": {},
-                    "configuration_space": {},
-                    "objectives": ["accuracy"],
-                }
-            )
+            with _patch_backend_validate():
+                result = await mock_cloud_client._submit_optimization(
+                    {
+                        "function_name": "test",
+                        "dataset": {},
+                        "configuration_space": {},
+                        "objectives": ["accuracy"],
+                    }
+                )
 
             assert result["best_config"] == {"param": "value"}
             assert result["best_metrics"] == {"accuracy": 0.9}
@@ -338,7 +359,9 @@ class TestTraigentCloudClient:
             ]
             mock_cloud_client._session = mock_session
 
-            with patch("asyncio.sleep", new_callable=AsyncMock):
+            with _patch_backend_validate(), patch(
+                "asyncio.sleep", new_callable=AsyncMock
+            ):
                 result = await mock_cloud_client._submit_optimization({})
 
             assert result["trials_count"] == 10
@@ -357,8 +380,9 @@ class TestTraigentCloudClient:
             mock_session.post.return_value.__aenter__.return_value = mock_response
             mock_cloud_client._session = mock_session
 
-            with pytest.raises(CloudServiceError, match="HTTP 500"):
-                await mock_cloud_client._submit_optimization({})
+            with _patch_backend_validate():
+                with pytest.raises(CloudServiceError, match="HTTP 500"):
+                    await mock_cloud_client._submit_optimization({})
 
         asyncio.run(run_test())
 
@@ -407,7 +431,8 @@ class TestTraigentCloudClient:
             mock_session.get.return_value.__aenter__.return_value = mock_response
             mock_cloud_client._session = mock_session
 
-            status = await mock_cloud_client.check_service_status()
+            with _patch_backend_validate():
+                status = await mock_cloud_client.check_service_status()
             assert status["status"] == "healthy"
             assert "uptime" in status
 

--- a/tests/unit/cloud/test_traigent_cloud_client.py
+++ b/tests/unit/cloud/test_traigent_cloud_client.py
@@ -130,8 +130,10 @@ class TestTraigentCloudClient:
 
         asyncio.run(run_test())
 
-    def test_optimize_function_success(self, mock_cloud_client, sample_dataset):
-        """Test successful optimization with cloud service."""
+    def test_optimize_function_remote_execution_unavailable(
+        self, mock_cloud_client, sample_dataset
+    ):
+        """Test cloud optimization fails closed until remote execution exists."""
 
         async def run_test():
             # Mock the auth and submission
@@ -156,23 +158,19 @@ class TestTraigentCloudClient:
                 }
 
                 async with mock_cloud_client as client:
-                    result = await client.optimize_function(
-                        function_name="test_function",
-                        dataset=sample_dataset,
-                        configuration_space={
-                            "param1": ["a", "b"],
-                            "param2": [0.1, 0.5, 0.9],
-                        },
-                        objectives=["accuracy", "speed"],
-                        max_trials=50,
-                    )
+                    with pytest.raises(CloudServiceError, match="use hybrid"):
+                        await client.optimize_function(
+                            function_name="test_function",
+                            dataset=sample_dataset,
+                            configuration_space={
+                                "param1": ["a", "b"],
+                                "param2": [0.1, 0.5, 0.9],
+                            },
+                            objectives=["accuracy", "speed"],
+                            max_trials=50,
+                        )
 
-                assert isinstance(result, CloudOptimizationResult)
-                assert result.best_config == {"param1": "value1", "param2": 0.5}
-                assert result.best_metrics == {"accuracy": 0.85, "speed": 0.9}
-                assert result.trials_count == 25
-                assert result.subset_used is True
-                assert result.cost_reduction > 0
+                mock_submit.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -198,8 +196,10 @@ class TestTraigentCloudClient:
 
         asyncio.run(run_test())
 
-    def test_optimize_function_with_fallback(self, mock_cloud_client, sample_dataset):
-        """Test fallback to local optimization when cloud fails."""
+    def test_optimize_function_does_not_fallback(
+        self, mock_cloud_client, sample_dataset
+    ):
+        """Test remote cloud optimization does not silently fallback."""
 
         async def local_function(text: str, param: int = 1) -> str:
             return f"{text}:{param}"
@@ -242,21 +242,17 @@ class TestTraigentCloudClient:
                 )
 
                 async with mock_cloud_client as client:
-                    result = await client.optimize_function(
-                        function_name="test_function",
-                        dataset=sample_dataset,
-                        configuration_space={"param": [1, 2, 3]},
-                        objectives=["accuracy"],
-                        local_function=local_function,
-                    )
+                    with pytest.raises(CloudServiceError, match="use hybrid"):
+                        await client.optimize_function(
+                            function_name="test_function",
+                            dataset=sample_dataset,
+                            configuration_space={"param": [1, 2, 3]},
+                            objectives=["accuracy"],
+                            local_function=local_function,
+                        )
 
-                # Should get fallback result
-                assert isinstance(result, CloudOptimizationResult)
-                assert result.best_config == {"param": 1}
-                assert result.best_metrics == {"accuracy": 0.8}
-                assert result.trials_count == 2
-                assert result.subset_used is False
-                assert result.cost_reduction == 0.0
+                mock_get_optimizer.assert_not_called()
+                mock_orchestrator_class.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -286,9 +282,7 @@ class TestTraigentCloudClient:
                 ),
             ):
                 async with client as c:
-                    with pytest.raises(
-                        CloudServiceError, match="Cloud optimization failed"
-                    ):
+                    with pytest.raises(CloudServiceError, match="use hybrid"):
                         await c.optimize_function(
                             function_name="test_function",
                             dataset=sample_dataset,

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -109,6 +109,68 @@ class TestMeasuresDictValidationInSubmission:
     """Test MeasuresDict validation warning path in submit_trial_result_via_session."""
 
     @pytest.mark.asyncio
+    async def test_hybrid_trial_submission_uses_session_results_endpoint(self) -> None:
+        """Hybrid/backend tracking posts trial metrics to the session results API."""
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = (
+            "https://api.example.com"  # pragma: allowlist secret
+        )
+        mock_client.backend_config.api_base_url = "https://api.example.com/api/v1"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="COMPLETED")
+        mock_client._normalize_execution_mode = Mock(return_value="local")
+        mock_client._sanitize_error_message = Mock(return_value="")
+
+        ops = TrialOperations(mock_client)
+        ops._handle_trial_success_response = AsyncMock(return_value=True)
+
+        mock_response = Mock()
+        mock_response.status = 201
+
+        mock_post_ctx = AsyncMock()
+        mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_post_ctx)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+
+            result = await ops.submit_trial_result_via_session(
+                session_id="session_123",
+                trial_id="trial_001",
+                config={"temperature": 0.2},
+                metrics={"accuracy": 0.95},
+                status="completed",
+                execution_mode="hybrid",
+            )
+
+        assert result is True
+        assert (
+            mock_session.post.call_args.args[0]
+            == "https://api.example.com/api/v1/sessions/session_123/results"
+        )
+        mock_client._normalize_execution_mode.assert_called_once_with("hybrid")
+
+    @pytest.mark.asyncio
     async def test_invalid_metric_key_logs_warning_and_submits_unvalidated(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/unit/core/optimized_function_tests/test_cloud_integration.py
+++ b/tests/unit/core/optimized_function_tests/test_cloud_integration.py
@@ -7,8 +7,28 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from traigent.cloud.auth import AuthManager
 from traigent.cloud.client import CloudServiceError
 from traigent.core.optimized_function import OptimizedFunction
+
+
+async def _stub_validate_backend(self, api_key):  # noqa: ARG001
+    """Bypass backend API key validation for offline tests.
+
+    B4 round 3 made ``get_auth_headers()`` fail closed when the backend
+    rejects a key. Tests that simulate cloud paths but never expect a real
+    backend call must stub this hook.
+    """
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _patch_backend_validate_autouse():
+    """Auto-applied: keep backend validation offline for all tests in this module."""
+    with patch.object(
+        AuthManager, "_validate_api_key_with_backend", new=_stub_validate_backend
+    ):
+        yield
 
 
 class TestCloudIntegration:

--- a/tests/unit/core/optimized_function_tests/test_cloud_integration.py
+++ b/tests/unit/core/optimized_function_tests/test_cloud_integration.py
@@ -8,7 +8,10 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from traigent.cloud.auth import AuthManager
-from traigent.cloud.client import CloudServiceError
+from traigent.cloud.client import (
+    CloudRemoteExecutionUnavailableError,
+    CloudServiceError,
+)
 from traigent.core.optimized_function import OptimizedFunction
 
 
@@ -159,6 +162,34 @@ class TestCloudIntegration:
             assert result is None
 
     @pytest.mark.asyncio
+    async def test_cloud_remote_unavailable_error_does_not_fallback(
+        self, simple_function, sample_config_space, sample_objectives, sample_dataset
+    ):
+        """Remote-execution unavailability is typed instead of string-matched."""
+        opt_func = OptimizedFunction(
+            func=simple_function,
+            configuration_space=sample_config_space,
+            objectives=sample_objectives,
+            eval_dataset=sample_dataset,
+            execution_mode="cloud",
+            cloud_fallback_policy="auto",
+        )
+
+        with patch.object(
+            opt_func,
+            "_optimize_with_cloud_service",
+            side_effect=CloudRemoteExecutionUnavailableError("optimize_function"),
+        ):
+            with pytest.raises(CloudRemoteExecutionUnavailableError, match="use hybrid"):
+                await opt_func._try_cloud_execution(
+                    dataset=sample_dataset,
+                    max_trials=5,
+                    timeout=10.0,
+                    effective_config_space=sample_config_space,
+                    algorithm_kwargs={},
+                )
+
+    @pytest.mark.asyncio
     async def test_cloud_mode_fail_closed_on_unexpected_exception(
         self, simple_function, sample_config_space, sample_objectives, sample_dataset
     ):
@@ -249,13 +280,18 @@ class TestCloudIntegration:
         )
 
         with patch(
-            "traigent.core.orchestrator.OptimizationOrchestrator"
+            "traigent.core.optimized_function.OptimizationOrchestrator"
         ) as MockOrchestrator:
             mock_orchestrator = MockOrchestrator.return_value
             mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
 
-            result = await opt_func.optimize()
-            assert result.best_score == 0.95
+            with patch.object(
+                opt_func,
+                "_optimize_with_cloud_service",
+                side_effect=OSError("network down"),
+            ):
+                result = await opt_func.optimize()
+                assert result.best_score == 0.95
 
     def test_disable_cloud_mode(
         self, simple_function, sample_config_space, sample_objectives
@@ -332,6 +368,7 @@ class TestCloudIntegration:
             objectives=sample_objectives,
             eval_dataset=sample_dataset,
             execution_mode="cloud",
+            cloud_fallback_policy="auto",
         )
 
         # Test that cloud execution enables cloud service
@@ -358,13 +395,18 @@ class TestCloudIntegration:
         )
 
         with patch(
-            "traigent.core.orchestrator.OptimizationOrchestrator"
+            "traigent.core.optimized_function.OptimizationOrchestrator"
         ) as MockOrchestrator:
             mock_orchestrator = MockOrchestrator.return_value
             mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
 
-            result = await opt_func.optimize()
-            assert result.best_score == 0.90
+            with patch.object(
+                opt_func,
+                "_optimize_with_cloud_service",
+                side_effect=OSError("network down"),
+            ):
+                result = await opt_func.optimize()
+                assert result.best_score == 0.90
 
     def test_cloud_result_caching(
         self, simple_function, sample_config_space, sample_objectives

--- a/tests/unit/core/test_ci_approval.py
+++ b/tests/unit/core/test_ci_approval.py
@@ -272,29 +272,34 @@ class TestCheckCiApproval:
         # Should not raise
         check_ci_approval(config)
 
-    def test_skips_in_mock_llm_mode(self) -> None:
-        config = MagicMock()
-        config.is_edge_analytics_mode.return_value = True
-        with (
-            patch("traigent.core.ci_approval.is_mock_llm", return_value=True),
-            patch("traigent.core.ci_approval.is_production", return_value=False),
-        ):
-            check_ci_approval(config)
+    def test_mock_llm_no_longer_bypasses_ci_approval(self, tmp_path: Path) -> None:
+        """S2-B retirement: TRAIGENT_MOCK_LLM=true must NOT skip CI approval.
 
-    def test_skips_in_mock_llm_production(self) -> None:
+        Previously, ``check_ci_approval`` short-circuited whenever
+        ``is_mock_llm()`` returned True. That made a security gate
+        bypassable by setting an env var, which was unsafe in production
+        deployments where the variable could leak in. The bypass is removed.
+        """
         config = MagicMock()
         config.is_edge_analytics_mode.return_value = True
+        config.get_local_storage_path.return_value = str(tmp_path)
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k != "TRAIGENT_RUN_APPROVED"
+        }
+        env["TRAIGENT_MOCK_LLM"] = "true"
         with (
-            patch("traigent.core.ci_approval.is_mock_llm", return_value=True),
-            patch("traigent.core.ci_approval.is_production", return_value=True),
+            patch("traigent.core.ci_approval._is_ci_environment", return_value=True),
+            patch.dict(os.environ, env, clear=True),
         ):
-            check_ci_approval(config)
+            with pytest.raises(OptimizationError, match="CI/CD Approval Required"):
+                check_ci_approval(config)
 
     def test_skips_when_not_ci(self) -> None:
         config = MagicMock()
         config.is_edge_analytics_mode.return_value = True
         with (
-            patch("traigent.core.ci_approval.is_mock_llm", return_value=False),
             patch("traigent.core.ci_approval._is_ci_environment", return_value=False),
         ):
             check_ci_approval(config)
@@ -305,7 +310,6 @@ class TestCheckCiApproval:
         config.get_local_storage_path.return_value = str(tmp_path)
         env = {k: v for k, v in os.environ.items() if k != "TRAIGENT_RUN_APPROVED"}
         with (
-            patch("traigent.core.ci_approval.is_mock_llm", return_value=False),
             patch("traigent.core.ci_approval._is_ci_environment", return_value=True),
             patch.dict(os.environ, env, clear=True),
         ):
@@ -318,7 +322,6 @@ class TestCheckCiApproval:
         config.get_local_storage_path.return_value = None
         env = {k: v for k, v in os.environ.items() if k != "TRAIGENT_RUN_APPROVED"}
         with (
-            patch("traigent.core.ci_approval.is_mock_llm", return_value=False),
             patch("traigent.core.ci_approval._is_ci_environment", return_value=True),
             patch.dict(os.environ, env, clear=True),
         ):
@@ -329,7 +332,6 @@ class TestCheckCiApproval:
         config = MagicMock()
         config.is_edge_analytics_mode.return_value = True
         with (
-            patch("traigent.core.ci_approval.is_mock_llm", return_value=False),
             patch("traigent.core.ci_approval._is_ci_environment", return_value=True),
             patch.dict(os.environ, {"TRAIGENT_RUN_APPROVED": "1"}),
         ):

--- a/tests/unit/core/test_config_builder.py
+++ b/tests/unit/core/test_config_builder.py
@@ -20,10 +20,7 @@ from traigent.core.config_builder import (
     create_advanced_config_space,
     create_simple_config_space,
 )
-from traigent.core.constants import (
-    DEFAULT_EXECUTION_MODE,
-    DEFAULT_MODEL,
-)
+from traigent.core.constants import DEFAULT_EXECUTION_MODE, DEFAULT_MODEL
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 from traigent.core.types import ParameterType
 
@@ -291,8 +288,8 @@ class TestOptimizedFunctionConfig:
     def test_validate_valid_execution_modes(self) -> None:
         """Test validation passes for edge_analytics execution mode.
 
-        Note: Only edge_analytics is currently supported. cloud/hybrid raise
-        ConfigurationError (not yet supported), privacy/standard were removed.
+        Note: This test exercises the local default. Hybrid is covered by
+        execution-mode tests; cloud remote execution raises ConfigurationError.
         """
         config = OptimizedFunctionConfig(
             execution_mode=ExecutionMode.EDGE_ANALYTICS.value

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -194,34 +194,55 @@ class TestCostEnforcerBasic:
 
 
 class TestCostEnforcerMockMode:
-    """Tests for mock mode behavior."""
+    """Tests pinning that TRAIGENT_MOCK_LLM is NOT honored by CostEnforcer.
 
-    def test_mock_mode_bypasses_tracking(self) -> None:
-        """Mock mode bypasses all tracking."""
+    S2-B Round 3 removed the mock-mode bypass: cost approval, permit
+    acquisition, and cost tracking always run regardless of the env flag.
+    """
+
+    def test_mock_mode_does_not_bypass_tracking(self) -> None:
+        """track_cost must update accumulated_cost even with TRAIGENT_MOCK_LLM=true."""
         with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
             enforcer = CostEnforcer()
-            enforcer.track_cost(
-                100.0, permit=_create_mock_permit()
-            )  # Would exceed any limit
+            permit = enforcer.acquire_permit()
+            enforcer.track_cost(0.05, permit=permit)
+            assert enforcer.accumulated_cost == pytest.approx(0.05)
 
-            # Should still be 0 because mock mode skips tracking
-            assert enforcer.accumulated_cost == 0.0
-
-    def test_mock_mode_always_permits(self) -> None:
-        """Mock mode always grants permits."""
+    def test_mock_mode_does_not_force_permits(self) -> None:
+        """Permit denial under tight limits must still occur with TRAIGENT_MOCK_LLM=true."""
         with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
-            config = CostEnforcerConfig(limit=0.01)  # Very low limit
+            config = CostEnforcerConfig(
+                limit=0.01, estimated_cost_per_trial=1.0
+            )  # Very low limit, high estimate
             enforcer = CostEnforcer(config=config)
 
             permit = enforcer.acquire_permit()
-            assert permit.is_granted, "Mock mode should always grant permits"
-            assert permit.amount > 0, "Mock mode permit should have positive amount"
+            # First permit reserves budget; subsequent acquisitions must be
+            # denied because the in-flight reservation already exceeds limit.
+            second = enforcer.acquire_permit()
+            assert not second.is_granted, (
+                "Mock mode must not override real permit limits"
+            )
+            enforcer.release_permit(permit)
 
-    def test_mock_mode_approves_any_cost(self) -> None:
-        """Mock mode approves any estimated cost."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
-            enforcer = CostEnforcer()
-            assert enforcer.check_and_approve(1000.0) is True
+    def test_mock_mode_does_not_auto_approve(self) -> None:
+        """check_and_approve must NOT short-circuit when TRAIGENT_MOCK_LLM=true.
+
+        With a non-interactive shell and an estimated cost above the limit,
+        approval should fail-safe to False (no auto-approval via mock mode).
+        """
+        with patch.dict(
+            os.environ,
+            {"TRAIGENT_MOCK_LLM": "true", "TRAIGENT_COST_APPROVED": "false"},
+        ):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=1.0, approved=False))
+            # Far above limit — without auto-approval and with no interactive
+            # shell available, this must NOT return True solely due to mock mode.
+            with patch(
+                "traigent.core.cost_enforcement.CostEnforcer._request_user_approval",
+                return_value=False,
+            ):
+                assert enforcer.check_and_approve(1000.0) is False
 
 
 class TestCostEnforcerUnknownCost:
@@ -1088,29 +1109,13 @@ class TestCostEnforcerInternals:
         assert enforcer._sync_used is False
         assert enforcer._async_used is False
 
-    def test_check_mock_mode(self) -> None:
-        """Verify _check_mock_mode handles env vars correctly."""
-        # Test "true"
+    def test_mock_mode_method_and_property_are_removed(self) -> None:
+        """S2-B Round 3 removed _check_mock_mode and is_mock_mode from CostEnforcer."""
         with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
             enforcer = CostEnforcer()
-            assert enforcer._check_mock_mode() is True
-
-        # Test "True" (case insensitive)
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "True"}):
-            enforcer = CostEnforcer()
-            assert enforcer._check_mock_mode() is True
-
-        # Test "false"
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "false"}):
-            enforcer = CostEnforcer()
-            assert enforcer._check_mock_mode() is False
-
-        # Test missing (default false)
-        with patch.dict(os.environ):
-            if "TRAIGENT_MOCK_LLM" in os.environ:
-                del os.environ["TRAIGENT_MOCK_LLM"]
-            enforcer = CostEnforcer()
-            assert enforcer._check_mock_mode() is False
+            assert not hasattr(enforcer, "_check_mock_mode")
+            assert not hasattr(enforcer, "is_mock_mode")
+            assert not hasattr(enforcer, "_mock_mode_cached")
 
     def test_get_approval_token_path(self) -> None:
         """Verify token path construction."""

--- a/tests/unit/core/test_cost_enforcement_ctd.py
+++ b/tests/unit/core/test_cost_enforcement_ctd.py
@@ -386,11 +386,10 @@ class TestCostEnforcerCTDPairwise:
             _run_parallel_transitions(enforcer, permits, cost_value, should_raise)
 
         status = enforcer.get_status()
-        if case.mock_mode:
-            assert status.trial_count == 0
-            assert status.accumulated_cost_usd == pytest.approx(0.0)
-            return
-
+        # S2-B Round 3: TRAIGENT_MOCK_LLM no longer bypasses cost tracking.
+        # Both mock-on and mock-off branches now exercise the real path, so
+        # trial_count / accumulated_cost_usd / unknown_cost_mode reflect real
+        # bookkeeping regardless of the env flag.
         if case.cost_value == "none" and not case.strict_tracking:
             assert status.unknown_cost_mode is True
 

--- a/tests/unit/core/test_cost_enforcement_no_bypass.py
+++ b/tests/unit/core/test_cost_enforcement_no_bypass.py
@@ -1,0 +1,199 @@
+"""S2-B Round 3 — pin that TRAIGENT_MOCK_LLM never bypasses cost enforcement.
+
+Codex's re-review flagged five sites in ``traigent/core/cost_enforcement.py``
+that read ``TRAIGENT_MOCK_LLM`` and behaviorally short-circuited cost
+enforcement (approval, permit acquisition, accounting, async tracking,
+sync tracking). If the env var ever leaked into production, customers'
+cost limits and accounting would be silently bypassed — a security/billing
+concern.
+
+These tests pin the post-fix behavior:
+
+* ``check_and_approve`` must NOT auto-return True when mock-mode is set.
+* ``acquire_permit`` / ``acquire_permit_async`` must NOT return synthetic
+  ``id=0`` permits and must respect real limits.
+* ``track_cost`` / ``track_cost_async`` must update ``accumulated_cost``.
+* ``release_permit`` / ``release_permit_async`` must go through the real
+  locked path.
+* The bypass machinery (``_check_mock_mode`` / ``is_mock_mode`` /
+  ``_mock_mode_cached``) is removed from the public+private API.
+* ``CostEstimator.check_cost_approval`` no longer skips when mock-mode is set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from traigent.core.cost_enforcement import CostEnforcer, CostEnforcerConfig
+
+
+@pytest.fixture
+def mock_env() -> dict[str, str]:
+    """Common env dict with TRAIGENT_MOCK_LLM=true plus auxiliary flags off."""
+    return {
+        "TRAIGENT_MOCK_LLM": "true",
+        "TRAIGENT_COST_APPROVED": "false",
+        "TRAIGENT_REQUIRE_COST_TRACKING": "false",
+        "TRAIGENT_STRICT_COST_ACCOUNTING": "false",
+    }
+
+
+class TestCostEnforcerNoMockBypass:
+    """CostEnforcer must not honor TRAIGENT_MOCK_LLM at any of the 5 flagged sites."""
+
+    def test_bypass_attributes_are_removed(self, mock_env: dict[str, str]) -> None:
+        """The mock-mode caching/property/method must be gone."""
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer()
+            assert not hasattr(enforcer, "_check_mock_mode")
+            assert not hasattr(enforcer, "is_mock_mode")
+            assert not hasattr(enforcer, "_mock_mode_cached")
+
+    def test_check_and_approve_does_not_short_circuit_on_mock_env(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """check_and_approve must NOT auto-return True on TRAIGENT_MOCK_LLM=true.
+
+        Pre-fix: the mock_env branch returned True without consulting
+        approval rules. Post-fix: approval must be requested (we patch
+        ``_request_user_approval`` to deny so the test is deterministic).
+        """
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=1.0, approved=False))
+            with patch(
+                "traigent.core.cost_enforcement.CostEnforcer._request_user_approval",
+                return_value=False,
+            ) as request_approval:
+                # Estimated cost above limit, no auto-approve, no token.
+                assert enforcer.check_and_approve(1000.0) is False
+                request_approval.assert_called_once_with(1000.0)
+
+    def test_acquire_permit_does_not_return_bypass_id_zero(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """acquire_permit must allocate a real permit id (>=1) under mock env."""
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer(
+                CostEnforcerConfig(limit=10.0, estimated_cost_per_trial=0.01)
+            )
+            permit = enforcer.acquire_permit()
+            assert permit.is_granted
+            # Pre-fix mock-mode short-circuit returned id=0; real permits start at 1.
+            assert permit.id != 0
+            assert enforcer._in_flight_count == 1
+
+    def test_acquire_permit_async_does_not_return_bypass_id_zero(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """acquire_permit_async must allocate a real permit id (>=1) under mock env."""
+
+        async def run() -> None:
+            with patch.dict(os.environ, mock_env, clear=False):
+                enforcer = CostEnforcer(
+                    CostEnforcerConfig(limit=10.0, estimated_cost_per_trial=0.01)
+                )
+                permit = await enforcer.acquire_permit_async()
+                assert permit.is_granted
+                assert permit.id != 0
+                assert enforcer._in_flight_count == 1
+
+        asyncio.run(run())
+
+    def test_track_cost_updates_accumulated_cost_under_mock_env(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """track_cost must update accumulated_cost when TRAIGENT_MOCK_LLM=true."""
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=10.0))
+            permit = enforcer.acquire_permit()
+            enforcer.track_cost(0.42, permit=permit)
+            assert enforcer.accumulated_cost == pytest.approx(0.42)
+            # Real bookkeeping increments the trial count.
+            assert enforcer._trial_count == 1
+
+    def test_track_cost_async_updates_accumulated_cost_under_mock_env(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """track_cost_async must update accumulated_cost under mock env."""
+
+        async def run() -> None:
+            with patch.dict(os.environ, mock_env, clear=False):
+                enforcer = CostEnforcer(CostEnforcerConfig(limit=10.0))
+                permit = await enforcer.acquire_permit_async()
+                await enforcer.track_cost_async(0.18, permit=permit)
+                assert enforcer.accumulated_cost == pytest.approx(0.18)
+                assert enforcer._trial_count == 1
+
+        asyncio.run(run())
+
+    def test_acquire_permit_respects_real_limits_under_mock_env(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """Tight limits must still deny permits under mock env (no auto-grant)."""
+        with patch.dict(os.environ, mock_env, clear=False):
+            # Limit equals one trial. After tracking one trial's actual cost,
+            # the next permit reservation must be denied.
+            enforcer = CostEnforcer(
+                CostEnforcerConfig(limit=0.10, estimated_cost_per_trial=0.05)
+            )
+            first = enforcer.acquire_permit()
+            assert first.is_granted, "First permit within budget should be granted"
+            enforcer.track_cost(0.10, permit=first)  # Consume entire budget.
+
+            # Now budget is exhausted; the bypass would have granted id=0,
+            # but the real path must deny.
+            second = enforcer.acquire_permit()
+            assert not second.is_granted, (
+                "Mock-mode must not override real cost limits after exhaustion"
+            )
+            assert second.id == -1, "Denied permit must use sentinel id=-1, not bypass id=0"
+
+    def test_release_permit_uses_real_locked_path_under_mock_env(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        """release_permit must traverse the real locked release path under mock env."""
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=10.0))
+            permit = enforcer.acquire_permit()
+            assert permit.id in enforcer._active_permits
+            assert enforcer._in_flight_count == 1
+
+            released = enforcer.release_permit(permit)
+            assert released is True
+            # Real release-path bookkeeping clears the permit.
+            assert permit.id not in enforcer._active_permits
+            assert enforcer._in_flight_count == 0
+
+
+class TestCostEstimatorNoMockBypass:
+    """CostEstimator.check_cost_approval must not skip on TRAIGENT_MOCK_LLM=true."""
+
+    def test_check_cost_approval_does_not_short_circuit(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        from traigent.core.cost_enforcement import OptimizationAborted
+        from traigent.core.cost_estimator import CostEstimator
+
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=0.01, approved=False))
+
+            estimator = CostEstimator.__new__(CostEstimator)
+            estimator._cost_enforcer = enforcer
+            # Force a high estimate via patching the estimation method
+            with (
+                patch.object(
+                    CostEstimator,
+                    "estimate_optimization_cost",
+                    return_value=999.0,
+                ),
+                patch(
+                    "traigent.core.cost_enforcement.CostEnforcer._request_user_approval",
+                    return_value=False,
+                ),
+            ):
+                with pytest.raises(OptimizationAborted):
+                    estimator.check_cost_approval(dataset=None)

--- a/tests/unit/core/test_cost_estimator.py
+++ b/tests/unit/core/test_cost_estimator.py
@@ -317,12 +317,16 @@ class TestEstimateOptimizationCost:
 
 
 class TestCheckCostApproval:
-    def test_skips_in_mock_mode(self) -> None:
-        enforcer = MagicMock(is_mock_mode=True)
+    def test_does_not_skip_in_mock_mode(self) -> None:
+        """S2-B Round 3: mock-mode bypass was removed; approval always runs."""
+        enforcer = MagicMock()
+        # is_mock_mode is no longer consulted; spec it away so attribute access
+        # would fail and prove the new code path doesn't read it.
+        del enforcer.is_mock_mode
+        enforcer.check_and_approve.return_value = True
         estimator = CostEstimator(enforcer, max_trials=5, max_total_examples=None)
-        # Should not raise
         estimator.check_cost_approval(_FakeDataset())
-        enforcer.check_and_approve.assert_not_called()
+        enforcer.check_and_approve.assert_called_once()
 
     def test_passes_when_approved(self) -> None:
         enforcer = MagicMock(is_mock_mode=False)

--- a/tests/unit/core/test_sample_budget_stop_conditions.py
+++ b/tests/unit/core/test_sample_budget_stop_conditions.py
@@ -15,6 +15,18 @@ PER_TRIAL_CAP = 8
 TOTAL_BUDGET = 60
 
 
+@pytest.fixture(autouse=True)
+def _approve_cost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """S2-B Round 3: cost approval no longer auto-skips on TRAIGENT_MOCK_LLM.
+
+    These budget-enforcement scenarios run a full orchestrator pass; the
+    estimated cost may exceed the default $2 limit. Pre-approve to avoid
+    blocking on user handshake.
+    """
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
+    monkeypatch.setenv("TRAIGENT_RUN_COST_LIMIT", "100.0")
+
+
 def _build_dataset(*, as_mapping: bool = False) -> Dataset:
     examples: list[EvaluationExample] = []
     for idx in range(PER_TRIAL_CAP):

--- a/tests/unit/evaluators/conftest.py
+++ b/tests/unit/evaluators/conftest.py
@@ -1,57 +1,12 @@
-"""Conftest for evaluator tests.
+"""Conftest for JS evaluator tests.
 
-CRITICAL: JS evaluator tests (test_js_evaluator*.py) spawn Node.js processes
-that can crash VSCode terminals. They MUST run via test_bridge_wrapper.py.
-
-DO NOT run directly:
-    pytest tests/unit/evaluators/test_js_evaluator.py -v  # WILL CRASH!
-
-Safe way:
+JS evaluator tests may exercise the JS bridge in integration-style paths. The
+bridge now owns subprocess isolation and cleanup, so direct test collection is
+allowed. The subprocess wrapper is still available when captured output is
+preferred:
     pytest tests/unit/test_bridge_wrapper.py -v
 """
 
 import os
-import sys
 
-import pytest
-
-# Environment variable set by test_bridge_wrapper.py when running via subprocess
-_SUBPROCESS_ENV_VAR = "TRAIGENT_JS_TEST_SUBPROCESS"
-
-
-def pytest_configure(config):
-    """HARD FAIL if JS evaluator tests are run directly."""
-    if os.environ.get(_SUBPROCESS_ENV_VAR) == "1":
-        return
-
-    args = config.args if hasattr(config, "args") else []
-
-    # Detect if JS evaluator tests are being run directly
-    is_js_evaluator_targeted = any("test_js_evaluator" in str(arg) for arg in args)
-
-    if is_js_evaluator_targeted:
-        print("\n" + "=" * 70, file=sys.stderr)
-        print("FATAL: JS evaluator tests cannot be run directly!", file=sys.stderr)
-        print("=" * 70, file=sys.stderr)
-        print(
-            "\nThese tests spawn Node.js processes that WILL CRASH your terminal.",
-            file=sys.stderr,
-        )
-        print("\nSafe way to run JS tests:", file=sys.stderr)
-        print("    pytest tests/unit/test_bridge_wrapper.py -v", file=sys.stderr)
-        print("\n" + "=" * 70 + "\n", file=sys.stderr)
-        pytest.exit(
-            "JS evaluator tests must run via test_bridge_wrapper.py", returncode=1
-        )
-
-
-def pytest_collection_modifyitems(config, items):
-    """Additional safety: skip any JS evaluator tests that slip through."""
-    if os.environ.get(_SUBPROCESS_ENV_VAR) == "1":
-        return
-
-    for item in items:
-        if "test_js_evaluator" in item.fspath.basename:
-            item.add_marker(
-                pytest.mark.skip(reason="BLOCKED: Run via test_bridge_wrapper.py only")
-            )
+os.environ.setdefault("TRAIGENT_JS_TEST_SUBPROCESS", "1")

--- a/tests/unit/evaluators/test_local_evaluator.py
+++ b/tests/unit/evaluators/test_local_evaluator.py
@@ -264,8 +264,8 @@ class TestLocalEvaluatorTokenEstimation:
     async def test_execution_modes_token_handling(self, sample_dataset):
         """Test token metrics handling with edge_analytics execution mode.
 
-        Note: Only edge_analytics is currently supported. privacy/standard
-        were removed, cloud/hybrid are not yet supported.
+        Local evaluator token accounting is independent of backend-tracked
+        hybrid sessions; this test exercises the local execution path.
         """
 
         async def test_function(text: str) -> str:

--- a/tests/unit/integrations/test_bedrock_client.py
+++ b/tests/unit/integrations/test_bedrock_client.py
@@ -1,7 +1,7 @@
 """Unit tests for AWS Bedrock client integration.
 
 Tests for BedrockChatClient and related helper functions, covering both
-mock mode and mocked boto3 interactions.
+normalized response parsing and mocked boto3 interactions.
 """
 
 # Traceability: CONC-Layer-Integration CONC-Quality-Compatibility
@@ -24,6 +24,24 @@ from traigent.integrations.bedrock_client import (
     _require_boto3,
     resolve_default_bedrock_model_id,
 )
+
+
+def _mock_invoke_client(payload: dict) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.invoke_model.return_value = {
+        "body": MagicMock(read=lambda: json.dumps(payload).encode())
+    }
+    return mock_client
+
+
+def _mock_stream_client(*payloads: dict) -> MagicMock:
+    mock_client = MagicMock()
+    mock_client.invoke_model_with_response_stream.return_value = {
+        "body": iter(
+            {"chunk": {"bytes": json.dumps(payload).encode()}} for payload in payloads
+        )
+    }
+    return mock_client
 
 
 class TestHelperFunctions:
@@ -169,44 +187,43 @@ class TestBedrockChatClientEnsureClient:
         result = client._ensure_client()
         assert result is mock_client
 
-    def test_ensure_client_with_mock_mode(
-        self, monkeypatch: pytest.MonkeyPatch
+    @patch("traigent.integrations.bedrock_client._require_boto3")
+    def test_ensure_client_uses_boto3_when_bedrock_mock_is_set(
+        self, mock_require: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test _ensure_client in mock mode returns placeholder object."""
+        """Test BEDROCK_MOCK does not bypass boto3 client creation."""
         monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
-        result = client._ensure_client()
-        assert result is not None
-        assert client._client is not None
+        mock_boto3 = MagicMock()
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.session.Session.return_value = mock_session
+        mock_require.return_value = mock_boto3
 
-    def test_ensure_client_with_mock_mode_case_insensitive(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test BEDROCK_MOCK environment variable is case insensitive."""
-        monkeypatch.setenv("BEDROCK_MOCK", "TrUe")
-        client = BedrockChatClient()
+        client = BedrockChatClient(region_name="us-west-2")
         result = client._ensure_client()
-        assert result is not None
 
-    def test_ensure_client_with_mock_mode_whitespace(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test BEDROCK_MOCK handles whitespace correctly."""
-        monkeypatch.setenv("BEDROCK_MOCK", "  true  ")
-        client = BedrockChatClient()
-        result = client._ensure_client()
-        assert result is not None
+        assert result is mock_client
+        mock_session.client.assert_called_once_with(
+            "bedrock-runtime", region_name="us-west-2"
+        )
 
 
 class TestBedrockChatClientInvoke:
     """Tests for BedrockChatClient.invoke method."""
 
-    def test_invoke_with_mock_mode_string_message(
+    def test_invoke_uses_configured_client_when_bedrock_mock_is_set(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test invoke in mock mode with string message."""
+        """Test BEDROCK_MOCK does not fabricate invoke responses."""
         monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        mock_client = _mock_invoke_client(
+            {
+                "content": [{"type": "text", "text": "Response text"}],
+                "usage": {"input_tokens": 5, "output_tokens": 10},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
 
         response = client.invoke(
             model_id="anthropic.claude-3-sonnet-20240229-v1:0",
@@ -214,18 +231,20 @@ class TestBedrockChatClientInvoke:
             max_tokens=16,
         )
 
-        assert "[MOCK:anthropic.claude-3-sonnet-20240229-v1:0]" in response.text
-        assert "Hello world" in response.text
-        assert response.raw["mock"] is True
+        assert response.text == "Response text"
+        assert "[MOCK:" not in response.text
         assert response.usage is not None
-        assert response.usage["output_tokens"] == 16
+        assert response.usage["output_tokens"] == 10
+        mock_client.invoke_model.assert_called_once()
 
-    def test_invoke_with_mock_mode_list_messages(
+    def test_invoke_with_list_messages(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test invoke in mock mode with list of messages."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        """Test invoke sends list messages to Bedrock payload."""
+        mock_client = _mock_invoke_client(
+            {"content": [{"type": "text", "text": "List response"}]}
+        )
+        client = BedrockChatClient(client=mock_client)
 
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "First"}]},
@@ -233,15 +252,18 @@ class TestBedrockChatClientInvoke:
         ]
         response = client.invoke(model_id="test-model", messages=messages)
 
-        assert "[MOCK:test-model]" in response.text
-        assert "Last message" in response.text
+        assert response.text == "List response"
+        body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
+        assert body["messages"] == messages
 
     def test_invoke_with_temperature_and_top_p(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test invoke accepts temperature and top_p parameters."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        mock_client = _mock_invoke_client(
+            {"content": [{"type": "text", "text": "Temperature response"}]}
+        )
+        client = BedrockChatClient(client=mock_client)
 
         response = client.invoke(
             model_id="test-model",
@@ -251,14 +273,18 @@ class TestBedrockChatClientInvoke:
             top_p=0.9,
         )
 
-        assert response is not None
-        # Mock mode caps output_tokens at min(max_tokens, 16)
-        assert response.usage["output_tokens"] == 16
+        assert response.text == "Temperature response"
+        body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
+        assert body["max_tokens"] == 100
+        assert body["temperature"] == 0.7
+        assert body["top_p"] == 0.9
 
     def test_invoke_with_extra_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invoke accepts extra_params."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        mock_client = _mock_invoke_client(
+            {"content": [{"type": "text", "text": "Extra params response"}]}
+        )
+        client = BedrockChatClient(client=mock_client)
 
         extra = {"stop_sequences": ["\n"], "custom_param": "value"}
         response = client.invoke(
@@ -267,7 +293,10 @@ class TestBedrockChatClientInvoke:
             extra_params=extra,
         )
 
-        assert response is not None
+        assert response.text == "Extra params response"
+        body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
+        assert body["stop_sequences"] == ["\n"]
+        assert body["custom_param"] == "value"
 
     @patch("traigent.integrations.bedrock_client._require_boto3")
     def test_invoke_with_real_boto3_client(
@@ -361,8 +390,13 @@ class TestBedrockChatClientInvoke:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test invoke delegates to _invoke_ai21 for AI21 models."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        mock_client = _mock_invoke_client(
+            {
+                "choices": [{"message": {"content": "AI21 response"}}],
+                "usage": {"input_tokens": 3, "output_tokens": 4},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
 
         response = client.invoke(
             model_id="ai21.jamba-1-5-mini-v1:0",
@@ -370,19 +404,24 @@ class TestBedrockChatClientInvoke:
             max_tokens=50,
         )
 
-        assert "[MOCK:ai21.jamba-1-5-mini-v1:0]" in response.text
-        assert "test prompt" in response.text
+        assert response.text == "AI21 response"
+        mock_client.invoke_model.assert_called_once()
 
 
 class TestBedrockChatClientInvokeAI21:
     """Tests for BedrockChatClient._invoke_ai21 method."""
 
-    def test_invoke_ai21_with_mock_mode_string(
+    def test_invoke_ai21_with_string_message(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test _invoke_ai21 in mock mode with string message."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        """Test _invoke_ai21 sends string messages to Bedrock."""
+        mock_client = _mock_invoke_client(
+            {
+                "choices": [{"message": {"content": "AI21 string response"}}],
+                "usage": {"input_tokens": 4, "output_tokens": 8},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
 
         response = client._invoke_ai21(
             model_id="ai21.jamba-1-5-large-v1:0",
@@ -392,17 +431,20 @@ class TestBedrockChatClientInvokeAI21:
             top_p=None,
         )
 
-        assert "[MOCK:ai21.jamba-1-5-large-v1:0]" in response.text
-        assert "AI21 test" in response.text
+        assert response.text == "AI21 string response"
         assert response.usage is not None
-        assert response.usage["output_tokens"] == 32
+        assert response.usage["output_tokens"] == 8
+        body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
+        assert body["messages"] == [{"role": "user", "content": "AI21 test"}]
 
-    def test_invoke_ai21_with_mock_mode_list(
+    def test_invoke_ai21_with_list_messages(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test _invoke_ai21 in mock mode with list of messages."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        """Test _invoke_ai21 sends list messages to Bedrock."""
+        mock_client = _mock_invoke_client(
+            {"choices": [{"message": {"content": "AI21 list response"}}]}
+        )
+        client = BedrockChatClient(client=mock_client)
 
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "First"}]},
@@ -416,7 +458,12 @@ class TestBedrockChatClientInvokeAI21:
             top_p=0.9,
         )
 
-        assert "[MOCK:ai21.jamba-1-5-mini-v1:0]" in response.text
+        assert response.text == "AI21 list response"
+        body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
+        assert body["messages"] == [
+            {"role": "user", "content": "First"},
+            {"role": "user", "content": "Second"},
+        ]
 
     @patch("traigent.integrations.bedrock_client._require_boto3")
     def test_invoke_ai21_real_mode_with_choices(
@@ -495,8 +542,10 @@ class TestBedrockChatClientInvokeAI21:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test _invoke_ai21 handles list content in messages."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        mock_client = _mock_invoke_client(
+            {"choices": [{"message": {"content": "Coerced response"}}]}
+        )
+        client = BedrockChatClient(client=mock_client)
 
         messages = [
             {
@@ -515,18 +564,24 @@ class TestBedrockChatClientInvokeAI21:
             top_p=None,
         )
 
-        assert response is not None
+        assert response.text == "Coerced response"
+        body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
+        assert body["messages"] == [{"role": "user", "content": "Part 1\nPart 2"}]
 
 
 class TestBedrockChatClientInvokeStream:
     """Tests for BedrockChatClient.invoke_stream method."""
 
-    def test_invoke_stream_with_mock_mode(
+    def test_invoke_stream_uses_configured_client_when_bedrock_mock_is_set(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test invoke_stream in mock mode yields chunks."""
+        """Test BEDROCK_MOCK does not fabricate streaming chunks."""
         monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        mock_client = _mock_stream_client(
+            {"content": [{"type": "text", "text": "Stream"}]},
+            {"content": [{"type": "text", "text": " response"}]},
+        )
+        client = BedrockChatClient(client=mock_client)
 
         gen = client.invoke_stream(
             model_id="anthropic.claude-3-opus-20240229-v1:0",
@@ -534,35 +589,29 @@ class TestBedrockChatClientInvokeStream:
             max_tokens=512,
         )
 
-        # Collect chunks (strings) and return value (BedrockChatResponse)
-        chunks = []
-        for chunk in gen:
-            chunks.append(chunk)
+        chunks = list(gen)
 
-        # Generator should yield string chunks only
-        assert len(chunks) > 0
-        assert all(isinstance(c, str) for c in chunks)
-        assert any("[MOCK:anthropic.claude-3-opus-20240229-v1:0]" in c for c in chunks)
+        assert chunks == ["Stream", "response"]
+        assert not any("[MOCK:" in c for c in chunks)
+        mock_client.invoke_model_with_response_stream.assert_called_once()
 
-    def test_invoke_stream_chunks_message_correctly(
+    def test_invoke_stream_sends_coerced_message(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test invoke_stream splits message into chunks."""
-        monkeypatch.setenv("BEDROCK_MOCK", "true")
-        client = BedrockChatClient()
+        """Test invoke_stream sends the message in the Bedrock payload."""
+        mock_client = _mock_stream_client()
+        client = BedrockChatClient(client=mock_client)
 
         long_message = "This is a longer message for testing"
         gen = client.invoke_stream(model_id="test-model", messages=long_message)
 
-        chunks = []
-        for chunk in gen:
-            if isinstance(chunk, str):
-                chunks.append(chunk)
+        chunks = list(gen)
 
-        # Should have prefix and split message parts
-        assert len(chunks) >= 2
-        combined = "".join(chunks)
-        assert long_message in combined
+        assert chunks == []
+        body = json.loads(
+            mock_client.invoke_model_with_response_stream.call_args.kwargs["body"]
+        )
+        assert body["messages"][0]["content"][0]["text"] == long_message
 
     @patch("traigent.integrations.bedrock_client._require_boto3")
     def test_invoke_stream_with_real_client(
@@ -653,22 +702,29 @@ class TestBedrockChatClientAsyncInvoke:
     """Tests for BedrockChatClient.ainvoke method."""
 
     @pytest.mark.asyncio
-    async def test_ainvoke_with_mock_mode(
+    async def test_ainvoke_uses_sync_fallback_when_bedrock_mock_is_set(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test ainvoke in mock mode returns mocked response."""
+        """Test BEDROCK_MOCK does not fabricate async invoke responses."""
         monkeypatch.setenv("BEDROCK_MOCK", "true")
+        mock_response = BedrockChatResponse(
+            text="Fallback response",
+            raw={"fallback": True},
+            usage={"input_tokens": 5, "output_tokens": 10},
+        )
         client = BedrockChatClient()
 
-        response = await client.ainvoke(
-            model_id="anthropic.claude-3-haiku-20240307-v1:0",
-            messages="Async test",
-            max_tokens=32,
-        )
+        with patch.object(client, "invoke", return_value=mock_response) as mock_invoke:
+            with patch("builtins.__import__", side_effect=ImportError("No aioboto3")):
+                response = await client.ainvoke(
+                    model_id="anthropic.claude-3-haiku-20240307-v1:0",
+                    messages="Async test",
+                    max_tokens=32,
+                )
 
-        assert "[MOCK:anthropic.claude-3-haiku-20240307-v1:0]" in response.text
-        assert "Async test" in response.text
-        assert response.usage is not None
+        assert response.text == "Fallback response"
+        assert "[MOCK:" not in response.text
+        mock_invoke.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_ainvoke_falls_back_to_sync_without_aioboto3(
@@ -736,22 +792,29 @@ class TestBedrockChatClientAsyncInvokeStream:
     """Tests for BedrockChatClient.ainvoke_stream method."""
 
     @pytest.mark.asyncio
-    async def test_ainvoke_stream_with_mock_mode(
+    async def test_ainvoke_stream_uses_sync_fallback_when_bedrock_mock_is_set(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test ainvoke_stream in mock mode yields chunks."""
+        """Test BEDROCK_MOCK does not fabricate async streaming chunks."""
         monkeypatch.setenv("BEDROCK_MOCK", "true")
         client = BedrockChatClient()
 
-        chunks = []
-        async for chunk in client.ainvoke_stream(
-            model_id="anthropic.claude-3-opus-20240229-v1:0",
-            messages="Async stream test",
-        ):
-            chunks.append(chunk)
+        def mock_sync_stream(*args, **kwargs):
+            yield "chunk1"
+            yield "chunk2"
+            return BedrockChatResponse(text="chunk1chunk2", raw={"streamed": True})
 
-        assert len(chunks) > 0
-        assert any("[MOCK:anthropic.claude-3-opus-20240229-v1:0]" in c for c in chunks)
+        with patch.object(client, "invoke_stream", side_effect=mock_sync_stream):
+            with patch("builtins.__import__", side_effect=ImportError("No aioboto3")):
+                chunks = []
+                async for chunk in client.ainvoke_stream(
+                    model_id="anthropic.claude-3-opus-20240229-v1:0",
+                    messages="Async stream test",
+                ):
+                    chunks.append(chunk)
+
+        assert chunks == ["chunk1", "chunk2"]
+        assert not any("[MOCK:" in c for c in chunks)
 
     @pytest.mark.asyncio
     async def test_ainvoke_stream_falls_back_to_sync(

--- a/tests/unit/integrations/test_bedrock_client_no_mock.py
+++ b/tests/unit/integrations/test_bedrock_client_no_mock.py
@@ -1,0 +1,44 @@
+"""Regression tests proving BEDROCK_MOCK is ignored by production code."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from traigent.integrations.bedrock_client import BedrockChatClient
+
+
+def test_bedrock_mock_env_does_not_short_circuit_invoke(monkeypatch) -> None:
+    """Setting BEDROCK_MOCK still uses the boto3 Bedrock Runtime client."""
+    monkeypatch.setenv("BEDROCK_MOCK", "true")
+
+    mock_boto3 = MagicMock()
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_client.invoke_model.return_value = {
+        "body": MagicMock(
+            read=lambda: json.dumps(
+                {"content": [{"type": "text", "text": "from mocked boto3"}]}
+            ).encode()
+        )
+    }
+    mock_session.client.return_value = mock_client
+    mock_boto3.session.Session.return_value = mock_session
+
+    with patch(
+        "traigent.integrations.bedrock_client._require_boto3",
+        return_value=mock_boto3,
+    ) as mock_require_boto3:
+        response = BedrockChatClient(region_name="us-east-1").invoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+    mock_require_boto3.assert_called_once()
+    mock_session.client.assert_called_once_with(
+        "bedrock-runtime", region_name="us-east-1"
+    )
+    mock_client.invoke_model.assert_called_once()
+    assert response.text == "from mocked boto3"
+    assert "[MOCK:" not in response.text
+    assert response.raw.get("mock") is None

--- a/tests/unit/integrations/test_mock_adapter.py
+++ b/tests/unit/integrations/test_mock_adapter.py
@@ -1,14 +1,19 @@
-"""Tests for mock adapter utilities."""
+"""Tests for mock adapter utilities.
+
+Note: ``MockAdapter`` previously consulted ``TRAIGENT_MOCK_LLM`` and a set
+of provider-specific ``*_MOCK`` environment variables to decide whether
+to swap real LLM calls for canned mock text. That env-toggle was removed
+because a stray env var in production caused real calls to be silently
+replaced with mock data. ``is_mock_enabled`` now always returns False;
+tests that need mock responses must patch the LLM client directly or
+call ``MockAdapter.get_mock_response`` from inside an explicit
+``unittest.mock.patch``.
+"""
 
 import os
 from unittest.mock import patch
 
-from traigent.integrations.utils.mock_adapter import (
-    MOCK_ENV_VARS,
-    MockAdapter,
-    MockResponse,
-    with_mock_support,
-)
+from traigent.integrations.utils.mock_adapter import MockAdapter, MockResponse
 
 
 class TestMockResponse:
@@ -41,77 +46,44 @@ class TestMockResponse:
         assert response.total_tokens == 300
 
 
-class TestMockEnvVars:
-    """Tests for MOCK_ENV_VARS configuration."""
-
-    def test_all_providers_have_env_vars(self) -> None:
-        """Test all expected providers have env var mappings."""
-        expected_providers = [
-            "openai",
-            "azure_openai",
-            "anthropic",
-            "gemini",
-            "cohere",
-            "huggingface",
-            "bedrock",
-            "traigent",
-        ]
-        for provider in expected_providers:
-            assert provider in MOCK_ENV_VARS
-
-
 class TestMockAdapterIsMockEnabled:
-    """Tests for MockAdapter.is_mock_enabled method."""
+    """``is_mock_enabled`` always returns False (env-toggle removed)."""
 
-    def test_global_mock_mode_true(self) -> None:
-        """Test global TRAIGENT_MOCK_LLM=true enables mock."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
-            assert MockAdapter.is_mock_enabled("openai") is True
-            assert MockAdapter.is_mock_enabled("anthropic") is True
-            assert MockAdapter.is_mock_enabled("unknown") is True
-
-    def test_global_mock_mode_1(self) -> None:
-        """Test global TRAIGENT_MOCK_LLM=1 enables mock."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "1"}, clear=True):
-            assert MockAdapter.is_mock_enabled("openai") is True
-
-    def test_global_mock_mode_yes(self) -> None:
-        """Test global TRAIGENT_MOCK_LLM=yes enables mock."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "yes"}, clear=True):
-            assert MockAdapter.is_mock_enabled("openai") is True
-
-    def test_provider_specific_mock(self) -> None:
-        """Test provider-specific mock env var."""
-        with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
-            assert MockAdapter.is_mock_enabled("openai") is True
+    def test_global_mock_env_is_ignored(self) -> None:
+        """TRAIGENT_MOCK_LLM=true must NOT enable mock mode."""
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=True):
+            assert MockAdapter.is_mock_enabled("openai") is False
             assert MockAdapter.is_mock_enabled("anthropic") is False
+            assert MockAdapter.is_mock_enabled("unknown") is False
 
-    def test_provider_specific_azure(self) -> None:
-        """Test Azure-specific mock env var."""
-        with patch.dict(os.environ, {"AZURE_OPENAI_MOCK": "true"}, clear=True):
-            assert MockAdapter.is_mock_enabled("azure_openai") is True
+    def test_global_mock_env_1_is_ignored(self) -> None:
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "1"}, clear=True):
             assert MockAdapter.is_mock_enabled("openai") is False
 
-    def test_no_mock_enabled(self) -> None:
-        """Test mock is disabled when no env vars set."""
+    def test_global_mock_env_yes_is_ignored(self) -> None:
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "yes"}, clear=True):
+            assert MockAdapter.is_mock_enabled("openai") is False
+
+    def test_provider_specific_env_is_ignored(self) -> None:
+        """Provider-specific ``*_MOCK`` env vars must NOT enable mock mode."""
+        with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
+            assert MockAdapter.is_mock_enabled("openai") is False
+            assert MockAdapter.is_mock_enabled("anthropic") is False
+
+    def test_no_env_returns_false(self) -> None:
+        """With no env vars, is_mock_enabled returns False."""
         with patch.dict(os.environ, {}, clear=True):
             assert MockAdapter.is_mock_enabled("openai") is False
             assert MockAdapter.is_mock_enabled("anthropic") is False
 
-    def test_mock_disabled_with_false(self) -> None:
-        """Test mock is disabled with false value."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "false"}, clear=True):
-            assert MockAdapter.is_mock_enabled("openai") is False
-
-    def test_case_insensitive_provider(self) -> None:
-        """Test provider name is case insensitive."""
+    def test_case_insensitive_provider_still_false(self) -> None:
         with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
-            assert MockAdapter.is_mock_enabled("OpenAI") is True
-            assert MockAdapter.is_mock_enabled("OPENAI") is True
+            assert MockAdapter.is_mock_enabled("OpenAI") is False
+            assert MockAdapter.is_mock_enabled("OPENAI") is False
 
 
 class TestMockAdapterGetMockResponse:
-    """Tests for MockAdapter.get_mock_response method."""
+    """``get_mock_response`` works for tests that invoke it explicitly."""
 
     def test_openai_mock_response(self) -> None:
         """Test OpenAI mock response structure."""
@@ -252,60 +224,3 @@ class TestBuildMockMethods:
         assert result["usage"]["prompt_tokens"] == data.prompt_tokens
         assert result["usage"]["completion_tokens"] == data.completion_tokens
         assert result["usage"]["total_tokens"] == data.total_tokens
-
-
-class TestWithMockSupportDecorator:
-    """Tests for with_mock_support decorator."""
-
-    def test_decorator_returns_mock_when_enabled(self) -> None:
-        """Test decorator returns mock response when enabled."""
-
-        @with_mock_support("openai")
-        def real_function(**kwargs):
-            return "real response"
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
-            result = real_function(model="gpt-4")
-
-        assert isinstance(result, dict)
-        assert "choices" in result
-
-    def test_decorator_calls_real_function_when_disabled(self) -> None:
-        """Test decorator calls real function when mock disabled."""
-
-        @with_mock_support("openai")
-        def real_function(**kwargs):
-            return "real response"
-
-        with patch.dict(os.environ, {}, clear=True):
-            result = real_function()
-
-        assert result == "real response"
-
-    def test_decorator_preserves_function_args(self) -> None:
-        """Test decorator preserves function arguments."""
-        calls = []
-
-        @with_mock_support("openai")
-        def capture_function(*args, **kwargs):
-            calls.append((args, kwargs))
-            return "real response"
-
-        with patch.dict(os.environ, {}, clear=True):
-            capture_function("arg1", key="value")
-
-        assert len(calls) == 1
-        assert calls[0] == (("arg1",), {"key": "value"})
-
-    def test_decorator_uses_provider_specific_env(self) -> None:
-        """Test decorator respects provider-specific env var."""
-
-        @with_mock_support("anthropic")
-        def real_function():
-            return "real response"
-
-        # Only OPENAI_MOCK is set, not ANTHROPIC_MOCK
-        with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
-            result = real_function()
-
-        assert result == "real response"

--- a/tests/unit/integrations/test_no_mock_llm_env.py
+++ b/tests/unit/integrations/test_no_mock_llm_env.py
@@ -1,0 +1,231 @@
+"""Verify TRAIGENT_MOCK_LLM is no longer honored anywhere in the SDK.
+
+Sprint 2 cleanup (S2-B) removed the ``TRAIGENT_MOCK_LLM`` env-toggle from
+three high-severity sites that previously shipped to customers:
+
+* ``traigent/integrations/utils/mock_adapter.py`` — ``with_mock_support``
+  decorator + ``MockAdapter.is_mock_enabled`` (env-toggle replaced real
+  LLM calls with canned mock text).
+* ``traigent/security/encryption.py`` — encrypt() / decrypt() fallback
+  branches (env-toggle produced ``b"mock_" + plaintext`` "ciphertext"
+  and stripped the prefix on decrypt).
+* ``traigent/evaluators/local.py`` — ``_compute_mock_accuracy`` (env-toggle
+  fabricated accuracy via random.uniform() + string-length heuristics).
+
+These tests pin the new behaviour: setting ``TRAIGENT_MOCK_LLM=true`` and
+calling the affected methods must hit real code paths and either succeed
+on real input or fail with a real error — never return mock data.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from traigent.integrations.utils.mock_adapter import MockAdapter
+from traigent.security.encryption import EncryptionManager, KeyManager
+
+
+class TestMockAdapterIgnoresEnv:
+    """``MockAdapter.is_mock_enabled`` must not consult any env variable."""
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "TRUE", "True"])
+    def test_traigent_mock_llm_does_not_enable_mock(self, value: str) -> None:
+        """No truthy form of TRAIGENT_MOCK_LLM should enable mock mode."""
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": value}, clear=True):
+            assert MockAdapter.is_mock_enabled("openai") is False
+            assert MockAdapter.is_mock_enabled("anthropic") is False
+            assert MockAdapter.is_mock_enabled("gemini") is False
+            assert MockAdapter.is_mock_enabled("cohere") is False
+            assert MockAdapter.is_mock_enabled("bedrock") is False
+            assert MockAdapter.is_mock_enabled("anything") is False
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "OPENAI_MOCK",
+            "AZURE_OPENAI_MOCK",
+            "ANTHROPIC_MOCK",
+            "GEMINI_MOCK",
+            "COHERE_MOCK",
+            "HUGGINGFACE_MOCK",
+            "BEDROCK_MOCK",
+        ],
+    )
+    def test_provider_specific_mock_envs_do_not_enable_mock(self, var: str) -> None:
+        """Provider-specific *_MOCK env vars must not enable mock mode either."""
+        with patch.dict(os.environ, {var: "true"}, clear=True):
+            # Strip the trailing _MOCK to derive the provider name.
+            provider = var.removesuffix("_MOCK").lower()
+            assert MockAdapter.is_mock_enabled(provider) is False
+
+    def test_with_mock_support_decorator_is_no_longer_exported(self) -> None:
+        """``with_mock_support`` was removed from the module + package API."""
+        import traigent.integrations.utils as utils_pkg
+        from traigent.integrations.utils import mock_adapter
+
+        assert not hasattr(mock_adapter, "with_mock_support")
+        assert not hasattr(utils_pkg, "with_mock_support")
+
+
+class TestEncryptionIgnoresEnv:
+    """encrypt() / decrypt() must fail closed regardless of TRAIGENT_MOCK_LLM."""
+
+    def test_encrypt_with_mock_env_still_raises_when_no_crypto(self) -> None:
+        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock encryption."""
+        key_manager = KeyManager()
+        em = EncryptionManager(key_manager)
+        em.crypto_available = False  # simulate missing cryptography lib
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            with pytest.raises(
+                RuntimeError, match="requires the 'cryptography' package"
+            ):
+                em.encrypt("payload that must not leak as plaintext")
+
+    def test_decrypt_with_mock_env_still_raises_when_no_crypto(self) -> None:
+        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock decryption."""
+        key_manager = KeyManager()
+        em = EncryptionManager(key_manager)
+        em.crypto_available = False
+        key_id = key_manager.generate_key("AES-256")
+        envelope = {
+            "ciphertext": b"mock_attacker_supplied_payload",
+            "iv": os.urandom(12),
+            "tag": os.urandom(16),
+            "key_id": key_id,
+        }
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            with pytest.raises(
+                RuntimeError, match="requires the 'cryptography' package"
+            ):
+                em.decrypt(envelope)
+
+    def test_encrypt_does_not_emit_mock_prefix_with_real_crypto(self) -> None:
+        """Real encryption never emits the legacy b'mock_' or b'encrypted_' prefix."""
+        key_manager = KeyManager()
+        em = EncryptionManager(key_manager)
+        if not em.crypto_available:
+            pytest.skip("cryptography not installed in this environment")
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            result = em.encrypt(b"sensitive payload")
+
+        assert not result["ciphertext"].startswith(b"mock_")
+        assert not result["ciphertext"].startswith(b"encrypted_")
+        # Round-trip must still succeed under real crypto.
+        assert em.decrypt(result) == b"sensitive payload"
+
+
+class TestLocalEvaluatorIgnoresEnv:
+    """LocalEvaluator must always compute real accuracy, regardless of env."""
+
+    def test_compute_mock_accuracy_method_is_removed(self) -> None:
+        """The fabricator method must no longer exist on LocalEvaluator."""
+        from traigent.evaluators.local import LocalEvaluator
+
+        assert not hasattr(LocalEvaluator, "_compute_mock_accuracy")
+        assert not hasattr(LocalEvaluator, "_log_mock_mode_warning")
+
+    def test_accuracy_metric_is_real_even_with_mock_env(self) -> None:
+        """With TRAIGENT_MOCK_LLM=true, accuracy must be deterministic real comparison."""
+        from traigent.evaluators.local import LocalEvaluator
+
+        evaluator = LocalEvaluator(metrics=["accuracy"])
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            # Identical strings — real accuracy must be 1.0.
+            metrics_match = evaluator._compute_example_metrics(
+                actual_output="hello",
+                expected_output="hello",
+            )
+            # Different strings — real accuracy must be 0.0.
+            metrics_mismatch = evaluator._compute_example_metrics(
+                actual_output="hello",
+                expected_output="goodbye",
+            )
+
+        assert metrics_match["accuracy"] == 1.0
+        assert metrics_mismatch["accuracy"] == 0.0
+
+    def test_accuracy_metric_does_not_use_random_with_mock_env(self) -> None:
+        """Repeat calls under TRAIGENT_MOCK_LLM=true must be deterministic.
+
+        The old _compute_mock_accuracy used random.uniform() so identical
+        inputs would yield different scores. The real path is purely
+        deterministic.
+        """
+        from traigent.evaluators.local import LocalEvaluator
+
+        evaluator = LocalEvaluator(metrics=["accuracy"])
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            scores = [
+                evaluator._compute_example_metrics(
+                    actual_output="positive sentiment indeed", expected_output="other"
+                )["accuracy"]
+                for _ in range(10)
+            ]
+
+        # All identical — no random fabrication.
+        assert len(set(scores)) == 1
+        # And it's the real-comparison value (mismatch -> 0.0).
+        assert scores[0] == 0.0
+
+
+class TestMockModeConfigIsInert:
+    """``mock_mode_config`` must not change optimizer or evaluator behaviour.
+
+    Round 2 of S2-B retired the last behavioural sites that consulted this
+    parameter. The parameter is still accepted on public APIs for backward
+    compatibility but must be a true no-op.
+    """
+
+    def test_resolve_custom_evaluator_ignores_mock_mode_config(self) -> None:
+        """``resolve_custom_evaluator`` must return the user evaluator regardless of mock_mode_config."""
+        from traigent.core.optimization_pipeline import resolve_custom_evaluator
+
+        def my_evaluator(*_args: object, **_kwargs: object) -> dict[str, float]:
+            return {"accuracy": 1.0}
+
+        # Even with TRAIGENT_MOCK_LLM=true AND a mock_mode_config that previously
+        # would have triggered the override, the user-supplied evaluator wins.
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            result = resolve_custom_evaluator(
+                my_evaluator,
+                mock_mode_config={"enabled": True, "override_evaluator": True},
+                decorator_custom_evaluator=None,
+            )
+        assert result is my_evaluator
+
+        # And without the env var, same behaviour.
+        with patch.dict(os.environ, {}, clear=True):
+            result = resolve_custom_evaluator(
+                None,
+                mock_mode_config={"enabled": True, "override_evaluator": True},
+                decorator_custom_evaluator=my_evaluator,
+            )
+        assert result is my_evaluator
+
+    def test_apply_mock_config_overrides_does_not_change_algorithm(self) -> None:
+        """``_apply_mock_config_overrides`` must not change the algorithm or seed."""
+        from traigent.core.optimized_function import OptimizedFunction
+
+        # Build a minimal stand-in with the attribute the method reads.
+        instance = OptimizedFunction.__new__(OptimizedFunction)
+        instance.mock_mode_config = {  # type: ignore[attr-defined]
+            "optimizer": "grid_search",  # would have rerouted in round 1
+            "random_seed": 1234,
+        }
+
+        kwargs: dict[str, object] = {}
+        algo = OptimizedFunction._apply_mock_config_overrides(
+            instance, "bayesian", kwargs
+        )
+
+        # Algorithm unchanged, no seed injected.
+        assert algo == "bayesian"
+        assert "random_seed" not in kwargs

--- a/tests/unit/security/test_audit.py
+++ b/tests/unit/security/test_audit.py
@@ -20,6 +20,9 @@ from traigent.security.audit import (
 )
 
 STRONG_AUDIT_SECRET = "StrongAuditSecretKey123!@#ABC4567890"
+COMPLIANCE_NOT_IMPLEMENTED = "Compliance reporting subsystem is not yet implemented"
+PERSISTENT_STORAGE_NOT_IMPLEMENTED = "Persistent audit storage is not yet implemented"
+TAMPER_DETECTION_NOT_IMPLEMENTED = "Tamper-detection is not yet implemented"
 
 
 class TestAuditEvent:
@@ -83,6 +86,11 @@ class TestAuditEvent:
 
 class TestAuditStorage:
     """Test AuditStorage class"""
+
+    def test_storage_path_fails_loud(self):
+        """Persistent storage paths should not silently use memory storage."""
+        with pytest.raises(NotImplementedError, match=PERSISTENT_STORAGE_NOT_IMPLEMENTED):
+            AuditStorage(storage_path="audit_logs")
 
     def test_store_and_retrieve_events(self):
         """Test storing and retrieving events"""
@@ -189,6 +197,20 @@ class TestAuditStorage:
         limited_events = storage.get_events(limit=5)
         assert len(limited_events) == 5
 
+    def test_retrieve_events_warns_when_time_filters_ignored(self):
+        """retrieve_events warns when its unsupported time filters are supplied."""
+        storage = AuditStorage()
+        event = AuditEvent(event_type=AuditEventType.DATA_READ, user_id="user123")
+        storage.store_event(event)
+
+        now = datetime.now(UTC)
+        with pytest.warns(UserWarning, match="ignores time filters"):
+            events = storage.retrieve_events(
+                start_time=now - timedelta(hours=1), end_time=now
+            )
+
+        assert events == [event]
+
     def test_verify_integrity(self):
         """Test audit log integrity verification"""
         storage = AuditStorage()
@@ -209,6 +231,20 @@ class TestAuditStorage:
         assert integrity.event_count == 3
         assert integrity.log_hash is not None
         assert len(integrity.log_hash) == 64  # SHA-256 hex digest
+
+
+class TestAuditLogIntegrity:
+    """Test AuditLogIntegrity class"""
+
+    def test_verify_integrity_fails_loud(self):
+        """Tamper detection should not report fake success."""
+        integrity = AuditLogIntegrity()
+        integrity.hash_chain = ["TAMPERED_NOT_A_HASH", "ANOTHER_BAD"]
+        integrity.event_count = 999
+        integrity.log_hash = "CORRUPTED"
+
+        with pytest.raises(NotImplementedError, match=TAMPER_DETECTION_NOT_IMPLEMENTED):
+            integrity.verify_integrity()
 
 
 class TestAuditLogger:
@@ -353,96 +389,49 @@ class TestComplianceReporter:
     """Test ComplianceReporter class"""
 
     def test_soc2_report_generation(self):
-        """Test SOC 2 compliance report generation"""
+        """SOC 2 compliance reporting fails loudly until implemented."""
         audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
         reporter = ComplianceReporter(audit_logger)
 
-        # Create test events with SOC 2 compliance tags
         start_date = datetime.now(UTC) - timedelta(days=30)
         end_date = datetime.now(UTC)
 
-        # Add some events to storage directly for testing
-        security_event = AuditEvent(
-            event_type=AuditEventType.LOGIN_SUCCESS,
-            user_id="user123",
-            compliance_tags=[ComplianceFramework.SOC2],
-        )
-        audit_logger.storage.store_event(security_event)
-
-        # Generate report
-        report = reporter.generate_report(
-            framework=ComplianceFramework.SOC2, start_date=start_date, end_date=end_date
-        )
-
-        assert report["framework"] == "SOC 2 Type II"
-        assert "trust_service_criteria" in report
-        assert "security" in report["trust_service_criteria"]
-        assert "availability" in report["trust_service_criteria"]
-        assert "processing_integrity" in report["trust_service_criteria"]
-        assert "confidentiality" in report["trust_service_criteria"]
-        assert "privacy" in report["trust_service_criteria"]
-        assert "summary" in report
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.generate_report(
+                framework=ComplianceFramework.SOC2,
+                start_date=start_date,
+                end_date=end_date,
+            )
 
     def test_iso27001_report_generation(self):
-        """Test ISO 27001 compliance report generation"""
+        """ISO 27001 compliance reporting fails loudly until implemented."""
         audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
         reporter = ComplianceReporter(audit_logger)
 
         start_date = datetime.now(UTC) - timedelta(days=30)
         end_date = datetime.now(UTC)
 
-        # Add test events
-        auth_event = AuditEvent(
-            event_type=AuditEventType.LOGIN_SUCCESS,
-            user_id="user123",
-            compliance_tags=[ComplianceFramework.ISO27001],
-        )
-        audit_logger.storage.store_event(auth_event)
-
-        # Generate report
-        report = reporter.generate_report(
-            framework=ComplianceFramework.ISO27001,
-            start_date=start_date,
-            end_date=end_date,
-        )
-
-        assert report["framework"] == "ISO 27001:2013"
-        assert "control_objectives" in report
-        assert "access_control" in report["control_objectives"]
-        assert "incident_management" in report["control_objectives"]
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.generate_report(
+                framework=ComplianceFramework.ISO27001,
+                start_date=start_date,
+                end_date=end_date,
+            )
 
     def test_gdpr_report_generation(self):
-        """Test GDPR compliance report generation"""
+        """GDPR compliance reporting fails loudly until implemented."""
         audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
         reporter = ComplianceReporter(audit_logger)
 
         start_date = datetime.now(UTC) - timedelta(days=30)
         end_date = datetime.now(UTC)
 
-        # Add test events
-        data_event = AuditEvent(
-            event_type=AuditEventType.DATA_READ,
-            user_id="user123",
-            compliance_tags=[ComplianceFramework.GDPR],
-        )
-        gdpr_request_event = AuditEvent(
-            event_type=AuditEventType.GDPR_REQUEST,
-            user_id="user123",
-            compliance_tags=[ComplianceFramework.GDPR],
-        )
-
-        audit_logger.storage.store_event(data_event)
-        audit_logger.storage.store_event(gdpr_request_event)
-
-        # Generate report
-        report = reporter.generate_report(
-            framework=ComplianceFramework.GDPR, start_date=start_date, end_date=end_date
-        )
-
-        assert report["framework"] == "GDPR (EU) 2016/679"
-        assert "data_protection_principles" in report
-        assert "lawfulness" in report["data_protection_principles"]
-        assert "data_subject_rights" in report["data_protection_principles"]
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.generate_report(
+                framework=ComplianceFramework.GDPR,
+                start_date=start_date,
+                end_date=end_date,
+            )
 
     def test_unsupported_framework(self):
         """Test error handling for unsupported framework"""
@@ -465,78 +454,54 @@ class TestComplianceReporter:
             )
 
     def test_compliance_dashboard(self):
-        """Test compliance dashboard generation"""
+        """Compliance dashboard fails loudly until implemented."""
         audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
         reporter = ComplianceReporter(audit_logger)
 
-        # Add some test events
-        events = [
-            AuditEvent(event_type=AuditEventType.LOGIN_SUCCESS, user_id="user123"),
-            AuditEvent(event_type=AuditEventType.LOGIN_FAILURE, user_id="user456"),
-            AuditEvent(event_type=AuditEventType.DATA_READ, user_id="user123"),
-            AuditEvent(
-                event_type=AuditEventType.SECURITY_VIOLATION,
-                severity=AuditSeverity.CRITICAL,
-            ),
-        ]
-
-        for event in events:
-            audit_logger.storage.store_event(event)
-
-        # Get dashboard
-        dashboard = reporter.get_compliance_dashboard()
-
-        assert "period" in dashboard
-        assert "metrics" in dashboard
-        assert "frameworks_status" in dashboard
-        assert "recent_alerts" in dashboard
-
-        metrics = dashboard["metrics"]
-        assert "total_events" in metrics
-        assert "critical_events" in metrics
-        assert "failed_logins" in metrics
-        assert "data_access_events" in metrics
-        assert "compliance_score" in metrics
-
-        # Should have some events
-        assert metrics["total_events"] >= 4
-        assert metrics["critical_events"] >= 1
-        assert metrics["failed_logins"] >= 1
-        assert metrics["data_access_events"] >= 1
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.get_compliance_dashboard()
 
     def test_tenant_specific_reporting(self):
-        """Test tenant-specific compliance reporting"""
+        """Tenant-specific compliance reporting fails loudly until implemented."""
         audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
         reporter = ComplianceReporter(audit_logger)
 
         start_date = datetime.now(UTC) - timedelta(days=30)
         end_date = datetime.now(UTC)
 
-        # Add events for different tenants
-        tenant1_event = AuditEvent(
-            event_type=AuditEventType.DATA_READ,
-            user_id="user123",
-            tenant_id="tenant1",
-            compliance_tags=[ComplianceFramework.GDPR],
-        )
-        tenant2_event = AuditEvent(
-            event_type=AuditEventType.DATA_READ,
-            user_id="user456",
-            tenant_id="tenant2",
-            compliance_tags=[ComplianceFramework.GDPR],
-        )
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.generate_report(
+                framework=ComplianceFramework.GDPR,
+                start_date=start_date,
+                end_date=end_date,
+                tenant_id="tenant1",
+            )
 
-        audit_logger.storage.store_event(tenant1_event)
-        audit_logger.storage.store_event(tenant2_event)
+    def test_legacy_compliance_methods_fail_loud(self):
+        """Legacy report entry points fail loudly instead of returning fake status."""
+        audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
+        reporter = ComplianceReporter(audit_logger)
 
-        # Generate report for specific tenant
-        report = reporter.generate_report(
-            framework=ComplianceFramework.GDPR,
-            start_date=start_date,
-            end_date=end_date,
-            tenant_id="tenant1",
-        )
+        start_date = datetime.now(UTC) - timedelta(days=30)
+        end_date = datetime.now(UTC)
 
-        # Report should be generated successfully (may be None if no events match)
-        # The key is that the call completed without error
-        assert isinstance(report, (dict, type(None)))  # Report is dict or None
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.generate_soc2_report(start_date, end_date)
+
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter.generate_gdpr_report(start_date, end_date)
+
+    def test_security_incident_analysis_fails_loud(self):
+        """Incident compliance analysis fails loudly instead of faking resolution."""
+        audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
+        reporter = ComplianceReporter(audit_logger)
+        events = [
+            AuditEvent(
+                event_type=AuditEventType.SECURITY_VIOLATION,
+                user_id="user123",
+                severity=AuditSeverity.CRITICAL,
+            )
+        ]
+
+        with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
+            reporter._analyze_security_incidents(events)

--- a/tests/unit/security/test_audit.py
+++ b/tests/unit/security/test_audit.py
@@ -87,10 +87,22 @@ class TestAuditEvent:
 class TestAuditStorage:
     """Test AuditStorage class"""
 
-    def test_storage_path_fails_loud(self):
-        """Persistent storage paths should not silently use memory storage."""
-        with pytest.raises(NotImplementedError, match=PERSISTENT_STORAGE_NOT_IMPLEMENTED):
-            AuditStorage(storage_path="audit_logs")
+    def test_default_storage_path_keeps_backward_compatible_value(self):
+        """No-arg construction preserves the historical default path."""
+        storage = AuditStorage()
+
+        assert storage.storage_path == "audit_logs"
+        assert storage.events == []
+
+    def test_explicit_storage_path_is_accepted_for_compatibility(self):
+        """Explicit paths remain constructible while storage stays in-memory."""
+        storage = AuditStorage(storage_path="custom_audit_logs")
+        event = AuditEvent(event_type=AuditEventType.LOGIN_SUCCESS, user_id="user123")
+
+        storage.store_event(event)
+
+        assert storage.storage_path == "custom_audit_logs"
+        assert storage.get_events() == [event]
 
     def test_store_and_retrieve_events(self):
         """Test storing and retrieving events"""

--- a/tests/unit/security/test_encryption.py
+++ b/tests/unit/security/test_encryption.py
@@ -626,61 +626,47 @@ class TestSecureStorage:
         assert decrypted == "Secret One-Time Token"
 
 
-class TestEncryptionMockMode:
-    """Test mock encryption behavior and security guards."""
+class TestEncryptionFailsClosedWithoutCrypto:
+    """Encryption must fail closed when ``cryptography`` is unavailable.
 
-    def test_mock_encrypt_decrypt_roundtrip(self):
-        """Test mock encryption produces b'mock_' prefix and round-trips."""
+    Previously the encrypt()/decrypt() methods had a TRAIGENT_MOCK_LLM-gated
+    fallback that returned ``b"mock_" + plaintext`` (encrypt) and stripped
+    that prefix on decrypt — which is not encryption at all and silently
+    leaked plaintext-as-ciphertext if the env var was set in production.
+    The fallback is now removed entirely; both methods raise RuntimeError
+    when crypto is not available, regardless of any env var.
+    """
+
+    def test_encrypt_raises_without_crypto(self):
+        """encrypt() must raise when cryptography is unavailable, no env override."""
         key_manager = KeyManager()
         em = EncryptionManager(key_manager)
-        em.crypto_available = False  # Force mock path
+        em.crypto_available = False
+        with pytest.raises(RuntimeError, match="requires the 'cryptography' package"):
+            em.encrypt("sensitive data")
 
-        result = em.encrypt("hello world")
-        assert result["ciphertext"].startswith(b"mock_")
-
-        decrypted = em.decrypt(result)
-        assert decrypted == b"hello world"
-
-    def test_decrypt_legacy_encrypted_prefix(self):
-        """Test backward compatibility with old b'encrypted_' prefix."""
+    def test_decrypt_raises_without_crypto(self):
+        """decrypt() must raise when cryptography is unavailable, no env override."""
         key_manager = KeyManager()
         em = EncryptionManager(key_manager)
-        em.crypto_available = False  # Force mock path
-
+        em.crypto_available = False
         key_id = key_manager.generate_key("AES-256")
-        legacy_result = {
-            "ciphertext": b"encrypted_" + b"test data",
+        encrypted = {
+            "ciphertext": b"mock_test",
             "iv": os.urandom(12),
             "tag": os.urandom(16),
             "key_id": key_id,
         }
-        decrypted = em.decrypt(legacy_result)
-        assert decrypted == b"test data"
+        with pytest.raises(RuntimeError, match="requires the 'cryptography' package"):
+            em.decrypt(encrypted)
 
-    def test_decrypt_raw_ciphertext_passthrough(self):
-        """Test that ciphertext without known prefix is returned as-is in mock."""
-        key_manager = KeyManager()
-        em = EncryptionManager(key_manager)
-        em.crypto_available = False  # Force mock path
-
-        key_id = key_manager.generate_key("AES-256")
-        raw_result = {
-            "ciphertext": b"raw bytes here",
-            "iv": os.urandom(12),
-            "tag": os.urandom(16),
-            "key_id": key_id,
-        }
-        decrypted = em.decrypt(raw_result)
-        assert decrypted == b"raw bytes here"
-
-    def test_encrypt_rejects_non_mock_mode(self):
-        """Test encryption raises RuntimeError when not in mock mode and crypto unavailable."""
+    def test_encrypt_ignores_traigent_mock_llm(self):
+        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock encryption."""
         import unittest.mock
 
         key_manager = KeyManager()
-
         with unittest.mock.patch.dict(
-            os.environ, {"TRAIGENT_MOCK_LLM": "false"}, clear=False
+            os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False
         ):
             em = EncryptionManager(key_manager)
             em.crypto_available = False
@@ -689,14 +675,13 @@ class TestEncryptionMockMode:
             ):
                 em.encrypt("sensitive data")
 
-    def test_decrypt_rejects_non_mock_mode(self):
-        """Test decryption raises RuntimeError when not in mock mode and crypto unavailable."""
+    def test_decrypt_ignores_traigent_mock_llm(self):
+        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock decryption."""
         import unittest.mock
 
         key_manager = KeyManager()
-
         with unittest.mock.patch.dict(
-            os.environ, {"TRAIGENT_MOCK_LLM": "false"}, clear=False
+            os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False
         ):
             em = EncryptionManager(key_manager)
             em.crypto_available = False

--- a/tests/unit/security/test_encryption_fail_closed.py
+++ b/tests/unit/security/test_encryption_fail_closed.py
@@ -1,0 +1,49 @@
+"""Fail-closed import guard tests for traigent.security.encryption.
+
+Codex review (B7) flagged the prior silent Fernet mock fallback at
+``traigent/security/encryption.py:38`` (``encrypt`` returning ``b"encrypted_" + data``).
+Real ``cryptography`` is now a hard dependency and the import block re-raises
+``ImportError`` with a clear remediation message instead of installing a fake
+class. These tests pin that behavior so it cannot regress silently.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_encryption_module_imports_cleanly_with_cryptography_installed():
+    """Module must import without falling back to a mock when crypto is available."""
+    module = importlib.import_module("traigent.security.encryption")
+    # CRYPTO_AVAILABLE flag must be true and Fernet must be the real class.
+    assert getattr(module, "CRYPTO_AVAILABLE", False) is True
+    fernet_cls = getattr(module, "Fernet")
+    # Real Fernet lives in cryptography.fernet — module path check is a
+    # cheap proxy for "this is not the in-file mock class".
+    assert fernet_cls.__module__.startswith("cryptography.")
+
+
+def test_encryption_module_reraises_importerror_when_cryptography_missing(monkeypatch):
+    """If cryptography import fails, we fail closed with a clear message."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("cryptography"):
+            raise ImportError(f"simulated missing dependency: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    # Force a fresh import so the try/except at module top runs.
+    sys.modules.pop("traigent.security.encryption", None)
+
+    with pytest.raises(ImportError, match=r"cryptography>=46\.0"):
+        importlib.import_module("traigent.security.encryption")
+
+    # Cleanup: restore the real module so other tests aren't poisoned.
+    monkeypatch.setattr(builtins, "__import__", real_import)
+    sys.modules.pop("traigent.security.encryption", None)
+    importlib.import_module("traigent.security.encryption")

--- a/tests/unit/test_bridge_wrapper.py
+++ b/tests/unit/test_bridge_wrapper.py
@@ -1,28 +1,15 @@
-"""Subprocess wrapper for running JS-related tests safely.
+"""Subprocess wrapper for running JS-related tests with captured output.
 
 This module runs JS-related tests (bridges, JS evaluators) in a subprocess with
-output captured, avoiding the VSCode terminal rendering issue that can trigger
-system crashes due to GPU-related instability.
+output captured. This avoids rendering heavy async output directly in the VSCode
+terminal, while JSBridge owns process isolation and cleanup.
 
-The following tests are excluded from VSCode test discovery and must be run
-via this wrapper:
-- tests/unit/bridges/ (JSBridge, JSProcessPool)
-- tests/unit/evaluators/test_js_evaluator*.py (JSEvaluator tests)
-
-IMPORTANT: This file is EXCLUDED from VSCode test discovery (.vscode/settings.json)
-to prevent system crashes. Run JS tests from the terminal only:
+Preferred captured-output command:
 
     pytest tests/unit/test_bridge_wrapper.py -v
 
-The wrapper captures all output, so even if tests produce heavy async output,
-it won't be rendered to the terminal until after completion (and only on failure).
-
-WARNING: DO NOT run JS tests directly! Always use this wrapper:
-    WRONG:  pytest tests/unit/bridges/ -v          # May crash system!
-    RIGHT:  pytest tests/unit/test_bridge_wrapper.py -v
-
-NOTE: In CI (GitHub Actions), these tests run directly without this wrapper
-since headless environments don't have terminal rendering issues.
+Direct bridge/evaluator test invocation is allowed; use the wrapper when you
+want subprocess isolation for the test runner output itself.
 """
 
 from __future__ import annotations
@@ -73,8 +60,7 @@ def _run_tests_safely(test_paths: list, test_name: str, timeout: int = 300):
             # Ensure tests run in mock mode
             "TRAIGENT_MOCK_LLM": "true",
             "TRAIGENT_OFFLINE_MODE": "true",
-            # Signal to conftest.py that we're running via subprocess wrapper
-            # This enables the JS tests which are otherwise skipped
+            # Signal to nested JS test conftests that this is a subprocess run.
             "TRAIGENT_JS_TEST_SUBPROCESS": "1",
         },
     )

--- a/tests/unit/test_js_bridge_safe.py
+++ b/tests/unit/test_js_bridge_safe.py
@@ -412,6 +412,27 @@ async def test_terminate_process_raises_after_failed_force_kill() -> None:
 
 
 @pytest.mark.asyncio
+async def test_terminate_finalizes_shutdown_after_failed_force_kill() -> None:
+    bridge = _make_bridge()
+    bridge._process = _make_mock_process()
+    bridge._pgid = 67890
+    bridge._started = True
+    bridge._terminate_process = AsyncMock(
+        side_effect=JSProcessError("JS process tree did not exit after force kill")
+    )
+
+    with pytest.raises(JSProcessError, match="did not exit after force kill"):
+        await bridge._terminate()
+
+    bridge._terminate_process.assert_awaited_once()
+    assert bridge._process is None
+    assert bridge._pgid is None
+    assert bridge._started is False
+    assert bridge._reader_task is None
+    assert bridge._stderr_task is None
+
+
+@pytest.mark.asyncio
 async def test_terminate_process_ignores_direct_process_lookup_error() -> None:
     bridge = _make_bridge()
     bridge._process = _make_mock_process()

--- a/tests/unit/test_js_bridge_safe.py
+++ b/tests/unit/test_js_bridge_safe.py
@@ -7,6 +7,8 @@ shutdown paths that are otherwise hard to cover without the JS runtime.
 from __future__ import annotations
 
 import asyncio
+import os
+import signal
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -27,6 +29,7 @@ def _make_bridge(**config_overrides: object) -> JSBridge:
 
 def _make_mock_process() -> MagicMock:
     process = MagicMock(returncode=None)
+    process.pid = 12345
     process.stdin = MagicMock()
     process.stdin.write = MagicMock()
     process.stdin.drain = AsyncMock()
@@ -38,6 +41,14 @@ def _make_mock_process() -> MagicMock:
     process.terminate = MagicMock()
     process.kill = MagicMock()
     return process
+
+
+_HAS_POSIX_PROCESS_GROUPS = (
+    os.name == "posix"
+    and hasattr(os, "getpgid")
+    and hasattr(os, "getpgrp")
+    and hasattr(os, "killpg")
+)
 
 
 @pytest.mark.asyncio
@@ -52,6 +63,30 @@ async def test_start_tracks_background_tasks_without_spawning_node() -> None:
     assert bridge._process is process
     assert bridge._reader_task is not None
     assert bridge._stderr_task is not None
+
+    await bridge._finalize_shutdown()
+
+
+@pytest.mark.skipif(
+    not _HAS_POSIX_PROCESS_GROUPS, reason="POSIX process groups are unavailable"
+)
+@pytest.mark.asyncio
+async def test_start_captures_process_group_before_health_check() -> None:
+    bridge = _make_bridge()
+    bridge.ping = AsyncMock(return_value={"ok": True})
+    process = _make_mock_process()
+    create_process = AsyncMock(return_value=process)
+
+    with (
+        patch("asyncio.create_subprocess_exec", create_process),
+        patch("os.getpgid", return_value=67890) as getpgid,
+        patch("os.getpgrp", return_value=11111),
+    ):
+        await bridge.start()
+
+    assert create_process.call_args.kwargs["start_new_session"] is True
+    assert bridge._pgid == 67890
+    getpgid.assert_called_once_with(process.pid)
 
     await bridge._finalize_shutdown()
 
@@ -324,13 +359,35 @@ async def test_finalize_shutdown_clears_state() -> None:
     assert bridge._reader_task is None
     assert bridge._stderr_task is None
     assert bridge._active_trial_id is None
+    assert bridge._pgid is None
     assert bridge._started is False
 
 
+@pytest.mark.skipif(
+    not _HAS_POSIX_PROCESS_GROUPS, reason="POSIX process groups are unavailable"
+)
 @pytest.mark.asyncio
-async def test_terminate_process_uses_kill_after_timeout() -> None:
+async def test_terminate_process_uses_process_group_after_timeout() -> None:
     bridge = _make_bridge()
-    bridge._process = MagicMock(returncode=None)
+    bridge._process = _make_mock_process()
+    bridge._pgid = 67890
+    bridge._process.wait = AsyncMock(side_effect=[TimeoutError(), 0])
+
+    with patch("os.killpg") as killpg:
+        await bridge._terminate_process()
+
+    killpg.assert_has_calls(
+        [call(67890, signal.SIGTERM), call(67890, signal.SIGKILL)]
+    )
+    bridge._process.terminate.assert_not_called()
+    bridge._process.kill.assert_not_called()
+    assert bridge._process.wait.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_terminate_process_falls_back_to_child_without_pgid() -> None:
+    bridge = _make_bridge()
+    bridge._process = _make_mock_process()
     bridge._process.wait = AsyncMock(side_effect=[TimeoutError(), 0])
 
     await bridge._terminate_process()
@@ -341,7 +398,21 @@ async def test_terminate_process_uses_kill_after_timeout() -> None:
 
 
 @pytest.mark.asyncio
-async def test_terminate_process_ignores_process_lookup_error() -> None:
+async def test_terminate_process_raises_after_failed_force_kill() -> None:
+    bridge = _make_bridge()
+    bridge._process = _make_mock_process()
+    bridge._process.wait = AsyncMock(side_effect=TimeoutError())
+
+    with pytest.raises(JSProcessError, match="did not exit after force kill"):
+        await bridge._terminate_process()
+
+    bridge._process.terminate.assert_called_once()
+    bridge._process.kill.assert_called_once()
+    assert bridge._process.wait.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_terminate_process_ignores_direct_process_lookup_error() -> None:
     bridge = _make_bridge()
     bridge._process = _make_mock_process()
     bridge._process.terminate.side_effect = ProcessLookupError()

--- a/tests/unit/test_traigent_client.py
+++ b/tests/unit/test_traigent_client.py
@@ -1,7 +1,7 @@
 """Unit tests for traigent.traigent_client.
 
 Tests for TraigentClient which provides high-level optimization
-with multiple execution modes (edge analytics, standard/hybrid, cloud/SaaS).
+with multiple execution modes (edge analytics, hybrid, cloud).
 """
 
 # Traceability: CONC-Layer-Integration CONC-Quality-Reliability CONC-Quality-Performance FUNC-CLOUD-HYBRID FUNC-INVOKERS REQ-CLOUD-009 REQ-INV-006 SYNC-CloudHybrid
@@ -104,8 +104,22 @@ class TestDetermineExecutionMode:
 
     def test_explicit_cloud_mode_raises(self) -> None:
         """Test explicit cloud mode raises ConfigurationError (not yet supported)."""
-        with pytest.raises(ConfigurationError, match="not yet supported"):
+        with pytest.raises(ConfigurationError, match="Cloud remote execution"):
             TraigentClient(execution_mode="cloud")
+
+    @patch("traigent.traigent_client.BackendIntegratedClient")
+    @patch("traigent.config.backend_config.BackendConfig")
+    def test_explicit_hybrid_mode_supported(
+        self, mock_backend_config: MagicMock, mock_backend_client: MagicMock
+    ) -> None:
+        """Test explicit hybrid mode initializes backend tracking."""
+        mock_backend_config.get_api_key.return_value = "key"
+        mock_backend_config.get_backend_url.return_value = "https://url"
+
+        client = TraigentClient(execution_mode="hybrid")
+
+        assert client.execution_mode == ExecutionMode.HYBRID
+        mock_backend_client.assert_called_once()
 
     @patch("traigent.traigent_client.BackendIntegratedClient")
     @patch("traigent.config.backend_config.BackendConfig")
@@ -128,7 +142,7 @@ class TestDetermineExecutionMode:
     ) -> None:
         """Test auto mode with TRAIGENT_FORCE_HYBRID defaults to edge_analytics.
 
-        Cloud/hybrid modes are not yet supported, so auto always resolves to edge_analytics.
+        Cloud remote execution is not yet supported, so auto resolves to edge_analytics.
         """
         mock_backend_config.get_api_key.return_value = "key"
         mock_backend_config.get_backend_url.return_value = "https://url"
@@ -455,22 +469,19 @@ class TestOptimizeValidation:
                     )
 
 
-@pytest.mark.skip(
-    reason="standard mode not yet supported — re-enable when mode is implemented"
-)
 class TestOptimizeHybrid:
-    """Tests for hybrid/standard mode optimization."""
+    """Tests for hybrid mode optimization."""
 
     @pytest.fixture
     def mock_client(self) -> TraigentClient:
-        """Create a mock TraigentClient in standard mode."""
+        """Create a mock TraigentClient in hybrid mode."""
         with patch("traigent.traigent_client.BackendIntegratedClient"):
             with patch("traigent.config.backend_config.BackendConfig") as mock_config:
                 mock_config.get_api_key.return_value = "key"
                 mock_config.get_backend_url.return_value = "https://url"
                 mock_builder = Mock()
                 return TraigentClient(
-                    execution_mode="standard", agent_builder=mock_builder
+                    execution_mode="hybrid", agent_builder=mock_builder
                 )
 
     @pytest.mark.asyncio
@@ -533,7 +544,7 @@ class TestOptimizeHybrid:
                     test_func, dataset, config_space, objectives, max_trials=5
                 )
 
-                assert result["execution_mode"] == "standard"
+                assert result["execution_mode"] == "hybrid"
                 assert result["completed_trials"] == 1
 
     @pytest.mark.asyncio

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -1281,7 +1281,8 @@ def _log_execution_mode_warnings(
     if local_storage_path and execution_mode_enum is ExecutionMode.CLOUD:
         logger.warning(
             "local_storage_path is ignored when execution_mode='cloud'. "
-            "Cloud mode uses Traigent cloud storage."
+            "Cloud remote execution is not available yet; use hybrid for "
+            "portal-tracked optimization."
         )
 
     if minimal_logging and execution_mode_enum is not ExecutionMode.EDGE_ANALYTICS:

--- a/traigent/bridges/js_bridge.py
+++ b/traigent/bridges/js_bridge.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import signal
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -32,20 +33,23 @@ logger = get_logger(__name__)
 # Protocol version must match traigent-js/src/cli/protocol.ts
 PROTOCOL_VERSION = "1.0"
 
-# Note: We intentionally do NOT use atexit handlers for process cleanup.
+# Process-group cleanup design:
 #
-# Reason: atexit handlers with os.killpg() are dangerous because:
-# 1. asyncio subprocess.returncode is only updated after wait() is called
-# 2. The process might have exited but returncode is still None
-# 3. The PID could be reused by the system for a different process
-# 4. os.killpg() would then kill a completely different process group!
+# We intentionally do NOT use atexit handlers for process cleanup. atexit
+# cleanup can run long after the child exited, when a reused PID or process
+# group could point at unrelated work.
 #
-# Instead, we rely on:
-# - Explicit cleanup: JSBridge.stop() and context manager __aexit__
-# - Direct child termination: We only signal the spawned JS process, avoiding
-#   process-group signals that can destabilize local desktop environments
-# - OS cleanup: If the JS runner has child processes, the OS is responsible
-#   for reaping any remaining descendants after parent exit
+# Instead, JSBridge captures the child's process group immediately after spawn
+# and uses it only from explicit stop/terminate paths. This lets us terminate
+# Node.js plus descendants such as npx, transpilers, and worker subprocesses
+# without relying on terminal-driven cleanup.
+
+_PROCESS_GROUPS_SUPPORTED = (
+    os.name == "posix"
+    and hasattr(os, "getpgid")
+    and hasattr(os, "getpgrp")
+    and hasattr(os, "killpg")
+)
 
 
 # Default timeout for trial execution (5 minutes)
@@ -154,6 +158,7 @@ class JSBridge:
         """
         self._config = config
         self._process: asyncio.subprocess.Process | None = None
+        self._pgid: int | None = None
         self._reader_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None
         self._pending_requests: dict[str, asyncio.Future[dict[str, Any]]] = {}
@@ -243,7 +248,9 @@ class JSBridge:
                     stderr=asyncio.subprocess.PIPE,
                     env=env,
                     cwd=self._config.cwd,
+                    start_new_session=_PROCESS_GROUPS_SUPPORTED,
                 )
+                self._pgid = self._capture_process_group_id(self._process)
             except FileNotFoundError as e:
                 raise JSProcessError(
                     f"Failed to start Node.js process: {e}. "
@@ -327,6 +334,59 @@ class JSBridge:
         with suppress(asyncio.CancelledError):
             await task
 
+    def _capture_process_group_id(
+        self, process: asyncio.subprocess.Process
+    ) -> int | None:
+        """Return a safe process group id for group termination, if available."""
+        if not _PROCESS_GROUPS_SUPPORTED:
+            return None
+
+        try:
+            pgid = os.getpgid(process.pid)
+            current_pgid = os.getpgrp()
+        except (AttributeError, ProcessLookupError, OSError, TypeError):
+            return None
+
+        if pgid == current_pgid:
+            logger.warning(
+                "JS bridge process joined the caller process group; "
+                "falling back to direct child termination"
+            )
+            return None
+
+        return pgid
+
+    def _signal_process_tree(self, *, force: bool = False) -> None:
+        """Signal the captured process group, falling back to the direct child."""
+        if self._process is None:
+            return
+
+        if self._pgid is not None and _PROCESS_GROUPS_SUPPORTED:
+            sig = (
+                getattr(signal, "SIGKILL", signal.SIGTERM) if force else signal.SIGTERM
+            )
+            try:
+                os.killpg(self._pgid, sig)
+                return
+            except ProcessLookupError:
+                return
+            except OSError as e:
+                logger.debug(
+                    "Failed to signal JS process group %s; falling back to child: %s",
+                    self._pgid,
+                    e,
+                )
+
+        try:
+            if force:
+                self._process.kill()
+            else:
+                self._process.terminate()
+        except ProcessLookupError:
+            return
+        except OSError as e:
+            logger.debug("Failed to signal JS process: %s", e)
+
     async def cancel_active_trial(self) -> None:
         """Request cooperative cancellation for the active trial, if any."""
         if not self._started or self._process is None:
@@ -362,6 +422,7 @@ class JSBridge:
         await self._cancel_task(self._stderr_task)
 
         self._process = None
+        self._pgid = None
         self._reader_task = None
         self._stderr_task = None
         self._started = False
@@ -375,21 +436,22 @@ class JSBridge:
         await self._finalize_shutdown()
 
     async def _terminate_process(self) -> None:
-        """Terminate the Node.js process with graceful fallback to force kill."""
+        """Terminate the Node.js process tree with graceful fallback to force kill."""
         if self._process is None:
             return
 
         try:
-            self._process.terminate()
+            self._signal_process_tree(force=False)
 
-            # Wait for graceful termination
-            try:
-                async with asyncio.timeout(5.0):
-                    await self._process.wait()
-            except TimeoutError:
-                logger.warning("JS process did not terminate, sending kill()")
-                self._process.kill()
-                await self._process.wait()
+            if not await self._wait_for_process_exit(5.0):
+                logger.warning(
+                    "JS process tree did not terminate after SIGTERM; forcing kill"
+                )
+                self._signal_process_tree(force=True)
+                if not await self._wait_for_process_exit(5.0):
+                    raise JSProcessError(
+                        "JS process tree did not exit after force kill"
+                    )
         except ProcessLookupError:
             pass  # Already dead
 

--- a/traigent/bridges/js_bridge.py
+++ b/traigent/bridges/js_bridge.py
@@ -430,10 +430,17 @@ class JSBridge:
 
     async def _terminate(self) -> None:
         """Force terminate the Node.js process and all its children."""
-        if self._process is not None:
-            await self._terminate_process()
+        terminate_error: JSProcessError | None = None
+        try:
+            if self._process is not None:
+                await self._terminate_process()
+        except JSProcessError as exc:
+            terminate_error = exc
+        finally:
+            await self._finalize_shutdown()
 
-        await self._finalize_shutdown()
+        if terminate_error is not None:
+            raise terminate_error
 
     async def _terminate_process(self) -> None:
         """Terminate the Node.js process tree with graceful fallback to force kill."""

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -7,24 +7,21 @@ including session creation, status updates, and configuration run management.
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013
 
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 from urllib.parse import urlparse
 
 from traigent.cloud.auth import AuthenticationError
-from traigent.cloud.client import CloudServiceError
+from traigent.cloud.client import CLOUD_REMOTE_EXECUTION_UNAVAILABLE, CloudServiceError
 from traigent.cloud.models import (
     AgentExecutionRequest,
     AgentExecutionResponse,
     AgentOptimizationRequest,
     AgentOptimizationResponse,
-    DatasetSubsetIndices,
     NextTrialRequest,
     NextTrialResponse,
-    OptimizationSessionStatus,
     SessionCreationRequest,
     SessionCreationResponse,
     TrialResultSubmission,
-    TrialSuggestion,
 )
 from traigent.config.backend_config import BackendConfig
 from traigent.utils.env_config import is_backend_offline
@@ -224,11 +221,10 @@ class ApiOperations:
             )
 
         if not AIOHTTP_AVAILABLE:
-            logger.warning("aiohttp not available, using fallback IDs")
-            return (
-                f"session_{int(time.time())}",
-                f"exp_{int(time.time())}",
-                f"run_{int(time.time())}",
+            raise CloudServiceError(
+                "aiohttp is required for backend session creation. Install "
+                "traigent[hybrid] or set TRAIGENT_OFFLINE_MODE=true for "
+                "explicit offline local-only mode."
             )
 
         try:
@@ -635,9 +631,9 @@ class ApiOperations:
             if backend_status not in valid_statuses:
                 logger.warning(
                     f"Unexpected status '{status}' (mapped to '{backend_status}'), "
-                    f"using COMPLETED as default"
+                    "using FAILED as default"
                 )
-                backend_status = "COMPLETED"
+                backend_status = "FAILED"
 
             # Prepare headers with API key
             headers = await self.client.auth_manager.augment_headers(
@@ -673,111 +669,44 @@ class ApiOperations:
 
     # Cloud API Methods
 
+    def _raise_cloud_remote_unavailable(self, operation: str) -> NoReturn:
+        """Raise the standard not-implemented error for remote cloud execution."""
+        raise CloudServiceError(f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} ({operation})")
+
     async def create_cloud_session(
         self, request: SessionCreationRequest
     ) -> SessionCreationResponse:
-        """Create cloud session for optimization.
-
-        Mock implementation for now - would connect to actual cloud API.
-        """
-        logger.debug("Creating cloud session (mock implementation)")
-
-        # Mock response
-        return SessionCreationResponse(
-            session_id=f"cloud_session_{int(time.time())}",
-            status=OptimizationSessionStatus.CREATED,
-            optimization_strategy=request.optimization_strategy or {},
-            metadata={
-                "created_at": time.time(),
-                "billing_tier": request.billing_tier,
-            },
-        )
+        """Create cloud session for optimization."""
+        _ = request
+        self._raise_cloud_remote_unavailable("create_cloud_session")
 
     async def get_cloud_trial_suggestion(
         self, request: NextTrialRequest
     ) -> NextTrialResponse:
-        """Get next trial suggestion from cloud optimizer.
-
-        Mock implementation for now - would connect to actual cloud API.
-        """
-        logger.debug("Getting cloud trial suggestion (mock implementation)")
-
-        # Mock response - no suggestion means optimization is complete
-        suggestion = TrialSuggestion(
-            trial_id=f"trial_{int(time.time())}",
-            session_id=request.session_id,
-            trial_number=1,
-            config={"param": 0},
-            dataset_subset=DatasetSubsetIndices(
-                indices=[0],
-                selection_strategy="mock",
-                confidence_level=0.9,
-                estimated_representativeness=0.9,
-            ),
-            exploration_type="exploration",
-        )
-
-        return NextTrialResponse(
-            suggestion=suggestion,
-            should_continue=True,
-            session_status=OptimizationSessionStatus.ACTIVE,
-            metadata={
-                "mock": True,
-                "session_id": request.session_id,
-            },
-        )
+        """Get next trial suggestion from cloud optimizer."""
+        _ = request
+        self._raise_cloud_remote_unavailable("get_cloud_trial_suggestion")
 
     async def submit_cloud_trial_results(
         self, submission: TrialResultSubmission
     ) -> None:
-        """Submit trial results to cloud service.
-
-        Mock implementation for now - would connect to actual cloud API.
-        """
-        logger.debug(f"Submitting cloud trial results for {submission.trial_id} (mock)")
-        # Mock implementation - just log
-        pass
+        """Submit trial results to cloud service."""
+        _ = submission
+        self._raise_cloud_remote_unavailable("submit_cloud_trial_results")
 
     async def submit_agent_optimization(
         self, request: AgentOptimizationRequest
     ) -> AgentOptimizationResponse:
-        """Submit agent for cloud optimization.
-
-        Mock implementation for now - would connect to actual cloud API.
-        """
-        agent_name = getattr(request.agent_spec, "name", "unknown")
-        logger.debug(f"Submitting agent optimization for {agent_name} (mock)")
-
-        # Mock response
-        return AgentOptimizationResponse(
-            session_id=f"agent_session_{int(time.time())}",
-            optimization_id=f"opt_{int(time.time())}",
-            status="started",
-            estimated_duration=300.0,
-            next_steps=["await_results"],
-        )
+        """Submit agent for cloud optimization."""
+        _ = request
+        self._raise_cloud_remote_unavailable("submit_agent_optimization")
 
     async def execute_cloud_agent(
         self, request: AgentExecutionRequest
     ) -> AgentExecutionResponse:
-        """Execute agent in cloud.
-
-        Mock implementation for now - would connect to actual cloud API.
-        """
-        agent_name = getattr(request.agent_spec, "name", "unknown")
-        logger.debug(f"Executing cloud agent {agent_name} (mock)")
-
-        # Mock response
-        return AgentExecutionResponse(
-            output="Mock agent response",
-            duration=1.5,
-            tokens_used=50,
-            cost=0.001,
-            metadata={
-                "status": "COMPLETED",
-                "session_id": getattr(request.agent_spec, "id", "mock_session"),
-            },
-        )
+        """Execute agent in cloud."""
+        _ = request
+        self._raise_cloud_remote_unavailable("execute_cloud_agent")
 
     # Deprecated methods that should not be used
 

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 from urllib.parse import urlparse
 
 from traigent.cloud.auth import AuthenticationError
-from traigent.cloud.client import CLOUD_REMOTE_EXECUTION_UNAVAILABLE, CloudServiceError
+from traigent.cloud.client import (
+    CloudRemoteExecutionUnavailableError,
+    CloudServiceError,
+)
 from traigent.cloud.models import (
     AgentExecutionRequest,
     AgentExecutionResponse,
@@ -671,7 +674,7 @@ class ApiOperations:
 
     def _raise_cloud_remote_unavailable(self, operation: str) -> NoReturn:
         """Raise the standard not-implemented error for remote cloud execution."""
-        raise CloudServiceError(f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} ({operation})")
+        raise CloudRemoteExecutionUnavailableError(operation)
 
     async def create_cloud_session(
         self, request: SessionCreationRequest

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1087,14 +1087,11 @@ class AuthManager:
                 error_message="Invalid API key format",
             )
 
-        # Structured warning: never log the key value, only a non-reversible
-        # preview so operators can correlate without leaking secrets.
-        key_preview = self._mask_api_key(api_key_value)
+        # Structured warning: never log the key value or any value derived from it.
         logger.warning(
             "auth.api_key.validate_start",
             extra={
                 "auth_mode": AuthMode.API_KEY.value,
-                "key_preview": key_preview,
             },
         )
 
@@ -1107,7 +1104,6 @@ class AuthManager:
                 "auth.api_key.validate_failed",
                 extra={
                     "auth_mode": AuthMode.API_KEY.value,
-                    "key_preview": key_preview,
                     "reason": validation_error,
                 },
             )

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse
 
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
 from traigent.cloud.api_key_manager import APIKeyManager
@@ -1390,6 +1391,10 @@ class AuthManager:
             return "backend URL not configured"
 
         url = f"{backend_api_url.rstrip('/')}/keys/validate"
+        unsafe_url_reason = self._validate_backend_validation_url(url)
+        if unsafe_url_reason:
+            return unsafe_url_reason
+
         headers = {"X-API-Key": api_key}
 
         if not AIOHTTP_AVAILABLE:
@@ -1403,7 +1408,11 @@ class AuthManager:
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=15)
             ) as session:
-                async with session.post(url, headers=headers) as response:
+                async with session.post(
+                    url,
+                    headers=headers,
+                    allow_redirects=False,
+                ) as response:
                     if response.status == 200:
                         try:
                             data = await response.json(content_type=None)
@@ -1442,6 +1451,16 @@ class AuthManager:
             return "rate limited"
         return f"backend returned status {status}"
 
+    @staticmethod
+    def _validate_backend_validation_url(url: str) -> str | None:
+        """Validate the configured backend URL before sending credentials to it."""
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return "backend validation URL is invalid"
+        if parsed.username or parsed.password:
+            return "backend validation URL must not include credentials"
+        return None
+
     def _validate_api_key_with_backend_sync(
         self,
         url: str,
@@ -1451,7 +1470,12 @@ class AuthManager:
         import requests
 
         try:
-            response = requests.post(url, headers=headers, timeout=15)
+            response = requests.post(
+                url,
+                headers=headers,
+                timeout=15,
+                allow_redirects=False,
+            )
         except requests.Timeout:
             return "backend validation timed out"
         except requests.RequestException as exc:

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1398,11 +1398,20 @@ class AuthManager:
         headers = {"X-API-Key": api_key}
 
         if not AIOHTTP_AVAILABLE:
-            return await asyncio.to_thread(
-                self._validate_api_key_with_backend_sync,
-                url,
-                headers,
-            )
+            try:
+                return await asyncio.to_thread(
+                    self._validate_api_key_with_backend_sync,
+                    url,
+                    headers,
+                )
+            except ImportError:
+                return "requests library not available for backend validation"
+            except Exception as exc:  # pragma: no cover - defensive thread boundary
+                logger.debug(
+                    "auth.api_key.validate_transport_error",
+                    extra={"error": str(exc)},
+                )
+                return f"transport error: {exc.__class__.__name__}"
 
         try:
             async with aiohttp.ClientSession(

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -13,6 +13,7 @@ import base64
 import hashlib
 import hmac
 import inspect
+import ipaddress
 import json
 import logging
 import os
@@ -1474,6 +1475,20 @@ class AuthManager:
             return "backend validation URL is invalid"
         if parsed.username or parsed.password:
             return "backend validation URL must not include credentials"
+        hostname = parsed.hostname
+        if not hostname:
+            return "backend validation URL is invalid"
+        normalized_host = hostname.strip("[]").lower()
+        if normalized_host in {"localhost", "localhost."} or normalized_host.endswith(
+            ".localhost"
+        ):
+            return "backend validation URL host is not allowed"
+        try:
+            host_ip = ipaddress.ip_address(normalized_host)
+        except ValueError:
+            return None
+        if not host_ip.is_global:
+            return "backend validation URL host is not allowed"
         return None
 
     def _validate_api_key_with_backend_sync(

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1305,9 +1305,15 @@ class AuthManager:
 
         expected_token = os.getenv("TRAIGENT_DEV_AUTH_TOKEN", "").strip()
         if not expected_token:
-            logger.warning(
+            logger.error(
                 "auth.development.env_missing",
-                extra={"auth_mode": AuthMode.DEVELOPMENT.value},
+                extra={
+                    "auth_mode": AuthMode.DEVELOPMENT.value,
+                    "migration": (
+                        "Set TRAIGENT_DEV_AUTH_TOKEN and pass the same value via "
+                        "AuthCredentials.metadata['dev_token']."
+                    ),
+                },
             )
             return AuthResult(
                 success=False,

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -887,16 +887,19 @@ class AuthManager:
             auth_result = await self.authenticate()
             if not auth_result.success or self._credentials is None:
                 self._authenticated = False
-                # Fall back to raw API key headers when full auth fails
-                # but an API key is available (e.g., local dev mode).
-                fallback = self._get_api_key_headers()
-                if fallback:
-                    self._add_common_headers(fallback, target)
-                    return fallback
-                return {}
+                # Fail closed: never emit headers built from an unverified or
+                # backend-rejected API key. Doing so would defeat backend
+                # validation by allowing the SDK to send the raw key anyway.
+                raise InvalidCredentialsError(
+                    auth_result.error_message
+                    or "Authentication failed; refusing to emit auth headers."
+                )
 
         if not self._credentials:
-            return {}
+            self._authenticated = False
+            raise InvalidCredentialsError(
+                "Authentication state is invalid; refusing to emit auth headers."
+            )
 
         # Generate headers based on authentication mode
         mode = self._credentials.mode
@@ -1059,7 +1062,14 @@ class AuthManager:
     # Authentication Mode Implementations
 
     async def _authenticate_api_key(self, credentials: AuthCredentials) -> AuthResult:
-        """Authenticate using API key."""
+        """Authenticate using API key.
+
+        Validates the supplied key against the configured backend. Format-only
+        checks are not sufficient — historically this path silently trusted any
+        well-formatted key, which allowed forged credentials to authenticate
+        offline. Backend validation is now required; transport errors are
+        surfaced as authentication failures rather than fake-passes.
+        """
         api_key_value = credentials.api_key or self._get_api_key_for_internal_use()
 
         if not api_key_value:
@@ -1077,8 +1087,36 @@ class AuthManager:
                 error_message="Invalid API key format",
             )
 
-        # For API key auth, we trust the key if format is valid
-        # Real validation would happen server-side
+        # Structured warning: never log the key value, only a non-reversible
+        # preview so operators can correlate without leaking secrets.
+        key_preview = self._mask_api_key(api_key_value)
+        logger.warning(
+            "auth.api_key.validate_start",
+            extra={
+                "auth_mode": AuthMode.API_KEY.value,
+                "key_preview": key_preview,
+            },
+        )
+
+        # Server-side validation. If the SDK cannot reach the backend we MUST
+        # fail closed — issuing a header on a network error would let any
+        # well-formatted string authenticate.
+        validation_error = await self._validate_api_key_with_backend(api_key_value)
+        if validation_error is not None:
+            logger.warning(
+                "auth.api_key.validate_failed",
+                extra={
+                    "auth_mode": AuthMode.API_KEY.value,
+                    "key_preview": key_preview,
+                    "reason": validation_error,
+                },
+            )
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message=f"API key validation failed: {validation_error}",
+            )
+
         self._clear_secure_tokens()
         expires_at = credentials.expires_at
         expires_dt: datetime | None
@@ -1249,8 +1287,80 @@ class AuthManager:
     async def _authenticate_development(
         self, credentials: AuthCredentials
     ) -> AuthResult:
-        """Authenticate using development mode."""
-        # Development mode - always succeed for testing
+        """Authenticate using development mode.
+
+        Development mode is intended for local testing only and historically
+        succeeded unconditionally — any caller could authenticate without any
+        credential. This is now gated behind an explicit shared secret in the
+        ``TRAIGENT_DEV_AUTH_TOKEN`` environment variable. The supplied
+        credential (``credentials.metadata['dev_token']`` or the JWT/api-key
+        slot) is compared in constant time against the env value. If the env
+        var is not set, development auth is rejected with a migration-friendly
+        error message rather than silently passing.
+        """
+        logger.warning(
+            "auth.development.attempt",
+            extra={
+                "auth_mode": AuthMode.DEVELOPMENT.value,
+                "dev_user": credentials.metadata.get("dev_user", "developer"),
+            },
+        )
+
+        expected_token = os.getenv("TRAIGENT_DEV_AUTH_TOKEN", "").strip()
+        if not expected_token:
+            logger.warning(
+                "auth.development.env_missing",
+                extra={"auth_mode": AuthMode.DEVELOPMENT.value},
+            )
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message=(
+                    "Development authentication is disabled: set "
+                    "TRAIGENT_DEV_AUTH_TOKEN to use development auth mode "
+                    "and supply the same value via "
+                    "AuthCredentials.metadata['dev_token']."
+                ),
+            )
+
+        # Accept the dev token from any of the conventional credential slots so
+        # existing callers can migrate by setting the env var without rewiring
+        # how they construct AuthCredentials.
+        supplied_token = (
+            credentials.metadata.get("dev_token")
+            or credentials.api_key
+            or credentials.jwt_token
+            or credentials.service_key
+            or ""
+        )
+        if not isinstance(supplied_token, str) or not supplied_token:
+            logger.warning(
+                "auth.development.no_token_supplied",
+                extra={"auth_mode": AuthMode.DEVELOPMENT.value},
+            )
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message=(
+                    "Development authentication requires a credential: pass "
+                    "the value of TRAIGENT_DEV_AUTH_TOKEN as "
+                    "AuthCredentials.metadata['dev_token']."
+                ),
+            )
+
+        if not hmac.compare_digest(
+            supplied_token.encode("utf-8"), expected_token.encode("utf-8")
+        ):
+            logger.warning(
+                "auth.development.token_mismatch",
+                extra={"auth_mode": AuthMode.DEVELOPMENT.value},
+            )
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message="Development authentication token does not match TRAIGENT_DEV_AUTH_TOKEN",
+            )
+
         headers = {
             "X-Development-Mode": "true",
             "X-Dev-User": credentials.metadata.get("dev_user", "developer"),
@@ -1262,6 +1372,60 @@ class AuthManager:
             credentials=credentials,
             headers=headers,
         )
+
+    async def _validate_api_key_with_backend(self, api_key: str) -> str | None:
+        """Call the backend ``/keys/validate`` endpoint to validate ``api_key``.
+
+        Returns ``None`` on success or a short error reason string on failure.
+        Never logs the key value. Network/transport errors are treated as
+        validation failures (fail-closed) so a missing backend cannot be used
+        to bypass authentication.
+        """
+        if not AIOHTTP_AVAILABLE:
+            return "aiohttp not available for backend validation"
+
+        from traigent.config.backend_config import BackendConfig
+
+        try:
+            backend_api_url = BackendConfig.build_api_base(
+                self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
+            )
+        except Exception as exc:  # pragma: no cover - misconfiguration
+            return f"backend URL unavailable: {exc}"
+
+        if not backend_api_url:
+            return "backend URL not configured"
+
+        url = f"{backend_api_url.rstrip('/')}/keys/validate"
+        headers = {"X-API-Key": api_key}
+
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as session:
+                async with session.post(url, headers=headers) as response:
+                    if response.status == 200:
+                        try:
+                            data = await response.json(content_type=None)
+                        except Exception:
+                            return "backend returned non-JSON success body"
+                        if isinstance(data, dict) and data.get("valid") is True:
+                            return None
+                        return "backend reported key invalid"
+                    if response.status in (401, 403):
+                        return "unauthorized"
+                    if response.status == 429:
+                        return "rate limited"
+                    return f"backend returned status {response.status}"
+        except TimeoutError:
+            return "backend validation timed out"
+        except Exception as exc:  # pragma: no cover - exercised via unit tests
+            # Note: log the exception type/message but never the key.
+            logger.debug(
+                "auth.api_key.validate_transport_error",
+                extra={"error": str(exc)},
+            )
+            return f"transport error: {exc.__class__.__name__}"
 
     # Helper Methods
 
@@ -1672,3 +1836,8 @@ def constant_time_compare(a: str, b: str) -> bool:
         True if strings are equal
     """
     return hmac.compare_digest(a.encode(), b.encode())
+
+
+# Public alias retained for callers (and tests) that import the manager under
+# its descriptive name. ``AuthManager`` is the canonical implementation.
+UnifiedAuthManager = AuthManager

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1377,9 +1377,6 @@ class AuthManager:
         validation failures (fail-closed) so a missing backend cannot be used
         to bypass authentication.
         """
-        if not AIOHTTP_AVAILABLE:
-            return "aiohttp not available for backend validation"
-
         from traigent.config.backend_config import BackendConfig
 
         try:
@@ -1395,6 +1392,13 @@ class AuthManager:
         url = f"{backend_api_url.rstrip('/')}/keys/validate"
         headers = {"X-API-Key": api_key}
 
+        if not AIOHTTP_AVAILABLE:
+            return await asyncio.to_thread(
+                self._validate_api_key_with_backend_sync,
+                url,
+                headers,
+            )
+
         try:
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=15)
@@ -1405,14 +1409,14 @@ class AuthManager:
                             data = await response.json(content_type=None)
                         except Exception:
                             return "backend returned non-JSON success body"
-                        if isinstance(data, dict) and data.get("valid") is True:
-                            return None
-                        return "backend reported key invalid"
-                    if response.status in (401, 403):
-                        return "unauthorized"
-                    if response.status == 429:
-                        return "rate limited"
-                    return f"backend returned status {response.status}"
+                        return self._interpret_backend_key_validation_response(
+                            response.status,
+                            data,
+                        )
+                    return self._interpret_backend_key_validation_response(
+                        response.status,
+                        None,
+                    )
         except TimeoutError:
             return "backend validation timed out"
         except Exception as exc:  # pragma: no cover - exercised via unit tests
@@ -1422,6 +1426,49 @@ class AuthManager:
                 extra={"error": str(exc)},
             )
             return f"transport error: {exc.__class__.__name__}"
+
+    @staticmethod
+    def _interpret_backend_key_validation_response(
+        status: int,
+        data: Any | None,
+    ) -> str | None:
+        if status == 200:
+            if isinstance(data, dict) and data.get("valid") is True:
+                return None
+            return "backend reported key invalid"
+        if status in (401, 403):
+            return "unauthorized"
+        if status == 429:
+            return "rate limited"
+        return f"backend returned status {status}"
+
+    def _validate_api_key_with_backend_sync(
+        self,
+        url: str,
+        headers: dict[str, str],
+    ) -> str | None:
+        """Requests fallback for backend key validation when aiohttp is unavailable."""
+        import requests
+
+        try:
+            response = requests.post(url, headers=headers, timeout=15)
+        except requests.Timeout:
+            return "backend validation timed out"
+        except requests.RequestException as exc:
+            logger.debug(
+                "auth.api_key.validate_transport_error",
+                extra={"error": str(exc)},
+            )
+            return f"transport error: {exc.__class__.__name__}"
+
+        status = int(response.status_code)
+        if status == 200:
+            try:
+                data = response.json()
+            except Exception:
+                return "backend returned non-JSON success body"
+            return self._interpret_backend_key_validation_response(status, data)
+        return self._interpret_backend_key_validation_response(status, None)
 
     # Helper Methods
 

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -1067,7 +1067,7 @@ class BackendIntegratedClient:
             experiment_run_id, status
         )
 
-    # Cloud API methods (mock implementations in api_operations)
+    # Cloud API methods (remote execution not implemented; fail closed in api_operations)
     async def _create_cloud_session(
         self, request: SessionCreationRequest
     ) -> SessionCreationResponse:

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -21,6 +21,7 @@ from urllib.parse import quote, urlparse, urlunparse
 # Import and re-export BackendClientConfig for backward compatibility
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
 from traigent.cloud.api_operations import ApiOperations
+from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.backend_bridges import SDKBackendBridge, SessionExperimentMapping
 from traigent.cloud.backend_bridges import bridge as _bridge
 from traigent.cloud.backend_components import (
@@ -411,8 +412,15 @@ class BackendIntegratedClient:
         """Async context manager entry."""
         if AIOHTTP_AVAILABLE:
             # Try to get headers, but don't fail if authentication is not available
+            # B4 ROUND 4: ``AuthenticationError`` must propagate -- a
+            # backend-rejected key must NEVER produce an authenticated session,
+            # even one with empty auth headers (which could be paired with a
+            # raw key elsewhere in the stack). Other exceptions (e.g. Edge
+            # Analytics mode without a key) continue with empty headers.
             try:
                 headers = await self.auth_manager.auth.get_headers()
+            except AuthenticationError:
+                raise
             except Exception as e:
                 # In Edge Analytics mode or when no API key is available, continue without auth headers
                 logger.debug(f"No authentication available for context manager: {e}")
@@ -452,15 +460,33 @@ class BackendIntegratedClient:
                     "Client session not initialized and aiohttp not available"
                 )
 
-            # Try to get headers, but don't fail if authentication is not available
+            # B4 ROUND 4: Fail closed on authentication errors. Previously, this
+            # block caught any exception from ``get_headers()`` and silently
+            # rebuilt headers from the raw stored API key (or from the
+            # private ``_get_api_key_headers()`` helper) -- defeating the
+            # round-3 fail-closed change in ``AuthManager.get_auth_headers()``
+            # because the backend-rejected key would still be shipped on the
+            # wire as ``X-API-Key`` / ``Authorization``.
+            #
+            # Now: ``AuthenticationError`` (and its ``InvalidCredentialsError``
+            # subclass) propagates so the caller sees the rejection. Other
+            # unexpected errors are surfaced as ``CloudServiceError`` rather
+            # than silently swallowed -- still fail-closed for auth, but
+            # without losing diagnostic context.
             try:
                 headers = await self.auth_manager.auth.get_headers()
+            except AuthenticationError:
+                # Do NOT fall back to raw-key headers. Re-raise so callers
+                # see the auth failure instead of getting a session that
+                # silently emits a rejected key.
+                raise
             except Exception as exc:
                 logger.warning("Could not get auth headers: %s", exc)
-                headers = self._build_session_fallback_headers()
-            else:
-                headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
-                headers.setdefault("User-Agent", _SDK_USER_AGENT)
+                raise CloudServiceError(
+                    f"Failed to build authenticated session: {exc}"
+                ) from exc
+            headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
+            headers.setdefault("User-Agent", _SDK_USER_AGENT)
 
             self._session = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
@@ -468,34 +494,6 @@ class BackendIntegratedClient:
             )
 
             return cast(AioClientSession, self._session)
-
-    def _build_session_fallback_headers(self) -> dict[str, str]:
-        """Build best-effort headers when auth header generation fails."""
-        headers = {
-            "Content-Type": _JSON_CONTENT_TYPE,
-            "User-Agent": _SDK_USER_AGENT,
-        }
-
-        auth = self.auth_manager.auth
-        api_key_headers_getter = getattr(auth, "_get_api_key_headers", None)
-        if callable(api_key_headers_getter):
-            try:
-                fallback_headers = api_key_headers_getter()
-            except Exception as exc:  # pragma: no cover - defensive logging
-                logger.debug("Could not build API-key fallback headers: %s", exc)
-            else:
-                if isinstance(fallback_headers, dict):
-                    for key, value in fallback_headers.items():
-                        if value:
-                            headers[key] = value
-                    if "X-API-Key" in headers or "Authorization" in headers:
-                        return headers
-
-        if self._api_key_fallback:
-            headers["X-API-Key"] = self._api_key_fallback
-            headers["Authorization"] = f"Bearer {self._api_key_fallback}"
-
-        return headers
 
     async def _reset_http_session(self, reason: str | None = None) -> None:
         """Close and discard the shared aiohttp session."""
@@ -709,14 +707,46 @@ class BackendIntegratedClient:
 
         Uses the async auth manager to preserve the canonical header-generation
         path, including JWT refresh behavior when available.
+
+        B4 ROUND 5: Fail closed on auth header generation. Previously this
+        method caught every exception from ``get_headers()`` (including
+        ``AuthenticationError`` raised by the round-3 fail-closed check in
+        ``AuthManager.get_auth_headers()``) and returned bare default
+        headers (``Content-Type`` + ``User-Agent``). The caller --
+        ``upload_example_features()`` -- then issued an UNAUTHENTICATED
+        ``requests.post`` to the backend, defeating round-3/round-4 closure
+        of the auth chain.
+
+        After round 5:
+
+        * ``AuthenticationError`` propagates so the caller surfaces the
+          backend rejection instead of silently shipping an unauthenticated
+          request.
+        * Any other unexpected failure is re-raised as ``CloudServiceError``
+          so callers cannot mistake "header generation blew up" for
+          "everything is fine, here are default headers".
+        * The bare ``default_headers`` short-circuit only fires when there
+          is *legitimately* no auth manager available (e.g. Edge Analytics
+          mode); in that case the caller decides whether to proceed.
         """
         default_headers = {
             "Content-Type": _JSON_CONTENT_TYPE,
             "User-Agent": _SDK_USER_AGENT,
         }
+        # B4 ROUND 6: Tighten the default-headers short-circuit. The bare
+        # defaults are ONLY a legitimate response when the caller is
+        # operating without any auth manager (e.g. anonymous Edge mode).
+        # If we have an auth manager but its ``.auth`` is missing or
+        # lacks ``get_headers``, that is an internal inconsistency -- not
+        # a license to ship an unauthenticated request. Surface it as a
+        # ``CloudServiceError`` so the caller fails closed instead.
+        if getattr(self, "auth_manager", None) is None:
+            return default_headers
         auth = getattr(self.auth_manager, "auth", None)
         if auth is None or not hasattr(auth, "get_headers"):
-            return default_headers
+            raise CloudServiceError(
+                "auth manager is in an invalid state; cannot construct " "auth headers"
+            )
 
         async def _get_headers_async() -> dict[str, str]:
             return cast(dict[str, str], await auth.get_headers(target=target))
@@ -737,9 +767,23 @@ class BackendIntegratedClient:
                     headers = future.result(timeout=min(self.timeout, 30.0))
             except RuntimeError:
                 headers = asyncio.run(_get_headers_async())
+        except AuthenticationError:
+            # Re-raise: a backend-rejected key must NEVER be downgraded to a
+            # silent unauthenticated POST. Callers (e.g.
+            # ``upload_example_features``) catch this and abort before any
+            # network I/O happens.
+            raise
         except Exception as exc:
-            logger.debug("Could not get auth headers for feature upload: %s", exc)
-            return default_headers
+            # Unexpected header-generation failures: surface as
+            # ``CloudServiceError`` rather than swallow into default headers.
+            logger.warning(
+                "Sync auth header generation failed; refusing to send "
+                "unauthenticated request: %s",
+                exc,
+            )
+            raise CloudServiceError(
+                f"Failed to build sync auth headers: {exc}"
+            ) from exc
 
         merged_headers = dict(headers or {})
         merged_headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
@@ -802,7 +846,27 @@ class BackendIntegratedClient:
             )
             return False
 
-        headers = self._get_sync_auth_headers(target="backend")
+        # B4 ROUND 5: Fail closed. If auth header generation raises
+        # (``AuthenticationError`` from a backend-rejected key, or
+        # ``CloudServiceError`` from an unexpected failure), do NOT issue an
+        # unauthenticated POST. Short-circuit and return False -- the
+        # request must never go out without auth.
+        try:
+            headers = self._get_sync_auth_headers(target="backend")
+        except AuthenticationError as exc:
+            logger.debug(
+                "Skipping example feature upload for run %s: auth rejected (%s)",
+                experiment_run_id,
+                exc,
+            )
+            return False
+        except CloudServiceError as exc:
+            logger.debug(
+                "Skipping example feature upload for run %s: header build failed (%s)",
+                experiment_run_id,
+                exc,
+            )
+            return False
         url = self._build_feature_upload_url(experiment_run_id)
         if not url:
             return False

--- a/traigent/cloud/backend_components.py
+++ b/traigent/cloud/backend_components.py
@@ -22,8 +22,14 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
-from traigent.cloud.auth import AuthManager, AuthMode, UnifiedAuthConfig
+from traigent.cloud.auth import (
+    AuthenticationError,
+    AuthManager,
+    AuthMode,
+    UnifiedAuthConfig,
+)
 from traigent.cloud.billing import UsageTracker
+from traigent.cloud.client import CloudServiceError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -146,9 +152,18 @@ class BackendAuthManager:
         merged_headers = dict(headers)
         # Auth errors are intentionally NOT caught here: callers must see
         # the rejection rather than receive a silently-unauthenticated
-        # header dict. Other unexpected errors are still logged to keep
-        # diagnostic context and re-raised for the same reason.
-        auth_headers = await self.auth.get_headers(target=target)
+        # header dict. Other unexpected errors are wrapped so callers see a
+        # cloud-layer failure with diagnostic context instead of a raw helper
+        # exception.
+        try:
+            auth_headers = await self.auth.get_headers(target=target)
+        except AuthenticationError:
+            raise
+        except Exception as exc:
+            logger.warning("Could not augment backend auth headers: %s", exc)
+            raise CloudServiceError(
+                f"Failed to augment backend auth headers: {exc}"
+            ) from exc
 
         for key, value in auth_headers.items():
             if key not in merged_headers:

--- a/traigent/cloud/backend_components.py
+++ b/traigent/cloud/backend_components.py
@@ -22,12 +22,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
-from traigent.cloud.auth import (
-    AuthenticationError,
-    AuthManager,
-    AuthMode,
-    UnifiedAuthConfig,
-)
+from traigent.cloud.auth import AuthManager, AuthMode, UnifiedAuthConfig
 from traigent.cloud.billing import UsageTracker
 from traigent.utils.logging import get_logger
 
@@ -96,11 +91,10 @@ class BackendClientConfig:
                 if parsed_origin:
                     api_path = path or BackendConfig.get_default_api_path()
                     self.api_base_url = f"{parsed_origin}{api_path}"
-        elif api_env:
+        elif api_env and not self.backend_explicitly_set:
             self.api_base_url = BackendConfig.get_backend_api_url()
             # Only derive backend_base_url from API URL if not explicitly provided
-            if not self.backend_explicitly_set:
-                self.backend_base_url = BackendConfig.get_backend_url().rstrip("/")
+            self.backend_base_url = BackendConfig.get_backend_url().rstrip("/")
         elif self.backend_base_url is not None:
             self.api_base_url = BackendConfig.build_api_base(self.backend_base_url)
 
@@ -139,17 +133,22 @@ class BackendAuthManager:
     async def augment_headers(
         self, headers: dict[str, str], target: str = "backend"
     ) -> dict[str, str]:
-        """Merge authentication headers into the provided dictionary."""
+        """Merge authentication headers into the provided dictionary.
+
+        B4 ROUND 4: ``AuthenticationError`` (and ``InvalidCredentialsError``)
+        must propagate. Previously this method swallowed every auth-side
+        exception and returned the caller's headers unchanged -- which
+        meant a backend-rejected key produced an unauthenticated request
+        instead of surfacing the auth failure. That is a parallel
+        fail-open path to the one in ``backend_client._ensure_session``.
+        """
 
         merged_headers = dict(headers)
-        try:
-            auth_headers = await self.auth.get_headers(target=target)
-        except AuthenticationError as exc:
-            logger.warning("Backend auth headers unavailable: %s", exc)
-            return merged_headers
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logger.debug("Unexpected error generating auth headers: %s", exc)
-            return merged_headers
+        # Auth errors are intentionally NOT caught here: callers must see
+        # the rejection rather than receive a silently-unauthenticated
+        # header dict. Other unexpected errors are still logged to keep
+        # diagnostic context and re-raised for the same reason.
+        auth_headers = await self.auth.get_headers(target=target)
 
         for key, value in auth_headers.items():
             if key not in merged_headers:

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -637,7 +637,7 @@ class TraigentCloudClient(BaseTraigentClient):
             target_cost_reduction,
             local_function,
         )
-        raise CloudServiceError(CLOUD_REMOTE_EXECUTION_UNAVAILABLE)
+        raise CloudRemoteExecutionUnavailableError()
 
     async def _submit_optimization(
         self, request_data: dict[str, Any]
@@ -1822,6 +1822,20 @@ class CloudServiceError(StandardizedClientError):
 
     def __init__(self, message: str, original_error: Exception | None = None) -> None:
         super().__init__(message, "cloud_service", original_error)
+
+
+class CloudRemoteExecutionUnavailableError(CloudServiceError):
+    """Raised when remote cloud execution endpoints are intentionally unavailable."""
+
+    def __init__(
+        self,
+        operation: str | None = None,
+        original_error: Exception | None = None,
+    ) -> None:
+        message = CLOUD_REMOTE_EXECUTION_UNAVAILABLE
+        if operation:
+            message = f"{message} ({operation})"
+        super().__init__(message, original_error)
 
 
 # Backward compatibility aliases

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -50,6 +50,11 @@ logger = get_logger(__name__)
 _SESSION_NOT_INITIALIZED = "Session not initialized"
 _CLIENT_SESSION_NOT_INITIALIZED = "Client session not initialized"
 _AGENT_SPEC_REQUIRED = "agent_spec is required"
+CLOUD_REMOTE_EXECUTION_UNAVAILABLE = (
+    "Cloud remote execution is not available yet; use hybrid for "
+    "portal-tracked optimization. Supported modes are local/edge_analytics "
+    "and hybrid."
+)
 
 
 def _session_is_closed(session: Any) -> bool:
@@ -617,101 +622,22 @@ class TraigentCloudClient(BaseTraigentClient):
         *,
         local_function: Callable[..., Any] | None = None,
     ) -> CloudOptimizationResult:
-        """Run optimization using Traigent Cloud Service.
+        """Fail closed for remote cloud optimization.
 
-        Args:
-            function_name: Name of function being optimized
-            dataset: Evaluation dataset
-            configuration_space: Parameter search space
-            objectives: Optimization objectives
-            max_trials: Maximum optimization trials
-            target_cost_reduction: Target cost reduction (0.0-1.0)
-            local_function: Callable to use for local fallback optimization.
-
-        Returns:
-            CloudOptimizationResult with optimization results
-
-        Raises:
-            CloudServiceError: If cloud optimization fails and fallback disabled
+        Remote cloud execution is reserved for a future implementation. The
+        working portal-visible path today is hybrid mode: trials execute
+        locally and metrics are submitted to the backend session API.
         """
-        start_time = time.time()
-
-        try:
-            # Check if aiohttp is available
-            if not AIOHTTP_AVAILABLE:
-                raise CloudServiceError("aiohttp not available, using fallback")
-
-            # Check authentication
-            auth_status = self.auth.is_authenticated()
-            if inspect.isawaitable(auth_status):
-                auth_status = await auth_status
-
-            if not auth_status:
-                raise CloudServiceError("Not authenticated with Traigent Cloud Service")
-
-            # Smart dataset subset selection for cost optimization
-            original_size = len(dataset.examples)
-            subset_dataset = await self.subset_selector.select_optimal_subset(
-                dataset, target_reduction=target_cost_reduction
-            )
-            subset_size = len(subset_dataset.examples)
-
-            logger.info(
-                f"Smart subset selection: {original_size} → {subset_size} examples "
-                f"({(1 - subset_size / original_size) * 100:.1f}% reduction)"
-            )
-
-            # Prepare optimization request
-            request_data = {
-                "function_name": function_name,
-                "dataset": self._serialize_dataset(subset_dataset),
-                "configuration_space": configuration_space,
-                "objectives": objectives,
-                "max_trials": max_trials,
-                "target_cost_reduction": target_cost_reduction,
-                "client_version": "0.1.0",
-            }
-
-            # Submit optimization to cloud
-            result = await self._submit_optimization(request_data)
-
-            # Track usage for billing
-            await self.usage_tracker.record_optimization(
-                function_name=function_name,
-                trials_count=result["trials_count"],
-                dataset_size=subset_size,
-                optimization_time=time.time() - start_time,
-            )
-
-            # Calculate actual cost reduction
-            cost_reduction = 1 - (subset_size / original_size)
-
-            return CloudOptimizationResult(
-                best_config=result["best_config"],
-                best_metrics=result["best_metrics"],
-                trials_count=result["trials_count"],
-                cost_reduction=cost_reduction,
-                optimization_time=time.time() - start_time,
-                subset_used=True,
-                subset_size=subset_size,
-            )
-
-        except Exception as e:
-            await self._reset_http_session("cloud optimization failure")
-            logger.warning(f"Cloud optimization failed: {e}")
-
-            if self.enable_fallback:
-                logger.info("Falling back to local optimization")
-                return await self._fallback_optimization(
-                    function_name,
-                    dataset,
-                    configuration_space,
-                    objectives,
-                    max_trials,
-                    local_function=local_function,
-                )
-            else:
-                raise CloudServiceError(f"Cloud optimization failed: {e}") from None
+        _ = (
+            function_name,
+            dataset,
+            configuration_space,
+            objectives,
+            max_trials,
+            target_cost_reduction,
+            local_function,
+        )
+        raise CloudServiceError(CLOUD_REMOTE_EXECUTION_UNAVAILABLE)
 
     async def _submit_optimization(
         self, request_data: dict[str, Any]

--- a/traigent/cloud/cloud_operations.py
+++ b/traigent/cloud/cloud_operations.py
@@ -8,7 +8,7 @@ executed in the cloud with full data transmission.
 
 from typing import TYPE_CHECKING, Any
 
-from traigent.cloud.client import CLOUD_REMOTE_EXECUTION_UNAVAILABLE, CloudServiceError
+from traigent.cloud.client import CloudRemoteExecutionUnavailableError
 from traigent.cloud.models import (
     AgentExecutionResponse,
     AgentOptimizationResponse,
@@ -54,9 +54,7 @@ class CloudOperations:
             Agent optimization response with session details
         """
         _ = (agent_spec, dataset, configuration_space, objectives, max_trials, user_id)
-        raise CloudServiceError(
-            f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} (start_agent_optimization)"
-        )
+        raise CloudRemoteExecutionUnavailableError("start_agent_optimization")
 
     async def execute_agent(
         self,
@@ -75,4 +73,4 @@ class CloudOperations:
             Agent execution response
         """
         _ = (agent_spec, input_data, config_overrides)
-        raise CloudServiceError(f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} (execute_agent)")
+        raise CloudRemoteExecutionUnavailableError("execute_agent")

--- a/traigent/cloud/cloud_operations.py
+++ b/traigent/cloud/cloud_operations.py
@@ -8,21 +8,16 @@ executed in the cloud with full data transmission.
 
 from typing import TYPE_CHECKING, Any
 
-from traigent.cloud.client import CloudServiceError
+from traigent.cloud.client import CLOUD_REMOTE_EXECUTION_UNAVAILABLE, CloudServiceError
 from traigent.cloud.models import (
-    AgentExecutionRequest,
     AgentExecutionResponse,
-    AgentOptimizationRequest,
     AgentOptimizationResponse,
     AgentSpecification,
 )
 from traigent.evaluators.base import Dataset
-from traigent.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from traigent.cloud.backend_client import BackendIntegratedClient
-
-logger = get_logger(__name__)
 
 
 class CloudOperations:
@@ -58,50 +53,10 @@ class CloudOperations:
         Returns:
             Agent optimization response with session details
         """
-        logger.info(f"Starting cloud SaaS optimization for agent {agent_spec.name}")
-
-        try:
-            # Create backend agent and experiment
-            (
-                experiment_id,
-                experiment_run_id,
-            ) = await self.client._create_backend_agent_experiment(
-                agent_spec, dataset, configuration_space, objectives, max_trials
-            )
-
-            # Submit to cloud for execution
-            request = AgentOptimizationRequest(
-                agent_spec=agent_spec,
-                dataset=dataset,
-                configuration_space=configuration_space,
-                objectives=objectives,
-                max_trials=max_trials,
-                user_id=user_id,
-                billing_tier="cloud",
-            )
-
-            response = await self.client._submit_agent_optimization(request)
-
-            # Create session mapping
-            if agent_spec.name is None:
-                raise ValueError("Agent name is required")
-            self.client.session_bridge.create_session_mapping(
-                session_id=response.session_id,
-                experiment_id=experiment_id,
-                experiment_run_id=experiment_run_id,
-                function_name=agent_spec.name,
-                configuration_space=configuration_space,
-                objectives=objectives,
-            )
-
-            logger.info(
-                f"Started cloud optimization: {response.session_id} -> {experiment_id}"
-            )
-            return response
-
-        except Exception as e:
-            logger.error(f"Failed to start agent optimization: {e}")
-            raise CloudServiceError(f"Failed to start optimization: {e}") from None
+        _ = (agent_spec, dataset, configuration_space, objectives, max_trials, user_id)
+        raise CloudServiceError(
+            f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} (start_agent_optimization)"
+        )
 
     async def execute_agent(
         self,
@@ -119,17 +74,5 @@ class CloudOperations:
         Returns:
             Agent execution response
         """
-        logger.debug(f"Executing agent {agent_spec.name}")
-
-        try:
-            request = AgentExecutionRequest(
-                agent_spec=agent_spec,
-                input_data=input_data,
-                config_overrides=config_overrides,
-            )
-
-            return await self.client._execute_cloud_agent(request)
-
-        except Exception as e:
-            logger.error(f"Failed to execute agent: {e}")
-            raise CloudServiceError(f"Failed to execute agent: {e}") from None
+        _ = (agent_spec, input_data, config_overrides)
+        raise CloudServiceError(f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} (execute_agent)")

--- a/traigent/cloud/credential_resolver.py
+++ b/traigent/cloud/credential_resolver.py
@@ -277,7 +277,13 @@ class CredentialResolver:
 
             elif mode == AuthMode.DEVELOPMENT:
                 dev_user = os.getenv("TRAIGENT_DEV_USER", "developer")
-                return AuthCredentials(mode=mode, metadata={"dev_user": dev_user})
+                dev_token = os.getenv("TRAIGENT_DEV_AUTH_TOKEN", "").strip()
+                dev_metadata: dict[str, Any] = {"dev_user": dev_user}
+                # Pass-through the dev token so AuthManager._authenticate_development
+                # can validate the supplied credential against the env value.
+                if dev_token:
+                    dev_metadata["dev_token"] = dev_token
+                return AuthCredentials(mode=mode, metadata=dev_metadata)
 
             return None
 

--- a/traigent/cloud/privacy_operations.py
+++ b/traigent/cloud/privacy_operations.py
@@ -1,12 +1,11 @@
 """Privacy-first optimization operations for Traigent Cloud Client.
 
 This module handles privacy-preserving optimization operations where data
-remains local and only metrics are transmitted to the cloud.
+remains local and only metrics are transmitted to the backend session API.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID REQ-CLOUD-009 SYNC-CloudHybrid
 
-import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +16,6 @@ from traigent.cloud.models import (
     OptimizationSessionStatus,
     SessionCreationRequest,
     TrialResultSubmission,
-    TrialStatus,
     TrialSuggestion,
 )
 from traigent.utils.logging import get_logger
@@ -48,10 +46,11 @@ class PrivacyOperations:
         max_trials: int = 50,
         user_id: str | None = None,
     ) -> tuple[str, str, str]:
-        """Create privacy-first optimization session with backend experiment tracking.
+        """Create a backend-tracked session for local/hybrid optimization.
 
-        This creates both a cloud session for configuration suggestions and a backend
-        experiment for tracking, while keeping sensitive data local.
+        Hybrid mode executes trials locally and uses the backend session API
+        for portal-visible tracking. It does not create a remote cloud
+        execution session.
 
         Args:
             function_name: Name of function being optimized
@@ -83,7 +82,6 @@ class PrivacyOperations:
         logger.info(f"Creating privacy-first optimization session for {function_name}")
 
         try:
-            # Create cloud session for configuration suggestions
             session_request = SessionCreationRequest(
                 function_name=function_name,
                 configuration_space=configuration_space,
@@ -93,9 +91,6 @@ class PrivacyOperations:
                 user_id=user_id,
                 billing_tier="privacy",  # Special tier for privacy mode
             )
-
-            session_response = await self.client._create_cloud_session(session_request)
-            session_id = session_response.session_id
 
             # Always use session endpoints for tracking
             logger.info("🔄 Creating session via Traigent session endpoints...")
@@ -138,9 +133,9 @@ class PrivacyOperations:
                 objectives=objectives,
                 max_trials=max_trials,
                 status=OptimizationSessionStatus.ACTIVE,
-                created_at=session_response.metadata.get("created_at", time.time()),
+                created_at=datetime.now(UTC),
                 updated_at=datetime.now(UTC),
-                optimization_strategy=session_response.optimization_strategy,
+                optimization_strategy={"mode": "local_execution"},
             )
 
             with self.client._active_sessions_lock:
@@ -203,7 +198,9 @@ class PrivacyOperations:
         logger.debug(f"Getting next trial for privacy session {session_id}")
 
         try:
-            # Get suggestion from cloud (no sensitive data transmitted)
+            # Remote suggestions are intentionally disabled until cloud
+            # execution is implemented. Local/hybrid optimization should use
+            # the SDK's local optimizer for suggestions.
             request = NextTrialRequest(
                 session_id=session_id, previous_results=previous_results
             )
@@ -291,18 +288,6 @@ class PrivacyOperations:
         logger.debug(f"Submitting privacy trial results: {session_id}/{trial_id}")
 
         try:
-            # Submit results to cloud (metrics only)
-            submission = TrialResultSubmission(
-                session_id=session_id,
-                trial_id=trial_id,
-                metrics=metrics,
-                duration=duration,
-                status=TrialStatus.FAILED if error_message else TrialStatus.COMPLETED,
-                error_message=error_message,
-            )
-
-            await self.client._submit_cloud_trial_results(submission)
-
             # Submit via session endpoint only - no fallback to config run endpoint
             session_submitted = await self.client._submit_trial_result_via_session(
                 session_id,

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -23,7 +23,8 @@ class ExecutionMode(StrEnum):
       if the backend is unreachable, but insights remain local.
     - PRIVACY: Legacy alias for hybrid mode with strict privacy toggles (no input/output sent).
     - STANDARD: Cloud orchestration with data sharing for balanced performance.
-    - CLOUD: Full SaaS execution where optimization and trials run in the cloud.
+    - CLOUD: Reserved for future remote execution where optimization and trials run
+      in Traigent Cloud. Not available yet.
     - HYBRID_API: External API-based optimization where trials execute via HTTP endpoints.
       Enables optimization of any agentic service that implements the Traigent API contract.
     """
@@ -63,8 +64,12 @@ def resolve_execution_mode(
 
 
 # Currently supported execution modes
-_SUPPORTED_MODES = {ExecutionMode.EDGE_ANALYTICS, ExecutionMode.HYBRID_API}
-_NOT_YET_SUPPORTED_MODES = {ExecutionMode.HYBRID, ExecutionMode.CLOUD}
+_SUPPORTED_MODES = {
+    ExecutionMode.EDGE_ANALYTICS,
+    ExecutionMode.HYBRID,
+    ExecutionMode.HYBRID_API,
+}
+_NOT_YET_SUPPORTED_MODES = {ExecutionMode.CLOUD}
 # PRIVACY and STANDARD are removed — not in either set
 
 
@@ -72,8 +77,8 @@ def validate_execution_mode(mode: ExecutionMode | str | None) -> ExecutionMode:
     """Resolve *and* validate that an execution mode is currently supported.
 
     Raises :class:`~traigent.utils.exceptions.ConfigurationError` for removed
-    modes (``privacy``, ``standard``) and not-yet-supported modes (``cloud``,
-    ``hybrid``).  Use :func:`resolve_execution_mode` when you only need
+    modes (``privacy``, ``standard``) and not-yet-supported modes (``cloud``).
+    Use :func:`resolve_execution_mode` when you only need
     string-to-enum conversion without support validation.
     """
     from traigent.utils.exceptions import ConfigurationError
@@ -84,7 +89,10 @@ def validate_execution_mode(mode: ExecutionMode | str | None) -> ExecutionMode:
         raise ConfigurationError(f"No such mode '{mode}'") from None
 
     if resolved in _NOT_YET_SUPPORTED_MODES:
-        raise ConfigurationError(f"'{resolved.value}' not yet supported")
+        raise ConfigurationError(
+            "Cloud remote execution is not available yet; use hybrid for "
+            "portal-tracked optimization."
+        )
     if resolved not in _SUPPORTED_MODES:
         raise ConfigurationError(f"No such mode '{resolved.value}'")
 
@@ -426,10 +434,7 @@ class TraigentConfig:
 
     def is_cloud_mode(self) -> bool:
         """Check if configuration is set to cloud mode."""
-        return self.execution_mode_enum in {
-            ExecutionMode.CLOUD,
-            ExecutionMode.STANDARD,
-        }
+        return self.execution_mode_enum is ExecutionMode.CLOUD
 
     def is_privacy_enabled(self) -> bool:
         """Whether privacy mode is enabled (content never logged or transmitted)."""

--- a/traigent/core/ci_approval.py
+++ b/traigent/core/ci_approval.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Any
 
 from traigent.config.types import TraigentConfig
-from traigent.utils.env_config import is_mock_llm, is_production
 from traigent.utils.exceptions import ConfigurationError, OptimizationError
 from traigent.utils.logging import get_logger
 from traigent.utils.secure_path import safe_open, validate_path
@@ -173,13 +172,11 @@ def check_ci_approval(traigent_config: TraigentConfig) -> None:
     if not traigent_config.is_edge_analytics_mode():
         return
 
-    if is_mock_llm():
-        msg = "Skipping CI approval in mock LLM mode"
-        if is_production():
-            logger.warning(f"{msg} while ENVIRONMENT=production.")
-        else:
-            logger.info(f"{msg}.")
-        return
+    # NOTE: ``TRAIGENT_MOCK_LLM`` no longer bypasses the CI approval gate
+    # (S2-B retirement). Bypassing a security control based on an env var
+    # was unsafe in production deployments where the variable could leak in.
+    # CI runs that legitimately need to skip approval should use
+    # ``TRAIGENT_RUN_APPROVED=1`` (signed token) explicitly.
 
     if not _is_ci_environment():
         return

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -15,12 +15,18 @@ Environment Variables:
     TRAIGENT_RUN_COST_LIMIT: Maximum USD spending per optimization run (default: 2.0)
     TRAIGENT_COST_APPROVED: Skip handshake if "true" (default: false)
     TRAIGENT_COST_WARNING_THRESHOLD: Warn at this fraction of limit (default: 0.5)
-    TRAIGENT_MOCK_LLM: Bypass all cost tracking when "true" (no real LLM costs)
     TRAIGENT_REQUIRE_COST_TRACKING: Raise exception if cost extraction fails (default: false)
     TRAIGENT_STRICT_COST_ACCOUNTING: Fail fast for unknown/missing runtime costs
         (default: false)
     TRAIGENT_COST_DIVERGENCE_THRESHOLD: Log warning if actual/estimated ratio exceeds
         this value (default: 2.0, meaning 2x divergence triggers warning)
+
+Note:
+    ``TRAIGENT_MOCK_LLM`` is intentionally NOT consulted here. Sprint 2-B
+    retired the mock-mode bypass because it could disable cost enforcement
+    and billing accounting if the variable ever leaked into a production
+    environment. Cost approval, permit acquisition, and cost tracking
+    always run regardless of any mock-mode flag.
 """
 
 from __future__ import annotations
@@ -215,12 +221,11 @@ class CostEnforcer:
         self._permit_counter: int = 0  # Monotonic counter for permit IDs
         self._active_permits: dict[int, Permit] = {}  # Track active permits by ID
 
-        # Cache mock LLM mode at init to prevent mid-run env var changes (Phase 2.2).
-        # NOTE: Changing TRAIGENT_MOCK_LLM after CostEnforcer is initialized will
-        # have NO EFFECT. This is intentional - toggling mock mode mid-run could
-        # cause stranded permits (acquired with tracking, released without tracking).
-        # If you need to change mock mode, create a new CostEnforcer instance.
-        self._mock_mode_cached: bool = self._check_mock_mode()
+        # S2-B Round 3: TRAIGENT_MOCK_LLM no longer suppresses cost enforcement.
+        # Previously this module cached a mock-mode flag at init and used it to
+        # short-circuit approval, permit acquisition, and cost tracking. That
+        # bypass was a security/billing risk if the env var leaked into prod, so
+        # all bypass branches were removed. Cost enforcement now always runs.
         # Cache strict-cost-tracking mode at init for consistent run semantics.
         # NOTE: Changing TRAIGENT_REQUIRE_COST_TRACKING or
         # TRAIGENT_STRICT_COST_ACCOUNTING after CostEnforcer initialization has
@@ -235,14 +240,6 @@ class CostEnforcer:
         # Sync/async usage tracking for mixing detection (Phase 3.2)
         self._sync_used: bool = False
         self._async_used: bool = False
-
-    def _check_mock_mode(self) -> bool:
-        """Check if mock LLM mode is enabled from environment.
-
-        When TRAIGENT_MOCK_LLM=true, cost tracking is bypassed because
-        there are no real LLM API costs to track.
-        """
-        return os.getenv("TRAIGENT_MOCK_LLM", "false").lower() == "true"
 
     @staticmethod
     def _check_require_cost_tracking_mode() -> bool:
@@ -370,15 +367,6 @@ class CostEnforcer:
                 return self._trial_count >= self.config.fallback_trial_limit
             return self._accumulated_cost >= self.config.limit
 
-    @property
-    def is_mock_mode(self) -> bool:
-        """Check if mock mode is enabled (bypasses all cost tracking).
-
-        Uses cached value from init to prevent mid-run env var changes
-        from causing stranded permits.
-        """
-        return self._mock_mode_cached
-
     def check_and_approve(self, estimated_cost: float) -> bool:
         """Pre-optimization handshake. Returns True if approved.
 
@@ -394,10 +382,6 @@ class CostEnforcer:
         Returns:
             True if approved to proceed, False if user declined or non-interactive abort.
         """
-        if self.is_mock_mode:
-            logger.debug("Mock mode enabled, skipping cost approval")
-            return True
-
         if self.config.approved:
             logger.info(
                 f"Cost pre-approved via TRAIGENT_COST_APPROVED "
@@ -530,10 +514,6 @@ Options:
         """
         self._check_mixing(is_async=False)
 
-        if self.is_mock_mode:
-            # Mock mode: return valid permit with estimated cost, id=0
-            return Permit(id=0, amount=self._estimated_cost, active=True)
-
         with self._lock:
             return self._acquire_permit_locked()
 
@@ -558,10 +538,6 @@ Options:
         """
         self._check_mixing(is_async=False)
 
-        if self.is_mock_mode:
-            permit.mark_released()  # Mark even in mock mode for consistency
-            return True
-
         with self._lock:
             return self._release_permit_locked(permit, caller="release_permit")
 
@@ -578,10 +554,6 @@ Options:
             True if permit was released, False if already released (double-release).
         """
         self._check_mixing(is_async=True)
-
-        if self.is_mock_mode:
-            permit.mark_released()  # Mark even in mock mode for consistency
-            return True
 
         # Use single RLock for both sync and async (Gemini recommendation)
         # Critical section is fast, no I/O
@@ -600,10 +572,6 @@ Options:
             if limit reached (amount=0.0, id=-1).
         """
         self._check_mixing(is_async=True)
-
-        if self.is_mock_mode:
-            # Mock mode: return valid permit with estimated cost, id=0
-            return Permit(id=0, amount=self._estimated_cost, active=True)
 
         # Use single RLock for both sync and async (Gemini recommendation)
         # Critical section is fast, no I/O
@@ -644,10 +612,6 @@ Options:
 
         if cost is not None and cost < 0:
             raise ValueError(f"Cost must be non-negative, got {cost}")
-
-        if self.is_mock_mode:
-            permit.mark_released()  # Mark for consistency
-            return
 
         # Read environment-driven strictness once per call.
         # Keep this outside the lock to minimize lock hold time.
@@ -856,10 +820,6 @@ Options:
 
         if cost is not None and cost < 0:
             raise ValueError(f"Cost must be non-negative, got {cost}")
-
-        if self.is_mock_mode:
-            permit.mark_released()  # Mark for consistency
-            return
 
         # Read environment-driven strictness once per call.
         # Keep this outside the lock to minimize lock hold time.

--- a/traigent/core/cost_estimator.py
+++ b/traigent/core/cost_estimator.py
@@ -199,8 +199,9 @@ class CostEstimator:
         Raises:
             OptimizationAborted: If cost approval is declined
         """
-        if self._cost_enforcer.is_mock_mode:
-            return
+        # S2-B Round 3: cost approval no longer skips on TRAIGENT_MOCK_LLM.
+        # The mock-mode bypass was removed because it could disable approval
+        # if the env var leaked into a production environment.
         estimated_cost = self.estimate_optimization_cost(dataset)
         if not self._cost_enforcer.check_and_approve(estimated_cost):
             from traigent.core.cost_enforcement import OptimizationAborted

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -24,7 +24,6 @@ from traigent.config.types import ExecutionMode, TraigentConfig, resolve_executi
 from traigent.core.evaluator_wrapper import CustomEvaluatorWrapper
 from traigent.evaluators.base import BaseEvaluator, Dataset
 from traigent.evaluators.local import LocalEvaluator
-from traigent.utils.env_config import is_mock_llm
 from traigent.utils.logging import get_logger
 from traigent.utils.validation import validate_config_space
 
@@ -262,34 +261,28 @@ def resolve_effective_parallel_config(
 def resolve_custom_evaluator(
     custom_evaluator: Callable[..., Any] | None,
     *,
-    mock_mode_config: dict[str, Any] | None,
+    mock_mode_config: dict[str, Any] | None,  # noqa: ARG001 - retained for API compat
     decorator_custom_evaluator: Callable[..., Any] | None,
 ) -> Callable[..., Any] | None:
-    """Resolve the effective custom evaluator based on mock mode settings.
+    """Resolve the effective custom evaluator.
+
+    The user-provided custom evaluator (from either the ``@optimize`` decorator
+    or the ``optimize()`` call) is always honoured. ``mock_mode_config`` is
+    accepted for backward compatibility with the public API but is otherwise
+    ignored: it previously combined with the now-retired ``TRAIGENT_MOCK_LLM``
+    env var to silently swap a user-supplied evaluator for ``LocalEvaluator``,
+    which was unsafe in production environments where the env var leaked.
 
     Args:
-        custom_evaluator: Custom evaluator from optimize() call
-        mock_mode_config: Mock mode configuration
-        decorator_custom_evaluator: Custom evaluator from decorator
+        custom_evaluator: Custom evaluator from optimize() call.
+        mock_mode_config: Ignored. Retained for backward-compatible signatures.
+        decorator_custom_evaluator: Custom evaluator from decorator.
 
     Returns:
         The custom evaluator to use, or None if LocalEvaluator should be used.
     """
-    mock_mode_env = is_mock_llm()
-    mock_config = mock_mode_config or {}
-    mock_enabled = mock_config.get("enabled", True)
-    override_evaluator = mock_config.get("override_evaluator", True)
-
     provided_custom_evaluator = custom_evaluator or decorator_custom_evaluator
-    has_custom = provided_custom_evaluator is not None
-
-    if mock_mode_env and mock_enabled and override_evaluator and has_custom:
-        logger.info(
-            "Mock mode enabled: overriding custom evaluator with LocalEvaluator"
-        )
-        return None
-
-    return provided_custom_evaluator if has_custom else None
+    return provided_custom_evaluator if provided_custom_evaluator is not None else None
 
 
 def build_metric_functions(

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1670,26 +1670,18 @@ class OptimizedFunction:
     def _apply_mock_config_overrides(
         self, algorithm: str, optimizer_kwargs: dict[str, Any]
     ) -> str:
-        """Apply mock config overrides to algorithm and optimizer_kwargs."""
-        mock_config = getattr(self, "mock_mode_config", None) or {}
-        if not isinstance(mock_config, dict):
-            return algorithm
+        """No-op retained for backward compatibility.
 
-        # Override algorithm if specified in mock config
-        mock_optimizer = mock_config.get("optimizer")
-        if mock_optimizer and isinstance(mock_optimizer, str):
-            algorithm = mock_optimizer
-            logger.debug("Using optimizer '%s' from mock_mode_config", mock_optimizer)
-
-        # Extract and pass random_seed to optimizer for reproducibility
-        random_seed = mock_config.get("random_seed")
-        if random_seed is not None:
-            optimizer_kwargs["random_seed"] = random_seed
-            logger.debug(
-                "Passing random_seed=%s to optimizer from mock_mode_config",
-                random_seed,
-            )
-
+        Historically this method consulted ``self.mock_mode_config`` to
+        override the optimizer algorithm and to inject ``random_seed`` into
+        ``optimizer_kwargs``. As part of the F5 retirement of the mock-mode
+        flag, ``mock_mode_config`` is now fully inert: callers may still pass
+        the parameter through public APIs, but it must not change optimizer
+        selection or seeding. A stray production config in the past silently
+        rerouted real optimizations to a different algorithm with a fixed
+        seed, so we now ignore it entirely. Real seeding should go through
+        the normal ``algorithm_kwargs`` / ``random_seed`` parameter path.
+        """
         return algorithm
 
     async def _execute_optimization(

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -388,11 +388,7 @@ class OptimizedFunction:
             mode_enum = resolve_execution_mode(
                 effective_mode, default=resolve_execution_mode(self.execution_mode)
             )
-        return mode_enum in {
-            ExecutionMode.CLOUD,
-            ExecutionMode.STANDARD,
-            ExecutionMode.HYBRID,
-        }
+        return mode_enum is ExecutionMode.CLOUD
 
     def _setup_configuration_space(self, configuration_space, config_space) -> None:
         """Setup configuration space with backward compatibility."""
@@ -1641,6 +1637,11 @@ class OptimizedFunction:
         if not use_cloud:
             return None
 
+        from traigent.cloud.client import (
+            CLOUD_REMOTE_EXECUTION_UNAVAILABLE,
+            CloudServiceError,
+        )
+
         try:
             return await self._optimize_with_cloud_service(
                 dataset,
@@ -1651,6 +1652,12 @@ class OptimizedFunction:
             )
         except (AuthenticationError, ConfigurationError, ValidationError):
             raise
+        except CloudServiceError as e:
+            if CLOUD_REMOTE_EXECUTION_UNAVAILABLE in str(e):
+                raise
+            if self.cloud_fallback_policy == "never":
+                raise
+            logger.warning("Cloud optimization failed, falling back to local: %s", e)
         except OSError as e:  # Includes TimeoutError and ConnectionError (subclasses)
             if self.cloud_fallback_policy == "never":
                 raise
@@ -1878,7 +1885,7 @@ class OptimizedFunction:
 
         # Initialize cloud client if not already done
         if self._cloud_client is None:
-            self._cloud_client = TraigentCloudClient(enable_fallback=True)
+            self._cloud_client = TraigentCloudClient(enable_fallback=False)
 
         if max_trials is not None and max_trials <= 0:
             logger.info("Cloud optimization skipped due to max_trials=0.")

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1638,7 +1638,7 @@ class OptimizedFunction:
             return None
 
         from traigent.cloud.client import (
-            CLOUD_REMOTE_EXECUTION_UNAVAILABLE,
+            CloudRemoteExecutionUnavailableError,
             CloudServiceError,
         )
 
@@ -1652,9 +1652,9 @@ class OptimizedFunction:
             )
         except (AuthenticationError, ConfigurationError, ValidationError):
             raise
+        except CloudRemoteExecutionUnavailableError:
+            raise
         except CloudServiceError as e:
-            if CLOUD_REMOTE_EXECUTION_UNAVAILABLE in str(e):
-                raise
             if self.cloud_fallback_policy == "never":
                 raise
             logger.warning("Cloud optimization failed, falling back to local: %s", e)

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import inspect
 import math
-import random
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -23,7 +22,6 @@ from traigent.evaluators.metrics_tracker import (
     MetricsTracker,
     extract_llm_metrics,
 )
-from traigent.utils.env_config import is_mock_llm
 from traigent.utils.exceptions import EvaluationError
 from traigent.utils.langchain_interceptor import (
     clear_captured_responses,
@@ -146,6 +144,7 @@ def _ensure_metadata_capture_patches() -> None:
     patch_litellm_for_metadata_capture()
     _METADATA_PATCHES_ATTEMPTED = True
 
+
 if TYPE_CHECKING:
     from traigent.core.sample_budget import SampleBudgetLease
 
@@ -200,16 +199,16 @@ class LocalEvaluator(BaseEvaluator):
             self.execution_mode_enum.value if self.execution_mode_enum else None
         )
         self.privacy_enabled = privacy_enabled
+        # ``mock_mode_config`` is retained as an accepted parameter for
+        # backward compatibility with public APIs that thread it through
+        # (e.g. ``@traigent.optimize(mock_mode_config=...)``), but it no
+        # longer drives any evaluator behaviour. The previous behaviour
+        # (TRAIGENT_MOCK_LLM-gated fabricated accuracy via
+        # ``_compute_mock_accuracy``) was removed because a stray env var
+        # in production caused real evaluations to be silently replaced
+        # with random.uniform()-based fake scores.
         self.mock_mode_config = mock_mode_config or {}
         self.metric_functions = metric_functions or {}
-        self._mock_mode_warning_shown = (
-            False  # Track if we've shown the mock mode warning
-        )
-
-        # Create seeded random instance for mock mode reproducibility
-        self._mock_random = random.Random()
-        if self.mock_mode_config.get("random_seed") is not None:
-            self._mock_random.seed(self.mock_mode_config["random_seed"])
 
     def _extract_prompt_info(
         self,
@@ -1389,38 +1388,6 @@ class LocalEvaluator(BaseEvaluator):
 
         return result
 
-    def _compute_mock_accuracy(
-        self, actual_output: Any, base_accuracy: float, variance: float
-    ) -> float:
-        """Compute simulated accuracy for mock mode.
-
-        Args:
-            actual_output: Output from function
-            base_accuracy: Base accuracy value (e.g., 0.75)
-            variance: Variance range for randomization
-
-        Returns:
-            Simulated accuracy value between 0.0 and 1.0
-        """
-        if actual_output is None:
-            return 0.0
-
-        adjusted_accuracy = base_accuracy
-        # Simulate better accuracy for certain outputs
-        if isinstance(actual_output, str):
-            if len(actual_output) > 20:  # Longer outputs generally better
-                adjusted_accuracy += 0.05
-            sentiment_words = ["positive", "negative", "neutral"]
-            if any(word in actual_output.lower() for word in sentiment_words):
-                adjusted_accuracy += 0.03  # Sentiment-like outputs
-
-        # Add random variance (using seeded random for reproducibility)
-        half_variance = variance / 2
-        raw_accuracy = adjusted_accuracy + self._mock_random.uniform(
-            -half_variance, half_variance
-        )
-        return min(1.0, max(0.0, raw_accuracy))
-
     def _compute_real_accuracy(self, actual_output: Any, expected_output: Any) -> float:
         """Compute real accuracy by comparing actual vs expected output.
 
@@ -1469,46 +1436,21 @@ class LocalEvaluator(BaseEvaluator):
         """
         metrics = {}
 
-        # Check if we're in mock LLM mode and if it should be applied
-        mock_mode_env = is_mock_llm()
-
-        # Check configuration for mock mode settings
-        mock_enabled = self.mock_mode_config.get("enabled", True)
-        override_evaluator = self.mock_mode_config.get("override_evaluator", True)
-        base_accuracy_config = self.mock_mode_config.get("base_accuracy", 0.75)
-        variance_config = self.mock_mode_config.get("variance", 0.25)
-
-        # Determine if we should actually use mock mode
-        use_mock = mock_mode_env and mock_enabled and override_evaluator
-
-        # Accuracy (exact match or mock)
+        # SECURITY: Always compute real accuracy. The previous
+        # TRAIGENT_MOCK_LLM-gated branch fabricated accuracy via
+        # ``random.uniform()`` plus output-string heuristics, which would
+        # silently replace real evaluation results with fake scores
+        # whenever the env var was set in a production environment.
         if "accuracy" in self.metrics:
-            if use_mock:
-                self._log_mock_mode_warning(base_accuracy_config, variance_config)
-                metrics["accuracy"] = self._compute_mock_accuracy(
-                    actual_output, base_accuracy_config, variance_config
-                )
-            else:
-                metrics["accuracy"] = self._compute_real_accuracy(
-                    actual_output, expected_output
-                )
+            metrics["accuracy"] = self._compute_real_accuracy(
+                actual_output, expected_output
+            )
 
         # Success (whether function completed without error)
         if "success_rate" in self.metrics:
             metrics["success"] = 1.0 if actual_output is not None else 0.0
 
         return metrics
-
-    def _log_mock_mode_warning(self, base_accuracy: float, variance: float) -> None:
-        """Log a one-time warning about mock mode accuracy."""
-        if not self._mock_mode_warning_shown:
-            logger.warning(
-                "MOCK LLM MODE: Metrics are simulated (base=%.2f ± %.2f). "
-                "Set TRAIGENT_MOCK_LLM=false for real evaluations.",
-                base_accuracy,
-                variance / 2,
-            )
-            self._mock_mode_warning_shown = True
 
     def compute_metrics(
         self,

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -959,13 +959,18 @@ def _calculate_cost_for_metrics(
     Uses cost_from_tokens() as the canonical cost path when token counts are
     available, falling back to deprecated text-based functions otherwise.
     """
-    from traigent.utils.env_config import is_mock_llm, is_strict_cost_accounting
+    from traigent.utils.env_config import is_strict_cost_accounting
 
-    mock_mode = is_mock_llm()
     strict_cost_accounting = is_strict_cost_accounting()
+    # NOTE: ``TRAIGENT_MOCK_LLM`` no longer suppresses cost calculation here
+    # (S2-B retirement of the mock flag). Cost is always computed from the
+    # real token counts so that production traces reflect real spend even if
+    # a stale env var leaks into a deployed environment. ``TRAIGENT_GENERATE_MOCKS``
+    # is preserved because it is an internal fixture-recording knob, not a
+    # user-facing mock-LLM toggle.
     generate_mocks_env = os.environ.get("TRAIGENT_GENERATE_MOCKS", "").lower()
 
-    if mock_mode or generate_mocks_env == "true":
+    if generate_mocks_env == "true":
         _handle_mock_mode(metrics, prompt_length, response_length)
         return
 

--- a/traigent/integrations/bedrock_client.py
+++ b/traigent/integrations/bedrock_client.py
@@ -100,10 +100,6 @@ class BedrockChatClient:
     def _ensure_client(self):  # pragma: no cover - network client guard
         if self._client is not None:
             return self._client
-        if os.getenv("BEDROCK_MOCK", "").strip().lower() == "true":
-            # Mock mode: no real client needed
-            self._client = object()
-            return self._client
         boto3 = _require_boto3()
         if self._profile_name:
             session = boto3.session.Session(profile_name=self._profile_name)
@@ -152,33 +148,19 @@ class BedrockChatClient:
         if extra_params:
             payload.update(dict(extra_params))
 
-        if os.getenv("BEDROCK_MOCK", "").strip().lower() == "true":
-            # Deterministic mock response echoes last user content
-            msgs = _coerce_user_messages(messages)
-            last = (
-                msgs[-1]["content"][0]["text"]
-                if msgs and msgs[-1].get("content")
-                else ""
-            )
-            data: dict[str, Any] = {
-                "mock": True,
-                "content": [{"type": "text", "text": f"[MOCK:{model_id}] {last}"}],
-                "usage": {"input_tokens": 0, "output_tokens": min(max_tokens, 16)},
-            }
-        else:
-            resp = client.invoke_model(
-                modelId=model_id,
-                accept="application/json",
-                contentType="application/json",
-                body=json.dumps(payload),
-            )
+        resp = client.invoke_model(
+            modelId=model_id,
+            accept="application/json",
+            contentType="application/json",
+            body=json.dumps(payload),
+        )
 
-            # `body` can be streaming-like; ensure we read and parse JSON
-            raw_body = resp.get("body")
-            if hasattr(raw_body, "read"):
-                data = json.loads(raw_body.read())
-            else:
-                data = json.loads(raw_body)
+        # `body` can be streaming-like; ensure we read and parse JSON
+        raw_body = resp.get("body")
+        if hasattr(raw_body, "read"):
+            data = json.loads(raw_body.read())
+        else:
+            data = json.loads(raw_body)
 
         text = _extract_text_from_messages_response(data)
         usage = data.get("usage") if isinstance(data, Mapping) else None
@@ -195,14 +177,11 @@ class BedrockChatClient:
     ) -> BedrockChatResponse:
         """Invoke an AI21 Jamba family model via Bedrock."""
 
-        prompt_text: str
         if isinstance(messages, str):
             request_messages = [{"role": "user", "content": messages}]
-            prompt_text = messages
         else:
             coalesced = _coerce_user_messages(messages)
             request_messages = []
-            combined_pieces: list[str] = []
             for item in coalesced:
                 role = str(item.get("role", "user"))
                 content = item.get("content", "")
@@ -215,17 +194,6 @@ class BedrockChatClient:
                 else:
                     text = str(content)
                 request_messages.append({"role": role, "content": text})
-                if text:
-                    combined_pieces.append(text)
-            prompt_text = "\n".join(combined_pieces)
-
-        if os.getenv("BEDROCK_MOCK", "").strip().lower() == "true":
-            usage: Mapping[str, Any] | None = {
-                "input_tokens": len(prompt_text.split()),
-                "output_tokens": min(max_tokens, 32),
-            }
-            text = f"[MOCK:{model_id}] {prompt_text.strip()}"
-            return BedrockChatResponse(text=text, raw={"mock": True}, usage=usage)
 
         client = self._ensure_client()
         payload = {
@@ -287,44 +255,28 @@ class BedrockChatClient:
             payload.update(dict(extra_params))
 
         final_text_parts: list[str] = []
-        if os.getenv("BEDROCK_MOCK", "").strip().lower() == "true":
-            msgs = _coerce_user_messages(messages)
-            last = (
-                msgs[-1]["content"][0]["text"]
-                if msgs and msgs[-1].get("content")
-                else ""
-            )
-            chunks = [
-                f"[MOCK:{model_id}] ",
-                last[: max(1, len(last) // 2)],
-                last[max(1, len(last) // 2) :],
-            ]
-            for piece in chunks:
-                final_text_parts.append(piece)
-                yield piece
-        else:
-            resp = client.invoke_model_with_response_stream(
-                modelId=model_id,
-                accept="application/json",
-                contentType="application/json",
-                body=json.dumps(payload),
-            )
+        resp = client.invoke_model_with_response_stream(
+            modelId=model_id,
+            accept="application/json",
+            contentType="application/json",
+            body=json.dumps(payload),
+        )
 
-            stream = resp.get("body")
-            if stream is not None:
-                for event in stream:
-                    chunk = event.get("chunk") if isinstance(event, Mapping) else None
-                    if not chunk:
-                        continue
-                    try:
-                        data = json.loads(chunk.get("bytes").decode("utf-8"))
-                    except Exception:  # noqa: BLE001 - defensive
-                        continue
-                    # Extract incremental text if present
-                    text_piece = _extract_text_from_messages_response(data)
-                    if text_piece:
-                        final_text_parts.append(text_piece)
-                        yield text_piece
+        stream = resp.get("body")
+        if stream is not None:
+            for event in stream:
+                chunk = event.get("chunk") if isinstance(event, Mapping) else None
+                if not chunk:
+                    continue
+                try:
+                    data = json.loads(chunk.get("bytes").decode("utf-8"))
+                except Exception:  # noqa: BLE001 - defensive
+                    continue
+                # Extract incremental text if present
+                text_piece = _extract_text_from_messages_response(data)
+                if text_piece:
+                    final_text_parts.append(text_piece)
+                    yield text_piece
 
         final = "".join(final_text_parts)
         return BedrockChatResponse(text=final, raw={"streamed": True}, usage=None)
@@ -344,23 +296,6 @@ class BedrockChatClient:
         Uses aioboto3 for true async or falls back to thread-pool executor.
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
-        # Check for mock mode first
-        if os.getenv("BEDROCK_MOCK", "").strip().lower() == "true":
-            msgs = _coerce_user_messages(messages)
-            last = (
-                msgs[-1]["content"][0]["text"]
-                if msgs and msgs[-1].get("content")
-                else ""
-            )
-            data: dict[str, Any] = {
-                "mock": True,
-                "content": [{"type": "text", "text": f"[MOCK:{model_id}] {last}"}],
-                "usage": {"input_tokens": 0, "output_tokens": min(max_tokens, 16)},
-            }
-            text = _extract_text_from_messages_response(data)
-            usage = data.get("usage") if isinstance(data, Mapping) else None
-            return BedrockChatResponse(text=text, raw=data, usage=usage)
-
         # Try aioboto3 for true async
         try:
             import aioboto3  # noqa: F401 - used for availability check and async method
@@ -452,23 +387,6 @@ class BedrockChatClient:
         Uses aioboto3 for true async streaming or falls back to sync streaming
         wrapped in an executor.
         """
-        # Check for mock mode first
-        if os.getenv("BEDROCK_MOCK", "").strip().lower() == "true":
-            msgs = _coerce_user_messages(messages)
-            last = (
-                msgs[-1]["content"][0]["text"]
-                if msgs and msgs[-1].get("content")
-                else ""
-            )
-            chunks = [
-                f"[MOCK:{model_id}] ",
-                last[: max(1, len(last) // 2)],
-                last[max(1, len(last) // 2) :],
-            ]
-            for piece in chunks:
-                yield piece
-            return
-
         # Try aioboto3 for true async streaming
         try:
             import aioboto3  # noqa: F401 - used for availability check and async stream
@@ -567,8 +485,6 @@ def resolve_default_bedrock_model_id(model_hint: str | None) -> str:
     Allows environment override via `BEDROCK_MODEL_ID`. Fallback mapping supports
     common Claude variants used in our experiments.
     """
-
-    import os
 
     override = os.getenv("BEDROCK_MODEL_ID")
     if override:

--- a/traigent/integrations/llms/litellm_plugin.py
+++ b/traigent/integrations/llms/litellm_plugin.py
@@ -55,7 +55,7 @@ class LiteLLMPlugin(LLMPlugin):
         return {
             # LiteLLM routing parameters
             "api_base": "api_base",
-            "api_key": "api_key",
+            "api_key": "api_key",  # pragma: allowlist secret
             "custom_llm_provider": "custom_llm_provider",
             # Response format
             "response_format": "response_format",

--- a/traigent/integrations/utils/__init__.py
+++ b/traigent/integrations/utils/__init__.py
@@ -10,11 +10,7 @@ from traigent.integrations.utils.message_coercion import (
     coerce_to_gemini_format,
     coerce_to_openai_format,
 )
-from traigent.integrations.utils.mock_adapter import (
-    MockAdapter,
-    MockResponse,
-    with_mock_support,
-)
+from traigent.integrations.utils.mock_adapter import MockAdapter, MockResponse
 from traigent.integrations.utils.parameter_normalizer import (
     Framework,
     ParameterAlias,
@@ -45,5 +41,4 @@ __all__ = [
     # Mock adapter
     "MockAdapter",
     "MockResponse",
-    "with_mock_support",
 ]

--- a/traigent/integrations/utils/mock_adapter.py
+++ b/traigent/integrations/utils/mock_adapter.py
@@ -2,6 +2,15 @@
 
 Provides a lightweight mock adapter pattern that keeps main plugin
 logic clean by separating mock functionality into dedicated methods.
+
+Security:
+    Mock activation is NEVER controlled by environment variables. Mock
+    responses are only produced when callers explicitly invoke
+    ``MockAdapter.get_mock_response(...)`` (typically from test code that
+    has already patched the LLM client at the integration boundary).
+    ``is_mock_enabled`` always returns ``False`` to guarantee that no
+    production code path can be silently swapped for fake responses by
+    setting an env var such as ``TRAIGENT_MOCK_LLM`` or ``OPENAI_MOCK``.
 """
 
 # Traceability: CONC-Layer-Integration FUNC-INTEGRATIONS REQ-INT-008
@@ -10,14 +19,13 @@ import asyncio
 import logging
 import os
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
 # Default mock delay in milliseconds (0 = no delay)
-# Set TRAIGENT_MOCK_DELAY_MS to simulate realistic LLM latency
+# Set TRAIGENT_MOCK_DELAY_MS to simulate realistic LLM latency in tests.
 DEFAULT_MOCK_DELAY_MS = 0
 
 
@@ -37,20 +45,6 @@ def _get_mock_delay_ms() -> int:
     except ValueError:
         logger.warning(f"Invalid TRAIGENT_MOCK_DELAY_MS value '{delay_str}', using 0")
         return 0
-
-
-# Environment variable names for each provider
-MOCK_ENV_VARS = {
-    "openai": "OPENAI_MOCK",
-    "azure_openai": "AZURE_OPENAI_MOCK",
-    "anthropic": "ANTHROPIC_MOCK",
-    "gemini": "GEMINI_MOCK",
-    "cohere": "COHERE_MOCK",
-    "huggingface": "HUGGINGFACE_MOCK",
-    "bedrock": "BEDROCK_MOCK",
-    # Global override
-    "traigent": "TRAIGENT_MOCK_LLM",
-}
 
 
 @dataclass
@@ -73,39 +67,37 @@ class MockResponse:
 class MockAdapter:
     """Lightweight mock adapter for testing without API calls.
 
-    Usage in plugins:
-        if MockAdapter.is_mock_enabled("openai"):
-            return MockAdapter.get_mock_response("openai", **kwargs)
+    Mock activation is **never** auto-enabled via environment variables.
+    Tests that need a mock response must call
+    ``MockAdapter.get_mock_response(...)`` directly (e.g. from inside a
+    ``unittest.mock.patch`` that replaces the real client method).
 
-    This keeps mock logic separate from main plugin code.
+    ``is_mock_enabled`` is preserved as a stub that always returns
+    ``False`` so any production interceptor that previously consulted it
+    will now always take the real-LLM path. Callers wanting mock
+    behaviour from tests must patch the underlying client instead.
     """
 
     _pending_tasks: ClassVar[set[asyncio.Task]] = set()
 
     @classmethod
     def is_mock_enabled(cls, provider: str) -> bool:
-        """Check if mock mode is enabled for a provider.
+        """Always returns ``False``.
 
-        Checks both provider-specific and global mock env vars.
+        Historically this consulted ``TRAIGENT_MOCK_LLM`` and a set of
+        provider-specific ``*_MOCK`` environment variables. That env-toggle
+        was removed because a stray env var in production caused real LLM
+        calls to be silently replaced with canned mock text. Tests must
+        patch the LLM client (or call ``get_mock_response`` directly)
+        rather than relying on a global flag.
 
         Args:
-            provider: Provider name (openai, anthropic, gemini, etc.)
+            provider: Provider name (kept for signature compatibility).
 
         Returns:
-            True if mock mode is enabled.
+            Always ``False``.
         """
-        # Check global mock LLM mode first
-        global_mock = os.getenv("TRAIGENT_MOCK_LLM", "").lower()
-        if global_mock in ("true", "1", "yes"):
-            return True
-
-        # Check provider-specific mock
-        env_var = MOCK_ENV_VARS.get(provider.lower())
-        if env_var:
-            provider_mock = os.getenv(env_var, "").lower()
-            if provider_mock in ("true", "1", "yes"):
-                return True
-
+        del provider  # signature compatibility only
         return False
 
     @classmethod
@@ -148,6 +140,11 @@ class MockAdapter:
         **kwargs: Any,
     ) -> Any:
         """Get a provider-appropriate mock response object.
+
+        This method is intended to be invoked **explicitly** from test
+        code (e.g. inside a ``unittest.mock.patch`` of the real client).
+        It is no longer reachable from any production code path via an
+        environment toggle.
 
         Args:
             provider: Provider name.
@@ -278,33 +275,3 @@ class MockAdapter:
                 "total_tokens": data.total_tokens,
             },
         }
-
-
-def with_mock_support(provider: str) -> Callable:
-    """Decorator to add mock support to a function.
-
-    Usage:
-        @with_mock_support("openai")
-        def create_completion(**kwargs):
-            # Real implementation
-            ...
-
-    Args:
-        provider: Provider name for mock lookup.
-
-    Returns:
-        Decorator function.
-    """
-
-    def decorator(func: Callable) -> Callable:
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            if MockAdapter.is_mock_enabled(provider):
-                logger.debug(
-                    f"Mock mode enabled for {provider}, returning mock response"
-                )
-                return MockAdapter.get_mock_response(provider, **kwargs)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator

--- a/traigent/optimizers/remote.py
+++ b/traigent/optimizers/remote.py
@@ -4,9 +4,9 @@ This optimizer integrates with a remote suggestion service when available.
 It is designed to be privacy-aware: only metadata (e.g., indices, metrics)
 should be sent upstream when `privacy_enabled` is True.
 
-Note: Remote optimization requires cloud or hybrid mode, which are not yet
-supported in the open-source SDK. This optimizer is reserved for future
-enterprise features.
+Note: Remote suggestion services are reserved for future enterprise features.
+Use `execution_mode="hybrid"` for the supported portal-tracked path where
+trials still execute locally.
 """
 
 # Traceability: CONC-Layer-Integration CONC-Quality-Reliability CONC-Quality-Performance FUNC-OPT-ALGORITHMS FUNC-CLOUD-HYBRID REQ-OPT-ALG-004 REQ-CLOUD-009 SYNC-CloudHybrid
@@ -26,8 +26,7 @@ logger = get_logger(__name__)
 class RemoteOptimizer(BaseOptimizer):
     """Optimizer that can request suggestions from a remote service.
 
-    Note: Remote optimization requires cloud or hybrid execution mode, which
-    are not yet supported in the open-source SDK. This optimizer currently
+    Note: Remote optimization is not implemented yet. This optimizer currently
     uses a local RandomSearchOptimizer as a placeholder.
 
     - Async suggestion APIs are provided to align with remote access patterns.

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -9,6 +9,7 @@ import json
 import re
 import threading
 import uuid
+import warnings
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -17,6 +18,18 @@ from typing import Any
 from ..utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+_COMPLIANCE_NOT_IMPLEMENTED = (
+    "Compliance reporting subsystem is not yet implemented; do not call in production"
+)
+_PERSISTENT_STORAGE_NOT_IMPLEMENTED = (
+    "Persistent audit storage is not yet implemented; "
+    "construct AuditStorage() with no arguments to use the in-memory variant"
+)
+_TAMPER_DETECTION_NOT_IMPLEMENTED = (
+    "Tamper-detection is not yet implemented; verify_integrity will be available "
+    "in a future release"
+)
 
 
 class AuditSeverity(Enum):
@@ -485,131 +498,37 @@ class ComplianceReporter:
         self, start_date: datetime, end_date: datetime
     ) -> dict[str, Any]:
         """Generate SOC 2 Type II compliance report."""
-        events = [
-            e for e in self.audit_logger.events if start_date <= e.timestamp <= end_date
-        ]
-
-        return {
-            "report_type": "SOC 2 Type II",
-            "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
-            "total_events": len(events),
-            "security_events": len(
-                [e for e in events if "security" in e.event_type.value]
-            ),
-            "access_events": len([e for e in events if "access" in e.event_type.value]),
-            "data_events": len([e for e in events if "data" in e.event_type.value]),
-            "controls_tested": {
-                "access_control": self._test_access_control(events),
-                "change_management": self._test_change_management(events),
-                "data_protection": self._test_data_protection(events),
-                "monitoring": self._test_monitoring(events),
-            },
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def generate_gdpr_report(
         self, start_date: datetime, end_date: datetime
     ) -> dict[str, Any]:
         """Generate GDPR compliance report."""
-        events = [
-            e for e in self.audit_logger.events if start_date <= e.timestamp <= end_date
-        ]
-
-        data_events = [
-            e
-            for e in events
-            if e.event_type
-            in [
-                AuditEventType.DATA_CREATED,
-                AuditEventType.DATA_READ,
-                AuditEventType.DATA_UPDATED,
-                AuditEventType.DATA_DELETED,
-                AuditEventType.DATA_EXPORTED,
-            ]
-        ]
-
-        return {
-            "report_type": "GDPR Compliance",
-            "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
-            "data_processing_activities": len(data_events),
-            "data_exports": len(
-                [e for e in events if e.event_type == AuditEventType.DATA_EXPORTED]
-            ),
-            "deletion_requests": len(
-                [e for e in events if e.event_type == AuditEventType.DATA_DELETED]
-            ),
-            "consent_management": self._analyze_consent_management(events),
-            "data_breach_incidents": self._analyze_security_incidents(events),
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _test_access_control(self, events: list[AuditEvent]) -> dict[str, Any]:
         """Test access control effectiveness."""
-        access_events = [e for e in events if "access" in e.event_type.value]
-        denied_events = [e for e in access_events if e.result == "denied"]
-
-        return {
-            "total_access_attempts": len(access_events),
-            "denied_attempts": len(denied_events),
-            "denial_rate": len(denied_events) / max(1, len(access_events)),
-            "status": "compliant" if len(denied_events) > 0 else "review_required",
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _test_change_management(self, events: list[AuditEvent]) -> dict[str, Any]:
         """Test change management controls."""
-        config_events = [
-            e for e in events if e.event_type == AuditEventType.CONFIGURATION_CHANGED
-        ]
-
-        return {
-            "configuration_changes": len(config_events),
-            "authorized_changes": len([e for e in config_events if e.user_id]),
-            "status": "compliant",
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _test_data_protection(self, events: list[AuditEvent]) -> dict[str, Any]:
         """Test data protection controls."""
-        data_events = [e for e in events if "data" in e.event_type.value]
-
-        return {
-            "data_operations": len(data_events),
-            "encrypted_operations": len(
-                [e for e in data_events if e.details.get("encrypted", False)]
-            ),
-            "status": "compliant",
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _test_monitoring(self, events: list[AuditEvent]) -> dict[str, Any]:
         """Test monitoring effectiveness."""
-        security_events = [e for e in events if "security" in e.event_type.value]
-
-        return {
-            "security_events_detected": len(security_events),
-            "response_time_avg": "< 5 minutes",  # Simplified
-            "status": "compliant",
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _analyze_consent_management(self, events: list[AuditEvent]) -> dict[str, Any]:
         """Analyze consent management for GDPR."""
-        return {
-            "consent_recorded": True,
-            "consent_withdrawals": 0,
-            "legal_basis_documented": True,
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _analyze_security_incidents(self, events: list[AuditEvent]) -> dict[str, Any]:
         """Analyze security incidents."""
-        security_events = [
-            e
-            for e in events
-            if e.event_type
-            in [AuditEventType.SECURITY_VIOLATION, AuditEventType.SUSPICIOUS_ACTIVITY]
-        ]
-
-        return {
-            "total_incidents": len(security_events),
-            "high_severity": 0,
-            "breach_notification_required": False,
-            "incidents_resolved": len(security_events),
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def generate_report(
         self,
@@ -619,76 +538,32 @@ class ComplianceReporter:
         tenant_id: str | None = None,
     ) -> dict[str, Any]:
         """Generate compliance report for specified framework."""
-        if framework == ComplianceFramework.SOC2:
-            return self._generate_soc2_report(start_date, end_date, tenant_id)
-        elif framework == ComplianceFramework.ISO27001:
-            return self._generate_iso27001_report(start_date, end_date, tenant_id)
-        elif framework == ComplianceFramework.GDPR:
-            return self._generate_gdpr_report(start_date, end_date, tenant_id)
-        else:
-            raise ValueError(f"Unsupported compliance framework: {framework}") from None
+        if framework in (
+            ComplianceFramework.SOC2,
+            ComplianceFramework.ISO27001,
+            ComplianceFramework.GDPR,
+        ):
+            raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
+
+        raise ValueError(f"Unsupported compliance framework: {framework}") from None
 
     def _generate_soc2_report(
         self, start_date: datetime, end_date: datetime, tenant_id: str | None = None
     ) -> dict[str, Any]:
         """Generate SOC 2 Type II compliance report."""
-        events = self._get_events_for_period(start_date, end_date, tenant_id)
-
-        return {
-            "framework": "SOC 2 Type II",
-            "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
-            "total_events": len(events),
-            "trust_service_criteria": {
-                "security": self._test_access_control(events),
-                "availability": self._test_monitoring(events),
-                "processing_integrity": self._test_change_management(events),
-                "confidentiality": self._test_data_protection(events),
-                "privacy": self._test_data_protection(events),
-            },
-            "summary": {"compliant": True, "recommendations": [], "tested_controls": 5},
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _generate_iso27001_report(
         self, start_date: datetime, end_date: datetime, tenant_id: str | None = None
     ) -> dict[str, Any]:
         """Generate ISO 27001 compliance report."""
-        events = self._get_events_for_period(start_date, end_date, tenant_id)
-
-        return {
-            "framework": "ISO 27001:2013",
-            "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
-            "total_events": len(events),
-            "control_objectives": {
-                "access_control": self._test_access_control(events),
-                "incident_management": self._analyze_security_incidents(events),
-                "information_security": self._test_data_protection(events),
-                "business_continuity": self._test_monitoring(events),
-            },
-            "summary": {"compliant": True, "risk_level": "low", "controls_tested": 4},
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _generate_gdpr_report(
         self, start_date: datetime, end_date: datetime, tenant_id: str | None = None
     ) -> dict[str, Any]:
         """Generate GDPR compliance report."""
-        events = self._get_events_for_period(start_date, end_date, tenant_id)
-
-        return {
-            "framework": "GDPR (EU) 2016/679",
-            "period": f"{start_date.isoformat()} to {end_date.isoformat()}",
-            "total_events": len(events),
-            "data_protection_principles": {
-                "lawfulness": self._analyze_consent_management(events),
-                "data_subject_rights": self._analyze_data_subject_requests(events),
-                "data_security": self._test_data_protection(events),
-                "breach_notification": self._analyze_security_incidents(events),
-            },
-            "summary": {
-                "compliant": True,
-                "data_subject_requests": 0,
-                "breach_notifications": 0,
-            },
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _get_events_for_period(
         self, start_date: datetime, end_date: datetime, tenant_id: str | None = None
@@ -709,62 +584,11 @@ class ComplianceReporter:
         self, events: list[AuditEvent]
     ) -> dict[str, Any]:
         """Analyze data subject requests for GDPR."""
-        gdpr_events = [e for e in events if e.event_type == AuditEventType.GDPR_REQUEST]
-
-        return {
-            "total_requests": len(gdpr_events),
-            "fulfilled_requests": len(gdpr_events),  # Assume all fulfilled for testing
-            "average_response_time": "< 30 days",
-            "compliant": True,
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def get_compliance_dashboard(self) -> dict[str, Any]:
         """Generate compliance dashboard with metrics."""
-        # Get events from storage to include manually added test events
-        all_events = self.audit_logger.storage.events
-        recent_events = [
-            e
-            for e in all_events
-            if e.timestamp >= datetime.now(UTC) - timedelta(days=30)
-        ]
-
-        critical_events = [
-            e for e in recent_events if e.severity == AuditSeverity.CRITICAL
-        ]
-        failed_logins = [
-            e for e in recent_events if e.event_type == AuditEventType.LOGIN_FAILURE
-        ]
-        data_events = [e for e in recent_events if "data" in e.event_type.value.lower()]
-
-        # Calculate compliance score (simplified)
-        total_critical = len(critical_events)
-        compliance_score = max(
-            0, 100 - (total_critical * 10)
-        )  # Deduct points for critical events
-
-        return {
-            "period": "Last 30 days",
-            "metrics": {
-                "total_events": len(recent_events),
-                "critical_events": total_critical,
-                "failed_logins": len(failed_logins),
-                "data_access_events": len(data_events),
-                "compliance_score": compliance_score,
-            },
-            "frameworks_status": {
-                "soc2": "compliant",
-                "gdpr": "compliant",
-                "iso27001": "compliant",
-            },
-            "recent_alerts": [
-                {
-                    "severity": e.severity.value if e.severity else "low",
-                    "message": e.message,
-                    "timestamp": e.timestamp.isoformat(),
-                }
-                for e in critical_events[:5]  # Show last 5 critical events
-            ],
-        }
+        raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
 
 class SecurityMonitor:
@@ -874,8 +698,10 @@ class EventProcessor:
 class AuditStorage:
     """Storage backend for audit events."""
 
-    def __init__(self, storage_path: str = "audit_logs") -> None:
+    def __init__(self, storage_path: str | None = None) -> None:
         """Initialize storage backend."""
+        if storage_path is not None:
+            raise NotImplementedError(_PERSISTENT_STORAGE_NOT_IMPLEMENTED)
         self.storage_path = storage_path
         self.events: list[Any] = []  # In-memory storage for testing
 
@@ -887,6 +713,12 @@ class AuditStorage:
         self, start_time: datetime | None = None, end_time: datetime | None = None
     ) -> list[AuditEvent]:
         """Retrieve audit events."""
+        if start_time is not None or end_time is not None:
+            warnings.warn(
+                "AuditStorage.retrieve_events ignores time filters; use get_events() "
+                "for filtered in-memory reads",
+                stacklevel=2,
+            )
         return self.events
 
     def get_events(
@@ -955,4 +787,4 @@ class AuditLogIntegrity:
 
     def verify_integrity(self) -> bool:
         """Verify audit log integrity."""
-        return True
+        raise NotImplementedError(_TAMPER_DETECTION_NOT_IMPLEMENTED)

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -23,8 +23,8 @@ _COMPLIANCE_NOT_IMPLEMENTED = (
     "Compliance reporting subsystem is not yet implemented; do not call in production"
 )
 _PERSISTENT_STORAGE_NOT_IMPLEMENTED = (
-    "Persistent audit storage is not yet implemented; "
-    "construct AuditStorage() with no arguments to use the in-memory variant"
+    "Persistent audit storage is not yet implemented; AuditStorage accepts "
+    "storage_path for compatibility but stores events in memory"
 )
 _TAMPER_DETECTION_NOT_IMPLEMENTED = (
     "Tamper-detection is not yet implemented; verify_integrity will be available "
@@ -701,12 +701,16 @@ class EventProcessor:
 
 
 class AuditStorage:
-    """Storage backend for audit events."""
+    """In-memory storage backend for audit events.
 
-    def __init__(self, storage_path: str | None = None) -> None:
+    ``storage_path`` is accepted for backward compatibility with callers that
+    previously constructed ``AuditStorage("audit_logs")``. This class does not
+    implement file-backed persistence yet; it records the configured path for
+    diagnostics while keeping events in memory.
+    """
+
+    def __init__(self, storage_path: str | None = "audit_logs") -> None:
         """Initialize storage backend."""
-        if storage_path is not None:
-            raise NotImplementedError(_PERSISTENT_STORAGE_NOT_IMPLEMENTED)
         self.storage_path = storage_path
         self.events: list[Any] = []  # In-memory storage for testing
 

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -777,7 +777,13 @@ class AuditStorage:
 
 
 class AuditLogIntegrity:
-    """Ensures audit log integrity and tamper detection."""
+    """Audit log integrity summary and future tamper-detection entry point.
+
+    ``AuditStorage.verify_integrity()`` can return event-count/hash metadata
+    today. Active tamper detection is not implemented in this release, so
+    ``AuditLogIntegrity.verify_integrity()`` intentionally raises
+    ``NotImplementedError`` instead of returning a misleading boolean.
+    """
 
     def __init__(self, event_count: int = 0, log_hash: str | None = None) -> None:
         """Initialize audit log integrity manager."""
@@ -791,5 +797,5 @@ class AuditLogIntegrity:
         return hashlib.sha256(event_data.encode()).hexdigest()
 
     def verify_integrity(self) -> bool:
-        """Verify audit log integrity."""
+        """Raise until active tamper detection is implemented."""
         raise NotImplementedError(_TAMPER_DETECTION_NOT_IMPLEMENTED)

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -488,7 +488,12 @@ class AuditLogger:
 
 
 class ComplianceReporter:
-    """Generates compliance reports for various standards."""
+    """Compliance report entry points.
+
+    Report generation is intentionally fail-loud until the real reporting
+    subsystem ships; callers must handle ``NotImplementedError`` instead of
+    consuming synthetic compliance data.
+    """
 
     def __init__(self, audit_logger: AuditLogger) -> None:
         """Initialize compliance reporter."""
@@ -497,13 +502,13 @@ class ComplianceReporter:
     def generate_soc2_report(
         self, start_date: datetime, end_date: datetime
     ) -> dict[str, Any]:
-        """Generate SOC 2 Type II compliance report."""
+        """Raise until SOC 2 Type II report generation is implemented."""
         raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def generate_gdpr_report(
         self, start_date: datetime, end_date: datetime
     ) -> dict[str, Any]:
-        """Generate GDPR compliance report."""
+        """Raise until GDPR report generation is implemented."""
         raise NotImplementedError(_COMPLIANCE_NOT_IMPLEMENTED)
 
     def _test_access_control(self, events: list[AuditEvent]) -> dict[str, Any]:
@@ -537,7 +542,7 @@ class ComplianceReporter:
         end_date: datetime,
         tenant_id: str | None = None,
     ) -> dict[str, Any]:
-        """Generate compliance report for specified framework."""
+        """Raise until real compliance report generation is implemented."""
         if framework in (
             ComplianceFramework.SOC2,
             ComplianceFramework.ISO27001,

--- a/traigent/security/encryption.py
+++ b/traigent/security/encryption.py
@@ -21,24 +21,15 @@ try:
 
     CRYPTO_AVAILABLE = True
     Fernet = _Fernet
-except ImportError:
-    CRYPTO_AVAILABLE = False
-    AESGCM = object
-
-    # Mock classes for when cryptography is not available
-    class Fernet:  # type: ignore[no-redef]
-        @staticmethod
-        def generate_key():
-            return b"mock_key"
-
-        def __init__(self, key) -> None:
-            self.key = key
-
-        def encrypt(self, data):
-            return b"encrypted_" + data
-
-        def decrypt(self, data):
-            return data[10:]  # Remove "encrypted_" prefix
+except ImportError as exc:  # pragma: no cover - fail-closed import guard
+    # SECURITY: Do not provide a silent mock fallback. Fake "encrypted_" prefix
+    # encryption masquerading as real crypto is a serious security issue. Fail
+    # closed and force callers to install the real cryptography library.
+    raise ImportError(
+        "Encryption requires `cryptography>=46.0`. "
+        "Install with `pip install cryptography`. "
+        "The fake fallback was removed in favor of fail-closed behavior."
+    ) from exc
 
 
 from ..utils.logging import get_logger
@@ -210,25 +201,15 @@ class EncryptionManager:
                 self._zeroize_key_buffer(key_buffer)
         else:
             self._zeroize_key_buffer(key_buffer)
-            # Mock encryption: ONLY allowed in test/mock mode
-            mock_mode = os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in (
-                "true",
-                "1",
+            # SECURITY: No mock-encryption fallback. The previous fallback was
+            # gated by TRAIGENT_MOCK_LLM and emitted ``b"mock_" + plaintext``,
+            # which is not encryption at all and silently exposed plaintext as
+            # ciphertext if the env var was ever set in production. Always
+            # require real crypto.
+            raise RuntimeError(
+                "Encryption requires the 'cryptography' package. "
+                "Install it with: pip install 'traigent[security]'"
             )
-            if not mock_mode:
-                raise RuntimeError(
-                    "Encryption requires the 'cryptography' package. "
-                    "Install it with: pip install 'traigent[security]'"
-                )
-            logger.warning(
-                "Using mock encryption - cryptography library not available. "
-                "This is only safe in test/mock mode."
-            )
-            iv = os.urandom(12)
-            ciphertext = (
-                b"mock_" + data_bytes
-            )  # NOSONAR — test-only, gated by TRAIGENT_MOCK_LLM
-            tag = os.urandom(16)
 
         return {
             "ciphertext": ciphertext,
@@ -303,25 +284,16 @@ class EncryptionManager:
                 self._zeroize_key_buffer(key_buffer)
         else:
             self._zeroize_key_buffer(key_buffer)
-            # Mock decryption: ONLY allowed in test/mock mode
-            mock_mode = os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in (
-                "true",
-                "1",
+            # SECURITY: No mock-decryption fallback. The previous fallback was
+            # gated by TRAIGENT_MOCK_LLM and stripped ``b"mock_"`` /
+            # ``b"encrypted_"`` prefixes (or simply returned the input) — i.e.
+            # it never decrypted anything, but masquerading as decrypt() it
+            # would silently surface attacker-supplied data on a system with
+            # the env var set. Always require real crypto.
+            raise RuntimeError(
+                "Decryption requires the 'cryptography' package. "
+                "Install it with: pip install 'traigent[security]'"
             )
-            if not mock_mode:
-                raise RuntimeError(
-                    "Decryption requires the 'cryptography' package. "
-                    "Install it with: pip install 'traigent[security]'"
-                )
-            logger.warning(
-                "Using mock decryption - cryptography library not available. "
-                "This is only safe in test/mock mode."
-            )
-            if ciphertext.startswith(b"mock_"):  # NOSONAR — test-only mock decryption
-                return ciphertext[5:]
-            if ciphertext.startswith(b"encrypted_"):  # NOSONAR — legacy mock compat
-                return ciphertext[10:]
-            return ciphertext
 
     def encrypt_file(
         self,

--- a/traigent/traigent_client.py
+++ b/traigent/traigent_client.py
@@ -71,8 +71,8 @@ class TraigentClient:
 
     This client automatically detects and uses the appropriate execution mode:
     - Local: Everything runs locally (no backend connection)
-    - Hybrid: Local execution with metric submission to backend
-    - SaaS: Full backend execution
+    - Hybrid: Local execution with metric submission to backend/portal tracking
+    - Cloud: Reserved for future remote execution; not available yet
     """
 
     def __init__(
@@ -91,7 +91,7 @@ class TraigentClient:
             agent_builder: Agent builder instance for local execution
 
         Note:
-            Cloud module is only required for 'hybrid', 'standard', and 'cloud' modes.
+            Cloud module is only required for 'hybrid' mode.
             Edge analytics mode works without cloud dependencies installed.
         """
         from traigent.config.backend_config import BackendConfig
@@ -165,7 +165,7 @@ class TraigentClient:
             )
 
         # Determine execution strategy
-        if self.execution_mode == ExecutionMode.STANDARD:
+        if self.execution_mode == ExecutionMode.HYBRID:
             return await self._optimize_hybrid(
                 function,
                 dataset,
@@ -176,14 +176,11 @@ class TraigentClient:
                 config_defaults,
             )
         elif self.execution_mode == ExecutionMode.CLOUD:
-            return await self._optimize_saas(
-                function,
-                dataset,
-                configuration_space,
-                objectives,
-                max_trials,
-                optimization_config or {},
-                config_defaults,
+            from traigent.cloud.client import CLOUD_REMOTE_EXECUTION_UNAVAILABLE
+
+            raise OptimizationError(
+                f"{CLOUD_REMOTE_EXECUTION_UNAVAILABLE} "
+                "Cloud mode will be enabled when remote agent execution is implemented."
             )
         else:
             # Edge Analytics mode
@@ -206,11 +203,11 @@ class TraigentClient:
         optimization_config: dict[str, Any | None],
         config_defaults: dict[str, Any],
     ) -> dict[str, Any]:
-        """Standard mode: local execution with backend orchestration.
+        """Hybrid mode: local execution with backend orchestration/tracking.
 
         Data never leaves the client, only metrics are submitted.
         """
-        logger.info("Starting standard mode optimization")
+        logger.info("Starting hybrid mode optimization")
 
         async with self.backend_client:
             # Create hybrid session
@@ -238,7 +235,7 @@ class TraigentClient:
             async with OptimizerDirectClient(endpoint, token) as optimizer:
                 # Initialize local execution adapter
                 if not self.agent_builder:
-                    raise ValueError("Agent builder required for standard mode")
+                    raise ValueError("Agent builder required for hybrid mode")
 
                 adapter = LocalExecutionAdapter(self.agent_builder)
 
@@ -302,7 +299,7 @@ class TraigentClient:
                 if best_result and not final_results.get("best_configuration"):
                     final_results["best_configuration"] = best_result
 
-                final_results["execution_mode"] = "standard"
+                final_results["execution_mode"] = "hybrid"
                 final_results["completed_trials"] = completed_trials
 
                 return final_results
@@ -675,7 +672,8 @@ class TraigentClient:
         if requested_mode != "auto":
             return validate_execution_mode(requested_mode)
 
-        # Auto-detection: only edge_analytics is currently supported
+        # Auto-detection remains conservative; users can request hybrid explicitly
+        # when they want backend/portal tracking.
         return ExecutionMode.EDGE_ANALYTICS
 
     def _check_privacy_requirements(self) -> bool:

--- a/traigent/utils/exceptions.py
+++ b/traigent/utils/exceptions.py
@@ -48,7 +48,7 @@ class ConfigurationError(TraigentError):
 
     This error is raised when:
     - Configuration values are invalid or malformed
-    - Configuration features are not yet supported (e.g., cloud/hybrid execution modes)
+    - Configuration features are not yet supported (e.g., cloud remote execution)
     - Required configuration is missing
 
     Set TRAIGENT_DEBUG=1 to see full tracebacks.


### PR DESCRIPTION
## Summary
- Close SDK release blockers B4, B5, B7 plus Sprint 2 A/B mock-mode cleanup.
- Regenerate detect-secrets baseline and pass the baseline explicitly through pre-commit.
- Harden auth fail-closed paths, credential resolution, cost enforcement, JS bridge handling, Bedrock/mock-mode behavior, audit, and encryption coverage.

## Verification
- Pushed with hooks enabled.
- `.venv/bin/pre-commit run --from-ref origin/develop --to-ref HEAD` passed.
- Pre-push hook ran and skipped SonarQube because `sonar-scanner` is not installed locally.