### PR TITLE
fix(security): close workflow template injection on main

### DIFF
--- a/.github/workflows/example-auto-tune-secure.yml
+++ b/.github/workflows/example-auto-tune-secure.yml
@@ -146,17 +146,19 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Validate budget limits
+        env:
+          INPUT_BUDGET: ${{ github.event.inputs.budget || '5.0' }}
         run: |
           python -c "
-          import yaml
+          import os, yaml
           with open('examples/ci-pipeline/params.yaml') as f:
               params = yaml.safe_load(f)
 
-          budget = float('${{ github.event.inputs.budget || 5.0 }}')
+          budget = float(os.environ['INPUT_BUDGET'])
           if budget > 25:
-              print(f'❌ Budget ${budget} exceeds maximum allowed ($25)')
+              print(f'❌ Budget \${budget} exceeds maximum allowed (\$25)')
               exit(1)
-          print(f'✅ Budget ${budget} is within limits')
+          print(f'✅ Budget \${budget} is within limits')
           "
 
   auto-tune:
@@ -219,34 +221,38 @@ jobs:
 
       - name: Set environment
         id: env
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
-          echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          echo "environment=$INPUT_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set tuning parameters
         id: params
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          INPUT_MAX_TRIALS: ${{ github.event.inputs.max_trials }}
+          INPUT_BUDGET: ${{ github.event.inputs.budget }}
         run: |
-          ENV="${{ steps.env.outputs.environment }}"
-
           # Set defaults based on environment with strict limits
-          if [[ "$ENV" == "production" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '50' }}"
-            BUDGET="${{ github.event.inputs.budget || '25.0' }}"
-          elif [[ "$ENV" == "staging" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '20' }}"
-            BUDGET="${{ github.event.inputs.budget || '10.0' }}"
+          if [[ "$STEP_ENV_OUTPUT" == "production" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-50}"
+            BUDGET="${INPUT_BUDGET:-25.0}"
+          elif [[ "$STEP_ENV_OUTPUT" == "staging" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-20}"
+            BUDGET="${INPUT_BUDGET:-10.0}"
           else
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '10' }}"
-            BUDGET="${{ github.event.inputs.budget || '5.0' }}"
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-10}"
+            BUDGET="${INPUT_BUDGET:-5.0}"
           fi
 
           # Enforce maximum limits
           if (( $(echo "$BUDGET > 25" | bc -l) )); then
-            echo "⚠️ Budget exceeds maximum, capping at $25"
+            echo "⚠️ Budget exceeds maximum, capping at \$25"
             BUDGET="25.0"
           fi
 
-          echo "max_trials=$MAX_TRIALS" >> $GITHUB_OUTPUT
-          echo "budget=$BUDGET" >> $GITHUB_OUTPUT
+          echo "max_trials=$MAX_TRIALS" >> "$GITHUB_OUTPUT"
+          echo "budget=$BUDGET" >> "$GITHUB_OUTPUT"
 
       - name: Run pre-optimization tests
         run: |
@@ -263,14 +269,16 @@ jobs:
           TRAIGENT_MOCK_LLM: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
           TRAIGENT_OFFLINE_MODE: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
           MAX_BUDGET: ${{ steps.params.outputs.budget }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Update DVC params
           python -c "
-          import yaml
+          import os, yaml
           with open('params.yaml', 'r') as f:
               params = yaml.safe_load(f)
-          params['optimize']['max_trials'] = ${{ steps.params.outputs.max_trials }}
-          params['optimize']['budget'] = ${{ steps.params.outputs.budget }}
+          params['optimize']['max_trials'] = int(os.environ['STEP_PARAMS_MAX_TRIALS'])
+          params['optimize']['budget'] = float(os.environ['STEP_PARAMS_BUDGET'])
           with open('params.yaml', 'w') as f:
               yaml.dump(params, f)
           "
@@ -283,13 +291,17 @@ jobs:
 
       - name: Generate CML report
         if: always()
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Create performance report
           echo "## 🤖 Secure Auto-Tuning Results" > report.md
           echo "" >> report.md
-          echo "**Environment:** ${{ steps.env.outputs.environment }}" >> report.md
-          echo "**Max Trials:** ${{ steps.params.outputs.max_trials }}" >> report.md
-          echo "**Budget:** \$${{ steps.params.outputs.budget }}" >> report.md
+          echo "**Environment:** $STEP_ENV_OUTPUT" >> report.md
+          echo "**Max Trials:** $STEP_PARAMS_MAX_TRIALS" >> report.md
+          echo "**Budget:** \$$STEP_PARAMS_BUDGET" >> report.md
           echo "" >> report.md
 
           # Add security scan results

--- a/.github/workflows/example-auto-tune.yml
+++ b/.github/workflows/example-auto-tune.yml
@@ -87,28 +87,32 @@ jobs:
 
       - name: Determine environment
         id: env
+        env:
+          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
-          echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
+          echo "environment=$INPUT_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
       - name: Set tuning parameters
         id: params
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          INPUT_MAX_TRIALS: ${{ github.event.inputs.max_trials }}
+          INPUT_BUDGET: ${{ github.event.inputs.budget }}
         run: |
-          ENV="${{ steps.env.outputs.environment }}"
-
           # Set defaults based on environment
-          if [[ "$ENV" == "production" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '50' }}"
-            BUDGET="${{ github.event.inputs.budget || '25.0' }}"
-          elif [[ "$ENV" == "staging" ]]; then
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '20' }}"
-            BUDGET="${{ github.event.inputs.budget || '10.0' }}"
+          if [[ "$STEP_ENV_OUTPUT" == "production" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-50}"
+            BUDGET="${INPUT_BUDGET:-25.0}"
+          elif [[ "$STEP_ENV_OUTPUT" == "staging" ]]; then
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-20}"
+            BUDGET="${INPUT_BUDGET:-10.0}"
           else
-            MAX_TRIALS="${{ github.event.inputs.max_trials || '10' }}"
-            BUDGET="${{ github.event.inputs.budget || '5.0' }}"
+            MAX_TRIALS="${INPUT_MAX_TRIALS:-10}"
+            BUDGET="${INPUT_BUDGET:-5.0}"
           fi
 
-          echo "max_trials=$MAX_TRIALS" >> $GITHUB_OUTPUT
-          echo "budget=$BUDGET" >> $GITHUB_OUTPUT
+          echo "max_trials=$MAX_TRIALS" >> "$GITHUB_OUTPUT"
+          echo "budget=$BUDGET" >> "$GITHUB_OUTPUT"
 
       - name: Run auto-tuning pipeline
         env:
@@ -116,14 +120,16 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TRAIGENT_MOCK_LLM: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
           TRAIGENT_OFFLINE_MODE: ${{ steps.env.outputs.environment == 'development' && 'true' || 'false' }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Update DVC params with current settings
           python -c "
-          import yaml
+          import os, yaml
           with open('params.yaml', 'r') as f:
               params = yaml.safe_load(f)
-          params['optimize']['max_trials'] = ${{ steps.params.outputs.max_trials }}
-          params['optimize']['budget'] = ${{ steps.params.outputs.budget }}
+          params['optimize']['max_trials'] = int(os.environ['STEP_PARAMS_MAX_TRIALS'])
+          params['optimize']['budget'] = float(os.environ['STEP_PARAMS_BUDGET'])
           with open('params.yaml', 'w') as f:
               yaml.dump(params, f)
           "
@@ -133,13 +139,17 @@ jobs:
 
       - name: Generate CML report
         if: always()
+        env:
+          STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
+          STEP_PARAMS_MAX_TRIALS: ${{ steps.params.outputs.max_trials }}
+          STEP_PARAMS_BUDGET: ${{ steps.params.outputs.budget }}
         run: |
           # Create performance report
           echo "## 🤖 Auto-Tuning Results" > report.md
           echo "" >> report.md
-          echo "**Environment:** ${{ steps.env.outputs.environment }}" >> report.md
-          echo "**Max Trials:** ${{ steps.params.outputs.max_trials }}" >> report.md
-          echo "**Budget:** \$${{ steps.params.outputs.budget }}" >> report.md
+          echo "**Environment:** $STEP_ENV_OUTPUT" >> report.md
+          echo "**Max Trials:** $STEP_PARAMS_MAX_TRIALS" >> report.md
+          echo "**Budget:** \$$STEP_PARAMS_BUDGET" >> report.md
           echo "" >> report.md
 
           # Add metrics

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,13 +42,16 @@ jobs:
 
     - name: Verify tag is on main branch
       if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GIT_SHA: ${{ github.sha }}
+        GIT_REF_NAME: ${{ github.ref_name }}
       run: |
         git fetch origin main
-        if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
-          echo "Error: tag ${{ github.ref_name }} is not on the main branch. Only tag from main."
+        if ! git merge-base --is-ancestor "$GIT_SHA" origin/main; then
+          echo "Error: tag $GIT_REF_NAME is not on the main branch. Only tag from main."
           exit 1
         fi
-        echo "Tag ${{ github.ref_name }} is on main — proceeding."
+        echo "Tag $GIT_REF_NAME is on main — proceeding."
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -73,8 +76,9 @@ jobs:
         echo "package_version=$VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Verify version consistency
+      env:
+        VERSION_PYPROJECT: ${{ steps.package_version.outputs.package_version }}
       run: |
-        VERSION_PYPROJECT=${{ steps.package_version.outputs.package_version }}
         echo "pyproject.toml version: $VERSION_PYPROJECT"
 
         # If triggered by a tag, verify the tag matches the package version
@@ -140,14 +144,18 @@ jobs:
 
     - name: Create deployment summary
       if: always()
+      env:
+        ENVIRONMENT: ${{ (github.event_name == 'push' && 'pypi (auto from tag)') || github.event.inputs.environment || 'unknown' }}
+        TRIGGER: ${{ github.event_name }}
+        REF: ${{ github.ref }}
+        JOB_STATUS: ${{ job.status }}
       run: |
-        ENVIRONMENT="${{ (github.event_name == 'push' && 'pypi (auto from tag)') || github.event.inputs.environment || 'unknown' }}"
-        echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
-        echo "- **Version**: $(python -c "import traigent; print(traigent.__version__)")" >> $GITHUB_STEP_SUMMARY
-        echo "- **Environment**: ${ENVIRONMENT}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Ref**: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+        echo "## Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Version**: $(python -c "import traigent; print(traigent.__version__)")" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Environment**: $ENVIRONMENT" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Trigger**: $TRIGGER" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Ref**: $REF" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Status**: $JOB_STATUS" >> "$GITHUB_STEP_SUMMARY"
 
   verify-publication:
     needs: publish
@@ -166,8 +174,9 @@ jobs:
     - name: Test installation from PyPI
       env:
         EXPECTED_VERSION: ${{ needs.publish.outputs.package_version }}
+        PUBLISH_ENVIRONMENT: ${{ github.event.inputs.environment }}
       run: |
-        if [ "${{ github.event.inputs.environment }}" = "testpypi" ]; then
+        if [ "$PUBLISH_ENVIRONMENT" = "testpypi" ]; then
           PACKAGE_LABEL="TestPyPI"
           PACKAGE_API_URL="https://test.pypi.org/pypi/traigent/json"
           INSTALL_ARGS=(--index-url "https://test.pypi.org/simple/" --extra-index-url "https://pypi.org/simple/")


### PR DESCRIPTION
## Summary
- backport the workflow template-injection hardening already merged to develop
- move workflow_dispatch inputs and GitHub context values out of inline shell interpolation
- keep publish and auto-tune workflows behavior-equivalent while using environment variables inside scripts

## Validation
- ruby YAML parse for the three touched workflows
- git diff --check

Fixes #774