### PR TITLE
fix(security): backport TVL website dependency pins to main

### DIFF
--- a/docs/tvl/tvl-website/package.json
+++ b/docs/tvl/tvl-website/package.json
@@ -97,7 +97,9 @@
       "qs": "6.14.2",
       "lodash": "4.18.1",
       "lodash-es": "4.18.1",
-      "tailwindcss>nanoid": "3.3.7"
+      "tailwindcss>nanoid": "3.3.7",
+      "dompurify": "^3.4.0",
+      "mdast-util-to-hast": "^13.2.1"
     }
   }
 }

--- a/docs/tvl/tvl-website/package.json
+++ b/docs/tvl/tvl-website/package.json
@@ -98,8 +98,8 @@
       "lodash": "4.18.1",
       "lodash-es": "4.18.1",
       "tailwindcss>nanoid": "3.3.7",
-      "dompurify": "^3.4.0",
-      "mdast-util-to-hast": "^13.2.1"
+      "dompurify": "3.4.1",
+      "mdast-util-to-hast": "13.2.1"
     }
   }
 }

--- a/docs/tvl/tvl-website/pnpm-lock.yaml
+++ b/docs/tvl/tvl-website/pnpm-lock.yaml
@@ -9,8 +9,8 @@ overrides:
   lodash: 4.18.1
   lodash-es: 4.18.1
   tailwindcss>nanoid: 3.3.7
-  dompurify: ^3.4.0
-  mdast-util-to-hast: ^13.2.1
+  dompurify: 3.4.1
+  mdast-util-to-hast: 13.2.1
 
 patchedDependencies:
   wouter@3.7.1:

--- a/docs/tvl/tvl-website/pnpm-lock.yaml
+++ b/docs/tvl/tvl-website/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   lodash: 4.18.1
   lodash-es: 4.18.1
   tailwindcss>nanoid: 3.3.7
+  dompurify: ^3.4.0
+  mdast-util-to-hast: ^13.2.1
 
 patchedDependencies:
   wouter@3.7.1:
@@ -2351,8 +2353,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.3.0:
-    resolution: {integrity: sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==}
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2868,8 +2870,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -5767,7 +5769,7 @@ snapshots:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
 
-  dompurify@3.3.0:
+  dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6108,7 +6110,7 @@ snapshots:
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       parse5: 7.3.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -6124,7 +6126,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -6479,7 +6481,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.1
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -6524,7 +6526,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.11
       dayjs: 1.11.18
-      dompurify: 3.3.0
+      dompurify: 3.4.1
       katex: 0.16.25
       khroma: 2.1.0
       lodash-es: 4.18.1
@@ -7122,7 +7124,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 


### PR DESCRIPTION
## Summary
- backport TVL website dompurify and mdast-util-to-hast security bumps from develop
- keep CVE-driven pnpm overrides pinned to exact reviewed versions
- preserve existing axios/lodash/lodash-es fixes already present on main

## Validation
- pnpm --dir docs/tvl/tvl-website install --lockfile-only --frozen-lockfile
- git diff --check

Fixes #733