### PR TITLE
fix(security): keep SDK localhost defaults local-only

### DIFF
--- a/tests/unit/utils/test_env_config.py
+++ b/tests/unit/utils/test_env_config.py
@@ -101,6 +101,31 @@ def test_get_env_var_masks_value_in_logs(monkeypatch, caplog):
     assert value not in caplog.text
 
 
+def test_database_and_redis_default_to_local_only_outside_production(monkeypatch):
+    """Local service defaults are allowed for SDK development only."""
+    _reset_env(monkeypatch)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+
+    assert env_config.get_database_url() == "postgresql://localhost:5432/traigent"
+    assert env_config.get_redis_url() == "redis://localhost:6379"
+
+
+def test_database_and_redis_are_required_in_production(monkeypatch):
+    """Production must not silently fall back to localhost services."""
+    _reset_env(monkeypatch)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    with pytest.raises(ValueError, match="DATABASE_URL"):
+        env_config.get_database_url()
+
+    with pytest.raises(ValueError, match="REDIS_URL"):
+        env_config.get_redis_url()
+
+
 @pytest.mark.parametrize(
     ("raw_value", "expected"),
     [

--- a/tests/unit/utils/test_error_handler.py
+++ b/tests/unit/utils/test_error_handler.py
@@ -283,6 +283,16 @@ class TestErrorHandlerConnectionErrors:
             exc_info.value
         ).lower() or "TRAIGENT_OFFLINE_MODE" in str(exc_info.value)
 
+    def test_handle_connection_error_any_localhost_port(self):
+        """Local backend hints should not depend on a single hardcoded port."""
+        error = ConnectionRefusedError("Connection refused to http://127.0.0.1:8000")
+
+        with pytest.raises(TraigentError) as exc_info:
+            ErrorHandler.handle_connection_error(error)
+
+        assert "backend" in str(exc_info.value).lower()
+        assert "offline mode" in str(exc_info.value).lower()
+
     def test_handle_connection_error_generic(self):
         """Test handling of generic connection error."""
         error = ConnectionError("Connection failed")

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -147,11 +147,15 @@ def get_api_key(provider: str) -> str | None:
 
 def get_database_url() -> str:
     """Get database URL from environment."""
+    if is_production():
+        return get_env_var("DATABASE_URL", required=True)
     return get_env_var("DATABASE_URL", default="postgresql://localhost:5432/traigent")
 
 
 def get_redis_url() -> str:
     """Get Redis URL from environment."""
+    if is_production():
+        return get_env_var("REDIS_URL", required=True)
     return get_env_var("REDIS_URL", default="redis://localhost:6379")
 
 

--- a/traigent/utils/error_handler.py
+++ b/traigent/utils/error_handler.py
@@ -6,6 +6,7 @@ Provides helpful error messages with actionable fixes and documentation links.
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability CONC-Quality-Security FUNC-ORCH-LIFECYCLE FUNC-CLOUD-HYBRID FUNC-SECURITY REQ-ORCH-003 REQ-CLOUD-009 REQ-SEC-010 SYNC-OptimizationFlow SYNC-CloudHybrid
 
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -183,7 +184,10 @@ class ErrorHandler:
         """Handle connection errors."""
         error_str = str(error)
 
-        if "localhost:5000" in error_str or "backend" in error_str.lower():
+        if (
+            re.search(r"\b(?:localhost|127\.0\.0\.1)(?::\d+)?\b", error_str)
+            or "backend" in error_str.lower()
+        ):
             raise TraigentError(
                 message="Cannot connect to Traigent backend",
                 fix="1. Start backend: cd backend && python app.py\n"


### PR DESCRIPTION
## Summary
- require explicit DATABASE_URL and REDIS_URL in SDK production mode instead of silently falling back to localhost
- keep localhost DB/Redis defaults for local SDK development
- detect localhost backend connection errors on any localhost/127.0.0.1 port instead of only localhost:5000

## Validation
- pytest -o addopts='' tests/unit/utils/test_env_config.py tests/unit/utils/test_error_handler.py -q
- ruff check traigent/utils/env_config.py traigent/utils/error_handler.py tests/unit/utils/test_env_config.py tests/unit/utils/test_error_handler.py
- git diff --check

Refs Traigent/traigent-pricing-simulator#42