### PR TITLE
docs: clarify SDK execution modes

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -109,6 +109,8 @@ jobs:
         env:
           TRAIGENT_MOCK_LLM: "true"
           TRAIGENT_OFFLINE_MODE: "true"
+          TRAIGENT_RUN_APPROVED: "1"
+          TRAIGENT_APPROVED_BY: "ci-install-smoke"
         working-directory: /tmp
         run: |
           python -m traigent.examples.quickstart

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Works with any LLM provider — [OpenAI](https://platform.openai.com/docs), [Ant
 |------|----------|------|
 | **Get started quickly** | [Quick Start Guide](docs/getting-started/GETTING_STARTED.md) | 5 min |
 | **Understand the architecture** | [Architecture Overview](#-architecture-overview) | 5 min |
-| **Connect to Traigent Cloud** | [Cloud Setup](#-traigent-cloud) | 5 min |
-| **Try examples locally, see them on the cloud** | [Mock walkthrough](walkthrough/mock/) (8 steps) → [Portal](https://portal.traigent.ai) | 15 min |
+| **Track local runs in the portal** | [Hybrid portal tracking](#portal-hybrid-tracking) | 5 min |
+| **Try examples locally, then make runs portal-visible** | [Mock walkthrough](walkthrough/mock/) (8 steps) → [Portal](https://portal.traigent.ai) | 15 min |
 | **Read the full API reference** | [Decorator Reference →](docs/api-reference/decorator-reference.md) | — |
 
 <details>
@@ -195,14 +195,18 @@ All examples run with `TRAIGENT_MOCK_LLM=true` — no API keys needed.
 
 ---
 
-### ☁️ Traigent Cloud
+<a id="portal-hybrid-tracking"></a>
 
-Connect to [Traigent Portal](https://portal.traigent.ai) to view results, compare trials, and collaborate.
+### ☁️ Traigent Portal & Hybrid Tracking
+
+Connect to [Traigent Portal](https://portal.traigent.ai) to view results, compare trials, and collaborate. The supported portal-visible SDK path today is `execution_mode="hybrid"`: trials run locally, while session and trial metrics are stored in the backend for portal tracking.
+
+`execution_mode="cloud"` is reserved for future remote agent execution. It is not available yet and fails with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.”
 
 1. **Sign up** at [portal.traigent.ai](https://portal.traigent.ai) — verify your email to activate
 2. **Create an API key** — click your name (top-right) → **API Keys** → **+ Create API Key**
 3. **Connect** — run `traigent auth login` or set `export TRAIGENT_API_KEY="sk_..."`  <!-- pragma: allowlist secret -->
-4. **Run** — results appear in the portal automatically
+4. **Run with hybrid tracking** — set `execution_mode="hybrid"` for portal-visible optimization
 
 <details>
 <summary>Credential priority and multi-provider setup</summary>
@@ -311,9 +315,9 @@ Provide a JSONL dataset — Traigent scores outputs using semantic similarity by
 
 | Mode | Status | Privacy | Algorithm | Best For |
 |------|--------|---------|-----------|----------|
-| **Local** (`edge_analytics`) | ✅ Available | ✅ Complete | All (Random/Grid/Bayesian/Optuna) | All use cases |
-| **Hybrid** | ✅ Available | ✅ Execution local | All (Random/Grid/Bayesian/Optuna) | Balanced approach |
-| **Cloud** | 🚧 Coming Soon | ⚠️ Metadata | Random/Grid/Bayesian | Production, teams |
+| **Local** (`edge_analytics`) | ✅ Available | ✅ Complete | All (Random/Grid/Bayesian/Optuna) | Local/private runs |
+| **Hybrid** (`hybrid`) | ✅ Available | ✅ Trial execution local | All (Random/Grid/Bayesian/Optuna) | Portal-tracked runs |
+| **Cloud** (`cloud`) | 🚧 Reserved | Not available | Future remote execution | Do not use yet |
 
 **[Execution modes guide →](docs/guides/execution-modes.md)** — mode comparisons, privacy details, migration path
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ def answer_question(question: str) -> str:
 - **[Optuna Integration](user-guide/optuna_integration.md)** - Optuna-backed optimizers, coordinator, and adapter
 
 ### 🧭 [Guides](guides/)
-- **[Execution Modes](guides/execution-modes.md)** - Local, hybrid, and cloud execution behavior
+- **[Execution Modes](guides/execution-modes.md)** - Local, hybrid portal tracking, and reserved cloud execution behavior
 - **[Evaluation](guides/evaluation.md)** - Evaluation best practices and troubleshooting
 - **[Parallel Configuration](guides/parallel-configuration.md)** - Concurrency settings and tuning
 - **[Secrets Management](guides/secrets_management.md)** - Securely manage API keys

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -135,28 +135,28 @@ sequenceDiagram
 
     User->>OF: @traigent.optimize()
     User->>OF: func.optimize(dataset)
-    
+
     OF->>Orch: Initialize optimization
-    
+
     loop Until stopping condition
         Orch->>Opt: suggest_next_trial(history)
         Opt-->>Orch: config candidate
-        
+
         Orch->>Orch: Acquire cost permit
-        
+
         Orch->>Eval: evaluate(config, dataset)
-        
+
         loop For each example
             Eval->>LLM: Execute with config
             LLM-->>Eval: Response + metrics
             Eval->>Eval: Run custom evaluators
         end
-        
+
         Eval-->>Orch: TrialResult (metrics)
         Orch->>Opt: Update with result
         Orch->>Orch: Check stopping conditions
     end
-    
+
     Orch-->>OF: OptimizationResult
     OF-->>User: Best config + insights
 ```
@@ -204,14 +204,14 @@ flowchart TB
 
     subgraph CloudMode["Cloud Mode"]
         direction TB
-        cloud_desc["Full SaaS execution<br/>Backend orchestration<br/>Advanced analytics"]
-        cloud_backend["Traigent Backend"]
-        cloud_storage["Cloud Storage"]
+        cloud_desc["Reserved future remote execution<br/>Not available today<br/>Fails closed"]
+        cloud_backend["Future Traigent Cloud"]
+        cloud_storage["Future Cloud Storage"]
     end
 
     subgraph HybridMode["Hybrid Mode"]
         direction TB
-        hybrid_desc["Local execution<br/>Cloud sync for insights<br/>Best of both worlds"]
+        hybrid_desc["Local trial execution<br/>Backend session/result tracking<br/>Portal-visible results"]
         hybrid_local["Local Execution"]
         hybrid_sync["Backend Sync"]
     end
@@ -389,13 +389,13 @@ from traigent import Range, Choices
     # Define parameter search space
     model=Choices(["gpt-4o", "gpt-4o-mini", "claude-3-sonnet"]),
     temperature=Range(0.0, 1.0),
-    
+
     # Set optimization objectives
     objectives=["accuracy", "cost"],
-    
+
     # Configure evaluation
     evaluation={"eval_dataset": "test_cases.jsonl"},
-    
+
     # Set budget
     exploration={"budget": 50}
 )

--- a/docs/examples/QUICK_REFERENCE.md
+++ b/docs/examples/QUICK_REFERENCE.md
@@ -33,6 +33,8 @@ def summarize(text: str) -> str:
 
 ## Execution mode
 - `edge_analytics` (default and supported) - local execution with analytics.
+- `hybrid` (supported) - local trial execution with backend/portal session and metric tracking.
+- `cloud` (reserved) - future remote execution; currently fails closed with guidance to use `hybrid`.
 - Mock: `TRAIGENT_MOCK_LLM=true` works in OSS/local mode.
 
 ## Quick knobs

--- a/docs/feature_matrices/evaluators.yml
+++ b/docs/feature_matrices/evaluators.yml
@@ -135,7 +135,7 @@ identified_gaps:
     name: "No remote evaluator"
     priority: low
     description: "No evaluator for remote/distributed evaluation"
-    recommendation: "Consider RemoteEvaluator for cloud execution"
+    recommendation: "Consider a future RemoteEvaluator only when cloud remote execution is implemented"
 
   - id: GAP-EVAL-003
     type: capability

--- a/docs/feature_matrices/optimizers.yml
+++ b/docs/feature_matrices/optimizers.yml
@@ -178,18 +178,18 @@ capabilities:
 
   - id: CAP-OPT-CLOUD
     name: "Cloud Optimizer"
-    description: "Cloud-backed optimizer with async support"
+    description: "Scaffold for future remote cloud optimization"
     implementations:
       - class_name: CloudOptimizer
         code_unit: traigent/optimizers/cloud_optimizer.py
-        status: complete
-        completion: 1.0
+        status: partial
+        completion: 0.5
         implemented_methods:
           - suggest_next_trial
           - suggest_next_trial_async
           - should_stop
           - should_stop_async
-        notes: "Async API for cloud orchestration"
+        notes: "Optimizer interface exists, but production cloud remote execution is not implemented; use hybrid for portal-tracked local execution."
 
   # ---------- Batch/Parallel Optimizers ----------
   - id: CAP-OPT-PARALLEL-BATCH
@@ -239,17 +239,17 @@ capabilities:
 # Summary Statistics
 summary:
   total_implementations: 15
-  complete: 15
-  partial: 0
+  complete: 14
+  partial: 1
   missing: 0
-  coverage_percentage: 100.0
+  coverage_percentage: 96.7
 
 # Feature Support Matrix
 feature_support:
   async_methods:
     full_support:
       - RemoteOptimizer (traigent/optimizers/remote.py)
-      - CloudOptimizer (traigent/optimizers/cloud_optimizer.py)
+      - CloudOptimizer interface methods (traigent/optimizers/cloud_optimizer.py)
     uses_default:
       - RandomSearchOptimizer
       - GridSearchOptimizer

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -127,6 +127,8 @@ Traigent executes your code locally. The default is `execution_mode="edge_analyt
 
 `execution_mode="cloud"` is reserved for future remote execution. It is not available yet and fails with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.”
 
+If you want website-visible results today, use `hybrid`; do not switch to `cloud`.
+
 To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MODE=true`.
 
 ---

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,6 +27,7 @@ pip install -e ".[recommended]"           # Recommended bundle: integrations, an
 | `bayesian` | Optuna + sklearn/scipy | `pip install -e ".[bayesian]"` |
 | `visualization` | matplotlib, plotly | `pip install -e ".[visualization]"` |
 | `hybrid` | HTTP/2 transport plus MCP-backed hybrid integrations | `pip install -e ".[hybrid]"` |
+| `cloud` | Reserved dependencies for future remote execution; not required for portal-tracked `hybrid` runs | `pip install -e ".[cloud]"` |
 | `security` | FastAPI, JWT, cryptography, Redis | `pip install -e ".[security]"` |
 | `test` | pytest + tooling | `pip install -e ".[test]"` |
 | `dev` | Linters + tests | `pip install -e ".[dev]"` |

--- a/docs/guides/execution-modes.md
+++ b/docs/guides/execution-modes.md
@@ -8,6 +8,10 @@ Use `edge_analytics` (default) to run locally. Use `hybrid` for website-visible 
 
 To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MODE=true`.
 
+## Migration Note
+
+If you want optimization results in the Traigent website, use `execution_mode="hybrid"`, not `execution_mode="cloud"`. Hybrid is the supported production path for portal-tracked SDK optimization. Cloud is reserved for a future product path where Traigent Cloud runs the remote agent execution itself.
+
 ## Modes at a Glance
 
 | Mode | OSS availability | Status | Notes |
@@ -62,7 +66,7 @@ def my_agent(query: str) -> str:
 
 ## Hybrid Mode
 
-Hybrid mode is the production path for portal-tracked SDK runs today. The SDK creates a backend session through `/api/v1/sessions`, runs each trial locally, and submits trial metrics through `/api/v1/sessions/{session_id}/results`.
+Hybrid mode is the production path for portal-tracked SDK runs today. The SDK creates a backend session, runs each trial locally, and submits trial metrics to the backend session/result endpoints so the run appears in the portal.
 
 Use `hybrid` when you want results to appear in the Traigent website. Use `edge_analytics` when you want fully local runs with no backend dependency.
 

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -121,15 +121,18 @@
   status: active
 
 - id: REQ-CLOUD-009
-  name: "Cloud/hybrid sync"
-  title: "Cloud and hybrid execution with backend synchronization"
+  name: "Backend/hybrid sync and reserved cloud"
+  title: "Hybrid backend synchronization and future cloud execution"
   description: >
-    Support authenticated access to Traigent backend services for session
-    creation, trial suggestion/submission, dataset conversion, subset selection, and billing.
+    Support authenticated access to Traigent backend services for hybrid
+    session creation, trial/result submission, dataset conversion, subset
+    selection, and billing. Remote cloud execution is reserved for a future
+    product path and must fail closed until implemented.
   acceptance_criteria:
     - Unified auth manager resolves credentials (env, CLI-stored) and emits secure headers.
-    - Backend clients synchronize sessions/trials and recover from transient errors.
-    - Cloud operations handle privacy settings, hybrid modes, and cost tracking.
+    - Hybrid backend clients synchronize sessions/trials and recover from transient errors.
+    - Cloud remote-execution operations raise clear unavailable errors until implemented.
+    - Backend operations handle privacy settings, hybrid modes, and cost tracking.
   tags: [cloud, backend, hybrid]
   priority: high
   type: functional

--- a/docs/traceability/concepts/cloud_service.yml
+++ b/docs/traceability/concepts/cloud_service.yml
@@ -1,6 +1,6 @@
 id: CONC-CloudService
 name: Cloud Service
-purpose: "Connect to Traigent backend for hybrid/cloud optimization, session sync, and billing-aware operations."
+purpose: "Connect to Traigent backend for hybrid session/result tracking, session sync, and billing-aware operations. Remote cloud execution is reserved for a future release."
 state:
   - name: auth_manager
     type: "AuthManager"
@@ -25,7 +25,7 @@ actions:
         fields:
           - name: error
             type: "AuthenticationError"
-    description: "Resolve credentials (env/CLI) and produce auth headers for cloud operations."
+    description: "Resolve credentials (env/CLI) and produce auth headers for backend operations."
   - name: sync_session
     inputs:
       - name: session_payload
@@ -63,7 +63,8 @@ actions:
             type: "bool"
     description: "Send trial metrics/results back to backend with retry/resilience."
 operational_principle:
-  - "Hybrid/cloud flows should tolerate network errors with retries or fallbacks."
+  - "Hybrid backend flows should tolerate network errors with retries or explicit failures."
+  - "Reserved cloud remote-execution flows must fail closed until implemented."
   - "Privacy flags and billing context must accompany backend interactions when configured."
 version: 1
 status: active

--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -1,10 +1,12 @@
 # Agent Optimization Guide
 
-This guide explains how to optimize AI agents using Traigent SDK's Model 2: Agent Specification-Based Execution.
+This guide describes the planned Model 2 agent-specification API.
+
+> **Current status:** Remote agent optimization in Traigent Cloud is not implemented yet. The `execution_mode="cloud"` path fails closed with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.” Use `execution_mode="hybrid"` for portal-visible SDK runs today; trials still execute locally.
 
 ## Overview
 
-Agent optimization allows you to send complete agent specifications to the Traigent Cloud Service for optimization. This approach is ideal when:
+Agent optimization is reserved for a future remote execution path where complete agent specifications can be optimized by Traigent Cloud. When available, this approach will be ideal when:
 
 - You want to optimize complex agent behaviors beyond simple parameter tuning
 - You're comfortable with sending agent specifications to the cloud
@@ -71,6 +73,8 @@ Common objectives include:
 ## Implementation Steps
 
 ### Step 1: Initialize Cloud Client
+
+The following examples are roadmap/reference examples for the future remote execution API. They should not be used as production instructions until cloud remote execution is released.
 
 ```python
 from traigent.cloud.client import TraigentCloudClient
@@ -451,9 +455,10 @@ except CloudServiceError as e:
 
 | Feature            | Agent Optimization (Model 2)         | Interactive Optimization (Model 1)  |
 | ------------------ | ------------------------------------ | ----------------------------------- |
-| Execution Location | Cloud service                        | Local client                        |
+| Current Status     | Not implemented                      | Requires a real remote guidance service |
+| Execution Location | Future cloud service                 | Local client                        |
 | Data Privacy       | Agent spec sent to cloud             | Only metadata sent                  |
-| Optimization Speed | Faster (parallel cloud execution)    | Slower (sequential local execution) |
+| Optimization Speed | Future remote execution path         | Local execution speed               |
 | Cost               | Higher (cloud compute)               | Lower (local compute)               |
 | Complexity         | Simpler setup                        | More complex integration            |
 | Use Case           | Standard agents, less sensitive data | Custom functions, sensitive data    |

--- a/docs/user-guide/choosing_optimization_model.md
+++ b/docs/user-guide/choosing_optimization_model.md
@@ -1,31 +1,30 @@
 # Choosing the Right Optimization Model
 
-Traigent SDK offers two distinct optimization models. This guide helps you choose the right approach for your use case.
+Traigent SDK currently supports local execution and portal-tracked local execution. This guide separates supported modes from future remote execution paths.
 
-> **OSS note:** The open-source build supports `edge_analytics` only. Interactive and agent optimization require a managed backend (TraigentCloudClient + API key).
+> **Current status:** Use `execution_mode="edge_analytics"` for fully local runs and `execution_mode="hybrid"` for portal-tracked runs where trials still execute locally. `execution_mode="cloud"` and managed remote agent execution are not implemented yet and fail closed with guidance to use `hybrid`.
 
 ## Quick Decision Guide
 
 ```mermaid
 graph TD
-    A[Start] --> B{Can you send function/agent<br/>to cloud?}
-    B -->|Yes| C{Is it a standard<br/>AI agent?}
-    B -->|No| D[Use Model 1:<br/>Interactive Optimization]
-    C -->|Yes| E[Use Model 2:<br/>Agent Optimization]
-    C -->|No| F{Need cloud<br/>optimization power?}
-    F -->|Yes| G[Use Hybrid Approach]
-    F -->|No| D
+    A[Start] --> B{Need results in<br/>Traigent Portal?}
+    B -->|No| C[Use edge_analytics:<br/>local execution]
+    B -->|Yes| D[Use hybrid:<br/>local trials + backend tracking]
+    D --> E{Need remote cloud<br/>agent execution?}
+    E -->|Yes| F[Not available yet:<br/>cloud is reserved]
+    E -->|No| D
 ```
 
 ## Model Comparison
 
-### Model 1: Interactive Optimization (Client-Side Execution)
+### Supported: Local Optimization (`edge_analytics`)
 
 **How it works:**
 
-- Optimization guidance runs in a remote service
-- Function execution happens locally
-- Only configuration suggestions and results are exchanged
+- Optimization and function execution happen locally
+- Results are stored locally unless optional analytics/backend settings are configured
+- No Traigent backend dependency when `TRAIGENT_OFFLINE_MODE=true`
 
 **Best for:**
 
@@ -41,20 +40,19 @@ graph TD
 - Hardware-in-the-loop optimization
 - Real-time systems
 
-### Model 2: Agent Optimization (Cloud-Based Execution)
+### Supported: Hybrid Portal Tracking (`hybrid`)
 
 **How it works:**
 
-- Complete agent specification sent to the managed backend
-- Execution and optimization happen in the cloud
-- Results returned after optimization completes
+- SDK creates a backend-tracked optimization session
+- Trials and LLM calls execute locally
+- Trial metrics are submitted to the backend so results appear in the portal
 
 **Best for:**
 
-- Standard AI agents (LangChain, OpenAI, etc.)
-- When you want parallel cloud execution
-- Complex optimization requiring significant compute
-- Multi-objective optimization scenarios
+- Teams that want website-visible optimization runs
+- Local execution with centralized session and metric tracking
+- Production runs where prompts, inputs, and outputs should remain local
 
 **Example use cases:**
 
@@ -65,20 +63,18 @@ graph TD
 
 ## Detailed Comparison Table
 
-| Aspect                 | Model 1: Interactive       | Model 2: Agent                 | Hybrid Approach       |
+| Aspect                 | `edge_analytics`           | `hybrid`                       | `cloud`               |
 | ---------------------- | -------------------------- | ------------------------------ | --------------------- |
-| **Execution Location** | Local client               | Cloud service                  | Both                  |
-| **Data Privacy**       | ✅ High (data stays local) | ⚠️ Medium (data sent to cloud) | 🔄 Configurable       |
-| **Setup Complexity**   | Medium                     | Low                            | High                  |
-| **Optimization Speed** | Slower (sequential)        | Faster (parallel)              | Fast with flexibility |
-| **Cost**               | Lower (local compute)      | Higher (cloud compute)         | Medium                |
-| **Scalability**        | Limited by local resources | High (cloud scale)             | High                  |
-| **Real-time Support**  | ✅ Yes                     | ❌ No                          | ✅ Yes (Phase 1)      |
-| **Custom Functions**   | ✅ Yes                     | ❌ No                          | ✅ Yes                |
-| **Standard AI Agents** | ⚠️ Requires adapter        | ✅ Native support              | ✅ Yes                |
-| **Network Dependency** | Low (suggestions only)     | High (full execution)          | Medium                |
+| **Current Status**     | Supported                  | Supported                      | Not implemented       |
+| **Execution Location** | Local client               | Local client                   | Future cloud service  |
+| **Portal Visibility**  | Local files by default     | Yes                            | Future path           |
+| **Data Privacy**       | High                       | High for trial execution       | Future policy         |
+| **Setup Complexity**   | Low                        | Medium                         | Not available         |
+| **Network Dependency** | None in offline mode       | Backend required               | Not available         |
 
 ## Implementation Examples
+
+The examples below are reference patterns for advanced remote-guidance APIs. For production SDK usage today, prefer `edge_analytics` or `hybrid` as described above.
 
 ### Model 1: Interactive Optimization
 
@@ -86,7 +82,7 @@ graph TD
 from traigent.cloud.client import TraigentCloudClient
 from traigent.optimizers.interactive_optimizer import InteractiveOptimizer
 
-cloud_client = TraigentCloudClient(api_key="your-api-key")  # Managed backend required
+cloud_client = TraigentCloudClient(api_key="your-api-key")  # Roadmap remote guidance client
 
 # For a custom local function
 async def my_custom_function(text: str, temperature: float) -> str:
@@ -127,14 +123,14 @@ while True:
     )
 ```
 
-### Model 2: Agent Optimization
+### Future: Agent Optimization
 
 ```python
 from traigent.cloud.client import TraigentCloudClient
 from traigent.cloud.models import AgentSpecification
 from traigent.evaluators.base import Dataset, EvaluationExample
 
-cloud_client = TraigentCloudClient(api_key="your-api-key")  # Managed backend required
+cloud_client = TraigentCloudClient(api_key="your-api-key")  # Roadmap remote execution client
 
 # Define a standard AI agent
 agent_spec = AgentSpecification(
@@ -151,7 +147,7 @@ dataset = Dataset([
     EvaluationExample(input_data={"question": "What is AI?"}, expected_output="Artificial Intelligence"),
 ])
 
-# Start cloud optimization
+# Start remote agent optimization when the cloud path is released
 async with cloud_client:
     response = await cloud_client.optimize_agent(
         agent_spec=agent_spec,
@@ -167,16 +163,16 @@ async with cloud_client:
 # response includes optimization details and best configuration
 ```
 
-### Hybrid Approach
+### Supported Hybrid Approach
 
-Use both models in sequence:
-- Phase 1: Run Interactive Optimization locally to narrow the search.
-- Phase 2: Use Agent Optimization in the cloud to refine on a larger space.
-- Phase 3: Validate the chosen configuration on the full local dataset.
+Use `execution_mode="hybrid"` when you want the supported portal-tracked path:
+- Trials execute locally.
+- The backend stores session metadata and trial metrics.
+- Results appear in the Traigent portal without using the unavailable remote cloud execution path.
 
 ## Decision Factors
 
-### Choose Model 1 When:
+### Choose `edge_analytics` When:
 
 1. **Data Sensitivity is Critical**
 
@@ -198,117 +194,83 @@ Use both models in sequence:
    - Have limited network bandwidth
    - Need to minimize API costs
 
-### Choose Model 2 When:
+### Choose `hybrid` When:
 
-1. **Using Standard AI Platforms**
+1. **Portal Visibility Matters**
 
-   - OpenAI GPT models
-   - LangChain agents
-   - Hugging Face models
-   - Other cloud-based AI services
+   - You want runs to appear in Traigent Portal
+   - Your team needs shared session and trial history
+   - You want backend-stored metrics without remote trial execution
 
-2. **Optimization Requirements**
+2. **Local Execution Still Matters**
 
-   - Need parallel execution
-   - Want sophisticated algorithms
-   - Require multi-objective optimization
-   - Have large configuration spaces
+   - Prompts, inputs, and outputs should stay in your environment
+   - Your optimized function depends on local services, files, or hardware
+   - You want the supported production path for website-visible SDK runs
 
-3. **Resource Availability**
-   - Have good network connectivity
-   - Can afford cloud compute costs
-   - Don't have local compute constraints
-   - Want hands-off optimization
+### Do Not Choose `cloud` Yet
 
-### Choose Hybrid When:
-
-1. **Complex Requirements**
-
-   - Need both privacy and power
-   - Want phased optimization
-   - Require flexible deployment
-   - Have mixed sensitivity data
-
-2. **Optimization Strategy**
-   - Fast initial exploration locally
-   - Cloud refinement for best results
-   - Local validation before deployment
-   - Cost-sensitive optimization
+`execution_mode="cloud"` is reserved for future remote agent execution. It is not available yet, and production cloud paths must fail closed instead of returning synthetic sessions, trial suggestions, agent outputs, or completed statuses.
 
 ## Cost Considerations
 
-### Model 1 Costs:
+### `edge_analytics` Costs:
 
-- **Cloud**: Only optimization suggestions (minimal)
 - **Local**: Your compute/electricity costs
-- **Network**: Minimal data transfer
+- **Network**: None for Traigent backend when `TRAIGENT_OFFLINE_MODE=true`
 
-### Model 2 Costs:
+### `hybrid` Costs:
 
-- **Cloud**: Full execution costs (can be significant)
-- **Local**: Minimal
-- **Network**: Dataset upload costs
-
-### Hybrid Costs:
-
-- **Cloud**: Reduced through intelligent phase management
-- **Local**: Moderate during exploration phase
-- **Network**: Optimized through subset selection
+- **Local**: Your trial execution and LLM provider costs
+- **Backend**: Portal-tracking traffic for sessions and metrics
+- **Network**: No remote execution traffic for prompts/outputs
 
 ## Migration Strategies
 
-### From Model 1 to Model 2:
+### From Local-Only to Portal-Tracked:
 
-1. Wrap your function as an agent specification
-2. Ensure function can be serialized/described
-3. Test with small dataset first
-4. Gradually move execution to cloud
+1. Keep the optimized function and dataset unchanged.
+2. Authenticate with `traigent auth login` or set `TRAIGENT_API_KEY`.
+3. Set `execution_mode="hybrid"`.
+4. Confirm the run appears in Traigent Portal.
 
-### From Model 2 to Model 1:
+### From Accidental Cloud Usage:
 
-1. Create local executor for your agent
-2. Implement evaluation locally
-3. Connect to interactive optimizer
-4. Test latency and accuracy
+1. Replace `execution_mode="cloud"` with `execution_mode="hybrid"` when you want website results.
+2. Use `execution_mode="edge_analytics"` and `TRAIGENT_OFFLINE_MODE=true` when you want no backend dependency.
+3. Treat cloud remote execution docs and APIs as roadmap/reference material until the product path is released.
 
 ## Performance Tips
 
-### Model 1 Performance:
+### Local and Hybrid Performance:
 
-- Use dataset subset suggestions efficiently
 - Batch local executions when possible
 - Cache results for similar configurations
 - Implement parallel local execution
-
-### Model 2 Performance:
-
 - Choose appropriate `parallel_config` settings (e.g., `parallel_config={"trial_concurrency": 4}`)
 - Use early stopping to save costs
 - Start with smaller datasets
-- Enable smart subset selection
 
 ## Security Considerations
 
-### Model 1 Security:
+### `edge_analytics` Security:
 
 - ✅ Data never leaves your environment
 - ✅ Full control over execution
-- ⚠️ Ensure secure connection for suggestions
-- ⚠️ Validate configuration suggestions
 
-### Model 2 Security:
+### `hybrid` Security:
 
-- ⚠️ Review cloud service security policies
-- ⚠️ Understand data retention policies
+- ✅ Trials execute locally
+- ✅ Backend receives session and trial metrics for tracking
+- ⚠️ Confirm privacy settings before enabling portal tracking
 - ✅ Use encryption in transit
-- ✅ Implement access controls
 
 ## Conclusion
 
 Choose based on your primary constraints:
 
-- **Privacy-first**: Model 1
-- **Performance-first**: Model 2
-- **Flexibility-first**: Hybrid
+- **Privacy/local-only**: `edge_analytics`
+- **Website-visible results**: `hybrid`
+- **Remote cloud execution**: reserved for a future release
 
-Remember that you can start with one model and migrate to another as your requirements evolve. The Traigent SDK is designed to support this flexibility.
+For now, users wanting website results should use `hybrid`, not `cloud`.

--- a/docs/user-guide/interactive_optimization.md
+++ b/docs/user-guide/interactive_optimization.md
@@ -1,12 +1,14 @@
 # Interactive Optimization Guide
 
-This guide explains how to use Traigent's interactive optimization model for client-side execution with remote guidance.
+This guide documents Traigent's interactive optimization model for client-side execution with remote guidance.
+
+> **Current status:** The generic `InteractiveOptimizer` can be used with a real `RemoteGuidanceService` implementation, but Traigent Cloud remote guidance is not a supported production path yet. Use `execution_mode="hybrid"` for portal-tracked SDK optimization today; use `execution_mode="edge_analytics"` for fully local runs.
 
 ## Overview
 
-The interactive optimization model enables a hybrid approach where:
+The interactive optimization model enables a remote-guidance approach where:
 
-- **Configuration suggestions** come from the Traigent Cloud Service
+- **Configuration suggestions** come from a remote guidance service
 - **Function execution** happens on your local machine
 - **Results** are reported back to guide the next suggestion
 
@@ -73,11 +75,13 @@ The service provides configurations based on:
 
 ### Step 1: Setup
 
+This example assumes you provide a remote guidance service that implements the `RemoteGuidanceService` protocol. The Traigent Cloud remote-guidance endpoint is roadmap-only until the managed remote execution path is released.
+
 ```python
 from traigent.cloud.client import TraigentCloudClient
 from traigent.optimizers.interactive_optimizer import InteractiveOptimizer
 
-# Initialize cloud client
+# Initialize a remote guidance client when that service is available.
 client = TraigentCloudClient(api_key="<API_KEY>")
 
 # Create interactive optimizer

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,7 +117,7 @@ For users comfortable with Traigent basics who want to explore advanced patterns
 
 ### Advanced Category Details
 
-- **execution-modes/**: Learn execution patterns. `edge_analytics` keeps data local while sending anonymized metrics. Cloud and hybrid modes coming in a future release.
+- **execution-modes/**: Learn execution patterns. `edge_analytics` keeps runs local; `hybrid` adds backend/portal tracking while trials still execute locally. `cloud` remote execution is reserved for a future release.
 
 - **results-analysis/**: Post-optimization analysis. Visualize trial results, compare configurations, and extract insights from completed optimization runs.
 

--- a/examples/advanced/execution-modes/_archived/ex05-cloud-basic/cloud_basic.py
+++ b/examples/advanced/execution-modes/_archived/ex05-cloud-basic/cloud_basic.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Execution Modes - Cloud Mode (Basic).
+"""Execution Modes - Archived Cloud Mode (Basic).
 
-Adapted from docs: in OSS extraction we run locally for speed/offline.
+This archived example is retained for historical context. Remote cloud
+execution is not available today, so the runnable function uses Edge Analytics.
 """
 
 from __future__ import annotations
@@ -114,7 +115,7 @@ def _summary_accuracy(
     eval_dataset=DATASET_FILE,
     objectives=["cost", "accuracy"],
     metric_functions={"accuracy": _summary_accuracy},
-    execution_mode="edge_analytics",  # cloud in docs; Edge Analytics here for offline run
+    execution_mode="edge_analytics",  # Cloud mode is reserved; run locally here.
     max_trials=10,
 )
 def text_summarizer(article: str) -> str:

--- a/examples/advanced/execution-modes/_archived/ex05-cloud-basic/run.py
+++ b/examples/advanced/execution-modes/_archived/ex05-cloud-basic/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Runner for Execution Modes - Cloud Mode (Basic)."""
+"""Runner for archived cloud-mode example; executes locally."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ def _serialize_trials(opt_result: Any, limit: int = 10) -> list[dict[str, Any]]:
 
 
 def main() -> None:
-    print("Running Execution Modes - Cloud (Basic)")
+    print("Running archived cloud-mode example locally")
     print("=" * 60)
 
     opt_result = asyncio.run(text_summarizer.optimize(max_trials=10))

--- a/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/cloud_limitations.py
+++ b/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/cloud_limitations.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Execution Modes - Cloud Limitations demo.
+"""Execution Modes - Archived Cloud Limitations demo.
 
-Shows a self-contained function suitable for cloud, and notes about
-functions that rely on local resources. For offline/run purposes we
-optimize only the simple classifier with a tiny dataset.
+This archived example is retained for historical context. Remote cloud
+execution is not available today, so the runnable function uses Edge Analytics.
 """
 
 from __future__ import annotations
@@ -88,7 +87,7 @@ def _ensure_dataset():
 _ensure_dataset()
 
 
-# ✅ Self-contained function (cloud-friendly in docs; local here)
+# Self-contained function; run locally because cloud mode is reserved.
 @traigent.optimize(
     eval_dataset=DATASET_FILE,
     objectives=["accuracy", "cost"],
@@ -105,7 +104,7 @@ def simple_classifier(text: str) -> str:
     return getattr(resp, "content", str(resp))
 
 
-# ❌ Not suitable for cloud in docs: database/file access
+# Local-resource examples kept as historical cloud-limitation notes.
 # Kept as illustrative (not optimized/run here)
 def database_function(query: str) -> str:
     import sqlite3

--- a/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/run.py
+++ b/examples/advanced/execution-modes/_archived/ex06-cloud-limitations/run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Runner for Execution Modes - Cloud Limitations (demo)."""
+"""Runner for archived cloud-limitations example; executes locally."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ def _serialize_trials(opt_result: Any, limit: int = 10) -> list[dict[str, Any]]:
 
 
 def main() -> None:
-    print("Running Execution Modes - Cloud Limitations (simple classifier)")
+    print("Running archived cloud-limitations example locally")
     print("=" * 60)
 
     opt_result = asyncio.run(simple_classifier.optimize(max_trials=10))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,8 @@ deepeval = [
     "deepeval>=1.0.0",
 ]
 
-# Cloud bundle (cloud execution mode, advanced session management)
+# Cloud bundle reserved for future remote execution support.
+# Portal-tracked SDK runs use the supported hybrid extra/mode today.
 cloud = [
     "traigent[security]",
     "boto3>=1.28.0",

--- a/traigent/adapters/execution_adapter.py
+++ b/traigent/adapters/execution_adapter.py
@@ -348,7 +348,7 @@ class LocalExecutionAdapter(ExecutionAdapter):
 
 
 class RemoteExecutionAdapter(ExecutionAdapter):
-    """Adapter for remote execution in SaaS mode."""
+    """Adapter scaffold for future remote execution mode."""
 
     def __init__(self, backend_client: Any) -> None:
         """Initialize remote execution adapter.
@@ -363,8 +363,8 @@ class RemoteExecutionAdapter(ExecutionAdapter):
     ) -> dict[str, Any]:
         """Execute configuration remotely.
 
-        In SaaS mode, the actual execution happens on the backend.
-        This adapter just handles the communication.
+        Remote backend execution is reserved for a future cloud path.
+        This adapter only documents the communication shape.
 
         Args:
             agent_spec: Agent specification
@@ -374,7 +374,7 @@ class RemoteExecutionAdapter(ExecutionAdapter):
         Returns:
             Execution results from backend
         """
-        # In SaaS mode, execution is handled by the backend
+        # In future remote mode, execution is handled by the backend.
         # The dataset should already be uploaded and we just reference it
         dataset_id = dataset.get("dataset_id")
         if not dataset_id:

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -145,15 +145,20 @@ class ExecutionOptions(BaseModel):
     """Execution and orchestration preferences for optimization runs.
 
     Attributes:
-        execution_mode: Execution mode (edge_analytics, cloud, local, hybrid).
+        execution_mode: Execution mode. Use ``edge_analytics`` for local
+            execution, ``hybrid`` for local trials plus backend/portal
+            tracking, or ``hybrid_api`` for external-agent API optimization.
+            ``cloud`` is reserved for future remote execution and currently
+            fails closed with guidance to use ``hybrid``.
         local_storage_path: Path for local result storage.
         minimal_logging: Whether to minimize logging output.
         parallel_config: Configuration for parallel execution.
         privacy_enabled: Whether to enable privacy-preserving mode.
         max_total_examples: Maximum total examples across all trials.
         samples_include_pruned: Whether to include pruned trials in sample count.
-        cloud_fallback_policy: Cloud fallback behavior on execution failure.
-            "auto" or "warn" falls back to local optimization; "never" re-raises.
+        cloud_fallback_policy: Legacy/future cloud fallback behavior. It does
+            not enable ``execution_mode="cloud"`` today; cloud remote execution
+            is not available yet.
         reps_per_trial: Number of repetitions per configuration for statistical stability.
             Running multiple repetitions helps account for LLM non-determinism.
             Default is 1 (no repetition). Set to 3-5 for noisy evaluations.
@@ -1700,16 +1705,19 @@ def optimize(  # NOSONAR(S107)
         Execution options:
             execution: Grouped execution settings (ExecutionOptions or dict) spanning
                 orchestration, storage, and parallelism.
-            execution_mode: Execution mode ("cloud", "edge_analytics", "privacy",
-                "standard"). Defaults to "edge_analytics".
+            execution_mode: Execution mode. Use "edge_analytics" for local
+                execution, "hybrid" for local trials plus backend/portal
+                tracking, or "hybrid_api" for external-agent API optimization.
+                "cloud" is reserved for future remote execution and fails
+                closed today.
             local_storage_path: Location for Edge Analytics storage. Falls back
                 to ``TRAIGENT_RESULTS_FOLDER`` or ``~/.traigent/`` when omitted.
             minimal_logging: Toggle for reduced logging noise in Edge mode.
             parallel_config: Consolidated parallel configuration (ParallelConfig
                 or dict). Preferred path for controlling concurrency.
             privacy_enabled: Flag enabling hybrid privacy safeguards.
-            cloud_fallback_policy: Cloud failure policy: "auto"/"warn" fallback to
-                local, "never" to fail closed.
+            cloud_fallback_policy: Legacy/future cloud fallback policy. It does
+                not enable cloud remote execution today.
             max_total_examples: Global sample budget across all trials.
             samples_include_pruned: Whether pruned trials count toward the sample budget.
 

--- a/traigent/cloud/README.md
+++ b/traigent/cloud/README.md
@@ -1,6 +1,8 @@
 # Traigent Cloud Integration Module
 
-This module provides the cloud integration capabilities for Traigent SDK, enabling communication with the Traigent backend for optimization tracking and analytics.
+This module provides backend integration capabilities for Traigent SDK, including portal-tracked hybrid sessions, privacy-preserving session/result submission, authentication, and analytics.
+
+Remote cloud execution is intentionally not implemented yet. `execution_mode="cloud"` fails closed with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.”
 
 ## Components
 
@@ -22,13 +24,13 @@ The `BackendIntegratedClient` provides:
 - HTTP communication with Traigent backend
 - Privacy-preserving session management
 - Asynchronous and synchronous interfaces
-- Automatic fallback for offline operation
+- Fail-closed behavior for backend-required operations when dependencies or credentials are missing
 
 ### Models (`models.py`)
 Core data models for optimization requests, sessions, and results.
 
 ### Optimizer Client (`optimizer_client.py`)
-Direct integration with the Traigent Optimizer service for advanced optimization strategies.
+Direct metric submission for hybrid mode, where the SDK executes trials locally while the backend tracks sessions and results.
 
 ## Privacy-Preserving Architecture
 
@@ -56,32 +58,32 @@ assert experiment.metadata["execution_mode"] == "edge_analytics"
 
 ## Usage
 
-The cloud module is automatically used by the Traigent orchestrator. No direct interaction is typically needed:
+The backend integration module is automatically used by the Traigent orchestrator when portal tracking is enabled. No direct interaction is typically needed:
 
 ```python
 from traigent import optimize
 
 @optimize(
     model="gpt-3.5-turbo",
-    optimization_mode="edge_analytics"  # Works with all modes
+    execution_mode="hybrid"  # Local trials plus backend/portal tracking
 )
 def my_function(prompt: str) -> str:
     return "response"
 
-# Metadata is automatically submitted to backend
+# Session and trial metrics are submitted to the backend.
 result = my_function("test")
 ```
 
 ## Configuration
 
 ### Backend URL
-- Default: `http://localhost:5000`
+- Default: production portal/backend configuration, unless explicitly overridden for local SDK development
 - Environment variable: `TRAIGENT_BACKEND_URL`
 - Optional API base override: `TRAIGENT_API_URL`
 - Config parameter: `backend_base_url`
 
 ### API Key
-- Required for authentication
+- Required for authenticated portal tracking
 - Set via `TRAIGENT_API_KEY` environment variable
 - Or pass to `@optimize` decorator
 

--- a/traigent/cloud/__init__.py
+++ b/traigent/cloud/__init__.py
@@ -1,7 +1,7 @@
-"""Traigent Cloud Service integration module.
+"""Traigent backend and reserved cloud integration module.
 
-This module provides the commercial cloud service integration for Traigent SDK,
-enabling smart optimization with dataset subset selection and cost reduction.
+This module provides backend integration for portal-tracked SDK runs. Remote
+cloud execution is reserved for a future release and fails closed today.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID REQ-CLOUD-009 SYNC-CloudHybrid

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -679,35 +679,35 @@ class ApiOperations:
     async def create_cloud_session(
         self, request: SessionCreationRequest
     ) -> SessionCreationResponse:
-        """Create cloud session for optimization."""
+        """Reserved cloud session path; fails closed until remote execution exists."""
         _ = request
         self._raise_cloud_remote_unavailable("create_cloud_session")
 
     async def get_cloud_trial_suggestion(
         self, request: NextTrialRequest
     ) -> NextTrialResponse:
-        """Get next trial suggestion from cloud optimizer."""
+        """Reserved cloud suggestion path; fails closed until remote execution exists."""
         _ = request
         self._raise_cloud_remote_unavailable("get_cloud_trial_suggestion")
 
     async def submit_cloud_trial_results(
         self, submission: TrialResultSubmission
     ) -> None:
-        """Submit trial results to cloud service."""
+        """Reserved cloud result path; fails closed until remote execution exists."""
         _ = submission
         self._raise_cloud_remote_unavailable("submit_cloud_trial_results")
 
     async def submit_agent_optimization(
         self, request: AgentOptimizationRequest
     ) -> AgentOptimizationResponse:
-        """Submit agent for cloud optimization."""
+        """Reserved cloud agent optimization path; fails closed until implemented."""
         _ = request
         self._raise_cloud_remote_unavailable("submit_agent_optimization")
 
     async def execute_cloud_agent(
         self, request: AgentExecutionRequest
     ) -> AgentExecutionResponse:
-        """Execute agent in cloud."""
+        """Reserved cloud agent execution path; fails closed until implemented."""
         _ = request
         self._raise_cloud_remote_unavailable("execute_cloud_agent")
 

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -341,8 +341,8 @@ class SecureToken:
 class AuthManager:
     """Authentication manager for SDK and backend integration.
 
-    This manager handles authentication for both Traigent Cloud services and
-    backend integrations, providing a single entry point for acquiring
+    This manager handles authentication for Traigent backend integration and
+    reserved cloud services, providing a single entry point for acquiring
     credentials and generating request headers.
     """
 

--- a/traigent/cloud/backend_bridges.py
+++ b/traigent/cloud/backend_bridges.py
@@ -1,8 +1,8 @@
 """Model bridges between Traigent SDK and Traigent Backend.
 
 This module provides conversion utilities to bridge the gap between
-SDK cloud models and backend database entities, enabling seamless
-integration between client-side optimization and server-side execution.
+SDK backend models and backend database entities, enabling integration between
+client-side optimization and backend session/result tracking.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -124,16 +124,16 @@ bridge = _bridge
 
 
 class BackendIntegratedClient:
-    """Enhanced cloud client with Traigent Backend integration (Refactored).
+    """Enhanced backend client with Traigent Backend integration (Refactored).
 
     This client supports both execution models:
-    - Model 1: Privacy-first optimization with client-side execution
-    - Model 2: Cloud SaaS optimization with backend agent execution
+    - Hybrid: client-side trial execution with backend session/result tracking
+    - Reserved cloud: future backend agent execution paths that fail closed today
 
     The refactored version delegates specific responsibilities to sub-modules:
     - validators: Data validation functions
     - privacy_operations: Privacy-first optimization operations
-    - cloud_operations: Cloud SaaS optimization operations
+    - cloud_operations: Reserved cloud remote-execution operations
     - session_operations: Session lifecycle management
     - trial_operations: Trial management and result submission
     - api_operations: Backend API integration methods
@@ -155,10 +155,10 @@ class BackendIntegratedClient:
         """Initialize backend integrated client.
 
         Args:
-            api_key: Traigent Cloud API key
-            base_url: Cloud service base URL
+            api_key: Traigent backend API key
+            base_url: Backend service base URL
             backend_config: Backend integration configuration
-            enable_fallback: Fall back to local optimization if cloud fails
+            enable_fallback: Reserved compatibility flag for future cloud behavior
             max_retries: Maximum retry attempts for requests
             timeout: Request timeout in seconds
             enable_rate_limiting: Enable rate limiting
@@ -601,7 +601,7 @@ class BackendIntegratedClient:
             session_id, trial_id, config, metrics, duration, error_message
         )
 
-    # Cloud Operations
+    # Reserved Cloud Operations
     async def start_agent_optimization(
         self,
         agent_spec: AgentSpecification,
@@ -611,7 +611,7 @@ class BackendIntegratedClient:
         max_trials: int = 50,
         user_id: str | None = None,
     ) -> AgentOptimizationResponse:
-        """Start cloud SaaS optimization with full agent execution.
+        """Start reserved cloud agent optimization.
         Delegates to cloud_operations module."""
         return await self._cloud_ops.start_agent_optimization(
             agent_spec, dataset, configuration_space, objectives, max_trials, user_id
@@ -623,7 +623,7 @@ class BackendIntegratedClient:
         input_data: dict[str, Any],
         config_overrides: dict[str, Any] | None = None,
     ) -> AgentExecutionResponse:
-        """Execute agent with specified configuration.
+        """Execute agent through the reserved cloud path.
         Delegates to cloud_operations module."""
         return await self._cloud_ops.execute_agent(
             agent_spec, input_data, config_overrides
@@ -1085,21 +1085,21 @@ class BackendIntegratedClient:
     async def _submit_cloud_trial_results(
         self, submission: TrialResultSubmission
     ) -> None:
-        """Submit trial results to cloud service.
+        """Reserved cloud result path; fails closed in api_operations.
         Delegates to api_operations module."""
         await self._api_ops.submit_cloud_trial_results(submission)
 
     async def _submit_agent_optimization(
         self, request: AgentOptimizationRequest
     ) -> AgentOptimizationResponse:
-        """Submit agent for cloud optimization.
+        """Reserved cloud agent optimization path; fails closed in api_operations.
         Delegates to api_operations module."""
         return await self._api_ops.submit_agent_optimization(request)
 
     async def _execute_cloud_agent(
         self, request: AgentExecutionRequest
     ) -> AgentExecutionResponse:
-        """Execute agent in cloud.
+        """Reserved cloud agent execution path; fails closed in api_operations.
         Delegates to api_operations module."""
         return await self._api_ops.execute_cloud_agent(request)
 

--- a/traigent/cloud/billing.py
+++ b/traigent/cloud/billing.py
@@ -1,4 +1,4 @@
-"""Unified Billing and Cost Tracking for Traigent Cloud Service.
+"""Unified billing and cost tracking for Traigent backend/cloud integration.
 
 This module provides comprehensive billing and cost tracking functionality,
 combining usage tracking, billing management, and detailed cost monitoring
@@ -130,7 +130,7 @@ class CostTrackingConfig:
 
 @dataclass
 class UsageRecord:
-    """Record of Traigent Cloud Service usage."""
+    """Record of Traigent backend/cloud usage."""
 
     timestamp: datetime
     function_name: str
@@ -173,7 +173,7 @@ class UsageRecord:
 
 @dataclass
 class BillingPlan:
-    """Traigent Cloud Service billing plan."""
+    """Traigent backend/cloud billing plan."""
 
     name: str
     monthly_credits: int

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -1,4 +1,4 @@
-"""Traigent Cloud Service Client for commercial optimization."""
+"""Traigent backend client with reserved cloud remote-execution methods."""
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013
 
@@ -183,7 +183,7 @@ class StandardizedClientError(Exception):
 
 @dataclass
 class CloudOptimizationResult:
-    """Result from cloud optimization service."""
+    """Result shape for future remote cloud optimization."""
 
     best_config: dict[str, Any]
     best_metrics: dict[str, float]
@@ -254,7 +254,12 @@ def _get_retry_delay(response: Any) -> float:
 
 
 class TraigentCloudClient(BaseTraigentClient):
-    """Client for Traigent Cloud Service - enables commercial optimization features."""
+    """Client for backend integration APIs and reserved cloud APIs.
+
+    Portal-tracked SDK runs should use hybrid mode. The SDK
+    ``execution_mode="cloud"`` product path fails closed until remote cloud
+    execution is implemented.
+    """
 
     _AUTH_FAILURE_MESSAGE = "Not authenticated with Traigent Cloud Service"
 
@@ -271,7 +276,7 @@ class TraigentCloudClient(BaseTraigentClient):
         Args:
             api_key: Traigent Cloud API key
             base_url: Cloud service base URL
-            enable_fallback: Fall back to local optimization if cloud fails
+            enable_fallback: Reserved compatibility setting for future cloud behavior
             max_retries: Maximum retry attempts for cloud requests
             timeout: Request timeout in seconds
         """
@@ -642,7 +647,7 @@ class TraigentCloudClient(BaseTraigentClient):
     async def _submit_optimization(
         self, request_data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Submit optimization request to cloud service."""
+        """Submit optimization request to the reserved remote service."""
         await self._ensure_session()
         if self._aio_session is None:
             raise CloudServiceError(_SESSION_NOT_INITIALIZED)
@@ -662,7 +667,7 @@ class TraigentCloudClient(BaseTraigentClient):
                         # Rate limited - convert to retryable error
                         retry_after = response.headers.get("Retry-After")
                         raise RateLimitError(
-                            "Rate limited by cloud service",
+                            "Rate limited by backend service",
                             retry_after=int(retry_after) if retry_after else None,
                         )
                     else:
@@ -704,7 +709,7 @@ class TraigentCloudClient(BaseTraigentClient):
         *,
         local_function: Callable[..., Any] | None = None,
     ) -> CloudOptimizationResult:
-        """Fallback to local optimization when cloud service unavailable."""
+        """Compatibility local fallback used by older remote-service flows."""
         from traigent.core.orchestrator import OptimizationOrchestrator
         from traigent.evaluators.local import LocalEvaluator
         from traigent.optimizers.registry import get_optimizer
@@ -818,7 +823,7 @@ class TraigentCloudClient(BaseTraigentClient):
         return cast(dict[str, Any], await self.usage_tracker.get_usage_stats())
 
     async def check_service_status(self) -> dict[str, Any]:
-        """Check Traigent Cloud Service status."""
+        """Check Traigent backend service status."""
         await self._ensure_session()
         if self._aio_session is None:
             raise CloudServiceError(_SESSION_NOT_INITIALIZED)
@@ -1066,7 +1071,7 @@ class TraigentCloudClient(BaseTraigentClient):
         session_id: str,
         previous_results: list[TrialResultSubmission] | None = None,
     ) -> NextTrialResponse:
-        """Get next trial suggestion from the cloud service.
+        """Get next trial suggestion from the backend service.
 
         Args:
             session_id: Optimization session ID
@@ -1125,7 +1130,7 @@ class TraigentCloudClient(BaseTraigentClient):
         error_message: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        """Submit trial results to the cloud service.
+        """Submit trial results to the backend service.
 
         Args:
             session_id: Optimization session ID
@@ -1439,7 +1444,10 @@ class TraigentCloudClient(BaseTraigentClient):
     async def start_agent_optimization(
         self, request: AgentOptimizationRequest
     ) -> AgentOptimizationResponse:
-        """Start agent optimization using cloud service (alternative entry point).
+        """Start agent optimization through the low-level managed endpoint.
+
+        This is not the supported SDK ``execution_mode="cloud"`` path. SDK
+        users wanting portal-visible runs should use ``execution_mode="hybrid"``.
 
         Args:
             request: Agent optimization request
@@ -1477,11 +1485,11 @@ class TraigentCloudClient(BaseTraigentClient):
         target_cost_reduction: float = 0.65,
         optimization_strategy: dict[str, Any] | None = None,
     ) -> AgentOptimizationResponse:
-        """Start agent optimization using cloud service.
+        """Start agent optimization through the low-level managed endpoint.
 
-        This method implements Model 2: Agent Specification-Based Execution where
-        the agent specification and dataset are sent to the cloud service for
-        remote execution and optimization.
+        This low-level client method is for backends that implement the managed
+        agent endpoint. It is not the supported SDK ``execution_mode="cloud"``
+        path; use hybrid for portal-tracked SDK optimization today.
 
         Args:
             agent_spec: Agent specification to optimize
@@ -1563,10 +1571,10 @@ class TraigentCloudClient(BaseTraigentClient):
         config_overrides: dict[str, Any] | None = None,
         execution_context: dict[str, Any] | None = None,
     ) -> AgentExecutionResponse:
-        """Execute agent on cloud service.
+        """Execute agent through the low-level managed endpoint.
 
-        This method allows direct agent execution on the cloud service
-        without optimization, useful for testing or production inference.
+        This method is separate from SDK ``execution_mode="cloud"``. Use hybrid
+        for supported portal-tracked SDK optimization today.
 
         Args:
             agent_spec_or_request: Either AgentExecutionRequest object or agent specification

--- a/traigent/cloud/cloud_operations.py
+++ b/traigent/cloud/cloud_operations.py
@@ -1,7 +1,7 @@
-"""Cloud SaaS optimization operations for Traigent Cloud Client.
+"""Reserved cloud remote-execution operations for Traigent backend clients.
 
-This module handles cloud-based optimization operations where agents are
-executed in the cloud with full data transmission.
+Remote cloud execution is not implemented yet. Operations in this module fail
+closed with guidance to use hybrid for portal-tracked local execution.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class CloudOperations:
-    """Handles cloud SaaS optimization operations."""
+    """Handles reserved cloud remote-execution operations."""
 
     def __init__(self, client: "BackendIntegratedClient"):
         """Initialize cloud operations handler.
@@ -40,7 +40,7 @@ class CloudOperations:
         max_trials: int = 50,
         user_id: str | None = None,
     ) -> AgentOptimizationResponse:
-        """Start cloud SaaS optimization with full agent execution.
+        """Start reserved cloud agent optimization.
 
         Args:
             agent_spec: Complete agent specification
@@ -51,7 +51,7 @@ class CloudOperations:
             user_id: Optional user identifier
 
         Returns:
-            Agent optimization response with session details
+            Agent optimization response with session details when implemented
         """
         _ = (agent_spec, dataset, configuration_space, objectives, max_trials, user_id)
         raise CloudRemoteExecutionUnavailableError("start_agent_optimization")
@@ -62,7 +62,7 @@ class CloudOperations:
         input_data: dict[str, Any],
         config_overrides: dict[str, Any] | None = None,
     ) -> AgentExecutionResponse:
-        """Execute agent with specified configuration.
+        """Execute agent through the reserved cloud path.
 
         Args:
             agent_spec: Agent specification
@@ -70,7 +70,7 @@ class CloudOperations:
             config_overrides: Optional configuration overrides
 
         Returns:
-            Agent execution response
+            Agent execution response when implemented
         """
         _ = (agent_spec, input_data, config_overrides)
         raise CloudRemoteExecutionUnavailableError("execute_agent")

--- a/traigent/cloud/integration_manager.py
+++ b/traigent/cloud/integration_manager.py
@@ -47,13 +47,9 @@ class IntegrationMode(Enum):
     """Integration execution modes."""
 
     EDGE_ANALYTICS = "edge_analytics"  # Client-side execution with local orchestration
-    PRIVACY = (
-        "privacy"  # Client-side execution, backend orchestration, privacy-preserving
-    )
-    STANDARD = (
-        "standard"  # Client-side execution, backend orchestration, full data sharing
-    )
-    CLOUD = "cloud"  # Full cloud execution
+    PRIVACY = "privacy"  # Client-side execution with privacy-preserving tracking
+    STANDARD = "standard"  # Legacy backend-tracked mode
+    CLOUD = "cloud"  # Reserved future remote execution
 
 
 @dataclass
@@ -395,14 +391,14 @@ class IntegrationManager:
     async def _start_cloud_integration(
         self, optimization_request: OptimizationRequest, integration_id: str
     ) -> IntegrationResult:
-        """Start cloud SaaS integration (Model 2).
+        """Start reserved cloud integration (future Model 2 path).
 
         Args:
             optimization_request: SDK optimization request
             integration_id: Integration identifier
 
         Returns:
-            IntegrationResult with cloud workflow details
+            IntegrationResult with cloud workflow details when implemented
         """
         if self._mcp_client is None:
             raise RuntimeError("MCP client not initialized")
@@ -432,7 +428,7 @@ class IntegrationManager:
                 optimization_request
             )
 
-            # Step 3: Start cloud agent optimization
+            # Step 3: Start reserved cloud agent optimization.
             optimization_response = await self._backend_client.start_agent_optimization(
                 agent_spec=optimization_request.agent_specification,
                 dataset=optimization_request.dataset,
@@ -459,7 +455,7 @@ class IntegrationManager:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.error(f"Cloud SaaS integration failed: {e}")
+            logger.error(f"Cloud remote integration failed: {e}")
             return IntegrationResult(success=False, error_message=str(e))
 
     async def _start_standard_integration(
@@ -488,7 +484,9 @@ class IntegrationManager:
                 optimization_request, integration_id
             )
         else:
-            logger.info(f"Hybrid mode choosing cloud SaaS for {integration_id}")
+            logger.info(
+                f"Hybrid mode choosing reserved cloud path for {integration_id}"
+            )
             return await self._start_cloud_integration(
                 optimization_request, integration_id
             )
@@ -540,9 +538,11 @@ class IntegrationManager:
                     session_id, previous_results
                 )
             else:
-                # For cloud SaaS, trials are managed by the cloud service
+                # For the reserved cloud path, trials would be managed remotely.
                 suggestion = None
-                logger.info("Cloud SaaS mode: trials managed by cloud service")
+                logger.info(
+                    "Reserved cloud mode: trials managed remotely when implemented"
+                )
 
             # Note: Trial registration is handled differently in the refactored lifecycle manager
             # The refactored manager tracks trials when results are submitted

--- a/traigent/cloud/models.py
+++ b/traigent/cloud/models.py
@@ -1,8 +1,8 @@
-"""Data models for cloud optimization service communication.
+"""Data models for backend integration and reserved cloud APIs.
 
 This module contains all the data classes used for communication between
-the Traigent client and cloud services, supporting both client-side execution
-and agent-based remote execution models.
+the Traigent client and backend services. Agent-based remote execution models
+are reserved for a future cloud release.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013

--- a/traigent/cloud/service.py
+++ b/traigent/cloud/service.py
@@ -1,4 +1,9 @@
-"""Traigent Cloud Service implementation."""
+"""In-process optimization service scaffold.
+
+This helper is not the SDK ``execution_mode="cloud"`` remote execution path.
+It runs locally inside the current process and exists for service experiments
+around subset selection, billing, and orchestration shapes.
+"""
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID REQ-CLOUD-009 SYNC-CloudHybrid
 
@@ -23,7 +28,7 @@ logger = get_logger(__name__)
 
 @dataclass
 class OptimizationRequest:
-    """Request for cloud optimization service."""
+    """Request for the in-process optimization service scaffold."""
 
     function_name: str
     dataset: Dataset
@@ -37,7 +42,7 @@ class OptimizationRequest:
 
 @dataclass
 class OptimizationResponse:
-    """Response from cloud optimization service."""
+    """Response shape for the in-process optimization service scaffold."""
 
     request_id: str
     best_config: dict[str, Any]
@@ -51,10 +56,10 @@ class OptimizationResponse:
 
 
 class TraigentCloudService:
-    """Main Traigent Cloud Service for commercial optimization."""
+    """Local scaffold for service-style optimization experiments."""
 
     def __init__(self) -> None:
-        """Initialize cloud service."""
+        """Initialize the local service scaffold."""
         self.subset_selector = SmartSubsetSelector()
         self.usage_tracker = UsageTracker()
         self.billing_manager = BillingManager(self.usage_tracker)
@@ -120,7 +125,7 @@ class TraigentCloudService:
     async def process_optimization_request(
         self, request: OptimizationRequest
     ) -> OptimizationResponse:
-        """Process optimization request with smart cost optimization.
+        """Process an in-process optimization request with cost controls.
 
         Args:
             request: OptimizationRequest with all parameters

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -1,5 +1,5 @@
 """
-Local-to-cloud sync manager for Traigent optimization sessions.
+Local-to-backend sync manager for Traigent optimization sessions.
 Handles migration of local data to Traigent backend when users upgrade.
 """
 
@@ -50,7 +50,7 @@ class SyncManager:
 
         Args:
             config: TraigentConfig with local storage settings
-            api_key: API key for cloud service authentication
+            api_key: API key for backend authentication
         """
         self.config = config
         self.storage = LocalStorageManager(config.get_local_storage_path())
@@ -333,9 +333,9 @@ class SyncManager:
             }
             return sync_result
 
-        # Actually sync to cloud
+        # Actually sync to backend.
         if not self.api_key:
-            msg = "No API key provided for cloud sync. " + get_no_credentials_hint()
+            msg = "No API key provided for backend sync. " + get_no_credentials_hint()
             logger.warning(msg)
             sync_result["status"] = "error"
             sync_result["errors"].append(msg)

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -22,7 +22,7 @@ class ExecutionMode(StrEnum):
       Non-sensitive telemetry syncs to the backend when available for analytics; runs continue
       if the backend is unreachable, but insights remain local.
     - PRIVACY: Legacy alias for hybrid mode with strict privacy toggles (no input/output sent).
-    - STANDARD: Cloud orchestration with data sharing for balanced performance.
+    - STANDARD: Removed legacy mode.
     - CLOUD: Reserved for future remote execution where optimization and trials run
       in Traigent Cloud. Not available yet.
     - HYBRID_API: External API-based optimization where trials execute via HTTP endpoints.
@@ -194,7 +194,7 @@ class TraigentConfig:
     ] = "edge_analytics"
     local_storage_path: str | None = None
     minimal_logging: bool = True
-    auto_sync: bool = False  # Auto-sync to cloud when API key available
+    auto_sync: bool = False  # Auto-sync to backend/portal when API key is available
     # Privacy toggle: when True, do not log or transmit input/output/prompts (local/hybrid)
     privacy_enabled: bool = False
 
@@ -206,7 +206,7 @@ class TraigentConfig:
 
     # Analytics and telemetry settings
     enable_usage_analytics: bool = (
-        True  # Send privacy-safe usage stats to encourage cloud adoption
+        True  # Send privacy-safe usage stats when backend/portal integration is configured
     )
     analytics_endpoint: str | None = None  # Custom analytics endpoint
     anonymous_user_id: str | None = None  # Anonymous identifier (auto-generated)
@@ -433,7 +433,7 @@ class TraigentConfig:
         return self.execution_mode_enum is ExecutionMode.EDGE_ANALYTICS
 
     def is_cloud_mode(self) -> bool:
-        """Check if configuration is set to cloud mode."""
+        """Check if configuration is set to reserved cloud mode."""
         return self.execution_mode_enum is ExecutionMode.CLOUD
 
     def is_privacy_enabled(self) -> bool:
@@ -533,7 +533,7 @@ class TraigentConfig:
         Args:
             storage_path: Custom storage path for local data
             minimal_logging: Whether to use minimal logging
-            auto_sync: Whether to auto-sync to cloud when API key is available
+            auto_sync: Whether to auto-sync to backend/portal when an API key is available
             **kwargs: Additional configuration parameters
 
         Returns:

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -154,11 +154,11 @@ class BackendSessionManager:
     def create_backend_client(
         traigent_config: TraigentConfig,
     ) -> BackendIntegratedClient | None:
-        """Initialize backend client if cloud features are available.
+        """Initialize backend client if backend integration features are available.
 
-        Returns None when cloud plugin is not installed (graceful degradation).
-        Raises FeatureNotAvailableError only when cloud mode is explicitly
-        requested but plugin is missing.
+        Returns None when backend integration modules are not installed
+        (graceful degradation). Cloud remote execution remains unavailable
+        and is validated elsewhere before use.
 
         Args:
             traigent_config: Global configuration for execution mode and storage
@@ -170,7 +170,7 @@ class BackendSessionManager:
             logger.debug("Offline mode - skipping backend client initialization")
             return None
 
-        # Try to import cloud module - may not be available if cloud plugin not installed
+        # Try to import backend integration module - may not be available in minimal installs.
         try:
             from traigent.cloud.backend_client import (
                 BackendClientConfig,
@@ -178,21 +178,21 @@ class BackendSessionManager:
             )
             from traigent.config.backend_config import BackendConfig
         except ModuleNotFoundError as err:
-            # Cloud module not installed - check if this was the cloud module itself
+            # Backend integration module not installed - check if this was the module itself.
             missing_module = getattr(err, "name", "") or ""
             if missing_module.startswith("traigent.cloud"):
                 if traigent_config.execution_mode == "cloud":
-                    # User explicitly requested cloud mode but plugin not installed
+                    # User explicitly requested reserved cloud mode but plugin not installed.
                     from traigent.utils.exceptions import FeatureNotAvailableError
 
                     raise FeatureNotAvailableError(
-                        "Cloud execution mode",
+                        "Cloud remote execution is not available yet; use hybrid for portal-tracked optimization",
                         plugin_name="traigent-cloud",
                         install_hint="pip install traigent[cloud]",
                     ) from err
-                # For edge_analytics or other modes, gracefully degrade to local-only
+                # For edge_analytics or other modes, gracefully degrade to local-only.
                 logger.info(
-                    f"Cloud module not available for {traigent_config.execution_mode} mode. "
+                    f"Backend integration module not available for {traigent_config.execution_mode} mode. "
                     "Continuing with local storage only."
                 )
                 return None

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -188,7 +188,7 @@ class BackendSessionManager:
                     raise FeatureNotAvailableError(
                         "Cloud remote execution is not available yet; use hybrid for portal-tracked optimization",
                         plugin_name="traigent-cloud",
-                        install_hint="pip install traigent[cloud]",
+                        install_hint="Use execution_mode='hybrid' for portal-tracked optimization",
                     ) from err
                 # For edge_analytics or other modes, gracefully degrade to local-only.
                 logger.info(

--- a/traigent/core/constants.py
+++ b/traigent/core/constants.py
@@ -136,12 +136,13 @@ VALIDATION_ERROR_CODES = {
 # EXECUTION MODE CONSTANTS
 # =============================================================================
 
-# Supported execution modes
+# Historical execution mode constants. Current support validation lives in
+# traigent.config.types.validate_execution_mode.
 EXECUTION_MODES = [
     "edge_analytics",  # Client-side execution only
-    "privacy",  # Privacy-preserving mode
-    "standard",  # Standard cloud execution
-    "cloud",  # Full cloud optimization
+    "privacy",  # Legacy alias handled by config normalization
+    "standard",  # Removed legacy mode
+    "cloud",  # Reserved future remote execution
 ]
 
 # Default execution mode

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1870,7 +1870,11 @@ class OptimizedFunction:
         timeout: float | None = None,
         **kwargs: Any,
     ) -> OptimizationResult:
-        """Run optimization using Traigent Cloud Service.
+        """Run optimization through the reserved Traigent Cloud path.
+
+        Remote cloud execution is not available yet. The cloud client is
+        expected to fail closed with guidance to use hybrid for portal-tracked
+        optimization.
 
         Args:
             dataset: Evaluation dataset
@@ -1879,7 +1883,7 @@ class OptimizedFunction:
             **kwargs: Additional arguments
 
         Returns:
-            OptimizationResult from cloud service
+            OptimizationResult from cloud service when the future path is implemented
         """
         from traigent.cloud.client import TraigentCloudClient
 

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -21,15 +21,6 @@ configure_quickstart_env(os.environ)
 _PACKAGE_DIR = str(Path(__file__).resolve().parent)
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", _PACKAGE_DIR)
 
-# NOTE: This uses LangChain's ChatOpenAI rather than the litellm calls shown
-# in the documentation. That is intentional and temporary: Traigent's mock
-# interceptor (TRAIGENT_MOCK_LLM=true) only patches LangChain's ChatOpenAI at
-# this point - it does not yet intercept raw litellm/openai calls.
-# Once the interceptor adds raw litellm support this file will be updated to
-# match the litellm style shown in the docs.
-from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
-
 import traigent
 from traigent.api.decorators import EvaluationOptions
 
@@ -46,6 +37,21 @@ _SYSTEM_PROMPT = (
 # In mock mode the LLM returns a fixed placeholder string, so contains_accuracy
 # would always score 0.  Let the built-in mock simulation handle accuracy instead.
 _mock_mode = is_truthy(os.environ.get("TRAIGENT_MOCK_LLM"))
+
+if not _mock_mode:
+    from langchain_core.messages import HumanMessage, SystemMessage
+    from langchain_openai import ChatOpenAI
+
+_MOCK_ANSWERS = {
+    "What is the capital of France?": "Paris",
+    "What is 2 + 2?": "4",
+    "Who wrote Romeo and Juliet?": "William Shakespeare",
+    "What is the largest planet in our solar system?": "Jupiter",
+    "What year did World War II end?": "1945",
+    "What is the chemical symbol for water?": "H2O",
+    "Who painted the Mona Lisa?": "Leonardo da Vinci",
+    "What is the speed of light?": "299,792,458 meters per second",
+}
 
 
 def contains_accuracy(output: str, expected: str) -> float:
@@ -65,6 +71,9 @@ def contains_accuracy(output: str, expected: str) -> float:
 def answer(question: str) -> str:
     """Call an LLM with the current trial's config."""
     cfg = traigent.get_config()
+    if _mock_mode:
+        return _MOCK_ANSWERS.get(question, "Mock answer")
+
     llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
     response = llm.invoke([SystemMessage(_SYSTEM_PROMPT), HumanMessage(question)])
     return str(response.content)

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -38,10 +38,6 @@ _SYSTEM_PROMPT = (
 # would always score 0.  Let the built-in mock simulation handle accuracy instead.
 _mock_mode = is_truthy(os.environ.get("TRAIGENT_MOCK_LLM"))
 
-if not _mock_mode:
-    from langchain_core.messages import HumanMessage, SystemMessage
-    from langchain_openai import ChatOpenAI
-
 _MOCK_ANSWERS = {
     "What is the capital of France?": "Paris",
     "What is 2 + 2?": "4",
@@ -73,6 +69,9 @@ def answer(question: str) -> str:
     cfg = traigent.get_config()
     if _mock_mode:
         return _MOCK_ANSWERS.get(question, "Mock answer")
+
+    from langchain_core.messages import HumanMessage, SystemMessage
+    from langchain_openai import ChatOpenAI
 
     llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
     response = llm.invoke([SystemMessage(_SYSTEM_PROMPT), HumanMessage(question)])

--- a/traigent/optimizers/cloud_optimizer.py
+++ b/traigent/optimizers/cloud_optimizer.py
@@ -1,8 +1,8 @@
-"""CloudOptimizer implementation for cloud optimization services.
+"""CloudOptimizer scaffold for future remote optimization services.
 
 This module provides the CloudOptimizer class that integrates with remote
-optimization services. Note: Cloud mode is not yet supported in the
-open-source SDK.
+optimization services. Cloud remote execution is not implemented yet; use
+hybrid for portal-tracked local execution.
 """
 
 # Traceability: CONC-Layer-Integration CONC-Quality-Reliability CONC-Quality-Performance FUNC-OPT-ALGORITHMS FUNC-CLOUD-HYBRID REQ-OPT-ALG-004 REQ-CLOUD-009 SYNC-CloudHybrid
@@ -63,15 +63,15 @@ def _run_async_safely(coro: Coroutine[Any, Any, T]) -> T:
 
 
 class CloudOptimizer(BaseOptimizer):
-    """Optimizer that delegates to cloud optimization service.
+    """Optimizer scaffold that delegates to a future remote optimization service.
 
     This optimizer provides:
-    - Advanced optimization algorithms from cloud services
+    - Advanced optimization hooks for future remote services
     - Smart dataset subset selection for cost optimization
     - Enhanced exploration-exploitation strategies
 
     Note:
-        Cloud mode is not yet supported in the open-source SDK.
+        Cloud remote execution is not implemented yet.
         This optimizer is reserved for future enterprise features.
         This is distinct from RemoteOptimizer (in remote.py) which is a simpler
         scaffold. CloudOptimizer provides full session management,
@@ -434,7 +434,7 @@ class CloudOptimizer(BaseOptimizer):
     async def generate_candidates_async(
         self, max_candidates: int, remote_context: dict[str, Any] | None = None
     ) -> list[dict[str, Any]]:
-        """Generate multiple candidate configurations using cloud service.
+        """Generate multiple candidate configurations using a remote service.
 
         This method leverages the remote service's batch suggestion capabilities
         for more efficient candidate generation compared to sequential calls.

--- a/traigent/optimizers/remote_services.py
+++ b/traigent/optimizers/remote_services.py
@@ -1,7 +1,7 @@
 """Remote optimization service interfaces and abstractions.
 
 This module provides the core interfaces for integrating with remote optimization
-services, enabling hybrid local/cloud optimization architectures.
+services, enabling local execution with optional remote guidance architectures.
 """
 
 # Traceability: CONC-Layer-Integration CONC-Quality-Reliability CONC-Quality-Compatibility FUNC-OPT-ALGORITHMS FUNC-CLOUD-HYBRID REQ-OPT-ALG-004 REQ-CLOUD-009 SYNC-CloudHybrid
@@ -188,7 +188,7 @@ class RemoteOptimizationService(ABC):
     """Abstract interface for remote optimization services.
 
     This interface defines the contract for communicating with remote optimization
-    services, whether they are Traigent Cloud services or third-party providers.
+    services, whether they are future Traigent services or third-party providers.
     """
 
     def __init__(

--- a/traigent/skills/traigent-debugging/SKILL.md
+++ b/traigent/skills/traigent-debugging/SKILL.md
@@ -37,7 +37,7 @@ Then run your optimization. Debug output includes:
 - Trial execution start/stop/status
 - Metric extraction and scoring
 - Cost tracking per trial
-- Backend communication (if using cloud mode)
+- Backend communication (if using hybrid portal tracking)
 
 ## Common Errors
 
@@ -160,8 +160,8 @@ traigent.utils.exceptions.ProviderValidationError: Provider validation failed:
 
 ```bash
 # Set the correct API keys
-export OPENAI_API_KEY="sk-..."
-export ANTHROPIC_API_KEY="sk-ant-..."
+export OPENAI_API_KEY="sk-..."  # pragma: allowlist secret
+export ANTHROPIC_API_KEY="sk-ant-..."  # pragma: allowlist secret
 ```
 
 ```python
@@ -242,7 +242,7 @@ Test your optimization setup without making real API calls or connecting to the 
 # Mock LLM responses (no API keys needed)
 export TRAIGENT_MOCK_LLM=true
 
-# Skip backend connection (no cloud service needed)
+# Skip backend connection (fully local/offline run)
 export TRAIGENT_OFFLINE_MODE=true
 ```
 

--- a/traigent/skills/traigent-decorator-setup/SKILL.md
+++ b/traigent/skills/traigent-decorator-setup/SKILL.md
@@ -195,7 +195,7 @@ Configure where and how optimization runs execute.
 ```python
 @traigent.optimize(
     execution=ExecutionOptions(
-        execution_mode="edge_analytics",  # Local execution, analytics to cloud
+        execution_mode="edge_analytics",  # Local execution
         local_storage_path="./results",
         privacy_enabled=True,
         reps_per_trial=3,              # Repeat each config 3 times
@@ -212,9 +212,9 @@ def my_func(query: str) -> str:
 
 | Mode | Description |
 |---|---|
-| `"edge_analytics"` | Default. Runs locally, sends analytics metadata to cloud. |
-| `"cloud"` | Full cloud execution with remote orchestration. |
-| `"hybrid"` | Split execution between local trials and cloud coordination. |
+| `"edge_analytics"` | Default. Runs locally. Set `TRAIGENT_OFFLINE_MODE=true` for no backend communication. |
+| `"hybrid"` | Supported portal-tracked mode: trials run locally while backend stores sessions and metrics. |
+| `"cloud"` | Reserved for future remote execution. Not available yet; use `hybrid` for portal-tracked optimization. |
 
 ## Config Access Lifecycle
 

--- a/traigent/skills/traigent-decorator-setup/references/execution-modes.md
+++ b/traigent/skills/traigent-decorator-setup/references/execution-modes.md
@@ -12,14 +12,14 @@ from traigent.api.decorators import ExecutionOptions
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `execution_mode` | `str` | `"edge_analytics"` | Where to run: `"edge_analytics"`, `"cloud"`, or `"hybrid"`. |
+| `execution_mode` | `str` | `"edge_analytics"` | Where to run: `"edge_analytics"` for local, `"hybrid"` for portal-tracked local execution, or `"cloud"` for the future remote execution path. |
 | `local_storage_path` | `str \| None` | `None` | Directory path for local result storage. |
 | `minimal_logging` | `bool` | `True` | Minimize logging output during optimization. |
 | `parallel_config` | `ParallelConfig \| dict \| None` | `None` | Parallel execution settings. See ParallelConfig section. |
 | `privacy_enabled` | `bool \| None` | `None` | Enable privacy-preserving mode (no raw data sent to cloud). |
 | `max_total_examples` | `int \| None` | `None` | Cap total examples evaluated across all trials. |
 | `samples_include_pruned` | `bool` | `True` | Whether pruned trials count toward sample limits. |
-| `cloud_fallback_policy` | `str \| None` | `None` | Behavior on cloud execution failure: `"auto"`, `"warn"`, or `"never"`. |
+| `cloud_fallback_policy` | `str \| None` | `None` | Legacy setting for future cloud execution. `cloud` is not available yet and fails closed. |
 
 ### Repetition Fields
 
@@ -58,7 +58,7 @@ from traigent.api.decorators import ExecutionOptions
 
 ### Edge Analytics (Default)
 
-Optimization runs entirely on your local machine. Only anonymized analytics metadata (trial counts, scores, timing) is sent to the Traigent cloud for dashboards and experiment tracking. Raw data, prompts, and model outputs never leave your environment.
+Optimization runs on your local machine. Set `TRAIGENT_OFFLINE_MODE=true` when you want no Traigent backend communication. Raw data, prompts, and model outputs never leave your environment in local mode.
 
 ```python
 @traigent.optimize(
@@ -74,36 +74,15 @@ def my_func(query: str) -> str:
     return call_llm(model=cfg["model"], prompt=query)
 ```
 
-**When to use**: Most use cases. Keeps data local, still get cloud dashboards.
-
-### Cloud
-
-Full remote execution. The Traigent cloud orchestrates trials, manages compute, and stores results. Requires authentication and network connectivity.
-
-```python
-@traigent.optimize(
-    execution=ExecutionOptions(execution_mode="cloud"),
-    configuration_space={"model": ["gpt-3.5-turbo", "gpt-4"]},
-)
-def my_func(query: str) -> str:
-    cfg = traigent.get_config()
-    return call_llm(model=cfg["model"], prompt=query)
-```
-
-**When to use**: When you want centralized orchestration, team collaboration, or need to run optimization on cloud infrastructure.
+**When to use**: Most local/private use cases.
 
 ### Hybrid
 
-Splits execution between local and cloud. Trials run locally, but the cloud coordinates configuration selection, tracks experiments, and provides advanced analytics.
+Supported portal-tracked execution. Trials run locally, while the backend stores sessions and trial metrics for website visibility.
 
 ```python
 @traigent.optimize(
-    execution=ExecutionOptions(
-        execution_mode="hybrid",
-        hybrid_api_endpoint="https://api.traigent.io/v1/hybrid",
-        hybrid_api_batch_size=4,
-        hybrid_api_batch_parallelism=2,
-    ),
+    execution=ExecutionOptions(execution_mode="hybrid"),
     configuration_space={"model": ["gpt-3.5-turbo", "gpt-4"]},
 )
 def my_func(query: str) -> str:
@@ -111,17 +90,26 @@ def my_func(query: str) -> str:
     return call_llm(model=cfg["model"], prompt=query)
 ```
 
-**When to use**: When you need cloud-level coordination but want trial execution to happen locally (e.g., for data privacy or custom infrastructure).
+**When to use**: When you want results in the Traigent portal while keeping trial execution local.
+
+### Cloud
+
+Reserved for future remote execution. It is not implemented yet and fails with: “Cloud remote execution is not available yet; use hybrid for portal-tracked optimization.”
+
+Do not configure new runs with `execution_mode="cloud"` yet. It raises a clear
+unavailable error instead of starting a synthetic remote optimization.
+
+**When to use**: Do not use yet. Choose `hybrid` for portal-tracked optimization.
 
 ### Cloud Fallback Policy
 
-Controls what happens when cloud or hybrid execution fails:
+Cloud fallback policy is retained for compatibility with the future cloud path. It does not make `execution_mode="cloud"` available today:
 
 | Policy | Behavior |
 |---|---|
-| `"auto"` | Silently falls back to local optimization on failure. |
-| `"warn"` | Falls back to local optimization but logs a warning. |
-| `"never"` | Re-raises the exception. No fallback. |
+| `"auto"` | Reserved for future cloud behavior. |
+| `"warn"` | Reserved for future cloud behavior. |
+| `"never"` | Re-raises cloud errors when applicable. |
 
 ## ParallelConfig Integration
 

--- a/traigent/skills/traigent-decorator-setup/references/execution-modes.md
+++ b/traigent/skills/traigent-decorator-setup/references/execution-modes.md
@@ -107,9 +107,9 @@ Cloud fallback policy is retained for compatibility with the future cloud path. 
 
 | Policy | Behavior |
 |---|---|
-| `"auto"` | Reserved for future cloud behavior. |
-| `"warn"` | Reserved for future cloud behavior. |
-| `"never"` | Re-raises cloud errors when applicable. |
+| `"auto"` | Reserved for future cloud behavior; currently inert because cloud mode fails validation before fallback. |
+| `"warn"` | Reserved for future cloud behavior; currently inert because cloud mode fails validation before fallback. |
+| `"never"` | Reserved for future cloud behavior; currently inert because cloud mode fails validation before fallback. |
 
 ## ParallelConfig Integration
 

--- a/traigent/skills/traigent-quickstart/references/environment-variables.md
+++ b/traigent/skills/traigent-quickstart/references/environment-variables.md
@@ -18,7 +18,7 @@ Complete reference of environment variables recognized by the Traigent SDK.
 | `TRAIGENT_STRICT_VALIDATION`      | `true`          | When `true`, DTO schema validation raises exceptions. When `false`, logs warnings only.             |
 | `ENVIRONMENT`                      | `development`   | Execution environment. Set to `production` for production deployments.                              |
 | `JWT_SECRET_KEY`                   | (none)          | Secret key for JWT token validation. Required for production security features.                     |
-| `TRAIGENT_API_KEY`                | (none)          | API key for Traigent Cloud mode. Required when using `execution_mode="cloud"`.                      |
+| `TRAIGENT_API_KEY`                | (none)          | API key for authenticated backend/portal tracking. Use with `execution_mode="hybrid"` for portal-visible runs. `execution_mode="cloud"` is reserved for future remote execution. |
 
 ## LLM Provider API Keys
 
@@ -63,6 +63,15 @@ export TRAIGENT_STRICT_COST_ACCOUNTING=true
 export TRAIGENT_COST_APPROVED=true
 export TRAIGENT_LOG_LEVEL=WARNING
 python optimize_production.py
+```
+
+### Portal-Tracked Hybrid Runs
+
+```bash
+export TRAIGENT_API_KEY=sk-... # pragma: allowlist secret
+export TRAIGENT_BACKEND_URL=https://portal.traigent.ai
+# In code: ExecutionOptions(execution_mode="hybrid")
+python optimize_with_portal_tracking.py
 ```
 
 ### Debug Mode

--- a/traigent/skills/traigent-quickstart/references/installation-extras.md
+++ b/traigent/skills/traigent-quickstart/references/installation-extras.md
@@ -13,13 +13,13 @@ Full reference of optional dependency groups available via `pip install 'traigen
 | `pydanticai`    | PydanticAI agent framework                         | pydantic-ai                                                                  |
 | `security`      | Enterprise security features                       | PyJWT, passlib, FastAPI, Starlette, uvicorn, redis, defusedxml, pyotp        |
 | `visualization` | Visualization and plotting                         | matplotlib, plotly                                                           |
-| `hybrid`        | Hybrid mode (external agentic service optimization)| httpx with HTTP/2                                                            |
+| `hybrid`        | Portal-tracked local execution and external hybrid API integrations | httpx with HTTP/2                                                            |
 | `tracing`       | OpenTelemetry tracing                              | opentelemetry-api, opentelemetry-sdk, opentelemetry-exporter-otlp            |
 | `test`          | Testing dependencies                               | pytest, pytest-asyncio, pytest-cov, pytest-mock, pytest-timeout, pytest-xdist, coverage, ragas, rapidfuzz, hypothesis |
 | `dev`           | Development tools (linting + testing)              | pytest suite, black, isort, flake8, mypy, pre-commit, ruff, bandit           |
 | `docs`          | Documentation generation                           | mkdocs, mkdocs-material, mkdocstrings                                        |
 | `ml`            | Machine learning bundle                            | bayesian + analytics + numpy + scipy                                         |
-| `cloud`         | Cloud execution mode                               | security + boto3                                                             |
+| `cloud`         | Reserved dependencies for future remote execution; not needed for portal-tracked `hybrid` runs | security + boto3                                                             |
 | `all`           | All optional features combined                     | analytics, bayesian, integrations, pydanticai, security, visualization, test, tracing, hybrid |
 | `enterprise`    | Enterprise bundle with all production features     | analytics, bayesian, integrations, security, visualization, test, tracing, ml, cloud, hybrid  |
 

--- a/traigent/traigent_client.py
+++ b/traigent/traigent_client.py
@@ -91,8 +91,8 @@ class TraigentClient:
             agent_builder: Agent builder instance for local execution
 
         Note:
-            Cloud module is only required for 'hybrid' mode.
-            Edge analytics mode works without cloud dependencies installed.
+            Backend integration dependencies are required for 'hybrid' mode.
+            Edge analytics mode works without backend/cloud dependencies installed.
         """
         from traigent.config.backend_config import BackendConfig
 


### PR DESCRIPTION
## Summary
- Clarifies SDK mode semantics across README, guides, skills, feature matrices, and cloud/backend docstrings.
- Documents hybrid as the supported portal-tracked path: trials run locally, backend stores sessions/results.
- Documents cloud as reserved for future remote execution and removes stale wording that implied production cloud execution works today.

## Validation
- git diff --check
- ruff check on touched Python/example files
- pytest -q -o addopts='' tests/unit/config/test_types.py tests/unit/test_traigent_client.py tests/integration/test_execution_modes.py tests/unit/cloud/test_api_operations.py

Focused pytest result: 161 passed, 5 skipped, 1 existing warning.