### PR TITLE
feat: cherry-pick #799 (deterministic keyless quickstart) to main

### DIFF
--- a/.agents/skills/traigent/SKILL.md
+++ b/.agents/skills/traigent/SKILL.md
@@ -115,15 +115,19 @@ This discovers `@traigent.optimize` decorated functions and validates that datas
 
 ## Step 3: Run Mock Optimization
 
-Set mock mode, then run the full optimization pipeline at zero cost. This tests everything — decorator wiring, config sampling, dataset loading, trial execution, scoring — end to end.
+Enable mock mode in code, then run the full optimization pipeline at zero cost. This tests everything — decorator wiring, config sampling, dataset loading, trial execution, scoring — end to end. Mock mode is hard-blocked when `ENVIRONMENT=production`, so this cannot accidentally swap real LLM calls for canned text in a deployed system.
+
+> **Scope note:** `enable_mock_mode_for_quickstart()` flips a *runtime* flag — the LLM interceptors honor it from the moment it's called. It runs AFTER `import traigent`, so any *import-time* behavior of the SDK's optional dependencies (e.g., LiteLLM's model-cost-map fetch) has already executed. For fully hermetic startup (CI, air-gapped runs), set the equivalent env vars BEFORE Python imports anything: `TRAIGENT_MOCK_LLM=true`, `TRAIGENT_OFFLINE_MODE=true`, `LITELLM_LOCAL_MODEL_COST_MAP=True`. The bundled `traigent quickstart` command does this for you.
 
 ```python
 import os
-os.environ["TRAIGENT_MOCK_LLM"] = "true"       # Mock LLM responses
-os.environ["TRAIGENT_OFFLINE_MODE"] = "true"    # Skip backend communication
+os.environ["TRAIGENT_OFFLINE_MODE"] = "true"   # Skip Traigent backend calls
 
 import traigent
 from traigent import Choices, Range
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()              # Mock LLM responses (dev-only)
 
 @traigent.optimize(
     eval_dataset="eval_data.jsonl",
@@ -201,17 +205,19 @@ When the user explicitly says to proceed:
 Models in the config space need corresponding provider keys. Traigent auto-validates keys before starting and raises `ProviderValidationError` with details if validation fails.
 
 ```bash
-export OPENAI_API_KEY="sk-..."         # For gpt-* models
-export ANTHROPIC_API_KEY="sk-ant-..."  # For claude-* models
-export GEMINI_API_KEY="..."            # For gemini-* models
+export OPENAI_API_KEY="sk-..."         # For gpt-* models  # pragma: allowlist secret
+export ANTHROPIC_API_KEY="sk-ant-..."  # For claude-* models  # pragma: allowlist secret
+export GEMINI_API_KEY="..."            # For gemini-* models  # pragma: allowlist secret
 ```
 
-### 2. Remove Mock Flags and Set Cost Controls
+### 2. Skip the Mock-Mode Activation and Set Cost Controls
 
 ```python
 import os
 
-os.environ.pop("TRAIGENT_MOCK_LLM", None)
+# Just don't call enable_mock_mode_for_quickstart() this run.
+# Mock mode is process-local — start a fresh interpreter for the
+# real run if the previous one had it on.
 os.environ.pop("TRAIGENT_OFFLINE_MODE", None)
 
 # Cost limit — default $2.00 USD per run
@@ -253,12 +259,13 @@ my_function.export_config("best_config.json")
 
 | | Mock (Dry Run) | Real |
 |---|---|---|
-| `TRAIGENT_MOCK_LLM` | `true` | unset |
+| Activation | `traigent.testing.enable_mock_mode_for_quickstart()` | (don't call it) |
 | `TRAIGENT_OFFLINE_MODE` | `true` | unset |
 | API keys needed | No | Yes |
 | LLM calls | Mocked | Real |
 | Cost | $0 | Real tokens |
-| Scores meaningful | No (random) | Yes |
+| Scores meaningful | Custom scorer recommended (built-in mock returns generic text) | Yes |
+| Production-safe | Hard-blocked when `ENVIRONMENT=production` | — |
 | Use when | Always first | After mock passes |
 
 ## See Also

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -142,23 +142,14 @@
         "filename": ".agents/skills/traigent/SKILL.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 204
+        "line_number": 208
       },
       {
         "type": "Secret Keyword",
         "filename": ".agents/skills/traigent/SKILL.md",
         "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
         "is_verified": false,
-        "line_number": 205
-      }
-    ],
-    "configs/env-templates/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "configs/env-templates/README.md",
-        "hashed_secret": "33f220dd67f717cc949db63e21c90e130a6137da",
-        "is_verified": false,
-        "line_number": 65
+        "line_number": 209
       }
     ],
     "docs/architecture/plugin_architecture.md": [
@@ -5578,15 +5569,6 @@
         "line_number": 390
       }
     ],
-    "tests/test_cli_auth_integration.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_cli_auth_integration.py",
-        "hashed_secret": "34ad4531592cb8f09eb6fdd15229ed5140ee45c0",
-        "is_verified": false,
-        "line_number": 91
-      }
-    ],
     "tests/unit/adapters/test_execution_adapter.py": [
       {
         "type": "Secret Keyword",
@@ -5632,28 +5614,28 @@
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 88
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "c44b91d6672bb1d7c51e050ababb0146efa84380",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 88
       },
       {
         "type": "Hex High Entropy String",
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 88
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_agent_client.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 201
       }
     ],
     "tests/unit/cloud/test_auth_data_classes.py": [
@@ -5699,21 +5681,21 @@
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "25b5a7e454ccbe4974ee239749935c9e32b887e1",
         "is_verified": false,
-        "line_number": 301
+        "line_number": 317
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "b3215fe1d22a64a131c0f9c09718c5b8860911ad",
         "is_verified": false,
-        "line_number": 334
+        "line_number": 350
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "495289ab973afae18fc84235f33dadc07a9608c4",
         "is_verified": false,
-        "line_number": 365
+        "line_number": 381
       }
     ],
     "tests/unit/cloud/test_backend_bridges_security.py": [
@@ -5738,84 +5720,84 @@
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
         "is_verified": false,
-        "line_number": 237
+        "line_number": 288
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44c08d71fbe20d2cf9c5842af590dda096bee6f9",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 302
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "801f9bf378fc57a61f95a66e2465a02ed3092d7e",
         "is_verified": false,
-        "line_number": 252
+        "line_number": 303
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "c6e454d960df4845f9d69eb11377c8b23882715b",
         "is_verified": false,
-        "line_number": 273
+        "line_number": 324
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
         "is_verified": false,
-        "line_number": 484
+        "line_number": 540
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 514
+        "line_number": 570
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "827ba56f5549ed55e91dc9fb84327b0148c01a5e",
         "is_verified": false,
-        "line_number": 575
+        "line_number": 631
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 681
+        "line_number": 775
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
         "is_verified": false,
-        "line_number": 1008
+        "line_number": 1102
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ad6ed643d097938d8f82b0945077efdc93928614",
         "is_verified": false,
-        "line_number": 1017
+        "line_number": 1111
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 1119
+        "line_number": 1213
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
-        "line_number": 1189
+        "line_number": 1283
       }
     ],
     "tests/unit/cloud/test_cloud_client_validation.py": [
@@ -5859,15 +5841,6 @@
         "line_number": 294
       }
     ],
-    "tests/unit/cloud/test_dataset_converter_validation.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/unit/cloud/test_dataset_converter_validation.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 25
-      }
-    ],
     "tests/unit/cloud/test_session_finalization.py": [
       {
         "type": "Secret Keyword",
@@ -5884,15 +5857,6 @@
         "hashed_secret": "d244bdec6e3b588fa5a9d63a735bc527d57ae878",
         "is_verified": false,
         "line_number": 29
-      }
-    ],
-    "tests/unit/cloud/test_sync_manager.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/cloud/test_sync_manager.py",
-        "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
-        "is_verified": false,
-        "line_number": 106
       }
     ],
     "tests/unit/config/test_api_keys.py": [
@@ -6322,5 +6286,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-19T20:20:57Z"
+  "generated_at": "2026-05-01T10:34:43Z"
 }

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -12,8 +12,12 @@ Works with Claude Code, Cursor, GitHub Copilot, OpenAI Codex, Gemini CLI, Windsu
 
 **Option A — npx (all 8 skills):**
 ```bash
-npx skills add Traigent/agent-skills
+npx skills add Traigent/agents-skills
 ```
+
+> **Note:** The older `Traigent/agent-skills` repo (without the trailing `s`)
+> is deprecated and pinned to 7 skills missing the dry-run-first orchestrator.
+> Use `Traigent/agents-skills` instead.
 
 **Option B — already included:**
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,73 @@
+"""Integration-test fixtures.
+
+Currently provides ``block_network`` — a deny-list socket monkeypatch used
+by the quickstart smoke test to prove the bundled demo runs without any
+outbound network traffic.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+
+import pytest
+
+
+class NetworkBlockedError(RuntimeError):
+    """Raised when test code tries to open a network socket while
+    :func:`block_network` is in effect.
+
+    This is a separate exception class so smoke tests can catch (or not)
+    network attempts unambiguously, without colliding with Python's
+    built-in ``OSError`` hierarchy that real network failures use.
+    """
+
+
+_NETWORK_FAMILIES = {socket.AF_INET, socket.AF_INET6}
+
+
+@pytest.fixture
+def block_network(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Block outbound network socket creation for the duration of the test.
+
+    Wraps ``socket.socket`` so any AF_INET / AF_INET6 construction raises
+    :class:`NetworkBlockedError`. AF_UNIX (and ``socket.socketpair`` which
+    uses it) is allowed — asyncio creates AF_UNIX pipes for its internal
+    self-pipe mechanism on Linux, and those are not network access.
+    Also wraps :func:`socket.create_connection` and
+    :func:`socket.getaddrinfo` to catch DNS resolution attempts a layer
+    above raw sockets.
+    """
+    real_socket = socket.socket
+
+    class _BlockingSocket(real_socket):  # type: ignore[misc, valid-type]
+        def __init__(  # noqa: D401 — wrapper, not a separate API
+            self, family: int = socket.AF_INET, *args: object, **kwargs: object
+        ) -> None:
+            if family in _NETWORK_FAMILIES:
+                raise NetworkBlockedError(
+                    f"socket.socket(family={family!r}) — "
+                    "test marked block_network expected no network access"
+                )
+            super().__init__(family, *args, **kwargs)  # type: ignore[arg-type]
+
+    def _blocked_create_connection(
+        address: tuple[str, int], *args: object, **kwargs: object
+    ) -> None:
+        raise NetworkBlockedError(
+            f"socket.create_connection({address!r}) — "
+            "test marked block_network expected no network access"
+        )
+
+    def _blocked_getaddrinfo(
+        host: str, port: object, *args: object, **kwargs: object
+    ) -> None:
+        raise NetworkBlockedError(
+            f"socket.getaddrinfo({host!r}, {port!r}) — "
+            "test marked block_network expected no network access"
+        )
+
+    monkeypatch.setattr(socket, "socket", _BlockingSocket)
+    monkeypatch.setattr(socket, "create_connection", _blocked_create_connection)
+    monkeypatch.setattr(socket, "getaddrinfo", _blocked_getaddrinfo)
+    yield

--- a/tests/integration/test_quickstart_smoke.py
+++ b/tests/integration/test_quickstart_smoke.py
@@ -1,0 +1,257 @@
+"""Smoke test for the bundled quickstart.
+
+Asserts the load-bearing contract advertised on the website: ``traigent
+quickstart`` (and ``python -m traigent.examples.quickstart``) must
+complete cleanly with **no API keys** and **no successful LLM provider
+calls**, in a true subprocess where any network attempt is blocked
+before any traigent module is imported.
+
+What this test does NOT promise: zero outbound network *attempts*.
+LiteLLM's pricing-map fetch from raw.githubusercontent.com is a
+known import-time attempt that gracefully falls back to bundled
+pricing data when blocked. The contract this file enforces is "no
+real LLM provider call succeeds" + "the user sees a working demo
+with non-zero results" — i.e., no spend and no broken funnel —
+which is what actually matters for the website experience.
+
+Codex's review of the first draft of this file flagged that an
+in-process ``CliRunner`` test cannot prove the no-spend claim if
+heavy SDK modules in ``traigent.__init__.py`` execute network code
+during their own import. So this file runs the bundled quickstart in
+true subprocesses, with a ``sitecustomize.py`` injected via
+``PYTHONPATH`` that monkeypatches ``socket`` BEFORE the interpreter
+processes the first ``import traigent``. Failures here mean the
+website funnel is broken before a user has any chance to see value.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# A sitecustomize.py the subprocess will pick up via PYTHONPATH. It
+# runs at interpreter start (BEFORE traigent imports) and replaces
+# socket.socket / create_connection / getaddrinfo with versions that
+# raise on AF_INET / AF_INET6 traffic. AF_UNIX is allowed so asyncio's
+# self-pipe (and other local IPC) keeps working.
+_SITECUSTOMIZE_SRC = '''
+"""Block all outbound network for this interpreter."""
+import socket as _socket
+
+_NETWORK_FAMILIES = {_socket.AF_INET, _socket.AF_INET6}
+_real_socket = _socket.socket
+
+
+class _BlockingSocket(_real_socket):
+    def __init__(self, family=_socket.AF_INET, *args, **kwargs):
+        if family in _NETWORK_FAMILIES:
+            raise RuntimeError(
+                f"NETWORK_BLOCKED: socket.socket(family={family!r}) — "
+                "smoke test expected no network access"
+            )
+        super().__init__(family, *args, **kwargs)
+
+
+def _blocked_create_connection(address, *args, **kwargs):
+    raise RuntimeError(
+        f"NETWORK_BLOCKED: socket.create_connection({address!r})"
+    )
+
+
+def _blocked_getaddrinfo(host, port, *args, **kwargs):
+    raise RuntimeError(
+        f"NETWORK_BLOCKED: socket.getaddrinfo({host!r}, {port!r})"
+    )
+
+
+_socket.socket = _BlockingSocket
+_socket.create_connection = _blocked_create_connection
+_socket.getaddrinfo = _blocked_getaddrinfo
+'''
+
+
+@pytest.fixture
+def hermetic_subprocess_env(tmp_path: Path) -> dict[str, str]:
+    """Build a clean subprocess env: no provider keys, no Traigent state,
+    network blocked at interpreter start via injected sitecustomize."""
+    site = tmp_path / "site"
+    site.mkdir()
+    (site / "sitecustomize.py").write_text(_SITECUSTOMIZE_SRC, encoding="utf-8")
+
+    # Build env from scratch — explicitly DROP any provider keys and any
+    # mock-mode toggles the parent shell or the autouse conftest fixture
+    # might have set. The bundled quickstart sets its own env vars at
+    # the top of its module, which is exactly the path we're verifying.
+    env: dict[str, str] = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(tmp_path),
+        # PYTHONPATH: site (for sitecustomize) + worktree (so `import
+        # traigent` finds my changes, not the editable install).
+        "PYTHONPATH": f"{site}:{Path(__file__).resolve().parents[2]}",
+        # Skip the SDK's .env auto-load — the main checkout's .env has
+        # TRAIGENT_BACKEND_URL=localhost:5000 etc. that would muddy the
+        # smoke contract.
+        "TRAIGENT_SKIP_DOTENV": "1",
+        # Ensure dev semantics so the in-code API can activate mock mode.
+        "ENVIRONMENT": "development",
+    }
+    return env
+
+
+def _run_in_subprocess(
+    venv_python: Path, args: list[str], env: dict[str, str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Spawn a fresh interpreter and capture both streams."""
+    return subprocess.run(
+        [str(venv_python), *args],
+        env=env,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
+@pytest.fixture
+def venv_python() -> Path:
+    """Path to the venv's python — same one running these tests."""
+    return Path(sys.executable)
+
+
+def _assert_no_provider_call_succeeded(combined: str) -> None:
+    """The contract is "no real LLM API call succeeded" — not "no
+    network attempt was ever made." LiteLLM still tries a model-cost
+    fetch from raw.githubusercontent.com at import time and falls back
+    gracefully when blocked; that's a different (lower-stakes) network
+    path than the LLM provider endpoints whose leak would bill a real
+    account. Assert that the LLM-provider domains specifically do not
+    appear in any successful response context."""
+    forbidden = (
+        "api.openai.com",
+        "api.anthropic.com",
+        "api.cohere.ai",
+        "generativelanguage.googleapis.com",
+    )
+    for host in forbidden:
+        # NETWORK_BLOCKED appearing alongside the host means the
+        # interceptor/blocker caught the attempt — that is the contract
+        # working, not a failure.
+        if host in combined and "NETWORK_BLOCKED" not in combined:
+            raise AssertionError(
+                f"Provider host {host!r} appeared in subprocess output "
+                f"WITHOUT a NETWORK_BLOCKED marker — a real LLM call may "
+                f"have succeeded:\n{combined}"
+            )
+
+
+def test_python_dash_m_runs_with_no_keys(
+    hermetic_subprocess_env: dict[str, str],
+    venv_python: Path,
+    tmp_path: Path,
+) -> None:
+    """``python -m traigent.examples.quickstart`` must complete in a
+    fresh subprocess with no provider keys and no successful network
+    call to any LLM provider, with the network block installed BEFORE
+    any traigent import.
+
+    A regression here means the website funnel is broken: the user
+    copy-pastes the install command, the demo crashes, they bounce.
+    """
+    result = _run_in_subprocess(
+        venv_python,
+        ["-m", "traigent.examples.quickstart"],
+        env=hermetic_subprocess_env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"quickstart exited {result.returncode}\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    _assert_no_provider_call_succeeded(combined)
+    # Mandatory once-per-process WARN must appear when mock mode flips
+    # on (proves the in-code API was actually called by the script).
+    assert "mock mode is now ACTIVE" in combined, (
+        "Expected the in-code activation WARN — got:\n" + combined
+    )
+    # Demo scoring must produce non-zero, model-correlated accuracy so
+    # the user actually sees a meaningful "best config" hit (Codex
+    # review #4 — exit-code-only is not enough).
+    assert "85.0%" in combined or "85%" in combined, (
+        "Demo scoring should produce non-zero, model-correlated scores "
+        "(gpt-4o ~ 85%). Got:\n" + combined
+    )
+    # And the optimization actually ranked a winner.
+    assert "Trial Results" in combined or "Best" in combined, (
+        "Expected a results table or best-config line. Got:\n" + combined
+    )
+
+
+def test_traigent_quickstart_cli_runs_with_no_keys(
+    hermetic_subprocess_env: dict[str, str],
+    venv_python: Path,
+    tmp_path: Path,
+) -> None:
+    """The ``traigent quickstart`` CLI subcommand must behave exactly
+    the same as ``python -m traigent.examples.quickstart`` — same
+    hermetic guarantees, same exit, same activation WARN. The CLI is
+    the canonical install instruction on the website."""
+    # Run via `python -c` so PYTHONPATH (worktree-first) takes precedence
+    # over the venv's editable finder for the main checkout. Same
+    # observable behavior as `traigent quickstart` for the user.
+    result = _run_in_subprocess(
+        venv_python,
+        ["-c", "from traigent.cli.main import cli; cli(['quickstart'])"],
+        env=hermetic_subprocess_env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"traigent quickstart exited {result.returncode}\n"
+        f"--- stdout ---\n{result.stdout}\n"
+        f"--- stderr ---\n{result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    _assert_no_provider_call_succeeded(combined)
+    assert "mock mode is now ACTIVE" in combined
+
+
+def test_subprocess_with_real_looking_key_does_not_spend_it(
+    hermetic_subprocess_env: dict[str, str],
+    venv_python: Path,
+    tmp_path: Path,
+) -> None:
+    """Codex's last point: even if a real-looking ``OPENAI_API_KEY`` is
+    present in the env, the bundled quickstart must NOT spend it. The
+    script overrides the key with a placeholder before any LLM client
+    instantiation, so a mock-regression cannot accidentally bill a real
+    account."""
+    env = dict(hermetic_subprocess_env)
+    env["OPENAI_API_KEY"] = (
+        "sk-fake-real-looking-key-DO-NOT-USE"  # pragma: allowlist secret
+    )
+
+    result = _run_in_subprocess(
+        venv_python,
+        ["-m", "traigent.examples.quickstart"],
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0
+    combined = result.stdout + result.stderr
+    # The provided "real" key must NOT appear anywhere — the script
+    # overwrites it before any client is built.
+    assert "sk-fake-real-looking-key-DO-NOT-USE" not in combined, (
+        "User's OPENAI_API_KEY leaked into output — a mock-regression "
+        "could spend it for real:\n" + combined
+    )
+    _assert_no_provider_call_succeeded(combined)

--- a/tests/unit/examples/test_quickstart_entry.py
+++ b/tests/unit/examples/test_quickstart_entry.py
@@ -1,9 +1,14 @@
 """Tests for the quickstart env-configuration helper.
 
-Guards the invariant raised in PR #664 review: when the quickstart runs in mock
-mode without a ``TRAIGENT_API_KEY``, the user must receive an explicit notice
-before the script silently forces ``TRAIGENT_OFFLINE_MODE=true`` (the offline
-short-circuit otherwise suppresses the downstream "No API key found" warning).
+Guards two invariants:
+
+* When the quickstart runs without a ``TRAIGENT_API_KEY``, the user must
+  receive an explicit notice before the script forces
+  ``TRAIGENT_OFFLINE_MODE=true`` (otherwise the offline short-circuit
+  suppresses the downstream "No API key found" warning — original PR #664
+  review).
+* The helper no longer touches ``TRAIGENT_MOCK_LLM`` — mock mode is
+  activated in code via :func:`traigent.testing.enable_mock_mode_for_quickstart`.
 """
 
 from __future__ import annotations
@@ -18,7 +23,7 @@ def empty_env() -> dict[str, str]:
     return {}
 
 
-def test_warns_when_no_api_key_in_mock_mode(
+def test_warns_when_no_api_key(
     empty_env: dict[str, str], capsys: pytest.CaptureFixture[str]
 ) -> None:
     configure_quickstart_env(empty_env)
@@ -27,7 +32,7 @@ def test_warns_when_no_api_key_in_mock_mode(
     assert "TRAIGENT_API_KEY" in stderr
     assert "offline" in stderr.lower()
     assert empty_env["TRAIGENT_OFFLINE_MODE"] == "true"
-    assert empty_env["TRAIGENT_MOCK_LLM"] == "true"
+    assert empty_env["OPENAI_API_KEY"] == "mock-key-for-demos"  # pragma: allowlist secret
 
 
 def test_no_warning_when_api_key_present(
@@ -40,37 +45,46 @@ def test_no_warning_when_api_key_present(
     stderr = capsys.readouterr().err
     assert "TRAIGENT_API_KEY" not in stderr
     assert "TRAIGENT_OFFLINE_MODE" not in env
-    assert env["TRAIGENT_MOCK_LLM"] == "true"
-
-
-def test_respects_explicit_mock_llm_false(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    env: dict[str, str] = {"TRAIGENT_MOCK_LLM": "false"}
-
-    configure_quickstart_env(env)
-
-    stderr = capsys.readouterr().err
-    assert stderr == ""
-    assert "TRAIGENT_OFFLINE_MODE" not in env
-    assert "OPENAI_API_KEY" not in env
-
-
-@pytest.mark.parametrize("truthy", ["1", "true", "YES", "On"])
-def test_accepts_all_truthy_mock_llm_values(truthy: str) -> None:
-    env: dict[str, str] = {"TRAIGENT_MOCK_LLM": truthy}
-
-    configure_quickstart_env(env)
-
     assert env["OPENAI_API_KEY"] == "mock-key-for-demos"  # pragma: allowlist secret
-    assert env["TRAIGENT_OFFLINE_MODE"] == "true"
 
 
-def test_preserves_existing_offline_mode(
+def test_does_not_set_legacy_mock_env_var(empty_env: dict[str, str]) -> None:
+    configure_quickstart_env(empty_env)
+    # Legacy env-var-based activation is gone; mock mode is enabled in
+    # code via traigent.testing.enable_mock_mode_for_quickstart().
+    assert "TRAIGENT_MOCK_LLM" not in empty_env
+
+
+def test_overrides_offline_false_when_no_api_key(
     empty_env: dict[str, str],
 ) -> None:
+    """Codex review (round 3) finding #4: without a portal API key the
+    SDK can't sync anyway, so an explicit ``TRAIGENT_OFFLINE_MODE=false``
+    plus no key would produce noisy auth errors. We force offline in
+    that case (override, not setdefault)."""
+    empty_env["TRAIGENT_OFFLINE_MODE"] = "false"
+
+    configure_quickstart_env(empty_env)
+
+    assert empty_env["TRAIGENT_OFFLINE_MODE"] == "true"
+
+
+def test_does_not_touch_offline_when_api_key_present(
+    empty_env: dict[str, str],
+) -> None:
+    """When a portal key IS set, the user wants results synced; this
+    helper must not override their offline-mode choice."""
+    empty_env["TRAIGENT_API_KEY"] = "real-key"  # pragma: allowlist secret
     empty_env["TRAIGENT_OFFLINE_MODE"] = "false"
 
     configure_quickstart_env(empty_env)
 
     assert empty_env["TRAIGENT_OFFLINE_MODE"] == "false"
+
+
+def test_preserves_existing_openai_key(empty_env: dict[str, str]) -> None:
+    empty_env["OPENAI_API_KEY"] = "real-openai-key"  # pragma: allowlist secret
+
+    configure_quickstart_env(empty_env)
+
+    assert empty_env["OPENAI_API_KEY"] == "real-openai-key"  # pragma: allowlist secret

--- a/tests/unit/integrations/test_mock_adapter.py
+++ b/tests/unit/integrations/test_mock_adapter.py
@@ -1,14 +1,40 @@
-"""Tests for mock adapter utilities."""
+"""Tests for mock adapter utilities.
+
+Note: ``MockAdapter`` previously consulted ``TRAIGENT_MOCK_LLM`` and a
+set of provider-specific ``*_MOCK`` env vars to decide whether to swap
+real LLM calls for canned mock text — and a stray env var in production
+caused real calls to be silently replaced with mock data. The current
+contract:
+
+* The recommended path is the in-code API
+  :func:`traigent.testing.enable_mock_mode_for_quickstart`, which is
+  the only thing tested here as a ground truth.
+* The legacy ``TRAIGENT_MOCK_LLM=true`` env var is honored as a
+  backward-compat path **only outside production**. ``is_mock_enabled``
+  delegates to :func:`traigent.utils.env_config.is_mock_llm`, which
+  hard-blocks the env-var path when ``ENVIRONMENT=production``. Those
+  guarantees are exercised in
+  ``tests/unit/integrations/test_mock_adapter_safety.py``.
+* Provider-specific ``*_MOCK`` env vars (e.g. ``OPENAI_MOCK=true``)
+  are still completely ignored — those were the worst offenders in the
+  original incident.
+"""
 
 import os
+from collections.abc import Iterator
 from unittest.mock import patch
 
-from traigent.integrations.utils.mock_adapter import (
-    MOCK_ENV_VARS,
-    MockAdapter,
-    MockResponse,
-    with_mock_support,
-)
+import pytest
+
+from traigent import testing as traigent_testing
+from traigent.integrations.utils.mock_adapter import MockAdapter, MockResponse
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock_mode_flag() -> Iterator[None]:
+    traigent_testing._reset_for_tests()
+    yield
+    traigent_testing._reset_for_tests()
 
 
 class TestMockResponse:
@@ -41,77 +67,72 @@ class TestMockResponse:
         assert response.total_tokens == 300
 
 
-class TestMockEnvVars:
-    """Tests for MOCK_ENV_VARS configuration."""
-
-    def test_all_providers_have_env_vars(self) -> None:
-        """Test all expected providers have env var mappings."""
-        expected_providers = [
-            "openai",
-            "azure_openai",
-            "anthropic",
-            "gemini",
-            "cohere",
-            "huggingface",
-            "bedrock",
-            "traigent",
-        ]
-        for provider in expected_providers:
-            assert provider in MOCK_ENV_VARS
-
-
 class TestMockAdapterIsMockEnabled:
-    """Tests for MockAdapter.is_mock_enabled method."""
+    """``is_mock_enabled`` honors the in-code API and the env-var fallback
+    (in non-production); provider-specific ``*_MOCK`` vars are ignored."""
 
-    def test_global_mock_mode_true(self) -> None:
-        """Test global TRAIGENT_MOCK_LLM=true enables mock."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
+    def test_in_code_api_enables_mock(self) -> None:
+        """The in-code API is the canonical path: it must flip every
+        provider's ``is_mock_enabled`` to True."""
+        with patch.dict(os.environ, {}, clear=True):
+            traigent_testing.enable_mock_mode_for_quickstart()
             assert MockAdapter.is_mock_enabled("openai") is True
             assert MockAdapter.is_mock_enabled("anthropic") is True
             assert MockAdapter.is_mock_enabled("unknown") is True
 
-    def test_global_mock_mode_1(self) -> None:
-        """Test global TRAIGENT_MOCK_LLM=1 enables mock."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "1"}, clear=True):
+    def test_global_mock_env_enables_in_dev(self) -> None:
+        """``TRAIGENT_MOCK_LLM=true`` is the legacy backward-compat path
+        and works in dev/test environments. The hard block in production
+        is exercised in ``test_mock_adapter_safety.py``."""
+        with patch.dict(
+            os.environ,
+            {"TRAIGENT_MOCK_LLM": "true", "ENVIRONMENT": "development"},
+            clear=True,
+        ):
+            assert MockAdapter.is_mock_enabled("openai") is True
+            assert MockAdapter.is_mock_enabled("anthropic") is True
+            assert MockAdapter.is_mock_enabled("unknown") is True
+
+    def test_global_mock_env_1_enables_in_dev(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"TRAIGENT_MOCK_LLM": "1", "ENVIRONMENT": "development"},
+            clear=True,
+        ):
             assert MockAdapter.is_mock_enabled("openai") is True
 
-    def test_global_mock_mode_yes(self) -> None:
-        """Test global TRAIGENT_MOCK_LLM=yes enables mock."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "yes"}, clear=True):
+    def test_global_mock_env_yes_enables_in_dev(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"TRAIGENT_MOCK_LLM": "yes", "ENVIRONMENT": "development"},
+            clear=True,
+        ):
             assert MockAdapter.is_mock_enabled("openai") is True
 
-    def test_provider_specific_mock(self) -> None:
-        """Test provider-specific mock env var."""
+    def test_provider_specific_env_is_ignored(self) -> None:
+        """Provider-specific ``*_MOCK`` env vars must NOT enable mock
+        mode — those were the worst offenders in the original incident
+        (one var per provider, easy to miss)."""
         with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
-            assert MockAdapter.is_mock_enabled("openai") is True
+            assert MockAdapter.is_mock_enabled("openai") is False
             assert MockAdapter.is_mock_enabled("anthropic") is False
 
-    def test_provider_specific_azure(self) -> None:
-        """Test Azure-specific mock env var."""
-        with patch.dict(os.environ, {"AZURE_OPENAI_MOCK": "true"}, clear=True):
-            assert MockAdapter.is_mock_enabled("azure_openai") is True
-            assert MockAdapter.is_mock_enabled("openai") is False
-
-    def test_no_mock_enabled(self) -> None:
-        """Test mock is disabled when no env vars set."""
+    def test_no_env_returns_false(self) -> None:
+        """With no env vars and no in-code activation, mock is off."""
         with patch.dict(os.environ, {}, clear=True):
             assert MockAdapter.is_mock_enabled("openai") is False
             assert MockAdapter.is_mock_enabled("anthropic") is False
 
-    def test_mock_disabled_with_false(self) -> None:
-        """Test mock is disabled with false value."""
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "false"}, clear=True):
-            assert MockAdapter.is_mock_enabled("openai") is False
-
-    def test_case_insensitive_provider(self) -> None:
-        """Test provider name is case insensitive."""
+    def test_case_insensitive_provider_still_irrelevant_for_provider_envs(
+        self,
+    ) -> None:
         with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
-            assert MockAdapter.is_mock_enabled("OpenAI") is True
-            assert MockAdapter.is_mock_enabled("OPENAI") is True
+            assert MockAdapter.is_mock_enabled("OpenAI") is False
+            assert MockAdapter.is_mock_enabled("OPENAI") is False
 
 
 class TestMockAdapterGetMockResponse:
-    """Tests for MockAdapter.get_mock_response method."""
+    """``get_mock_response`` works for tests that invoke it explicitly."""
 
     def test_openai_mock_response(self) -> None:
         """Test OpenAI mock response structure."""
@@ -252,60 +273,3 @@ class TestBuildMockMethods:
         assert result["usage"]["prompt_tokens"] == data.prompt_tokens
         assert result["usage"]["completion_tokens"] == data.completion_tokens
         assert result["usage"]["total_tokens"] == data.total_tokens
-
-
-class TestWithMockSupportDecorator:
-    """Tests for with_mock_support decorator."""
-
-    def test_decorator_returns_mock_when_enabled(self) -> None:
-        """Test decorator returns mock response when enabled."""
-
-        @with_mock_support("openai")
-        def real_function(**kwargs):
-            return "real response"
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}):
-            result = real_function(model="gpt-4")
-
-        assert isinstance(result, dict)
-        assert "choices" in result
-
-    def test_decorator_calls_real_function_when_disabled(self) -> None:
-        """Test decorator calls real function when mock disabled."""
-
-        @with_mock_support("openai")
-        def real_function(**kwargs):
-            return "real response"
-
-        with patch.dict(os.environ, {}, clear=True):
-            result = real_function()
-
-        assert result == "real response"
-
-    def test_decorator_preserves_function_args(self) -> None:
-        """Test decorator preserves function arguments."""
-        calls = []
-
-        @with_mock_support("openai")
-        def capture_function(*args, **kwargs):
-            calls.append((args, kwargs))
-            return "real response"
-
-        with patch.dict(os.environ, {}, clear=True):
-            capture_function("arg1", key="value")
-
-        assert len(calls) == 1
-        assert calls[0] == (("arg1",), {"key": "value"})
-
-    def test_decorator_uses_provider_specific_env(self) -> None:
-        """Test decorator respects provider-specific env var."""
-
-        @with_mock_support("anthropic")
-        def real_function():
-            return "real response"
-
-        # Only OPENAI_MOCK is set, not ANTHROPIC_MOCK
-        with patch.dict(os.environ, {"OPENAI_MOCK": "true"}, clear=True):
-            result = real_function()
-
-        assert result == "real response"

--- a/tests/unit/integrations/test_mock_adapter_safety.py
+++ b/tests/unit/integrations/test_mock_adapter_safety.py
@@ -1,0 +1,203 @@
+"""Safety guarantees for mock-mode activation.
+
+These tests guard the original prod incident: a stray ``TRAIGENT_MOCK_LLM``
+env var must NOT silently swap real LLM calls for canned mock responses.
+Mock mode is process-local and only flips on after an explicit in-code
+call to :func:`traigent.testing.enable_mock_mode_for_quickstart`.
+
+Also covers Codex review finding #5: every LLM-interceptor call site must
+read the same flag. We check all four (LangChain OpenAI, LangChain
+Anthropic, LiteLLM sync, LiteLLM async) via ``MockAdapter.is_mock_enabled``,
+which is what each interceptor consults at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from traigent import testing as traigent_testing
+from traigent.integrations.utils.mock_adapter import MockAdapter
+from traigent.utils.env_config import is_mock_llm
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_mode_flag() -> Iterator[None]:
+    traigent_testing._reset_for_tests()
+    yield
+    traigent_testing._reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ() -> Iterator[None]:
+    """Snapshot ``os.environ`` and restore it after the test.
+
+    Codex review (round 3) finding #2: tests that call
+    ``importlib.reload(env_config)`` trigger ``load_dotenv()`` at module
+    init, which mutates ``os.environ`` *outside* of monkeypatch's
+    tracking. Without this fixture, vars added by a ``.env`` file leak
+    into subsequent tests — including ``ENVIRONMENT=production``, which
+    flipped a downstream test result.
+    """
+    snapshot = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(snapshot)
+
+
+def test_env_var_does_not_enable_in_code_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The in-code flag must remain false when only the env var is set —
+    the API call is the only thing that flips :func:`is_mock_mode_enabled`.
+
+    The env var still triggers the SDK's mock-aware behavior in
+    non-production (see ``test_env_var_works_in_dev_blocks_in_prod``),
+    but that path is gated by environment, not by this flag."""
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+    assert traigent_testing.is_mock_mode_enabled() is False, (
+        "enable_mock_mode_for_quickstart() is the only way to flip the "
+        "in-code flag — env var must not touch it."
+    )
+
+
+def test_env_var_works_in_dev_blocks_in_prod(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backward-compat path: ``TRAIGENT_MOCK_LLM=true`` activates mock
+    mode in dev/test (so existing fixtures keep working) but the env-var
+    branch is hard-skipped when ``ENVIRONMENT=production``. This is the
+    surviving guard against the original prod incident."""
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    # Re-evaluate the cached _is_production_env in env_config — it's set
+    # at import time; re-import to refresh.
+    import importlib
+
+    from traigent.utils import env_config as _ec
+
+    importlib.reload(_ec)
+    assert _ec.is_mock_llm() is True, "dev env must honor env-var fallback"
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    # Production env-var presence is now hard-blocked at import; the
+    # import itself must raise. This is why the sweeping prod-time
+    # incident is no longer reachable.
+    with pytest.raises(OSError, match="production"):
+        importlib.reload(_ec)
+
+    # Restore for downstream tests.
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    importlib.reload(_ec)
+
+
+def test_in_code_api_enables_mock_for_every_interceptor() -> None:
+    """Codex finding #5: all four interceptor call sites must consult the
+    same flag. ``MockAdapter.is_mock_enabled`` is what each interceptor
+    actually calls — verify every provider name flips on together."""
+    assert traigent_testing.is_mock_mode_enabled() is False
+
+    traigent_testing.enable_mock_mode_for_quickstart()
+
+    assert traigent_testing.is_mock_mode_enabled() is True
+    assert is_mock_llm() is True
+    for provider in ("openai", "anthropic", "litellm", "azure_openai", "gemini"):
+        assert MockAdapter.is_mock_enabled(provider) is True, (
+            f"Provider {provider} did not see mock mode after explicit "
+            "API call — interceptor sites are not centralized."
+        )
+
+
+def test_activation_is_idempotent_and_logs_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """First activation logs a single mandatory WARN. Subsequent calls
+    are no-ops and must NOT spam logs (Codex finding #2)."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="traigent.testing"):
+        traigent_testing.enable_mock_mode_for_quickstart()
+        traigent_testing.enable_mock_mode_for_quickstart()
+        traigent_testing.enable_mock_mode_for_quickstart()
+
+    activation_warns = [
+        r for r in caplog.records if "mock mode is now ACTIVE" in r.getMessage()
+    ]
+    assert len(activation_warns) == 1, (
+        f"Expected exactly one mandatory activation WARN, got "
+        f"{len(activation_warns)} — log spam will hide the signal"
+    )
+
+
+def test_in_code_api_is_blocked_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review #3: ``enable_mock_mode_for_quickstart`` itself must
+    be blocked in production, not just the env-var path. Otherwise a
+    misconfigured deployment that runs example scripts in prod could
+    silently activate mock mode."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    with pytest.raises(RuntimeError, match="production"):
+        traigent_testing.enable_mock_mode_for_quickstart()
+
+    assert traigent_testing.is_mock_mode_enabled() is False, (
+        "Mock mode must NOT be enabled when the in-code API was rejected"
+    )
+
+
+def test_dotenv_late_load_does_not_bypass_prod_guard(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex review #1 regression test: a ``.env`` file that lands
+    ``ENVIRONMENT=production`` and ``TRAIGENT_MOCK_LLM=true`` into
+    ``os.environ`` AFTER the first guard runs must still trigger the
+    OSError on the post-dotenv pass."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "ENVIRONMENT=production\nTRAIGENT_MOCK_LLM=true\n",  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+
+    # Drop any pre-existing values so the dotenv load is the path that
+    # introduces them. ``load_dotenv`` is non-overriding by default —
+    # which is the exact reason a manual ``os.environ.update`` would not
+    # reproduce this scenario.
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+
+    from dotenv import load_dotenv
+
+    from traigent.utils.env_config import _check_mock_llm_prod_guard
+
+    # First pass (no .env loaded yet) — guard sees clean env, no-op.
+    _check_mock_llm_prod_guard()
+
+    # Simulate the SDK's own dotenv load, then re-run the guard exactly
+    # as env_config.py does at module import.
+    load_dotenv(env_file)
+    with pytest.raises(OSError, match="production"):
+        _check_mock_llm_prod_guard()
+
+
+def test_reset_for_tests_clears_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The private test helper must fully reset both the flag and the
+    once-only log gate, so tests that re-activate get the WARN again."""
+    # The repo's autouse conftest fixture sets TRAIGENT_MOCK_LLM=true for
+    # every test. Clear it here so we can prove the in-code flag is the
+    # only thing keeping mock mode on; otherwise the env-var fallback
+    # would mask whether the reset actually worked.
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+
+    traigent_testing.enable_mock_mode_for_quickstart()
+    assert traigent_testing.is_mock_mode_enabled() is True
+
+    traigent_testing._reset_for_tests()
+
+    assert traigent_testing.is_mock_mode_enabled() is False
+    for provider in ("openai", "anthropic", "litellm"):
+        assert MockAdapter.is_mock_enabled(provider) is False

--- a/tests/unit/integrations/test_no_mock_llm_env.py
+++ b/tests/unit/integrations/test_no_mock_llm_env.py
@@ -1,0 +1,231 @@
+"""Verify dangerous env-toggles are not honored.
+
+Sprint 2 cleanup (S2-B) removed the ``TRAIGENT_MOCK_LLM`` env-toggle
+from three high-severity sites that previously shipped to customers:
+
+* ``traigent/integrations/utils/mock_adapter.py`` — ``with_mock_support``
+  decorator was deleted entirely. ``MockAdapter.is_mock_enabled`` now
+  consults the in-code flag set by
+  :func:`traigent.testing.enable_mock_mode_for_quickstart`. The legacy
+  ``TRAIGENT_MOCK_LLM=true`` env var is honored only outside production
+  (and is hard-blocked when ``ENVIRONMENT=production``); see
+  ``test_mock_adapter_safety.py`` for those guarantees.
+* ``traigent/security/encryption.py`` — encrypt() / decrypt() fallback
+  branches (env-toggle produced ``b"mock_" + plaintext`` "ciphertext"
+  and stripped the prefix on decrypt). These were deleted with no
+  fallback at all.
+* ``traigent/evaluators/local.py`` — ``_compute_mock_accuracy`` (env
+  toggle fabricated accuracy via random.uniform() + string-length
+  heuristics). Deleted with no fallback.
+
+These tests pin the surviving guarantees: provider-specific
+``*_MOCK`` env vars are completely ignored everywhere, the
+``with_mock_support`` decorator is gone, and the encryption /
+evaluation paths fail closed regardless of any mock-style env var.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from traigent.integrations.utils.mock_adapter import MockAdapter
+from traigent.security.encryption import EncryptionManager, KeyManager
+
+
+class TestProviderSpecificMockEnvsAreIgnored:
+    """Provider-specific ``*_MOCK`` env vars (e.g. ``OPENAI_MOCK=true``)
+    were the worst offenders in the original prod incident — one var
+    per provider, easy to miss in a deployment audit. Those are
+    completely ignored regardless of ``ENVIRONMENT`` or any other
+    settings."""
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "OPENAI_MOCK",
+            "AZURE_OPENAI_MOCK",
+            "ANTHROPIC_MOCK",
+            "GEMINI_MOCK",
+            "COHERE_MOCK",
+            "HUGGINGFACE_MOCK",
+            "BEDROCK_MOCK",
+        ],
+    )
+    def test_provider_specific_mock_envs_do_not_enable_mock(self, var: str) -> None:
+        """Provider-specific *_MOCK env vars must not enable mock mode."""
+        with patch.dict(os.environ, {var: "true"}, clear=True):
+            # Strip the trailing _MOCK to derive the provider name.
+            provider = var.removesuffix("_MOCK").lower()
+            assert MockAdapter.is_mock_enabled(provider) is False
+
+    def test_with_mock_support_decorator_is_no_longer_exported(self) -> None:
+        """``with_mock_support`` was removed from the module + package API."""
+        import traigent.integrations.utils as utils_pkg
+        from traigent.integrations.utils import mock_adapter
+
+        assert not hasattr(mock_adapter, "with_mock_support")
+        assert not hasattr(utils_pkg, "with_mock_support")
+
+
+class TestEncryptionIgnoresEnv:
+    """encrypt() / decrypt() must fail closed regardless of TRAIGENT_MOCK_LLM."""
+
+    def test_encrypt_with_mock_env_still_raises_when_no_crypto(self) -> None:
+        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock encryption."""
+        key_manager = KeyManager()
+        em = EncryptionManager(key_manager)
+        em.crypto_available = False  # simulate missing cryptography lib
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            with pytest.raises(
+                RuntimeError, match="requires the 'cryptography' package"
+            ):
+                em.encrypt("payload that must not leak as plaintext")
+
+    def test_decrypt_with_mock_env_still_raises_when_no_crypto(self) -> None:
+        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock decryption."""
+        key_manager = KeyManager()
+        em = EncryptionManager(key_manager)
+        em.crypto_available = False
+        key_id = key_manager.generate_key("AES-256")
+        envelope = {
+            "ciphertext": b"mock_attacker_supplied_payload",
+            "iv": os.urandom(12),
+            "tag": os.urandom(16),
+            "key_id": key_id,
+        }
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            with pytest.raises(
+                RuntimeError, match="requires the 'cryptography' package"
+            ):
+                em.decrypt(envelope)
+
+    def test_encrypt_does_not_emit_mock_prefix_with_real_crypto(self) -> None:
+        """Real encryption never emits the legacy b'mock_' or b'encrypted_' prefix."""
+        key_manager = KeyManager()
+        em = EncryptionManager(key_manager)
+        if not em.crypto_available:
+            pytest.skip("cryptography not installed in this environment")
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            result = em.encrypt(b"sensitive payload")
+
+        assert not result["ciphertext"].startswith(b"mock_")
+        assert not result["ciphertext"].startswith(b"encrypted_")
+        # Round-trip must still succeed under real crypto.
+        assert em.decrypt(result) == b"sensitive payload"
+
+
+class TestLocalEvaluatorIgnoresEnv:
+    """LocalEvaluator must always compute real accuracy, regardless of env."""
+
+    def test_compute_mock_accuracy_method_is_removed(self) -> None:
+        """The fabricator method must no longer exist on LocalEvaluator."""
+        from traigent.evaluators.local import LocalEvaluator
+
+        assert not hasattr(LocalEvaluator, "_compute_mock_accuracy")
+        assert not hasattr(LocalEvaluator, "_log_mock_mode_warning")
+
+    def test_accuracy_metric_is_real_even_with_mock_env(self) -> None:
+        """With TRAIGENT_MOCK_LLM=true, accuracy must be deterministic real comparison."""
+        from traigent.evaluators.local import LocalEvaluator
+
+        evaluator = LocalEvaluator(metrics=["accuracy"])
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            # Identical strings — real accuracy must be 1.0.
+            metrics_match = evaluator._compute_example_metrics(
+                actual_output="hello",
+                expected_output="hello",
+            )
+            # Different strings — real accuracy must be 0.0.
+            metrics_mismatch = evaluator._compute_example_metrics(
+                actual_output="hello",
+                expected_output="goodbye",
+            )
+
+        assert metrics_match["accuracy"] == 1.0
+        assert metrics_mismatch["accuracy"] == 0.0
+
+    def test_accuracy_metric_does_not_use_random_with_mock_env(self) -> None:
+        """Repeat calls under TRAIGENT_MOCK_LLM=true must be deterministic.
+
+        The old _compute_mock_accuracy used random.uniform() so identical
+        inputs would yield different scores. The real path is purely
+        deterministic.
+        """
+        from traigent.evaluators.local import LocalEvaluator
+
+        evaluator = LocalEvaluator(metrics=["accuracy"])
+
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            scores = [
+                evaluator._compute_example_metrics(
+                    actual_output="positive sentiment indeed", expected_output="other"
+                )["accuracy"]
+                for _ in range(10)
+            ]
+
+        # All identical — no random fabrication.
+        assert len(set(scores)) == 1
+        # And it's the real-comparison value (mismatch -> 0.0).
+        assert scores[0] == 0.0
+
+
+class TestMockModeConfigIsInert:
+    """``mock_mode_config`` must not change optimizer or evaluator behaviour.
+
+    Round 2 of S2-B retired the last behavioural sites that consulted this
+    parameter. The parameter is still accepted on public APIs for backward
+    compatibility but must be a true no-op.
+    """
+
+    def test_resolve_custom_evaluator_ignores_mock_mode_config(self) -> None:
+        """``resolve_custom_evaluator`` must return the user evaluator regardless of mock_mode_config."""
+        from traigent.core.optimization_pipeline import resolve_custom_evaluator
+
+        def my_evaluator(*_args: object, **_kwargs: object) -> dict[str, float]:
+            return {"accuracy": 1.0}
+
+        # Even with TRAIGENT_MOCK_LLM=true AND a mock_mode_config that previously
+        # would have triggered the override, the user-supplied evaluator wins.
+        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
+            result = resolve_custom_evaluator(
+                my_evaluator,
+                mock_mode_config={"enabled": True, "override_evaluator": True},
+                decorator_custom_evaluator=None,
+            )
+        assert result is my_evaluator
+
+        # And without the env var, same behaviour.
+        with patch.dict(os.environ, {}, clear=True):
+            result = resolve_custom_evaluator(
+                None,
+                mock_mode_config={"enabled": True, "override_evaluator": True},
+                decorator_custom_evaluator=my_evaluator,
+            )
+        assert result is my_evaluator
+
+    def test_apply_mock_config_overrides_does_not_change_algorithm(self) -> None:
+        """``_apply_mock_config_overrides`` must not change the algorithm or seed."""
+        from traigent.core.optimized_function import OptimizedFunction
+
+        # Build a minimal stand-in with the attribute the method reads.
+        instance = OptimizedFunction.__new__(OptimizedFunction)
+        instance.mock_mode_config = {  # type: ignore[attr-defined]
+            "optimizer": "grid_search",  # would have rerouted in round 1
+            "random_seed": 1234,
+        }
+
+        kwargs: dict[str, object] = {}
+        algo = OptimizedFunction._apply_mock_config_overrides(
+            instance, "bayesian", kwargs
+        )
+
+        # Algorithm unchanged, no seed injected.
+        assert algo == "bayesian"
+        assert "random_seed" not in kwargs

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -38,8 +38,66 @@ Example:
 from __future__ import annotations
 
 import builtins
+import os
 import sys
 import warnings
+
+
+# ---------------------------------------------------------------------------
+# Quickstart bootstrap (must run BEFORE the heavy package imports below).
+# ---------------------------------------------------------------------------
+#
+# ``traigent quickstart`` and ``python -m traigent.examples.quickstart`` both
+# trigger ``traigent/__init__.py`` first (Python imports the parent package
+# before resolving any submodule), which pulls in optional dependencies
+# (LiteLLM model discovery, langfuse, etc.) that may attempt network at
+# import time. The bundled quickstart is the load-bearing demo on the
+# website funnel and MUST work with no API keys, no network, and no
+# surprises — so we detect quickstart invocations by inspecting ``sys.argv``
+# at the top of this module and seed the legacy env-var paths the SDK
+# already knows about. For non-quickstart invocations this is a no-op,
+# preserving the SDK's normal behavior for production code.
+def _is_quickstart_invocation() -> bool:
+    if not sys.argv:
+        return False
+    argv0 = sys.argv[0] or ""
+    # ``python -m traigent.examples.quickstart`` — argv[0] is the path
+    # to the quickstart's __main__.py
+    if argv0.endswith(("quickstart/__main__.py", "quickstart\\__main__.py")):
+        return True
+    # ``traigent quickstart`` — argv[0] is the venv's bin/traigent script
+    # and argv[1] is the subcommand name. Gate on argv[0] basename being
+    # *exactly* the traigent CLI so an unrelated tool whose name happens
+    # to contain "traigent" (e.g. ``my-traigent-util quickstart``) does
+    # NOT silently override the user's OPENAI_API_KEY.
+    if len(sys.argv) >= 2 and sys.argv[1] == "quickstart":
+        basename = os.path.basename(argv0).lower()
+        if basename in {"traigent", "traigent.exe"}:
+            return True
+    return False
+
+
+if _is_quickstart_invocation():
+    # Sentinel telling env_config's prod guard that this env-var write is
+    # internal bootstrap, not user code. The prod hard-block still fires
+    # if ENVIRONMENT=production (correct: mock mode is blocked even from
+    # quickstart in prod), but the dev-mode deprecation warning meant for
+    # users who set TRAIGENT_MOCK_LLM themselves is suppressed — they
+    # ARE using the in-code path; the env var is just how we hand state
+    # across the import boundary.
+    os.environ["_TRAIGENT_QUICKSTART_BOOTSTRAP"] = "1"
+    os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    # Only force offline if the user hasn't supplied a portal key — they
+    # may want results synced even while LLM calls stay mocked.
+    if not os.environ.get("TRAIGENT_API_KEY"):
+        os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+    # OVERRIDE OPENAI_API_KEY (not setdefault): if a real key is sitting
+    # in the parent shell, a mock-regression in the demo could otherwise
+    # spend it. The placeholder cannot succeed against a real OpenAI
+    # endpoint, which is the whole point.
+    os.environ["OPENAI_API_KEY"] = "mock-key-for-demos"  # pragma: allowlist secret
+
 
 # Suppress noisy FutureWarning from transitive deps (instructor → google.generativeai)
 warnings.filterwarnings(
@@ -131,6 +189,7 @@ from traigent.api.validation_protocol import (
 from traigent.api.validation_protocol import (
     ValidationResult as ConstraintValidationResult,
 )
+from traigent.cloud.benchmark_client import BenchmarkClient, BenchmarkClientConfig
 
 # Thread context helpers
 from traigent.config.context import copy_context_to_thread, get_trial_context
@@ -165,6 +224,7 @@ from traigent.evaluation import (
     ScoreRecordListResponse,
     ScoreSource,
 )
+from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.observability import (
     CorrelationIds,
     ObservabilityClient,

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -376,10 +376,14 @@ def cli(verbose: bool, debug: bool, quiet: bool) -> None:
 
 @cli.command()
 def quickstart() -> None:
-    """Run the bundled mock-mode demo. Zero API keys, zero network.
+    """Run the bundled mock-mode demo. No API keys, no LLM provider calls.
 
     Equivalent to ``python -m traigent.examples.quickstart`` — this is
-    the canonical "first run" surface advertised on the website.
+    the canonical "first run" surface advertised on the website. LiteLLM
+    may still attempt an import-time model-cost-map fetch from
+    raw.githubusercontent.com (it falls back to bundled pricing data
+    when offline); the guarantee is no provider spend, not zero
+    outbound packets.
     """
     from traigent.examples.quickstart.__main__ import main as run_quickstart
 

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -375,6 +375,18 @@ def cli(verbose: bool, debug: bool, quiet: bool) -> None:
 
 
 @cli.command()
+def quickstart() -> None:
+    """Run the bundled mock-mode demo. Zero API keys, zero network.
+
+    Equivalent to ``python -m traigent.examples.quickstart`` — this is
+    the canonical "first run" surface advertised on the website.
+    """
+    from traigent.examples.quickstart.__main__ import main as run_quickstart
+
+    run_quickstart()
+
+
+@cli.command()
 def info() -> None:
     """Show Traigent SDK version and system information."""
     version_info = get_version_info()

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -1,37 +1,48 @@
 """Find the best model and temperature for your task - in one decorator.
 
-No API keys needed - runs in mock mode and simulates LLM responses
-so you can see the optimization flow instantly. Set ``TRAIGENT_API_KEY``
-to sync results to the portal even while LLM calls stay mocked.
-For a real run with actual LLM calls, see walkthrough/real/01_tuning_qa.py.
+No API keys, no network, no surprises. The bundled quickstart is the
+load-bearing demo on the website funnel; everything below is structured
+to make that promise true.
+
+The hermetic env-var setup that makes "no keys, no network" work has to
+run before ``traigent/__init__.py`` itself executes (because that module
+pulls in optional deps like LiteLLM that may try to fetch model cost
+maps at import time). It can't live here — by the time this file
+executes, the parent package has already loaded. Instead, the bootstrap
+lives at the very top of :mod:`traigent.__init__`, gated on a
+``sys.argv`` check that detects quickstart invocations
+(``traigent quickstart`` and ``python -m traigent.examples.quickstart``).
+This file is the *demo*; the SDK package itself owns the bootstrap.
+
+Set ``TRAIGENT_API_KEY`` to sync results to the portal even while LLM
+calls stay mocked. For a real run with actual LLM calls, see
+``walkthrough/real/01_tuning_qa.py``.
 """
 
 import asyncio
 import os
 from pathlib import Path
 
+# Flip the in-code mock-mode flag too. The bootstrap in traigent/__init__.py
+# already set TRAIGENT_MOCK_LLM=true so the env-var path is active, but
+# calling the API here makes mock mode visible in code review and proves
+# the recommended user-facing API works (it would also activate mock if
+# the bootstrap somehow didn't fire).
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
+
 from traigent.examples.quickstart._env import configure_quickstart_env
-from traigent.utils.env_config import is_truthy
 
 configure_quickstart_env(os.environ)
 
-# The bundled dataset lives next to this file (inside the installed package).
-# Set TRAIGENT_DATASET_ROOT so the SDK's path validation accepts it regardless
-# of which directory the user runs from.
+# Bundled dataset — set TRAIGENT_DATASET_ROOT so the SDK's path
+# validation accepts it regardless of the user's CWD.
 _PACKAGE_DIR = str(Path(__file__).resolve().parent)
 os.environ.setdefault("TRAIGENT_DATASET_ROOT", _PACKAGE_DIR)
 
-# NOTE: This uses LangChain's ChatOpenAI rather than the litellm calls shown
-# in the documentation. That is intentional and temporary: Traigent's mock
-# interceptor (TRAIGENT_MOCK_LLM=true) only patches LangChain's ChatOpenAI at
-# this point - it does not yet intercept raw litellm/openai calls.
-# Once the interceptor adds raw litellm support this file will be updated to
-# match the litellm style shown in the docs.
-from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
-
-import traigent
-from traigent.api.decorators import EvaluationOptions
+import traigent  # noqa: E402
+from traigent.api.decorators import EvaluationOptions  # noqa: E402
 
 DATASET = str(Path(__file__).resolve().parent / "qa_samples.jsonl")
 CONFIG_SPACE = {
@@ -43,32 +54,82 @@ _SYSTEM_PROMPT = (
     "Answer in as few words as possible. Give only the answer itself, nothing else."
 )
 
-# In mock mode the LLM returns a fixed placeholder string, so contains_accuracy
-# would always score 0.  Let the built-in mock simulation handle accuracy instead.
-_mock_mode = is_truthy(os.environ.get("TRAIGENT_MOCK_LLM"))
+# Model-correlated scores so the demo's results table actually ranks
+# trials. The mock interceptor returns a generic placeholder string —
+# a real ``contains``-style metric on that output would always score 0,
+# making every trial look identical and hiding the optimization signal.
+# This scorer is independent of the LLM output: it produces non-zero,
+# model-correlated values so users see a meaningful "best config" hit.
+# A custom scoring function is the right escape hatch for mock-mode
+# demos; users who switch to real LLMs replace it with their own
+# accuracy metric (see walkthrough/real/01_tuning_qa.py).
+_MODEL_DEMO_SCORE = {"gpt-4o": 0.85, "gpt-4o-mini": 0.65}
 
 
-def contains_accuracy(output: str, expected: str) -> float:
-    """1.0 if the expected answer appears anywhere in the output (case-insensitive)."""
-    return 1.0 if expected.lower() in output.lower() else 0.0
+def _demo_scorer(
+    output: str,
+    expected: str,
+    config: dict[str, object] | None = None,
+    **_kwargs: object,
+) -> float:
+    """Mock-mode demo scorer — produces model-correlated, deterministic scores.
+
+    Ignores ``output`` (which is a generic mock string in mock mode) and
+    returns a score derived from the trial's ``model`` and
+    ``temperature``. Lower temperature gets a tiny boost so trials
+    within the same model rank distinctly.
+
+    If the SDK does not forward the trial config as a ``config=`` kwarg
+    to metric functions (Greptile review #2 — silent zero-score risk),
+    fall back to :func:`traigent.get_config` so the demo doesn't
+    silently degrade into "every trial scores the same".
+    """
+    cfg = config
+    if not cfg:
+        # Fall back to the active trial's config from the SDK context.
+        # This may itself be empty if called outside an optimization
+        # (e.g. during validation) — in that case we return a neutral
+        # mid-range score rather than silently asserting a winner.
+        try:
+            from traigent.api.functions import get_config
+
+            cfg = get_config() or {}
+        except Exception:
+            cfg = {}
+    base = _MODEL_DEMO_SCORE.get(str(cfg.get("model")), 0.5)
+    temperature_raw = cfg.get("temperature", 0.5)
+    temperature = (
+        float(temperature_raw)
+        if isinstance(temperature_raw, (int, float, str))
+        else 0.5
+    )
+    return max(0.0, base - 0.05 * temperature)
 
 
 @traigent.optimize(
     configuration_space=CONFIG_SPACE,
     objectives=["accuracy"],
     evaluation=EvaluationOptions(
-        eval_dataset=DATASET,
-        metric_functions=None if _mock_mode else {"accuracy": contains_accuracy},
+        eval_dataset=DATASET, metric_functions={"accuracy": _demo_scorer}
     ),
     execution_mode="edge_analytics",
 )
 def answer(question: str) -> str:
-    """Call an LLM with the current trial's config."""
+    """Call an LLM with the current trial's config (intercepted in mock mode)."""
     cfg = traigent.get_config()
+
+    from langchain_core.messages import HumanMessage, SystemMessage
+    from langchain_openai import ChatOpenAI
+
     llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
     response = llm.invoke([SystemMessage(_SYSTEM_PROMPT), HumanMessage(question)])
     return str(response.content)
 
 
+def main() -> None:
+    """Synchronous entry point used by the CLI subcommand and ``python -m``."""
+    asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))
+
+
 if __name__ == "__main__":
-    result = asyncio.run(answer.optimize(max_trials=6, algorithm="grid"))
+    main()

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -1,10 +1,13 @@
 """Find the best model and temperature for your task - in one decorator.
 
-No API keys, no network, no surprises. The bundled quickstart is the
-load-bearing demo on the website funnel; everything below is structured
-to make that promise true.
+No API keys, no LLM provider calls, no spend. The bundled quickstart
+is the load-bearing demo on the website funnel; everything below is
+structured to make that promise true. LiteLLM may still attempt an
+import-time model-cost-map fetch from raw.githubusercontent.com (it
+falls back to bundled pricing data when offline); the guarantee is no
+provider spend, not zero outbound packets.
 
-The hermetic env-var setup that makes "no keys, no network" work has to
+The hermetic env-var setup that makes "no provider calls" work has to
 run before ``traigent/__init__.py`` itself executes (because that module
 pulls in optional deps like LiteLLM that may try to fetch model cost
 maps at import time). It can't live here — by the time this file

--- a/traigent/examples/quickstart/_env.py
+++ b/traigent/examples/quickstart/_env.py
@@ -3,6 +3,11 @@
 Kept in a small module so tests can exercise the logic without importing the
 full ``__main__`` (which pulls in LangChain and registers an ``@optimize``
 function at import time).
+
+Mock mode itself is enabled in code via
+:func:`traigent.testing.enable_mock_mode_for_quickstart`; this helper only
+seeds the surrounding env so LangChain can instantiate and the user gets a
+clear notice when results won't sync to the portal.
 """
 
 from __future__ import annotations
@@ -10,24 +15,25 @@ from __future__ import annotations
 import sys
 from collections.abc import MutableMapping
 
-from traigent.utils.env_config import is_truthy
-
 _PORTAL_SIGNUP_URL = "https://app.traigent.ai"
 
 
 def configure_quickstart_env(env: MutableMapping[str, str]) -> None:
-    """Seed mock-mode env vars and warn when the portal won't receive results.
+    """Seed env vars LangChain expects and force offline-mode without an
+    API key.
 
-    - Defaults ``TRAIGENT_MOCK_LLM=true`` so the script works without API keys.
-    - In mock mode, seeds a placeholder ``OPENAI_API_KEY`` so LangChain is happy.
-    - If no ``TRAIGENT_API_KEY`` is set, prints a clear stderr notice *before*
-      forcing ``TRAIGENT_OFFLINE_MODE=true`` — otherwise the downstream
-      "No API key found" warning is suppressed by the offline short-circuit.
+    - Seeds a placeholder ``OPENAI_API_KEY`` so :class:`ChatOpenAI` can
+      instantiate. The real LLM call is intercepted by the mock-mode
+      flag set via :func:`traigent.testing.enable_mock_mode_for_quickstart`.
+    - If no ``TRAIGENT_API_KEY`` is set, prints a clear stderr notice
+      and **forces** ``TRAIGENT_OFFLINE_MODE=true`` (override, not
+      ``setdefault``). Without a portal key the SDK can't sync results
+      anyway — leaving offline-mode unset would just produce noisy
+      auth errors instead of useful output.
+    - If ``TRAIGENT_API_KEY`` IS set, this function does NOT touch
+      ``TRAIGENT_OFFLINE_MODE`` — the user wants results synced and
+      should control offline-mode themselves.
     """
-    env.setdefault("TRAIGENT_MOCK_LLM", "true")
-    if not is_truthy(env.get("TRAIGENT_MOCK_LLM")):
-        return
-
     env.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
 
     if not env.get("TRAIGENT_API_KEY"):
@@ -37,4 +43,4 @@ def configure_quickstart_env(env: MutableMapping[str, str]) -> None:
             "results to the portal while keeping LLM calls mocked.",
             file=sys.stderr,
         )
-        env.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+        env["TRAIGENT_OFFLINE_MODE"] = "true"

--- a/traigent/integrations/utils/__init__.py
+++ b/traigent/integrations/utils/__init__.py
@@ -10,11 +10,7 @@ from traigent.integrations.utils.message_coercion import (
     coerce_to_gemini_format,
     coerce_to_openai_format,
 )
-from traigent.integrations.utils.mock_adapter import (
-    MockAdapter,
-    MockResponse,
-    with_mock_support,
-)
+from traigent.integrations.utils.mock_adapter import MockAdapter, MockResponse
 from traigent.integrations.utils.parameter_normalizer import (
     Framework,
     ParameterAlias,
@@ -45,5 +41,4 @@ __all__ = [
     # Mock adapter
     "MockAdapter",
     "MockResponse",
-    "with_mock_support",
 ]

--- a/traigent/integrations/utils/mock_adapter.py
+++ b/traigent/integrations/utils/mock_adapter.py
@@ -2,6 +2,23 @@
 
 Provides a lightweight mock adapter pattern that keeps main plugin
 logic clean by separating mock functionality into dedicated methods.
+
+Security:
+    Mock activation in **production is impossible** — neither the
+    in-code API (:func:`traigent.testing.enable_mock_mode_for_quickstart`)
+    nor the legacy ``TRAIGENT_MOCK_LLM=true`` env var can flip mock
+    mode on when ``ENVIRONMENT=production``. The in-code path raises
+    ``RuntimeError``; the env-var path raises ``OSError`` at module
+    import in :mod:`traigent.utils.env_config`. That's the surviving
+    guard against the original prod incident — a stray env var
+    silently swapping real LLM calls for canned mock text.
+
+    Outside production, mock mode can be activated by either the
+    in-code API (recommended) or the legacy env var (kept for
+    backward compatibility with existing test fixtures and example
+    scripts). Provider-specific ``*_MOCK`` env vars (e.g.
+    ``OPENAI_MOCK``) are completely ignored everywhere — those were
+    the worst offenders in the original incident.
 """
 
 # Traceability: CONC-Layer-Integration FUNC-INTEGRATIONS REQ-INT-008
@@ -10,14 +27,13 @@ import asyncio
 import logging
 import os
 import time
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
 
 # Default mock delay in milliseconds (0 = no delay)
-# Set TRAIGENT_MOCK_DELAY_MS to simulate realistic LLM latency
+# Set TRAIGENT_MOCK_DELAY_MS to simulate realistic LLM latency in tests.
 DEFAULT_MOCK_DELAY_MS = 0
 
 
@@ -37,20 +53,6 @@ def _get_mock_delay_ms() -> int:
     except ValueError:
         logger.warning(f"Invalid TRAIGENT_MOCK_DELAY_MS value '{delay_str}', using 0")
         return 0
-
-
-# Environment variable names for each provider
-MOCK_ENV_VARS = {
-    "openai": "OPENAI_MOCK",
-    "azure_openai": "AZURE_OPENAI_MOCK",
-    "anthropic": "ANTHROPIC_MOCK",
-    "gemini": "GEMINI_MOCK",
-    "cohere": "COHERE_MOCK",
-    "huggingface": "HUGGINGFACE_MOCK",
-    "bedrock": "BEDROCK_MOCK",
-    # Global override
-    "traigent": "TRAIGENT_MOCK_LLM",
-}
 
 
 @dataclass
@@ -73,40 +75,43 @@ class MockResponse:
 class MockAdapter:
     """Lightweight mock adapter for testing without API calls.
 
-    Usage in plugins:
-        if MockAdapter.is_mock_enabled("openai"):
-            return MockAdapter.get_mock_response("openai", **kwargs)
-
-    This keeps mock logic separate from main plugin code.
+    Mock activation is **never** auto-enabled via environment variables.
+    The single source of truth is
+    :func:`traigent.testing.is_mock_mode_enabled`, which is only flipped
+    on by an explicit in-code call to
+    :func:`traigent.testing.enable_mock_mode_for_quickstart`. Tests that
+    want a one-off mock response without flipping the global flag can
+    still call :meth:`get_mock_response` directly from inside a
+    ``unittest.mock.patch`` of the underlying client.
     """
 
     _pending_tasks: ClassVar[set[asyncio.Task]] = set()
 
     @classmethod
     def is_mock_enabled(cls, provider: str) -> bool:
-        """Check if mock mode is enabled for a provider.
+        """Return ``True`` iff mock mode should intercept LLM calls.
 
-        Checks both provider-specific and global mock env vars.
+        Delegates to :func:`traigent.utils.env_config.is_mock_llm`, which
+        is the single source of truth for both LLM interceptors and the
+        SDK's mock-aware behavior. The original prod incident — a stray
+        env var swapping real calls for canned text — is prevented by
+        :func:`is_mock_llm`'s production hard-block: in production
+        environments the env-var path is rejected at import time, and
+        only the in-code
+        :func:`traigent.testing.enable_mock_mode_for_quickstart` opt-in
+        can flip the flag. Tests and dev environments can still set
+        ``TRAIGENT_MOCK_LLM=true`` for backward compatibility.
 
         Args:
-            provider: Provider name (openai, anthropic, gemini, etc.)
+            provider: Provider name (kept for signature compatibility).
 
         Returns:
-            True if mock mode is enabled.
+            ``True`` if mock mode is on, ``False`` otherwise.
         """
-        # Check global mock LLM mode first
-        global_mock = os.getenv("TRAIGENT_MOCK_LLM", "").lower()
-        if global_mock in ("true", "1", "yes"):
-            return True
+        del provider  # signature compatibility only
+        from traigent.utils.env_config import is_mock_llm
 
-        # Check provider-specific mock
-        env_var = MOCK_ENV_VARS.get(provider.lower())
-        if env_var:
-            provider_mock = os.getenv(env_var, "").lower()
-            if provider_mock in ("true", "1", "yes"):
-                return True
-
-        return False
+        return is_mock_llm()
 
     @classmethod
     def _apply_mock_delay(cls, provider: str) -> None:
@@ -148,6 +153,11 @@ class MockAdapter:
         **kwargs: Any,
     ) -> Any:
         """Get a provider-appropriate mock response object.
+
+        This method is intended to be invoked **explicitly** from test
+        code (e.g. inside a ``unittest.mock.patch`` of the real client).
+        It is no longer reachable from any production code path via an
+        environment toggle.
 
         Args:
             provider: Provider name.
@@ -278,33 +288,3 @@ class MockAdapter:
                 "total_tokens": data.total_tokens,
             },
         }
-
-
-def with_mock_support(provider: str) -> Callable:
-    """Decorator to add mock support to a function.
-
-    Usage:
-        @with_mock_support("openai")
-        def create_completion(**kwargs):
-            # Real implementation
-            ...
-
-    Args:
-        provider: Provider name for mock lookup.
-
-    Returns:
-        Decorator function.
-    """
-
-    def decorator(func: Callable) -> Callable:
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            if MockAdapter.is_mock_enabled(provider):
-                logger.debug(
-                    f"Mock mode enabled for {provider}, returning mock response"
-                )
-                return MockAdapter.get_mock_response(provider, **kwargs)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator

--- a/traigent/testing/__init__.py
+++ b/traigent/testing/__init__.py
@@ -1,0 +1,123 @@
+"""Explicit mock-mode controls for the SDK.
+
+Mock mode intercepts LLM calls and returns canned responses so demos
+and tests can run without API keys or network. It is the load-bearing
+path for ``traigent quickstart`` and the bundled walkthroughs.
+
+There are TWO ways mock mode can be enabled, with different safety
+properties:
+
+1. **Recommended path — in-code API** (this module):
+   :func:`enable_mock_mode_for_quickstart` flips a process-local flag
+   that interceptors and SDK code consult. Hard-blocked in production:
+   if ``ENVIRONMENT=production`` the function raises ``RuntimeError``
+   instead of activating.
+
+2. **Legacy path — env var** (``TRAIGENT_MOCK_LLM=true``): kept for
+   backward compatibility with existing test fixtures and example
+   scripts that set the env var as a convention. Honored ONLY outside
+   production; the import-time guard in
+   :mod:`traigent.utils.env_config` raises ``OSError`` if the env var
+   is set together with ``ENVIRONMENT=production``. Provider-specific
+   ``*_MOCK`` env vars (the worst offenders in the original prod
+   incident — one var per provider, easy to miss) are completely
+   ignored.
+
+Both paths converge on :func:`is_mock_mode_enabled` and
+:func:`traigent.utils.env_config.is_mock_llm`, which are the single
+sources of truth for interceptors and SDK behavior.
+
+Public surface:
+
+* :func:`enable_mock_mode_for_quickstart` — opt in (warns once on
+  activation, ``RuntimeError`` in prod).
+* :func:`is_mock_mode_enabled` — runtime check (in-code flag only;
+  use :func:`is_mock_llm` if you also want the env-var fallback).
+
+The module-level flag is process-local; importing the SDK in a fresh
+interpreter starts with mock mode off.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+__all__ = [
+    "enable_mock_mode_for_quickstart",
+    "is_mock_mode_enabled",
+]
+
+_logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_enabled = False
+_activation_logged = False
+
+
+def enable_mock_mode_for_quickstart() -> None:
+    """Activate process-local mock mode for LLM calls.
+
+    Idempotent: subsequent calls are no-ops. The first activation emits
+    a single mandatory ``WARNING`` log line so anyone tailing logs in a
+    production-shaped environment sees that mock mode just turned on.
+
+    Hard-blocked in production: if ``ENVIRONMENT=production`` (or
+    ``prod``), this function raises ``RuntimeError`` rather than
+    enabling mock mode. The same guarantee applies to the legacy
+    ``TRAIGENT_MOCK_LLM=true`` env-var path. Mock mode in production
+    is a safety bug, not a feature — the policy is "no mock mode in
+    prod, period."
+
+    Intended for: bundled demos, walkthroughs, examples, and tests.
+    """
+    import os
+
+    global _enabled, _activation_logged
+    with _lock:
+        if _enabled:
+            return
+        # Re-read ENVIRONMENT inside the lock (Greptile review #4 —
+        # close the TOCTOU window where another thread could mutate
+        # ENVIRONMENT to "production" between an unlocked check and
+        # ``_enabled = True``). A correctness re-check elsewhere
+        # (``is_mock_llm()`` recomputes ``is_production()`` live) makes
+        # exploitability low, but tightening the invariant here is
+        # cheap.
+        env_name = os.environ.get("ENVIRONMENT", "development").strip().lower()
+        if env_name in {"prod", "production"}:
+            raise RuntimeError(
+                "traigent.testing.enable_mock_mode_for_quickstart() was "
+                "called with ENVIRONMENT=production. Mock mode is "
+                "hard-blocked in production to prevent silent substitution "
+                "of real LLM calls. If you want a keyless demo, run with "
+                "ENVIRONMENT!=production."
+            )
+        _enabled = True
+        if not _activation_logged:
+            _activation_logged = True
+            _logger.warning(
+                "[traigent.testing] mock mode is now ACTIVE — LLM calls will "
+                "be intercepted and return canned responses. This must NEVER "
+                "run in production. Enabled via "
+                "traigent.testing.enable_mock_mode_for_quickstart()."
+            )
+
+
+def is_mock_mode_enabled() -> bool:
+    """Return ``True`` iff :func:`enable_mock_mode_for_quickstart` was called.
+
+    Read by ``MockAdapter.is_mock_enabled`` (LLM interceptors) and
+    ``env_config.is_mock_llm`` (SDK-level mock-aware behavior). Both
+    consult this single flag so the SDK never ends up in a "real LLM,
+    mock SDK behavior" inconsistent state.
+    """
+    return _enabled
+
+
+def _reset_for_tests() -> None:
+    """Reset the flag. Tests only — not part of the public API."""
+    global _enabled, _activation_logged
+    with _lock:
+        _enabled = False
+        _activation_logged = False

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -23,15 +23,93 @@ if os.environ.get("TRAIGENT_MOCK_MODE"):
     raise OSError(
         "TRAIGENT_MOCK_MODE is deprecated and no longer supported.\n"
         "Please migrate to:\n"
-        "  - TRAIGENT_MOCK_LLM=true (to mock LLM API calls)\n"
-        "  - TRAIGENT_OFFLINE_MODE=true (to skip backend communication)\n"
-        "For local testing, set both: TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true"
+        "  - traigent.testing.enable_mock_mode_for_quickstart() (in code) "
+        "to mock LLM API calls\n"
+        "  - TRAIGENT_OFFLINE_MODE=true (to skip backend communication)"
     )
+
+
+def _is_production_env_name(name: str | None) -> bool:
+    """Internal helper used by the prod-guard before :func:`is_production`
+    is defined. Mirrors :func:`is_production`'s semantics so the guard
+    and the runtime check stay in lockstep."""
+    if name is None:
+        return False
+    return name.strip().lower() in {"prod", "production"}
+
+
+def _is_truthy_env_value(value: str | None) -> bool:
+    """Internal version of :func:`is_truthy` (defined later in the file).
+
+    Defined here so the prod-guard can run before :func:`is_truthy` is
+    in scope. Same accepted truthy strings.
+    """
+    if value is None:
+        return False
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _check_mock_llm_prod_guard() -> None:
+    """Reject ``TRAIGENT_MOCK_LLM=true`` in production; warn elsewhere.
+
+    Reads ``os.environ`` live so the result reflects the current process
+    state — important because this is called both before AND after
+    :func:`load_dotenv`, and a ``.env`` file may add the variables on
+    the second pass. Tightness is intentional:
+
+    * ``TRAIGENT_MOCK_LLM=false`` (or unset) — no-op, no warn.
+    * ``TRAIGENT_MOCK_LLM=true`` and ``ENVIRONMENT=production`` —
+      ``OSError`` (hard-block; the surviving guard against the original
+      prod incident).
+    * ``TRAIGENT_MOCK_LLM=true`` outside production — emit a single
+      ``DeprecationWarning`` so the migration path is visible in
+      pytest's warnings summary and interactive Python sessions.
+    """
+    if not _is_truthy_env_value(os.environ.get("TRAIGENT_MOCK_LLM")):
+        return
+    if _is_production_env_name(os.environ.get("ENVIRONMENT")):
+        raise OSError(
+            "TRAIGENT_MOCK_LLM=true is set in a production environment "
+            "(ENVIRONMENT=production). Mock mode is hard-blocked in "
+            "production to prevent silent substitution of real LLM "
+            "calls. Either unset TRAIGENT_MOCK_LLM, or run with "
+            "ENVIRONMENT!=production. For programmatic mock activation "
+            "use traigent.testing.enable_mock_mode_for_quickstart()."
+        )
+    # Suppress the user-facing deprecation warning when the env var was
+    # written by the quickstart bootstrap in ``traigent/__init__.py``
+    # (the user IS using the recommended in-code path; the env var is
+    # internal handoff across the import boundary). The prod hard-block
+    # above still applies — bootstrap cannot bypass it.
+    if os.environ.get("_TRAIGENT_QUICKSTART_BOOTSTRAP") == "1":
+        return
+    warnings.warn(
+        "TRAIGENT_MOCK_LLM is deprecated. Call "
+        "traigent.testing.enable_mock_mode_for_quickstart() in code "
+        "instead. The env var still works in non-production environments "
+        "for backward compatibility but will be removed in a future "
+        "release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+# ============================================================================
+# DEPRECATION: TRAIGENT_MOCK_LLM still works in dev/test, blocked in prod
+# ============================================================================
+# Run the guard before dotenv to catch the explicit-env-var case fast,
+# THEN run it again after dotenv so a `.env` setting `ENVIRONMENT=production
+# TRAIGENT_MOCK_LLM=true` is also caught (even though those vars only land
+# in os.environ after load_dotenv). is_mock_llm() recomputes the prod
+# check live as a defence in depth — no module-level cache is read after
+# import, so late env mutation cannot bypass the guard.
+_check_mock_llm_prod_guard()
 
 # Load environment variables from .env file if it exists
 env_file = Path(__file__).parent.parent.parent / ".env"
 if env_file.exists():
     load_dotenv(env_file)
+    _check_mock_llm_prod_guard()
 
 _MIN_JWT_SECRET_LENGTH = 32
 _PRODUCTION_ENV_NAMES = {"prod", "production"}
@@ -217,19 +295,42 @@ def is_truthy(value: str | None) -> bool:
 def is_mock_llm() -> bool:
     """Check if LLM API calls should be mocked with simulated responses.
 
-    When TRAIGENT_MOCK_LLM=true, LLM provider calls (OpenAI, Anthropic, etc.)
-    are intercepted and return simulated responses instead of making real API calls.
+    Mock mode is on when EITHER:
 
-    This is separate from backend communication - use is_backend_offline() to
-    control whether Traigent backend calls are skipped.
+    * the in-code flag set via
+      :func:`traigent.testing.enable_mock_mode_for_quickstart` is true
+      (the recommended path), OR
+    * ``TRAIGENT_MOCK_LLM=true`` is set AND ``ENVIRONMENT`` is not
+      ``production`` (legacy path kept for backward compatibility with
+      existing test fixtures and examples; hard-blocked in prod by the
+      import-time guard at the top of this module).
+
+    This is separate from backend communication - use
+    :func:`is_backend_offline` to control whether Traigent backend calls
+    are skipped.
 
     Returns:
         True if LLM calls should be mocked, False for real LLM API calls.
 
     See also:
-        - is_backend_offline(): Check if Traigent backend calls should be skipped
+        - :func:`is_backend_offline`: Check if Traigent backend calls should be skipped
     """
-    return get_env_var("TRAIGENT_MOCK_LLM", "false").lower() == "true"
+    # Production hard-block runs FIRST — even if the in-code flag was
+    # flipped on in a previous shell-script step or a misconfigured
+    # deployment, ``is_mock_llm()`` must NEVER report True in production.
+    # ``is_production()`` is recomputed live from ``os.environ`` so late
+    # mutation cannot bypass the guard.
+    if is_production():
+        return False
+    from traigent.testing import is_mock_mode_enabled
+
+    if is_mock_mode_enabled():
+        return True
+    # Match the broader truthy set used by the import-time prod guard
+    # (1/true/yes/on) so a value like ``TRAIGENT_MOCK_LLM=1`` doesn't get
+    # blocked at import but then quietly return False here — the two
+    # paths must agree on what counts as "set".
+    return is_truthy(os.environ.get("TRAIGENT_MOCK_LLM"))
 
 
 def is_strict_cost_accounting() -> bool:
@@ -287,7 +388,8 @@ def skip_provider_validation() -> bool:
 
     Provider validation is skipped when:
     - TRAIGENT_SKIP_PROVIDER_VALIDATION=true is set
-    - TRAIGENT_MOCK_LLM=true is set (no real API calls)
+    - Mock mode is on via :func:`traigent.testing.enable_mock_mode_for_quickstart`
+      (no real API calls)
 
     This allows users to bypass validation for:
     - Custom/internal models not recognized by Traigent
@@ -298,8 +400,8 @@ def skip_provider_validation() -> bool:
         True if provider validation should be skipped, False otherwise.
 
     See also:
-        - is_mock_llm(): Check if LLM API calls should be mocked
-        - validate_providers param in @traigent.optimize decorator
+        - :func:`is_mock_llm`: Check if LLM API calls should be mocked
+        - ``validate_providers`` param in ``@traigent.optimize`` decorator
     """
     # Skip if mock mode is enabled (no real API calls anyway)
     if is_mock_llm():


### PR DESCRIPTION
## Summary

Cherry-pick of [#799](https://github.com/Traigent/Traigent/pull/799) (squash `8ba5e157`) from `develop` onto `main` so the next PyPI release ships `traigent quickstart`. The website hero ([traigent-web#13](https://github.com/Traigent/traigent-web/pull/13)) advertises that command, and visitors install from PyPI — without this cherry-pick the copy-paste flow lands on a broken command.

This is **only** the quickstart determinism + mock-mode API change. None of the other 41 commits between main and develop are included.

## What lands

* `traigent.testing.enable_mock_mode_for_quickstart()` — explicit in-code activation; raises `RuntimeError` when `ENVIRONMENT=production`.
* `MockAdapter.is_mock_enabled` / `env_config.is_mock_llm` centralized through a single source of truth; `is_production()` checked first so the in-code flag cannot bypass the prod hard-block.
* Legacy `TRAIGENT_MOCK_LLM=true` env-var path honored only outside production (raises `OSError` pre/post-dotenv when `ENVIRONMENT=production`). Provider-specific `*_MOCK` env vars completely ignored.
* `sys.argv` detector at the top of `traigent/__init__.py` seeds the hermetic env vars when invoked as `traigent quickstart` or `python -m traigent.examples.quickstart`. No-op for any other path.
* `traigent quickstart` Click subcommand — the canonical install line.
* New `tests/integration/test_quickstart_smoke.py` — three subprocess tests with `sitecustomize.py` socket-block injected via PYTHONPATH.
* New `tests/unit/integrations/test_mock_adapter_safety.py` — eight safety tests (dotenv-late-load, prod-blocks-in-code-API, etc.).

## Conflicts resolved

* `tests/unit/integrations/test_mock_adapter.py`, `test_no_mock_llm_env.py` — took develop's version (the dev-allows / prod-blocks semantics).
* `traigent/examples/quickstart/__main__.py`, `traigent/integrations/utils/mock_adapter.py` — took develop's version.
* `traigent/integrations/utils/__init__.py` — took develop's version (drops `with_mock_support` re-export, which the cherry-pick's `mock_adapter.py` no longer defines).
* `.secrets.baseline` — took develop's superset.
* Added `pragma: allowlist secret` to three example provider-key shell snippets in `.agents/skills/traigent/SKILL.md` so the secrets detector accepts the cherry-pick on main (those lines pre-existed on develop and were silently OK there).

## Test plan

- [x] All conflicts resolved by taking develop's "done right" state.
- [x] Local pre-commit (mypy, bandit, ruff, isort, black, secrets) green.
- [ ] CI green on this branch.
- [ ] After merge: bump version + publish to PyPI before merging traigent-web#13 (the launch sequencing Codex flagged).
- [ ] PyPI clean-env smoke before site goes live:
  ```
  python -m venv /tmp/traigent-smoke
  /tmp/traigent-smoke/bin/python -m pip install "traigent[recommended]"
  /tmp/traigent-smoke/bin/traigent quickstart
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)