### PR TITLE
fix: address Greptile review of #800 (cherry-pick followup)

### DIFF
--- a/tests/integration/test_quickstart_smoke.py
+++ b/tests/integration/test_quickstart_smoke.py
@@ -203,13 +203,29 @@ def test_traigent_quickstart_cli_runs_with_no_keys(
     """The ``traigent quickstart`` CLI subcommand must behave exactly
     the same as ``python -m traigent.examples.quickstart`` — same
     hermetic guarantees, same exit, same activation WARN. The CLI is
-    the canonical install instruction on the website."""
-    # Run via `python -c` so PYTHONPATH (worktree-first) takes precedence
-    # over the venv's editable finder for the main checkout. Same
-    # observable behavior as `traigent quickstart` for the user.
+    the canonical install instruction on the website.
+
+    Greptile review of #800 caught that ``python -c "...cli(['quickstart'])"``
+    sets ``sys.argv = ['-c']`` and so does NOT trigger the
+    ``__init__.py`` bootstrap that real ``traigent quickstart``
+    invocations rely on. The real shell command sets
+    ``sys.argv[0]`` to the venv's ``bin/traigent`` script and
+    ``sys.argv[1] = "quickstart"`` — only that combination flips the
+    detector. We mirror that exact ``sys.argv`` shape inside a tiny
+    bootstrap script so the test exercises the same code path the
+    user hits.
+    """
+    bootstrap = (
+        # Set sys.argv BEFORE the first traigent import — that's the
+        # only thing the detector inspects, and it must be in place
+        # when traigent/__init__.py runs.
+        "import sys; sys.argv = ['traigent', 'quickstart']\n"
+        "from traigent.cli.main import cli\n"
+        "cli(['quickstart'])\n"
+    )
     result = _run_in_subprocess(
         venv_python,
-        ["-c", "from traigent.cli.main import cli; cli(['quickstart'])"],
+        ["-c", bootstrap],
         env=hermetic_subprocess_env,
         cwd=tmp_path,
     )

--- a/tests/unit/integrations/test_mock_adapter_safety.py
+++ b/tests/unit/integrations/test_mock_adapter_safety.py
@@ -73,26 +73,27 @@ def test_env_var_works_in_dev_blocks_in_prod(
     surviving guard against the original prod incident."""
     monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
 
+    # Greptile review of #800: don't use ``importlib.reload(env_config)``
+    # — reloading has side effects beyond ``os.environ`` (sys.modules
+    # reference churn, .env re-loaded). The prod guard is a callable
+    # function (``_check_mock_llm_prod_guard``) and ``is_mock_llm`` reads
+    # ``is_production()`` live, so we can test both without a reload.
+    from traigent.utils.env_config import _check_mock_llm_prod_guard
+
     monkeypatch.setenv("ENVIRONMENT", "development")
-    # Re-evaluate the cached _is_production_env in env_config — it's set
-    # at import time; re-import to refresh.
-    import importlib
-
-    from traigent.utils import env_config as _ec
-
-    importlib.reload(_ec)
-    assert _ec.is_mock_llm() is True, "dev env must honor env-var fallback"
+    assert is_mock_llm() is True, "dev env must honor env-var fallback"
 
     monkeypatch.setenv("ENVIRONMENT", "production")
-    # Production env-var presence is now hard-blocked at import; the
-    # import itself must raise. This is why the sweeping prod-time
-    # incident is no longer reachable.
+    # Production env-var presence is hard-blocked: invoking the guard
+    # function raises just like it would on a fresh interpreter import.
     with pytest.raises(OSError, match="production"):
-        importlib.reload(_ec)
+        _check_mock_llm_prod_guard()
+    # And ``is_mock_llm`` itself returns False under prod regardless of
+    # env-var presence (the prod-first ordering closes the bypass).
+    assert is_mock_llm() is False, "prod must block env-var fallback"
 
     # Restore for downstream tests.
     monkeypatch.setenv("ENVIRONMENT", "development")
-    importlib.reload(_ec)
 
 
 def test_in_code_api_enables_mock_for_every_interceptor() -> None:

--- a/tests/unit/integrations/test_no_mock_llm_env.py
+++ b/tests/unit/integrations/test_no_mock_llm_env.py
@@ -1,27 +1,27 @@
-"""Verify dangerous env-toggles are not honored.
+"""Verify dangerous env-toggles are not honored by ``MockAdapter``.
 
 Sprint 2 cleanup (S2-B) removed the ``TRAIGENT_MOCK_LLM`` env-toggle
-from three high-severity sites that previously shipped to customers:
+from the ``MockAdapter`` and ``with_mock_support`` decorator surface
+in :mod:`traigent.integrations.utils.mock_adapter`. The current
+contract on this surface:
 
-* ``traigent/integrations/utils/mock_adapter.py`` — ``with_mock_support``
-  decorator was deleted entirely. ``MockAdapter.is_mock_enabled`` now
-  consults the in-code flag set by
-  :func:`traigent.testing.enable_mock_mode_for_quickstart`. The legacy
-  ``TRAIGENT_MOCK_LLM=true`` env var is honored only outside production
-  (and is hard-blocked when ``ENVIRONMENT=production``); see
-  ``test_mock_adapter_safety.py`` for those guarantees.
-* ``traigent/security/encryption.py`` — encrypt() / decrypt() fallback
-  branches (env-toggle produced ``b"mock_" + plaintext`` "ciphertext"
-  and stripped the prefix on decrypt). These were deleted with no
-  fallback at all.
-* ``traigent/evaluators/local.py`` — ``_compute_mock_accuracy`` (env
-  toggle fabricated accuracy via random.uniform() + string-length
-  heuristics). Deleted with no fallback.
+* The recommended path is the in-code API
+  :func:`traigent.testing.enable_mock_mode_for_quickstart`.
+* The legacy ``TRAIGENT_MOCK_LLM=true`` env var is honored as a
+  backward-compat path **only outside production**. ``is_mock_enabled``
+  delegates to :func:`traigent.utils.env_config.is_mock_llm`, which
+  hard-blocks the env-var path when ``ENVIRONMENT=production``. Those
+  guarantees are exercised in
+  ``tests/unit/integrations/test_mock_adapter_safety.py``.
+* Provider-specific ``*_MOCK`` env vars (e.g. ``OPENAI_MOCK=true``)
+  are still completely ignored — those were the worst offenders in
+  the original incident.
 
-These tests pin the surviving guarantees: provider-specific
-``*_MOCK`` env vars are completely ignored everywhere, the
-``with_mock_support`` decorator is gone, and the encryption /
-evaluation paths fail closed regardless of any mock-style env var.
+Companion S2-B test classes for ``traigent/security/encryption.py``,
+``traigent/evaluators/local.py``, and ``traigent/core/optimization_pipeline.py``
+live on ``develop`` and will land here once their corresponding source
+changes are cherry-picked to ``main`` (the cherry-pick of #799 was
+scoped to the mock-mode API only).
 """
 
 from __future__ import annotations
@@ -32,7 +32,6 @@ from unittest.mock import patch
 import pytest
 
 from traigent.integrations.utils.mock_adapter import MockAdapter
-from traigent.security.encryption import EncryptionManager, KeyManager
 
 
 class TestProviderSpecificMockEnvsAreIgnored:
@@ -68,164 +67,3 @@ class TestProviderSpecificMockEnvsAreIgnored:
 
         assert not hasattr(mock_adapter, "with_mock_support")
         assert not hasattr(utils_pkg, "with_mock_support")
-
-
-class TestEncryptionIgnoresEnv:
-    """encrypt() / decrypt() must fail closed regardless of TRAIGENT_MOCK_LLM."""
-
-    def test_encrypt_with_mock_env_still_raises_when_no_crypto(self) -> None:
-        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock encryption."""
-        key_manager = KeyManager()
-        em = EncryptionManager(key_manager)
-        em.crypto_available = False  # simulate missing cryptography lib
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
-            with pytest.raises(
-                RuntimeError, match="requires the 'cryptography' package"
-            ):
-                em.encrypt("payload that must not leak as plaintext")
-
-    def test_decrypt_with_mock_env_still_raises_when_no_crypto(self) -> None:
-        """Setting TRAIGENT_MOCK_LLM=true must NOT enable mock decryption."""
-        key_manager = KeyManager()
-        em = EncryptionManager(key_manager)
-        em.crypto_available = False
-        key_id = key_manager.generate_key("AES-256")
-        envelope = {
-            "ciphertext": b"mock_attacker_supplied_payload",
-            "iv": os.urandom(12),
-            "tag": os.urandom(16),
-            "key_id": key_id,
-        }
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
-            with pytest.raises(
-                RuntimeError, match="requires the 'cryptography' package"
-            ):
-                em.decrypt(envelope)
-
-    def test_encrypt_does_not_emit_mock_prefix_with_real_crypto(self) -> None:
-        """Real encryption never emits the legacy b'mock_' or b'encrypted_' prefix."""
-        key_manager = KeyManager()
-        em = EncryptionManager(key_manager)
-        if not em.crypto_available:
-            pytest.skip("cryptography not installed in this environment")
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
-            result = em.encrypt(b"sensitive payload")
-
-        assert not result["ciphertext"].startswith(b"mock_")
-        assert not result["ciphertext"].startswith(b"encrypted_")
-        # Round-trip must still succeed under real crypto.
-        assert em.decrypt(result) == b"sensitive payload"
-
-
-class TestLocalEvaluatorIgnoresEnv:
-    """LocalEvaluator must always compute real accuracy, regardless of env."""
-
-    def test_compute_mock_accuracy_method_is_removed(self) -> None:
-        """The fabricator method must no longer exist on LocalEvaluator."""
-        from traigent.evaluators.local import LocalEvaluator
-
-        assert not hasattr(LocalEvaluator, "_compute_mock_accuracy")
-        assert not hasattr(LocalEvaluator, "_log_mock_mode_warning")
-
-    def test_accuracy_metric_is_real_even_with_mock_env(self) -> None:
-        """With TRAIGENT_MOCK_LLM=true, accuracy must be deterministic real comparison."""
-        from traigent.evaluators.local import LocalEvaluator
-
-        evaluator = LocalEvaluator(metrics=["accuracy"])
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
-            # Identical strings — real accuracy must be 1.0.
-            metrics_match = evaluator._compute_example_metrics(
-                actual_output="hello",
-                expected_output="hello",
-            )
-            # Different strings — real accuracy must be 0.0.
-            metrics_mismatch = evaluator._compute_example_metrics(
-                actual_output="hello",
-                expected_output="goodbye",
-            )
-
-        assert metrics_match["accuracy"] == 1.0
-        assert metrics_mismatch["accuracy"] == 0.0
-
-    def test_accuracy_metric_does_not_use_random_with_mock_env(self) -> None:
-        """Repeat calls under TRAIGENT_MOCK_LLM=true must be deterministic.
-
-        The old _compute_mock_accuracy used random.uniform() so identical
-        inputs would yield different scores. The real path is purely
-        deterministic.
-        """
-        from traigent.evaluators.local import LocalEvaluator
-
-        evaluator = LocalEvaluator(metrics=["accuracy"])
-
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
-            scores = [
-                evaluator._compute_example_metrics(
-                    actual_output="positive sentiment indeed", expected_output="other"
-                )["accuracy"]
-                for _ in range(10)
-            ]
-
-        # All identical — no random fabrication.
-        assert len(set(scores)) == 1
-        # And it's the real-comparison value (mismatch -> 0.0).
-        assert scores[0] == 0.0
-
-
-class TestMockModeConfigIsInert:
-    """``mock_mode_config`` must not change optimizer or evaluator behaviour.
-
-    Round 2 of S2-B retired the last behavioural sites that consulted this
-    parameter. The parameter is still accepted on public APIs for backward
-    compatibility but must be a true no-op.
-    """
-
-    def test_resolve_custom_evaluator_ignores_mock_mode_config(self) -> None:
-        """``resolve_custom_evaluator`` must return the user evaluator regardless of mock_mode_config."""
-        from traigent.core.optimization_pipeline import resolve_custom_evaluator
-
-        def my_evaluator(*_args: object, **_kwargs: object) -> dict[str, float]:
-            return {"accuracy": 1.0}
-
-        # Even with TRAIGENT_MOCK_LLM=true AND a mock_mode_config that previously
-        # would have triggered the override, the user-supplied evaluator wins.
-        with patch.dict(os.environ, {"TRAIGENT_MOCK_LLM": "true"}, clear=False):
-            result = resolve_custom_evaluator(
-                my_evaluator,
-                mock_mode_config={"enabled": True, "override_evaluator": True},
-                decorator_custom_evaluator=None,
-            )
-        assert result is my_evaluator
-
-        # And without the env var, same behaviour.
-        with patch.dict(os.environ, {}, clear=True):
-            result = resolve_custom_evaluator(
-                None,
-                mock_mode_config={"enabled": True, "override_evaluator": True},
-                decorator_custom_evaluator=my_evaluator,
-            )
-        assert result is my_evaluator
-
-    def test_apply_mock_config_overrides_does_not_change_algorithm(self) -> None:
-        """``_apply_mock_config_overrides`` must not change the algorithm or seed."""
-        from traigent.core.optimized_function import OptimizedFunction
-
-        # Build a minimal stand-in with the attribute the method reads.
-        instance = OptimizedFunction.__new__(OptimizedFunction)
-        instance.mock_mode_config = {  # type: ignore[attr-defined]
-            "optimizer": "grid_search",  # would have rerouted in round 1
-            "random_seed": 1234,
-        }
-
-        kwargs: dict[str, object] = {}
-        algo = OptimizedFunction._apply_mock_config_overrides(
-            instance, "bayesian", kwargs
-        )
-
-        # Algorithm unchanged, no seed injected.
-        assert algo == "bayesian"
-        assert "random_seed" not in kwargs

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -189,7 +189,6 @@ from traigent.api.validation_protocol import (
 from traigent.api.validation_protocol import (
     ValidationResult as ConstraintValidationResult,
 )
-from traigent.cloud.benchmark_client import BenchmarkClient, BenchmarkClientConfig
 
 # Thread context helpers
 from traigent.config.context import copy_context_to_thread, get_trial_context

--- a/traigent/examples/quickstart/_env.py
+++ b/traigent/examples/quickstart/_env.py
@@ -22,9 +22,16 @@ def configure_quickstart_env(env: MutableMapping[str, str]) -> None:
     """Seed env vars LangChain expects and force offline-mode without an
     API key.
 
-    - Seeds a placeholder ``OPENAI_API_KEY`` so :class:`ChatOpenAI` can
-      instantiate. The real LLM call is intercepted by the mock-mode
-      flag set via :func:`traigent.testing.enable_mock_mode_for_quickstart`.
+    - Seeds a placeholder ``OPENAI_API_KEY`` (via ``setdefault``) so
+      :class:`ChatOpenAI` can instantiate. In the canonical invocation
+      path the bootstrap in :mod:`traigent.__init__` has already
+      OVERWRITTEN ``OPENAI_API_KEY`` with the placeholder before this
+      function runs, so the ``setdefault`` here is a no-op in that
+      flow — intentional. If a future entry point ever calls this
+      helper WITHOUT going through the package bootstrap, the
+      placeholder is seeded here as a fallback. The real LLM call is
+      intercepted by the mock-mode flag set via
+      :func:`traigent.testing.enable_mock_mode_for_quickstart`.
     - If no ``TRAIGENT_API_KEY`` is set, prints a clear stderr notice
       and **forces** ``TRAIGENT_OFFLINE_MODE=true`` (override, not
       ``setdefault``). Without a portal key the SDK can't sync results
@@ -34,7 +41,7 @@ def configure_quickstart_env(env: MutableMapping[str, str]) -> None:
       ``TRAIGENT_OFFLINE_MODE`` — the user wants results synced and
       should control offline-mode themselves.
     """
-    env.setdefault("OPENAI_API_KEY", "mock-key-for-demos")
+    env.setdefault("OPENAI_API_KEY", "mock-key-for-demos")  # pragma: allowlist secret
 
     if not env.get("TRAIGENT_API_KEY"):
         print(

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -109,13 +109,13 @@ _check_mock_llm_prod_guard()
 # caller has explicitly opted out via TRAIGENT_SKIP_DOTENV. Tests and
 # hermetic subprocess smokes set this so the repo's ``.env`` (which
 # typically contains TRAIGENT_BACKEND_URL=localhost:5000 etc.) does
-# NOT leak into a "clean env" run.
+# NOT leak into a "clean env" run. Reuse ``_is_truthy_env_value`` so the
+# accepted-truthy set (``1``/``true``/``yes``/``on``, whitespace-tolerant)
+# matches the prod guard above — a value like ``" true"`` should opt out
+# here just as it would activate the prod guard.
 env_file = Path(__file__).parent.parent.parent / ".env"
-if env_file.exists() and os.environ.get("TRAIGENT_SKIP_DOTENV", "").lower() not in (
-    "1",
-    "true",
-    "yes",
-    "on",
+if env_file.exists() and not _is_truthy_env_value(
+    os.environ.get("TRAIGENT_SKIP_DOTENV")
 ):
     load_dotenv(env_file)
     _check_mock_llm_prod_guard()

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -105,9 +105,18 @@ def _check_mock_llm_prod_guard() -> None:
 # import, so late env mutation cannot bypass the guard.
 _check_mock_llm_prod_guard()
 
-# Load environment variables from .env file if it exists
+# Load environment variables from .env file if it exists, unless the
+# caller has explicitly opted out via TRAIGENT_SKIP_DOTENV. Tests and
+# hermetic subprocess smokes set this so the repo's ``.env`` (which
+# typically contains TRAIGENT_BACKEND_URL=localhost:5000 etc.) does
+# NOT leak into a "clean env" run.
 env_file = Path(__file__).parent.parent.parent / ".env"
-if env_file.exists():
+if env_file.exists() and os.environ.get("TRAIGENT_SKIP_DOTENV", "").lower() not in (
+    "1",
+    "true",
+    "yes",
+    "on",
+):
     load_dotenv(env_file)
     _check_mock_llm_prod_guard()
 


### PR DESCRIPTION
## Summary

Followup to merged [#800](https://github.com/Traigent/Traigent/pull/800). Greptile flagged 4 issues after the merge — and the cherry-pick had also accidentally pulled in an orphan import. All fixed here in one focused commit.

## What changed

### Greptile P1 (load-bearing)

1. **`TRAIGENT_SKIP_DOTENV` guard restored** in [`traigent/utils/env_config.py`](https://github.com/Traigent/Traigent/blob/fix/cherry-pick-followup-greptile/traigent/utils/env_config.py). The conflict resolution accidentally dropped the existing guard around `load_dotenv`. Hermetic subprocess smoke tests pass `TRAIGENT_SKIP_DOTENV=1` to prevent the repo's `.env` from leaking into a clean-env run; without the guard the `.env` was loaded unconditionally.

2. **CLI smoke test now actually triggers the bootstrap.** The previous `python -c "from traigent.cli.main import cli; cli(['quickstart'])"` form left `sys.argv = ['-c']`, so `_is_quickstart_invocation()` returned `False` and the `traigent/__init__.py` bootstrap did not fire. The test now sets `sys.argv = ['traigent', 'quickstart']` BEFORE the first traigent import, mirroring the real shell command's `sys.argv` shape.

### Greptile P2 (defensive)

3. **Docstring note on `OPENAI_API_KEY` override interaction.** Added a paragraph in `configure_quickstart_env` explaining that the bootstrap has already overwritten `OPENAI_API_KEY` by the time this helper runs, so its `setdefault` is intentionally a no-op in the canonical flow.

4. **Reload pattern refactored out of safety test.** `test_env_var_works_in_dev_blocks_in_prod` no longer calls `importlib.reload(env_config)` (which has side effects beyond `os.environ`). Instead it calls `_check_mock_llm_prod_guard` directly and asserts `is_mock_llm()` reflects current env state — the prod check is recomputed live.

### Bonus (cherry-pick orphan)

5. **Removed `from traigent.cloud.benchmark_client import ...`** from `traigent/__init__.py`. The conflict resolution pulled this line from develop, but the corresponding `benchmark_client.py` file is not on main yet — `import traigent` was raising `ModuleNotFoundError`. Removed the line; will be re-added when that source change is cherry-picked.

6. **Trimmed `test_no_mock_llm_env.py`** to the `TestProviderSpecificMockEnvsAreIgnored` class only. The other classes (`TestEncryptionIgnoresEnv`, `TestLocalEvaluatorIgnoresEnv`, `TestMockModeConfigIsInert`) test S2-B source changes that haven't been cherry-picked to main yet — their tests were failing because the corresponding source-side changes aren't here. Companion S2-B test classes will land when their source-side changes are cherry-picked.

## Test plan

- [x] 47/47 targeted tests pass: `tests/integration/test_quickstart_smoke.py`, `tests/unit/integrations/test_mock_adapter_safety.py`, `tests/unit/integrations/test_mock_adapter.py`, `tests/unit/integrations/test_no_mock_llm_env.py`, `tests/unit/examples/test_quickstart_entry.py`.
- [ ] CI green on this branch.
- [ ] `import traigent` succeeds in a fresh interpreter (regression check for the orphan import fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)