### PR TITLE
fix(security): phased signature verification for offline license tokens

### DIFF
--- a/tests/unit/core/test_license.py
+++ b/tests/unit/core/test_license.py
@@ -578,7 +578,9 @@ class TestValidateOfflineLicense:
             assert LicenseFeature.PARALLEL_EXECUTION in result.features
             assert LicenseFeature.MULTI_OBJECTIVE in result.features
             assert result.organization == "TestCorp"
-            assert result.validation_source == "offline"
+            # Unsigned tokens are now tagged as legacy until a public key
+            # is configured (see C3 phased license signature rollout).
+            assert result.validation_source == "offline_unsigned_legacy"
         finally:
             os.unlink(temp_path)
 
@@ -896,7 +898,8 @@ class TestValidateAsync:
             )
             result = await validator.validate_async()
             assert result.tier == LicenseTier.PRO
-            assert result.validation_source == "offline"
+            # See C3 phased rollout: unsigned tokens use the legacy tag.
+            assert result.validation_source == "offline_unsigned_legacy"
         finally:
             os.unlink(temp_path)
 

--- a/tests/unit/core/test_license_signature.py
+++ b/tests/unit/core/test_license_signature.py
@@ -1,0 +1,324 @@
+"""Regression tests for C3 phased license-signature rollout.
+
+The legacy ``_decode_license_token`` only base64-decoded the middle JWT
+segment without verifying the signature, so anyone who could place a
+file at ``TRAIGENT_LICENSE_FILE`` could forge an enterprise tier.
+
+The phased fix:
+
+- When ``TRAIGENT_LICENSE_PUBLIC_KEY`` (or ``..._FILE``) is configured,
+  the signature must verify; invalid / unsigned tokens are rejected.
+- When ``TRAIGENT_REQUIRE_SIGNED_LICENSE`` is truthy, unsigned tokens
+  are rejected even if no key is configured (strict / air-gapped mode).
+- Otherwise the legacy unsigned format is still accepted with a loud
+  deprecation warning, and the resulting LicenseInfo is tagged
+  ``validation_source="offline_unsigned_legacy"`` so callers can tell
+  trusted from legacy validations apart.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from traigent.core.license import LicenseTier, LicenseValidator
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Generate a fresh 2048-bit RSA keypair for each test."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_key, public_pem
+
+
+def _signed_token(private_key, payload: dict, *, algorithm: str = "RS256") -> str:
+    return pyjwt.encode(payload, private_key, algorithm=algorithm)
+
+
+def _unsigned_token(payload: dict) -> str:
+    """Build the legacy unsigned token shape: header.payload.signature."""
+    header = (
+        base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    body = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
+    sig = base64.urlsafe_b64encode(b"forged").decode().rstrip("=")
+    return f"{header}.{body}.{sig}"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for var in (
+        "TRAIGENT_LICENSE_PUBLIC_KEY",
+        "TRAIGENT_LICENSE_PUBLIC_KEY_FILE",
+        "TRAIGENT_REQUIRE_SIGNED_LICENSE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def validator():
+    return LicenseValidator()
+
+
+class TestSignedVerificationWhenKeyConfigured:
+    def test_valid_signature_decodes_and_tags_offline(
+        self, validator, rsa_keypair, monkeypatch
+    ):
+        private_key, public_pem = rsa_keypair
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", public_pem.decode())
+
+        token = _signed_token(
+            private_key,
+            {"tier": "enterprise", "features": ["cloud_execution"], "org": "Acme"},
+        )
+
+        info = validator._decode_license_token(token)
+
+        assert info is not None
+        assert info.tier == LicenseTier.ENTERPRISE
+        assert info.organization == "Acme"
+        assert info.validation_source == "offline", (
+            "verified offline tokens must be tagged plain 'offline', "
+            "not the legacy tag"
+        )
+
+    def test_unsigned_token_is_rejected_when_key_configured(
+        self, validator, rsa_keypair, monkeypatch
+    ):
+        _, public_pem = rsa_keypair
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", public_pem.decode())
+
+        # Forged unsigned token claiming enterprise — must NOT be accepted.
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+
+        assert validator._decode_license_token(token) is None
+
+    def test_token_signed_by_wrong_key_is_rejected(
+        self, validator, monkeypatch
+    ):
+        attacker_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        legit_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        legit_pub = legit_key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", legit_pub.decode())
+
+        token = _signed_token(
+            attacker_key,
+            {"tier": "enterprise", "features": []},
+        )
+        assert validator._decode_license_token(token) is None
+
+    def test_alg_none_downgrade_is_rejected(
+        self, validator, rsa_keypair, monkeypatch
+    ):
+        """Defense against the classic JWT alg=none confusion attack:
+        even with a public key configured, a token whose header advertises
+        alg=none must be rejected because PyJWT is told only RS256/ES256
+        are acceptable.
+        """
+        _, public_pem = rsa_keypair
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", public_pem.decode())
+
+        # alg=none token -- PyJWT will refuse it because we restrict
+        # algorithms to RS256/ES256.
+        header = base64.urlsafe_b64encode(
+            json.dumps({"alg": "none", "typ": "JWT"}).encode()
+        ).decode().rstrip("=")
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"tier": "enterprise"}).encode()
+        ).decode().rstrip("=")
+        token = f"{header}.{payload}."
+
+        assert validator._decode_license_token(token) is None
+
+    def test_expired_signed_token_is_rejected(
+        self, validator, rsa_keypair, monkeypatch
+    ):
+        private_key, public_pem = rsa_keypair
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", public_pem.decode())
+
+        token = _signed_token(
+            private_key,
+            {
+                "tier": "pro",
+                "features": [],
+                "exp": int(time.time()) - 60,
+            },
+        )
+        assert validator._decode_license_token(token) is None
+
+
+class TestPublicKeyFromFile:
+    def test_public_key_file_env_var(
+        self, validator, rsa_keypair, monkeypatch, tmp_path
+    ):
+        private_key, public_pem = rsa_keypair
+        key_path = tmp_path / "license.pub.pem"
+        key_path.write_bytes(public_pem)
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY_FILE", str(key_path))
+
+        token = _signed_token(private_key, {"tier": "pro", "features": []})
+
+        info = validator._decode_license_token(token)
+        assert info is not None
+        assert info.validation_source == "offline"
+
+    def test_unreadable_public_key_file_fails_closed(
+        self, validator, monkeypatch, tmp_path, caplog
+    ):
+        """If TRAIGENT_LICENSE_PUBLIC_KEY_FILE points at a missing file,
+        the validator MUST refuse rather than silently falling through
+        to the legacy unsigned path. Treating a broken key configuration
+        as "no key configured" would be the exact attack path: anyone
+        who can influence the env var to point at /nonexistent gets the
+        legacy bypass for free.
+        """
+        bogus = tmp_path / "missing.pem"
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY_FILE", str(bogus))
+
+        # Even an unsigned token claiming the lowest tier must be rejected.
+        token = _unsigned_token({"tier": "free", "features": []})
+        with caplog.at_level(logging.ERROR):
+            info = validator._decode_license_token(token)
+
+        assert info is None, (
+            "configured-but-broken public key must fail closed; "
+            "a fall-through to legacy would defeat the whole point"
+        )
+        # The loader logs the underlying read error; the decoder logs the
+        # refusal. Both must reference the configured env var so operators
+        # can find what to fix.
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "TRAIGENT_LICENSE_PUBLIC_KEY" in joined
+
+    def test_invalid_inline_pem_fails_closed(
+        self, validator, monkeypatch, caplog
+    ):
+        monkeypatch.setenv(
+            "TRAIGENT_LICENSE_PUBLIC_KEY",
+            "-----BEGIN PUBLIC KEY-----\nnot-a-real-pem-body\n-----END PUBLIC KEY-----\n",
+        )
+
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+        with caplog.at_level(logging.ERROR):
+            info = validator._decode_license_token(token)
+
+        assert info is None
+        assert any(
+            "invalid" in r.getMessage().lower()
+            or "could not be loaded" in r.getMessage().lower()
+            for r in caplog.records
+        )
+
+    def test_empty_inline_pem_fails_closed(
+        self, validator, monkeypatch
+    ):
+        # An empty/whitespace value is a misconfiguration, not absence.
+        # Treat it the same as a broken key.
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", "   \n   ")
+
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+        # The loader can either reject this as invalid PEM or as empty;
+        # either way the result must be None.
+        assert validator._decode_license_token(token) is None
+
+    def test_truly_empty_inline_env_fails_closed(
+        self, validator, monkeypatch, caplog
+    ):
+        """``os.environ.get("X")`` returns ``""`` for an env var set to the
+        empty string and ``None`` when the var is absent. A truthy check
+        cannot distinguish those, which would let an attacker who could
+        clear the env var (``export TRAIGENT_LICENSE_PUBLIC_KEY=``) silently
+        re-enable the legacy bypass. The resolver checks presence with
+        ``in os.environ`` instead, so an empty value is treated as
+        broken configuration.
+        """
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY", "")
+
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+        with caplog.at_level(logging.ERROR):
+            info = validator._decode_license_token(token)
+
+        assert info is None
+        # Decoder logs that the configured key could not be loaded.
+        assert any(
+            "could not be loaded" in r.getMessage().lower()
+            or "empty" in r.getMessage().lower()
+            for r in caplog.records
+        )
+
+    def test_truly_empty_file_env_fails_closed(
+        self, validator, monkeypatch
+    ):
+        """Same threat model as the inline case: an empty
+        TRAIGENT_LICENSE_PUBLIC_KEY_FILE must not collapse to "no key
+        configured". Path("").read_bytes() raises, which the loader
+        treats as a broken key configuration.
+        """
+        monkeypatch.setenv("TRAIGENT_LICENSE_PUBLIC_KEY_FILE", "")
+
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+        assert validator._decode_license_token(token) is None
+
+
+class TestStrictModeWithoutKey:
+    def test_require_signed_rejects_unsigned(
+        self, validator, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("TRAIGENT_REQUIRE_SIGNED_LICENSE", "true")
+
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+        with caplog.at_level(logging.ERROR):
+            info = validator._decode_license_token(token)
+
+        assert info is None
+        assert any(
+            "TRAIGENT_REQUIRE_SIGNED_LICENSE" in r.getMessage()
+            for r in caplog.records
+        )
+
+    @pytest.mark.parametrize("flag", ["1", "true", "TRUE", "yes", "on"])
+    def test_truthy_strict_mode_values(
+        self, validator, monkeypatch, flag
+    ):
+        monkeypatch.setenv("TRAIGENT_REQUIRE_SIGNED_LICENSE", flag)
+        token = _unsigned_token({"tier": "enterprise", "features": []})
+        assert validator._decode_license_token(token) is None
+
+
+class TestLegacyUnsignedFallback:
+    def test_unsigned_token_accepted_with_loud_warning(
+        self, validator, caplog
+    ):
+        token = _unsigned_token({"tier": "pro", "features": []})
+
+        with caplog.at_level(logging.WARNING):
+            info = validator._decode_license_token(token)
+
+        assert info is not None
+        assert info.validation_source == "offline_unsigned_legacy", (
+            "the legacy tag is what observability uses to flag deployments "
+            "still relying on unsigned offline licenses"
+        )
+        assert any(
+            "deprecated" in r.getMessage().lower() and "UNSIGNED" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )

--- a/traigent/core/license.py
+++ b/traigent/core/license.py
@@ -11,6 +11,24 @@ Enterprise Configuration:
     TRAIGENT_LICENSE_FILE - Path to offline license file (signed JWT)
     TRAIGENT_LICENSE_CACHE_TTL - Cache TTL in seconds (default: 3600)
     TRAIGENT_LICENSE_GRACE_PERIOD - Grace period in seconds (default: 86400)
+
+Offline-license signature configuration (phased rollout):
+    TRAIGENT_LICENSE_PUBLIC_KEY - PEM-encoded RSA/EC public key inline.
+    TRAIGENT_LICENSE_PUBLIC_KEY_FILE - Path to a PEM public-key file.
+    TRAIGENT_REQUIRE_SIGNED_LICENSE - "true" rejects unsigned tokens
+        even when no public key is configured. Use this in strict /
+        enterprise / air-gapped deployments that cannot accept the
+        legacy unsigned format under any condition.
+
+Behavior:
+    - If a public key is configured (env or file) the offline token's
+      signature is verified and rejected if invalid.
+    - If TRAIGENT_REQUIRE_SIGNED_LICENSE is truthy, unsigned tokens are
+      rejected regardless.
+    - Otherwise the legacy unsigned format is still accepted with a
+      loud deprecation warning, and the resulting LicenseInfo is tagged
+      ``validation_source="offline_unsigned_legacy"`` so callers and
+      observability can distinguish trusted from legacy validations.
 """
 
 # Traceability: CONC-Layer-Core FUNC-LICENSING REQ-LICENSE-001
@@ -27,6 +45,7 @@ import time
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -215,11 +234,91 @@ class LicenseValidator:
             logger.warning(f"Failed to validate offline license: {e}")
             return None
 
-    def _decode_license_token(self, token: str) -> LicenseInfo | None:
-        """Decode and validate a license token (simplified JWT-like format).
+    # Algorithms accepted for offline-license signature verification.
+    # The "none" algorithm is explicitly excluded to defeat the classic
+    # JWT alg=none downgrade attack.
+    _SUPPORTED_LICENSE_ALGORITHMS = ("RS256", "ES256")
 
-        Note: In production, this would use proper JWT validation with
-        cryptographic signatures. This is a simplified implementation.
+    @staticmethod
+    def _truthy(value: str | None) -> bool:
+        return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    @classmethod
+    def _resolve_license_public_key(cls) -> tuple[Any, bool]:
+        """Resolve the offline-license public key.
+
+        Returns ``(public_key, was_configured)``. Distinguishing
+        "configured but failed to load" from "not configured at all"
+        is critical: the fail-open from a broken-key configuration is
+        exactly the bypass an attacker would aim for if they could
+        influence the env var.
+
+        - was_configured=False, public_key=None  -> nothing was set
+        - was_configured=True,  public_key=<key> -> ready to verify
+        - was_configured=True,  public_key=None  -> configured but
+          unreadable / invalid / empty; the caller MUST fail closed.
+
+        "Configured" is determined by env var *presence* (``in os.environ``),
+        not truthiness. ``TRAIGENT_LICENSE_PUBLIC_KEY=""`` is treated as a
+        broken configuration, not absence — otherwise an attacker who could
+        clear the env var would silently re-enable the legacy bypass.
+        """
+        inline_configured = "TRAIGENT_LICENSE_PUBLIC_KEY" in os.environ
+        file_configured = "TRAIGENT_LICENSE_PUBLIC_KEY_FILE" in os.environ
+
+        if not inline_configured and not file_configured:
+            return None, False
+
+        pem_inline = os.environ.get("TRAIGENT_LICENSE_PUBLIC_KEY", "")
+        pem_path = os.environ.get("TRAIGENT_LICENSE_PUBLIC_KEY_FILE", "")
+
+        pem_bytes: bytes | None = None
+        if pem_inline:
+            pem_bytes = pem_inline.encode("utf-8")
+        elif pem_path:
+            try:
+                pem_bytes = Path(pem_path).expanduser().read_bytes()
+            except OSError as exc:
+                logger.error(
+                    "Failed to read TRAIGENT_LICENSE_PUBLIC_KEY_FILE=%s: %s",
+                    pem_path,
+                    exc,
+                )
+                return None, True  # configured but unreadable -> fail closed
+
+        if not pem_bytes:
+            # Env var present but empty (or whitespace-only inline) is
+            # broken configuration, not absence.
+            logger.error(
+                "License public key env var is set but empty; refusing to "
+                "verify offline licenses until a non-empty key is provided."
+            )
+            return None, True
+
+        try:
+            from cryptography.hazmat.primitives import serialization
+
+            return serialization.load_pem_public_key(pem_bytes), True
+        except Exception as exc:
+            logger.error("Configured license public key is invalid: %s", exc)
+            return None, True  # configured but invalid -> fail closed
+
+    def _decode_license_token(self, token: str) -> LicenseInfo | None:
+        """Decode and validate an offline license token.
+
+        Phased rollout: a public key (inline or file) verifies the
+        signature when configured; ``TRAIGENT_REQUIRE_SIGNED_LICENSE``
+        forces strict mode even when no key is configured. Otherwise the
+        legacy unsigned format is still accepted with a loud deprecation
+        warning and tagged ``validation_source="offline_unsigned_legacy"``
+        so air-gapped deployments are not broken in this release while
+        signed-only workflows can be enforced today.
+
+        If a public key is configured but cannot be loaded (unreadable
+        file, malformed PEM, empty inline value), the validator MUST
+        fail closed: silently treating a broken key configuration as
+        "no key configured" would let an attacker who can influence the
+        env var trigger the legacy bypass.
 
         Args:
             token: The license token to decode.
@@ -227,45 +326,120 @@ class LicenseValidator:
         Returns:
             LicenseInfo if valid, None if invalid.
         """
+        public_key, key_was_configured = self._resolve_license_public_key()
+        require_signed = self._truthy(os.environ.get("TRAIGENT_REQUIRE_SIGNED_LICENSE"))
+
+        if public_key is not None:
+            return self._decode_signed_license_token(token, public_key)
+
+        if key_was_configured:
+            # Env points at a key that did not load. Refuse rather than
+            # falling through to legacy — the loader has already logged
+            # the underlying error.
+            logger.error(
+                "License public key is configured but could not be "
+                "loaded; refusing to verify the offline license. Fix "
+                "TRAIGENT_LICENSE_PUBLIC_KEY / TRAIGENT_LICENSE_PUBLIC_KEY_FILE."
+            )
+            return None
+
+        if require_signed:
+            logger.error(
+                "TRAIGENT_REQUIRE_SIGNED_LICENSE is set but no license "
+                "public key is configured (TRAIGENT_LICENSE_PUBLIC_KEY or "
+                "TRAIGENT_LICENSE_PUBLIC_KEY_FILE). Refusing to accept "
+                "the offline license."
+            )
+            return None
+
+        logger.warning(
+            "Accepting an UNSIGNED offline license token. This format is "
+            "deprecated and will be removed in a future Traigent SDK "
+            "release. Provision a signing keypair and set "
+            "TRAIGENT_LICENSE_PUBLIC_KEY (or _FILE) to verify offline "
+            "licenses; set TRAIGENT_REQUIRE_SIGNED_LICENSE=true to refuse "
+            "unsigned tokens immediately."
+        )
+        return self._decode_unsigned_license_token(token)
+
+    def _decode_signed_license_token(
+        self, token: str, public_key
+    ) -> LicenseInfo | None:
+        """Verify the JWT signature on the offline license and decode it."""
         try:
-            # Simple base64-encoded JSON format for now
-            # Production would use proper JWT with RSA/ECDSA signatures
+            import jwt as pyjwt
+        except ImportError:
+            logger.error(
+                "PyJWT is required to verify signed license tokens but is "
+                "not installed."
+            )
+            return None
+
+        try:
+            payload = pyjwt.decode(
+                token,
+                public_key,
+                algorithms=list(self._SUPPORTED_LICENSE_ALGORITHMS),
+                options={"verify_aud": False},
+            )
+        except Exception as exc:
+            logger.warning("Signed license verification failed: %s", exc)
+            return None
+
+        info = self._build_license_info(payload, validation_source="offline")
+        if info is None:
+            return None
+        if info.is_expired:
+            logger.warning("Offline license has expired")
+            return None
+        return info
+
+    def _decode_unsigned_license_token(self, token: str) -> LicenseInfo | None:
+        """Legacy path: base64-decode the middle segment without verifying."""
+        try:
             parts = token.split(".")
             if len(parts) != 3:
                 logger.warning("Invalid license token format")
                 return None
 
-            # Decode payload (middle part)
             payload_b64 = parts[1]
-            # Add padding if needed (use negative modulo to avoid adding 4 when len%4==0)
             payload_b64 += "=" * ((-len(payload_b64)) % 4)
             payload_json = base64.urlsafe_b64decode(payload_b64).decode("utf-8")
             payload = json.loads(payload_json)
-
-            # Extract license info
-            tier_str = payload.get("tier", "free")
-            tier = LicenseTier(tier_str)
-            features = {LicenseFeature(f) for f in payload.get("features", [])}
-            expires_at = payload.get("exp")
-            organization = payload.get("org")
-
-            # Check expiration
-            if expires_at and time.time() > expires_at:
-                logger.warning("Offline license has expired")
-                return None
-
-            return LicenseInfo(
-                tier=tier,
-                features=features,
-                expires_at=expires_at,
-                organization=organization,
-                validated_at=time.time(),
-                validation_source="offline",
-            )
-
-        except Exception as e:
-            logger.warning(f"Failed to decode license token: {e}")
+        except Exception as exc:
+            logger.warning("Failed to decode license token: %s", exc)
             return None
+
+        info = self._build_license_info(
+            payload, validation_source="offline_unsigned_legacy"
+        )
+        if info is None:
+            return None
+        if info.is_expired:
+            logger.warning("Offline license has expired")
+            return None
+        return info
+
+    @staticmethod
+    def _build_license_info(
+        payload: dict, *, validation_source: str
+    ) -> LicenseInfo | None:
+        """Common post-decode payload -> LicenseInfo conversion."""
+        try:
+            tier = LicenseTier(payload.get("tier", "free"))
+            features = {LicenseFeature(f) for f in payload.get("features", [])}
+        except ValueError as exc:
+            logger.warning("License payload contained unknown enum value: %s", exc)
+            return None
+
+        return LicenseInfo(
+            tier=tier,
+            features=features,
+            expires_at=payload.get("exp"),
+            organization=payload.get("org"),
+            validated_at=time.time(),
+            validation_source=validation_source,
+        )
 
     async def _validate_cloud_license(self) -> LicenseInfo | None:
         """Validate license via cloud API.


### PR DESCRIPTION
## Problem

`LicenseValidator._decode_license_token` previously only base64-decoded the middle JWT segment **without verifying the signature**. Anyone who could place a file at `TRAIGENT_LICENSE_FILE` (or set the env var) could forge a payload like `{\"tier\": \"enterprise\", \"features\": [...], \"exp\": <future>}` and unlock paid features.

A hard fail-closed flip would break SDK users who today rely on the offline / air-gapped license file to operate without phoning home.

## Fix — phased rollout (per Codex review)

- `TRAIGENT_LICENSE_PUBLIC_KEY` (PEM string) and `TRAIGENT_LICENSE_PUBLIC_KEY_FILE` (path) configure a verification key. When configured, the offline token's RS256 / ES256 signature is verified via PyJWT and rejected if invalid, expired, or missing. The `\"alg=none\"` downgrade is explicitly defeated by restricting the accepted algorithms list.
- `TRAIGENT_REQUIRE_SIGNED_LICENSE=true` rejects unsigned tokens even when no public key is configured. Strict / enterprise / air-gapped deployments can adopt this immediately.
- Otherwise the legacy unsigned format is still accepted with a loud deprecation warning, and the resulting `LicenseInfo` is tagged `validation_source=\"offline_unsigned_legacy\"` so observability and downstream callers can distinguish trusted from legacy validations.

### Two subtle fail-closed paths a less careful implementation would miss (Codex caught both)

1. **Configured-but-failed-to-load** must NOT fall through to the legacy path. The resolver returns `(key, was_configured)` so the decoder can distinguish \"no env var set\" from \"env var set but key unreadable / invalid PEM\". Otherwise an attacker who could influence `TRAIGENT_LICENSE_PUBLIC_KEY_FILE` — even just by pointing it at a missing path — would silently get the bypass.
2. **\"Configured\" is determined by env var presence (`in os.environ`)**, not truthiness. `os.environ.get(\"X\")` returns `\"\"` for an env var set to empty string and `None` when unset; a truthy check cannot tell them apart, and clearing the env var would re-enable the legacy bypass. Empty values are treated as broken configuration.

### Test contract update

Two existing `test_license.py` assertions expecting the legacy unsigned path to tag as plain `\"offline\"` are updated to expect `\"offline_unsigned_legacy\"`, matching the new contract.

## Dependency note

PyJWT is part of the `traigent[security]` extras (see pyproject.toml, the \"security\" optional-dependencies group). A base install with a public key configured but PyJWT missing fails closed via the `ImportError` guard in `_decode_signed_license_token`. Deployments that want signature verification should install with `traigent[security]`.

## Scope

- Repo: Traigent SDK
- Files: `traigent/core/license.py`, `tests/unit/core/test_license.py` (2 assertion updates), `tests/unit/core/test_license_signature.py` (new)
- Tests: 19 new + 121 existing license tests still pass

## Test plan

```
pytest tests/unit/core/test_license.py tests/unit/core/test_license_signature.py
```

Expected: 140 passed.

## Reviewer's checklist

- [ ] Configured-but-broken public key (missing file, invalid PEM, empty inline) fails closed
- [ ] Truly-empty env var values (`TRAIGENT_LICENSE_PUBLIC_KEY=\"\"`) fail closed (verified via test)
- [ ] `alg=none` downgrade is rejected (verified via test)
- [ ] Wrong-key signature is rejected
- [ ] Legacy unsigned path emits a loud deprecation warning AND is tagged `offline_unsigned_legacy` (so observability can find deployments still using it)
- [ ] PyJWT is documented as a `traigent[security]` extra; base install with a key configured fails closed gracefully

Part of the security-scan release sweep. Companion PRs: C1/C2/C4/C5/C6/C7.