### PR TITLE
docs: harden SDK cost disclaimers

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,7 +1,10 @@
 # Traigent SDK Disclaimer
 
-This document outlines important disclaimers and terms of use for the Traigent SDK.
-By using this software, you acknowledge and agree to the following terms.
+This document provides cost, warranty, and operational-risk guidance for the Traigent SDK.
+For paid services or portal users, contractual terms are governed by the applicable Traigent
+Terms of Service, order form, or other signed agreement. For open-source SDK use without a
+separate agreement, warranty and liability are governed by the AGPL-3.0 license; this document
+is informational unless incorporated into a separate agreement.
 
 ## Cost Liability
 
@@ -24,9 +27,27 @@ Users are **solely responsible** for:
 
 1. Monitoring and controlling their API spending
 2. Configuring appropriate spending limits via `TRAIGENT_RUN_COST_LIMIT`
-3. Using `TRAIGENT_MOCK_LLM=true` for development and testing
+3. Using `enable_mock_mode_for_quickstart()` from `traigent.testing` for local development and testing,
+   or `python -m traigent.examples.quickstart` for the no-cost demo
 4. Reviewing actual API provider billing independently
 5. Understanding provider pricing before production use
+6. Setting hard provider-side billing caps, quotas, budgets, and alerts directly with their LLM,
+   API, cloud, and infrastructure providers
+
+### Cost Limits Are Best-Effort Guardrails
+
+Traigent cost limits, budgets, alerts, thresholds, stop conditions, and estimates are
+**best-effort software controls**. They are not guarantees, insurance, financial commitments,
+provider-side billing controls, or a substitute for provider/account-level spending caps.
+
+Actual costs may exceed configured Traigent limits or estimates due to, among other things:
+
+- Provider pricing changes, billing rules, or tokenization differences
+- Parallel execution, retries, partial failures, timeouts, or cancelled requests
+- Cached tokens, output tokens, tool calls, embeddings, or provider-specific usage accounting
+- Stale pricing data, unrecognized model names, custom endpoints, or self-hosted models
+- Bugs, race conditions, network failures, misconfiguration, or user-supplied credentials
+- Provider dashboards or invoices applying charges differently than local estimates
 
 ### Parallel Execution Warning
 
@@ -54,6 +75,8 @@ Traigent is **not responsible** for:
 - Changes to provider pricing or terms
 - Provider account suspension or termination
 - Data handling by third-party providers
+- API, cloud, infrastructure, or provider charges that exceed Traigent estimates, budgets,
+  thresholds, alerts, stop conditions, or limits
 
 ## No Warranty
 
@@ -85,16 +108,23 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 - API costs incurred during optimization
 - Costs from misconfigured limits or settings
 - Costs from parallel execution of LLM calls
+- Costs from bugs, retries, race conditions, stale pricing data, custom model mappings, failed
+  stop conditions, missed alerts, or provider billing differences
 - Any financial damages related to LLM API usage
 
 ## Best Practices for Cost Control
 
 To minimize unexpected costs, we strongly recommend:
 
-1. **Always use mock mode for development**:
-   ```bash
-   export TRAIGENT_MOCK_LLM=true
+1. **Always use mock mode for local development**:
+   ```python
+   from traigent.testing import enable_mock_mode_for_quickstart
+
+   enable_mock_mode_for_quickstart()
    ```
+   For the packaged demo, run `python -m traigent.examples.quickstart`. The legacy
+   `TRAIGENT_MOCK_LLM=true` env var remains available for older local scripts and is disabled
+   when `ENVIRONMENT=production`.
 
 2. **Set explicit cost limits**:
    ```bash
@@ -110,7 +140,10 @@ To minimize unexpected costs, we strongly recommend:
 
 4. **Monitor your provider dashboards** for actual usage and billing
 
-5. **Use the approval flow** for production runs:
+5. **Set hard caps directly with your providers** whenever available, including provider-side
+   budgets, quotas, alerts, organization limits, project limits, and payment controls
+
+6. **Use the approval flow** for production runs:
    ```bash
    export TRAIGENT_COST_APPROVED=true  # Only after reviewing estimates
    ```
@@ -162,5 +195,5 @@ https://github.com/Traigent/Traigent/issues
 
 ---
 
-*Last updated: March 2026*
+*Last updated: May 2026*
 *Licensed under GNU Affero General Public License v3.0 (AGPL-3.0-only) - See [LICENSE](LICENSE) for full terms*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Our mission: **Anything you can measure, we can improve.** Whether it's accuracy, speed of response, cost, or any other business metric — we bring strong results that deliver real business value.
 
-> **Runs multiple LLM trials** — use `TRAIGENT_MOCK_LLM=true` to test without spending money, or set `TRAIGENT_RUN_COST_LIMIT=2.0` to cap spend. See [Cost Management](#cost-management).
+> **Runs multiple LLM trials** — run `python -m traigent.examples.quickstart` for a no-cost demo, or call `enable_mock_mode_for_quickstart()` from `traigent.testing` in local tutorial code. Set `TRAIGENT_RUN_COST_LIMIT=2.0` as a best-effort local guardrail and set hard caps with your LLM/cloud providers; actual billing is determined by those providers. The legacy `TRAIGENT_MOCK_LLM=true` env var remains for backwards compatibility and is disabled when `ENVIRONMENT=production`. See [Cost Management](#cost-management).
 
 **Quick Install:**
 
@@ -173,7 +173,7 @@ Works with any LLM provider — [OpenAI](https://platform.openai.com/docs), [Ant
 
 ## 🚀 Walkthrough — 8 runnable examples
 
-All examples run with `TRAIGENT_MOCK_LLM=true` — no API keys needed.
+The walkthrough examples use local mock mode through the quickstart/testing helpers — no API keys needed.
 
 <details>
 <summary>Show all 8 walkthrough steps</summary>
@@ -292,10 +292,14 @@ pip install -e ".[recommended]"
 
 | Setting | How |
 |---------|-----|
-| Testing (no API calls) | `TRAIGENT_MOCK_LLM=true` |
+| Testing (no API calls) | Import and call `enable_mock_mode_for_quickstart()` from `traigent.testing`, or run `python -m traigent.examples.quickstart` for the demo |
 | Cost Limit | `TRAIGENT_RUN_COST_LIMIT=2.0` (default: $2/run) |
 
-Cost estimates are approximations. See [DISCLAIMER.md](DISCLAIMER.md) for details.
+Cost estimates, budgets, limits, alerts, and thresholds are best-effort software controls, not
+provider-side billing guarantees. Actual billing is determined by your LLM/cloud providers, and you
+remain responsible for provider charges. The legacy `TRAIGENT_MOCK_LLM=true` env var is supported
+only for backwards-compatible local scripts and is disabled when `ENVIRONMENT=production`. See
+[DISCLAIMER.md](DISCLAIMER.md) for details.
 
 ### Evaluation
 
@@ -357,8 +361,8 @@ traigent --help                              # Full command reference
 | Problem | Fix |
 |---------|-----|
 | `ModuleNotFoundError` | `pip install -e ".[recommended]"` or check venv is activated |
-| 0.0% accuracy | Set `TRAIGENT_MOCK_LLM=true`, or check dataset format |
-| Missing API keys | Copy `.env.example` to `.env`; or use mock mode |
+| 0.0% accuracy | Check dataset format; for local demos, import and call `enable_mock_mode_for_quickstart()` from `traigent.testing` |
+| Missing API keys | Copy `.env.example` to `.env`; or run `python -m traigent.examples.quickstart` for a no-key demo |
 | Permission errors | Create a fresh venv and reinstall dependencies |
 
 </details>
@@ -370,7 +374,7 @@ traigent --help                              # Full command reference
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[all,dev]"              # Install with dev dependencies
-TRAIGENT_MOCK_LLM=true pytest            # Run tests
+pytest                                   # Run tests
 make format && make lint                 # Format and lint
 ```
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -1750,8 +1750,11 @@ def optimize(  # NOSONAR(S107)
                 ``auto_detect_tvars_include`` / ``auto_detect_tvars_exclude``.
 
     Warning:
-        Optimization runs multiple LLM calls. Use TRAIGENT_MOCK_LLM=true for testing.
+        Optimization runs multiple LLM calls. Use
+        ``traigent.testing.enable_mock_mode_for_quickstart()`` for local testing.
         Cost estimates are approximations; actual billing is determined by your LLM provider.
+        Traigent cost limits, alerts, thresholds, and stop conditions are best-effort
+        local guardrails, not provider-side billing caps.
         See DISCLAIMER.md for full liability terms.
 
     Important - Configuration Access:

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -469,6 +469,7 @@ Your current cost limit:     ${self.config.limit:.2f} USD
 
 NOTE: This is an ESTIMATE based on maximum context. Actual billing is
       determined solely by your LLM provider.
+NOTE: Traigent limits are best-effort local guardrails, not provider billing caps.
 
 Options:
   [y] Approve and continue with current limit

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -179,11 +179,15 @@ def _emit_cost_warning_once() -> None:
             f"\n{YELLOW}{BOLD}[!] COST WARNING{RESET}\n"
             f"{YELLOW}Traigent optimization will make multiple LLM API calls.{RESET}\n"
             f"Cost estimates are approximations based on {CYAN}litellm{RESET} library pricing.\n"
+            f"Traigent limits are best-effort local guardrails, not provider billing caps.\n"
             f"Actual billing is determined by your LLM provider.\n\n"
             f"{BOLD}Configuration:{RESET}\n"
             f"  - Custom pricing file:   {CYAN}TRAIGENT_CUSTOM_MODEL_PRICING_FILE{RESET}\n"
             f"  - Custom pricing JSON:   {CYAN}TRAIGENT_CUSTOM_MODEL_PRICING_JSON{RESET}\n"
-            f"  - Disable for testing:   {CYAN}TRAIGENT_MOCK_LLM=true{RESET}\n"
+            f"  - Local mock helper:     {CYAN}from traigent.testing import enable_mock_mode_for_quickstart{RESET}\n"
+            f"  - Then call:            {CYAN}enable_mock_mode_for_quickstart(){RESET}\n"
+            f"  - Legacy env mock:       {CYAN}TRAIGENT_MOCK_LLM=true{RESET} (non-production only)\n"
+            f"  - Set provider caps:     billing limits in your LLM/cloud provider account\n"
             f"  - Full details:          {CYAN}DISCLAIMER.md{RESET}\n"
         )
     else:
@@ -191,11 +195,15 @@ def _emit_cost_warning_once() -> None:
             "\n[!] COST WARNING\n"
             "Traigent optimization will make multiple LLM API calls.\n"
             "Cost estimates are approximations based on litellm library pricing.\n"
+            "Traigent limits are best-effort local guardrails, not provider billing caps.\n"
             "Actual billing is determined by your LLM provider.\n\n"
             "Configuration:\n"
             "  - Custom pricing file:   TRAIGENT_CUSTOM_MODEL_PRICING_FILE\n"
             "  - Custom pricing JSON:   TRAIGENT_CUSTOM_MODEL_PRICING_JSON\n"
-            "  - Disable for testing:   TRAIGENT_MOCK_LLM=true\n"
+            "  - Local mock helper:     from traigent.testing import enable_mock_mode_for_quickstart\n"
+            "  - Then call:             enable_mock_mode_for_quickstart()\n"
+            "  - Legacy env mock:       TRAIGENT_MOCK_LLM=true (non-production only)\n"
+            "  - Set provider caps:     billing limits in your LLM/cloud provider account\n"
             "  - Full details:          DISCLAIMER.md\n"
         )
 


### PR DESCRIPTION
## Summary

- Expands SDK disclaimer language for third-party provider/API/cloud charges, cost-estimate drift, best-effort guardrails, provider-side caps, and AGPL-vs-contractual scope.
- Updates README guidance to prefer the canonical in-code mock helper and quickstart path instead of recommending `TRAIGENT_MOCK_LLM=true` as the primary flow.
- Updates runtime cost warnings and decorator docs to clarify that Traigent limits are local guardrails, not provider billing caps.

## Scope

This PR is limited to disclaimer/docs/runtime-warning wording. It intentionally does not include the parallel security/mock-mode implementation work.

## Validation

- `.venv/bin/python -m py_compile traigent/core/optimized_function.py traigent/core/cost_enforcement.py traigent/api/decorators.py`
- `.venv/bin/ruff check traigent/api/decorators.py traigent/core/cost_enforcement.py traigent/core/optimized_function.py`
- `.venv/bin/python -m pytest -o addopts='' tests/unit/examples/test_quickstart_entry.py tests/unit/integrations/test_mock_adapter.py tests/unit/integrations/test_no_mock_llm_env.py tests/unit/integrations/test_mock_adapter_safety.py` — 52 passed
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

## Notes

- `DISCLAIMER.md` already uses CRLF line endings, so the diff-check command explicitly allows CR at EOL.
- Push hook skipped SonarQube because `sonar-scanner` is not installed locally.
