### PR TITLE
test: guard JS public client parity

### DIFF
--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -25,40 +25,23 @@ jobs:
         with:
           path: Traigent
 
-      - name: Checkout JS SDK
+      - name: Check JS SDK token
         env:
           TRAIGENT_JS_SDK_TOKEN: ${{ secrets.TRAIGENT_JS_SDK_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ -z "${TRAIGENT_JS_SDK_TOKEN:-}" ]; then
+            echo "::error::Configure TRAIGENT_JS_SDK_TOKEN with read access to Traigent/traigent-js."
+            exit 1
+          fi
 
-          for token_name in \
-            TRAIGENT_JS_SDK_TOKEN \
-            TRAIGENT_SCHEMAS_PAT \
-            TRAIGENT_PRIVATE_DEPS_TOKEN \
-            TRAIGENT_SCHEMA_TOKEN \
-            GITHUB_TOKEN
-          do
-            token="${!token_name:-}"
-            if [ -z "$token" ]; then
-              continue
-            fi
-
-            auth="$(printf 'x-access-token:%s' "$token" | base64 -w 0)"
-            if git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
-              clone --depth 1 --branch main https://github.com/Traigent/traigent-js.git traigent-js
-            then
-              echo "Checked out Traigent/traigent-js with $token_name."
-              exit 0
-            fi
-            rm -rf traigent-js
-          done
-
-          echo "Unable to check out Traigent/traigent-js. Configure TRAIGENT_JS_SDK_TOKEN with read access."
-          exit 1
+      - name: Checkout JS SDK
+        uses: actions/checkout@v4
+        with:
+          repository: Traigent/traigent-js
+          ref: main
+          path: traigent-js
+          token: ${{ secrets.TRAIGENT_JS_SDK_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -2,6 +2,9 @@ name: JS Public Parity
 
 on:
   pull_request:
+    # Client/config file moves outside these conventional module names are still
+    # caught by the weekly schedule; keep PR triggers scoped to parity-relevant
+    # files so unrelated Python changes do not pay the cross-repo clone/install cost.
     paths:
       - ".github/workflows/js-public-parity.yml"
       - "tests/cross_sdk_oracles/test_js_public_parity_manifest.py"
@@ -39,7 +42,8 @@ jobs:
           echo "available=true" >> "$GITHUB_OUTPUT"
 
       # The JS API-surface snapshot remains sourced from traigent-js main so the
-      # Python guard tracks the package users install, instead of a vendored copy.
+      # Python guard tracks the next JS release surface, instead of a vendored
+      # copy or the latest npm-published tag.
       - name: Checkout JS SDK
         if: steps.js-sdk-token.outputs.available == 'true'
         uses: actions/checkout@v4

--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -1,0 +1,86 @@
+name: JS Public Parity
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/js-public-parity.yml"
+      - "tests/cross_sdk_oracles/test_js_public_parity_manifest.py"
+      - "traigent/__init__.py"
+      - "traigent/**/client.py"
+      - "traigent/**/config.py"
+  workflow_dispatch:
+  schedule:
+    - cron: "17 7 * * 1"
+
+env:
+  TRAIGENT_SCHEMA_REF: "7d8539f45e978c5148e4335e8250843f097e3b67" # pragma: allowlist secret
+
+jobs:
+  js-public-parity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Python SDK
+        uses: actions/checkout@v4
+        with:
+          path: Traigent
+
+      - name: Checkout JS SDK
+        env:
+          TRAIGENT_JS_SDK_TOKEN: ${{ secrets.TRAIGENT_JS_SDK_TOKEN }}
+          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
+          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
+          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          for token_name in \
+            TRAIGENT_JS_SDK_TOKEN \
+            TRAIGENT_SCHEMAS_PAT \
+            TRAIGENT_PRIVATE_DEPS_TOKEN \
+            TRAIGENT_SCHEMA_TOKEN \
+            GITHUB_TOKEN
+          do
+            token="${!token_name:-}"
+            if [ -z "$token" ]; then
+              continue
+            fi
+
+            auth="$(printf 'x-access-token:%s' "$token" | base64 -w 0)"
+            if git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
+              clone --depth 1 --branch main https://github.com/Traigent/traigent-js.git traigent-js
+            then
+              echo "Checked out Traigent/traigent-js with $token_name."
+              exit 0
+            fi
+            rm -rf traigent-js
+          done
+
+          echo "Unable to check out Traigent/traigent-js. Configure TRAIGENT_JS_SDK_TOKEN with read access."
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python SDK
+        working-directory: Traigent
+        env:
+          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
+          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
+          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
+          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
+        run: |
+          bash scripts/ci/install_sdk_requirements.sh build wheel -e ".[dev,all]"
+
+      - name: Check JS public parity
+        working-directory: Traigent
+        env:
+          TRAIGENT_JS_SDK_PATH: ${{ github.workspace }}/traigent-js
+          TRAIGENT_MOCK_LLM: "true"
+          TRAIGENT_OFFLINE_MODE: "true"
+          PYTHONPATH: .
+        run: |
+          pytest -o addopts= -q tests/cross_sdk_oracles/test_js_public_parity_manifest.py

--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -26,16 +26,22 @@ jobs:
           path: Traigent
 
       - name: Check JS SDK token
+        id: js-sdk-token
         env:
           TRAIGENT_JS_SDK_TOKEN: ${{ secrets.TRAIGENT_JS_SDK_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "${TRAIGENT_JS_SDK_TOKEN:-}" ]; then
-            echo "::error::Configure TRAIGENT_JS_SDK_TOKEN with read access to Traigent/traigent-js."
-            exit 1
+            echo "::warning::Skipping JS public parity guard. Configure TRAIGENT_JS_SDK_TOKEN with read access to Traigent/traigent-js to enable it."
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
+      # The JS API-surface snapshot remains sourced from traigent-js main so the
+      # Python guard tracks the package users install, instead of a vendored copy.
       - name: Checkout JS SDK
+        if: steps.js-sdk-token.outputs.available == 'true'
         uses: actions/checkout@v4
         with:
           repository: Traigent/traigent-js
@@ -44,11 +50,13 @@ jobs:
           token: ${{ secrets.TRAIGENT_JS_SDK_TOKEN }}
 
       - name: Set up Python
+        if: steps.js-sdk-token.outputs.available == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install Python SDK
+        if: steps.js-sdk-token.outputs.available == 'true'
         working-directory: Traigent
         env:
           TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
@@ -59,6 +67,7 @@ jobs:
           bash scripts/ci/install_sdk_requirements.sh build wheel -e ".[dev,all]"
 
       - name: Check JS public parity
+        if: steps.js-sdk-token.outputs.available == 'true'
         working-directory: Traigent
         env:
           TRAIGENT_JS_SDK_PATH: ${{ github.workspace }}/traigent-js

--- a/tests/cross_sdk_oracles/test_js_public_parity_manifest.py
+++ b/tests/cross_sdk_oracles/test_js_public_parity_manifest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import traigent
+
+IGNORED_FROM_CLIENT_PARITY: set[str] = set()
+
+TRACKED_CONFIG_SYMBOLS = {
+    "CoreMetricsConfig",
+    "EnterpriseAdminConfig",
+    "EvaluationConfig",
+    "ObservabilityConfig",
+    "ProjectManagementConfig",
+    "PromptManagementConfig",
+}
+
+
+def _find_js_api_surface_snapshot() -> Path:
+    env_path = os.environ.get("TRAIGENT_JS_SDK_PATH")
+    candidates: list[Path] = []
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    current = Path(__file__).resolve()
+    candidates.extend(parent / "traigent-js" for parent in current.parents)
+
+    for js_repo in candidates:
+        snapshot_path = (
+            js_repo / "tests" / "integration" / "fixtures" / "api-surface.snapshot.json"
+        )
+        if snapshot_path.exists():
+            return snapshot_path
+
+    formatted = ", ".join(str(candidate) for candidate in candidates)
+    raise AssertionError(
+        "Missing JS API surface snapshot. Set TRAIGENT_JS_SDK_PATH or place "
+        f"traigent-js beside a parent of this checkout. Checked: {formatted}"
+    )
+
+
+def test_python_public_clients_are_represented_in_js_api_surface() -> None:
+    snapshot_path = _find_js_api_surface_snapshot()
+    js_surface = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    js_root = set(js_surface["root"])
+    # This guard tracks the public client/config migration surface. DTO/function
+    # parity is covered separately through TraigentSchema generation and JS API
+    # snapshot tests because JS intentionally exposes camelCase generated types.
+    python_client_symbols = {
+        name
+        for name in traigent.__all__
+        if name.endswith("Client") or name in TRACKED_CONFIG_SYMBOLS
+    }
+
+    missing = sorted(python_client_symbols - js_root - IGNORED_FROM_CLIENT_PARITY)
+    assert missing == [], (
+        "Python exported client/config symbols without JS parity coverage. "
+        "Add the JS export/stub or document the omission in IGNORED_FROM_CLIENT_PARITY: "
+        f"{missing}"
+    )


### PR DESCRIPTION
## Summary

- add a Python-side guard that compares canonical `traigent.__all__` client/config exports against the merged JS SDK API-surface snapshot
- add a dedicated JS Public Parity workflow that checks out `Traigent/traigent-js` main and runs the guard on parity-relevant changes plus a weekly schedule
- skip the workflow with a GitHub warning when `TRAIGENT_JS_SDK_TOKEN` is not configured, avoiding unrelated Python PR red builds while the secret is being added
- keep the existing security/preprod worktree untouched by building this from a clean `origin/main` worktree

## Verification

- `pytest -o addopts= -q tests/cross_sdk_oracles/test_js_public_parity_manifest.py`
- `ruff check tests/cross_sdk_oracles/test_js_public_parity_manifest.py`
- workflow YAML passed local pre-commit `check yaml` during commit

## Notes

- `BenchmarkClient` is not ignored here because it is not exported from Python `main` today. If Python adds it later, this guard should fail and force an explicit JS decision.
- The JS API-surface snapshot source of truth is the `traigent-js` main checkout, not a vendored copy or npm-latest tag, so the guard tracks the next JS release surface.
- The PR path filter intentionally covers conventional client/config module locations; the weekly schedule is the backstop for module-rename refactors outside those paths.
- DTO/function parity remains out of scope for this guard; follow-up issue #806 tracks a separate guard if those become part of the JS parity contract.
