### PR TITLE
chore: add Peacock workspace title-bar colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,7 +354,8 @@ traigent_example.py
 reports/
 
 # IDE settings (may contain local paths)
-.vscode/
+.vscode/*
+!.vscode/settings.json
 
 # Backup environments
 .venv.bkp/

--- a/.gitignore
+++ b/.gitignore
@@ -185,9 +185,6 @@ cython_debug/
 #  https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 .idea/
 
-# VS Code
-# Keep .vscode settings tracked for team consistency
-# .vscode/
 
 # Internal design docs (IP/private during implementation)
 resampling_configs.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "workbench.colorCustomizations": {
+  "activityBar.background": "#14532d3c",
+  "activityBar.foreground": "#e7e7e7",
+  "statusBar.background": "#14532d3c",
+  "statusBar.foreground": "#e7e7e7",
+  "titleBar.activeBackground": "#14532d3c",
+  "titleBar.activeForeground": "#e7e7e7",
+  "titleBar.inactiveBackground": "#14532d3c",
+  "titleBar.inactiveForeground": "#e7e7e799"
+}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,12 @@
 {
     "workbench.colorCustomizations": {
-  "activityBar.background": "#14532d3c",
-  "activityBar.foreground": "#e7e7e7",
-  "statusBar.background": "#14532d3c",
-  "statusBar.foreground": "#e7e7e7",
-  "titleBar.activeBackground": "#14532d3c",
-  "titleBar.activeForeground": "#e7e7e7",
-  "titleBar.inactiveBackground": "#14532d3c",
-  "titleBar.inactiveForeground": "#e7e7e799"
-}
+        "activityBar.background": "#14532d3c",
+        "activityBar.foreground": "#e7e7e7",
+        "statusBar.background": "#14532d3c",
+        "statusBar.foreground": "#e7e7e7",
+        "titleBar.activeBackground": "#14532d3c",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#14532d3c",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    }
 }


### PR DESCRIPTION
## Summary
Adds subtle dark-mode title-bar tint in `.vscode/settings.json` so this repo's VS Code window is visually distinct from the other Traigent repos when multiple are open at once.

Also updates `.gitignore` to use `.vscode/*` with `!.vscode/settings.json` exception, so the settings file is tracked while other IDE files remain ignored.

Approved with the team beforehand. If anyone prefers no colors, they can opt out locally with:
`git update-index --skip-worktree .vscode/settings.json`

## Test plan
- [ ] Open this project in VS Code → confirm title bar shows the new tint