### PR TITLE
[codex] Expose experiment list stats DTO fields

### DIFF
--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -16,6 +16,7 @@ from traigent.cloud.dtos import (
     ConfigurationsDTO,
     ExampleMeasure,
     ExperimentDTO,
+    ExperimentListRunSummaryDTO,
     ExperimentRunDTO,
     InfrastructureDTO,
 )
@@ -391,6 +392,67 @@ class TestExperimentDTO:
                 status=status,
             )
             assert exp.status == status
+
+    def test_to_dict_includes_list_response_stats(self):
+        """ExperimentDTO should carry backend experiment-list stats when present."""
+        exp = ExperimentDTO(
+            id="exp-list-stats",
+            name="List Stats",
+            description="Experiment list payload",
+            configuration_runs_count=3,
+            total_examples=42,
+            optimization_runs_count=2,
+            experiment_run=ExperimentListRunSummaryDTO(
+                id="run-list-latest",
+                run_id="external-run-id",
+                experiment_id="exp-list-stats",
+                status="completed",
+                configuration_runs_count=1,
+                summary_stats={"total_examples": 12, "accuracy": 0.9},
+                metrics={"latency_ms": 123},
+            ),
+        )
+
+        result = exp.to_dict()
+
+        assert result["configuration_runs_count"] == 3
+        assert result["total_examples"] == 42
+        assert result["optimization_runs_count"] == 2
+        assert result["experiment_run"]["run_id"] == "external-run-id"
+        assert result["experiment_run"]["summary_stats"]["accuracy"] == 0.9
+
+    def test_list_run_summary_preserves_empty_string_run_id(self):
+        """ExperimentListRunSummaryDTO should only fall back when run_id is None."""
+        summary = ExperimentListRunSummaryDTO(
+            id="run-list-latest",
+            run_id="",
+            experiment_id="exp-list-stats",
+            status="completed",
+        )
+
+        result = summary.to_dict()
+
+        assert result["run_id"] == ""
+
+    def test_to_dict_passes_through_raw_experiment_run_stats(self):
+        """ExperimentDTO should pass through raw embedded run stats when provided."""
+        raw_run = {
+            "id": "run-list-latest",
+            "run_id": "raw-run-id",
+            "experiment_id": "exp-list-stats",
+            "status": "completed",
+            "configuration_runs_count": 1,
+        }
+        exp = ExperimentDTO(
+            id="exp-list-stats",
+            name="List Stats",
+            description="Experiment list payload",
+            experiment_run=raw_run,
+        )
+
+        result = exp.to_dict()
+
+        assert result["experiment_run"] is raw_run
 
 
 class TestExperimentRunDTO:

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -355,6 +355,47 @@ class ConfigurationsDTO:
 
 
 @dataclass
+class ExperimentListRunSummaryDTO:
+    """Compact experiment-run summary embedded in experiment list responses."""
+
+    id: str
+    experiment_id: str
+    status: str
+    run_id: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    configuration_runs_count: int = 0
+    summary_stats: dict[str, Any] | None = None
+    metrics: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the compact backend list-response shape."""
+        _warn_if_unknown_status(
+            status=self.status,
+            allowed=EXPERIMENT_RUN_STATUS_VALUES,
+            dto_name="ExperimentListRunSummaryDTO",
+        )
+        result: dict[str, Any] = {
+            "id": self.id,
+            "run_id": self.run_id if self.run_id is not None else self.id,
+            "experiment_id": self.experiment_id,
+            "status": self.status,
+            "configuration_runs_count": int(self.configuration_runs_count),
+        }
+        for field_name in ("created_at", "updated_at", "started_at", "completed_at"):
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        if self.summary_stats is not None:
+            result["summary_stats"] = self.summary_stats
+        if self.metrics is not None:
+            result["metrics"] = self.metrics
+        return result
+
+
+@dataclass
 class ExperimentDTO:
     """Experiment DTO based on experiment_schema.json.
 
@@ -382,6 +423,10 @@ class ExperimentDTO:
     status: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
+    configuration_runs_count: int | None = None
+    total_examples: int | None = None
+    optimization_runs_count: int | None = None
+    experiment_run: ExperimentListRunSummaryDTO | dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API submission."""
@@ -434,6 +479,17 @@ class ExperimentDTO:
             result["benchmark_id"] = resolved_dataset_id
         if self.status is not None:
             result["status"] = self.status
+        if self.configuration_runs_count is not None:
+            result["configuration_runs_count"] = int(self.configuration_runs_count)
+        if self.total_examples is not None:
+            result["total_examples"] = int(self.total_examples)
+        if self.optimization_runs_count is not None:
+            result["optimization_runs_count"] = int(self.optimization_runs_count)
+        if self.experiment_run is not None:
+            if isinstance(self.experiment_run, ExperimentListRunSummaryDTO):
+                result["experiment_run"] = self.experiment_run.to_dict()
+            else:
+                result["experiment_run"] = self.experiment_run
 
         return result
 


### PR DESCRIPTION
## Summary
- Add `ExperimentListRunSummaryDTO` for compact embedded list-run payloads.
- Expose optional experiment list stats fields on `ExperimentDTO`.
- Add DTO serialization coverage for the new list response shape.

## Validation
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts='' tests/unit/cloud/test_dtos.py::TestExperimentDTO::test_to_dict_includes_list_response_stats`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m ruff check traigent/cloud/dtos.py tests/unit/cloud/test_dtos.py`
- SDK pre-commit hooks during commit: isort, black, ruff, detect-secrets, bandit, mypy, guardrails
- `git diff --cached --check`