### PR TITLE
[codex] Add harmonic cloud DTOs

### DIFF
--- a/tests/cloud/fixtures/evaluator_dto.json
+++ b/tests/cloud/fixtures/evaluator_dto.json
@@ -1,0 +1,26 @@
+{
+  "name": "Answer Helpfulness Judge",
+  "measure_id": "answer_helpfulness",
+  "target_type": "observability_trace",
+  "judge_config": {
+    "instructions": "Score whether the final answer directly helps the user.",
+    "model_id": "gpt-4o-mini",
+    "context_type": "trace",
+    "context_source": "observability.trace",
+    "parameters": {
+      "model_id": "gpt-4o-mini",
+      "temperature": 0.0
+    },
+    "scoring_rubric": {
+      "0": "The answer is unhelpful or unsafe.",
+      "1": "The answer is useful and grounded."
+    },
+    "response_format_instructions": "Return a numeric score and short rationale.",
+    "max_budget": 0.05
+  },
+  "sampling_rate": 1.0,
+  "target_filters": {
+    "environment": "production"
+  },
+  "is_active": true
+}

--- a/tests/cloud/fixtures/measure_dto.json
+++ b/tests/cloud/fixtures/measure_dto.json
@@ -1,0 +1,31 @@
+{
+  "id": "answer_helpfulness",
+  "version": "1.0.0",
+  "label": "Answer Helpfulness",
+  "description": "Scores whether the response directly and usefully answers the user's request.",
+  "category": "Response Quality",
+  "measure_type": "quality",
+  "evaluation_method": "llm_based",
+  "target_aspect": "response",
+  "metric_type": "single_turn",
+  "output_type": "continuous",
+  "agent_types": [
+    "chat"
+  ],
+  "domain_min": 0.0,
+  "domain_max": 1.0,
+  "inverse": false,
+  "is_custom": true,
+  "target_types": [
+    "observability_trace",
+    "configuration_run"
+  ],
+  "allowed_score_sources": [
+    "manual",
+    "evaluator"
+  ],
+  "criteria": [
+    "The response addresses the user's stated goal.",
+    "The response includes enough detail to be actionable."
+  ]
+}

--- a/tests/cloud/fixtures/planner_draft_dto.json
+++ b/tests/cloud/fixtures/planner_draft_dto.json
@@ -1,8 +1,6 @@
 {
   "draft_id": "draft_answer_quality",
   "description": "Create a customer support agent and evaluate answer helpfulness.",
-  "agent": null,
-  "benchmark": null,
   "measures": [
     {
       "id": "answer_helpfulness",

--- a/tests/cloud/fixtures/planner_draft_dto.json
+++ b/tests/cloud/fixtures/planner_draft_dto.json
@@ -1,0 +1,43 @@
+{
+  "draft_id": "draft_answer_quality",
+  "description": "Create a customer support agent and evaluate answer helpfulness.",
+  "agent": null,
+  "benchmark": null,
+  "measures": [
+    {
+      "id": "answer_helpfulness",
+      "version": "1.0.0",
+      "label": "Answer Helpfulness",
+      "description": "Scores whether the response directly and usefully answers the user's request.",
+      "category": "Response Quality",
+      "measure_type": "quality",
+      "evaluation_method": "llm_based",
+      "target_aspect": "response",
+      "metric_type": "single_turn",
+      "output_type": "continuous",
+      "agent_types": [
+        "chat"
+      ],
+      "domain_min": 0.0,
+      "domain_max": 1.0,
+      "inverse": false,
+      "is_custom": true,
+      "target_types": [
+        "observability_trace",
+        "configuration_run"
+      ],
+      "allowed_score_sources": [
+        "manual",
+        "evaluator"
+      ],
+      "criteria": [
+        "The response addresses the user's stated goal.",
+        "The response includes enough detail to be actionable."
+      ]
+    }
+  ],
+  "metadata": {
+    "source": "phase1_fixture"
+  },
+  "status": "created"
+}

--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -6,7 +6,9 @@ with focus on schema compliance, serialization, and edge cases.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -14,13 +16,23 @@ import traigent.cloud.dtos as cloud_dtos
 from traigent.cloud.dtos import (
     ConfigurationRunDTO,
     ConfigurationsDTO,
+    EvaluatorDTO,
     ExampleMeasure,
     ExperimentDTO,
     ExperimentListRunSummaryDTO,
     ExperimentRunDTO,
     InfrastructureDTO,
+    MeasureDTO,
+    PlannerDraftDTO,
 )
 from traigent.utils.exceptions import DTOSerializationError
+
+FIXTURES_DIR = Path(__file__).parents[2] / "cloud" / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    with (FIXTURES_DIR / name).open(encoding="utf-8") as fixture:
+        return json.load(fixture)
 
 
 class TestInfrastructureDTO:
@@ -780,6 +792,53 @@ class TestConfigurationRunDTO:
                 trial_number=i,
             )
             assert config_run.trial_number == i
+
+
+class TestEvaluatorDTO:
+    """Test EvaluatorDTO round-trip behavior."""
+
+    def test_fixture_round_trip(self):
+        payload = _load_fixture("evaluator_dto.json")
+        evaluator = EvaluatorDTO(**payload)
+
+        assert evaluator.to_dict() == payload
+        assert evaluator.to_dict()["judge_config"]["model_id"] == "gpt-4o-mini"
+
+
+class TestMeasureDTO:
+    """Test MeasureDTO round-trip behavior."""
+
+    def test_fixture_round_trip(self):
+        payload = _load_fixture("measure_dto.json")
+        measure = MeasureDTO(**payload)
+
+        assert measure.to_dict() == payload
+        assert measure.to_dict()["id"] == "answer_helpfulness"
+        assert "measure_id" not in measure.to_dict()
+
+
+class TestPlannerDraftDTO:
+    """Test PlannerDraftDTO round-trip behavior."""
+
+    def test_fixture_round_trip(self):
+        payload = _load_fixture("planner_draft_dto.json")
+        planner = PlannerDraftDTO(**payload)
+
+        assert planner.to_dict() == payload
+        assert planner.to_dict()["measures"][0]["id"] == "answer_helpfulness"
+
+    def test_accepts_measure_dto_items(self):
+        measure_payload = _load_fixture("measure_dto.json")
+        measure = MeasureDTO(**measure_payload)
+        planner = PlannerDraftDTO(
+            draft_id="draft_with_measure_dto",
+            description="Create a support agent.",
+            measures=[measure],
+        )
+
+        result = planner.to_dict()
+
+        assert result["measures"] == [measure_payload]
 
 
 class TestEdgeCases:

--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -804,6 +804,19 @@ class TestEvaluatorDTO:
         assert evaluator.to_dict() == payload
         assert evaluator.to_dict()["judge_config"]["model_id"] == "gpt-4o-mini"
 
+    def test_to_dict_deep_copies_nested_judge_config(self):
+        evaluator = EvaluatorDTO(
+            name="Nested Judge",
+            measure_id="answer_helpfulness",
+            target_type="observability_trace",
+            judge_config={"parameters": {"temperature": 0.0}},
+        )
+
+        result = evaluator.to_dict()
+        result["judge_config"]["parameters"]["temperature"] = 0.7
+
+        assert evaluator.judge_config["parameters"]["temperature"] == 0.0
+
 
 class TestMeasureDTO:
     """Test MeasureDTO round-trip behavior."""
@@ -815,6 +828,15 @@ class TestMeasureDTO:
         assert measure.to_dict() == payload
         assert measure.to_dict()["id"] == "answer_helpfulness"
         assert "measure_id" not in measure.to_dict()
+
+    def test_to_dict_omits_none_domain_bounds(self):
+        payload = _load_fixture("measure_dto.json")
+        measure = MeasureDTO(**{**payload, "domain_min": None, "domain_max": None})
+
+        result = measure.to_dict()
+
+        assert "domain_min" not in result
+        assert "domain_max" not in result
 
 
 class TestPlannerDraftDTO:
@@ -839,6 +861,25 @@ class TestPlannerDraftDTO:
         result = planner.to_dict()
 
         assert result["measures"] == [measure_payload]
+
+    def test_to_dict_omits_none_agent_and_benchmark(self):
+        planner = PlannerDraftDTO(description="Create a support agent.")
+
+        result = planner.to_dict()
+
+        assert "agent" not in result
+        assert "benchmark" not in result
+
+    def test_to_dict_deep_copies_nested_measure_dicts(self):
+        planner = PlannerDraftDTO(
+            description="Create a support agent.",
+            measures=[{"id": "answer_helpfulness", "metadata": {"weight": 1}}],
+        )
+
+        result = planner.to_dict()
+        result["measures"][0]["metadata"]["weight"] = 2
+
+        assert planner.measures[0]["metadata"]["weight"] == 1
 
 
 class TestEdgeCases:

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -9,6 +9,7 @@ privacy-preserving defaults for Edge Analytics mode execution.
 import re
 from collections import UserDict
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -706,9 +707,9 @@ class EvaluatorDTO:
             "name": self.name,
             "measure_id": self.measure_id,
             "target_type": self.target_type,
-            "judge_config": dict(self.judge_config),
+            "judge_config": deepcopy(self.judge_config),
             "sampling_rate": self.sampling_rate,
-            "target_filters": dict(self.target_filters),
+            "target_filters": deepcopy(self.target_filters),
             "is_active": self.is_active,
         }
         for field_name in (
@@ -723,7 +724,7 @@ class EvaluatorDTO:
         ):
             value = getattr(self, field_name)
             if value is not None:
-                result[field_name] = value
+                result[field_name] = deepcopy(value)
         return result
 
 
@@ -766,21 +767,21 @@ class MeasureDTO:
             "metric_type": self.metric_type,
             "output_type": self.output_type,
             "agent_types": list(self.agent_types),
-            "domain_min": self.domain_min,
-            "domain_max": self.domain_max,
             "inverse": self.inverse,
             "is_custom": self.is_custom,
             "target_types": list(self.target_types),
             "allowed_score_sources": list(self.allowed_score_sources),
         }
+        if self.domain_min is not None:
+            result["domain_min"] = self.domain_min
+        if self.domain_max is not None:
+            result["domain_max"] = self.domain_max
         if self.criteria is not None:
             result["criteria"] = list(self.criteria)
         if self.python_packages is not None:
-            result["python_packages"] = [dict(item) for item in self.python_packages]
+            result["python_packages"] = deepcopy(self.python_packages)
         if self.measure_parameters is not None:
-            result["measure_parameters"] = [
-                dict(item) for item in self.measure_parameters
-            ]
+            result["measure_parameters"] = deepcopy(self.measure_parameters)
         return result
 
 
@@ -802,18 +803,27 @@ class PlannerDraftDTO:
         """Convert to the canonical planner draft shape."""
         result: dict[str, Any] = {
             "description": self.description,
-            "agent": self.agent,
-            "benchmark": self.benchmark,
             "measures": [
-                measure.to_dict() if isinstance(measure, MeasureDTO) else dict(measure)
+                (
+                    measure.to_dict()
+                    if isinstance(measure, MeasureDTO)
+                    else deepcopy(measure)
+                )
                 for measure in self.measures
             ],
-            "metadata": dict(self.metadata),
+            "metadata": deepcopy(self.metadata),
         }
-        for field_name in ("draft_id", "status", "created_at", "updated_at"):
+        for field_name in (
+            "agent",
+            "benchmark",
+            "draft_id",
+            "status",
+            "created_at",
+            "updated_at",
+        ):
             value = getattr(self, field_name)
             if value is not None:
-                result[field_name] = value
+                result[field_name] = deepcopy(value)
         return result
 
 

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -680,6 +680,143 @@ class ConfigurationRunDTO:
         }
 
 
+@dataclass
+class EvaluatorDTO:
+    """Evaluator definition DTO based on observability/evaluator_definition_schema.json."""
+
+    name: str
+    measure_id: str
+    target_type: str
+    judge_config: dict[str, Any]
+    id: str | None = None
+    description: str | None = None
+    sampling_rate: float = 1.0
+    target_filters: dict[str, Any] = field(default_factory=dict)
+    is_active: bool = True
+    primary_measure_id: str | None = None
+    measure: dict[str, Any] | None = None
+    created_by: str | None = None
+    updated_by: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the canonical evaluator definition shape."""
+        result: dict[str, Any] = {
+            "name": self.name,
+            "measure_id": self.measure_id,
+            "target_type": self.target_type,
+            "judge_config": dict(self.judge_config),
+            "sampling_rate": self.sampling_rate,
+            "target_filters": dict(self.target_filters),
+            "is_active": self.is_active,
+        }
+        for field_name in (
+            "id",
+            "description",
+            "primary_measure_id",
+            "measure",
+            "created_by",
+            "updated_by",
+            "created_at",
+            "updated_at",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        return result
+
+
+@dataclass
+class MeasureDTO:
+    """Measure DTO based on measures/measure_schema.json."""
+
+    id: str
+    label: str
+    description: str
+    category: str
+    measure_type: str = "quality"
+    evaluation_method: str = "llm_based"
+    target_aspect: str = "response"
+    metric_type: str = "single_turn"
+    output_type: str = "continuous"
+    agent_types: list[str] = field(default_factory=lambda: ["chat"])
+    domain_min: float | None = 0.0
+    domain_max: float | None = 1.0
+    inverse: bool = False
+    is_custom: bool = True
+    version: str = "1.0.0"
+    target_types: list[str] = field(default_factory=list)
+    allowed_score_sources: list[str] = field(default_factory=list)
+    criteria: list[str] | None = None
+    python_packages: list[dict[str, Any]] | None = None
+    measure_parameters: list[dict[str, Any]] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the canonical measure schema shape."""
+        result: dict[str, Any] = {
+            "id": self.id,
+            "version": self.version,
+            "label": self.label,
+            "description": self.description,
+            "category": self.category,
+            "measure_type": self.measure_type,
+            "evaluation_method": self.evaluation_method,
+            "target_aspect": self.target_aspect,
+            "metric_type": self.metric_type,
+            "output_type": self.output_type,
+            "agent_types": list(self.agent_types),
+            "domain_min": self.domain_min,
+            "domain_max": self.domain_max,
+            "inverse": self.inverse,
+            "is_custom": self.is_custom,
+            "target_types": list(self.target_types),
+            "allowed_score_sources": list(self.allowed_score_sources),
+        }
+        if self.criteria is not None:
+            result["criteria"] = list(self.criteria)
+        if self.python_packages is not None:
+            result["python_packages"] = [dict(item) for item in self.python_packages]
+        if self.measure_parameters is not None:
+            result["measure_parameters"] = [
+                dict(item) for item in self.measure_parameters
+            ]
+        return result
+
+
+@dataclass
+class PlannerDraftDTO:
+    """Planner draft DTO for the planner spine."""
+
+    description: str
+    agent: dict[str, Any] | None = None
+    benchmark: dict[str, Any] | None = None
+    measures: list[MeasureDTO | dict[str, Any]] = field(default_factory=list)
+    draft_id: str | None = None
+    status: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the canonical planner draft shape."""
+        result: dict[str, Any] = {
+            "description": self.description,
+            "agent": self.agent,
+            "benchmark": self.benchmark,
+            "measures": [
+                measure.to_dict() if isinstance(measure, MeasureDTO) else dict(measure)
+                for measure in self.measures
+            ],
+            "metadata": dict(self.metadata),
+        }
+        for field_name in ("draft_id", "status", "created_at", "updated_at"):
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        return result
+
+
 # Helper functions for creating privacy-preserving DTOs
 
 


### PR DESCRIPTION
Summary:
- Add EvaluatorDTO, MeasureDTO, and PlannerDraftDTO to the cloud SDK DTO spine.
- Add golden fixtures for canonical evaluator, measure, and planner draft payloads.

Validation:
- pytest -o addopts= tests/unit/cloud/test_dtos.py -q
- git diff --check