### PR TITLE
Install public schema repo in CI helper

### DIFF
--- a/scripts/ci/install_sdk_requirements.sh
+++ b/scripts/ci/install_sdk_requirements.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 python -m pip install --upgrade pip
 
 private_deps_token="${TRAIGENT_PRIVATE_DEPS_TOKEN:-${TRAIGENT_SCHEMA_TOKEN:-${TRAIGENT_SCHEMAS_PAT:-}}}"
-schema_ref="${TRAIGENT_SCHEMA_REF:-7d8539f45e978c5148e4335e8250843f097e3b67}"
+schema_ref="${TRAIGENT_SCHEMA_REF:-0af2a11e0485513465dd0a4f88d62ef27a7e6336}"
 install_schema="${TRAIGENT_INSTALL_SCHEMA:-}"
 
 for arg in "$@"; do
@@ -18,11 +18,7 @@ if [ -n "$private_deps_token" ]; then
 fi
 
 if [ "$install_schema" = "1" ]; then
-  if [ -n "$private_deps_token" ]; then
-    python -m pip install "traigent-schema @ git+https://x-access-token:${private_deps_token}@github.com/Traigent/TraigentSchema.git@${schema_ref}"
-  else
-    python -m pip install "traigent-schema>=3.2.0"
-  fi
+  python -m pip install "traigent-schema @ git+https://github.com/Traigent/TraigentSchema.git@${schema_ref}"
 fi
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- update the SDK CI install helper to fetch TraigentSchema from public GitHub instead of falling back to PyPI before the package is published
- bump the default schema ref to the 4.1.0 schema release-prep commit
- keep token URL rewriting for legacy/private configurations without putting tokens in the explicit pip URL

## Verification
- bash -n scripts/ci/install_sdk_requirements.sh
- git diff --check
- pre-commit hook suite during commit