### PR TITLE
Install schema helper from PyPI

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -20,9 +20,6 @@ on:
 permissions:
   contents: read
 
-env:
-  TRAIGENT_SCHEMA_REF: "7d8539f45e978c5148e4335e8250843f097e3b67" # pragma: allowlist secret
-
 jobs:
   # .[recommended] is the default user-facing bundle — test across all platforms
   install-recommended:
@@ -41,11 +38,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install .[recommended]
-        env:
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
         shell: bash
         run: |
           bash scripts/ci/install_sdk_requirements.sh -e ".[recommended]"
@@ -70,11 +62,6 @@ jobs:
           python-version: "3.11"
 
       - name: Install .[enterprise]
-        env:
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
         run: |
           bash scripts/ci/install_sdk_requirements.sh -e ".[enterprise]"
 

--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -18,9 +18,6 @@ on:
 permissions:
   contents: read
 
-env:
-  TRAIGENT_SCHEMA_REF: "7d8539f45e978c5148e4335e8250843f097e3b67" # pragma: allowlist secret
-
 jobs:
   js-public-parity:
     runs-on: ubuntu-latest
@@ -65,11 +62,6 @@ jobs:
       - name: Install Python SDK
         if: steps.js-sdk-token.outputs.available == 'true'
         working-directory: Traigent
-        env:
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
         run: |
           bash scripts/ci/install_sdk_requirements.sh build wheel -e ".[dev,all]"
 

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -37,8 +37,6 @@ env:
   RELEASE_GATE_CODEQL_ENABLED: "false"
   TRAIGENT_MOCK_LLM: "true"
   TRAIGENT_OFFLINE_MODE: "true"
-  TRAIGENT_SCHEMA_REF: "7d8539f45e978c5148e4335e8250843f097e3b67" # pragma: allowlist secret
-
 jobs:
   lint_type:
     name: lint-type
@@ -51,11 +49,6 @@ jobs:
         with:
           python-version: ${{ env.LINT_PYTHON_VERSION }}
       - name: Install lint and type tooling
-        env:
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
         run: |
           bash scripts/ci/install_sdk_requirements.sh -e ".[dev]"
       - name: Black + isort + Ruff + MyPy + dep-floor-drift
@@ -91,11 +84,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install test deps
-        env:
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
         run: |
           bash scripts/ci/install_sdk_requirements.sh -e ".[all,dev]"
       - name: Run unit tests
@@ -128,11 +116,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install test deps
-        env:
-          TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-          TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-          TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-          TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
         run: |
           bash scripts/ci/install_sdk_requirements.sh -e ".[all,dev]"
       - name: Run integration tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,6 @@ on:
 permissions:
   contents: read
 
-env:
-  TRAIGENT_SCHEMA_REF: "7d8539f45e978c5148e4335e8250843f097e3b67" # pragma: allowlist secret
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -34,11 +31,6 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Install dependencies
-      env:
-        TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-        TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-        TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-        TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
       run: |
         bash scripts/ci/install_sdk_requirements.sh build wheel -e ".[dev,all]"
 
@@ -85,11 +77,6 @@ jobs:
         python-version: "3.11"
 
     - name: Install dependencies
-      env:
-        TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-        TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-        TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-        TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
       run: |
         bash scripts/ci/install_sdk_requirements.sh -e ".[all]"
 
@@ -114,11 +101,6 @@ jobs:
         python-version: "3.11"
 
     - name: Install dependencies
-      env:
-        TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-        TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-        TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-        TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
       run: |
         bash scripts/ci/install_sdk_requirements.sh safety bandit[toml] -e .
 
@@ -152,11 +134,6 @@ jobs:
         python-version: "3.11"
 
     - name: Install build dependencies
-      env:
-        TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-        TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-        TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-        TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
       run: |
         bash scripts/ci/install_sdk_requirements.sh build twine
 
@@ -169,11 +146,6 @@ jobs:
         twine check dist/*
 
     - name: Test installation from built package
-      env:
-        TRAIGENT_PRIVATE_DEPS_TOKEN: ${{ secrets.TRAIGENT_PRIVATE_DEPS_TOKEN }}
-        TRAIGENT_SCHEMA_TOKEN: ${{ secrets.TRAIGENT_SCHEMA_TOKEN }}
-        TRAIGENT_SCHEMAS_PAT: ${{ secrets.TRAIGENT_SCHEMAS_PAT }}
-        TRAIGENT_SCHEMA_REF: ${{ env.TRAIGENT_SCHEMA_REF }}
       run: |
         bash scripts/ci/install_sdk_requirements.sh
         pip install dist/*.whl

--- a/scripts/ci/install_sdk_requirements.sh
+++ b/scripts/ci/install_sdk_requirements.sh
@@ -3,8 +3,7 @@ set -euo pipefail
 
 python -m pip install --upgrade pip
 
-private_deps_token="${TRAIGENT_PRIVATE_DEPS_TOKEN:-${TRAIGENT_SCHEMA_TOKEN:-${TRAIGENT_SCHEMAS_PAT:-}}}"
-schema_ref="${TRAIGENT_SCHEMA_REF:-0af2a11e0485513465dd0a4f88d62ef27a7e6336}"
+schema_requirement="${TRAIGENT_SCHEMA_REQUIREMENT:-traigent-schema>=4.1.0,<5.0.0}"
 install_schema="${TRAIGENT_INSTALL_SCHEMA:-}"
 
 for arg in "$@"; do
@@ -13,12 +12,8 @@ for arg in "$@"; do
   esac
 done
 
-if [ -n "$private_deps_token" ]; then
-  git config --global url."https://x-access-token:${private_deps_token}@github.com/Traigent/".insteadOf "https://github.com/Traigent/"
-fi
-
 if [ "$install_schema" = "1" ]; then
-  python -m pip install "traigent-schema @ git+https://github.com/Traigent/TraigentSchema.git@${schema_ref}"
+  python -m pip install "$schema_requirement"
 fi
 
 if [ "$#" -gt 0 ]; then

--- a/scripts/ci/install_sdk_requirements.sh
+++ b/scripts/ci/install_sdk_requirements.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 python -m pip install --upgrade pip
 
-schema_requirement="${TRAIGENT_SCHEMA_REQUIREMENT:-traigent-schema>=4.1.0,<5.0.0}"
+schema_requirement="${TRAIGENT_SCHEMA_REQUIREMENT:-traigent-schema==4.1.0}"
 install_schema="${TRAIGENT_INSTALL_SCHEMA:-}"
 
 for arg in "$@"; do


### PR DESCRIPTION
## Summary\n- install the optional schema helper dependency from the published traigent-schema 4.1.x package instead of a TraigentSchema GitHub ref\n- remove now-unused schema GitHub ref and token env plumbing from SDK workflows\n\n## Checks\n- bash -n scripts/ci/install_sdk_requirements.sh\n- git diff --check