### PR TITLE
feat(api): align multi-objective normalization with schema 4.1

### DIFF
--- a/tests/fixtures/multi_objective_normalization.json
+++ b/tests/fixtures/multi_objective_normalization.json
@@ -1,0 +1,99 @@
+{
+  "_meta": {
+    "schema_contract": "TraigentSchema/optimization/multi_objective_semantics_schema.json v1.0.0",
+    "purpose": "Lock cross-SDK parity for the multi-objective normalization meta-contract: zero_span_fallback=0.5, zero_span_epsilon=1e-9, weight_normalization=sum_to_one, dominance_guard.max_normalized_weight=0.99 (sdk-only).",
+    "tolerance": 1e-9,
+    "instructions": "Each case has trials + objectives + raw weights; runners must produce per-trial normalized values matching `expected.normalized` and weighted scores matching `expected.weighted` to <= tolerance. The `expects_validation_error` flag marks cases that must throw before scoring (dominance guard)."
+  },
+  "cases": [
+    {
+      "id": "partial_zero_span",
+      "description": "All trials tie on `cost` while `accuracy` varies. The constant objective contributes 0.5 to every trial regardless of value; ranking is driven entirely by accuracy.",
+      "trials": [
+        {"trial_id": "t1", "metrics": {"accuracy": 0.70, "cost": 1.00}},
+        {"trial_id": "t2", "metrics": {"accuracy": 0.90, "cost": 1.00}},
+        {"trial_id": "t3", "metrics": {"accuracy": 0.80, "cost": 1.00}}
+      ],
+      "objectives": [
+        {"metric": "accuracy", "direction": "maximize", "weight": 1},
+        {"metric": "cost", "direction": "minimize", "weight": 1}
+      ],
+      "expected": {
+        "trial_scores": [
+          {"trial_id": "t1", "normalized": {"accuracy": 0.0, "cost": 0.5}, "weighted": 0.25},
+          {"trial_id": "t2", "normalized": {"accuracy": 1.0, "cost": 0.5}, "weighted": 0.75},
+          {"trial_id": "t3", "normalized": {"accuracy": 0.5, "cost": 0.5}, "weighted": 0.5}
+        ]
+      }
+    },
+    {
+      "id": "full_zero_span",
+      "description": "All trials tie on every objective. Each trial's contribution is 0.5 across the board; weighted score = 0.5; best-pick falls back to insertion order.",
+      "trials": [
+        {"trial_id": "t1", "metrics": {"accuracy": 0.85, "cost": 1.00}},
+        {"trial_id": "t2", "metrics": {"accuracy": 0.85, "cost": 1.00}},
+        {"trial_id": "t3", "metrics": {"accuracy": 0.85, "cost": 1.00}}
+      ],
+      "objectives": [
+        {"metric": "accuracy", "direction": "maximize", "weight": 1},
+        {"metric": "cost", "direction": "minimize", "weight": 1}
+      ],
+      "expected": {
+        "trial_scores": [
+          {"trial_id": "t1", "normalized": {"accuracy": 0.5, "cost": 0.5}, "weighted": 0.5},
+          {"trial_id": "t2", "normalized": {"accuracy": 0.5, "cost": 0.5}, "weighted": 0.5},
+          {"trial_id": "t3", "normalized": {"accuracy": 0.5, "cost": 0.5}, "weighted": 0.5}
+        ]
+      }
+    },
+    {
+      "id": "weight_rescaling",
+      "description": "Mixed maximize/minimize objectives with raw weights [2, 1, 1] rescaling to [0.5, 0.25, 0.25]. Weighted scores must use rescaled weights.",
+      "trials": [
+        {"trial_id": "t1", "metrics": {"accuracy": 0.80, "cost": 0.50, "latency": 100}},
+        {"trial_id": "t2", "metrics": {"accuracy": 0.90, "cost": 0.10, "latency": 200}}
+      ],
+      "objectives": [
+        {"metric": "accuracy", "direction": "maximize", "weight": 2},
+        {"metric": "cost", "direction": "minimize", "weight": 1},
+        {"metric": "latency", "direction": "minimize", "weight": 1}
+      ],
+      "expected": {
+        "trial_scores": [
+          {"trial_id": "t1", "normalized": {"accuracy": 0.0, "cost": 0.0, "latency": 1.0}, "weighted": 0.25},
+          {"trial_id": "t2", "normalized": {"accuracy": 1.0, "cost": 1.0, "latency": 0.0}, "weighted": 0.75}
+        ]
+      }
+    },
+    {
+      "id": "boundary_epsilon",
+      "description": "Span of 5e-10 lies between the old (1e-10) and new (1e-9) epsilon. Must collapse to 0.5 under the new contract; pre-rollout it would have normalized linearly producing different per-trial values.",
+      "trials": [
+        {"trial_id": "t1", "metrics": {"accuracy": 0.85}},
+        {"trial_id": "t2", "metrics": {"accuracy": 8.500000005e-1}}
+      ],
+      "objectives": [
+        {"metric": "accuracy", "direction": "maximize", "weight": 1}
+      ],
+      "expected": {
+        "trial_scores": [
+          {"trial_id": "t1", "normalized": {"accuracy": 0.5}, "weighted": 0.5},
+          {"trial_id": "t2", "normalized": {"accuracy": 0.5}, "weighted": 0.5}
+        ]
+      }
+    },
+    {
+      "id": "dominance_guard_violation",
+      "description": "Raw weights [100, 1] rescale to [100/101, 1/101] ~= [0.9901, 0.0099]. The 100/101 share exceeds the 0.99 cap, so SDK schema construction must reject this with a validation error before any scoring happens.",
+      "trials": [
+        {"trial_id": "t1", "metrics": {"accuracy": 0.80, "cost": 0.50}},
+        {"trial_id": "t2", "metrics": {"accuracy": 0.90, "cost": 0.10}}
+      ],
+      "objectives": [
+        {"metric": "accuracy", "direction": "maximize", "weight": 100},
+        {"metric": "cost", "direction": "minimize", "weight": 1}
+      ],
+      "expects_validation_error": true
+    }
+  ]
+}

--- a/tests/integration/test_cross_sdk_normalization.py
+++ b/tests/integration/test_cross_sdk_normalization.py
@@ -1,0 +1,163 @@
+"""Cross-SDK normalization parity test.
+
+Asserts the Python SDK's ``score_trials()`` and weight-rescaling logic match
+the numerical contract pinned in
+``integrations/traigent-cross-sdk-benchmarks/fixtures/multi_objective_normalization.json``.
+
+The traigent-js SDK has a parallel test
+(``traigent-js/tests/cross-sdk/multi-objective-normalization.test.ts``)
+asserting the same fixture. Drift on either side fails its own suite;
+agreement on the fixture is the cross-SDK contract.
+
+Contract source: TraigentSchema/optimization/multi_objective_semantics_schema.json v1.0.0.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from traigent.api.types import OptimizationResult, TrialResult, TrialStatus
+from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
+
+
+def _locate_fixture() -> Path:
+    """Find the fixture under the workspace's `integrations/` directory.
+
+    Depth varies between main checkout and worktree, so walk upward looking
+    for the `integrations` sibling. Override via TRAIGENT_CROSS_SDK_FIXTURE_PATH.
+    """
+    override = os.environ.get("TRAIGENT_CROSS_SDK_FIXTURE_PATH")
+    if override and Path(override).exists():
+        return Path(override)
+    cursor = Path(__file__).resolve()
+    for _ in range(10):
+        candidate = (
+            cursor.parent
+            / "integrations"
+            / "traigent-cross-sdk-benchmarks"
+            / "fixtures"
+            / "multi_objective_normalization.json"
+        )
+        if candidate.exists():
+            return candidate
+        if cursor.parent == cursor:
+            break
+        cursor = cursor.parent
+    raise FileNotFoundError(
+        "Could not locate multi_objective_normalization.json; set "
+        "TRAIGENT_CROSS_SDK_FIXTURE_PATH."
+    )
+
+
+FIXTURE_PATH = _locate_fixture()
+FIXTURE = json.loads(FIXTURE_PATH.read_text())
+TOLERANCE = float(FIXTURE["_meta"]["tolerance"])
+
+
+def _build_schema(case_objectives: list[dict]) -> ObjectiveSchema:
+    """Build an ObjectiveSchema from the fixture objectives.
+
+    Mirrors the JS SDK's `normalizeObjectiveWeights` chokepoint: the schema
+    constructor performs sum-to-one rescaling and dominance-guard validation.
+    """
+    objs = [
+        ObjectiveDefinition(
+            name=o["metric"],
+            orientation=o["direction"],  # "maximize" | "minimize"
+            weight=float(o["weight"]),
+        )
+        for o in case_objectives
+    ]
+    return ObjectiveSchema.from_objectives(objs)
+
+
+def _build_optimization_result(
+    case_id: str, case_trials: list[dict], case_objectives: list[dict]
+) -> OptimizationResult:
+    trials = [
+        TrialResult(
+            trial_id=t["trial_id"],
+            config={},
+            metrics=dict(t["metrics"]),
+            status=TrialStatus.COMPLETED,
+            duration=1.0,
+            timestamp=datetime.now(),
+        )
+        for t in case_trials
+    ]
+    first_trial = trials[0] if trials else None
+    return OptimizationResult(
+        trials=trials,
+        best_config=first_trial.config if first_trial else {},
+        best_score=0.0,
+        optimization_id=f"fixture_{case_id}",
+        duration=float(len(trials)),
+        convergence_info={},
+        status="completed",
+        objectives=[o["metric"] for o in case_objectives],
+        algorithm="fixture",
+        timestamp=datetime.now(),
+    )
+
+
+_normal_cases = [c for c in FIXTURE["cases"] if not c.get("expects_validation_error")]
+_violation_cases = [c for c in FIXTURE["cases"] if c.get("expects_validation_error")]
+
+
+@pytest.mark.parametrize("case", _normal_cases, ids=lambda c: c["id"])
+def test_per_trial_normalized_values_match_fixture(case: dict) -> None:
+    """Per-trial normalized values and weighted scores match the fixture."""
+    schema = _build_schema(case["objectives"])
+    result = _build_optimization_result(case["id"], case["trials"], case["objectives"])
+
+    actual = result.score_trials(objective_schema=schema)
+    expected = case["expected"]["trial_scores"]
+
+    assert len(actual) == len(expected), (
+        f"{case['id']}: trial count mismatch (got {len(actual)}, want {len(expected)})"
+    )
+
+    for got, want in zip(actual, expected):
+        assert got["trial_id"] == want["trial_id"], (
+            f"{case['id']}: trial order mismatch"
+        )
+        for metric, expected_value in want["normalized"].items():
+            assert metric in got["normalized"], (
+                f"{case['id']}/{got['trial_id']}: missing normalized {metric}"
+            )
+            assert got["normalized"][metric] == pytest.approx(
+                expected_value, abs=TOLERANCE
+            ), (
+                f"{case['id']}/{got['trial_id']}/{metric}: "
+                f"got {got['normalized'][metric]}, want {expected_value}"
+            )
+        assert got["weighted"] == pytest.approx(want["weighted"], abs=TOLERANCE), (
+            f"{case['id']}/{got['trial_id']}: weighted score "
+            f"got {got['weighted']}, want {want['weighted']}"
+        )
+
+
+@pytest.mark.parametrize("case", _normal_cases, ids=lambda c: c["id"])
+def test_weights_rescale_to_sum_to_one(case: dict) -> None:
+    """ObjectiveSchema construction rescales raw weights to sum-to-one."""
+    schema = _build_schema(case["objectives"])
+    total = sum(schema.weights_normalized.values())
+    assert total == pytest.approx(1.0, abs=TOLERANCE)
+
+    raw_total = sum(o["weight"] for o in case["objectives"])
+    for raw in case["objectives"]:
+        expected = raw["weight"] / raw_total
+        assert schema.weights_normalized[raw["metric"]] == pytest.approx(
+            expected, abs=TOLERANCE
+        )
+
+
+@pytest.mark.parametrize("case", _violation_cases, ids=lambda c: c["id"])
+def test_dominance_guard_violations_raise(case: dict) -> None:
+    """Cases marked `expects_validation_error` must raise at schema build."""
+    with pytest.raises(ValueError):
+        _build_schema(case["objectives"])

--- a/tests/integration/test_cross_sdk_normalization.py
+++ b/tests/integration/test_cross_sdk_normalization.py
@@ -1,13 +1,12 @@
 """Cross-SDK normalization parity test.
 
 Asserts the Python SDK's ``score_trials()`` and weight-rescaling logic match
-the numerical contract pinned in
-``integrations/traigent-cross-sdk-benchmarks/fixtures/multi_objective_normalization.json``.
+the numerical contract pinned in ``tests/fixtures/multi_objective_normalization.json``.
 
 The traigent-js SDK has a parallel test
 (``traigent-js/tests/cross-sdk/multi-objective-normalization.test.ts``)
-asserting the same fixture. Drift on either side fails its own suite;
-agreement on the fixture is the cross-SDK contract.
+asserting its repo-local mirror of the same fixture. Drift on either side
+fails its own suite; agreement on the fixture is the cross-SDK contract.
 
 Contract source: TraigentSchema/optimization/multi_objective_semantics_schema.json v1.0.0.
 """
@@ -25,14 +24,20 @@ from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 
 
 def _locate_fixture() -> Path:
-    """Find the fixture under the workspace's `integrations/` directory.
+    """Find the normalization fixture.
 
-    Depth varies between main checkout and worktree, so walk upward looking
-    for the `integrations` sibling. Override via TRAIGENT_CROSS_SDK_FIXTURE_PATH.
+    CI uses the repo-local fixture. Local enterprise parity runs may override
+    with TRAIGENT_CROSS_SDK_FIXTURE_PATH or use the workspace-level
+    integrations/traigent-cross-sdk-benchmarks copy when present.
     """
     override = os.environ.get("TRAIGENT_CROSS_SDK_FIXTURE_PATH")
     if override and Path(override).exists():
         return Path(override)
+
+    local = Path(__file__).resolve().parent.parent / "fixtures" / "multi_objective_normalization.json"
+    if local.exists():
+        return local
+
     cursor = Path(__file__).resolve()
     for _ in range(10):
         candidate = (
@@ -48,8 +53,8 @@ def _locate_fixture() -> Path:
             break
         cursor = cursor.parent
     raise FileNotFoundError(
-        "Could not locate multi_objective_normalization.json; set "
-        "TRAIGENT_CROSS_SDK_FIXTURE_PATH."
+        "Could not locate tests/fixtures/multi_objective_normalization.json; set "
+        "TRAIGENT_CROSS_SDK_FIXTURE_PATH to a compatible fixture copy."
     )
 
 

--- a/tests/unit/api/test_types_advanced.py
+++ b/tests/unit/api/test_types_advanced.py
@@ -783,6 +783,90 @@ class TestOptimizationResultNormalizationMethods:
         )
         assert normalized == pytest.approx(0.5)
 
+    def test_legacy_normalize_value_boundary_epsilon_collapses(self):
+        """Spans below the new normative epsilon (1e-9) collapse to 0.5.
+
+        Pre-rollout the legacy path used 1e-10, so spans in the boundary
+        band [1e-10, 1e-9) normalized linearly. Per
+        TraigentSchema/optimization/multi_objective_semantics_schema.json
+        v1.0.0 the legacy and schema-aware paths now share the same
+        epsilon, so this band collapses to the neutral 0.5 fallback.
+        """
+        # Span = 5e-10: between old 1e-10 and new 1e-9 epsilon.
+        normalized = OptimizationResult._legacy_normalize_value(
+            value=0.85, min_val=0.85, max_val=0.85 + 5e-10, minimize=False
+        )
+        assert normalized == pytest.approx(0.5)
+
+        # Same span, minimize direction: still collapses to the neutral 0.5.
+        normalized = OptimizationResult._legacy_normalize_value(
+            value=0.85 + 5e-10, min_val=0.85, max_val=0.85 + 5e-10, minimize=True
+        )
+        assert normalized == pytest.approx(0.5)
+
+    def test_recompute_zero_span_both_paths(self):
+        """Both backend recompute paths return 0.5 on a zero-span trial set.
+
+        Exercises:
+        - The schema-aware path (objective_schema is provided), which
+          delegates to ObjectiveSchema.normalize_metrics().
+        - The legacy path (no objective_schema), which calls
+          _legacy_normalize_value() inline.
+
+        The plan calls out that these are *separate* code paths in
+        api/types.py; this test pins agreement between them.
+        """
+        from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
+
+        # All trials carry the same accuracy and cost: every objective
+        # must return 0.5 from both paths, weighted score = 0.5.
+        trials = [
+            TrialResult(
+                trial_id=f"trial_{i}",
+                config={"seed": i},
+                metrics={"accuracy": 0.9, "cost": 0.1},
+                status=TrialStatus.COMPLETED,
+                duration=1.0,
+                timestamp=datetime.now(),
+            )
+            for i in range(3)
+        ]
+        result = OptimizationResult(
+            trials=trials,
+            best_config={"seed": 0},
+            best_score=0.9,
+            optimization_id="recompute_zero_span",
+            duration=3.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy", "cost"],
+            algorithm="test",
+            timestamp=datetime.now(),
+        )
+
+        # Legacy path (no schema): minimize_objectives is the only
+        # direction signal.
+        legacy = result.score_trials(minimize_objectives=["cost"])
+        assert len(legacy) == 3
+        for entry in legacy:
+            assert entry["normalized"]["accuracy"] == pytest.approx(0.5)
+            assert entry["normalized"]["cost"] == pytest.approx(0.5)
+            assert entry["weighted"] == pytest.approx(0.5)
+
+        # Schema-aware path: ObjectiveSchema drives orientation + weights.
+        schema = ObjectiveSchema.from_objectives(
+            [
+                ObjectiveDefinition(name="accuracy", orientation="maximize", weight=1.0),
+                ObjectiveDefinition(name="cost", orientation="minimize", weight=1.0),
+            ]
+        )
+        schema_aware = result.score_trials(objective_schema=schema)
+        assert len(schema_aware) == 3
+        for entry in schema_aware:
+            assert entry["normalized"]["accuracy"] == pytest.approx(0.5)
+            assert entry["normalized"]["cost"] == pytest.approx(0.5)
+            assert entry["weighted"] == pytest.approx(0.5)
+
     def test_legacy_normalize_value_preserves_out_of_range_values(self):
         """Test _legacy_normalize_value keeps out-of-range signal (no clipping)."""
         # Value below min

--- a/tests/unit/core/test_objectives_edge_cases.py
+++ b/tests/unit/core/test_objectives_edge_cases.py
@@ -247,6 +247,25 @@ class TestZeroRangeHandling:
         )
         assert normalized == 0.5  # Should return middle value for near-zero range
 
+    def test_boundary_epsilon_collapses_to_half(self):
+        """Spans in the boundary band [1e-10, 1e-9) collapse under the new
+        normative epsilon (TraigentSchema multi_objective_semantics_schema.json
+        v1.0.0). Pre-rollout this band normalized linearly.
+        """
+        schema = create_default_objectives(["accuracy"])
+
+        # Span = 5e-10: between the old 1e-10 and the new 1e-9 epsilon.
+        normalized = schema.normalize_value(
+            "accuracy", 0.85, min_val=0.85, max_val=0.85 + 5e-10
+        )
+        assert normalized == 0.5
+
+        # normalize_metrics() must agree (it forwards epsilon to normalize_value).
+        bulk = schema.normalize_metrics(
+            {"accuracy": 0.85}, ranges={"accuracy": (0.85, 0.85 + 5e-10)}
+        )
+        assert bulk["accuracy"] == 0.5
+
 
 class TestMixedOrientationParetoFront:
     """Tests for Pareto fronts with mixed maximize/minimize objectives."""

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1054,7 +1054,11 @@ class OptimizationResult:
     def _legacy_normalize_value(
         value: Any, min_val: float, max_val: float, minimize: bool
     ) -> float | None:
-        """Normalize a single metric value using legacy orientation rules."""
+        """Normalize a single metric value using legacy orientation rules.
+
+        Zero-span tolerance and fallback follow the TraigentSchema
+        multi_objective_semantics meta-contract (epsilon=1e-9, fallback=0.5).
+        """
 
         if value is None:
             return None
@@ -1064,7 +1068,7 @@ class OptimizationResult:
         except (TypeError, ValueError):
             return None
 
-        if abs(max_val - min_val) < 1e-10:
+        if abs(max_val - min_val) < 1e-9:
             return 0.5
 
         span = max_val - min_val

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1163,6 +1163,66 @@ class OptimizationResult:
         best_trial, best_score = max(weighted_scores, key=lambda item: item[1])
         return best_trial.config, best_score
 
+    def score_trials(
+        self,
+        objective_weights: dict[str, float] | None = None,
+        minimize_objectives: list[str] | None = None,
+        objective_schema: ObjectiveSchema | None = None,
+    ) -> list[dict[str, Any]]:
+        """Per-trial normalized + weighted scores for cross-SDK parity.
+
+        Returns the per-objective normalized values and weighted score for
+        every successful trial. This is the public surface used by the
+        ``traigent-cross-sdk-benchmarks`` normalization harness; it shares
+        all preference-resolution and ranging logic with
+        :meth:`calculate_weighted_scores`.
+
+        Args:
+            objective_weights: Same as :meth:`calculate_weighted_scores`.
+            minimize_objectives: Same as :meth:`calculate_weighted_scores`.
+            objective_schema: Same as :meth:`calculate_weighted_scores`.
+
+        Returns:
+            List of dicts, one per successful trial, each containing:
+                - ``trial_id``: Trial identifier.
+                - ``normalized``: Per-objective normalized values (0..1).
+                - ``weighted``: Weighted-sum score using sum-to-one weights.
+        """
+        if not self.successful_trials:
+            return []
+
+        (
+            resolved_weights,
+            resolved_minimize,
+            resolved_schema,
+        ) = self._prepare_objective_preferences(
+            objective_weights, minimize_objectives, objective_schema
+        )
+        normalized_weights = self._normalize_weight_map(resolved_weights)
+        ranges = self._calculate_objective_ranges()
+
+        per_trial: list[dict[str, Any]] = []
+        for trial in self.successful_trials:
+            if not trial.metrics:
+                per_trial.append(
+                    {"trial_id": trial.trial_id, "normalized": {}, "weighted": 0.0}
+                )
+                continue
+            normalized = self._normalize_trial_metrics(
+                trial, ranges, resolved_minimize, resolved_schema
+            )
+            weighted = (
+                self._score_trial(normalized, normalized_weights) if normalized else 0.0
+            )
+            per_trial.append(
+                {
+                    "trial_id": trial.trial_id,
+                    "normalized": dict(normalized),
+                    "weighted": float(weighted),
+                }
+            )
+        return per_trial
+
     def calculate_weighted_scores(
         self,
         objective_weights: dict[str, float] | None = None,

--- a/traigent/core/objectives.py
+++ b/traigent/core/objectives.py
@@ -197,6 +197,12 @@ class ObjectiveDefinition:
 class ObjectiveSchema:
     """Complete schema for multi-objective optimization.
 
+    Behavior is governed by TraigentSchema's
+    ``optimization/multi_objective_semantics_schema.json`` meta-contract
+    (zero-span fallback 0.5, zero-span epsilon 1e-9, sum-to-one weight
+    rescaling, dominance-guard cap 0.99 with sdk-only validation scope).
+    Those constants are not wire-format fields; this class hard-codes them.
+
     Attributes:
         objectives: List of objective definitions
         weights_sum: Sum of all objective weights
@@ -373,7 +379,7 @@ class ObjectiveSchema:
         value: float,
         min_val: float | None = None,
         max_val: float | None = None,
-        epsilon: float = 1e-10,
+        epsilon: float = 1e-9,
     ) -> float:
         """Normalize a value based on objective orientation.
 
@@ -382,10 +388,13 @@ class ObjectiveSchema:
             value: Value to normalize
             min_val: Minimum value (if None, uses bounds if available)
             max_val: Maximum value (if None, uses bounds if available)
-            epsilon: Small value to handle zero-range cases
+            epsilon: Zero-span tolerance. Default 1e-9 matches the normative
+                value pinned in TraigentSchema's
+                multi_objective_semantics_schema.json.
 
         Returns:
-            Normalized value in [0, 1] range
+            Normalized value in [0, 1] range. When |max - min| < epsilon,
+            returns 0.5 (zero-span fallback per the schema meta-contract).
         """
         obj = self.get_objective(objective_name)
         if obj is None:
@@ -420,7 +429,7 @@ class ObjectiveSchema:
         self,
         metrics: dict[str, float],
         ranges: dict[str, tuple[float, float]] | None = None,
-        epsilon: float = 1e-10,
+        epsilon: float = 1e-9,
     ) -> dict[str, float]:
         """Normalize all metrics based on their orientations.
 


### PR DESCRIPTION
## Summary

- Bumps zero-span epsilon from `1e-10` to `1e-9` at three sites in `objectives.py` / `api/types.py` so all normalization paths agree with the schema meta-contract.
- Adds `OptimizationResult.score_trials()` exposing per-trial normalized + weighted scores using the existing preference-resolution pipeline. `calculate_weighted_scores()` is unchanged behaviorally; the new method shares its plumbing.
- Adds the cross-SDK parity test (`tests/integration/test_cross_sdk_normalization.py`) asserting the SDK matches `tests/fixtures/multi_objective_normalization.json` (with workspace-level fallback). The traigent-js companion PR has a parallel test asserting the same fixture — agreement on the fixture is the cross-SDK contract.
- Adds backend recompute regression covering both code paths (schema-aware and legacy `_legacy_normalize_value`).

Zero-span fallback `0.5`, sum-to-one weight rescaling, and the 99% dominance guard were already canonical in the Python SDK, so this PR is the smallest of the train on the behavior side — only the epsilon constant and the helper/tests are new.

## Companion PRs

- Traigent/TraigentSchema#26 (schema meta-contract — must land first)
- traigent-js #41 (zero-span fix + scoreTrials)
- TraigentFrontend #446 (zero-span fix)

## Test plan

- [x] `pytest tests/unit/core/test_objectives*.py tests/unit/utils/test_multi_objective.py` — 104 pass
- [x] `pytest tests/unit/api/test_types_advanced.py -k "not aggregated_dataframe"` — 49 pass
- [x] `pytest tests/integration/test_cross_sdk_normalization.py` — 9 pass
- [ ] Reviewer: confirm `score_trials()` signature matches `calculate_weighted_scores()` for ergonomic parity.
- [ ] Reviewer: spans in `[1e-10, 1e-9)` band now collapse to 0.5 — intentional behavior change at the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)