### PR TITLE
chore(sonar): configure analysis scope and add local scan support

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,10 +1,15 @@
 name: SonarCloud Analysis
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Disable concurrency to prevent job cancellation issues
 # Each PR gets its own run without interference

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,10 +6,12 @@ sonar.projectName=Traigent SDK
 sonar.projectVersion=0.10.0
 
 # Source code location
-# Note: tests excluded from scanning to stay within SonarCloud line limits
+# Note: tests excluded from scanning to stay within SonarCloud line limits.
+# tests/ contains ~127K lines; including it pushes the org over its private-LOC
+# quota. Coverage is still consumed via sonar.python.coverage.reportPaths below.
 sonar.sources=traigent/
 # sonar.tests=tests/  # Excluded: 127K lines, would exceed org limit
-sonar.exclusions=**/__pycache__/**,**/venv/**,**/*.pyc,**/build/**,**/dist/**,**/archive/**,**/node_modules/**,**/examples/**,**/playground/**,**/experimental/**,**/demos/**,**/scripts/**,**/walkthrough/**
+sonar.exclusions=**/__pycache__/**,**/venv/**,**/.venv/**,**/*.pyc,**/build/**,**/dist/**,**/archive/**,**/node_modules/**,**/examples/**,**/playground/**,**/experimental/**,**/demos/**,**/scripts/**,**/walkthrough/**,**/coverage/**,**/.pytest_cache/**,**/.mypy_cache/**,**/.ruff_cache/**,**/migrations/**,**/vendor/**,**/__generated__/**,**/*.generated.*,**/*.egg-info/**,**/poetry.lock,**/uv.lock
 
 # Python-specific settings
 sonar.python.version=3.11,3.12,3.13


### PR DESCRIPTION
## Summary

Harmonizes the SonarCloud analysis scope with the workspace-wide Sonar runbook and unblocks PR decoration on this repo.

### Changes

- **`sonar-project.properties`** — adds defensive structural exclusions to `sonar.exclusions`: `.venv`, `coverage`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `migrations`, `vendor`, `__generated__`, `*.generated.*`, `*.egg-info`, `poetry.lock`, `uv.lock`. All pre-existing exclusions are preserved verbatim.
- **`.github/workflows/sonarcloud.yml`** — restores `push: branches: [main]` and `pull_request:` triggers (workflow was previously `workflow_dispatch`-only, which made the PR-keyed concurrency group unreachable). `SonarSource/sonarqube-scan-action@v6` SHA-pin and the existing pytest+coverage step are unchanged.

### Scope verification (per runbook Step 1.1)

```
$ find traigent -type f -name '*.py' -not -path '*/__pycache__/*' | xargs wc -l | tail -1
 169745 total
```

`tests/` (~127K lines) remains intentionally excluded from `sonar.sources` per the long-standing comment — coverage is still consumed via `sonar.python.coverage.reportPaths`.

### Behavioral impact

- Quality Gate now runs on every PR and push to main (previously only manual). Expect non-zero issue counts on the next scan.
- LOC accounting is unchanged: same `sonar.sources`, same exclusions otherwise. New exclusions cover paths that were never source-of-truth Python.

### Verification

- After merge, confirm new branches show up here: https://sonarcloud.io/project/branches_list?id=Traigent_Traigent

### Out of scope

- Bumping `sonar.projectVersion` (currently 0.10.0 vs. workspace `Traigent/` at 0.11.4) — pre-existing drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)