### PR TITLE
[codex] add uv quickstart install path

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "pyproject.toml"
       - "uv.lock"
+      - "docs/getting-started/**"
+      - "hello_world.py"
       - "scripts/ci/**"
       - ".github/workflows/install-smoke.yml"
   pull_request:
@@ -13,6 +15,8 @@ on:
     paths:
       - "pyproject.toml"
       - "uv.lock"
+      - "docs/getting-started/**"
+      - "hello_world.py"
       - "scripts/ci/**"
       - ".github/workflows/install-smoke.yml"
   workflow_dispatch:
@@ -49,6 +53,44 @@ jobs:
         run: |
           python -c "from langchain_openai import ChatOpenAI; print('langchain_openai OK')"
           python -c "import numpy; print(f'numpy {numpy.__version__} OK')"
+
+      - name: Run source checkout quickstart
+        env:
+          TRAIGENT_MOCK_LLM: "true"
+          TRAIGENT_OFFLINE_MODE: "true"
+          TRAIGENT_RUN_APPROVED: "1"
+          TRAIGENT_APPROVED_BY: "ci-install-smoke"
+        run: python hello_world.py
+
+  # Validates the documented uv source-checkout path from the user guide.
+  install-recommended-uv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Install .[recommended] with uv
+        run: |
+          uv venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[recommended]"
+
+      - name: Run source checkout quickstart
+        env:
+          TRAIGENT_MOCK_LLM: "true"
+          TRAIGENT_OFFLINE_MODE: "true"
+          TRAIGENT_RUN_APPROVED: "1"
+          TRAIGENT_APPROVED_BY: "ci-install-smoke-uv"
+        run: |
+          source .venv/bin/activate
+          python hello_world.py
 
   # .[enterprise] on Linux only — validates the full dependency surface
   install-enterprise:

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -13,9 +13,20 @@ python -m traigent.examples.quickstart
 
 Or from a source checkout:
 
+Pip:
+
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"
+python hello_world.py
+```
+
+Uv:
+
+```bash
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[recommended]"
 python hello_world.py
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,6 +13,20 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e ".[recommended]"           # Recommended bundle: integrations, analytics, bayesian, visualization, hybrid, pydanticai
 ```
 
+### Fast path (uv)
+
+Use this path if your environment already uses `uv`. It installs the same
+source checkout and extras; `pip` remains fully supported. Replace `3.11` with
+any supported Python 3.11-3.13 interpreter available in your environment.
+
+```bash
+git clone https://github.com/Traigent/Traigent.git
+cd Traigent
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[recommended]"        # Same recommended bundle as the pip path
+```
+
 ### PyPI vs source installs
 
 `0.10.0` release validation uses the source install from this repository. Use a published package only if your team separately validates that artifact for your environment.
@@ -37,12 +51,20 @@ pip install -e ".[recommended]"           # Recommended bundle: integrations, an
 
 ## Common Scenarios
 
-- **Run examples (no API keys):**
+- **Run examples from a pip-managed source checkout (no API keys):**
 
   ```bash
   pip install -e ".[recommended]"
   export TRAIGENT_MOCK_LLM=true
-  python examples/core/rag-optimization/run.py
+  python hello_world.py
+  ```
+
+- **Run examples from a uv-managed source checkout (no API keys):**
+
+  ```bash
+  uv pip install -e ".[recommended]"
+  export TRAIGENT_MOCK_LLM=true
+  python hello_world.py
   ```
 
 - **Develop/contribute:**

--- a/scripts/validation/verify_installation.py
+++ b/scripts/validation/verify_installation.py
@@ -31,6 +31,7 @@ def main() -> int:
     print("Traigent Installation Verification")
     print("=" * 50)
     print('Expected install path: pip install -e ".[recommended]"')
+    print('Equivalent uv path:    uv venv --python 3.11 && uv pip install -e ".[recommended]"')
 
     all_ok = True
 
@@ -139,6 +140,7 @@ def main() -> int:
     print("Installation verification failed.")
     print("\nReinstall the documented source bundle:")
     print('  pip install -e ".[recommended]"')
+    print('  # or: uv venv --python 3.11 && uv pip install -e ".[recommended]"')
     return 1
 
 


### PR DESCRIPTION
Refs #557. Partially addresses #580 and #523. Follow-up for #537.

## Summary

- document both pip and uv source-checkout install paths for the SDK quickstart
- make the uv path explicit about supported Python selection with `uv venv --python 3.11`
- make install smoke CI run when getting-started docs or `hello_world.py` change
- add a uv install smoke path and run `hello_world.py` after both documented source installs
- update the installation verifier text to include the uv equivalent

## Validation

- pre-commit hooks during commit: isort, detect-secrets, check yaml, bandit, mypy, strict cost guardrails
- `git diff --check`
- `python3 -m py_compile scripts/validation/verify_installation.py`
- workflow YAML parsed with PyYAML
- fresh pip path: clean venv -> `pip install -e ".[recommended]"` -> `python hello_world.py`
- fresh uv path: clean uv venv with explicit supported Python 3.12 locally -> `uv pip install -e ".[recommended]"` -> `python hello_world.py`
- installation verifier passed in both fresh pip and fresh uv environments

## Notes

- Local machine does not have `python3.11`; CI uses setup-python 3.11, while local uv validation used explicit Python 3.12, which is also supported.
- Full optional-extra matrix from #523 remains broader than this PR; this PR covers the documented recommended bundle and first automated user-guide smoke.
