### PR TITLE
[codex] smooth first-run onboarding notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,10 @@ TRAIGENT_MOCK_LLM=true
 # Get your key from https://traigent.ai
 TRAIGENT_API_KEY=
 
-# Backend URLs (for local development)
-TRAIGENT_API_URL=http://localhost:5000/api/v1
-TRAIGENT_BACKEND_URL=http://localhost:5000
+# Backend URLs are only needed when you are running a local backend.
+# Leave these unset for the default Traigent Cloud / CLI configuration.
+# TRAIGENT_API_URL=http://localhost:5000/api/v1
+# TRAIGENT_BACKEND_URL=http://localhost:5000
 
 # Local Results Storage
 # Default: ~/.traigent

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Traigent
 
-**Traigent is an AI Agent infrastructure that allows companies to take AI agents out of the lab and deploy them at high scale with high confidence.**
-
-**Our mission:** Anything you can measure, we can improve. Whether it's accuracy, speed of response, cost, or any other business metric — we bring strong results that deliver real business value.
-
-
-
 <p align="center">
   <a href="https://github.com/Traigent/Traigent/actions/workflows/tests.yml"><img src="https://github.com/Traigent/Traigent/actions/workflows/tests.yml/badge.svg" alt="CI"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL-3.0"></a>
@@ -363,6 +357,7 @@ traigent --help                              # Full command reference
 | `ModuleNotFoundError` | `pip install -e ".[recommended]"` or check venv is activated |
 | 0.0% accuracy | Check dataset format; for local demos, import and call `enable_mock_mode_for_quickstart()` from `traigent.testing` |
 | Missing API keys | Copy `.env.example` to `.env`; or run `python -m traigent.examples.quickstart` for a no-key demo |
+| `pytest` rejects `-n` / `--dist` | Install dev test tooling first: `pip install -e ".[all,dev]"` |
 | `execution={"runtime": "node"}` fails | Python SDK 0.12.0 removed the temporary JS bridge. Use native `@traigent/sdk`; see [JS bridge migration](docs/guides/js-bridge.md). |
 | Permission errors | Create a fresh venv and reinstall dependencies |
 


### PR DESCRIPTION
Partially addresses #592.

## Summary

- remove the duplicated README tagline/mission block at the top of the page
- make `.env.example` local backend URLs opt-in comments instead of active defaults
- add a README troubleshooting row explaining that running the test suite requires dev extras

## Validation

- pre-commit hooks during commit: detect-secrets, whitespace/end-of-file checks, merge conflict checks, strict cost guardrails
- `git diff --check`

## Notes

#592 remains open. This PR only handles the low-risk documentation rough edges that are still reproducible. The broader onboarding journey, historical develop test failures, and warning/noise items need separate verification.
