### PR TITLE
Fix critical SDK license and Claude permission bypasses

### DIFF
--- a/plugins/traigent-ui/traigent_ui/problem_generation/improved_problem_classifier.py
+++ b/plugins/traigent-ui/traigent_ui/problem_generation/improved_problem_classifier.py
@@ -618,7 +618,6 @@ Respond with valid JSON only."""
                 prompt=prompt,
                 options=ClaudeCodeOptions(
                     system_prompt="You are an expert at problem classification. Always respond with valid JSON containing the requested fields.",
-                    permission_mode="bypassPermissions",
                     max_turns=1,  # We only need one response
                 ),
             ):

--- a/plugins/traigent-ui/traigent_ui/problem_management/llm_providers.py
+++ b/plugins/traigent-ui/traigent_ui/problem_management/llm_providers.py
@@ -208,7 +208,6 @@ class ClaudeCodeSDKProvider(LLMProvider):
                 prompt=generation_prompt,
                 options=ClaudeCodeOptions(
                     system_prompt="You are an expert at generating diverse, high-quality training examples for LLM optimization problems. Always respond with valid JSON only.",
-                    permission_mode="bypassPermissions",  # Since we're just generating text
                     max_turns=1,  # We only need one response
                 ),
             ):

--- a/plugins/traigent-ui/traigent_ui/problem_management/smart_problem_analyzer.py
+++ b/plugins/traigent-ui/traigent_ui/problem_management/smart_problem_analyzer.py
@@ -388,7 +388,6 @@ Keep the response simple and focused on these four key fields.
                 prompt=analysis_prompt,
                 options=ClaudeCodeOptions(
                     system_prompt="You are an expert at analyzing problem descriptions and understanding user intent for LLM task creation. Provide accurate, detailed analysis in valid JSON format.",
-                    permission_mode="bypassPermissions",
                     max_turns=1,
                 ),
             ):
@@ -676,7 +675,6 @@ For "elementary school math problems" → name: "elementary_math_word_problems"
                 prompt=spec_prompt,
                 options=ClaudeCodeOptions(
                     system_prompt="You are an expert at creating detailed, accurate problem specifications for LLM tasks. Generate comprehensive, contextually appropriate specifications in valid JSON format.",
-                    permission_mode="bypassPermissions",
                     max_turns=1,
                 ),
             ):
@@ -987,7 +985,6 @@ For "elementary school math problems" → name: "elementary_math_word_problems"
                     prompt=examples_prompt,
                     options=ClaudeCodeOptions(
                         system_prompt="You are an expert at creating diverse, high-quality examples for LLM training tasks. Generate contextually appropriate, realistic examples in valid JSON format. Never use placeholders like 'To be determined' - always provide complete, valid outputs.",
-                        permission_mode="bypassPermissions",
                         max_turns=1,
                     ),
                 ):

--- a/tests/unit/core/test_license.py
+++ b/tests/unit/core/test_license.py
@@ -655,11 +655,35 @@ class TestValidateOfflineLicense:
         return f"{header}.{body}.{cls._b64url_encode(signature)}"
 
     @staticmethod
+    def _create_es256_token(payload: dict, private_key) -> str:
+        """Create an ES256 JWT-like token for signature verification tests."""
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+        header = TestValidateOfflineLicense._b64url_encode(
+            json.dumps({"alg": "ES256"}).encode()
+        )
+        body = TestValidateOfflineLicense._b64url_encode(json.dumps(payload).encode())
+        signing_input = f"{header}.{body}".encode("ascii")
+        der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+        r, s = utils.decode_dss_signature(der_signature)
+        raw_signature = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+        signature = TestValidateOfflineLicense._b64url_encode(raw_signature)
+        return f"{header}.{body}.{signature}"
+
+    @staticmethod
     def _rsa_private_key():
         """Create a small test RSA keypair."""
         from cryptography.hazmat.primitives.asymmetric import rsa
 
         return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    @staticmethod
+    def _ec_private_key():
+        """Create a P-256 test keypair."""
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        return ec.generate_private_key(ec.SECP256R1())
 
     @staticmethod
     def _public_key_pem(private_key) -> str:
@@ -718,6 +742,53 @@ class TestDecodeLicenseToken:
         assert result.organization == "Acme"
         assert result.validation_source == "offline"
 
+    def test_valid_es256_token_is_accepted(self):
+        """Test a valid ES256 token exercises the ECDSA verification branch."""
+        payload = {"tier": "pro", "features": ["parallel_execution"], "org": "Acme"}
+        private_key = TestValidateOfflineLicense._ec_private_key()
+        token = TestValidateOfflineLicense._create_es256_token(payload, private_key)
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_LICENSE_PUBLIC_KEY": TestValidateOfflineLicense._public_key_pem(
+                    private_key
+                )
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token(token)
+        assert result is not None
+        assert result.tier == LicenseTier.PRO
+        assert LicenseFeature.PARALLEL_EXECUTION in result.features
+        assert result.organization == "Acme"
+        assert result.validation_source == "offline"
+
+    def test_es256_token_tampering_is_rejected(self):
+        """Test ES256 payload tampering fails after raw-signature conversion."""
+        private_key = TestValidateOfflineLicense._ec_private_key()
+        token = TestValidateOfflineLicense._create_es256_token(
+            {"tier": "free", "features": []}, private_key
+        )
+        header, _body, signature = token.split(".")
+        tampered_body = TestValidateOfflineLicense._b64url_encode(
+            json.dumps({"tier": "pro", "features": ["parallel_execution"]}).encode()
+        )
+        tampered_token = f"{header}.{tampered_body}.{signature}"
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_LICENSE_PUBLIC_KEY": TestValidateOfflineLicense._public_key_pem(
+                    private_key
+                )
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(tampered_token) is None
+
     def test_signed_token_tampering_is_rejected(self):
         """Test a signed token with a modified payload is rejected."""
         private_key = TestValidateOfflineLicense._rsa_private_key()
@@ -748,6 +819,22 @@ class TestDecodeLicenseToken:
         token = TestValidateOfflineLicense._create_token(payload)
 
         with patch.dict(os.environ, {}, clear=True):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(token) is None
+
+    def test_require_signed_overrides_unsigned_legacy_escape_hatch(self):
+        """Test require-signed mode rejects unsigned tokens even if legacy is allowed."""
+        payload = {"tier": "enterprise", "features": ["cloud_execution"], "org": "Acme"}
+        token = TestValidateOfflineLicense._create_token(payload)
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true",
+                "TRAIGENT_REQUIRE_SIGNED_LICENSE": "true",
+            },
+            clear=True,
+        ):
             validator = LicenseValidator()
             assert validator._decode_license_token(token) is None
 

--- a/tests/unit/core/test_license.py
+++ b/tests/unit/core/test_license.py
@@ -571,8 +571,11 @@ class TestValidateOfflineLicense:
             temp_path = f.name
 
         try:
-            validator = LicenseValidator(license_file=temp_path)
-            result = validator._validate_offline_license()
+            with patch.dict(
+                os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+            ):
+                validator = LicenseValidator(license_file=temp_path)
+                result = validator._validate_offline_license()
             assert result is not None
             assert result.tier == LicenseTier.PRO
             assert LicenseFeature.PARALLEL_EXECUTION in result.features
@@ -599,8 +602,11 @@ class TestValidateOfflineLicense:
             temp_path = f.name
 
         try:
-            validator = LicenseValidator(license_file=temp_path)
-            result = validator._validate_offline_license()
+            with patch.dict(
+                os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+            ):
+                validator = LicenseValidator(license_file=temp_path)
+                result = validator._validate_offline_license()
             assert result is None
         finally:
             os.unlink(temp_path)
@@ -620,18 +626,54 @@ class TestValidateOfflineLicense:
             os.unlink(temp_path)
 
     @staticmethod
-    def _create_token(payload: dict) -> str:
+    def _b64url_encode(data: bytes) -> str:
+        """Encode bytes as an unpadded JWT base64url segment."""
+        return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+    @classmethod
+    def _create_token(cls, payload: dict) -> str:
         """Create a simplified JWT-like token for testing."""
-        header = (
-            base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode())
-            .decode()
-            .rstrip("=")
-        )
-        body = (
-            base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
-        )
-        signature = base64.urlsafe_b64encode(b"test-sig").decode().rstrip("=")
+        header = cls._b64url_encode(json.dumps({"alg": "none"}).encode())
+        body = cls._b64url_encode(json.dumps(payload).encode())
+        signature = cls._b64url_encode(b"test-sig")
         return f"{header}.{body}.{signature}"
+
+    @classmethod
+    def _create_rs256_token(cls, payload: dict, private_key) -> str:
+        """Create an RS256 JWT-like token for signature verification tests."""
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        header = cls._b64url_encode(json.dumps({"alg": "RS256"}).encode())
+        body = cls._b64url_encode(json.dumps(payload).encode())
+        signing_input = f"{header}.{body}".encode("ascii")
+        signature = private_key.sign(
+            signing_input,
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+        return f"{header}.{body}.{cls._b64url_encode(signature)}"
+
+    @staticmethod
+    def _rsa_private_key():
+        """Create a small test RSA keypair."""
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    @staticmethod
+    def _public_key_pem(private_key) -> str:
+        """Serialize a test RSA public key to PEM."""
+        from cryptography.hazmat.primitives import serialization
+
+        return (
+            private_key.public_key()
+            .public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            .decode("ascii")
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -654,24 +696,71 @@ class TestDecodeLicenseToken:
         assert validator._decode_license_token("one.two.three.four") is None
 
     def test_valid_token_no_expiry(self):
-        """Test valid token without expiry is accepted."""
+        """Test a signed valid token without expiry is accepted."""
         payload = {"tier": "enterprise", "features": ["cloud_execution"], "org": "Acme"}
-        token = TestValidateOfflineLicense._create_token(payload)
+        private_key = TestValidateOfflineLicense._rsa_private_key()
+        token = TestValidateOfflineLicense._create_rs256_token(payload, private_key)
 
-        validator = LicenseValidator()
-        result = validator._decode_license_token(token)
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_LICENSE_PUBLIC_KEY": TestValidateOfflineLicense._public_key_pem(
+                    private_key
+                )
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token(token)
         assert result is not None
         assert result.tier == LicenseTier.ENTERPRISE
         assert LicenseFeature.CLOUD_EXECUTION in result.features
         assert result.organization == "Acme"
+        assert result.validation_source == "offline"
+
+    def test_signed_token_tampering_is_rejected(self):
+        """Test a signed token with a modified payload is rejected."""
+        private_key = TestValidateOfflineLicense._rsa_private_key()
+        token = TestValidateOfflineLicense._create_rs256_token(
+            {"tier": "free", "features": []}, private_key
+        )
+        header, _body, signature = token.split(".")
+        tampered_body = TestValidateOfflineLicense._b64url_encode(
+            json.dumps({"tier": "enterprise", "features": ["cloud_execution"]}).encode()
+        )
+        tampered_token = f"{header}.{tampered_body}.{signature}"
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_LICENSE_PUBLIC_KEY": TestValidateOfflineLicense._public_key_pem(
+                    private_key
+                )
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(tampered_token) is None
+
+    def test_unsigned_token_rejected_by_default(self):
+        """Test unsigned offline tokens are rejected unless explicitly allowed."""
+        payload = {"tier": "enterprise", "features": ["cloud_execution"], "org": "Acme"}
+        token = TestValidateOfflineLicense._create_token(payload)
+
+        with patch.dict(os.environ, {}, clear=True):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(token) is None
 
     def test_valid_token_defaults_to_free(self):
-        """Test token with no tier defaults to free."""
+        """Test explicitly allowed legacy token with no tier defaults to free."""
         payload = {"features": []}
         token = TestValidateOfflineLicense._create_token(payload)
 
-        validator = LicenseValidator()
-        result = validator._decode_license_token(token)
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token(token)
         assert result is not None
         assert result.tier == LicenseTier.FREE
 
@@ -710,13 +799,16 @@ class TestDecodeLicenseToken:
     def test_base64_padding_handling(self):
         """Test that base64 padding is handled correctly for various payload lengths."""
         # Try payloads of different lengths to exercise the padding logic
-        for extra in ["", "x", "xx", "xxx"]:
-            payload = {"tier": "free", "features": [], "extra": extra}
-            token = TestValidateOfflineLicense._create_token(payload)
-            validator = LicenseValidator()
-            result = validator._decode_license_token(token)
-            assert result is not None
-            assert result.tier == LicenseTier.FREE
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            for extra in ["", "x", "xx", "xxx"]:
+                payload = {"tier": "free", "features": [], "extra": extra}
+                token = TestValidateOfflineLicense._create_token(payload)
+                validator = LicenseValidator()
+                result = validator._decode_license_token(token)
+                assert result is not None
+                assert result.tier == LicenseTier.FREE
 
 
 # ---------------------------------------------------------------------------
@@ -892,11 +984,14 @@ class TestValidateAsync:
             temp_path = f.name
 
         try:
-            validator = LicenseValidator(
-                license_file=temp_path,
-                offline_mode=True,
-            )
-            result = await validator.validate_async()
+            with patch.dict(
+                os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+            ):
+                validator = LicenseValidator(
+                    license_file=temp_path,
+                    offline_mode=True,
+                )
+                result = await validator.validate_async()
             assert result.tier == LicenseTier.PRO
             # See C3 phased rollout: unsigned tokens use the legacy tag.
             assert result.validation_source == "offline_unsigned_legacy"
@@ -1122,8 +1217,11 @@ class TestHasFeatureSync:
             temp_path = f.name
 
         try:
-            validator = LicenseValidator(license_file=temp_path)
-            result = validator.has_feature_sync(LicenseFeature.PARALLEL_EXECUTION)
+            with patch.dict(
+                os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+            ):
+                validator = LicenseValidator(license_file=temp_path)
+                result = validator.has_feature_sync(LicenseFeature.PARALLEL_EXECUTION)
             assert result is True
         finally:
             os.unlink(temp_path)

--- a/tests/unit/core/test_license.py
+++ b/tests/unit/core/test_license.py
@@ -710,14 +710,20 @@ class TestDecodeLicenseToken:
 
     def test_invalid_format_no_dots(self):
         """Test token without dots returns None."""
-        validator = LicenseValidator()
-        assert validator._decode_license_token("nodots") is None
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token("nodots") is None
 
     def test_invalid_format_wrong_parts(self):
         """Test token with wrong number of parts returns None."""
-        validator = LicenseValidator()
-        assert validator._decode_license_token("one.two") is None
-        assert validator._decode_license_token("one.two.three.four") is None
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token("one.two") is None
+            assert validator._decode_license_token("one.two.three.four") is None
 
     def test_valid_token_no_expiry(self):
         """Test a signed valid token without expiry is accepted."""
@@ -813,6 +819,52 @@ class TestDecodeLicenseToken:
             validator = LicenseValidator()
             assert validator._decode_license_token(tampered_token) is None
 
+    def test_signed_token_with_unsupported_algorithm_is_rejected(self):
+        """Test configured-key verification rejects unsupported JWT algorithms."""
+        private_key = TestValidateOfflineLicense._rsa_private_key()
+        header = TestValidateOfflineLicense._b64url_encode(
+            json.dumps({"alg": "HS256"}).encode()
+        )
+        body = TestValidateOfflineLicense._b64url_encode(
+            json.dumps({"tier": "pro", "features": ["parallel_execution"]}).encode()
+        )
+        token = f"{header}.{body}.{TestValidateOfflineLicense._b64url_encode(b'sig')}"
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_LICENSE_PUBLIC_KEY": TestValidateOfflineLicense._public_key_pem(
+                    private_key
+                )
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(token) is None
+
+    def test_malformed_es256_signature_is_rejected(self):
+        """Test ES256 signatures must be raw 64-byte P1363 signatures."""
+        private_key = TestValidateOfflineLicense._ec_private_key()
+        token = TestValidateOfflineLicense._create_es256_token(
+            {"tier": "pro", "features": ["parallel_execution"]}, private_key
+        )
+        header, body, _signature = token.split(".")
+        malformed_token = (
+            f"{header}.{body}.{TestValidateOfflineLicense._b64url_encode(b'short')}"
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_LICENSE_PUBLIC_KEY": TestValidateOfflineLicense._public_key_pem(
+                    private_key
+                )
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(malformed_token) is None
+
     def test_unsigned_token_rejected_by_default(self):
         """Test unsigned offline tokens are rejected unless explicitly allowed."""
         payload = {"tier": "enterprise", "features": ["cloud_execution"], "org": "Acme"}
@@ -821,6 +873,61 @@ class TestDecodeLicenseToken:
         with patch.dict(os.environ, {}, clear=True):
             validator = LicenseValidator()
             assert validator._decode_license_token(token) is None
+
+    def test_signed_looking_token_rejected_even_when_legacy_is_allowed(self):
+        """Test legacy mode refuses signed-looking tokens without verification."""
+        private_key = TestValidateOfflineLicense._rsa_private_key()
+        token = TestValidateOfflineLicense._create_rs256_token(
+            {"tier": "pro", "features": ["parallel_execution"]}, private_key
+        )
+
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(token) is None
+
+    def test_empty_public_key_configuration_fails_closed(self):
+        """Test configured-but-empty public key does not fall back to legacy mode."""
+        payload = {"tier": "enterprise", "features": ["cloud_execution"], "org": "Acme"}
+        token = TestValidateOfflineLicense._create_token(payload)
+
+        with patch.dict(
+            os.environ,
+            {
+                "TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true",
+                "TRAIGENT_LICENSE_PUBLIC_KEY": "",
+            },
+            clear=True,
+        ):
+            validator = LicenseValidator()
+            assert validator._decode_license_token(token) is None
+
+    def test_public_key_file_configuration_is_used(self):
+        """Test signed offline licenses can be verified from a public-key file."""
+        payload = {"tier": "pro", "features": ["parallel_execution"], "org": "FileCorp"}
+        private_key = TestValidateOfflineLicense._rsa_private_key()
+        token = TestValidateOfflineLicense._create_rs256_token(payload, private_key)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as f:
+            f.write(TestValidateOfflineLicense._public_key_pem(private_key))
+            f.flush()
+            temp_path = f.name
+
+        try:
+            with patch.dict(
+                os.environ,
+                {"TRAIGENT_LICENSE_PUBLIC_KEY_FILE": temp_path},
+                clear=True,
+            ):
+                validator = LicenseValidator()
+                result = validator._decode_license_token(token)
+            assert result is not None
+            assert result.tier == LicenseTier.PRO
+            assert result.organization == "FileCorp"
+            assert result.validation_source == "offline"
+        finally:
+            os.unlink(temp_path)
 
     def test_require_signed_overrides_unsigned_legacy_escape_hatch(self):
         """Test require-signed mode rejects unsigned tokens even if legacy is allowed."""
@@ -853,16 +960,25 @@ class TestDecodeLicenseToken:
 
     def test_invalid_base64_payload(self):
         """Test token with invalid base64 payload returns None."""
-        validator = LicenseValidator()
-        result = validator._decode_license_token("header.!!!invalid!!!.signature")
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token("header.!!!invalid!!!.signature")
         assert result is None
 
     def test_invalid_json_payload(self):
         """Test token with non-JSON payload returns None."""
+        header = TestValidateOfflineLicense._b64url_encode(
+            json.dumps({"alg": "none"}).encode()
+        )
         bad_payload = base64.urlsafe_b64encode(b"not json").decode().rstrip("=")
-        token = f"header.{bad_payload}.signature"
-        validator = LicenseValidator()
-        result = validator._decode_license_token(token)
+        token = f"{header}.{bad_payload}.signature"
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token(token)
         assert result is None
 
     def test_invalid_tier_value(self):
@@ -870,8 +986,11 @@ class TestDecodeLicenseToken:
         payload = {"tier": "platinum", "features": []}
         token = TestValidateOfflineLicense._create_token(payload)
 
-        validator = LicenseValidator()
-        result = validator._decode_license_token(token)
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token(token)
         assert result is None
 
     def test_invalid_feature_value(self):
@@ -879,8 +998,11 @@ class TestDecodeLicenseToken:
         payload = {"tier": "pro", "features": ["nonexistent_feature"]}
         token = TestValidateOfflineLicense._create_token(payload)
 
-        validator = LicenseValidator()
-        result = validator._decode_license_token(token)
+        with patch.dict(
+            os.environ, {"TRAIGENT_ALLOW_UNSIGNED_LICENSE": "true"}, clear=True
+        ):
+            validator = LicenseValidator()
+            result = validator._decode_license_token(token)
         assert result is None
 
     def test_base64_padding_handling(self):

--- a/traigent/core/license.py
+++ b/traigent/core/license.py
@@ -15,20 +15,21 @@ Enterprise Configuration:
 Offline-license signature configuration (phased rollout):
     TRAIGENT_LICENSE_PUBLIC_KEY - PEM-encoded RSA/EC public key inline.
     TRAIGENT_LICENSE_PUBLIC_KEY_FILE - Path to a PEM public-key file.
+    TRAIGENT_ALLOW_UNSIGNED_LICENSE - "true" temporarily accepts the
+        legacy unsigned offline-license format for migration only.
     TRAIGENT_REQUIRE_SIGNED_LICENSE - "true" rejects unsigned tokens
-        even when no public key is configured. Use this in strict /
-        enterprise / air-gapped deployments that cannot accept the
-        legacy unsigned format under any condition.
+        even when TRAIGENT_ALLOW_UNSIGNED_LICENSE is also set.
 
 Behavior:
     - If a public key is configured (env or file) the offline token's
       signature is verified and rejected if invalid.
-    - If TRAIGENT_REQUIRE_SIGNED_LICENSE is truthy, unsigned tokens are
-      rejected regardless.
-    - Otherwise the legacy unsigned format is still accepted with a
-      loud deprecation warning, and the resulting LicenseInfo is tagged
-      ``validation_source="offline_unsigned_legacy"`` so callers and
-      observability can distinguish trusted from legacy validations.
+    - If no public key is configured, offline tokens are rejected by
+      default because their signature cannot be verified.
+    - The legacy unsigned format is accepted only when
+      TRAIGENT_ALLOW_UNSIGNED_LICENSE=true, and the resulting
+      LicenseInfo is tagged ``validation_source="offline_unsigned_legacy"``
+      so callers and observability can distinguish trusted from legacy
+      validations.
 """
 
 # Traceability: CONC-Layer-Core FUNC-LICENSING REQ-LICENSE-001
@@ -306,13 +307,12 @@ class LicenseValidator:
     def _decode_license_token(self, token: str) -> LicenseInfo | None:
         """Decode and validate an offline license token.
 
-        Phased rollout: a public key (inline or file) verifies the
-        signature when configured; ``TRAIGENT_REQUIRE_SIGNED_LICENSE``
-        forces strict mode even when no key is configured. Otherwise the
-        legacy unsigned format is still accepted with a loud deprecation
-        warning and tagged ``validation_source="offline_unsigned_legacy"``
-        so air-gapped deployments are not broken in this release while
-        signed-only workflows can be enforced today.
+        A public key (inline or file) verifies the signature when
+        configured. Without a public key, the validator fails closed by
+        default because accepting the payload without verifying the
+        signature makes license forgery trivial. A short-term legacy
+        escape hatch is available via ``TRAIGENT_ALLOW_UNSIGNED_LICENSE``
+        and is tagged ``validation_source="offline_unsigned_legacy"``.
 
         If a public key is configured but cannot be loaded (unreadable
         file, malformed PEM, empty inline value), the validator MUST
@@ -328,6 +328,7 @@ class LicenseValidator:
         """
         public_key, key_was_configured = self._resolve_license_public_key()
         require_signed = self._truthy(os.environ.get("TRAIGENT_REQUIRE_SIGNED_LICENSE"))
+        allow_unsigned = self._truthy(os.environ.get("TRAIGENT_ALLOW_UNSIGNED_LICENSE"))
 
         if public_key is not None:
             return self._decode_signed_license_token(token, public_key)
@@ -352,38 +353,74 @@ class LicenseValidator:
             )
             return None
 
+        if not allow_unsigned:
+            logger.error(
+                "Offline license token cannot be verified because no "
+                "license public key is configured. Set "
+                "TRAIGENT_LICENSE_PUBLIC_KEY or "
+                "TRAIGENT_LICENSE_PUBLIC_KEY_FILE to verify signed "
+                "offline licenses. For a temporary legacy migration only, "
+                "set TRAIGENT_ALLOW_UNSIGNED_LICENSE=true."
+            )
+            return None
+
         logger.warning(
-            "Accepting an UNSIGNED offline license token. This format is "
-            "deprecated and will be removed in a future Traigent SDK "
-            "release. Provision a signing keypair and set "
-            "TRAIGENT_LICENSE_PUBLIC_KEY (or _FILE) to verify offline "
-            "licenses; set TRAIGENT_REQUIRE_SIGNED_LICENSE=true to refuse "
-            "unsigned tokens immediately."
+            "Accepting an UNSIGNED offline license token because "
+            "TRAIGENT_ALLOW_UNSIGNED_LICENSE=true. This format is "
+            "deprecated and must be used only for short-term migration. "
+            "Provision a signing keypair and set TRAIGENT_LICENSE_PUBLIC_KEY "
+            "(or _FILE) to verify offline licenses."
         )
         return self._decode_unsigned_license_token(token)
+
+    @staticmethod
+    def _b64url_decode(segment: str) -> bytes:
+        """Decode a JWT base64url segment strictly."""
+        padded = segment + "=" * ((-len(segment)) % 4)
+        return base64.b64decode(padded.encode("ascii"), altchars=b"-_", validate=True)
+
+    @classmethod
+    def _decode_jwt_json_segment(cls, segment: str, name: str) -> dict | None:
+        """Decode a JWT JSON segment into an object dictionary."""
+        try:
+            value = json.loads(cls._b64url_decode(segment).decode("utf-8"))
+        except Exception as exc:
+            logger.warning("Failed to decode license token %s: %s", name, exc)
+            return None
+        if not isinstance(value, dict):
+            logger.warning("Invalid license token %s: expected object", name)
+            return None
+        return value
 
     def _decode_signed_license_token(
         self, token: str, public_key
     ) -> LicenseInfo | None:
         """Verify the JWT signature on the offline license and decode it."""
         try:
-            import jwt as pyjwt
-        except ImportError:
-            logger.error(
-                "PyJWT is required to verify signed license tokens but is "
-                "not installed."
-            )
-            return None
+            parts = token.split(".")
+            if len(parts) != 3:
+                logger.warning("Invalid license token format")
+                return None
 
-        try:
-            payload = pyjwt.decode(
-                token,
-                public_key,
-                algorithms=list(self._SUPPORTED_LICENSE_ALGORITHMS),
-                options={"verify_aud": False},
-            )
+            header = self._decode_jwt_json_segment(parts[0], "header")
+            if header is None:
+                return None
+
+            alg = header.get("alg")
+            if alg not in self._SUPPORTED_LICENSE_ALGORITHMS:
+                logger.warning("Unsupported offline license signing algorithm: %s", alg)
+                return None
+
+            signing_input = f"{parts[0]}.{parts[1]}".encode("ascii")
+            signature = self._b64url_decode(parts[2])
+            self._verify_license_signature(alg, public_key, signature, signing_input)
+
+            payload = self._decode_jwt_json_segment(parts[1], "payload")
         except Exception as exc:
             logger.warning("Signed license verification failed: %s", exc)
+            return None
+
+        if payload is None:
             return None
 
         info = self._build_license_info(payload, validation_source="offline")
@@ -394,6 +431,34 @@ class LicenseValidator:
             return None
         return info
 
+    @staticmethod
+    def _verify_license_signature(
+        alg: str, public_key, signature: bytes, signing_input: bytes
+    ) -> None:
+        """Verify a JWT signature with cryptography's public-key APIs."""
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec, padding, utils
+
+        if alg == "RS256":
+            public_key.verify(
+                signature,
+                signing_input,
+                padding.PKCS1v15(),
+                hashes.SHA256(),
+            )
+            return
+
+        if alg == "ES256":
+            if len(signature) != 64:
+                raise ValueError("ES256 signature must be 64 raw bytes")
+            r = int.from_bytes(signature[:32], "big")
+            s = int.from_bytes(signature[32:], "big")
+            der_signature = utils.encode_dss_signature(r, s)
+            public_key.verify(der_signature, signing_input, ec.ECDSA(hashes.SHA256()))
+            return
+
+        raise ValueError(f"Unsupported offline license signing algorithm: {alg}")
+
     def _decode_unsigned_license_token(self, token: str) -> LicenseInfo | None:
         """Legacy path: base64-decode the middle segment without verifying."""
         try:
@@ -402,12 +467,22 @@ class LicenseValidator:
                 logger.warning("Invalid license token format")
                 return None
 
-            payload_b64 = parts[1]
-            payload_b64 += "=" * ((-len(payload_b64)) % 4)
-            payload_json = base64.urlsafe_b64decode(payload_b64).decode("utf-8")
-            payload = json.loads(payload_json)
+            header = self._decode_jwt_json_segment(parts[0], "header")
+            if header is None:
+                return None
+            if str(header.get("alg", "none")).lower() != "none":
+                logger.warning(
+                    "Refusing to parse a signed-looking license token without "
+                    "signature verification."
+                )
+                return None
+
+            payload = self._decode_jwt_json_segment(parts[1], "payload")
         except Exception as exc:
             logger.warning("Failed to decode license token: %s", exc)
+            return None
+
+        if payload is None:
             return None
 
         info = self._build_license_info(


### PR DESCRIPTION
## Summary

- Fail closed for offline license tokens when no verification public key is configured; unsigned legacy tokens now require the explicit `TRAIGENT_ALLOW_UNSIGNED_LICENSE=true` migration escape hatch.
- Verify signed offline license JWTs directly with `cryptography` for `RS256` and `ES256`, and add tests for valid signatures, tampered payload rejection, and unsigned default rejection.
- Remove Claude Code SDK `bypassPermissions` from the Traigent UI plugin text-generation/classification paths.
- Verified the two TVL `ch3_constraint_tests.py` `eval()` findings from the reviewed SHA are not present on current `main`/`develop`; there is no live file to patch on this branch.

Refs #846.

## Verification

- `pytest -o addopts='' -p no:rerunfailures tests/unit/core/test_license.py` -> 124 passed
- `python -m compileall traigent/core/license.py plugins/traigent-ui/traigent_ui/problem_generation/improved_problem_classifier.py plugins/traigent-ui/traigent_ui/problem_management/llm_providers.py plugins/traigent-ui/traigent_ui/problem_management/smart_problem_analyzer.py tests/unit/core/test_license.py`
- `ruff check --select E9,F63,F7,F82 traigent/core/license.py tests/unit/core/test_license.py plugins/traigent-ui/traigent_ui/problem_generation/improved_problem_classifier.py plugins/traigent-ui/traigent_ui/problem_management/llm_providers.py plugins/traigent-ui/traigent_ui/problem_management/smart_problem_analyzer.py`
- `git diff --check`
- Commit hooks passed: isort, black, ruff, detect-secrets, whitespace/end-of-file checks, merge-conflict/large-file checks, private-key check, bandit, mypy, TVL spec validation, strict cost guardrails

Note: the push hook attempted a SonarQube scan, but `sonar-scanner` is not installed locally, so that local scan was skipped.
