### PR TITLE
fix: harden SDK auth and transport security

### DIFF
--- a/tests/unit/cloud/test_token_manager.py
+++ b/tests/unit/cloud/test_token_manager.py
@@ -543,6 +543,54 @@ class TestBuildCredentialsFromTokenData:
         set_key_fn.assert_called_once()
 
 
+class TestOAuth2RefreshHardening:
+    """Security regressions for OAuth2 token refresh."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_oauth2_rejects_local_cloud_base_url(self, config):
+        credentials = AuthCredentials(
+            mode=AuthMode.OAUTH2,
+            refresh_token="refresh_token_placeholder",
+            client_id="client-id",
+            client_secret="client-secret",  # pragma: allowlist secret
+        )
+        tm = TokenManager(config)
+        tm.set_callbacks(
+            get_credentials=lambda: credentials,
+            set_credentials=MagicMock(),
+            cache_credentials=AsyncMock(),
+            auth_lock=asyncio.Lock(),
+        )
+
+        result = await tm.refresh_oauth2()
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
+        assert result.error_message == "OAuth2 cloud_base_url is not allowed"
+
+    @pytest.mark.asyncio
+    async def test_refresh_jwt_error_message_does_not_return_raw_body(
+        self, token_manager_with_callbacks
+    ):
+        token_manager, _credentials = token_manager_with_callbacks
+
+        async def fail_refresh(*_args, **_kwargs):
+            raise RuntimeError(
+                "500: {'access_token':'secret-token-value','password':'secret'}"  # pragma: allowlist secret
+            )
+
+        with patch(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            side_effect=fail_refresh,
+        ):
+            result = await token_manager.refresh_jwt_secure("refresh_token")
+
+        assert result.success is False
+        assert result.error_message == "Token refresh failed"
+        assert "secret-token-value" not in result.error_message
+        assert "password" not in result.error_message
+
+
 class TestGetAuthorizationHeader:
     """Test authorization header generation."""
 

--- a/tests/unit/core/test_ci_approval.py
+++ b/tests/unit/core/test_ci_approval.py
@@ -9,7 +9,7 @@ import json
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -212,7 +212,7 @@ class TestValidateHmacToken:
         assert _validate_hmac_token(token) is False
 
     def test_no_secret_with_valid_expiry(self) -> None:
-        """When secret is not set, token is accepted if not expired (with warning)."""
+        """When secret is not set, HMAC token validation must fail closed."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
         token = {
             "approver": "ci-bot",
@@ -222,7 +222,7 @@ class TestValidateHmacToken:
         }
         env = {k: v for k, v in os.environ.items() if k != "TRAIGENT_APPROVAL_SECRET"}
         with patch.dict(os.environ, env, clear=True):
-            assert _validate_hmac_token(token) is True
+            assert _validate_hmac_token(token) is False
 
     def test_no_secret_with_expired_token(self) -> None:
         past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()

--- a/tests/unit/hybrid/test_transport.py
+++ b/tests/unit/hybrid/test_transport.py
@@ -122,6 +122,22 @@ class TestCreateTransport:
                 require_http2=True,
             )
 
+    def test_create_http_transport_rejects_embedded_credentials(self) -> None:
+        """HTTP transport base URLs must not smuggle credentials."""
+        with pytest.raises(ValueError, match="embedded credentials"):
+            create_transport(
+                transport_type="http",
+                base_url="https://user:pass@example.com",  # pragma: allowlist secret
+            )
+
+    def test_create_http_transport_rejects_metadata_endpoint(self) -> None:
+        """HTTP transport base URLs must not target metadata services."""
+        with pytest.raises(ValueError, match="metadata service|non-routable"):
+            create_transport(
+                transport_type="http",
+                base_url="http://169.254.169.254",
+            )
+
     def test_create_mcp_transport(self) -> None:
         """Test creating MCP transport."""
         mock_client = MagicMock()

--- a/tests/unit/utils/test_url_security.py
+++ b/tests/unit/utils/test_url_security.py
@@ -1,0 +1,45 @@
+"""Tests for outbound URL safety validation."""
+
+import pytest
+
+from traigent.utils.url_security import UnsafeUrlError, validate_outbound_url
+
+
+def test_validate_outbound_url_normalizes_trailing_slash() -> None:
+    assert validate_outbound_url("https://api.example.com/") == "https://api.example.com"
+
+
+@pytest.mark.parametrize(
+    "url, message",
+    [
+        ("", "must not be empty"),
+        ("file:///tmp/socket", "http or https"),
+        ("https://example.com?token=abc", "query or fragment"),
+        ("https://user:pass@example.com", "embedded credentials"),  # pragma: allowlist secret
+        ("https://example.com:99999", "invalid port"),
+        ("https://api.example.com/v1/..", "dot-segment"),
+        ("https://api.example.com/v1/%2e%2e", "dot-segment"),
+        ("https://api.example.com/v1%2f..", "dot-segment"),
+        ("http://metadata.google.internal", "metadata service"),
+        ("http://169.254.169.254", "non-routable"),
+        ("http://2130706433", "non-standard IP"),
+        ("http://0x7f.0.0.1", "non-standard IP"),
+        ("http://127.0.0.1", "private address"),
+        ("http://localhost", "localhost"),
+    ],
+)
+def test_validate_outbound_url_rejects_unsafe_urls(url: str, message: str) -> None:
+    with pytest.raises(UnsafeUrlError, match=message):
+        validate_outbound_url(url)
+
+
+def test_validate_outbound_url_allows_private_hosts_when_requested() -> None:
+    assert (
+        validate_outbound_url("http://127.0.0.1:8080/", allow_private_hosts=True)
+        == "http://127.0.0.1:8080"
+    )
+
+
+def test_validate_outbound_url_still_blocks_metadata_when_private_hosts_allowed() -> None:
+    with pytest.raises(UnsafeUrlError, match="non-routable"):
+        validate_outbound_url("http://169.254.169.254", allow_private_hosts=True)

--- a/traigent/cloud/token_manager.py
+++ b/traigent/cloud/token_manager.py
@@ -12,10 +12,11 @@ import asyncio
 import logging
 import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
 from traigent.core.constants import MAX_RETRIES
+from traigent.utils.url_security import UnsafeUrlError, validate_outbound_url
 
 if TYPE_CHECKING:
     from traigent.cloud.auth import (
@@ -26,6 +27,8 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+_GENERIC_REFRESH_ERROR = "Token refresh failed"
 
 
 class TokenManager:
@@ -298,9 +301,11 @@ class TokenManager:
                 )
 
             except Exception as exc:
-                logger.error(f"Token refresh failed: {exc}")
+                logger.error("Token refresh failed: %s", type(exc).__name__)
                 return AuthResult(
-                    success=False, status=AuthStatus.INVALID, error_message=str(exc)
+                    success=False,
+                    status=AuthStatus.INVALID,
+                    error_message=_GENERIC_REFRESH_ERROR,
                 )
 
     async def refresh_jwt_secure(self, refresh_token_value: str) -> AuthResult:
@@ -343,15 +348,14 @@ class TokenManager:
                     if response.status == 401:
                         raise ValueError("Refresh token invalid or expired")
                     if response.status == 429:
-                        error_msg = await response.text()
-                        raise Exception(f"429 Rate Limited: {error_msg}")
+                        raise RuntimeError("Token refresh failed with HTTP 429")
                     if response.status != 200:
-                        error_text = await response.text()
-                        raise Exception(f"{response.status}: {error_text}")
-
+                        raise RuntimeError(
+                            f"Token refresh failed with HTTP {response.status}"
+                        )
                     data = await response.json()
                     if not data.get("success"):
-                        raise ValueError(data.get("error", "Token refresh failed"))
+                        raise ValueError(_GENERIC_REFRESH_ERROR)
 
                     payload = data.get("data", {})
                     if "refresh_token" not in payload or not payload["refresh_token"]:
@@ -404,12 +408,45 @@ class TokenManager:
                 error_message=str(exc),
             )
         except Exception as exc:
-            logger.error(f"Token refresh error: {type(exc).__name__}: {exc}")
+            logger.error("Token refresh error: %s", type(exc).__name__)
             return AuthResult(
                 success=False,
                 status=AuthStatus.INVALID,
-                error_message=str(exc),
+                error_message=_GENERIC_REFRESH_ERROR,
             )
+
+    def _build_oauth2_token_url(self) -> str:
+        cloud_base_url = validate_outbound_url(
+            self.config.cloud_base_url,
+            purpose="OAuth2 cloud_base_url",
+            allow_private_hosts=False,
+        )
+        return f"{cloud_base_url}/oauth/token"
+
+    async def _apply_oauth2_token_response(
+        self,
+        credentials: AuthCredentials,
+        token_data: dict[str, Any],
+    ) -> AuthResult:
+        from traigent.cloud.auth import AuthResult, AuthStatus
+
+        credentials.jwt_token = token_data["access_token"]
+        if "refresh_token" in token_data:
+            credentials.refresh_token = token_data["refresh_token"]
+        credentials.expires_at = time.time() + token_data.get("expires_in", 3600)
+
+        if self._set_credentials_fn:
+            self._set_credentials_fn(credentials, AuthStatus.AUTHENTICATED)
+
+        if self.config.cache_credentials and self._cache_credentials_fn:
+            await self._cache_credentials_fn(credentials)
+
+        return AuthResult(
+            success=True,
+            status=AuthStatus.AUTHENTICATED,
+            credentials=credentials,
+            expires_in=token_data.get("expires_in", 3600),
+        )
 
     async def refresh_oauth2(self) -> AuthResult:
         """Refresh OAuth2 access token.
@@ -430,13 +467,21 @@ class TokenManager:
                 error_message="No refresh token available",
             )
 
-        token_url = f"{self.config.cloud_base_url}/oauth/token"
-
         if credentials.client_id is None or credentials.client_secret is None:
             return AuthResult(
                 success=False,
                 status=AuthStatus.INVALID,
                 error_message="OAuth2 client credentials missing",
+            )
+
+        try:
+            token_url = self._build_oauth2_token_url()
+        except UnsafeUrlError as exc:
+            logger.warning("Rejected unsafe OAuth2 cloud_base_url: %s", exc)
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message="OAuth2 cloud_base_url is not allowed",
             )
 
         data = {
@@ -448,35 +493,12 @@ class TokenManager:
 
         async with aiohttp.ClientSession() as session:
             async with session.post(token_url, data=data) as response:
-                if response.status == 200:
-                    token_data = await response.json()
-
-                    # Update credentials
-                    credentials.jwt_token = token_data["access_token"]
-                    if "refresh_token" in token_data:
-                        credentials.refresh_token = token_data["refresh_token"]
-                    credentials.expires_at = time.time() + token_data.get(
-                        "expires_in", 3600
-                    )
-
-                    if self._set_credentials_fn:
-                        self._set_credentials_fn(credentials, AuthStatus.AUTHENTICATED)
-
-                    # Cache updated credentials
-                    if self.config.cache_credentials and self._cache_credentials_fn:
-                        await self._cache_credentials_fn(credentials)
-
-                    return AuthResult(
-                        success=True,
-                        status=AuthStatus.AUTHENTICATED,
-                        credentials=credentials,
-                        expires_in=token_data.get("expires_in", 3600),
-                    )
-                else:
-                    error_text = await response.text()
+                if response.status != 200:
                     raise RuntimeError(
-                        f"Token refresh failed: {response.status} {error_text}"
+                        f"OAuth2 token refresh failed with HTTP {response.status}"
                     )
+                token_data = await response.json()
+                return await self._apply_oauth2_token_response(credentials, token_data)
 
     def build_credentials_from_token_data(
         self, token_data: dict[str, Any]
@@ -534,5 +556,5 @@ class TokenManager:
             TokenExpiredError: If token has expired
         """
         if self._current_token and not self._current_token.is_expired:
-            return self._current_token.get_header()
+            return cast(dict[str, str], self._current_token.get_header())
         return {}

--- a/traigent/core/ci_approval.py
+++ b/traigent/core/ci_approval.py
@@ -90,21 +90,9 @@ def _validate_hmac_token(token_data: dict[str, Any]) -> bool:
     secret = os.getenv("TRAIGENT_APPROVAL_SECRET", "").encode()
     if not secret:
         logger.warning(
-            "TRAIGENT_APPROVAL_SECRET not set, cannot validate token signature"
+            "TRAIGENT_APPROVAL_SECRET not set; rejecting HMAC approval token "
+            "because its signature cannot be verified"
         )
-        try:
-            expires_at = datetime.fromisoformat(
-                token_data["expires_iso"].replace("Z", _UTC_TIMEZONE_SUFFIX)
-            )
-            now = datetime.now(UTC) if expires_at.tzinfo else datetime.now()
-            if expires_at > now:
-                logger.warning(
-                    "Token approved by %s (signature not verified)",
-                    _sanitize_for_log(token_data.get("approver", "unknown")),
-                )
-                return True
-        except (ValueError, KeyError):
-            pass
         return False
 
     # Compute expected signature

--- a/traigent/core/evaluator_wrapper.py
+++ b/traigent/core/evaluator_wrapper.py
@@ -23,6 +23,7 @@ from traigent.evaluators.base import (
     _maybe_restore_trial_context,
 )
 from traigent.utils.logging import get_logger
+from traigent.utils.optimization_logger import sanitize_for_logging
 
 logger = get_logger(__name__)
 
@@ -389,7 +390,9 @@ class CustomEvaluatorWrapper(BaseEvaluator):
             EvaluationError: If evaluation fails
         """
         logger.info(
-            f"Starting custom evaluation with {len(dataset.examples)} examples, config: {config}"
+            "Starting custom evaluation with %s examples, config: %s",
+            len(dataset.examples),
+            sanitize_for_logging(config),
         )
 
         start_time = time.time()

--- a/traigent/hybrid/transport.py
+++ b/traigent/hybrid/transport.py
@@ -8,7 +8,7 @@ supporting both HTTP REST and MCP transports.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, cast, runtime_checkable
 
 from traigent.hybrid.protocol import (
     BenchmarksResponse,
@@ -20,6 +20,7 @@ from traigent.hybrid.protocol import (
     HybridExecuteResponse,
     ServiceCapabilities,
 )
+from traigent.utils.url_security import validate_outbound_url
 
 if TYPE_CHECKING:
     from traigent.cloud.production_mcp_client import (
@@ -265,23 +266,34 @@ def create_transport(
     if transport_type == "http":
         if base_url is None:
             raise ValueError("base_url is required for HTTP transport")
+        safe_base_url = validate_outbound_url(
+            base_url,
+            purpose="hybrid HTTP base_url",
+            allow_private_hosts=True,
+        )
 
         from traigent.hybrid.http_transport import HTTPTransport
 
-        return HTTPTransport(
-            base_url=base_url,
-            auth_header=auth_header,
-            timeout=timeout,
-            max_connections=max_connections,
-            require_http2=require_http2,
+        return cast(
+            HybridTransport,
+            HTTPTransport(
+                base_url=safe_base_url,
+                auth_header=auth_header,
+                timeout=timeout,
+                max_connections=max_connections,
+                require_http2=require_http2,
+            ),
         )
 
     elif transport_type == "mcp":
         from traigent.hybrid.mcp_transport import MCPTransport
 
-        return MCPTransport(
-            mcp_client=mcp_client,
-            mcp_config=mcp_config,
+        return cast(
+            HybridTransport,
+            MCPTransport(
+                mcp_client=mcp_client,
+                mcp_config=mcp_config,
+            ),
         )
 
     else:

--- a/traigent/utils/url_security.py
+++ b/traigent/utils/url_security.py
@@ -1,0 +1,125 @@
+"""Outbound URL validation helpers."""
+
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import ParseResult, unquote, urlparse, urlunparse
+
+
+class UnsafeUrlError(ValueError):
+    """Raised when a configured outbound URL is unsafe."""
+
+
+_LOCALHOST_NAMES = {"localhost", "localhost.localdomain"}
+_METADATA_HOSTNAMES = {
+    "metadata",
+    "metadata.google.internal",
+    "metadata.google.internal.",
+}
+
+
+def _is_numeric_hostname_label(label: str) -> bool:
+    lowered = label.lower()
+    if lowered.startswith("0x"):
+        return len(lowered) > 2 and all(ch in "0123456789abcdef" for ch in lowered[2:])
+    return lowered.isdigit()
+
+
+def _reject_nonstandard_ip_notation(hostname: str, purpose: str) -> None:
+    labels = hostname.split(".")
+    if labels and all(_is_numeric_hostname_label(label) for label in labels):
+        raise UnsafeUrlError(f"{purpose} uses non-standard IP address notation")
+
+
+def _parse_ip_literal(
+    hostname: str,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(hostname.strip("[]"))
+    except ValueError:
+        return None
+
+
+def _validate_parsed_url(parsed: ParseResult, purpose: str) -> None:
+    if parsed.scheme not in {"http", "https"}:
+        raise UnsafeUrlError(f"{purpose} must use http or https")
+    if not parsed.netloc or not parsed.hostname:
+        raise UnsafeUrlError(f"{purpose} must include a hostname")
+    if parsed.username or parsed.password:
+        raise UnsafeUrlError(f"{purpose} must not include embedded credentials")
+    if parsed.query or parsed.fragment:
+        raise UnsafeUrlError(f"{purpose} must not include query or fragment data")
+
+    try:
+        _ = parsed.port
+    except ValueError as exc:
+        raise UnsafeUrlError(f"{purpose} has an invalid port") from exc
+
+
+def _validate_hostname(
+    hostname: str,
+    *,
+    purpose: str,
+    allow_private_hosts: bool,
+) -> None:
+    normalized_hostname = hostname.rstrip(".").lower()
+    if normalized_hostname in _METADATA_HOSTNAMES:
+        raise UnsafeUrlError(f"{purpose} points at a metadata service")
+
+    ip = _parse_ip_literal(normalized_hostname)
+    if ip is not None:
+        _validate_ip_address(
+            ip, purpose=purpose, allow_private_hosts=allow_private_hosts
+        )
+        return
+
+    _reject_nonstandard_ip_notation(normalized_hostname, purpose)
+    if not allow_private_hosts and normalized_hostname in _LOCALHOST_NAMES:
+        raise UnsafeUrlError(f"{purpose} points at localhost")
+
+
+def _normalize_path(path: str, purpose: str) -> str:
+    decoded_path = unquote(path)
+    if any(segment in {".", ".."} for segment in decoded_path.split("/")):
+        raise UnsafeUrlError(f"{purpose} must not include dot-segment paths")
+    return path.rstrip("/")
+
+
+def _validate_ip_address(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    *,
+    purpose: str,
+    allow_private_hosts: bool,
+) -> None:
+    if ip.is_link_local or ip.is_multicast or ip.is_unspecified or ip.is_reserved:
+        raise UnsafeUrlError(f"{purpose} points at a non-routable address")
+    if not allow_private_hosts and (ip.is_private or ip.is_loopback):
+        raise UnsafeUrlError(f"{purpose} points at a private address")
+
+
+def validate_outbound_url(
+    url: str,
+    *,
+    purpose: str = "outbound URL",
+    allow_private_hosts: bool = False,
+) -> str:
+    """Validate and normalize an outbound HTTP(S) base URL.
+
+    The helper blocks common SSRF footguns: unsupported schemes, embedded
+    credentials, query/fragment smuggling, localhost/private IPs unless
+    explicitly allowed, and link-local metadata endpoints.
+    """
+    candidate = (url or "").strip()
+    if not candidate:
+        raise UnsafeUrlError(f"{purpose} must not be empty")
+
+    parsed = urlparse(candidate)
+    _validate_parsed_url(parsed, purpose)
+    _validate_hostname(
+        parsed.hostname or "",
+        purpose=purpose,
+        allow_private_hosts=allow_private_hosts,
+    )
+
+    normalized_path = _normalize_path(parsed.path, purpose)
+    return urlunparse((parsed.scheme, parsed.netloc, normalized_path, "", "", ""))


### PR DESCRIPTION
## Summary

- Fail closed for HMAC CI approval tokens when `TRAIGENT_APPROVAL_SECRET` is unset.
- Add shared outbound URL validation and apply it to OAuth2 token refresh and hybrid HTTP transport creation.
- Stop logging/returning raw token refresh response bodies that may contain credentials.
- Redact custom evaluator config values before writing them to INFO logs.
- Refactor URL/token-refresh helpers and add direct URL-validation tests for Sonar new-code coverage.

## Issue Coverage

Addresses live production SDK high findings from Traigent/Traigent#846:

- `traigent/core/ci_approval.py` — unsigned HMAC approval accepted without secret.
- `traigent/cloud/token_manager.py` — raw error bodies leaked through logs/results.
- `traigent/cloud/token_manager.py` — unvalidated OAuth2 `cloud_base_url`.
- `traigent/hybrid/transport.py` — unvalidated HTTP `base_url`.
- `traigent/core/evaluator_wrapper.py` — plaintext config dict logged.

## Verification

- `pytest -o addopts='' -p no:rerunfailures tests/unit/utils/test_url_security.py tests/unit/cloud/test_token_manager.py tests/unit/hybrid tests/unit/evaluators/test_hybrid_api_evaluator.py tests/unit/evaluators/test_custom_evaluator_wrapper_budget.py tests/unit/core/test_ci_approval.py`
- `ruff check traigent/utils/url_security.py traigent/cloud/token_manager.py tests/unit/utils/test_url_security.py tests/unit/cloud/test_token_manager.py tests/unit/hybrid/test_transport.py`
- `mypy traigent/utils/url_security.py traigent/cloud/token_manager.py traigent/hybrid/transport.py traigent/core/evaluator_wrapper.py traigent/core/ci_approval.py`
- Commit hooks passed: isort, black, ruff, detect-secrets, bandit, mypy, TVL validation, strict cost guardrails.
