### PR TITLE
Harden integration plugin loading

### DIFF
--- a/tests/unit/integrations/test_plugin_registry.py
+++ b/tests/unit/integrations/test_plugin_registry.py
@@ -86,6 +86,14 @@ def sample_plugin(sample_metadata: PluginMetadata) -> _MinimalPlugin:
     return _MinimalPlugin(sample_metadata)
 
 
+def _allowed_plugins_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create the cwd-local plugin directory allowed by PluginRegistry."""
+    monkeypatch.chdir(tmp_path)
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    return plugins_dir
+
+
 class TestPluginRegistrySingleton:
     """Tests for singleton pattern behavior."""
 
@@ -557,9 +565,11 @@ class TestLoadPluginFromModule:
         mock_module.TestPlugin = TestLoadedPlugin
         mock_import.return_value = mock_module
 
-        isolated_registry.load_plugin_from_module("test.module", "TestPlugin")
+        isolated_registry.load_plugin_from_module(
+            "traigent_plugins.test_module", "TestPlugin"
+        )
 
-        mock_import.assert_called_once_with("test.module")
+        mock_import.assert_called_once_with("traigent_plugins.test_module")
         assert "loaded_plugin" in isolated_registry._plugins
 
     @patch("traigent.integrations.plugin_registry.importlib.import_module")
@@ -589,10 +599,10 @@ class TestLoadPluginFromModule:
         mock_import.return_value = mock_module
 
         isolated_registry.load_plugin_from_module(
-            "test.module", "TestPlugin", config_path=config_path
+            "traigent_plugins.test_module", "TestPlugin", config_path=config_path
         )
 
-        mock_import.assert_called_once_with("test.module")
+        mock_import.assert_called_once_with("traigent_plugins.test_module")
         # Verify plugin was registered with config
         assert "loaded_plugin" in isolated_registry._plugins
 
@@ -604,7 +614,9 @@ class TestLoadPluginFromModule:
         mock_import.side_effect = ImportError("Module not found")
 
         with pytest.raises(TraigentError, match="Failed to import module"):
-            isolated_registry.load_plugin_from_module("invalid.module", "TestPlugin")
+            isolated_registry.load_plugin_from_module(
+                "traigent_plugins.missing", "TestPlugin"
+            )
 
     @patch("traigent.integrations.plugin_registry.importlib.import_module")
     def test_load_plugin_from_module_attribute_error(
@@ -615,7 +627,9 @@ class TestLoadPluginFromModule:
         mock_import.return_value = mock_module
 
         with pytest.raises(TraigentError, match="Class .* not found"):
-            isolated_registry.load_plugin_from_module("test.module", "MissingClass")
+            isolated_registry.load_plugin_from_module(
+                "traigent_plugins.test_module", "MissingClass"
+            )
 
     @patch("traigent.integrations.plugin_registry.importlib.import_module")
     def test_load_plugin_from_module_not_subclass(
@@ -627,37 +641,69 @@ class TestLoadPluginFromModule:
         mock_import.return_value = mock_module
 
         with pytest.raises(TraigentError, match="not a valid IntegrationPlugin"):
-            isolated_registry.load_plugin_from_module("test.module", "NotAPlugin")
+            isolated_registry.load_plugin_from_module(
+                "traigent_plugins.test_module", "NotAPlugin"
+            )
+
+    @patch("traigent.integrations.plugin_registry.importlib.import_module")
+    def test_load_plugin_from_module_rejects_untrusted_module(
+        self, mock_import: MagicMock, isolated_registry: PluginRegistry
+    ) -> None:
+        """Untrusted module paths must fail before import side effects can run."""
+        with pytest.raises(TraigentError, match="not allowed"):
+            isolated_registry.load_plugin_from_module("os", "TestPlugin")
+
+        mock_import.assert_not_called()
+
+    @patch("traigent.integrations.plugin_registry.importlib.import_module")
+    def test_load_plugin_from_module_rejects_invalid_class_name(
+        self, mock_import: MagicMock, isolated_registry: PluginRegistry
+    ) -> None:
+        """Invalid class names must fail before module import."""
+        with pytest.raises(TraigentError, match="class name"):
+            isolated_registry.load_plugin_from_module(
+                "traigent_plugins.test_module", "not-a-class"
+            )
+
+        mock_import.assert_not_called()
 
 
 class TestDiscoverPluginsInDirectory:
     """Tests for plugin discovery in directories."""
 
     def test_discover_plugins_in_directory_empty_dir(
-        self, isolated_registry: PluginRegistry, tmp_path: Path
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test discovery in empty directory returns empty list."""
-        empty_dir = tmp_path / "plugins"
-        empty_dir.mkdir()
+        empty_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
 
         result = isolated_registry.discover_plugins_in_directory(empty_dir)
         assert result == []
 
     def test_discover_plugins_in_directory_nonexistent(
-        self, isolated_registry: PluginRegistry, tmp_path: Path
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test discovery in non-existent directory returns empty list."""
-        nonexistent = tmp_path / "nonexistent"
+        monkeypatch.chdir(tmp_path)
+        nonexistent = tmp_path / "plugins" / "nonexistent"
 
         result = isolated_registry.discover_plugins_in_directory(nonexistent)
         assert result == []
 
     def test_discover_plugins_skips_private_files(
-        self, isolated_registry: PluginRegistry, tmp_path: Path
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that files starting with underscore are skipped."""
-        plugins_dir = tmp_path / "plugins"
-        plugins_dir.mkdir()
+        plugins_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
 
         # Create private file
         private_file = plugins_dir / "_private.py"
@@ -674,10 +720,10 @@ class TestDiscoverPluginsInDirectory:
         mock_spec_from_file: MagicMock,
         isolated_registry: PluginRegistry,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that import errors during discovery are handled gracefully."""
-        plugins_dir = tmp_path / "plugins"
-        plugins_dir.mkdir()
+        plugins_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
 
         plugin_file = plugins_dir / "broken_plugin.py"
         plugin_file.write_text("# Broken plugin")
@@ -688,11 +734,13 @@ class TestDiscoverPluginsInDirectory:
         assert result == []
 
     def test_discover_plugins_loads_valid_plugin(
-        self, isolated_registry: PluginRegistry, tmp_path: Path
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test successful plugin discovery from directory."""
-        plugins_dir = tmp_path / "plugins"
-        plugins_dir.mkdir()
+        plugins_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
 
         # Create a valid plugin file
         plugin_code = '''
@@ -735,11 +783,13 @@ class DiscoveredPlugin(IntegrationPlugin):
         assert "discovered" in isolated_registry._plugins
 
     def test_discover_plugins_with_config_file(
-        self, isolated_registry: PluginRegistry, tmp_path: Path
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test plugin discovery finds and uses config files."""
-        plugins_dir = tmp_path / "plugins"
-        plugins_dir.mkdir()
+        plugins_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
 
         # Create a config file
         config_file = plugins_dir / "discoveredplugin.yaml"
@@ -785,11 +835,13 @@ class DiscoveredPlugin(IntegrationPlugin):
         assert "discovered" in result
 
     def test_discover_plugins_handles_exceptions(
-        self, isolated_registry: PluginRegistry, tmp_path: Path
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that exceptions during plugin loading are logged."""
-        plugins_dir = tmp_path / "plugins"
-        plugins_dir.mkdir()
+        plugins_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
 
         # Create a plugin file that will raise an exception
         plugin_code = """
@@ -799,6 +851,35 @@ raise RuntimeError("Test error during module load")
         plugin_file.write_text(plugin_code)
 
         # Should not raise, just log error
+        result = isolated_registry.discover_plugins_in_directory(plugins_dir)
+        assert result == []
+
+    def test_discover_plugins_rejects_untrusted_directory(
+        self, isolated_registry: PluginRegistry, tmp_path: Path
+    ) -> None:
+        """Plugin discovery must not execute Python from arbitrary directories."""
+        untrusted_dir = tmp_path / "not_plugins"
+        untrusted_dir.mkdir()
+
+        with pytest.raises(TraigentError, match="allowed plugin root"):
+            isolated_registry.discover_plugins_in_directory(untrusted_dir)
+
+    def test_discover_plugins_skips_symlink_escape(
+        self,
+        isolated_registry: PluginRegistry,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Symlinked plugin files must not escape the trusted plugin directory."""
+        plugins_dir = _allowed_plugins_dir(tmp_path, monkeypatch)
+        outside_file = tmp_path / "outside_plugin.py"
+        outside_file.write_text('raise RuntimeError("should not load")\n')
+        link = plugins_dir / "outside_plugin.py"
+        try:
+            link.symlink_to(outside_file)
+        except OSError:
+            pytest.skip("symlink creation is not supported on this filesystem")
+
         result = isolated_registry.discover_plugins_in_directory(plugins_dir)
         assert result == []
 

--- a/traigent/integrations/plugin_registry.py
+++ b/traigent/integrations/plugin_registry.py
@@ -9,6 +9,7 @@ including discovery, registration, and lifecycle management.
 import importlib
 import importlib.util
 import inspect
+import keyword
 import logging
 from pathlib import Path
 from threading import RLock
@@ -20,6 +21,44 @@ if TYPE_CHECKING:
     from traigent.integrations.base_plugin import IntegrationPlugin, PluginMetadata
 
 logger = logging.getLogger(__name__)
+
+_ALLOWED_PLUGIN_MODULE_PREFIXES = (
+    "traigent.integrations",
+    "traigent_plugins",
+    "custom_plugins",
+)
+_UNSAFE_PLUGIN_MODULE_PARTS = {
+    "__builtin__",
+    "__import__",
+    "builtins",
+    "compile",
+    "eval",
+    "exec",
+    "file",
+    "importlib",
+    "input",
+    "open",
+    "os",
+    "raw_input",
+    "subprocess",
+    "sys",
+}
+
+
+def _is_valid_module_identifier(value: str) -> bool:
+    return value.isidentifier() and not keyword.iskeyword(value)
+
+
+def _is_allowed_plugin_module_path(module_path: str) -> bool:
+    parts = module_path.split(".")
+    if not parts or not all(_is_valid_module_identifier(part) for part in parts):
+        return False
+    if any(part.lower() in _UNSAFE_PLUGIN_MODULE_PARTS for part in parts):
+        return False
+    return any(
+        module_path == prefix or module_path.startswith(f"{prefix}.")
+        for prefix in _ALLOWED_PLUGIN_MODULE_PREFIXES
+    )
 
 
 class PluginRegistry:
@@ -305,6 +344,11 @@ class PluginRegistry:
             class_name: Name of the plugin class
             config_path: Optional path to configuration file
         """
+        if not _is_allowed_plugin_module_path(module_path):
+            raise TraigentError(f"Plugin module path '{module_path}' is not allowed")
+        if not _is_valid_module_identifier(class_name):
+            raise TraigentError(f"Plugin class name '{class_name}' is invalid")
+
         try:
             module = importlib.import_module(module_path)
             plugin_class = getattr(module, class_name)
@@ -330,6 +374,60 @@ class PluginRegistry:
         except Exception as e:
             raise TraigentError(f"Failed to load plugin {class_name}: {e}") from None
 
+    def _allowed_plugin_directories(self) -> tuple[Path, ...]:
+        """Return roots trusted for filesystem plugin discovery."""
+        return (
+            self._config_dir,
+            Path.cwd() / "traigent_plugins",
+            Path.cwd() / "plugins",
+            Path(__file__).parent / "contrib",
+        )
+
+    def _resolve_trusted_plugin_directory(self, directory: Path) -> Path:
+        """Resolve and verify that a plugin directory stays inside a trusted root."""
+        resolved = directory.expanduser().resolve()
+        for allowed_dir in self._allowed_plugin_directories():
+            trusted_root = allowed_dir.expanduser().resolve()
+            try:
+                resolved.relative_to(trusted_root)
+                return resolved
+            except (ValueError, RuntimeError):
+                continue
+
+        allowed = ", ".join(str(path) for path in self._allowed_plugin_directories())
+        raise TraigentError(
+            f"Plugin directory '{directory}' is not under an allowed plugin root: {allowed}"
+        )
+
+    @staticmethod
+    def _resolve_plugin_file(py_file: Path, directory: Path) -> Path | None:
+        """Return a plugin file only when it does not escape the trusted directory."""
+        try:
+            resolved_file = py_file.resolve(strict=True)
+            resolved_file.relative_to(directory)
+        except (OSError, RuntimeError, ValueError):
+            logger.warning(
+                "Skipping plugin file outside trusted directory: %s", py_file
+            )
+            return None
+        return resolved_file
+
+    @staticmethod
+    def _safe_config_path(directory: Path, class_name: str) -> Path | None:
+        """Return an adjacent config file only if it remains inside the plugin root."""
+        candidate = directory / f"{class_name.lower()}.yaml"
+        if not candidate.exists():
+            return None
+        try:
+            resolved = candidate.resolve(strict=True)
+            resolved.relative_to(directory)
+        except (OSError, RuntimeError, ValueError):
+            logger.warning(
+                "Ignoring plugin config outside trusted directory: %s", candidate
+            )
+            return None
+        return resolved
+
     def discover_plugins_in_directory(self, directory: Path) -> list[str]:
         """Discover and load plugins from a directory.
 
@@ -340,16 +438,25 @@ class PluginRegistry:
             List of loaded plugin names
         """
         loaded: list[str] = []
+        trusted_directory = self._resolve_trusted_plugin_directory(directory)
 
-        if not directory.exists():
+        if not trusted_directory.exists():
             return loaded
+        if not trusted_directory.is_dir():
+            raise TraigentError(f"Plugin path '{directory}' is not a directory")
 
-        for py_file in directory.glob("*.py"):
+        for py_file in sorted(trusted_directory.glob("*.py")):
             if py_file.stem.startswith("_"):
                 continue
 
-            module_name = py_file.stem
-            spec = importlib.util.spec_from_file_location(module_name, py_file)
+            resolved_plugin_file = self._resolve_plugin_file(py_file, trusted_directory)
+            if resolved_plugin_file is None:
+                continue
+
+            module_name = resolved_plugin_file.stem
+            spec = importlib.util.spec_from_file_location(
+                module_name, resolved_plugin_file
+            )
             if spec and spec.loader:
                 try:
                     module = importlib.util.module_from_spec(spec)
@@ -366,9 +473,8 @@ class PluginRegistry:
                             and obj != IntegrationPlugin
                         ):
                             # Check for config file
-                            candidate = directory / f"{name.lower()}.yaml"
-                            config_path: Path | None = (
-                                candidate if candidate.exists() else None
+                            config_path = self._safe_config_path(
+                                trusted_directory, name
                             )
 
                             plugin = obj(config_path=config_path)


### PR DESCRIPTION
Addresses the next production SDK high-severity slice from #846.

Changes:
- Validate legacy integration plugin module paths before import, limited to trusted Traigent/custom plugin namespaces.
- Reject invalid plugin class names before importing caller-supplied modules.
- Restrict filesystem plugin discovery to trusted plugin roots and resolve directories before loading.
- Skip symlink/traversal plugin files and config files that escape the trusted directory.
- Add regression coverage for unsafe module paths, invalid class names, untrusted directories, and symlink escape attempts.

Verification:
- ruff check traigent/integrations/plugin_registry.py tests/unit/integrations/test_plugin_registry.py
- mypy traigent/integrations/plugin_registry.py
- pytest -o addopts="" -p no:rerunfailures tests/unit/integrations/test_plugin_registry.py tests/unit/integrations/test_plugin_registry_discovery.py tests/unit/integrations/test_plugin_registry_builtin_plugins.py tests/unit/integrations/test_plugin_registry_utils.py -> 65 passed
- Commit hooks passed: isort, black, ruff, detect-secrets, bandit, mypy, TVL validation, strict cost guardrails

Note: a broader pytest -o addopts="" -p no:rerunfailures tests/unit/integrations run hit 4 existing MLflow test environment failures because pandas is not installed; unrelated plugin-registry tests passed in that run.