### PR TITLE
Harden password auth dev-mode validation

### DIFF
--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -1290,8 +1290,8 @@ class TestPasswordAuthentication:
 
         assert result is False
 
-    def test_validate_login_credentials_dev_mode_skips_validation(self):
-        """Test _validate_login_credentials skips validation in dev mode."""
+    def test_validate_login_credentials_dev_mode_enforces_format(self):
+        """Test _validate_login_credentials still validates format in dev mode."""
         manager = AuthManager()
         credentials = {
             "email": "bad",
@@ -1303,7 +1303,7 @@ class TestPasswordAuthentication:
         ):
             result = manager._validate_login_credentials(credentials)
 
-        assert result is True
+        assert result is False
 
     def test_should_rate_limit_login_no_failures(self):
         """Test _should_rate_limit_login returns False with no failures."""

--- a/tests/unit/cloud/test_password_auth_handler.py
+++ b/tests/unit/cloud/test_password_auth_handler.py
@@ -36,6 +36,44 @@ def test_explicit_local_backend_still_enables_dev_mode():
         assert handler._is_dev_mode_enabled() is True
 
 
+def test_dev_mode_still_enforces_credential_format():
+    """Dev mode must not allow malformed email/password dictionaries."""
+    handler = PasswordAuthHandler()
+
+    with patch.object(handler, "_is_dev_mode_enabled", return_value=True):
+        assert handler._validate_credentials({"email": "bad", "password": "x"}) is False
+
+
+def test_validated_backend_api_url_rejects_private_host_outside_dev_mode():
+    """Password login must not send credentials to private hosts in production mode."""
+    handler = PasswordAuthHandler()
+
+    with patch.object(handler, "_is_dev_mode_enabled", return_value=False):
+        with pytest.raises(ValueError, match="host is not allowed"):
+            handler._validated_backend_api_url("http://127.0.0.1:5000/api/v1")
+
+
+def test_validated_backend_api_url_allows_local_host_in_dev_mode():
+    """Explicit dev mode may target a local backend."""
+    handler = PasswordAuthHandler()
+
+    with patch.object(handler, "_is_dev_mode_enabled", return_value=True):
+        assert (
+            handler._validated_backend_api_url("http://localhost:5000/api/v1/")
+            == "http://localhost:5000/api/v1"
+        )
+
+
+def test_validated_backend_api_url_rejects_embedded_credentials():
+    """Backend URL validation should fail before credentials are posted."""
+    handler = PasswordAuthHandler()
+
+    with pytest.raises(ValueError, match="must not include credentials"):
+        handler._validated_backend_api_url(
+            "https://user:pass@portal.traigent.ai/api/v1"  # pragma: allowlist secret
+        )
+
+
 @pytest.mark.asyncio
 async def test_invalid_credentials_propagate_even_in_dev_mode():
     """Wrong credentials should fail loudly instead of returning mock tokens."""

--- a/traigent/cloud/password_auth_handler.py
+++ b/traigent/cloud/password_auth_handler.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import ipaddress
 import json
 import logging
 import os
@@ -18,6 +19,7 @@ import secrets
 import time
 import uuid
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
 from traigent.core.constants import MAX_RETRIES
@@ -164,9 +166,9 @@ class PasswordAuthHandler:
         """Validate email/password credentials without logging sensitive values."""
         if self._is_dev_mode_enabled():
             logger.warning(
-                "Development mode enabled - skipping strict credential validation"
+                "Development mode enabled - backend outage fallback is allowed, "
+                "but credential format is still enforced"
             )
-            return True
 
         required_fields = {"email", "password"}
         if not all(field in credentials for field in required_fields):
@@ -210,6 +212,40 @@ class PasswordAuthHandler:
 
         return False
 
+    def _validated_backend_api_url(self, backend_api_url: str) -> str:
+        """Validate the backend login target before sending credentials."""
+        candidate = (backend_api_url or "").strip().rstrip("/")
+        parsed = urlparse(candidate)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Backend API URL is invalid") from None
+        if parsed.username or parsed.password:
+            raise ValueError("Backend API URL must not include credentials") from None
+        if parsed.query or parsed.fragment:
+            raise ValueError(
+                "Backend API URL must not include query or fragment data"
+            ) from None
+
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("Backend API URL is invalid") from None
+
+        normalized_host = hostname.strip("[]").rstrip(".").lower()
+        allow_local = self._is_dev_mode_enabled()
+        if not allow_local and (
+            normalized_host in {"localhost", "localhost.localdomain"}
+            or normalized_host.endswith(".localhost")
+        ):
+            raise ValueError("Backend API URL host is not allowed") from None
+
+        try:
+            host_ip = ipaddress.ip_address(normalized_host)
+        except ValueError:
+            return candidate
+
+        if not allow_local and not host_ip.is_global:
+            raise ValueError("Backend API URL host is not allowed") from None
+        return candidate
+
     async def _perform_authentication(
         self, credentials: dict[str, str]
     ) -> dict[str, Any] | None:
@@ -222,7 +258,9 @@ class PasswordAuthHandler:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.get_cloud_api_url()
+        backend_api_url = self._validated_backend_api_url(
+            BackendConfig.get_cloud_api_url()
+        )
         login_url = f"{backend_api_url}/auth/login"
 
         client = ResilientClient(
@@ -246,15 +284,17 @@ class PasswordAuthHandler:
                     if response.status == 401:
                         raise InvalidCredentialsError("Invalid credentials")
                     if response.status == 429:
-                        error_msg = await response.text()
-                        raise Exception(f"429 Rate Limited: {error_msg}")
+                        await response.text()
+                        raise RuntimeError("Backend authentication rate limited")
                     if response.status != 200:
-                        error_text = await response.text()
-                        raise Exception(f"{response.status}: {error_text}")
+                        await response.text()
+                        raise RuntimeError(
+                            f"Backend authentication failed with status {response.status}"
+                        )
 
                     data = await response.json()
                     if not data.get("success"):
-                        raise ValueError(data.get("error", "Authentication failed"))
+                        raise ValueError("Authentication failed")
 
                     token_data = data.get("data", {})
                     access_token = token_data.get("access_token", "")
@@ -276,9 +316,10 @@ class PasswordAuthHandler:
                     return token_data
 
         try:
-            return await client.execute_with_retry(
+            result = await client.execute_with_retry(
                 perform_login, operation_name="backend_authentication"
             )
+            return cast(dict[str, Any] | None, result)
         except InvalidCredentialsError:
             raise
         except Exception as exc:


### PR DESCRIPTION
Addresses the next live SDK high-severity finding from #846.

Changes:
- Dev mode no longer bypasses email/password format validation. It only controls the explicit mock-token fallback after non-auth backend outages.
- Password login now validates the backend API URL before sending credentials, rejecting embedded credentials, query/fragment data, and private or localhost targets outside dev mode.
- Backend auth error handling now drains but does not include raw response bodies in raised errors, preventing accidental token or server-detail leakage.
- Updated regression tests for dev-mode credential validation and backend URL validation.

Verification:
- ruff check traigent/cloud/password_auth_handler.py tests/unit/cloud/test_password_auth_handler.py tests/unit/cloud/test_cloud_authentication.py
- mypy traigent/cloud/password_auth_handler.py
- pytest -o addopts="" -p no:rerunfailures tests/unit/cloud/test_password_auth_handler.py tests/unit/cloud/test_cloud_authentication.py tests/unit/test_secure_auth.py -> 120 passed
- Commit hooks passed: isort, black, ruff, detect-secrets, bandit, mypy, TVL validation, strict cost guardrails

Note: an additional broader auth-security run hit an existing timing-variance assertion in tests/unit/cloud/test_authentication_security.py::TestAuthenticationFlows::test_account_enumeration_prevention. That path exercises API-key authentication timing, not this password-auth handler change.