### PR TITLE
Harden API key helper secret handling

### DIFF
--- a/scripts/auth/get_api_key.py
+++ b/scripts/auth/get_api_key.py
@@ -2,20 +2,21 @@
 """Generate Traigent API key from email/password.
 
 Usage:
-    # Via command line args:
-    python scripts/auth/get_api_key.py --email user@example.com --password yourpass
+    # Via interactive prompt:
+    python scripts/auth/get_api_key.py --email user@example.com
 
     # Via environment variables:
     export TRAIGENT_AUTH_EMAIL=user@example.com
     export TRAIGENT_AUTH_PASSWORD=yourpass
     python scripts/auth/get_api_key.py
 
-    # Mixed (CLI args take precedence):
-    export TRAIGENT_AUTH_PASSWORD=yourpass
-    python scripts/auth/get_api_key.py --email user@example.com
+    # Via stdin for automation:
+    printf '%s\n' "$TRAIGENT_AUTH_PASSWORD" | \
+        python scripts/auth/get_api_key.py --email user@example.com --password-stdin
 """
 
 import argparse
+import getpass
 import ipaddress
 import json
 import os
@@ -23,9 +24,10 @@ import socket
 import sys
 from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 from urllib.parse import urlparse, urlunparse
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 # Auto-load .env file if python-dotenv is available
 try:
@@ -76,6 +78,14 @@ def _safe_response_headers(headers: Mapping[str, str]) -> dict[str, str]:
         else:
             safe_headers[key] = value
     return safe_headers
+
+
+def _read_password_from_stdin() -> str:
+    """Read one password line from stdin without exposing it in process args."""
+    password = sys.stdin.readline().rstrip("\r\n")
+    if not password:
+        raise ValueError("No password received on stdin") from None
+    return password
 
 
 def normalize_backend_url(backend_url: str) -> str:
@@ -249,7 +259,7 @@ def get_api_key(
     if key_resp.status_code != 201:
         raise Exception(f"API key creation failed: HTTP {key_resp.status_code}")
 
-    api_key = key_data["data"]["key"]
+    api_key = cast(str, key_data["data"]["key"])
     print("\n✅ API key created successfully!")
 
     return api_key
@@ -265,9 +275,9 @@ def main() -> None:
         help="Email address (or set TRAIGENT_AUTH_EMAIL env var)",
     )
     parser.add_argument(
-        "--password",
-        "-p",
-        help="Password (or set TRAIGENT_AUTH_PASSWORD env var)",
+        "--password-stdin",
+        action="store_true",
+        help="Read password from stdin instead of TRAIGENT_AUTH_PASSWORD or prompt",
     )
     parser.add_argument(
         "--backend-url",
@@ -279,7 +289,7 @@ def main() -> None:
         "-v",
         action="store_true",
         default=True,
-        help="Show full response bodies (default: True)",
+        help="Show redacted response diagnostics (default: True)",
     )
     parser.add_argument(
         "--quiet",
@@ -290,9 +300,14 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # Get values from args or env vars (args take precedence)
+    # Get values from args or env vars. Passwords are intentionally never accepted
+    # as argv because local users can inspect process arguments on many systems.
     email = args.email or os.environ.get("TRAIGENT_AUTH_EMAIL")
-    password = args.password or os.environ.get("TRAIGENT_AUTH_PASSWORD")
+    password = os.environ.get("TRAIGENT_AUTH_PASSWORD")
+    if args.password_stdin:
+        password = _read_password_from_stdin()
+    elif not password and sys.stdin.isatty():
+        password = getpass.getpass("Password: ")
     backend_url = (
         args.backend_url
         or os.environ.get("TRAIGENT_BACKEND_URL")
@@ -305,7 +320,10 @@ def main() -> None:
         sys.exit(1)
 
     if not password:
-        print("Error: Password required. Use --password or set TRAIGENT_AUTH_PASSWORD")
+        print(
+            "Error: Password required. Set TRAIGENT_AUTH_PASSWORD, use "
+            "--password-stdin, or run from an interactive terminal."
+        )
         sys.exit(1)
 
     verbose = not args.quiet

--- a/tests/unit/scripts/test_get_api_key.py
+++ b/tests/unit/scripts/test_get_api_key.py
@@ -6,6 +6,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
+from unittest.mock import Mock
 
 import pytest
 
@@ -84,10 +85,71 @@ def test_main_quiet_prints_generated_key(
             "get_api_key.py",
             "--email",
             "user@example.com",
-            "--password",
-            "test-password",  # pragma: allowlist secret
             "--backend-url",
             "https://api.traigent.ai",
+            "--quiet",
+        ],
+    )
+    monkeypatch.setenv(
+        "TRAIGENT_AUTH_PASSWORD",
+        "test-password",  # pragma: allowlist secret
+    )
+
+    module.main()
+
+    assert capfd.readouterr().out == "tg_generated_key\n"
+
+
+def test_main_rejects_password_cli_argument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passwords must not be accepted through argv."""
+    module = _load_get_api_key_module()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "get_api_key.py",
+            "--email",
+            "user@example.com",
+            "--password",
+            "test-password",  # pragma: allowlist secret
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 2
+
+
+def test_main_reads_password_from_stdin(
+    monkeypatch: pytest.MonkeyPatch, capfd: pytest.CaptureFixture[str]
+) -> None:
+    """Automation can provide a password through stdin instead of argv."""
+    module = _load_get_api_key_module()
+
+    monkeypatch.setattr(
+        module,
+        "get_api_key",
+        lambda email, password, backend_url, verbose=True: "tg_generated_key"
+        if password == "stdin-password"  # pragma: allowlist secret
+        else "wrong",
+    )
+    monkeypatch.setattr(
+        sys.stdin,
+        "readline",
+        lambda: "stdin-password\n",  # pragma: allowlist secret
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "get_api_key.py",
+            "--email",
+            "user@example.com",
+            "--password-stdin",
             "--quiet",
         ],
     )
@@ -95,3 +157,51 @@ def test_main_quiet_prints_generated_key(
     module.main()
 
     assert capfd.readouterr().out == "tg_generated_key\n"
+
+
+def test_verbose_responses_are_redacted(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Verbose diagnostics must not print JWTs or generated API keys."""
+    module = _load_get_api_key_module()
+    jwt = "jwt.secret.token"  # pragma: allowlist secret
+    api_key = "tg_secret_key"  # pragma: allowlist secret
+
+    responses = [
+        Mock(
+            status_code=200,
+            headers={"Authorization": "Bearer " + jwt},
+            json=lambda: {
+                "success": True,
+                "data": {
+                    "access_token": jwt,
+                    "refresh_token": "refresh-secret",  # pragma: allowlist secret
+                },
+            },
+        ),
+        Mock(
+            status_code=201,
+            headers={},
+            json=lambda: {"data": {"key": api_key}},
+        ),
+    ]
+    monkeypatch.setattr(
+        module.requests, "post", lambda *args, **kwargs: responses.pop(0)
+    )
+
+    assert (
+        module.get_api_key(
+            "user@example.com",
+            "test-password",  # pragma: allowlist secret
+            "https://api.traigent.ai",
+            verbose=True,
+        )
+        == api_key
+    )
+
+    output = capsys.readouterr().out
+    assert jwt not in output
+    assert api_key not in output
+    assert "refresh-secret" not in output
+    assert '"access_token": "***"' in output
+    assert '"key": "***"' in output


### PR DESCRIPTION
Addresses the scripts/auth high-severity findings from #846.

Changes:
- Removed the password CLI argument so passwords are not exposed through process listings.
- Added --password-stdin for automation, while keeping TRAIGENT_AUTH_PASSWORD and interactive getpass support.
- Kept intentionally requested final API-key output behavior, but response diagnostics remain redacted.
- Added regression tests that reject --password, verify stdin password flow, and ensure verbose response bodies do not print JWTs, refresh tokens, or generated API keys.

Verification:
- ruff check scripts/auth/get_api_key.py tests/unit/scripts/test_get_api_key.py
- mypy scripts/auth/get_api_key.py
- pytest -o addopts="" -p no:rerunfailures tests/unit/scripts/test_get_api_key.py -> 12 passed
- Commit hooks passed: isort, detect-secrets, bandit, mypy, TVL validation, strict cost guardrails