### PR TITLE
Redact database URLs in migration logs

### DIFF
--- a/scripts/db/migrate_optuna.py
+++ b/scripts/db/migrate_optuna.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import argparse
 import os
 import sqlite3
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, Tuple
-from urllib.parse import urlparse
+from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 from traigent.utils.logging import get_logger
 
@@ -40,6 +41,36 @@ def _load_migrations(directory: Path) -> Iterable[Path]:
     return sorted(directory.glob("*.sql"))
 
 
+def _redact_database_url(database_url: str) -> str:
+    """Return a database URL safe enough for logs."""
+    parsed = urlparse(database_url)
+    if parsed.scheme.startswith("sqlite"):
+        return database_url
+    if not parsed.netloc:
+        return "<invalid database URL>"
+
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    try:
+        port = f":{parsed.port}" if parsed.port else ""
+    except ValueError:
+        port = ""
+
+    userinfo = ""
+    if parsed.username is not None:
+        userinfo = parsed.username
+        if parsed.password is not None:
+            userinfo += ":***"
+        userinfo += "@"
+    elif parsed.password is not None:
+        userinfo = "***@"
+
+    query = "***" if parsed.query else ""
+    return urlunparse(parsed._replace(netloc=f"{userinfo}{host}{port}", query=query))
+
+
 def _adapt_sql_for_sqlite(sql: str) -> str:
     replacements = {
         "UUID": "TEXT",
@@ -54,7 +85,7 @@ def _adapt_sql_for_sqlite(sql: str) -> str:
     return sql
 
 
-def _connect(database_url: str) -> Tuple[str, object]:
+def _connect(database_url: str) -> tuple[str, Any]:
     parsed = urlparse(database_url)
     scheme = parsed.scheme
 
@@ -83,14 +114,12 @@ def _connect(database_url: str) -> Tuple[str, object]:
     return "sqlalchemy", engine
 
 
-def _execute_sql(engine_type: str, handle: object, sql: str) -> None:
+def _execute_sql(engine_type: str, handle: Any, sql: str) -> None:
     if engine_type == "sqlite":
         conn = handle
         conn.executescript(sql)
         conn.commit()
         return
-
-    from sqlalchemy import text
 
     engine = handle
     statements = [stmt.strip() for stmt in sql.split(";") if stmt.strip()]
@@ -107,7 +136,11 @@ def apply_migrations(database_url: str, migrations_dir: Path, dry_run: bool) -> 
         logger.info("No migrations found in %s", migrations_dir)
         return
 
-    logger.info("Applying %s migrations to %s", len(migrations), database_url)
+    logger.info(
+        "Applying %s migrations to %s",
+        len(migrations),
+        _redact_database_url(database_url),
+    )
 
     for migration in migrations:
         sql = migration.read_text()

--- a/tests/unit/scripts/test_migrate_optuna.py
+++ b/tests/unit/scripts/test_migrate_optuna.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 
+from scripts.db import migrate_optuna
 from scripts.db.migrate_optuna import apply_migrations
 
 
@@ -37,3 +38,39 @@ def test_migration_applies_to_sqlite(tmp_path):
     )
     assert cursor.fetchone() is not None
     conn.close()
+
+
+def test_redact_database_url_hides_password_and_query():
+    password = "secret"  # pragma: allowlist secret
+    database_url = (
+        f"postgresql://user:{password}@db.example.com:5432/traigent?sslmode=require"
+    )
+    redacted = migrate_optuna._redact_database_url(database_url)
+
+    assert "secret" not in redacted
+    assert "sslmode=require" not in redacted
+    assert redacted == "postgresql://user:***@db.example.com:5432/traigent?***"
+
+
+def test_apply_migrations_logs_redacted_database_url(tmp_path, monkeypatch, caplog):
+    class FakeConnection:
+        def close(self):
+            pass
+
+    migrations_dir = tmp_path / "migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "0001.sql").write_text("SELECT 1;")
+    password = "secret"  # pragma: allowlist secret
+    database_url = f"postgresql://user:{password}@db.example.com/traigent"
+
+    monkeypatch.setattr(
+        migrate_optuna,
+        "_connect",
+        lambda url: ("sqlite", FakeConnection()),
+    )
+
+    caplog.set_level("INFO")
+    migrate_optuna.apply_migrations(database_url, migrations_dir, dry_run=True)
+
+    assert "secret" not in caplog.text
+    assert "postgresql://user:***@db.example.com/traigent" in caplog.text


### PR DESCRIPTION
Addresses a contained high-severity script finding from #846.

Changes:
- Added `_redact_database_url()` for migration logging.
- Redacts database passwords and query strings before logging migration targets.
- Keeps sqlite URLs unchanged for local migration clarity.
- Added regression coverage for the redactor and the `apply_migrations()` log path.
- Cleaned stale typing in the same script so ruff/mypy pass on the touched file.

Verification:
- ruff check scripts/db/migrate_optuna.py tests/unit/scripts/test_migrate_optuna.py
- mypy scripts/db/migrate_optuna.py
- pytest -o addopts="" -p no:rerunfailures tests/unit/scripts/test_migrate_optuna.py -> 4 passed
- Commit hooks passed: isort, detect-secrets, bandit, mypy, TVL validation, strict cost guardrails