### PR TITLE
fix(security): remove hard-coded dev-mode credential sentinel (Sonar S6418)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -788,15 +788,6 @@
         "line_number": 16
       }
     ],
-    "tests/unit/cloud/test_credential_manager.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/cloud/test_credential_manager.py",
-        "hashed_secret": "020accf7751ee352c63fe6f98bc23247c907e67a",
-        "is_verified": false,
-        "line_number": 40
-      }
-    ],
     "tests/unit/cloud/test_credential_resolver.py": [
       {
         "type": "Secret Keyword",
@@ -1265,5 +1256,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-01T10:34:43Z"
+  "generated_at": "2026-05-10T04:27:10Z"
 }

--- a/tests/unit/cloud/test_credential_manager.py
+++ b/tests/unit/cloud/test_credential_manager.py
@@ -10,6 +10,7 @@ from traigent.cloud.credential_manager import CredentialManager
 def _clear_env(monkeypatch) -> None:
     for key in (
         "TRAIGENT_API_KEY",
+        "TRAIGENT_DEV_API_KEY",
         "TRAIGENT_DEV_MODE",
         "TRAIGENT_GENERATE_MOCKS",
         "TESTING",
@@ -27,16 +28,41 @@ def test_testing_env_does_not_enable_dev_fallback(monkeypatch) -> None:
         assert CredentialManager.get_credentials() == {}
 
 
-def test_explicit_dev_mode_still_enables_dev_fallback(monkeypatch) -> None:
-    """Development mode should still expose the dev credential path."""
+def test_dev_mode_without_dev_api_key_returns_none(monkeypatch) -> None:
+    """Enabling TRAIGENT_DEV_MODE alone must NOT return a sentinel credential.
+
+    The SDK no longer ships a hard-coded sentinel string fallback
+    (Sonar python:S6418); the operator must explicitly set
+    ``TRAIGENT_DEV_API_KEY`` for the dev-mode credential path to fire.
+    """
     _clear_env(monkeypatch)
     monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
 
     with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
-        assert CredentialManager.get_api_key() == "test_api_key_for_development"
+        assert CredentialManager.get_api_key() is None
+        assert CredentialManager.get_credentials() == {}
+
+
+def test_dev_mode_with_dev_api_key_returns_value(monkeypatch) -> None:
+    """When TRAIGENT_DEV_API_KEY is set alongside dev mode, return that value."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
+    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "dev-key-xyz")  # pragma: allowlist secret
+
+    with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
+        assert CredentialManager.get_api_key() == "dev-key-xyz"  # pragma: allowlist secret
         creds = CredentialManager.get_credentials()
 
-    assert (
-        creds["api_key"] == "test_api_key_for_development"
-    )  # pragma: allowlist secret
+    assert creds["api_key"] == "dev-key-xyz"  # pragma: allowlist secret
     assert creds["source"] == "development"
+
+
+def test_dev_mode_with_blank_dev_api_key_returns_none(monkeypatch) -> None:
+    """Whitespace-only TRAIGENT_DEV_API_KEY is treated as unset."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
+    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "   ")
+
+    with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
+        assert CredentialManager.get_api_key() is None
+        assert CredentialManager.get_credentials() == {}

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -57,10 +57,22 @@ class CredentialManager:
                 logger.debug("Using JWT token from CLI credentials")
                 return cast(str, stored_creds["jwt_token"])
 
-        # Development fallback
+        # Development fallback. The dev-mode credential is no longer hard-coded
+        # in source: the operator must explicitly set TRAIGENT_DEV_API_KEY when
+        # they enable development mode. This removes the SAST blocker on a
+        # literal credential string in source (Sonar python:S6418) and makes
+        # accidental dev-mode-in-production strictly inert rather than handing
+        # out a known sentinel string.
         if cls._is_development_environment():
-            logger.debug("Using default test credentials (development only)")
-            return "test_api_key_for_development"
+            dev_key = cls._get_dev_api_key()
+            if dev_key:
+                logger.debug("Using TRAIGENT_DEV_API_KEY (development only)")
+                return dev_key
+            logger.debug(
+                "Development mode is enabled but TRAIGENT_DEV_API_KEY is not set; "
+                "no dev-mode credential will be returned. Set TRAIGENT_DEV_API_KEY "
+                "to a value the backend recognizes for dev-mode auth."
+            )
 
         logger.debug("No API key found in any source")
         return None
@@ -87,13 +99,15 @@ class CredentialManager:
             stored_creds["source"] = "cli"
             return stored_creds
 
-        # Development fallback
+        # Development fallback (env-driven; see get_api_key for rationale).
         if cls._is_development_environment():
-            return {
-                "api_key": "test_api_key_for_development",  # pragma: allowlist secret
-                "backend_url": BackendConfig.get_backend_url(),
-                "source": "development",
-            }
+            dev_key = cls._get_dev_api_key()
+            if dev_key:
+                return {
+                    "api_key": dev_key,
+                    "backend_url": BackendConfig.get_backend_url(),
+                    "source": "development",
+                }
 
         return {}
 
@@ -203,6 +217,18 @@ class CredentialManager:
         """Return API key from supported environment variables."""
 
         return os.environ.get("TRAIGENT_API_KEY")
+
+    @staticmethod
+    def _get_dev_api_key() -> str | None:
+        """Return the development-mode API key from TRAIGENT_DEV_API_KEY.
+
+        Used only when :meth:`_is_development_environment` is true. Empty or
+        unset values yield None — the SDK does NOT fall back to a hard-coded
+        sentinel string, so accidentally enabling dev mode in production is
+        inert rather than handing out a known credential.
+        """
+        value = os.environ.get("TRAIGENT_DEV_API_KEY", "").strip()
+        return value or None
 
     @classmethod
     def clear_credentials(cls) -> bool:

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -108,6 +108,11 @@ class CredentialManager:
                     "backend_url": BackendConfig.get_backend_url(),
                     "source": "development",
                 }
+            logger.debug(
+                "Development mode is enabled but TRAIGENT_DEV_API_KEY is not set; "
+                "returning empty credentials. Set TRAIGENT_DEV_API_KEY to a value "
+                "the backend recognizes for dev-mode auth."
+            )
 
         return {}
 


### PR DESCRIPTION
## What

Replace the hard-coded `"test_api_key_for_development"` sentinel in `traigent/cloud/credential_manager.py` with an env-var lookup (`TRAIGENT_DEV_API_KEY`).

## Why

Sonar python:S6418 (Blocker, Vulnerability) on `traigent/cloud/credential_manager.py:63` and `:93`. The literal credential string sat behind a `_is_development_environment()` gate, but:

- The line-93 occurrence had `# pragma: allowlist secret` (suppresses `detect-secrets` only — Sonar still fires).
- The line-63 occurrence had no annotation at all, so the Sonar issue stayed Open + Blocker.
- More importantly, an accidental dev-mode toggle in prod (env-var injection, misconfigured deployment) handed out a known sentinel string. If any backend happened to recognise it, that's a backdoor; if not, it's still a confusing fingerprint to deal with.

## How

- New helper `_get_dev_api_key()` reads `TRAIGENT_DEV_API_KEY` env var. Empty / whitespace-only → `None`.
- `get_api_key` and `get_credentials` now consult `_get_dev_api_key()` only when dev mode is enabled, and return `None` / `{}` if the env var isn't set.
- No literal credential string remains in source (`grep test_api_key_for_development traigent/ tests/` returns zero matches).

## Behavioural change

Anyone who relied on `TRAIGENT_DEV_MODE=true` alone now also needs `TRAIGENT_DEV_API_KEY=<value>`. The migration is a one-line `.env` edit. The default `if dev_mode: return sentinel` path is gone — accidentally enabling dev mode in production is now strictly inert rather than handing out a known string.

## Tests

```
$ pytest tests/unit/cloud/test_credential_manager.py -v
test_testing_env_does_not_enable_dev_fallback     PASSED
test_dev_mode_without_dev_api_key_returns_none    PASSED
test_dev_mode_with_dev_api_key_returns_value      PASSED
test_dev_mode_with_blank_dev_api_key_returns_none PASSED
4 passed in 0.03s
```

The retired `test_explicit_dev_mode_still_enables_dev_fallback` is replaced by the four cases above, which cover: dev-mode-but-no-key (returns None — the new behaviour), dev-mode-with-key (returns the env value), and the whitespace-only edge.

## Provenance

Reported by Sonar as `python:S6418` on the SDK's static analysis dashboard. Surfaced during the cleanup pass on the AI security review (issue Traigent/Traigent#846, post-#853–#857 batch). The literal was the next-most-visible secret-shaped string in `cloud/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)