### PR TITLE
docs+test: address codex review on PR #861 (sync to develop)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,7 +167,7 @@
         "filename": "docs/features/authentication.md",
         "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
         "is_verified": false,
-        "line_number": 371
+        "line_number": 382
       }
     ],
     "docs/installation-guide-offline.md": [
@@ -1256,5 +1256,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T04:27:10Z"
+  "generated_at": "2026-05-10T15:13:48Z"
 }

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -164,7 +164,15 @@ Credentials are stored using file-based storage with restricted permissions:
 The SDK checks for credentials in this order:
 1. Environment variables (highest priority)
 2. CLI stored credentials (from `traigent auth login`)
-3. Default test credentials (development mode only)
+3. Explicit dev-mode credentials — only when **both** of these are set:
+   - `TRAIGENT_DEV_MODE=true` (or `TRAIGENT_GENERATE_MOCKS=true`)
+   - `TRAIGENT_DEV_API_KEY=<value>`
+
+   Setting only the dev-mode flag (without `TRAIGENT_DEV_API_KEY`) returns no
+   credential — the SDK does **not** ship a hard-coded sentinel string fallback.
+   This keeps an accidental `TRAIGENT_DEV_MODE=true` in production strictly
+   inert rather than handing out a known string the backend may have hardcoded
+   for testing.
 
 ## Security Features
 

--- a/tests/unit/cloud/test_credential_manager.py
+++ b/tests/unit/cloud/test_credential_manager.py
@@ -66,3 +66,45 @@ def test_dev_mode_with_blank_dev_api_key_returns_none(monkeypatch) -> None:
     with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
         assert CredentialManager.get_api_key() is None
         assert CredentialManager.get_credentials() == {}
+
+
+def test_dev_api_key_alone_does_not_activate_dev_fallback(monkeypatch) -> None:
+    """Setting TRAIGENT_DEV_API_KEY without TRAIGENT_DEV_MODE / GENERATE_MOCKS
+    must NOT activate the dev-mode credential path.
+
+    The dev-mode toggle is the gate; the API-key env var only supplies the
+    value once the gate is open. Without the gate, the SDK should behave as
+    if no credentials are configured.
+    """
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "leaked-dev-key")  # pragma: allowlist secret
+
+    with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
+        assert CredentialManager.get_api_key() is None
+        assert CredentialManager.get_credentials() == {}
+
+
+def test_get_auth_headers_jwt_shaped_dev_key_uses_bearer(monkeypatch) -> None:
+    """A dot-separated three-segment dev key is treated as a JWT and emitted
+    via Authorization: Bearer rather than X-API-Key. Pins the heuristic in
+    `get_auth_headers` for the env-driven dev path."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
+    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "header.payload.signature")  # pragma: allowlist secret
+
+    with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
+        headers = CredentialManager.get_auth_headers()
+
+    assert headers == {"Authorization": "Bearer header.payload.signature"}
+
+
+def test_get_auth_headers_opaque_dev_key_uses_x_api_key(monkeypatch) -> None:
+    """An opaque (non-JWT-shaped) dev key uses the X-API-Key header."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
+    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "tg_opaque_token_value")  # pragma: allowlist secret
+
+    with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
+        headers = CredentialManager.get_auth_headers()
+
+    assert headers == {"X-API-Key": "tg_opaque_token_value"}


### PR DESCRIPTION
## What

Sync to `develop` of the docs + test improvements landed on the `main`-target PR [#861](https://github.com/Traigent/Traigent/pull/861) (cherry-pick of `1498daa4`). Keeps `develop` aligned with the post-codex-review state of the dev-credential refactor — no functional code change here, since [#858](https://github.com/Traigent/Traigent/pull/858) already landed the credential change on develop.

## Why

Codex (gpt-5.5 xhigh) reviewed #861 and surfaced two non-blocking nits that apply equally to develop:

1. **Stale auth docs** at `docs/features/authentication.md:167` still said *"Default test credentials (development mode only)"* — the new contract is "explicit `TRAIGENT_DEV_API_KEY` when dev flags are enabled".
2. **Test gaps** — no test pinning that `TRAIGENT_DEV_API_KEY` alone (without dev-mode flag) does NOT authenticate, and no test pinning the JWT-vs-X-API-Key heuristic in `get_auth_headers` for the dev path.

## Diff

- `docs/features/authentication.md` — Priority Order section now describes the env-var-driven contract.
- `tests/unit/cloud/test_credential_manager.py` — adds 3 tests:
  - `test_dev_api_key_alone_does_not_activate_dev_fallback`
  - `test_get_auth_headers_jwt_shaped_dev_key_uses_bearer`
  - `test_get_auth_headers_opaque_dev_key_uses_x_api_key`
- `.secrets.baseline` — auto-bumped by detect-secrets pre-commit (line shifts only).

## Verification

```
$ pytest tests/unit/cloud/test_credential_manager.py -v
7 passed in 0.04s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)