### PR TITLE
Extend Python SDK observability lifecycle contracts

### DIFF
--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -24,7 +24,7 @@ from traigent.utils.exceptions import AuthenticationError, ClientError
 
 
 def _encoded_trace_batch_size(traces: list[dict]) -> int:
-    return len(json.dumps({"traces": traces}, default=str).encode("utf-8"))
+    return len(json.dumps({"traces": traces}).encode("utf-8"))
 
 
 def test_observability_client_flushes_trace_payloads():
@@ -192,6 +192,33 @@ def test_observability_client_drops_single_payload_over_byte_limit():
     assert result.items_dropped == 1
     assert result.items_pending == 0
     assert "exceeding max_batch_bytes" in result.errors[0]
+
+
+def test_observability_client_drops_non_json_payload_before_send():
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    transport = _SyncBatchTransport(
+        sender=sender,
+        batch_size=100,
+        max_buffer_age=999.0,
+        max_queue_size=10,
+        max_batch_bytes=10_000,
+    )
+
+    assert transport.submit("trace_bad", {"id": "trace_bad", "when": datetime.now()})
+    assert transport.submit("trace_good", {"id": "trace_good", "name": "ok"})
+
+    result = transport.flush()
+    transport.close()
+
+    assert sent_batches == [[{"id": "trace_good", "name": "ok"}]]
+    assert result.items_sent == 1
+    assert result.items_dropped == 1
+    assert result.items_pending == 0
+    assert "not JSON serializable" in result.errors[0]
 
 
 def test_observability_client_preserves_existing_usage_fields_on_update():

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -128,6 +128,41 @@ def test_observability_client_tracks_dropped_payloads_when_buffer_is_full():
     assert result.items_dropped >= 1
 
 
+def test_observability_client_chunks_flushes_by_byte_limit():
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=100,
+            max_buffer_age=999.0,
+            max_queue_size=10,
+            max_batch_bytes=1,
+        ),
+        sender=sender,
+    )
+
+    for index in range(3):
+        trace_id = client.start_trace(
+            f"trace-{index}",
+            trace_id=f"trace_{index}",
+            input_data={"prompt": "hello"},
+        )
+        client.end_trace(trace_id, output_data={"answer": "hi"})
+
+    result = client.flush()
+    client.close()
+
+    assert result.success is True
+    assert [len(batch) for batch in sent_batches] == [1, 1, 1]
+    assert result.items_pending == 0
+    assert result.successful_batches == 3
+
+
 def test_observability_client_preserves_existing_usage_fields_on_update():
     sent_batches: list[list[dict]] = []
 

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
 from datetime import datetime, timezone
 from urllib import error
@@ -16,9 +17,14 @@ from traigent.observability import (
     ThumbRating,
     observe,
 )
+from traigent.observability.client import _SyncBatchTransport
 from traigent.observability.decorators import set_default_observability_client
 from traigent.observability.dtos import ObservationDTO
 from traigent.utils.exceptions import AuthenticationError, ClientError
+
+
+def _encoded_trace_batch_size(traces: list[dict]) -> int:
+    return len(json.dumps({"traces": traces}, default=str).encode("utf-8"))
 
 
 def test_observability_client_flushes_trace_payloads():
@@ -134,33 +140,58 @@ def test_observability_client_chunks_flushes_by_byte_limit():
     def sender(traces):
         sent_batches.append(traces)
 
-    client = ObservabilityClient(
-        ObservabilityConfig(
-            backend_origin="http://localhost:5000",
-            api_key="test-key",  # pragma: allowlist secret
-            batch_size=100,
-            max_buffer_age=999.0,
-            max_queue_size=10,
-            max_batch_bytes=1,
-        ),
+    payloads = [
+        {"id": f"trace_{index}", "input_data": {"prompt": "x" * 64}}
+        for index in range(3)
+    ]
+    max_batch_bytes = _encoded_trace_batch_size(payloads[:2])
+    assert _encoded_trace_batch_size(payloads[:3]) > max_batch_bytes
+
+    transport = _SyncBatchTransport(
         sender=sender,
+        batch_size=100,
+        max_buffer_age=999.0,
+        max_queue_size=10,
+        max_batch_bytes=max_batch_bytes,
     )
 
-    for index in range(3):
-        trace_id = client.start_trace(
-            f"trace-{index}",
-            trace_id=f"trace_{index}",
-            input_data={"prompt": "hello"},
-        )
-        client.end_trace(trace_id, output_data={"answer": "hi"})
+    for payload in payloads:
+        transport.submit(payload["id"], payload)
 
-    result = client.flush()
-    client.close()
+    result = transport.flush()
+    transport.close()
 
     assert result.success is True
-    assert [len(batch) for batch in sent_batches] == [1, 1, 1]
+    assert [len(batch) for batch in sent_batches] == [2, 1]
     assert result.items_pending == 0
-    assert result.successful_batches == 3
+    assert result.successful_batches == 2
+
+
+def test_observability_client_drops_single_payload_over_byte_limit():
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    payload = {"id": "trace_oversized", "input_data": {"prompt": "x" * 128}}
+    transport = _SyncBatchTransport(
+        sender=sender,
+        batch_size=100,
+        max_buffer_age=999.0,
+        max_queue_size=10,
+        max_batch_bytes=_encoded_trace_batch_size([payload]) - 1,
+    )
+
+    assert transport.submit(payload["id"], payload) is True
+
+    result = transport.flush()
+    transport.close()
+
+    assert sent_batches == []
+    assert result.items_sent == 0
+    assert result.items_dropped == 1
+    assert result.items_pending == 0
+    assert "exceeding max_batch_bytes" in result.errors[0]
 
 
 def test_observability_client_preserves_existing_usage_fields_on_update():

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -192,19 +192,43 @@ class _SyncBatchTransport:
                     return
 
                 batch_items: list[tuple[str, dict[str, Any]]] = []
-                batch_bytes = 0
+                batch_payloads: list[dict[str, Any]] = []
                 for _ in range(min(self.batch_size, len(self._buffer))):
-                    item = next(iter(self._buffer.items()))
-                    item_bytes = len(
-                        json.dumps({"traces": [item[1]]}, default=str).encode("utf-8")
+                    item_id, payload = next(iter(self._buffer.items()))
+                    item_bytes = self._batch_payload_size([payload])
+                    if item_bytes > self.max_batch_bytes:
+                        self._buffer.popitem(last=False)
+                        self._stats["dropped_items"] += 1
+                        self._append_error(
+                            "observability payload for item "
+                            f"'{item_id}' is {item_bytes} bytes, exceeding "
+                            f"max_batch_bytes={self.max_batch_bytes}; dropped"
+                        )
+                        logger.warning(
+                            "Observability transport dropped payload '%s' because "
+                            "its encoded size %d exceeds max_batch_bytes=%d",
+                            item_id,
+                            item_bytes,
+                            self.max_batch_bytes,
+                        )
+                        continue
+
+                    projected_bytes = self._batch_payload_size(
+                        [*batch_payloads, payload]
                     )
-                    if batch_items and batch_bytes + item_bytes > self.max_batch_bytes:
+                    if batch_items and projected_bytes > self.max_batch_bytes:
                         break
                     batch_items.append(self._buffer.popitem(last=False))
-                    batch_bytes += item_bytes
+                    batch_payloads.append(payload)
                 self._stats["pending_items"] = len(self._buffer)
 
+            if not batch_items:
+                continue
             self._send_batch(batch_items)
+
+    @staticmethod
+    def _batch_payload_size(payloads: list[dict[str, Any]]) -> int:
+        return len(json.dumps({"traces": payloads}, default=str).encode("utf-8"))
 
     def _send_batch(self, batch_items: list[tuple[str, dict[str, Any]]]) -> None:
         payloads = [payload for _, payload in batch_items]

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -48,6 +48,10 @@ from traigent.utils.retry import CLOUD_API_RETRY_CONFIG, RetryHandler
 
 logger = get_logger(__name__)
 
+_TRACE_BATCH_PREFIX_BYTES = len(b'{"traces": [')
+_TRACE_BATCH_SUFFIX_BYTES = len(b"]}")
+_TRACE_BATCH_ITEM_SEPARATOR_BYTES = len(b", ")
+
 
 def _new_trace_id() -> str:
     return f"trace_{uuid.uuid4().hex}"
@@ -192,10 +196,11 @@ class _SyncBatchTransport:
                     return
 
                 batch_items: list[tuple[str, dict[str, Any]]] = []
-                batch_payloads: list[dict[str, Any]] = []
+                batch_body_bytes = 0
                 for _ in range(min(self.batch_size, len(self._buffer))):
                     item_id, payload = next(iter(self._buffer.items()))
-                    item_bytes = self._batch_payload_size([payload])
+                    payload_bytes = self._payload_json_size(payload)
+                    item_bytes = self._batch_payload_size_from_body(payload_bytes)
                     if item_bytes > self.max_batch_bytes:
                         self._buffer.popitem(last=False)
                         self._stats["dropped_items"] += 1
@@ -213,13 +218,16 @@ class _SyncBatchTransport:
                         )
                         continue
 
-                    projected_bytes = self._batch_payload_size(
-                        [*batch_payloads, payload]
+                    projected_body_bytes = batch_body_bytes + payload_bytes
+                    if batch_items:
+                        projected_body_bytes += _TRACE_BATCH_ITEM_SEPARATOR_BYTES
+                    projected_bytes = self._batch_payload_size_from_body(
+                        projected_body_bytes
                     )
                     if batch_items and projected_bytes > self.max_batch_bytes:
                         break
                     batch_items.append(self._buffer.popitem(last=False))
-                    batch_payloads.append(payload)
+                    batch_body_bytes = projected_body_bytes
                 self._stats["pending_items"] = len(self._buffer)
 
             if not batch_items:
@@ -229,6 +237,14 @@ class _SyncBatchTransport:
     @staticmethod
     def _batch_payload_size(payloads: list[dict[str, Any]]) -> int:
         return len(json.dumps({"traces": payloads}, default=str).encode("utf-8"))
+
+    @staticmethod
+    def _payload_json_size(payload: dict[str, Any]) -> int:
+        return len(json.dumps(payload, default=str).encode("utf-8"))
+
+    @staticmethod
+    def _batch_payload_size_from_body(body_bytes: int) -> int:
+        return _TRACE_BATCH_PREFIX_BYTES + body_bytes + _TRACE_BATCH_SUFFIX_BYTES
 
     def _send_batch(self, batch_items: list[tuple[str, dict[str, Any]]]) -> None:
         payloads = [payload for _, payload in batch_items]

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -92,11 +92,13 @@ class _SyncBatchTransport:
         batch_size: int,
         max_buffer_age: float,
         max_queue_size: int,
+        max_batch_bytes: int,
     ) -> None:
         self._sender = sender
         self.batch_size = batch_size
         self.max_buffer_age = max_buffer_age
         self.max_queue_size = max_queue_size
+        self.max_batch_bytes = max_batch_bytes
         self._retry_handler = RetryHandler(CLOUD_API_RETRY_CONFIG)
         self._buffer: OrderedDict[str, dict[str, Any]] = OrderedDict()
         self._lock = threading.RLock()
@@ -189,9 +191,17 @@ class _SyncBatchTransport:
                     self._stats["pending_items"] = 0
                     return
 
-                batch_items = []
+                batch_items: list[tuple[str, dict[str, Any]]] = []
+                batch_bytes = 0
                 for _ in range(min(self.batch_size, len(self._buffer))):
+                    item = next(iter(self._buffer.items()))
+                    item_bytes = len(
+                        json.dumps({"traces": [item[1]]}, default=str).encode("utf-8")
+                    )
+                    if batch_items and batch_bytes + item_bytes > self.max_batch_bytes:
+                        break
                     batch_items.append(self._buffer.popitem(last=False))
+                    batch_bytes += item_bytes
                 self._stats["pending_items"] = len(self._buffer)
 
             self._send_batch(batch_items)
@@ -663,6 +673,7 @@ class ObservabilityClient:
             batch_size=self.config.batch_size,
             max_buffer_age=self.config.max_buffer_age,
             max_queue_size=self.config.max_queue_size,
+            max_batch_bytes=self.config.max_batch_bytes,
         )
 
     def _send_payload_batch(

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -199,7 +199,22 @@ class _SyncBatchTransport:
                 batch_body_bytes = 0
                 for _ in range(min(self.batch_size, len(self._buffer))):
                     item_id, payload = next(iter(self._buffer.items()))
-                    payload_bytes = self._payload_json_size(payload)
+                    try:
+                        payload_bytes = self._payload_json_size(payload)
+                    except TypeError as exc:
+                        self._buffer.popitem(last=False)
+                        self._stats["dropped_items"] += 1
+                        self._append_error(
+                            "observability payload for item "
+                            f"'{item_id}' is not JSON serializable: {exc}; dropped"
+                        )
+                        logger.warning(
+                            "Observability transport dropped payload '%s' because "
+                            "it is not JSON serializable: %s",
+                            item_id,
+                            exc,
+                        )
+                        continue
                     item_bytes = self._batch_payload_size_from_body(payload_bytes)
                     if item_bytes > self.max_batch_bytes:
                         self._buffer.popitem(last=False)
@@ -236,7 +251,7 @@ class _SyncBatchTransport:
 
     @staticmethod
     def _payload_json_size(payload: dict[str, Any]) -> int:
-        return len(json.dumps(payload, default=str).encode("utf-8"))
+        return len(json.dumps(payload).encode("utf-8"))
 
     @staticmethod
     def _batch_payload_size_from_body(body_bytes: int) -> int:

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -235,10 +235,6 @@ class _SyncBatchTransport:
             self._send_batch(batch_items)
 
     @staticmethod
-    def _batch_payload_size(payloads: list[dict[str, Any]]) -> int:
-        return len(json.dumps({"traces": payloads}, default=str).encode("utf-8"))
-
-    @staticmethod
     def _payload_json_size(payload: dict[str, Any]) -> int:
         return len(json.dumps(payload, default=str).encode("utf-8"))
 

--- a/traigent/observability/config.py
+++ b/traigent/observability/config.py
@@ -11,6 +11,7 @@ from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_opti
 
 MAX_BATCH_SIZE = 10_000
 MAX_QUEUE_SIZE = 1_000_000
+MAX_BATCH_BYTES = 10 * 1024 * 1024
 MAX_BUFFER_AGE_SECONDS = 3600.0
 MAX_TIMEOUT_SECONDS = 600.0
 
@@ -32,6 +33,7 @@ class ObservabilityConfig:
     batch_size: int = 100
     max_buffer_age: float = 5.0
     max_queue_size: int = 10_000
+    max_batch_bytes: int = 4 * 1024 * 1024
     flush_timeout: float = 30.0
     request_timeout: float = 10.0
     enable_atexit_flush: bool = True
@@ -71,6 +73,12 @@ class ObservabilityConfig:
         if self.max_queue_size > MAX_QUEUE_SIZE:
             raise ValueError(
                 f"max_queue_size must be less than or equal to {MAX_QUEUE_SIZE}"
+            )
+        if self.max_batch_bytes <= 0:
+            raise ValueError("max_batch_bytes must be greater than 0")
+        if self.max_batch_bytes > MAX_BATCH_BYTES:
+            raise ValueError(
+                f"max_batch_bytes must be less than or equal to {MAX_BATCH_BYTES}"
             )
         if self.flush_timeout <= 0:
             raise ValueError("flush_timeout must be greater than 0")

--- a/traigent/projects/dtos.py
+++ b/traigent/projects/dtos.py
@@ -127,6 +127,12 @@ class ProjectRateLimitPolicyDTO:
 class ProjectRetentionPolicySettingsDTO:
     export_artifact_retention_days: int
     materialized_export_retention_days: int
+    trace_retention_days: int
+    dataset_retention_days: int
+    dataset_storage_limit_bytes: int
+    observability_ingest_rpm: int
+    inline_payload_max_bytes: int
+    payload_max_bytes: int
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> ProjectRetentionPolicySettingsDTO:
@@ -137,6 +143,16 @@ class ProjectRetentionPolicySettingsDTO:
             materialized_export_retention_days=int(
                 payload["materialized_export_retention_days"]
             ),
+            trace_retention_days=int(payload.get("trace_retention_days", 30)),
+            dataset_retention_days=int(payload.get("dataset_retention_days", 30)),
+            dataset_storage_limit_bytes=int(
+                payload.get("dataset_storage_limit_bytes", 5 * 1024 * 1024 * 1024)
+            ),
+            observability_ingest_rpm=int(payload.get("observability_ingest_rpm", 600)),
+            inline_payload_max_bytes=int(
+                payload.get("inline_payload_max_bytes", 256 * 1024)
+            ),
+            payload_max_bytes=int(payload.get("payload_max_bytes", 10 * 1024 * 1024)),
         )
 
 


### PR DESCRIPTION
## Summary
- Add Python SDK observability batch byte guardrails.
- Propagate project lifecycle/retention DTO fields for storage access P0.
- Keep observability retry behavior covered with the existing retry handler path.

## Validation
- `pytest tests/unit/observability/test_observability_client.py -q` (24 passed)

## Notes
- This pairs with the backend observability payload caps and schema lifecycle fields.