### PR TITLE
[codex] fix public contract drift in SDK surfaces

### DIFF
--- a/docs/hybrid-mode-api-contract.md
+++ b/docs/hybrid-mode-api-contract.md
@@ -204,7 +204,7 @@ Returns service capabilities for the initial handshake.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `version` | string | Yes | API version (currently "1.0") |
-| `supports_evaluate` | boolean | No | Whether `/evaluate` endpoint is available (default: `true`) |
+| `supports_evaluate` | boolean | No | Whether `/evaluate` endpoint is available (default: `false`) |
 | `supports_keep_alive` | boolean | No | Whether session heartbeat is supported |
 | `supports_streaming` | boolean | No | Whether streaming responses are supported |
 | `max_batch_size` | integer | No | Maximum inputs per execute request (default: 100) |

--- a/docs/hybrid-mode-openapi.yaml
+++ b/docs/hybrid-mode-openapi.yaml
@@ -594,7 +594,7 @@ components:
         supports_evaluate:
           type: boolean
           description: Whether separate evaluate endpoint is available
-          default: true
+          default: false
           example: true
         supports_evaluation_kwargs:
           type: boolean

--- a/docs/hybrid-mode-schemas.json
+++ b/docs/hybrid-mode-schemas.json
@@ -18,7 +18,7 @@
         "supports_evaluate": {
           "type": "boolean",
           "description": "Whether separate evaluate endpoint is available",
-          "default": true
+          "default": false
         },
         "supports_keep_alive": {
           "type": "boolean",

--- a/tests/unit/api/test_functions.py
+++ b/tests/unit/api/test_functions.py
@@ -21,6 +21,21 @@ from traigent.config.types import TraigentConfig
 from traigent.utils.exceptions import ConfigAccessWarning, OptimizationStateError
 
 
+def test_batch_optimizers_are_publicly_exported() -> None:
+    """Batch optimizer classes should be importable from traigent.optimizers."""
+    from traigent.optimizers import (
+        AdaptiveBatchOptimizer,
+        BatchOptimizationConfig,
+        MultiObjectiveBatchOptimizer,
+        ParallelBatchOptimizer,
+    )
+
+    assert BatchOptimizationConfig.__name__ == "BatchOptimizationConfig"
+    assert ParallelBatchOptimizer.__name__ == "ParallelBatchOptimizer"
+    assert MultiObjectiveBatchOptimizer.__name__ == "MultiObjectiveBatchOptimizer"
+    assert AdaptiveBatchOptimizer.__name__ == "AdaptiveBatchOptimizer"
+
+
 class TestConfigure:
     """Test the configure function."""
 
@@ -429,6 +444,18 @@ class TestGetAvailableStrategies:
         assert bayesian_info["deterministic"] is False
         assert "acquisition_function" in bayesian_info["parameters"]
         assert "initial_random_samples" in bayesian_info["parameters"]
+
+    @patch("traigent.api.functions.list_optimizers")
+    def test_get_available_strategies_optuna_metadata(self, mock_list_optimizers):
+        """Test registered Optuna strategies have concrete metadata."""
+        mock_list_optimizers.return_value = ["optuna_tpe", "nsga2", "optuna_grid"]
+
+        strategies = get_available_strategies()
+
+        assert strategies["optuna_tpe"]["name"] == "Optuna TPE Optimization"
+        assert strategies["nsga2"]["name"] == "Optuna NSGA-II Optimization"
+        assert strategies["optuna_grid"]["description"] != "Custom optimization algorithm"
+        assert "max_trials" in strategies["optuna_tpe"]["parameters"]
 
     @patch("traigent.api.functions.list_optimizers")
     def test_get_available_strategies_custom(self, mock_list_optimizers):

--- a/tests/unit/api/test_safety.py
+++ b/tests/unit/api/test_safety.py
@@ -718,6 +718,27 @@ class TestDecoratorIntegration:
         assert len(my_func.safety_constraints) == 1
         assert isinstance(my_func.safety_constraints[0], CompoundSafetyConstraint)
 
+    def test_safety_constraints_are_post_eval_orchestrator_constraints(self) -> None:
+        """Safety constraints must be wired into runtime post-eval enforcement."""
+        from traigent.core.orchestrator import OptimizationOrchestrator
+        from traigent.evaluators.local import LocalEvaluator
+        from traigent.optimizers.random import RandomSearchOptimizer
+
+        constraint = custom_safety(
+            "must_pass",
+            lambda config, metrics: metrics.get("safety_score", 0.0),
+        ).above(1.0)
+
+        orchestrator = OptimizationOrchestrator(
+            optimizer=RandomSearchOptimizer({"p": [1]}, ["accuracy"], max_trials=1),
+            evaluator=LocalEvaluator(metrics=["accuracy"]),
+            max_trials=1,
+            safety_constraints=[constraint],
+        )
+
+        assert constraint in orchestrator._constraints_post_eval
+        assert constraint({"p": 1}, {"safety_score": 0.0}) is False
+
 
 class TestAPIExports:
     """Tests for public API exports."""

--- a/tests/unit/evaluators/test_metrics.py
+++ b/tests/unit/evaluators/test_metrics.py
@@ -433,6 +433,28 @@ class TestMetricsComputer:
         assert "custom_metric" in result
         assert result["custom_metric"] == 2 / 3
 
+    def test_compute_metrics_includes_registered_custom_metrics(
+        self, default_computer: MetricsComputer
+    ) -> None:
+        """Test compute_metrics includes registered custom metric values."""
+
+        def custom_func(outputs: list, expected: list) -> float:
+            return len(outputs) / len(expected)
+
+        default_computer.add_custom_metric("custom_metric", custom_func)
+
+        invocation_results = [
+            InvocationResult(result="output1", is_successful=True),
+            InvocationResult(result="output2", is_successful=True),
+        ]
+        expected_outputs = ["output1", "output2"]
+
+        result = default_computer.compute_metrics(
+            invocation_results, expected_outputs
+        )
+
+        assert result.metrics["custom_metric"] == 1.0
+
     def test_compute_custom_metrics_filters_failed_invocations(
         self, default_computer: MetricsComputer
     ) -> None:

--- a/tests/unit/hybrid/test_http_transport.py
+++ b/tests/unit/hybrid/test_http_transport.py
@@ -676,7 +676,7 @@ class TestHTTPTransportAdditionalMethods:
             caps = await transport.capabilities()
 
         assert caps.version == "1.0"
-        assert caps.supports_evaluate is True  # Default
+        assert caps.supports_evaluate is False  # Safe default
 
     @pytest.mark.asyncio
     async def test_discover_config_space(self, transport: HTTPTransport) -> None:

--- a/tests/unit/hybrid/test_mcp_transport.py
+++ b/tests/unit/hybrid/test_mcp_transport.py
@@ -342,7 +342,7 @@ class TestMCPTransportCapabilities:
         caps = await transport.capabilities()
 
         assert caps.version == "1.0"
-        assert caps.supports_evaluate is True  # Default
+        assert caps.supports_evaluate is False  # Safe default
         assert caps.supports_keep_alive is False  # Default
 
 

--- a/tests/unit/hybrid/test_protocol.py
+++ b/tests/unit/hybrid/test_protocol.py
@@ -208,12 +208,18 @@ class TestServiceCapabilities:
         """Test default capabilities."""
         caps = ServiceCapabilities(version="1.0")
         assert caps.version == "1.0"
-        assert caps.supports_evaluate is True
+        assert caps.supports_evaluate is False
         assert caps.supports_evaluation_kwargs is False
         assert caps.supports_keep_alive is False
         assert caps.supports_streaming is False
         assert caps.max_batch_size == 100
         assert caps.max_payload_bytes is None
+
+    def test_from_dict_defaults_do_not_claim_evaluate(self) -> None:
+        """Missing optional endpoint flags should fail closed."""
+        caps = ServiceCapabilities.from_dict({"version": "1.0"})
+
+        assert caps.supports_evaluate is False
 
     def test_from_dict(self) -> None:
         """Test creating from dictionary."""

--- a/tests/unit/integrations/test_base_llm_plugin.py
+++ b/tests/unit/integrations/test_base_llm_plugin.py
@@ -9,8 +9,13 @@ from traigent.integrations.base_plugin import (
     PluginMetadata,
     ValidationRule,
 )
-from traigent.integrations.llms import LLMPlugin
+from traigent.integrations.llms import LiteLLMPlugin, LLMPlugin
 from traigent.integrations.utils import Framework
+
+
+def test_litellm_plugin_is_publicly_exported() -> None:
+    """LiteLLMPlugin should be available from traigent.integrations.llms."""
+    assert LiteLLMPlugin.__name__ == "LiteLLMPlugin"
 
 
 class ConcreteOpenAIPlugin(LLMPlugin):

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -831,6 +831,40 @@ def get_available_strategies() -> dict[str, dict[str, Any]]:
                 "best_for": "Expensive evaluations, continuous optimization, sample efficiency",
             }
 
+        elif algorithm in {
+            "optuna",
+            "optuna_tpe",
+            "tpe",
+            "optuna_random",
+            "optuna_grid",
+            "optuna_cmaes",
+            "optuna_nsga2",
+            "nsga2",
+        }:
+            optuna_names = {
+                "optuna": "Optuna TPE Optimization",
+                "optuna_tpe": "Optuna TPE Optimization",
+                "tpe": "Optuna TPE Optimization",
+                "optuna_random": "Optuna Random Search",
+                "optuna_grid": "Optuna Grid Search",
+                "optuna_cmaes": "Optuna CMA-ES Optimization",
+                "optuna_nsga2": "Optuna NSGA-II Optimization",
+                "nsga2": "Optuna NSGA-II Optimization",
+            }
+            strategies[algorithm] = {
+                "name": optuna_names[algorithm],
+                "description": "Optuna-backed optimization strategy",
+                "supports_continuous": algorithm not in {"optuna_grid"},
+                "supports_categorical": True,
+                "deterministic": algorithm in {"optuna_grid"},
+                "parameters": {
+                    "max_trials": "Maximum number of trials",
+                    "random_seed": "Random seed for reproducibility when supported",
+                    "objective_weights": "Weights for multi-objective aggregation",
+                },
+                "best_for": "Advanced search strategies and multi-objective optimization",
+            }
+
         # Add more algorithms as they are implemented
 
         else:

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -591,6 +591,7 @@ def collect_orchestrator_kwargs(
     agent_measures: dict[str, Any] | None,
     global_measures: dict[str, Any] | None,
     promotion_gate: Any | None,
+    safety_constraints: list[Any] | None = None,
     invocations_per_example: int = 1,
 ) -> dict[str, Any]:
     """Collect optional kwargs for orchestrator from algorithm_kwargs and attrs.
@@ -605,6 +606,7 @@ def collect_orchestrator_kwargs(
         agent_measures: Agent measures mapping
         global_measures: Global measures mapping
         promotion_gate: Promotion gate configuration
+        safety_constraints: Post-evaluation safety constraints
         invocations_per_example: Number of invocations per example (default: 1)
 
     Returns:
@@ -642,6 +644,7 @@ def collect_orchestrator_kwargs(
         ("agent_measures", agent_measures, None),
         ("global_measures", global_measures, None),
         ("promotion_gate", promotion_gate, None),
+        ("safety_constraints", safety_constraints, None),
     ]
     for attr_name, value, transform in optional_attrs:
         if value is not None:

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1519,6 +1519,7 @@ class OptimizedFunction:
             agent_measures=getattr(self, "agent_measures", None),
             global_measures=getattr(self, "global_measures", None),
             promotion_gate=getattr(self, "promotion_gate", None),
+            safety_constraints=getattr(self, "safety_constraints", None),
         )
 
         # Auto-initialize workflow traces tracker if backend is configured

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -167,8 +167,11 @@ class OptimizationOrchestrator:
         )
 
         raw_constraints = kwargs.pop("constraints", None)
+        raw_safety_constraints = kwargs.pop("safety_constraints", None)
         default_config = kwargs.pop("default_config", None)
-        self._init_constraints(raw_constraints)
+        combined_constraints = list(raw_constraints or [])
+        combined_constraints.extend(raw_safety_constraints or [])
+        self._init_constraints(combined_constraints)
 
         self.objectives, self.objective_schema = prepare_objectives(
             objectives, objective_schema

--- a/traigent/evaluators/metrics.py
+++ b/traigent/evaluators/metrics.py
@@ -154,7 +154,10 @@ class MetricsComputer:
             else:
                 computed_metrics["avg_output_length"] = 0.0
 
-        # Custom metric computation can be added here
+        custom_metrics = self.compute_custom_metrics(
+            invocation_results, expected_outputs
+        )
+        computed_metrics.update(custom_metrics)
 
         end_time = time.time()
         duration = end_time - start_time

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -296,8 +296,8 @@ class HTTPTransport:
             )
             return self._capabilities
         except TransportError:
-            # If capabilities endpoint not available, return defaults
-            logger.warning("Capabilities endpoint not available, using defaults")
+            # Missing capabilities must not claim support for optional endpoints.
+            logger.warning("Capabilities endpoint not available, using safe defaults")
             self._capabilities = ServiceCapabilities(version="1.0")
             return self._capabilities
 

--- a/traigent/hybrid/mcp_transport.py
+++ b/traigent/hybrid/mcp_transport.py
@@ -208,8 +208,8 @@ class MCPTransport:
             )
             return self._capabilities
         except TransportError:
-            # If capabilities resource not available, return defaults
-            logger.warning("Capabilities resource not available, using defaults")
+            # Missing capabilities must not claim support for optional endpoints.
+            logger.warning("Capabilities resource not available, using safe defaults")
             self._capabilities = ServiceCapabilities(version="1.0")
             return self._capabilities
 

--- a/traigent/hybrid/protocol.py
+++ b/traigent/hybrid/protocol.py
@@ -235,7 +235,7 @@ class ServiceCapabilities:
     """
 
     version: str
-    supports_evaluate: bool = True
+    supports_evaluate: bool = False
     supports_evaluation_kwargs: bool = False
     supports_keep_alive: bool = False
     supports_streaming: bool = False
@@ -248,7 +248,7 @@ class ServiceCapabilities:
         """Create from dictionary (API response)."""
         return cls(
             version=data.get("version", "1.0"),
-            supports_evaluate=data.get("supports_evaluate", True),
+            supports_evaluate=data.get("supports_evaluate", False),
             supports_evaluation_kwargs=data.get("supports_evaluation_kwargs", False),
             supports_keep_alive=data.get("supports_keep_alive", False),
             supports_streaming=data.get("supports_streaming", False),

--- a/traigent/integrations/llms/__init__.py
+++ b/traigent/integrations/llms/__init__.py
@@ -12,6 +12,7 @@ from traigent.integrations.llms.cohere_plugin import CoherePlugin
 from traigent.integrations.llms.gemini_plugin import GeminiPlugin
 from traigent.integrations.llms.huggingface_plugin import HuggingFacePlugin
 from traigent.integrations.llms.langchain_plugin import LangChainPlugin
+from traigent.integrations.llms.litellm_plugin import LiteLLMPlugin
 from traigent.integrations.llms.llamaindex_plugin import LlamaIndexPlugin
 from traigent.integrations.llms.mistral_plugin import MistralPlugin
 from traigent.integrations.llms.openai_plugin import OpenAIPlugin
@@ -26,6 +27,7 @@ __all__ = [
     "HuggingFacePlugin",
     "LangChainPlugin",
     "LlamaIndexPlugin",
+    "LiteLLMPlugin",
     "MistralPlugin",
     "OpenAIPlugin",
 ]

--- a/traigent/optimizers/__init__.py
+++ b/traigent/optimizers/__init__.py
@@ -5,6 +5,12 @@
 from __future__ import annotations
 
 from traigent.optimizers.base import BaseOptimizer
+from traigent.optimizers.batch_optimizers import (
+    AdaptiveBatchOptimizer,
+    BatchOptimizationConfig,
+    MultiObjectiveBatchOptimizer,
+    ParallelBatchOptimizer,
+)
 from traigent.optimizers.grid import GridSearchOptimizer
 from traigent.optimizers.optuna_adapter import OptunaAdapter
 from traigent.optimizers.optuna_coordinator import (
@@ -79,6 +85,10 @@ __all__ = [
     "BaseOptimizer",
     "GridSearchOptimizer",
     "RandomSearchOptimizer",
+    "BatchOptimizationConfig",
+    "ParallelBatchOptimizer",
+    "MultiObjectiveBatchOptimizer",
+    "AdaptiveBatchOptimizer",
     "OptunaBaseOptimizer",
     "OptunaTPEOptimizer",
     "OptunaRandomOptimizer",


### PR DESCRIPTION
## Summary
- fail closed on missing hybrid capability declarations instead of claiming `/evaluate` support
- wire safety constraints into orchestrator post-evaluation enforcement and include custom metrics in aggregate metrics
- repair public SDK exports and strategy metadata for LLM and optimizer surfaces

## Issues
- Addresses #921
- Addresses #923
- Addresses #932
- Addresses #946
- Addresses #947
- Partially addresses #919 by exporting batch optimizer classes without registering constructor-incompatible wrappers as standard optimizer factories

## Validation
- `PYTHONPATH=. TRAIGENT_OFFLINE_MODE=true pytest -q -o addopts='' tests/unit/hybrid/test_protocol.py tests/unit/hybrid/test_http_transport.py tests/unit/hybrid/test_mcp_transport.py tests/unit/evaluators/test_metrics.py tests/unit/api/test_safety.py tests/unit/integrations/test_base_llm_plugin.py tests/unit/api/test_functions.py`
- pre-commit: isort, black, ruff, detect-secrets, YAML/JSON checks, bandit, mypy, repository guardrails

## Notes
- SonarQube pre-push hook skipped because `sonar-scanner` is not installed locally.
