### PR TITLE
[codex] fail closed on cloud false-success paths

### DIFF
--- a/tests/unit/cloud/test_cloud_service.py
+++ b/tests/unit/cloud/test_cloud_service.py
@@ -657,48 +657,38 @@ class TestTraigentCloudService:
         asyncio.run(run_test())
 
     def test_get_optimization_history(self, cloud_service):
-        """Test getting optimization history."""
+        """Unwired history retrieval should return no records."""
 
         async def run_test():
             history = await cloud_service.get_optimization_history(
                 user_id="test_user", limit=5
             )
 
-            assert len(history) == 5
-            for record in history:
-                assert "request_id" in record
-                assert "function_name" in record
-                assert "timestamp" in record
-                assert "trials_count" in record
-                assert "cost_reduction" in record
-                assert "status" in record
-                assert record["status"] == "completed"
+            assert history == []
 
         import asyncio
 
         asyncio.run(run_test())
 
     def test_get_optimization_history_large_limit(self, cloud_service):
-        """Test optimization history with large limit."""
+        """Large limits should not synthesize fake history."""
 
         async def run_test():
             history = await cloud_service.get_optimization_history(limit=100)
 
-            # Should return max 10 records (mock data limit)
-            assert len(history) == 10
+            assert history == []
 
         import asyncio
 
         asyncio.run(run_test())
 
     def test_get_optimization_history_no_user_id(self, cloud_service):
-        """Test optimization history without user ID."""
+        """Missing user IDs should not synthesize fake history."""
 
         async def run_test():
             history = await cloud_service.get_optimization_history(limit=3)
 
-            assert len(history) == 3
-            # Should work without user_id (demo mode)
+            assert history == []
 
         import asyncio
 

--- a/tests/unit/cloud/test_cost_tracking.py
+++ b/tests/unit/cloud/test_cost_tracking.py
@@ -453,6 +453,26 @@ class TestCostTrackerAsync:
             with pytest.raises(asyncio.CancelledError):
                 await tracker._sync_loop()
 
+    @pytest.mark.asyncio
+    async def test_manual_sync_fails_closed_without_server_transport(self):
+        """Manual sync must not clear pending items without a real transport."""
+        tracker = CostTracker(
+            CostTrackingConfig(enable_server_sync=True, cache_costs_locally=False)
+        )
+        tracker.track_custom_cost(
+            session_id="session-123",
+            category=CostCategory.COMPUTE,
+            description="compute",
+            cost=0.1,
+        )
+
+        success = await tracker.manual_sync()
+
+        assert success is False
+        assert len(tracker._pending_sync_items) == 1
+        assert tracker._stats["failed_syncs"] == 1
+        assert tracker._stats["successful_syncs"] == 0
+
 
 class TestCostTrackerIntegration:
     """Integration tests for CostTracker."""

--- a/tests/unit/cloud/test_integration_manager_validation.py
+++ b/tests/unit/cloud/test_integration_manager_validation.py
@@ -237,6 +237,33 @@ async def test_cancel_session_returns_backend_cancel_result(monkeypatch):
     manager._backend_client.cancel_session.assert_awaited_once_with("session-1")
 
 
+@pytest.mark.asyncio
+async def test_cancel_session_success_removes_active_integration(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace(
+        cancel_session=AsyncMock(return_value=True)
+    )
+    manager._active_integrations = {
+        "integration-1": {
+            "result": IntegrationResult(success=True, session_id="session-1"),
+            "mode": "privacy",
+        }
+    }
+    manager._integration_stats["active_sessions"] = 1
+
+    success = await manager.cancel_session("session-1")
+
+    assert success is True
+    assert lifecycle_stub.calls == [("cancel_session", "session-1")]
+    manager._backend_client.cancel_session.assert_awaited_once_with("session-1")
+    assert manager._active_integrations == {}
+    assert manager._integration_stats["active_sessions"] == 0
+
+
 # Tests for RuntimeError when clients are not initialized
 
 

--- a/tests/unit/cloud/test_integration_manager_validation.py
+++ b/tests/unit/cloud/test_integration_manager_validation.py
@@ -1,7 +1,7 @@
 """Validation tests for IntegrationManager identifier handling."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -65,6 +65,108 @@ async def test_submit_trial_results_validates_identifiers(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_submit_trial_results_returns_false_without_integration(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace(
+        submit_privacy_trial_results=AsyncMock(return_value=True)
+    )
+    manager._active_integrations = {}
+
+    success = await manager.submit_trial_results(
+        "session-1", "trial-1", {}, {"accuracy": 0.9}, 1.0
+    )
+
+    assert success is False
+    manager._backend_client.submit_privacy_trial_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_trial_results_returns_false_for_unsupported_mode(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace(
+        submit_privacy_trial_results=AsyncMock(return_value=True)
+    )
+    manager._active_integrations = {
+        "integration-1": {
+            "result": IntegrationResult(success=True, session_id="session-1"),
+            "mode": "cloud",
+        }
+    }
+
+    success = await manager.submit_trial_results(
+        "session-1", "trial-1", {}, {"accuracy": 0.9}, 1.0
+    )
+
+    assert success is False
+    manager._backend_client.submit_privacy_trial_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_trial_results_uses_privacy_mode_alias(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace(
+        submit_privacy_trial_results=AsyncMock(return_value=True)
+    )
+    manager._active_integrations = {
+        "integration-1": {
+            "result": IntegrationResult(
+                success=True,
+                session_id="session-1",
+                metadata={"mode": "privacy"},
+            ),
+            "mode": "standard",
+        }
+    }
+
+    success = await manager.submit_trial_results(
+        "session-1", "trial-1", {}, {"accuracy": 0.9}, 1.0
+    )
+
+    assert success is True
+    manager._backend_client.submit_privacy_trial_results.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_submit_trial_results_ignores_mock_metadata(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    result = Mock()
+    result.session_id = "session-1"
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace(
+        submit_privacy_trial_results=AsyncMock(return_value=True)
+    )
+    manager._active_integrations = {
+        "integration-1": {
+            "result": result,
+            "mode": "private",
+        }
+    }
+
+    success = await manager.submit_trial_results(
+        "session-1", "trial-1", {}, {"accuracy": 0.9}, 1.0
+    )
+
+    assert success is True
+    manager._backend_client.submit_privacy_trial_results.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_finalize_session_validates_identifiers(monkeypatch):
     lifecycle_stub = StubLifecycleManager()
     monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
@@ -90,6 +192,49 @@ async def test_cancel_session_validates_identifiers(monkeypatch):
     success = await manager.cancel_session("")
     assert success is False
     assert lifecycle_stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_session_returns_false_without_backend_cancel(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace()
+    manager._active_integrations = {
+        "integration-1": {
+            "result": IntegrationResult(success=True, session_id="session-1"),
+            "mode": "privacy",
+        }
+    }
+    manager._integration_stats["active_sessions"] = 1
+
+    success = await manager.cancel_session("session-1")
+
+    assert success is False
+    assert lifecycle_stub.calls == []
+    assert "integration-1" in manager._active_integrations
+    assert manager._integration_stats["active_sessions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_session_returns_backend_cancel_result(monkeypatch):
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = SimpleNamespace(
+        cancel_session=AsyncMock(return_value=True)
+    )
+    manager._active_integrations = {}
+
+    success = await manager.cancel_session("session-1")
+
+    assert success is True
+    assert lifecycle_stub.calls == [("cancel_session", "session-1")]
+    manager._backend_client.cancel_session.assert_awaited_once_with("session-1")
 
 
 # Tests for RuntimeError when clients are not initialized
@@ -144,6 +289,20 @@ async def test_finalize_session_raises_when_backend_not_initialized(monkeypatch)
 
     with pytest.raises(RuntimeError, match="Backend client not initialized"):
         await manager.finalize_session("session-123", None)
+
+
+@pytest.mark.asyncio
+async def test_cancel_session_raises_when_backend_not_initialized(monkeypatch):
+    """Test that cancel_session raises RuntimeError when backend client is None."""
+    lifecycle_stub = StubLifecycleManager()
+    monkeypatch.setattr(integration_module, "lifecycle_manager", lifecycle_stub)
+
+    manager = IntegrationManager()
+    manager._initialized = True
+    manager._backend_client = None
+
+    with pytest.raises(RuntimeError, match="Backend client not initialized"):
+        await manager.cancel_session("session-123")
 
 
 # Tests for RuntimeError when MCP client is not initialized

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -658,7 +658,9 @@ class TestSyncManager:
         """A 404 from an existing /datasets endpoint should not hit the legacy route."""
         benchmark_data = {"id": "bench_123", "name": "Test Benchmark"}
 
-        sync_manager._session.post.return_value = Mock(status_code=404, text="dataset not found")
+        sync_manager._session.post.return_value = Mock(
+            status_code=404, text="dataset not found"
+        )
         sync_manager._session.get.return_value = Mock(status_code=200)
 
         result = sync_manager._sync_benchmark(benchmark_data)
@@ -670,6 +672,21 @@ class TestSyncManager:
             json=benchmark_data,
             timeout=sync_manager._request_timeout,
         )
+
+    def test_dataset_route_probe_exception_does_not_cache_support(
+        self, sync_manager: SyncManager
+    ) -> None:
+        """Transient probe failures should not become cached route truth."""
+        sync_manager._session.get.side_effect = requests.Timeout("timed out")
+
+        assert sync_manager._supports_dataset_route() is True
+        assert sync_manager._dataset_route_supported is None
+
+        sync_manager._session.get.side_effect = None
+        sync_manager._session.get.return_value = Mock(status_code=404)
+
+        assert sync_manager._supports_dataset_route() is False
+        assert sync_manager._dataset_route_supported is False
 
     def test_sync_experiment_success(self, sync_manager: SyncManager) -> None:
         """Test successful experiment sync."""

--- a/traigent/cloud/billing.py
+++ b/traigent/cloud/billing.py
@@ -1178,7 +1178,7 @@ class CostTracker:
                     "sync_timestamp": time.time(),
                 }
 
-                # Simulate server sync (would be actual HTTP call in production)
+                # Attempt server sync through the configured transport.
                 success = await self._send_costs_to_server(sync_payload)
 
                 if success:
@@ -1208,11 +1208,12 @@ class CostTracker:
         Returns:
             True if successful
         """
-        # Placeholder for actual server communication
-        # In production, this would make HTTP requests to the backend
-        logger.debug(f"Simulating server sync of {len(payload['cost_items'])} items")
-        await asyncio.sleep(0.1)  # Simulate network delay
-        return True
+        logger.warning(
+            "Cost server sync requested for %d items, but no billing sync "
+            "transport is configured",
+            len(payload["cost_items"]),
+        )
+        return False
 
     # Utility Methods
 

--- a/traigent/cloud/billing.py
+++ b/traigent/cloud/billing.py
@@ -1208,7 +1208,7 @@ class CostTracker:
         Returns:
             True if successful
         """
-        logger.warning(
+        logger.debug(
             "Cost server sync requested for %d items, but no billing sync "
             "transport is configured",
             len(payload["cost_items"]),

--- a/traigent/cloud/integration_manager.py
+++ b/traigent/cloud/integration_manager.py
@@ -11,6 +11,7 @@ and MCP client operations.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 import time
 from dataclasses import dataclass, field
@@ -531,9 +532,7 @@ class IntegrationManager:
                 logger.warning(f"No integration found for session {session_id}")
                 return None
 
-            mode = integration["mode"]
-
-            if mode == "private":
+            if self._is_privacy_integration(integration):
                 suggestion = await self._backend_client.get_next_privacy_trial(
                     session_id, previous_results
                 )
@@ -604,13 +603,32 @@ class IntegrationManager:
 
             # Submit to backend client
             integration = self._get_integration_for_session(session_id)
-            if integration and integration["mode"] == "private":
-                success = await self._backend_client.submit_privacy_trial_results(
+            if not integration:
+                logger.warning(f"No integration found for session {session_id}")
+                return False
+
+            if self._is_privacy_integration(integration):
+                submit_results = getattr(
+                    self._backend_client,
+                    "submit_privacy_trial_results",
+                    None,
+                )
+                if submit_results is None:
+                    logger.warning(
+                        "Backend client does not support privacy trial result submission"
+                    )
+                    return False
+
+                success = await submit_results(
                     session_id, trial_id, config, metrics, duration, error_message
                 )
                 return cast(bool, success)
 
-            return True
+            logger.warning(
+                "Trial result submission is not implemented for integration mode %s",
+                self._integration_mode_name(integration),
+            )
+            return False
 
         except asyncio.CancelledError:
             raise
@@ -676,6 +694,9 @@ class IntegrationManager:
         Returns:
             True if cancellation successful
         """
+        if self._backend_client is None:
+            raise RuntimeError(_BACKEND_CLIENT_NOT_INITIALIZED)
+
         try:
             validate_or_raise(
                 CoreValidators.validate_string_non_empty(session_id, "session_id")
@@ -685,7 +706,27 @@ class IntegrationManager:
             return False
 
         try:
-            # Cancel in lifecycle manager
+            backend_cancel = getattr(self._backend_client, "cancel_session", None)
+            if backend_cancel is None:
+                logger.warning(
+                    "Backend client does not expose cancel_session; "
+                    "session %s was not cancelled",
+                    session_id,
+                )
+                return False
+
+            backend_result = backend_cancel(session_id)
+            if inspect.isawaitable(backend_result):
+                backend_result = await backend_result
+
+            if not backend_result:
+                logger.warning(
+                    "Backend cancellation for session %s did not succeed",
+                    session_id,
+                )
+                return False
+
+            # Cancel in lifecycle manager after backend cancellation succeeds.
             lifecycle_manager.cancel_session(session_id)
 
             # Update integration tracking
@@ -714,6 +755,26 @@ class IntegrationManager:
                 if integration["result"].session_id == session_id:
                     return integration
         return None
+
+    @staticmethod
+    def _integration_mode_name(integration: dict[str, Any]) -> str:
+        """Return the effective integration mode name."""
+        result = integration.get("result")
+        result_metadata = getattr(result, "metadata", None)
+        if not isinstance(result_metadata, dict):
+            result_metadata = {}
+        mode = result_metadata.get("mode", integration.get("mode", ""))
+        if isinstance(mode, IntegrationMode):
+            return mode.value
+        return str(mode)
+
+    @classmethod
+    def _is_privacy_integration(cls, integration: dict[str, Any]) -> bool:
+        """Return whether an active integration uses the privacy workflow."""
+        return cls._integration_mode_name(integration) in {
+            IntegrationMode.PRIVACY.value,
+            "private",
+        }
 
     def _get_integration_id_for_session(self, session_id: str) -> str | None:
         """Get integration ID for session."""

--- a/traigent/cloud/service.py
+++ b/traigent/cloud/service.py
@@ -365,10 +365,11 @@ class TraigentCloudService:
         Returns:
             List of optimization records
         """
-        logger.warning(
+        logger.debug(
             "Optimization history retrieval is not wired to persistent storage; "
-            "returning no records",
-            extra={"user_id": user_id, "limit": limit},
+            "returning no records (user_id=%s, limit=%d)",
+            user_id,
+            limit,
         )
         return []
 

--- a/traigent/cloud/service.py
+++ b/traigent/cloud/service.py
@@ -365,22 +365,12 @@ class TraigentCloudService:
         Returns:
             List of optimization records
         """
-        # In real implementation, this would query a database
-        # For demo, return mock data
-        mock_history = []
-        for i in range(min(limit, 10)):
-            mock_history.append(
-                {
-                    "request_id": f"opt_{int(time.time() * 1000) - i * 60000}",
-                    "function_name": f"function_{i % 3 + 1}",
-                    "timestamp": time.time() - i * 3600,
-                    "trials_count": 25 + i * 5,
-                    "cost_reduction": 0.6 + (i % 3) * 0.1,
-                    "status": "completed",
-                }
-            )
-
-        return mock_history
+        logger.warning(
+            "Optimization history retrieval is not wired to persistent storage; "
+            "returning no records",
+            extra={"user_id": user_id, "limit": limit},
+        )
+        return []
 
     def create_optimization_request(
         self,

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -512,10 +512,10 @@ class SyncManager:
             )
         except requests.RequestException as exc:
             logger.warning(
-                "Failed probing /datasets route support; assuming canonical endpoint exists: %s",
+                "Failed probing /datasets route support; using canonical endpoint "
+                "for this attempt without caching route support: %s",
                 exc,
             )
-            self._dataset_route_supported = True
             return True
 
         self._dataset_route_supported = response.status_code != 404


### PR DESCRIPTION
## Summary
- make billing cost sync fail closed when no server transport is configured, preserving pending items
- make integration trial submission and cancellation return false when no backend operation occurred
- stop returning fabricated optimization history records from the cloud service
- avoid caching dataset route support after transient probe failures

## Issues
- Addresses #917
- Addresses #928
- Addresses #941
- Addresses #942

## Claude Review
- Claude Opus xhigh reviewed the uncommitted diff and found one blocking issue: `_integration_mode_name()` mishandled `Mock` results whose `metadata` attribute is a synthetic mock.
- Fixed by requiring metadata to be a real `dict`, then added a regression test and ran the cited integration test.

## Validation
- `PYTHONPATH=. TRAIGENT_OFFLINE_MODE=true pytest -q -o addopts='' tests/unit/cloud/test_cost_tracking.py tests/unit/cloud/test_integration_manager_validation.py tests/unit/cloud/test_integration_manager_cancelled.py tests/unit/cloud/test_cloud_service.py tests/unit/cloud/test_sync_manager.py -x`
- `PYTHONPATH=. TRAIGENT_OFFLINE_MODE=true pytest -q -o addopts='' tests/integration/test_backend_integration.py::TestIntegrationManager::test_trial_management -x`
- pre-commit: isort, black, ruff, detect-secrets, YAML/JSON checks, bandit, mypy, repository guardrails

## Notes
- SonarQube pre-push hook skipped because `sonar-scanner` is not installed locally.
