### PR TITLE
test(security): strengthen session-fixation prevention assertion (Batch 2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -660,21 +660,21 @@
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "25b5a7e454ccbe4974ee239749935c9e32b887e1",
         "is_verified": false,
-        "line_number": 317
+        "line_number": 325
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "b3215fe1d22a64a131c0f9c09718c5b8860911ad",
         "is_verified": false,
-        "line_number": 350
+        "line_number": 358
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "495289ab973afae18fc84235f33dadc07a9608c4",
         "is_verified": false,
-        "line_number": 381
+        "line_number": 389
       }
     ],
     "tests/unit/cloud/test_backend_bridges_security.py": [
@@ -1256,5 +1256,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T15:13:48Z"
+  "generated_at": "2026-05-13T21:14:05Z"
 }

--- a/tests/unit/cloud/test_authentication_security.py
+++ b/tests/unit/cloud/test_authentication_security.py
@@ -283,7 +283,7 @@ class TestCredentialSecurity:
             result2 = asyncio.run(auth_manager.authenticate(credentials))
             assert result2.success
 
-        headers2 = asyncio.run(auth_manager.get_auth_headers())
+            headers2 = asyncio.run(auth_manager.get_auth_headers())
 
         # Stateless auth: headers are derived from credentials each call,
         # NOT from a server-issued session token. So `headers1 == headers2`

--- a/tests/unit/cloud/test_authentication_security.py
+++ b/tests/unit/cloud/test_authentication_security.py
@@ -285,11 +285,19 @@ class TestCredentialSecurity:
 
         headers2 = asyncio.run(auth_manager.get_auth_headers())
 
-        # Headers should be different (if session tokens are used)
-        # This test may need adjustment based on actual implementation
-        assert (
-            headers1 == headers2 or True
-        )  # Currently always passes due to stateless auth
+        # Stateless auth: headers are derived from credentials each call,
+        # NOT from a server-issued session token. So `headers1 == headers2`
+        # IS the prevention property — there's no session ID for an
+        # attacker to fix between authentications.
+        # If this test starts failing because the headers differ, it means
+        # hidden session state crept in and the fixation-prevention guarantee
+        # needs re-verification (potentially restructure the test to assert
+        # the new session token differs from any prior one).
+        assert headers1 == headers2, (
+            "Stateless auth should produce identical headers on re-authentication "
+            "with the same credentials; any difference indicates hidden session "
+            "state that could be vulnerable to fixation attacks."
+        )
 
     def test_credential_injection_attempts(self):
         """Test prevention of credential injection attacks."""


### PR DESCRIPTION
## Summary

The validation spine's `tautological_test_detector` flagged `test_session_fixation_prevention` as `assertion_or_true` (Batch 2 of the public-surface gate).

Previous code:
```python
assert (headers1 == headers2 or True)  # Currently always passes due to stateless auth
```

The comment explicitly admits the assertion is inert. This is exactly the "tests preserved the wrong story" pattern Reflection-1 named.

## Change

Replace with an honest assertion that captures the actual security property for stateless auth:

```python
# Stateless auth: headers are derived from credentials each call,
# NOT from a server-issued session token. So headers1 == headers2
# IS the prevention property — there's no session ID for an attacker
# to fix between authentications.
assert headers1 == headers2, (
    "Stateless auth should produce identical headers on re-authentication "
    "with the same credentials; any difference indicates hidden session "
    "state that could be vulnerable to fixation attacks."
)
```

If hidden session state ever creeps in (a real regression of the fixation-prevention guarantee), this test will now fail loudly.

## Test plan

- [x] `pytest tests/unit/cloud/test_authentication_security.py::TestCredentialSecurity::test_session_fixation_prevention -q` passes locally (verified).
- [ ] CI passes (Aikido, Analyze, js-public-parity).

## Validation spine impact

After this lands, the public-surface gate's tautological_test count drops by one. The `regulated_surface_strict_gate` (security namespace bump) no longer fires for this specific test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)