### PR TITLE
fix(sdk): harden tracing privacy and flush

### DIFF
--- a/tests/unit/evaluators/test_evaluator_base.py
+++ b/tests/unit/evaluators/test_evaluator_base.py
@@ -531,6 +531,53 @@ class TestBaseEvaluator:
         with pytest.raises(TypeError):
             BaseEvaluator()
 
+    def test_privacy_mode_redacts_expected_and_actual_outputs_from_tracing(
+        self, mock_evaluator, monkeypatch
+    ):
+        """Privacy mode must not export expected/actual outputs to tracing spans."""
+        mock_evaluator.privacy_enabled = True
+        span_kwargs: dict[str, Any] = {}
+        record_kwargs: dict[str, Any] = {}
+
+        class _SpanContext:
+            def __enter__(self):
+                return object()
+
+            def __exit__(self, *_args):
+                return False
+
+        def span_fn(**kwargs):
+            span_kwargs.update(kwargs)
+            return _SpanContext()
+
+        def record_fn(_span, **kwargs):
+            record_kwargs.update(kwargs)
+
+        monkeypatch.setattr(
+            "traigent.evaluators.base._get_tracing_functions",
+            lambda: (span_fn, record_fn, True),
+        )
+
+        example = EvaluationExample({"prompt": "secret"}, "expected secret")
+        with mock_evaluator._example_trace_context("ex-1", 0, example) as span:
+            mock_evaluator._record_example_trace(
+                span,
+                ExampleResult(
+                    example_id="ex-1",
+                    input_data=example.input_data,
+                    expected_output=example.expected_output,
+                    actual_output="actual secret",
+                    metrics={"accuracy": 1.0},
+                    execution_time=0.01,
+                    success=True,
+                    error_message=None,
+                ),
+            )
+
+        assert span_kwargs["input_data"] is None
+        assert span_kwargs["expected_output"] is None
+        assert record_kwargs["actual_output"] is None
+
     @pytest.mark.asyncio
     async def test_mock_evaluator_basic_evaluation(
         self, mock_evaluator, sample_dataset

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -134,6 +134,50 @@ def test_observability_client_tracks_dropped_payloads_when_buffer_is_full():
     assert result.items_dropped >= 1
 
 
+def test_observability_client_close_flushes_active_trace_payloads_without_explicit_flush():
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=100,
+            max_buffer_age=999.0,
+            max_queue_size=10,
+        ),
+        sender=sender,
+    )
+
+    trace_id = client.start_trace("close-flush", trace_id="trace_close_flush")
+    client.record_observation(trace_id, name="close-observation")
+
+    result = client.close()
+
+    assert result.success is True
+    assert result.items_sent == 1
+    assert sent_batches[-1][-1]["id"] == "trace_close_flush"
+
+
+def test_sync_batch_transport_records_closed_transport_drops():
+    transport = _SyncBatchTransport(
+        sender=lambda traces: None,
+        batch_size=100,
+        max_buffer_age=999.0,
+        max_queue_size=10,
+        max_batch_bytes=1024,
+    )
+
+    transport.close()
+    accepted = transport.submit("trace_after_close", {"id": "trace_after_close"})
+
+    assert accepted is False
+    stats = transport.get_stats()
+    assert "transport closed; dropped payload for item 'trace_after_close'" in stats["errors"]
+
+
 def test_observability_client_chunks_flushes_by_byte_limit():
     sent_batches: list[list[dict]] = []
 

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -1941,10 +1941,13 @@ class BaseEvaluator(ABC):
         if not available or record_fn is None:
             return
 
+        actual_output = (
+            None if getattr(self, "privacy_enabled", False) else result.actual_output
+        )
         record_fn(
             span,
             success=result.success,
-            actual_output=result.actual_output,
+            actual_output=actual_output,
             metrics=result.metrics,
             error=result.error_message,
             execution_time=result.execution_time,
@@ -1973,15 +1976,15 @@ class BaseEvaluator(ABC):
             return
 
         # Get input data for tracing (respect privacy settings)
-        input_data = (
-            None if getattr(self, "privacy_enabled", False) else (example.input_data)
-        )
+        privacy_enabled = getattr(self, "privacy_enabled", False)
+        input_data = None if privacy_enabled else example.input_data
+        expected_output = None if privacy_enabled else example.expected_output
 
         with span_fn(
             example_id=example_id,
             example_index=example_index,
             input_data=input_data,
-            expected_output=example.expected_output,
+            expected_output=expected_output,
         ) as span:
             yield span
 

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -123,6 +123,9 @@ class _SyncBatchTransport:
         send_now = False
         with self._lock:
             if self._closed:
+                self._append_error(
+                    f"transport closed; dropped payload for item '{item_id}'"
+                )
                 return False
 
             if item_id in self._buffer:
@@ -561,6 +564,11 @@ class ObservabilityClient:
                 warnings=[],
             )
 
+        with self._lock:
+            trace_ids = list(self._trace_states.keys())
+        for trace_id in trace_ids:
+            self._queue_trace_snapshot(trace_id)
+
         self._closed = True
         result = self._transport.close()
         return FlushResult(
@@ -873,7 +881,12 @@ class ObservabilityClient:
             if state is None or self._closed:
                 return
             payload = state.to_payload()
-        self._transport.submit(trace_id, payload)
+        if not self._transport.submit(trace_id, payload):
+            logger.warning(
+                "Observability transport did not accept snapshot for trace %s; "
+                "inspect flush() or get_stats() for delivery errors",
+                trace_id,
+            )
 
     def _build_query_string(self, **params: Any) -> str:
         serialized: dict[str, str] = {}


### PR DESCRIPTION
Summary:
- redact expected and actual evaluator outputs from tracing in privacy mode
- surface closed-transport drops as delivery errors
- flush active observability traces during close() without requiring explicit flush()

Verification:
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest tests/unit/evaluators/test_evaluator_base.py::TestBaseEvaluator::test_privacy_mode_redacts_expected_and_actual_outputs_from_tracing tests/unit/observability/test_observability_client.py::test_observability_client_tracks_dropped_payloads_when_buffer_is_full tests/unit/observability/test_observability_client.py::test_observability_client_close_flushes_active_trace_payloads_without_explicit_flush
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m py_compile traigent/evaluators/base.py traigent/observability/client.py