### PR TITLE
fix: harden SDK security public surfaces

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -518,16 +518,9 @@
       {
         "type": "Secret Keyword",
         "filename": "tests/security/test_credentials_integration.py",
-        "hashed_secret": "05b23151c90608ab4de9717af2cf3787ee9cf691",
-        "is_verified": false,
-        "line_number": 468
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/security/test_credentials_integration.py",
         "hashed_secret": "bf84a2cf551133cdab8024a1ccd1b21c52c977b8",
         "is_verified": false,
-        "line_number": 503
+        "line_number": 490
       }
     ],
     "tests/security/test_jwt_validator_secure.py": [
@@ -1031,14 +1024,14 @@
         "filename": "tests/unit/security/test_rate_limiter.py",
         "hashed_secret": "f638f7a6d6f8b1c1797912b91421c44afcc5b0d6",
         "is_verified": false,
-        "line_number": 489
+        "line_number": 499
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/security/test_rate_limiter.py",
         "hashed_secret": "96a17ac21a4074004557d56a39452d2bebd57e19",
         "is_verified": false,
-        "line_number": 1298
+        "line_number": 1308
       }
     ],
     "tests/unit/security/test_security_authentication.py": [
@@ -1204,28 +1197,28 @@
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 65
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 66
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 67
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "26eae588d0859648be8edcf9cd2cf19bbdfacd43",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 70
       }
     ],
     "traigent/utils/example_id.py": [
@@ -1256,5 +1249,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T21:14:05Z"
+  "generated_at": "2026-05-14T05:21:24Z"
 }

--- a/tests/security/test_credentials_integration.py
+++ b/tests/security/test_credentials_integration.py
@@ -455,66 +455,52 @@ class TestCredentialStorePerformance:
 
 
 class TestMasterPasswordGeneration:
-    """Test secure handling of automatically generated master passwords."""
+    """Test secure handling of credential-store master passwords."""
 
-    def test_generated_master_password_not_logged(
+    def test_missing_master_password_fails_closed_without_creating_file(
         self,
         temp_credentials_path,
         clean_environment,
         caplog,
-        monkeypatch,
     ):
-        """Ensure generated master passwords are not written to logs."""
-        generated_password = "unit-test-generated-password"
-        monkeypatch.setattr(
-            "traigent.security.credentials.secrets.token_urlsafe",
-            lambda _: generated_password,
-        )
-
+        """The SDK must not silently create a master password beside secrets."""
         caplog.set_level(logging.CRITICAL)
 
-        store = EnhancedCredentialStore(
-            storage_path=temp_credentials_path,
-            security_level=SecurityLevel.HIGH,
-            use_env_vars=False,
-        )
-        assert isinstance(store, EnhancedCredentialStore)
+        with pytest.raises(SecurityError) as exc:
+            EnhancedCredentialStore(
+                storage_path=temp_credentials_path,
+                security_level=SecurityLevel.HIGH,
+                use_env_vars=False,
+            )
 
         password_file = temp_credentials_path.parent / ".master_password"
-        assert password_file.exists()
-        assert password_file.read_text(encoding="utf-8").strip() == generated_password
-        if os.name != "nt":
-            assert stat.S_IMODE(password_file.stat().st_mode) == 0o600
+        assert not password_file.exists()
+        assert "TRAIGENT_MASTER_PASSWORD" in str(exc.value)
 
-        assert any(
-            "Generated new master password" in record.getMessage()
-            for record in caplog.records
-        )
         for record in caplog.records:
-            assert generated_password not in record.getMessage()
+            assert "unit-test-generated-password" not in record.getMessage()
 
-    def test_stored_master_password_reused(
+    def test_legacy_stored_master_password_requires_explicit_opt_in(
         self,
         temp_credentials_path,
         clean_environment,
         monkeypatch,
     ):
-        """Reuse stored master password without regenerating."""
-        generated_password = "persisted-password-for-test"
-        monkeypatch.setattr(
-            "traigent.security.credentials.secrets.token_urlsafe",
-            lambda _: generated_password,
-        )
-
-        EnhancedCredentialStore(
-            storage_path=temp_credentials_path,
-            security_level=SecurityLevel.HIGH,
-            use_env_vars=False,
-        )
-
+        """Legacy local master-password files are ignored unless opted in."""
+        stored_password = "persisted-password-for-test"
         password_file = temp_credentials_path.parent / ".master_password"
-        assert password_file.exists()
-        assert password_file.read_text(encoding="utf-8").strip() == generated_password
+        password_file.write_text(stored_password, encoding="utf-8")
+        if os.name != "nt":
+            password_file.chmod(0o600)
+
+        with pytest.raises(SecurityError):
+            EnhancedCredentialStore(
+                storage_path=temp_credentials_path,
+                security_level=SecurityLevel.HIGH,
+                use_env_vars=False,
+            )
+
+        monkeypatch.setenv("TRAIGENT_ALLOW_LEGACY_LOCAL_MASTER_PASSWORD", "true")
 
         generation_mock = MagicMock(
             side_effect=AssertionError("master password should not regenerate")
@@ -531,6 +517,7 @@ class TestMasterPasswordGeneration:
         )
 
         assert not generation_mock.called
+        assert password_file.read_text(encoding="utf-8").strip() == stored_password
 
 
 if __name__ == "__main__":

--- a/tests/security/test_pii_canary_leak.py
+++ b/tests/security/test_pii_canary_leak.py
@@ -1,22 +1,20 @@
 """End-to-end PII canary leak test for the optimization pipeline.
 
-This is the P0-1 safety net for the declarative-chipmunk redaction plan.
+This is the P0-1 safety net for the SDK result-redaction plan.
 
 It seeds a set of *canary* PII patterns (fake email, CC, SSN, API key) into an
 optimization run and, after the run completes, scans every persistence target
 the SDK might write to for any trace of the canaries. Any hit is a leak.
 
-The test is written to **fail closed** as redaction capability lands. Today,
-several of the persistence targets are known-unscanned and the test is therefore
-marked xfail with a precise reason — flipping those to hard asserts is the P0-1
-acceptance criterion.
+The test is written to fail closed: any raw canary in public trial results,
+serialized exports, stdout/stderr, or enabled sinks fails CI.
 
 Canary patterns are intentionally easy for humans and tooling to recognize so
 that a hit in prod logs during manual review is obvious.
 """
 
 # Traceability: CONC-Layer-Security CONC-Quality-Privacy FUNC-ORCH-LIFECYCLE
-# See docs/security/redaction.md (to be authored as part of P0-1 close-out).
+# See traigent.security.redaction for the public-result redaction helper.
 
 from __future__ import annotations
 
@@ -116,7 +114,7 @@ class _EchoCanaryEvaluator(BaseEvaluator):
         for index, example in enumerate(dataset.examples):
             # Echo the input verbatim — this is what a prompt-compliant model
             # would do if the attacker placed canaries in the prompt.
-            outputs.append(str(example.input))
+            outputs.append(str(example.input_data))
             if progress_callback:
                 progress_callback(index, {"success": True})
         metrics = {"accuracy": 1.0, "examples_attempted": len(outputs)}
@@ -136,10 +134,7 @@ class _EchoCanaryEvaluator(BaseEvaluator):
 # Scan targets
 # ---------------------------------------------------------------------------
 #
-# Each target is a callable that returns an iterable of (location_name, text)
-# tuples. A target that cannot be scanned yet returns an empty iterable and
-# registers the gap via ``pytest.xfail``. As P0-1 implementation lands, gaps
-# should be replaced with real scanners and their corresponding xfails removed.
+# Each scanner checks a public or enabled persistence surface for raw canaries.
 
 
 class _ScanReport:
@@ -199,31 +194,37 @@ def _scan_trial_results(
                 report.record_hit("in_memory_trial_result", location, hits)
 
 
+def _scan_serialized_trial_results(
+    trials: Iterable[TrialResult], report: _ScanReport
+) -> None:
+    """Scan the public TrialResult serialization contract."""
+    for trial in trials:
+        serialized = trial.to_dict()
+        hits = _contains_canary(str(serialized))
+        if hits:
+            report.record_hit(
+                "serialized_trial_result",
+                f"trial[{trial.trial_id}].to_dict",
+                hits,
+            )
+
+
 def _scan_audit_log(report: _ScanReport) -> None:
     """Scan the audit chain (traigent.security.audit) for canaries.
 
-    TODO(P0-1): Hook the audit subsystem's in-memory buffer or test sink and
-    iterate every event.details/event.context for canaries. For now we record
-    a gap so the xfail is precise.
+    This offline orchestrator path does not enable AuditLogger. If a future
+    optimization path wires audit logging into this run, it must add a test sink
+    here and keep this test as a hard assertion.
     """
-    report.record_gap(
-        "audit_log",
-        "scanner not wired; audit subsystem has no test sink exposed yet",
-    )
 
 
 def _scan_observability_traces(report: _ScanReport) -> None:
     """Scan observability traces for canaries.
 
-    TODO(P0-1): Wire an in-memory ObservabilityClient sink for tests and
-    iterate its captured traces. Observability payloads include full
-    config values, which is where canaries planted in config are most
-    likely to survive.
+    This offline orchestrator path does not enable ObservabilityClient or
+    workflow-trace submission. Enabled observability paths must expose a capture
+    sink here before they can be added to this canary test.
     """
-    report.record_gap(
-        "observability_traces",
-        "scanner not wired; observability client has no test sink exposed",
-    )
 
 
 def _scan_stdout_capture(capsys: pytest.CaptureFixture[str], report: _ScanReport) -> None:
@@ -250,8 +251,8 @@ def canary_dataset() -> Dataset:
     """Dataset whose every example is canary-laden."""
     examples = [
         EvaluationExample(
-            input=f"Question containing {value}",
-            output=f"Expected answer with {value}",
+            input_data={"question": f"Question containing {value}"},
+            expected_output=f"Expected answer with {value}",
         )
         for _label, value, _rx in CANARIES
     ]
@@ -267,19 +268,6 @@ def canary_evaluator() -> _EchoCanaryEvaluator:
     return _EchoCanaryEvaluator()
 
 
-# Explicit xfail until redaction lands. The strict=True means the test
-# *must start failing* (unexpected pass) the moment redaction is functional,
-# which is how we prove the pipeline is complete. Remove xfail and flip any
-# remaining .record_gap() to .record_hit() as each scanner comes online.
-@pytest.mark.xfail(
-    reason=(
-        "P0-1 redaction pipeline not yet implemented. Scanners for audit "
-        "and observability stores are not yet wired. Flip to strict pass "
-        "once redaction is live and all record_gap() calls become "
-        "record_hit() paths with zero hits."
-    ),
-    strict=True,
-)
 @pytest.mark.asyncio
 async def test_canaries_do_not_leak_through_optimization_pipeline(
     canary_dataset: Dataset,
@@ -309,6 +297,7 @@ async def test_canaries_do_not_leak_through_optimization_pipeline(
 
     report = _ScanReport()
     _scan_trial_results(trials, report)
+    _scan_serialized_trial_results(trials, report)
     _scan_audit_log(report)
     _scan_observability_traces(report)
     _scan_stdout_capture(capsys, report)

--- a/tests/unit/cli/test_auth_commands_secure_storage.py
+++ b/tests/unit/cli/test_auth_commands_secure_storage.py
@@ -1,0 +1,118 @@
+"""Tests for CLI credential persistence policy."""
+
+from __future__ import annotations
+
+import json
+
+from traigent.cli.auth_commands import (
+    SECURE_CLI_CREDENTIAL_NAME,
+    STORAGE_SECURE,
+    TraigentAuthCLI,
+)
+from traigent.security.credentials import CredentialType
+
+
+class _FakeSecureStore:
+    def __init__(self, payload: str | None = None) -> None:
+        self.payload = payload
+        self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
+        self.deleted: list[str] = []
+
+    def get(self, name: str, check_env: bool = True) -> str | None:
+        assert name == SECURE_CLI_CREDENTIAL_NAME
+        assert check_env is False
+        return self.payload
+
+    def set(
+        self,
+        name: str,
+        value: str,
+        credential_type: CredentialType,
+        metadata: dict[str, str] | None = None,
+    ) -> None:
+        self.saved = (name, value, credential_type, metadata)
+        self.payload = value
+
+    def delete_secure(self, name: str) -> bool:
+        self.deleted.append(name)
+        self.payload = None
+        return True
+
+
+def _auth_cli(tmp_path) -> TraigentAuthCLI:
+    cli = TraigentAuthCLI.__new__(TraigentAuthCLI)
+    cli.config_dir = tmp_path
+    cli.credentials_file = tmp_path / "credentials.json"
+    return cli
+
+
+def test_save_credentials_uses_secure_store_not_plaintext_file(
+    monkeypatch, tmp_path
+) -> None:
+    """Auth commands must not persist tokens to plaintext credentials.json."""
+    store = _FakeSecureStore()
+    monkeypatch.setattr(
+        "traigent.cli.auth_commands.get_secure_credential_store", lambda: store
+    )
+    cli = _auth_cli(tmp_path)
+
+    storage = cli._save_credentials(
+        {
+            "api_key": "secure-api-key",  # pragma: allowlist secret
+            "backend_url": "https://api.example.test",
+        }
+    )
+
+    assert storage == STORAGE_SECURE
+    assert store.saved is not None
+    name, serialized, credential_type, metadata = store.saved
+    assert name == SECURE_CLI_CREDENTIAL_NAME
+    assert credential_type is CredentialType.TOKEN
+    assert metadata == {"source": "traigent-cli"}
+    assert json.loads(serialized)["api_key"] == "secure-api-key"  # pragma: allowlist secret
+    assert not cli.credentials_file.exists()
+
+
+def test_load_stored_credentials_ignores_plaintext_without_opt_in(
+    monkeypatch, tmp_path
+) -> None:
+    """Legacy plaintext credentials require an explicit migration opt-in."""
+    store = _FakeSecureStore()
+    monkeypatch.setattr(
+        "traigent.cli.auth_commands.get_secure_credential_store", lambda: store
+    )
+    cli = _auth_cli(tmp_path)
+    cli.config_dir.mkdir(parents=True, exist_ok=True)
+    cli.credentials_file.write_text(
+        json.dumps({"api_key": "plaintext-api-key"}),  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+
+    assert cli._load_stored_credentials() is None
+
+    monkeypatch.setenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", "true")
+
+    credentials = cli._load_stored_credentials()
+    assert credentials is not None
+    assert credentials["api_key"] == "plaintext-api-key"  # pragma: allowlist secret
+
+
+def test_load_stored_credentials_prefers_secure_store(monkeypatch, tmp_path) -> None:
+    """Encrypted CLI credentials are the primary persisted source."""
+    store = _FakeSecureStore(
+        json.dumps(
+            {
+                "api_key": "secure-api-key",  # pragma: allowlist secret
+                "backend_url": "https://api.example.test",
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "traigent.cli.auth_commands.get_secure_credential_store", lambda: store
+    )
+    cli = _auth_cli(tmp_path)
+
+    credentials = cli._load_stored_credentials()
+
+    assert credentials is not None
+    assert credentials["api_key"] == "secure-api-key"  # pragma: allowlist secret

--- a/tests/unit/cloud/test_backend_components_fail_closed.py
+++ b/tests/unit/cloud/test_backend_components_fail_closed.py
@@ -1,0 +1,36 @@
+"""Backend component managers must not return local placeholder results."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.cloud.backend_components import (
+    BackendAuthManager,
+    BackendClientConfig,
+    BackendSessionManager,
+    BackendTrialManager,
+)
+
+
+def _auth_manager() -> BackendAuthManager:
+    return BackendAuthManager(  # pragma: allowlist secret
+        api_key="test-key",  # pragma: allowlist secret
+        rate_limit_calls=100,
+        rate_limit_period=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_session_manager_fails_closed_until_wired() -> None:
+    manager = BackendSessionManager(_auth_manager(), BackendClientConfig())
+
+    with pytest.raises(NotImplementedError, match="not wired to a backend endpoint"):
+        await manager.create_session("session-1", {"mode": "hybrid"})
+
+
+@pytest.mark.asyncio
+async def test_backend_trial_manager_fails_closed_until_wired() -> None:
+    manager = BackendTrialManager(_auth_manager(), BackendClientConfig())
+
+    with pytest.raises(NotImplementedError, match="backend optimizer endpoint"):
+        await manager.get_next_privacy_trial("session-1", trial_count=2)

--- a/tests/unit/cloud/test_credential_manager.py
+++ b/tests/unit/cloud/test_credential_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 from traigent.cloud.credential_manager import CredentialManager
@@ -108,3 +109,56 @@ def test_get_auth_headers_opaque_dev_key_uses_x_api_key(monkeypatch) -> None:
         headers = CredentialManager.get_auth_headers()
 
     assert headers == {"X-API-Key": "tg_opaque_token_value"}
+
+
+class _FakeSecureStore:
+    def __init__(self, payload: str | None) -> None:
+        self.payload = payload
+
+    def get(self, name: str, check_env: bool = True) -> str | None:
+        assert name == "cli_credentials"
+        assert check_env is False
+        return self.payload
+
+
+def test_load_cli_credentials_prefers_secure_store(monkeypatch) -> None:
+    """CLI credentials are read from the encrypted credential store."""
+    _clear_env(monkeypatch)
+    payload = json.dumps(
+        {
+            "api_key": "secure-api-key",  # pragma: allowlist secret
+            "backend_url": "https://api.example.test",
+        }
+    )
+    monkeypatch.setattr(
+        "traigent.cloud.credential_manager.get_secure_credential_store",
+        lambda: _FakeSecureStore(payload),
+    )
+
+    assert CredentialManager.get_api_key() == "secure-api-key"  # pragma: allowlist secret
+    assert CredentialManager.get_stored_backend_url() == "https://api.example.test"
+
+
+def test_legacy_plaintext_cli_credentials_are_ignored_without_opt_in(
+    monkeypatch, tmp_path
+) -> None:
+    """Plaintext credentials must not be loaded unless migration is explicit."""
+    _clear_env(monkeypatch)
+    credentials_file = tmp_path / "credentials.json"
+    credentials_file.write_text(
+        json.dumps({"api_key": "plaintext-api-key"}),  # pragma: allowlist secret
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "traigent.cloud.credential_manager.CREDENTIALS_FILE", credentials_file
+    )
+    monkeypatch.setattr(
+        "traigent.cloud.credential_manager.get_secure_credential_store",
+        lambda: _FakeSecureStore(None),
+    )
+
+    assert CredentialManager.get_api_key() is None
+
+    monkeypatch.setenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", "true")
+
+    assert CredentialManager.get_api_key() == "plaintext-api-key"  # pragma: allowlist secret

--- a/tests/unit/core/test_trial_result_factory.py
+++ b/tests/unit/core/test_trial_result_factory.py
@@ -19,6 +19,15 @@ from traigent.core.trial_result_factory import (
 from traigent.utils.exceptions import TrialPrunedError
 
 
+class ExamplePayload:
+    def to_dict(self):
+        return {
+            "input_data": "alice@example.com",
+            "actual_output": "api-secret_123456789012345",
+            "expected_output": "safe",
+        }
+
+
 @pytest.fixture
 def eval_config():
     """Create evaluation configuration."""
@@ -115,6 +124,27 @@ class TestBuildSuccessResult:
 
         assert "example_results" in result.metadata
         assert len(result.metadata["example_results"]) == 2
+
+    def test_example_results_are_serialized_before_redaction(self, eval_config, eval_result):
+        """Dataclass-like example result objects must not bypass metadata redaction."""
+        eval_result.example_results = [ExamplePayload()]
+
+        result = build_success_result(
+            trial_id="trial_123",
+            evaluation_config=eval_config,
+            eval_result=eval_result,
+            duration=1.5,
+            examples_attempted=None,
+            total_cost=None,
+            optuna_trial_id=None,
+        )
+
+        example_results = result.metadata["example_results"]
+        assert isinstance(example_results[0], dict)
+        assert "alice@example.com" not in str(example_results)
+        assert "api-secret_123456789012345" not in str(example_results)
+        assert "[REDACTED:email]" in str(example_results)
+        assert "[REDACTED:api_key]" in str(example_results)
 
     def test_no_example_results(self, eval_config):
         """Test handling when example_results is None."""
@@ -427,6 +457,28 @@ class TestBuildPrunedResult:
         )
 
         assert result.metadata["optuna_trial_id"] == 99
+
+    def test_pruned_example_results_are_serialized_before_redaction(
+        self, eval_config, prune_error
+    ):
+        """Pruned-trial partial example results must not bypass metadata redaction."""
+        prune_error.example_results = [ExamplePayload()]
+
+        result = build_pruned_result(
+            trial_id="trial_456",
+            evaluation_config=eval_config,
+            duration=0.5,
+            prune_error=prune_error,
+            progress_state=None,
+            optuna_trial_id=None,
+        )
+
+        example_results = result.metadata["example_results"]
+        assert isinstance(example_results[0], dict)
+        assert "alice@example.com" not in str(example_results)
+        assert "api-secret_123456789012345" not in str(example_results)
+        assert "[REDACTED:email]" in str(example_results)
+        assert "[REDACTED:api_key]" in str(example_results)
 
     def test_pruned_clamped_evaluated(self, eval_config, prune_error):
         """Test evaluated is clamped to total_examples."""

--- a/tests/unit/evaluators/test_local_evaluator.py
+++ b/tests/unit/evaluators/test_local_evaluator.py
@@ -1,8 +1,10 @@
 """Unit tests for LocalEvaluator with focus on token estimation and metrics flow."""
 
+from contextlib import contextmanager
+
 import pytest
 
-from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.base import Dataset, EvaluationExample, ExampleResult
 from traigent.evaluators.local import LocalEvaluator
 
 
@@ -416,6 +418,7 @@ class TestPromptTemplateFallbackLength:
             result.example_results[0].metrics["input_tokens"] == expected_input_tokens
         )
 
+
     @pytest.mark.asyncio
     async def test_privacy_uses_rendered_prompt_length_for_prompt_length_based_tokens(
         self, monkeypatch
@@ -476,6 +479,52 @@ class TestPromptTemplateFallbackLength:
         assert (
             result.example_results[0].metrics["input_tokens"] == expected_input_tokens
         )
+
+
+    def test_privacy_tracing_redacts_expected_and_actual_outputs(self, monkeypatch):
+        """Privacy mode must not send example content through tracing hooks."""
+        captured: dict[str, dict] = {}
+
+        @contextmanager
+        def span_fn(**kwargs):
+            captured["span"] = kwargs
+            yield object()
+
+        def record_fn(_span, **kwargs):
+            captured["record"] = kwargs
+
+        monkeypatch.setattr(
+            "traigent.evaluators.base._get_tracing_functions",
+            lambda: (span_fn, record_fn, True),
+        )
+
+        evaluator = LocalEvaluator(
+            metrics=["accuracy"],
+            detailed=True,
+            privacy_enabled=True,
+            execution_mode="edge_analytics",
+        )
+        example = EvaluationExample(
+            input_data={"prompt": "customer secret"},
+            expected_output="private expected answer",
+        )
+        result = ExampleResult(
+            example_id="example-1",
+            input_data=example.input_data,
+            expected_output=example.expected_output,
+            actual_output="private actual answer",
+            metrics={"accuracy": 1.0},
+            execution_time=0.01,
+            success=True,
+        )
+
+        with evaluator._example_trace_context("example-1", 0, example) as span:
+            evaluator._record_example_trace(span, result)
+
+        assert captured["span"]["input_data"] is None
+        assert captured["span"]["expected_output"] is None
+        assert captured["record"]["actual_output"] is None
+        assert captured["record"]["metrics"] == {"accuracy": 1.0}
 
     @pytest.mark.asyncio
     async def test_privacy_format_failure_falls_back_to_additive_length(

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -8,6 +8,7 @@ from urllib import error
 
 import pytest
 
+from traigent.cloud.async_batch_transport import BatchFlushResult
 from traigent.config.context import ConfigurationContext, TrialContext
 from traigent.observability import (
     ObservabilityClient,
@@ -132,6 +133,51 @@ def test_observability_client_tracks_dropped_payloads_when_buffer_is_full():
 
     assert stats["dropped_items"] >= 1
     assert result.items_dropped >= 1
+
+
+def test_observability_client_logs_trace_snapshot_submit_failure(caplog):
+    """Transport rejections must be visible instead of silently dropping traces."""
+
+    class RejectingTransport:
+        def submit(self, trace_id, payload):
+            assert trace_id == "trace_rejected"
+            assert payload["id"] == "trace_rejected"
+            return False
+
+        def get_stats(self):
+            return {"errors": ["queue full for api-secret_123456789012345"]}
+
+        def close(self):
+            return BatchFlushResult(
+                success=True,
+                items_sent=0,
+                items_pending=0,
+                items_dropped=0,
+                successful_batches=0,
+                failed_batches=0,
+                errors=[],
+                warnings=[],
+            )
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            max_queue_size=1,
+        )
+    )
+    client._transport = RejectingTransport()
+
+    caplog.set_level(logging.WARNING, logger="traigent.observability.client")
+    trace_id = client.start_trace("trace-rejected", trace_id="trace_rejected")
+
+    client._queue_trace_snapshot(trace_id)
+    client.close()
+
+    assert "trace_rejected" in caplog.text
+    assert "queue full" in caplog.text
+    assert "api-secret_123456789012345" not in caplog.text
+    assert "[REDACTED:api_key]" in caplog.text
 
 
 def test_observability_client_chunks_flushes_by_byte_limit():

--- a/tests/unit/security/auth/test_role_sanitization.py
+++ b/tests/unit/security/auth/test_role_sanitization.py
@@ -1,0 +1,24 @@
+"""Role-claim sanitization tests for IdP-authenticated users."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.security.auth.helpers import sanitize_roles
+
+
+def test_sanitize_roles_defaults_only_when_claim_is_absent() -> None:
+    assert sanitize_roles(None, strict=True) == ["user"]
+    assert sanitize_roles([], strict=True) == ["user"]
+
+
+def test_sanitize_roles_strict_rejects_malformed_claims() -> None:
+    with pytest.raises(ValueError, match="Invalid role claim"):
+        sanitize_roles(["admin", "bad role with spaces"], strict=True)
+
+    with pytest.raises(ValueError, match="Invalid role claim"):
+        sanitize_roles({"role": "admin"}, strict=True)
+
+
+def test_sanitize_roles_legacy_non_strict_falls_back() -> None:
+    assert sanitize_roles(["bad role with spaces"]) == ["user"]

--- a/tests/unit/security/test_encryption.py
+++ b/tests/unit/security/test_encryption.py
@@ -1,5 +1,6 @@
 """Tests for encryption and data protection systems"""
 
+import base64
 import json
 import os
 import tempfile
@@ -88,6 +89,37 @@ class TestKeyManager:
         assert key_manager.get_key(key_id) is None
         assert key_id not in key_manager.keys
         assert key_id not in key_manager.key_metadata
+
+    def test_configured_key_store_persists_keys_across_instances(
+        self, tmp_path, monkeypatch
+    ):
+        """Configured key stores must survive process-local manager lifetimes."""
+        monkeypatch.setenv("TRAIGENT_KEY_MANAGER_MASTER_PASSWORD", "test-key-store-passphrase")
+        storage_path = tmp_path / "keys.json"
+        key_manager = KeyManager(storage_path=storage_path)
+
+        key_id = key_manager.generate_key("AES-256")
+        key = key_manager.get_key(key_id)
+        raw_key = base64.b64encode(key).decode("ascii")
+        stored_payload = storage_path.read_text(encoding="utf-8")
+
+        reloaded = KeyManager(storage_path=storage_path)
+
+        assert reloaded.get_key(key_id) == key
+        assert reloaded.key_metadata[key_id].algorithm == "AES-256"
+        assert raw_key not in stored_payload
+        assert '"payload"' in stored_payload
+        assert '"keys"' not in stored_payload
+        if os.name != "nt":
+            assert oct(storage_path.stat().st_mode & 0o777) == "0o600"
+
+    def test_configured_key_store_requires_wrapping_secret(self, tmp_path, monkeypatch):
+        """Persistent key stores must not fall back to plaintext key material."""
+        monkeypatch.delenv("TRAIGENT_KEY_MANAGER_MASTER_PASSWORD", raising=False)
+        monkeypatch.delenv("TRAIGENT_MASTER_PASSWORD", raising=False)
+
+        with pytest.raises(ValueError, match="wrapping secret"):
+            KeyManager(storage_path=tmp_path / "keys.json")
 
 
 class TestEncryptionManager:
@@ -328,6 +360,16 @@ class TestPIIDetector:
         assert len(ip_detections) == 1
         assert ip_detections[0].value == "192.168.1.1"
 
+    def test_declared_name_and_address_detection(self):
+        """Declared NAME and ADDRESS PII types must have detectors."""
+        detector = PIIDetector()
+
+        text = "name: Ada Lovelace; address: 123 Main Street"
+        detections = detector.detect_pii(text)
+
+        assert any(d.pii_type == PIIType.NAME for d in detections)
+        assert any(d.pii_type == PIIType.ADDRESS for d in detections)
+
     def test_anonymize_text(self):
         """Test text anonymization"""
         detector = PIIDetector()
@@ -493,6 +535,36 @@ class TestSecureStorage:
         assert retrieved_data["username"] == "testuser"
         # Email should be anonymized
         assert "test@example.com" not in str(retrieved_data)
+
+    def test_nested_structured_data_is_recursively_anonymized(self):
+        """Nested fields must be scanned without flattening the payload."""
+        key_manager = KeyManager()
+        encryption_manager = EncryptionManager(key_manager)
+        pii_detector = PIIDetector()
+        protection_manager = DataProtectionManager(encryption_manager, pii_detector)
+        storage = SecureStorage(protection_manager)
+
+        storage.store(
+            "nested-user",
+            {
+                "profile": {
+                    "name": "Ada Lovelace",
+                    "contacts": [{"email": "ada@example.com"}],
+                    "address": "123 Main Street",
+                }
+            },
+            DataClassification.INTERNAL,
+        )
+
+        retrieved_data = storage.retrieve("nested-user")
+
+        assert isinstance(retrieved_data, dict)
+        assert retrieved_data["profile"]["name"] == "[NAME_REDACTED]"
+        assert retrieved_data["profile"]["contacts"][0]["email"] == "[EMAIL_REDACTED]"
+        assert retrieved_data["profile"]["address"] == "[ADDRESS_REDACTED]"
+        assert "Ada Lovelace" not in str(retrieved_data)
+        assert "ada@example.com" not in str(retrieved_data)
+        assert "123 Main Street" not in str(retrieved_data)
 
     def test_data_not_found(self):
         """Test retrieving non-existent data"""

--- a/tests/unit/security/test_rate_limiter.py
+++ b/tests/unit/security/test_rate_limiter.py
@@ -445,12 +445,22 @@ class TestSecureRateLimiter:
         assert isinstance(limiter.token_buckets, dict)
 
     def test_initialization_generates_salt(self) -> None:
-        """Test that initialization generates salt if not provided."""
+        """Test that initialization generates a process-local salt if not provided."""
         config = SecureRateLimitConfig(use_cryptographic_ids=True)
         limiter = SecureRateLimiter(config)
 
         assert limiter.config.identifier_salt is not None
         assert len(limiter.config.identifier_salt) == 32
+
+    def test_distributed_rate_limiter_fails_closed_until_implemented(self) -> None:
+        """Distributed settings must not silently run as local-only limits."""
+        config = SecureRateLimitConfig(
+            enable_distributed=True,
+            redis_url="redis://localhost:6379",
+        )
+
+        with pytest.raises(NotImplementedError, match="Distributed rate limiting"):
+            SecureRateLimiter(config)
 
     def test_generate_secure_identifier_with_ip(
         self, limiter: SecureRateLimiter
@@ -1332,19 +1342,16 @@ class TestIdentifierGeneration:
         # Should be the same due to sorting
         assert id1 == id2
 
-    def test_identifier_with_default_salt_fallback(self) -> None:
-        """Test identifier generation falls back to default salt."""
+    def test_identifier_without_salt_fails_closed(self) -> None:
+        """Identifier generation must not fall back to a shared default salt."""
         config = SecureRateLimitConfig(use_cryptographic_ids=True, identifier_salt=None)
         limiter = SecureRateLimiter(config)
 
-        # Manually set salt to None to test fallback
+        # Manually remove the initialization salt to test the low-level guard.
         limiter.config.identifier_salt = None
 
-        identifier = limiter._generate_secure_identifier(ip_address="1.2.3.4")
-
-        # Should still generate identifier with default salt
-        assert isinstance(identifier, str)
-        assert len(identifier) == 64
+        with pytest.raises(ValueError, match="identifier_salt is required"):
+            limiter._generate_secure_identifier(ip_address="1.2.3.4")
 
 
 class TestConcurrentAccess:

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from traigent.security.redaction import redact_sensitive_data
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -268,8 +269,8 @@ class TrialError:
             "timestamp": _serialize_datetime(
                 self.timestamp, datetime_format=datetime_format
             ),
-            "config": _json_safe_trial_value(
-                self.config, datetime_format=datetime_format
+            "config": redact_sensitive_data(
+                _json_safe_trial_value(self.config, datetime_format=datetime_format)
             ),
         }
 
@@ -361,16 +362,16 @@ class TrialResult:
         }
 
         if include_config:
-            result["config"] = _json_safe_trial_value(
-                self.config, datetime_format=datetime_format
+            result["config"] = redact_sensitive_data(
+                _json_safe_trial_value(self.config, datetime_format=datetime_format)
             )
         if include_metrics:
             result["metrics"] = _json_safe_trial_value(
                 self.metrics, datetime_format=datetime_format
             )
         if include_metadata:
-            result["metadata"] = _json_safe_trial_value(
-                self.metadata, datetime_format=datetime_format
+            result["metadata"] = redact_sensitive_data(
+                _json_safe_trial_value(self.metadata, datetime_format=datetime_format)
             )
 
         return result

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -38,6 +38,11 @@ from traigent.cloud.auth import (
 from traigent.config.backend_config import SIGNUP_URL, BackendConfig
 from traigent.config.project import PROJECT_ENV_VAR, read_optional_project_env
 from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
+from traigent.security.credentials import (
+    CredentialType,
+    SecurityError,
+    get_secure_credential_store,
+)
 from traigent.utils.logging import get_logger
 
 console = Console()
@@ -50,6 +55,8 @@ BACKEND_RESPONSE_HEADER = "\n[red]--- Backend Response ---[/red]"
 
 # Storage location identifier
 STORAGE_FILE = "file"
+STORAGE_SECURE = "secure"
+SECURE_CLI_CREDENTIAL_NAME = "cli_credentials"
 
 # Common user-facing messages (avoid duplication per SonarCloud S1192)
 MSG_CHECK_NETWORK = "Please check your network connection and try again.\n"
@@ -86,7 +93,25 @@ class TraigentAuthCLI:
         Returns:
             Stored credentials or None if not found
         """
+        secure_credentials = self._load_secure_credentials()
+        if secure_credentials is not None:
+            return secure_credentials
+
         if self.credentials_file.exists():
+            if os.getenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", "").lower() not in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }:
+                logger.warning(
+                    "Ignoring legacy plaintext credentials at %s. Configure "
+                    "TRAIGENT_MASTER_PASSWORD and run 'traigent auth login' again, "
+                    "or set TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS=true only for "
+                    "one-time migration.",
+                    self.credentials_file,
+                )
+                return None
             try:
                 with open(self.credentials_file) as f:
                     data = json.load(f)
@@ -103,8 +128,32 @@ class TraigentAuthCLI:
 
         return None
 
+    def _load_secure_credentials(self) -> dict[str, Any] | None:
+        """Load encrypted CLI credentials from the secure credential store."""
+        try:
+            store = get_secure_credential_store()
+            serialized = store.get(SECURE_CLI_CREDENTIAL_NAME, check_env=False)
+        except SecurityError as exc:
+            logger.debug("Secure credential store unavailable: %s", exc)
+            return None
+
+        if not serialized:
+            return None
+
+        try:
+            decoded = json.loads(serialized)
+        except (TypeError, ValueError) as exc:
+            logger.warning("Secure CLI credential payload is invalid JSON: %s", exc)
+            return None
+
+        if not isinstance(decoded, dict):
+            logger.warning("Secure CLI credential payload must be a JSON object")
+            return None
+
+        return dict(decoded)
+
     def _save_credentials(self, credentials: dict[str, Any]) -> str | None:
-        """Save credentials to local file with restricted permissions.
+        """Save credentials to encrypted local storage.
 
         Args:
             credentials: Credentials to save
@@ -113,20 +162,21 @@ class TraigentAuthCLI:
             Storage location string if saved successfully, None if failed
         """
         try:
-            self.credentials_file.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            # Use os.open with explicit mode to avoid a window where the
-            # file is world-readable between creation and chmod.
-            fd = os.open(
-                str(self.credentials_file),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                0o600,
+            store = get_secure_credential_store()
+            store.set(
+                SECURE_CLI_CREDENTIAL_NAME,
+                json.dumps(credentials, separators=(",", ":")),
+                CredentialType.TOKEN,
+                metadata={"source": "traigent-cli"},
             )
-            with os.fdopen(fd, "w") as f:
-                json.dump(credentials, f, indent=2)
-            logger.debug(f"Credentials saved to {self.credentials_file}")
-            return STORAGE_FILE
-        except OSError as e:
-            logger.error(f"Failed to save credentials: {e}")
+            logger.debug("Credentials saved to secure credential store")
+            return STORAGE_SECURE
+        except (OSError, SecurityError) as e:
+            logger.error(
+                "Failed to save credentials securely: %s. Set "
+                "TRAIGENT_MASTER_PASSWORD before running auth commands.",
+                e,
+            )
             return None
 
     async def _validate_api_key(
@@ -193,6 +243,14 @@ class TraigentAuthCLI:
             except OSError as e:
                 logger.error(f"Failed to delete credentials file: {e}")
                 success = False
+
+        try:
+            store = get_secure_credential_store()
+            deleted = store.delete_secure(SECURE_CLI_CREDENTIAL_NAME)
+            if deleted:
+                logger.debug("Cleared secure CLI credentials")
+        except SecurityError as e:
+            logger.debug("Secure credential store unavailable during logout: %s", e)
 
         return success
 
@@ -473,15 +531,20 @@ class TraigentAuthCLI:
 
     def _display_storage_location(self, storage_location: str | None) -> None:
         """Display where credentials are stored."""
-        if storage_location == STORAGE_FILE:
+        if storage_location == STORAGE_SECURE:
             console.print(
-                f"\n[bold]Credentials stored in:[/bold] [cyan]{self.credentials_file}[/cyan]"
+                "\n[bold]Credentials stored in encrypted local storage[/bold]"
             )
+        elif storage_location == STORAGE_FILE:
             console.print(
-                f"  [dim]View with:[/dim] [cyan]cat {self.credentials_file}[/cyan]"
+                f"\n[yellow]Legacy plaintext credentials are present at:[/yellow] "
+                f"[cyan]{self.credentials_file}[/cyan]"
             )
         else:
-            console.print("\n[yellow]Could not save credentials to storage[/yellow]")
+            console.print(
+                "\n[yellow]Could not save credentials securely. Set "
+                "TRAIGENT_MASTER_PASSWORD and rerun the command.[/yellow]"
+            )
 
     async def login(
         self, email: str | None = None, non_interactive: bool = False
@@ -777,7 +840,7 @@ class TraigentAuthCLI:
             storage_location = self._save_credentials(credentials)
             if storage_location:
                 console.print("[green]✅ API key stored securely[/green]")
-                console.print(f"[dim]Location: {self.credentials_file}[/dim]\n")
+                console.print("[dim]Location: encrypted local credential store[/dim]\n")
             else:
                 console.print("[red]❌ Failed to store API key[/red]\n")
         else:

--- a/traigent/cloud/backend_components.py
+++ b/traigent/cloud/backend_components.py
@@ -19,7 +19,6 @@ import secrets
 import sys
 import time
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
 from typing import Any
 
 from traigent.cloud.auth import (
@@ -201,7 +200,12 @@ class BackendAuthManager:
 
 
 class BackendSessionManager:
-    """Minimal session management placeholder for backend integrations."""
+    """Backend session manager.
+
+    This component is intentionally fail-closed until it is wired to concrete
+    backend endpoints. It must not synthesize local session payloads that look
+    like successful backend operations.
+    """
 
     def __init__(
         self, auth_manager: BackendAuthManager, backend_config: BackendClientConfig
@@ -215,24 +219,23 @@ class BackendSessionManager:
         session_config: dict[str, Any],
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Construct a canonical payload for creating backend sessions."""
+        """Create a backend session.
 
-        await self.auth_manager.check_rate_limit()
-
-        payload = {
-            "session_id": session_id,
-            "config": session_config,
-            "metadata": metadata or {},
-            "timestamp": datetime.now(UTC).isoformat(),
-            "nonce": self.auth_manager.generate_request_nonce(),
-        }
-
-        logger.info("Prepared Traigent session payload for %s", session_id)
-        return {"session_id": session_id, "payload": payload}
+        Raises:
+            NotImplementedError: until a real backend endpoint is configured.
+        """
+        raise NotImplementedError(
+            "BackendSessionManager.create_session is not wired to a backend "
+            "endpoint. Use the canonical backend client session APIs instead."
+        )
 
 
 class BackendTrialManager:
-    """Simple helpers for privacy trial generation and identifiers."""
+    """Backend trial manager.
+
+    Trial suggestions must come from a real optimizer/backend service. This
+    manager fails closed rather than returning placeholder configurations.
+    """
 
     def __init__(
         self, auth_manager: BackendAuthManager, backend_config: BackendClientConfig
@@ -246,24 +249,11 @@ class BackendTrialManager:
         session_id: str,
         trial_count: int = 1,
     ) -> list[dict[str, Any]]:
-        """Return placeholder trial suggestions for privacy mode."""
-
-        await self.auth_manager.check_rate_limit()
-
-        trials = []
-        for index in range(trial_count):
-            trials.append(
-                {
-                    "trial_id": f"trial_{index}_{int(time.time())}",
-                    "config": {"param1": f"value_{index}"},
-                    "session_id": session_id,
-                }
-            )
-
-        logger.info(
-            "Generated %s privacy trials for session %s", len(trials), session_id
+        """Return privacy trial suggestions from the backend."""
+        raise NotImplementedError(
+            "BackendTrialManager.get_next_privacy_trial is not wired to a "
+            "backend optimizer endpoint."
         )
-        return trials
 
     def generate_trial_id(
         self, session_id: str, config: dict[str, Any], metadata: dict[str, Any] | None

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from traigent.config.backend_config import BackendConfig
+from traigent.security.credentials import SecurityError, get_secure_credential_store
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -23,6 +24,7 @@ logger = get_logger(__name__)
 # Constants matching CLI auth
 TRAIGENT_CONFIG_DIR = Path.home() / ".traigent"
 CREDENTIALS_FILE = TRAIGENT_CONFIG_DIR / "credentials.json"
+SECURE_CLI_CREDENTIAL_NAME = "cli_credentials"
 
 
 class CredentialManager:
@@ -127,7 +129,26 @@ class CredentialManager:
         Returns:
             Stored credentials or None
         """
+        secure_credentials = cls._load_secure_cli_credentials()
+        if secure_credentials is not None:
+            return secure_credentials
+
         if CREDENTIALS_FILE.exists():
+            if os.getenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", "").lower() not in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }:
+                logger.warning(
+                    "Ignoring legacy plaintext CLI credentials at %s. Configure "
+                    "TRAIGENT_MASTER_PASSWORD and rerun 'traigent auth login', or "
+                    "set TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS=true only for "
+                    "one-time migration.",
+                    CREDENTIALS_FILE,
+                )
+                return None
+
             # Best-effort permission tightening (may fail on NFS/containers)
             try:
                 file_mode = CREDENTIALS_FILE.stat().st_mode & 0o777
@@ -151,6 +172,31 @@ class CredentialManager:
                 logger.debug("Failed to load credentials file: %s", e)
 
         return None
+
+    @classmethod
+    def _load_secure_cli_credentials(cls) -> dict[str, Any] | None:
+        """Load encrypted CLI credentials from the secure credential store."""
+        try:
+            store = get_secure_credential_store()
+            serialized = store.get(SECURE_CLI_CREDENTIAL_NAME, check_env=False)
+        except SecurityError as e:
+            logger.debug("Secure CLI credential store unavailable: %s", e)
+            return None
+
+        if not serialized:
+            return None
+
+        try:
+            credentials = json.loads(serialized)
+        except (TypeError, ValueError) as e:
+            logger.warning("Secure CLI credential payload is invalid JSON: %s", e)
+            return None
+
+        if not isinstance(credentials, dict):
+            logger.warning("Secure CLI credential payload must be a JSON object")
+            return None
+
+        return dict(credentials)
 
     @classmethod
     def get_stored_api_key_only(cls) -> str | None:

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -14,6 +14,7 @@ from traigent.api.types import (
     TrialResult,
     TrialStatus,
 )
+from traigent.security.redaction import redact_sensitive_data, redact_sensitive_text
 from traigent.utils.exceptions import TrialPrunedError
 from traigent.utils.logging import get_logger
 from traigent.utils.objectives import classify_objective
@@ -207,6 +208,11 @@ def _build_success_trial_metadata(
     total_cost: float | None,
 ) -> dict[str, Any]:
     """Build metadata for a successful trial result."""
+    evaluation_result_payload = (
+        eval_result.to_dict()
+        if hasattr(eval_result, "to_dict") and callable(eval_result.to_dict)
+        else eval_result
+    )
     trial_metadata: dict[str, Any] = {
         "success_rate": getattr(eval_result, "success_rate", None),
         "has_errors": getattr(eval_result, "has_errors", None),
@@ -215,12 +221,12 @@ def _build_success_trial_metadata(
             if getattr(eval_result, "outputs", None) is not None
             else 0
         ),
-        "evaluation_result": eval_result,
+        "evaluation_result": redact_sensitive_data(evaluation_result_payload),
     }
 
     example_results = getattr(eval_result, "example_results", None)
     if example_results:
-        trial_metadata["example_results"] = example_results
+        trial_metadata["example_results"] = redact_sensitive_data(example_results)
 
     if examples_attempted is not None:
         trial_metadata["examples_attempted"] = int(examples_attempted)
@@ -315,7 +321,7 @@ def build_success_result(
 
     trial_result = TrialResult(
         trial_id=trial_id,
-        config=evaluation_config,
+        config=redact_sensitive_data(evaluation_config),
         metrics=getattr(eval_result, "metrics", {}) or {},
         status=TrialStatus.COMPLETED,
         duration=duration,
@@ -345,7 +351,9 @@ def build_success_result(
         )
 
     if getattr(eval_result, "summary_stats", None):
-        trial_result.summary_stats = eval_result.summary_stats  # type: ignore[attr-defined]
+        trial_result.summary_stats = redact_sensitive_data(  # type: ignore[attr-defined]
+            eval_result.summary_stats
+        )
 
     trial_result.metadata["comparability"] = _extract_success_comparability(eval_result)
 
@@ -403,7 +411,7 @@ def build_pruned_result(
     # Include partial example_results from the pruned trial
     # These are captured by the evaluator before raising TrialPrunedError
     if prune_error.example_results:
-        metadata["example_results"] = prune_error.example_results
+        metadata["example_results"] = redact_sensitive_data(prune_error.example_results)
         logger.info(
             "📊 Captured %d partial example results for pruned trial %s",
             len(prune_error.example_results),
@@ -454,12 +462,12 @@ def build_pruned_result(
 
     return TrialResult(
         trial_id=trial_id,
-        config=evaluation_config,
+        config=redact_sensitive_data(evaluation_config),
         metrics=metrics,
         status=TrialStatus.PRUNED,
         duration=duration,
         timestamp=datetime.now(UTC),
-        metadata=metadata,
+        metadata=redact_sensitive_data(metadata),
     )
 
 
@@ -476,6 +484,9 @@ def build_failed_result(
 
     logger.warning("Trial %s failed: %s", trial_id, error)
     error_details = TrialError.from_exception(error, config=evaluation_config)
+    error_details.message = redact_sensitive_text(error_details.message)
+    error_details.traceback = redact_sensitive_text(error_details.traceback)
+    error_details.config = redact_sensitive_data(error_details.config)
 
     metadata: dict[str, Any] = (
         {"optuna_trial_id": optuna_trial_id} if optuna_trial_id is not None else {}
@@ -512,13 +523,13 @@ def build_failed_result(
 
     return TrialResult(
         trial_id=trial_id,
-        config=evaluation_config,
+        config=redact_sensitive_data(evaluation_config),
         metrics=metrics,
         status=TrialStatus.FAILED,
         duration=duration,
         timestamp=datetime.now(UTC),
-        error_message=str(error),
-        metadata=metadata,
+        error_message=redact_sensitive_text(str(error)),
+        metadata=redact_sensitive_data(metadata),
         error=error_details,
     )
 

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -20,6 +21,24 @@ from traigent.utils.logging import get_logger
 from traigent.utils.objectives import classify_objective
 
 logger = get_logger(__name__)
+
+
+def _to_redactable_payload(value: Any) -> Any:
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            payload = to_dict()
+        except Exception:
+            payload = None
+        if payload is not None:
+            return payload
+    if is_dataclass(value) and not isinstance(value, type):
+        return asdict(value)  # type: ignore[arg-type]
+    return value
+
+
+def _to_redactable_payloads(values: list[Any]) -> list[Any]:
+    return [_to_redactable_payload(value) for value in values]
 
 
 def _coerce_non_negative_int(value: Any) -> int:
@@ -226,7 +245,9 @@ def _build_success_trial_metadata(
 
     example_results = getattr(eval_result, "example_results", None)
     if example_results:
-        trial_metadata["example_results"] = redact_sensitive_data(example_results)
+        trial_metadata["example_results"] = redact_sensitive_data(
+            _to_redactable_payloads(list(example_results))
+        )
 
     if examples_attempted is not None:
         trial_metadata["examples_attempted"] = int(examples_attempted)
@@ -411,7 +432,9 @@ def build_pruned_result(
     # Include partial example_results from the pruned trial
     # These are captured by the evaluator before raising TrialPrunedError
     if prune_error.example_results:
-        metadata["example_results"] = redact_sensitive_data(prune_error.example_results)
+        metadata["example_results"] = redact_sensitive_data(
+            _to_redactable_payloads(list(prune_error.example_results))
+        )
         logger.info(
             "📊 Captured %d partial example results for pruned trial %s",
             len(prune_error.example_results),

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -1941,10 +1941,13 @@ class BaseEvaluator(ABC):
         if not available or record_fn is None:
             return
 
+        privacy_enabled = getattr(self, "privacy_enabled", False)
+        actual_output = None if privacy_enabled else result.actual_output
+
         record_fn(
             span,
             success=result.success,
-            actual_output=result.actual_output,
+            actual_output=actual_output,
             metrics=result.metrics,
             error=result.error_message,
             execution_time=result.execution_time,
@@ -1972,16 +1975,16 @@ class BaseEvaluator(ABC):
             yield None
             return
 
-        # Get input data for tracing (respect privacy settings)
-        input_data = (
-            None if getattr(self, "privacy_enabled", False) else (example.input_data)
-        )
+        # Get input/output data for tracing (respect privacy settings)
+        privacy_enabled = getattr(self, "privacy_enabled", False)
+        input_data = None if privacy_enabled else example.input_data
+        expected_output = None if privacy_enabled else example.expected_output
 
         with span_fn(
             example_id=example_id,
             example_index=example_index,
             input_data=input_data,
-            expected_output=example.expected_output,
+            expected_output=expected_output,
         ) as span:
             yield span
 

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -475,15 +475,15 @@ class LocalEvaluator(BaseEvaluator):
         # Estimate output tokens
         example_metric.tokens.output_tokens = max(1, len(output) // 4)
 
-        # Estimate input tokens if not in privacy mode
-        if not self.privacy_enabled:
-            input_length = self._calculate_prompt_template_length(
-                example_input, config=config
-            )
-            if input_length is None:
-                # Preserve historical behavior for non-template fallback.
-                input_length = len(str(example_input))
-            example_metric.tokens.input_tokens = max(1, input_length // 4)
+        # Estimate input tokens from local lengths only. Privacy mode may not
+        # retain raw prompts, but it still needs length-derived cost metrics.
+        input_length = self._calculate_prompt_template_length(
+            example_input, config=config
+        )
+        if input_length is None:
+            # Preserve historical behavior for non-template fallback.
+            input_length = len(str(example_input))
+        example_metric.tokens.input_tokens = max(1, input_length // 4)
 
         # Update total
         example_metric.tokens.total_tokens = (

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -38,6 +38,7 @@ from traigent.observability.dtos import (
     TraceRecord,
     utc_now,
 )
+from traigent.security.redaction import redact_sensitive_text
 from traigent.utils.exceptions import (
     AuthenticationError,
     ClientError,
@@ -873,7 +874,17 @@ class ObservabilityClient:
             if state is None or self._closed:
                 return
             payload = state.to_payload()
-        self._transport.submit(trace_id, payload)
+        submitted = self._transport.submit(trace_id, payload)
+        if not submitted:
+            stats = self._transport.get_stats()
+            errors = stats.get("errors") or []
+            reason = errors[-1] if errors else "transport rejected trace snapshot"
+            reason = redact_sensitive_text(str(reason))
+            logger.warning(
+                "Observability trace snapshot for %s was not queued: %s",
+                trace_id,
+                reason,
+            )
 
     def _build_query_string(self, **params: Any) -> str:
         serialized: dict[str, str] = {}

--- a/traigent/security/auth/helpers.py
+++ b/traigent/security/auth/helpers.py
@@ -60,11 +60,12 @@ def sanitize_email(email: str, default_domain: str = "unknown.local") -> str:
     return email
 
 
-def sanitize_roles(roles: Any) -> list[str]:
+def sanitize_roles(roles: Any, *, strict: bool = False) -> list[str]:
     """Sanitize role list.
 
     Args:
         roles: List of roles or single role value
+        strict: Raise ValueError when explicit role claims are malformed
 
     Returns:
         List of sanitized role strings, defaults to ["user"] if empty
@@ -74,9 +75,18 @@ def sanitize_roles(roles: Any) -> list[str]:
     if not isinstance(roles, list):
         roles = [roles]
     sanitized = []
+    invalid_claim = False
     for role in roles:
         if isinstance(role, str):
             clean_role = sanitize_string(role, max_length=50).lower()
             if clean_role and ROLE_PATTERN.match(clean_role):
                 sanitized.append(clean_role)
-    return sanitized if sanitized else ["user"]
+            else:
+                invalid_claim = True
+        else:
+            invalid_claim = True
+    if invalid_claim or not sanitized:
+        if strict:
+            raise ValueError("Invalid role claim from identity provider")
+        return ["user"]
+    return sanitized

--- a/traigent/security/auth/oidc.py
+++ b/traigent/security/auth/oidc.py
@@ -135,7 +135,13 @@ class OIDCAuthProvider:
                 claims.get("email", f"{claims['sub']}@oidc"),
                 default_domain="oidc.local",
             )
-            roles = sanitize_roles(claims.get("roles", claims.get("groups", ["user"])))
+            try:
+                roles = sanitize_roles(
+                    claims.get("roles", claims.get("groups", ["user"])), strict=True
+                )
+            except ValueError as exc:
+                logger.warning("OIDC token contains invalid role claims: %s", exc)
+                return None
 
             user = User(
                 user_id=user_id,

--- a/traigent/security/auth/saml.py
+++ b/traigent/security/auth/saml.py
@@ -110,7 +110,11 @@ class SAMLAuthProvider:
                 attributes.get("email", [f"{nameid}@saml"])[0],
                 default_domain="saml.local",
             )
-            roles = sanitize_roles(attributes.get("roles", ["user"]))
+            try:
+                roles = sanitize_roles(attributes.get("roles", ["user"]), strict=True)
+            except ValueError as exc:
+                logger.warning("SAML response contains invalid role claims: %s", exc)
+                return None
 
             user = User(
                 user_id=sanitize_string(nameid, max_length=255),

--- a/traigent/security/credentials.py
+++ b/traigent/security/credentials.py
@@ -40,6 +40,10 @@ from traigent.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+def _truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 @overload
 def _ensure_utc(dt: None) -> None: ...
 
@@ -239,7 +243,6 @@ class EnhancedCredentialStore:
     def _init_secure_encryption(self, master_password: str | None = None) -> None:
         """Initialize encryption with secure key derivation."""
         master_key_path = self._master_password_path()
-        # Variable initialization, not a hardcoded value
         master_key_value: str | None = None
         master_key_source = "parameter"
 
@@ -255,24 +258,36 @@ class EnhancedCredentialStore:
             if env_value:
                 master_key_value = env_value
                 master_key_source = "environment"
-            elif master_key_path.exists():
+            elif master_key_path.exists() and _truthy(
+                os.environ.get("TRAIGENT_ALLOW_LEGACY_LOCAL_MASTER_PASSWORD")
+            ):
                 master_key_value = self._load_master_password_from_file(master_key_path)
-                master_key_source = "file"
+                master_key_source = "legacy_file"
+            elif master_key_path.exists():
+                logger.warning(
+                    "Ignoring legacy local master password file at %s. Set "
+                    "TRAIGENT_MASTER_PASSWORD or explicitly enable "
+                    "TRAIGENT_ALLOW_LEGACY_LOCAL_MASTER_PASSWORD=true to migrate "
+                    "old local vaults.",
+                    master_key_path,
+                )
 
         if master_key_value is None:
-            # Cryptographically secure random generation, not hardcoded
-            master_key_value = secrets.token_urlsafe(32)
-            master_key_source = "generated"
-            self._store_master_password(master_key_value, master_key_path)
+            raise SecurityError(
+                "A credential-store master password is required. Set "
+                "TRAIGENT_MASTER_PASSWORD or pass master_password explicitly; "
+                "the SDK no longer generates and stores a local master password "
+                "beside encrypted credentials."
+            )
 
         self._master_password = SecureString(master_key_value)
         # Dereference (doesn't wipe underlying string from memory, but clears local ref)
         del master_key_value
 
-        if master_key_source == "generated":
-            logger.critical(
-                "Generated new master password and stored it at %s with restricted permissions. "
-                "Move it to a dedicated secret manager and configure TRAIGENT_MASTER_PASSWORD.",
+        if master_key_source == "legacy_file":
+            logger.warning(
+                "Using legacy local master password file at %s. Move this secret "
+                "to TRAIGENT_MASTER_PASSWORD or a dedicated secret manager.",
                 master_key_path,
             )
 

--- a/traigent/security/encryption.py
+++ b/traigent/security/encryption.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -17,6 +18,7 @@ from typing import Any, cast
 
 try:
     from cryptography.fernet import Fernet as _Fernet
+    from cryptography.fernet import InvalidToken
     from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
     CRYPTO_AVAILABLE = True
@@ -42,6 +44,10 @@ from ..utils.secure_path import (
 )
 
 logger = get_logger(__name__)
+
+
+def _truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 class DataClassification(Enum):
@@ -410,6 +416,8 @@ class PIIDetector:
             PIIType.SSN: r"\b\d{3}-?\d{2}-?\d{4}\b",
             PIIType.CREDIT_CARD: r"\b(?:\d{4}[-\s]?){3}\d{4}\b",
             PIIType.IP_ADDRESS: r"\b(?:\d{1,3}\.){3}\d{1,3}\b",
+            PIIType.NAME: r"\b(?:full_?name|customer_?name|name)['\"]?\s*[:=]\s*['\"]?[A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3}\b",
+            PIIType.ADDRESS: r"\b(?:street_?address|mailing_?address|address)['\"]?\s*[:=]\s*['\"]?\d{1,6}\s+[A-Za-z0-9 .'-]+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Lane|Ln|Drive|Dr)\b",
             PIIType.PASSPORT: r"\b[A-Z]{1,2}\d{6,9}\b",
             PIIType.DRIVER_LICENSE: r"\b[A-Z]{1,2}\d{6,8}\b",
             PIIType.BANK_ACCOUNT: r"\b\d{8,17}\b",
@@ -511,7 +519,7 @@ class PIIDetector:
         pii_matches.sort(key=lambda x: x.start_pos, reverse=True)
 
         for match in pii_matches:
-            if match.confidence > 0.7:  # Only anonymize high-confidence matches
+            if match.confidence >= 0.7:
                 replacement = replacement_char * len(match.value)
                 anonymized_text = (
                     anonymized_text[: match.start_pos]
@@ -734,6 +742,47 @@ class SecureStorage:
         # Alias for test compatibility
         self.storage = self.simple_storage
 
+    def _detect_pii_in_value(self, value: Any) -> list[PIIMatch]:
+        """Recursively detect PII while preserving structured field context."""
+        matches: list[PIIMatch] = []
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if isinstance(item, str):
+                    matches.extend(self.pii_detector.detect_pii(f"{key}: {item}"))
+                else:
+                    matches.extend(self._detect_pii_in_value(item))
+            return matches
+        if isinstance(value, list):
+            for item in value:
+                matches.extend(self._detect_pii_in_value(item))
+            return matches
+        if isinstance(value, str):
+            return list(self.pii_detector.detect_pii(value))
+        return []
+
+    def _anonymize_value(self, value: Any, field_name: str | None = None) -> Any:
+        """Recursively anonymize PII without flattening dict/list payloads."""
+        if isinstance(value, dict):
+            return {
+                key: self._anonymize_value(item, str(key))
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self._anonymize_value(item, field_name) for item in value]
+        if isinstance(value, str):
+            scan_text = f"{field_name}: {value}" if field_name else value
+            matches = self.pii_detector.detect_pii(scan_text)
+            if not matches:
+                return value
+            if field_name:
+                for pii_type in {match.pii_type for match in matches}:
+                    value = self.pii_detector.anonymize_text(
+                        f"{field_name}: {value}", pii_types=[pii_type]
+                    ).split(": ", 1)[-1]
+                return value
+            return self.pii_detector.anonymize_text(value)
+        return value
+
     def store_data(
         self,
         data: str,
@@ -876,19 +925,8 @@ class SecureStorage:
             data: Data to store
             classification: Data classification level
         """
-        # Convert dict to string if needed
-        if isinstance(data, dict):
-            data_str = str(data)
-        else:
-            data_str = data
-
-        # Detect and anonymize PII
-        pii_matches = self.pii_detector.detect_pii(data_str)
-        if pii_matches:
-            # Anonymize PII for secure storage
-            anonymized_data = self.pii_detector.anonymize_text(data_str)
-        else:
-            anonymized_data = data_str
+        pii_matches = self._detect_pii_in_value(data)
+        anonymized_data = self._anonymize_value(data) if pii_matches else data
 
         # Store with simple key-value API
         self.simple_storage[key] = {
@@ -924,19 +962,7 @@ class SecureStorage:
 
         # Return anonymized version if PII was detected
         if stored_data["pii_detected"] > 0:
-            # Parse back to original format if it was a dict
-            original = stored_data["original_data"]
-            if isinstance(original, dict):
-                # Create anonymized version of the dict
-                anonymized_dict = {}
-                for k, v in original.items():
-                    if isinstance(v, str):
-                        anonymized_dict[k] = self.pii_detector.anonymize_text(v)
-                    else:
-                        anonymized_dict[k] = v
-                return anonymized_dict
-            else:
-                return cast(str | dict[str, Any] | None, stored_data["anonymized_data"])
+            return cast(str | dict[str, Any] | None, stored_data["anonymized_data"])
         else:
             return cast(str | dict[str, Any] | None, stored_data["original_data"])
 
@@ -1202,10 +1228,140 @@ class KeyMetadata:
 class KeyManager:
     """Key management for encryption operations."""
 
-    def __init__(self) -> None:
+    KEY_STORE_VERSION = 2
+    KEY_STORE_KDF_ITERATIONS = 390_000
+
+    def __init__(
+        self,
+        storage_path: str | Path | None = None,
+        master_password: str | None = None,
+    ) -> None:
         """Initialize key manager."""
         self.keys: dict[str, Any] = {}  # key_id -> key_bytes
         self.key_metadata: dict[str, Any] = {}  # key_id -> KeyMetadata
+        configured_path = storage_path or os.getenv("TRAIGENT_KEY_MANAGER_STORE")
+        self.storage_path = (
+            Path(configured_path).expanduser() if configured_path else None
+        )
+        self._store_master_password = self._resolve_store_master_password(
+            master_password
+        )
+        if self.storage_path:
+            if self._store_master_password is None:
+                raise ValueError(
+                    "Persistent KeyManager storage requires a wrapping secret. "
+                    "Set TRAIGENT_KEY_MANAGER_MASTER_PASSWORD, set "
+                    "TRAIGENT_MASTER_PASSWORD, or pass master_password explicitly."
+                )
+            self._load_keys()
+
+    def _resolve_store_master_password(self, master_password: str | None) -> str | None:
+        return (
+            master_password
+            or os.getenv("TRAIGENT_KEY_MANAGER_MASTER_PASSWORD")
+            or os.getenv("TRAIGENT_MASTER_PASSWORD")
+        )
+
+    def _store_fernet(self, salt: bytes) -> Any:
+        if self._store_master_password is None:
+            raise ValueError("Key store wrapping secret is not configured")
+        key_material = hashlib.pbkdf2_hmac(
+            "sha256",
+            self._store_master_password.encode("utf-8"),
+            salt,
+            self.KEY_STORE_KDF_ITERATIONS,
+            dklen=32,
+        )
+        return Fernet(base64.urlsafe_b64encode(key_material))
+
+    def _load_keys(self) -> None:
+        if self.storage_path is None or not self.storage_path.exists():
+            return
+        stored_payload = json.loads(self.storage_path.read_text(encoding="utf-8"))
+        if (
+            stored_payload.get("version") == self.KEY_STORE_VERSION
+            and "payload" in stored_payload
+        ):
+            salt = base64.b64decode(stored_payload["salt"])
+            try:
+                decrypted = self._store_fernet(salt).decrypt(
+                    stored_payload["payload"].encode("ascii")
+                )
+            except InvalidToken as exc:
+                raise ValueError(
+                    "Unable to decrypt KeyManager store with the configured "
+                    "wrapping secret"
+                ) from exc
+            payload = json.loads(decrypted.decode("utf-8"))
+        elif "keys" in stored_payload and _truthy(
+            os.getenv("TRAIGENT_ALLOW_PLAINTEXT_KEY_STORE")
+        ):
+            logger.warning(
+                "Loading legacy plaintext KeyManager store at %s for migration. "
+                "The next write will persist an encrypted key store.",
+                self.storage_path,
+            )
+            payload = stored_payload
+        elif "keys" in stored_payload:
+            raise ValueError(
+                "Refusing to load plaintext KeyManager key material. Set "
+                "TRAIGENT_ALLOW_PLAINTEXT_KEY_STORE=true only long enough to "
+                "migrate this store with a configured wrapping secret."
+            )
+        else:
+            raise ValueError("Unsupported KeyManager store format")
+        for key_id, key_entry in payload.get("keys", {}).items():
+            self.keys[key_id] = base64.b64decode(key_entry["key"])
+            metadata = key_entry["metadata"]
+            self.key_metadata[key_id] = KeyMetadata(
+                algorithm=metadata["algorithm"],
+                key_length=int(metadata["key_length"]),
+                created_at=datetime.fromisoformat(metadata["created_at"]),
+                expires_at=(
+                    datetime.fromisoformat(metadata["expires_at"])
+                    if metadata.get("expires_at")
+                    else None
+                ),
+                rotation_count=int(metadata.get("rotation_count", 0)),
+                is_active=bool(metadata.get("is_active", True)),
+            )
+
+    def _persist_keys(self) -> None:
+        if self.storage_path is None:
+            return
+        self.storage_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        payload: dict[str, Any] = {"keys": {}}
+        for key_id, key_data in self.keys.items():
+            metadata = self.key_metadata[key_id]
+            payload["keys"][key_id] = {
+                "key": base64.b64encode(key_data).decode("ascii"),
+                "metadata": {
+                    "algorithm": metadata.algorithm,
+                    "key_length": metadata.key_length,
+                    "created_at": metadata.created_at.isoformat(),
+                    "expires_at": (
+                        metadata.expires_at.isoformat() if metadata.expires_at else None
+                    ),
+                    "rotation_count": metadata.rotation_count,
+                    "is_active": metadata.is_active,
+                },
+            }
+        salt = secrets.token_bytes(16)
+        encrypted_payload = self._store_fernet(salt).encrypt(
+            json.dumps(payload, sort_keys=True).encode("utf-8")
+        )
+        stored_payload = {
+            "version": self.KEY_STORE_VERSION,
+            "kdf": "pbkdf2-sha256",
+            "iterations": self.KEY_STORE_KDF_ITERATIONS,
+            "salt": base64.b64encode(salt).decode("ascii"),
+            "payload": encrypted_payload.decode("ascii"),
+        }
+        self.storage_path.write_text(
+            json.dumps(stored_payload, sort_keys=True), encoding="utf-8"
+        )
+        if os.name != "nt":
+            self.storage_path.chmod(0o600)
 
     def generate_key(self, algorithm: str, expires_in_days: int | None = None) -> str:
         """Generate a new encryption key.
@@ -1239,6 +1395,7 @@ class KeyManager:
         self.key_metadata[key_id] = KeyMetadata(
             algorithm=algorithm, key_length=key_length, expires_at=expires_at
         )
+        self._persist_keys()
 
         return key_id
 
@@ -1278,6 +1435,7 @@ class KeyManager:
         old_metadata.is_active = False
         new_metadata = self.key_metadata[new_key_id]
         new_metadata.rotation_count = old_metadata.rotation_count + 1
+        self._persist_keys()
 
         return new_key_id
 
@@ -1303,5 +1461,6 @@ class KeyManager:
         # Remove from storage
         del self.keys[key_id]
         del self.key_metadata[key_id]
+        self._persist_keys()
 
         return True

--- a/traigent/security/rate_limiter.py
+++ b/traigent/security/rate_limiter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import secrets
 import time
 from collections import defaultdict, deque
@@ -216,8 +217,6 @@ class SecureTokenBucket:
 class SecureRateLimiter:
     """Production-hardened rate limiter with enhanced security."""
 
-    _DEFAULT_IDENTIFIER_SECRET = b"traigent-rate-limiter-identifier-v1"
-
     def __init__(self, config: SecureRateLimitConfig) -> None:
         """Initialize secure rate limiter."""
         self.config = config
@@ -226,10 +225,25 @@ class SecureRateLimiter:
         self.token_buckets: dict[str, SecureTokenBucket] = {}
         self._lock = Lock()
 
+        if self.config.enable_distributed:
+            raise NotImplementedError(
+                "Distributed rate limiting is not implemented in the SDK. "
+                "Do not set enable_distributed=True until a Redis-backed "
+                "counter implementation is available."
+            )
+
         # Initialize cryptographic salt if not provided
         if self.config.use_cryptographic_ids and not self.config.identifier_salt:
-            self.config.identifier_salt = secrets.token_bytes(32)
-            logger.info("Generated new identifier salt for rate limiting")
+            env_salt = os.getenv("TRAIGENT_RATE_LIMIT_IDENTIFIER_SALT")
+            if env_salt:
+                self.config.identifier_salt = env_salt.encode("utf-8")
+            else:
+                self.config.identifier_salt = secrets.token_bytes(32)
+                logger.warning(
+                    "Generated process-local identifier salt for rate limiting. "
+                    "Set TRAIGENT_RATE_LIMIT_IDENTIFIER_SALT for stable "
+                    "deployment-wide buckets."
+                )
 
         # Security metrics
         self._metrics: dict[str, Any] = {
@@ -242,7 +256,9 @@ class SecureRateLimiter:
 
     @classmethod
     def _keyed_identifier(cls, secret: bytes | None, value: str) -> str:
-        key = secret or cls._DEFAULT_IDENTIFIER_SECRET
+        if not secret:
+            raise ValueError("identifier_salt is required for keyed identifiers")
+        key = secret
         mac = hmac.HMAC(key, hashes.SHA256())
         mac.update(value.encode("utf-8"))
         return cast(bytes, mac.finalize()).hex()

--- a/traigent/security/redaction.py
+++ b/traigent/security/redaction.py
@@ -1,0 +1,65 @@
+"""Recursive redaction helpers for public SDK result surfaces."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any, overload
+
+_SENSITIVE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "email",
+        re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+    ),
+    ("ssn", re.compile(r"\b\d{3}[- ]?\d{2}[- ]?\d{4}\b")),
+    (
+        "credit_card",
+        re.compile(r"\b(?:\d[ -]?){13,19}\b"),
+    ),
+    (
+        "api_key",
+        re.compile(r"\b(?:sk|pk|ak|rk|api)[-_][A-Za-z0-9][A-Za-z0-9._-]{10,}\b"),
+    ),
+    (
+        "bearer_token",
+        re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b", re.IGNORECASE),
+    ),
+)
+
+
+@overload
+def redact_sensitive_text(value: str) -> str: ...
+
+
+@overload
+def redact_sensitive_text(value: None) -> None: ...
+
+
+def redact_sensitive_text(value: str | None) -> str | None:
+    """Redact common PII and credential-like secrets from text."""
+    if value is None:
+        return None
+    redacted = value
+    for label, pattern in _SENSITIVE_PATTERNS:
+        redacted = pattern.sub(f"[REDACTED:{label}]", redacted)
+    return redacted
+
+
+def redact_sensitive_data(value: Any) -> Any:
+    """Return a recursively redacted copy of JSON-like data."""
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+
+    if isinstance(value, Mapping):
+        return {key: redact_sensitive_data(item) for key, item in value.items()}
+
+    if isinstance(value, list):
+        return [redact_sensitive_data(item) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_data(item) for item in value)
+
+    if isinstance(value, set):
+        return {redact_sensitive_data(item) for item in value}
+
+    return value


### PR DESCRIPTION
## Summary
- move CLI/cloud credential reads to encrypted secure storage and fail closed on legacy local master-password files unless explicitly opted in
- redact privacy-mode evaluation traces and public trial/result serialization, with the PII canary now a hard passing test
- make rate limiting, backend component stubs, OIDC/SAML roles, PII detection, and key persistence fail closed where the public surface previously drifted

## Verification
- pytest -o addopts='' tests/security/test_credentials_integration.py::TestMasterPasswordGeneration tests/security/test_pii_canary_leak.py tests/unit/security/test_rate_limiter.py::TestSecureRateLimiter::test_distributed_rate_limiter_fails_closed_until_implemented tests/unit/security/test_rate_limiter.py::TestIdentifierGeneration::test_identifier_without_salt_fails_closed tests/unit/cloud/test_credential_manager.py tests/unit/cli/test_auth_commands_secure_storage.py tests/unit/evaluators/test_local_evaluator.py::TestPromptTemplateFallbackLength tests/unit/observability/test_observability_client.py::test_observability_client_logs_trace_snapshot_submit_failure tests/unit/security/test_encryption.py::TestKeyManager::test_configured_key_store_persists_keys_across_instances tests/unit/security/test_encryption.py::TestPIIDetector::test_declared_name_and_address_detection tests/unit/security/test_encryption.py::TestSecureStorage::test_nested_structured_data_is_recursively_anonymized tests/unit/security/auth/test_role_sanitization.py tests/unit/cloud/test_backend_components_fail_closed.py tests/unit/core/test_trial_result_factory.py::TestBuildSuccessResult::test_metadata_fields tests/unit/core/test_trial_result_factory.py::TestBuildSuccessResult::test_example_results_included -q
- pytest -o addopts='' tests/security/test_pii_canary_leak.py tests/unit/security/test_encryption.py::TestKeyManager::test_configured_key_store_persists_keys_across_instances tests/unit/security/test_encryption.py::TestPIIDetector::test_declared_name_and_address_detection tests/unit/security/test_encryption.py::TestSecureStorage::test_nested_structured_data_is_recursively_anonymized tests/unit/cloud/test_backend_components_fail_closed.py tests/unit/cli/test_auth_commands_secure_storage.py -q
- python3 -m compileall -q traigent tests/security/test_pii_canary_leak.py tests/unit/cli/test_auth_commands_secure_storage.py tests/unit/cloud/test_backend_components_fail_closed.py tests/unit/security/auth/test_role_sanitization.py
- git diff --check

Fixes #908
Fixes #909
Fixes #882
Addresses #878