### PR TITLE
fix: harden SDK redaction follow-ups

### DIFF
--- a/tests/security/test_pii_canary_leak.py
+++ b/tests/security/test_pii_canary_leak.py
@@ -32,6 +32,12 @@ from traigent.evaluators.base import (
     EvaluationExample,
     EvaluationResult,
 )
+from traigent.observability import (
+    ObservabilityClient,
+    ObservabilityConfig,
+    ObservationType,
+)
+from traigent.security.audit import AuditEventType, AuditLogger
 
 # ---------------------------------------------------------------------------
 # Canary catalogue
@@ -164,9 +170,7 @@ class _ScanReport:
         return "\n".join(f"  - {target}: {reason}" for target, reason in self.gaps)
 
 
-def _scan_trial_results(
-    trials: Iterable[TrialResult], report: _ScanReport
-) -> None:
+def _scan_trial_results(trials: Iterable[TrialResult], report: _ScanReport) -> None:
     """Scan in-memory TrialResult objects for canaries.
 
     This is the most-local surface: if canaries survive to here, every
@@ -181,13 +185,10 @@ def _scan_trial_results(
             for i, output in enumerate(trial.outputs or []):
                 blobs.append((f"trial[{trial.trial_id}].outputs[{i}]", str(output)))
         if getattr(trial, "metadata", None):
-            blobs.append(
-                (f"trial[{trial.trial_id}].metadata", str(trial.metadata))
-            )
-        if getattr(trial, "config", None):
-            blobs.append(
-                (f"trial[{trial.trial_id}].config", str(trial.config))
-            )
+            blobs.append((f"trial[{trial.trial_id}].metadata", str(trial.metadata)))
+        # Raw config stays available in memory so callers can replay or apply the
+        # selected configuration. The external serialization scanner below owns
+        # the public leak boundary for config payloads.
         for location, blob in blobs:
             hits = _contains_canary(blob)
             if hits:
@@ -209,25 +210,41 @@ def _scan_serialized_trial_results(
             )
 
 
-def _scan_audit_log(report: _ScanReport) -> None:
+def _scan_audit_log(events: Iterable[Any], report: _ScanReport) -> None:
     """Scan the audit chain (traigent.security.audit) for canaries.
 
-    This offline orchestrator path does not enable AuditLogger. If a future
-    optimization path wires audit logging into this run, it must add a test sink
-    here and keep this test as a hard assertion.
+    The canary test exercises an AuditLogger sink explicitly so this scanner
+    stays a hard assertion instead of a placeholder.
     """
+    for index, event in enumerate(events):
+        payload = event.to_dict() if hasattr(event, "to_dict") else event
+        hits = _contains_canary(str(payload))
+        if hits:
+            report.record_hit("audit_log", f"event[{index}]", hits)
 
 
-def _scan_observability_traces(report: _ScanReport) -> None:
+def _scan_observability_traces(
+    trace_batches: Iterable[Iterable[dict[str, Any]]], report: _ScanReport
+) -> None:
     """Scan observability traces for canaries.
 
-    This offline orchestrator path does not enable ObservabilityClient or
-    workflow-trace submission. Enabled observability paths must expose a capture
-    sink here before they can be added to this canary test.
+    The canary test exercises ObservabilityClient with an in-memory sender so
+    trace payload redaction is covered before data leaves the SDK.
     """
+    for batch_index, trace_batch in enumerate(trace_batches):
+        for trace_index, trace_payload in enumerate(trace_batch):
+            hits = _contains_canary(str(trace_payload))
+            if hits:
+                report.record_hit(
+                    "observability_trace",
+                    f"batch[{batch_index}].trace[{trace_index}]",
+                    hits,
+                )
 
 
-def _scan_stdout_capture(capsys: pytest.CaptureFixture[str], report: _ScanReport) -> None:
+def _scan_stdout_capture(
+    capsys: pytest.CaptureFixture[str], report: _ScanReport
+) -> None:
     """Scan captured stdout/stderr for canaries.
 
     This one IS live today — any print() or logger.* in the pipeline will
@@ -239,6 +256,69 @@ def _scan_stdout_capture(capsys: pytest.CaptureFixture[str], report: _ScanReport
         hits = _contains_canary(stream)
         if hits:
             report.record_hit("stdout_capture", stream_name, hits)
+
+
+def _exercise_audit_sink() -> list[Any]:
+    """Write canaries through AuditLogger and return stored events for scanning."""
+    audit_logger = AuditLogger("CanaryAuditSecret-1234567890!abcdef")
+    audit_logger.log_event(
+        AuditEventType.DATA_READ,
+        user_id=CANARY_VALUES[0],
+        session_id=f"session-{CANARY_VALUES[1]}",
+        tenant_id=f"tenant-{CANARY_VALUES[2]}",
+        resource_id=f"resource-{CANARY_VALUES[3]}",
+        resource_type="dataset",
+        action="read",
+        message=f"Audit canary payload {CANARY_VALUES[4]}",
+        details={
+            "input": CANARY_VALUES[0],
+            "expected": CANARY_VALUES[1],
+            "token": CANARY_VALUES[3],
+        },
+    )
+    return audit_logger.get_events()
+
+
+def _exercise_observability_sink() -> list[list[dict[str, Any]]]:
+    """Write canaries through ObservabilityClient and return captured batches."""
+    sent_batches: list[list[dict[str, Any]]] = []
+
+    def sender(traces: list[dict[str, Any]]) -> None:
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=1,
+            max_buffer_age=999.0,
+            max_queue_size=10,
+        ),
+        sender=sender,
+    )
+    trace_id = client.start_trace(
+        "pii-canary-trace",
+        trace_id="trace_pii_canary",
+        user_id=CANARY_VALUES[0],
+        metadata={"credit_card": CANARY_VALUES[1]},
+        input_data={"ssn": CANARY_VALUES[2]},
+    )
+    client.record_observation(
+        trace_id,
+        name="pii-canary-observation",
+        observation_type=ObservationType.GENERATION,
+        input_data={"api_key": CANARY_VALUES[3]},
+        output_data={"bearer": CANARY_VALUES[4]},
+        metadata={"email": CANARY_VALUES[0]},
+    )
+    client.end_trace(
+        trace_id,
+        output_data={"answer": CANARY_VALUES[3]},
+        metadata={"ssn": CANARY_VALUES[2]},
+    )
+    client.flush()
+    client.close()
+    return sent_batches
 
 
 # ---------------------------------------------------------------------------
@@ -289,17 +369,17 @@ async def test_canaries_do_not_leak_through_optimization_pipeline(
 
     result = await orchestrator.optimize(lambda x: x, canary_dataset)
     assert result.trials, "optimization produced no trials; canary test vacuous"
+    audit_events = _exercise_audit_sink()
+    observability_trace_batches = _exercise_observability_sink()
 
-    trials = [
-        t for t in result.trials if t.status == TrialStatus.COMPLETED
-    ]
+    trials = [t for t in result.trials if t.status == TrialStatus.COMPLETED]
     assert trials, "no completed trials; cannot assess canary leakage"
 
     report = _ScanReport()
     _scan_trial_results(trials, report)
     _scan_serialized_trial_results(trials, report)
-    _scan_audit_log(report)
-    _scan_observability_traces(report)
+    _scan_audit_log(audit_events, report)
+    _scan_observability_traces(observability_trace_batches, report)
     _scan_stdout_capture(capsys, report)
 
     # Assertion: zero leaks, no unresolved gaps.
@@ -321,7 +401,9 @@ def test_canary_regexes_match_their_own_values() -> None:
     meaningless even if it passes.
     """
     for label, value, rx in CANARIES:
-        assert rx.search(value), f"canary regex for {label!r} does not match its seed value"
+        assert rx.search(value), (
+            f"canary regex for {label!r} does not match its seed value"
+        )
 
 
 def test_contains_canary_detects_partial_embeddings() -> None:

--- a/tests/unit/core/test_trial_result_factory.py
+++ b/tests/unit/core/test_trial_result_factory.py
@@ -28,6 +28,9 @@ class ExamplePayload:
         }
 
 
+FAKE_API_KEY = "sk-ant-canary-DO-NOT-USE-123456789abcdef"  # pragma: allowlist secret
+
+
 @pytest.fixture
 def eval_config():
     """Create evaluation configuration."""
@@ -90,6 +93,33 @@ class TestBuildSuccessResult:
             "total_cost": 0.05,
         }
 
+    def test_success_config_is_raw_in_memory_but_redacted_when_serialized(
+        self, eval_result
+    ):
+        """Config remains replayable in memory; to_dict owns public redaction."""
+        eval_result.to_dict.return_value = {"metrics": eval_result.metrics}
+        eval_result.example_results = []
+        eval_result.summary_stats = None
+        eval_config = {
+            "model": "gpt-4",
+            "api_key": FAKE_API_KEY,
+        }
+
+        result = build_success_result(
+            trial_id="trial_123",
+            evaluation_config=eval_config,
+            eval_result=eval_result,
+            duration=1.5,
+            examples_attempted=None,
+            total_cost=None,
+            optuna_trial_id=None,
+        )
+
+        assert result.config == eval_config
+        serialized = result.to_dict()
+        assert FAKE_API_KEY not in str(serialized)
+        assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
+
     def test_metadata_fields(self, eval_config, eval_result):
         """Test metadata fields are populated correctly."""
         result = build_success_result(
@@ -125,7 +155,9 @@ class TestBuildSuccessResult:
         assert "example_results" in result.metadata
         assert len(result.metadata["example_results"]) == 2
 
-    def test_example_results_are_serialized_before_redaction(self, eval_config, eval_result):
+    def test_example_results_are_serialized_before_redaction(
+        self, eval_config, eval_result
+    ):
         """Dataclass-like example result objects must not bypass metadata redaction."""
         eval_result.example_results = [ExamplePayload()]
 
@@ -353,9 +385,7 @@ class TestBuildSuccessResult:
         assert comparability["coverage_ratio"] == pytest.approx(1.0)
         assert comparability["ranking_eligible"] is True
 
-    def test_invalid_ranking_eligible_in_summary_metadata_falls_back(
-        self, eval_config
-    ):
+    def test_invalid_ranking_eligible_in_summary_metadata_falls_back(self, eval_config):
         """Invalid nested summary comparability should not leak through unchanged."""
         eval_result = Mock()
         eval_result.metrics = {"accuracy": 0.85, "cost": 0.05}
@@ -412,6 +442,29 @@ class TestBuildPrunedResult:
         assert result.duration == 0.5
         assert result.metadata["pruned"] is True
         assert result.metadata["pruned_step"] == 5
+
+    def test_pruned_config_is_raw_in_memory_but_redacted_when_serialized(
+        self, prune_error
+    ):
+        """Pruned trial configs remain usable for replay and redact on export."""
+        eval_config = {
+            "model": "gpt-4",
+            "api_key": FAKE_API_KEY,
+        }
+
+        result = build_pruned_result(
+            trial_id="trial_456",
+            evaluation_config=eval_config,
+            duration=0.5,
+            prune_error=prune_error,
+            progress_state=None,
+            optuna_trial_id=None,
+        )
+
+        assert result.config == eval_config
+        serialized = result.to_dict()
+        assert FAKE_API_KEY not in str(serialized)
+        assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
 
     def test_pruned_with_progress_state(self, eval_config, prune_error, progress_state):
         """Test pruned result with progress state."""
@@ -569,6 +622,30 @@ class TestBuildFailedResult:
         assert "raise ValueError" in result.error.traceback
         assert result.error.config == eval_config
         assert result.error.timestamp.tzinfo == UTC
+
+    def test_failed_config_is_raw_in_memory_but_redacted_when_serialized(self):
+        """Failed trial config and TrialError config redact at serialization."""
+        eval_config = {
+            "model": "gpt-4",
+            "api_key": FAKE_API_KEY,
+        }
+
+        result = build_failed_result(
+            trial_id="trial_789",
+            evaluation_config=eval_config,
+            duration=0.3,
+            error=ValueError("Test error"),
+            progress_state=None,
+            optuna_trial_id=None,
+        )
+
+        assert result.config == eval_config
+        assert result.error is not None
+        assert result.error.config == eval_config
+        serialized = result.to_dict()
+        assert FAKE_API_KEY not in str(serialized)
+        assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
+        assert serialized["error"]["config"]["api_key"] == "[REDACTED:api_key]"
 
     def test_failed_with_progress_state(self, eval_config, progress_state):
         """Test failed result with progress state."""

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from urllib import error
 
 import pytest
@@ -26,6 +26,11 @@ from traigent.utils.exceptions import AuthenticationError, ClientError
 
 def _encoded_trace_batch_size(traces: list[dict]) -> int:
     return len(json.dumps({"traces": traces}).encode("utf-8"))
+
+
+FAKE_TRACE_API_KEY = (
+    "sk-ant-canary-DO-NOT-USE-123456789abcdef"  # pragma: allowlist secret
+)
 
 
 def test_observability_client_flushes_trace_payloads():
@@ -180,6 +185,60 @@ def test_observability_client_logs_trace_snapshot_submit_failure(caplog):
     assert "[REDACTED:api_key]" in caplog.text
 
 
+def test_observability_client_redacts_trace_payloads_before_submit():
+    """Trace payloads must be scrubbed before they reach the transport."""
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=1,
+            max_buffer_age=999.0,
+            max_queue_size=10,
+        ),
+        sender=sender,
+    )
+
+    trace_id = client.start_trace(
+        "trace-redaction",
+        trace_id="trace_redaction",
+        user_id="alice@example.com",
+        metadata={"token": FAKE_TRACE_API_KEY},
+        input_data={"ssn": "123-45-6789"},
+    )
+    client.record_observation(
+        trace_id,
+        name="llm-call",
+        observation_type=ObservationType.GENERATION,
+        input_data={"prompt": "card 4111111111111234"},
+        output_data={"answer": "Bearer canary.jwt.header.payload.signature"},
+        metadata={"email": "alice@example.com"},
+    )
+    client.end_trace(
+        trace_id,
+        output_data={"answer": FAKE_TRACE_API_KEY},
+    )
+
+    client.flush()
+    client.close()
+
+    payload_blob = str(sent_batches)
+    assert "alice@example.com" not in payload_blob
+    assert "123-45-6789" not in payload_blob
+    assert "4111111111111234" not in payload_blob
+    assert FAKE_TRACE_API_KEY not in payload_blob
+    assert "canary.jwt.header.payload.signature" not in payload_blob
+    assert "[REDACTED:email]" in payload_blob
+    assert "[REDACTED:ssn]" in payload_blob
+    assert "[REDACTED:credit_card]" in payload_blob
+    assert "[REDACTED:api_key]" in payload_blob
+    assert "[REDACTED:bearer_token]" in payload_blob
+
+
 def test_observability_client_close_flushes_active_trace_payloads_without_explicit_flush():
     sent_batches: list[list[dict]] = []
 
@@ -221,7 +280,10 @@ def test_sync_batch_transport_records_closed_transport_drops():
 
     assert accepted is False
     stats = transport.get_stats()
-    assert "transport closed; dropped payload for item 'trace_after_close'" in stats["errors"]
+    assert (
+        "transport closed; dropped payload for item 'trace_after_close'"
+        in stats["errors"]
+    )
 
 
 def test_observability_client_chunks_flushes_by_byte_limit():
@@ -376,7 +438,9 @@ def test_observe_decorator_creates_nested_observations():
     )
     set_default_observability_client(client)
 
-    @observe("inner-operation", client=client, observation_type=ObservationType.TOOL_CALL)
+    @observe(
+        "inner-operation", client=client, observation_type=ObservationType.TOOL_CALL
+    )
     def inner(value: int) -> int:
         return value + 1
 
@@ -694,7 +758,9 @@ def test_observability_client_collaboration_helpers_follow_backend_contract():
                     "bookmarked_at": "2026-03-10T14:13:00+00:00"
                     if payload.get("is_bookmarked")
                     else None,
-                    "bookmarked_by": "sdk-user" if payload.get("is_bookmarked") else None,
+                    "bookmarked_by": "sdk-user"
+                    if payload.get("is_bookmarked")
+                    else None,
                     "is_published": bool(payload.get("is_published")),
                     "published_at": "2026-03-10T14:14:00+00:00"
                     if payload.get("is_published")
@@ -750,7 +816,11 @@ def test_observability_client_collaboration_helpers_follow_backend_contract():
     assert published.is_published is True
     assert request_calls == [
         ("GET", "/traces/trace_sdk/comments", None),
-        ("POST", "/traces/trace_sdk/comments", {"content": "Ship this after QA review."}),
+        (
+            "POST",
+            "/traces/trace_sdk/comments",
+            {"content": "Ship this after QA review."},
+        ),
         (
             "PUT",
             "/traces/trace_sdk/feedback",
@@ -923,7 +993,7 @@ def test_observability_client_query_helpers_follow_backend_contract():
         per_page=10,
         environment="production",
         tags=["demo"],
-        start_time_from=datetime(2026, 3, 10, 12, 0, 0, tzinfo=timezone.utc),
+        start_time_from=datetime(2026, 3, 10, 12, 0, 0, tzinfo=UTC),
     )
     trace = client.get_trace("trace_sdk_query")
     observations = client.get_trace_observations("trace_sdk_query")
@@ -955,7 +1025,9 @@ def test_observability_client_rejects_collaboration_requests_after_close():
             max_queue_size=10,
         ),
         sender=lambda traces: None,
-        request_sender=lambda method, path, payload: request_calls.append((method, path, payload)) or {"data": {}},
+        request_sender=lambda method, path, payload: (
+            request_calls.append((method, path, payload)) or {"data": {}}
+        ),
     )
     client.close()
 
@@ -979,7 +1051,9 @@ def test_observability_client_validates_feedback_correction_output():
     )
 
     with pytest.raises(ClientError, match="correction_output"):
-        client.submit_feedback("trace_sdk", ThumbRating.UP, correction_output={"bad": {1, 2, 3}})
+        client.submit_feedback(
+            "trace_sdk", ThumbRating.UP, correction_output={"bad": {1, 2, 3}}
+        )
 
     client.close()
 
@@ -1043,7 +1117,7 @@ def test_observability_client_logs_ingest_warnings(monkeypatch, caplog):
         def read(self):
             return (
                 b'{"data":{"warnings":["Prompt reference could not be resolved for trace '
-                b'\'trace_warn\': support/missing (label=latest)"]}}'
+                b"'trace_warn': support/missing (label=latest)\"]}}"
             )
 
     client = ObservabilityClient(
@@ -1063,7 +1137,9 @@ def test_observability_client_logs_ingest_warnings(monkeypatch, caplog):
     )
 
     with caplog.at_level(logging.WARNING):
-        client._post_batch_sync([{"id": "trace_warn", "name": "warn-trace", "observations": []}])
+        client._post_batch_sync(
+            [{"id": "trace_warn", "name": "warn-trace", "observations": []}]
+        )
 
     client.close()
 
@@ -1073,11 +1149,21 @@ def test_observability_client_logs_ingest_warnings(monkeypatch, caplog):
 @pytest.mark.parametrize(
     ("method_name", "args", "message"),
     [
-        ("_post_batch_sync", ([{"id": "trace_sdk"}],), "Observability ingest failed with status 500"),
-        ("_request_json_sync", ("GET", "/traces/trace_sdk", None), "Observability request failed with status 500"),
+        (
+            "_post_batch_sync",
+            ([{"id": "trace_sdk"}],),
+            "Observability ingest failed with status 500",
+        ),
+        (
+            "_request_json_sync",
+            ("GET", "/traces/trace_sdk", None),
+            "Observability request failed with status 500",
+        ),
     ],
 )
-def test_observability_client_closes_http_errors(monkeypatch, method_name, args, message):
+def test_observability_client_closes_http_errors(
+    monkeypatch, method_name, args, message
+):
     http_error = error.HTTPError(
         url="http://localhost:5000",
         code=500,

--- a/tests/unit/security/auth/test_role_sanitization.py
+++ b/tests/unit/security/auth/test_role_sanitization.py
@@ -20,5 +20,11 @@ def test_sanitize_roles_strict_rejects_malformed_claims() -> None:
         sanitize_roles({"role": "admin"}, strict=True)
 
 
+def test_sanitize_roles_strict_accepts_common_idp_separators() -> None:
+    assert sanitize_roles(
+        ["admin", "api:read", "team.member", "org/admin"], strict=True
+    ) == ["admin", "api:read", "team.member", "org/admin"]
+
+
 def test_sanitize_roles_legacy_non_strict_falls_back() -> None:
     assert sanitize_roles(["bad role with spaces"]) == ["user"]

--- a/tests/unit/security/auth/test_role_sanitization.py
+++ b/tests/unit/security/auth/test_role_sanitization.py
@@ -22,8 +22,9 @@ def test_sanitize_roles_strict_rejects_malformed_claims() -> None:
 
 def test_sanitize_roles_strict_accepts_common_idp_separators() -> None:
     assert sanitize_roles(
-        ["admin", "api:read", "team.member", "org/admin"], strict=True
-    ) == ["admin", "api:read", "team.member", "org/admin"]
+        ["admin", "api:read", "team.member", "org/admin", "_internal", "-system"],
+        strict=True,
+    ) == ["admin", "api:read", "team.member", "org/admin", "_internal", "-system"]
 
 
 def test_sanitize_roles_legacy_non_strict_falls_back() -> None:

--- a/tests/unit/security/test_audit.py
+++ b/tests/unit/security/test_audit.py
@@ -23,6 +23,9 @@ STRONG_AUDIT_SECRET = "StrongAuditSecretKey123!@#ABC4567890"
 COMPLIANCE_NOT_IMPLEMENTED = "Compliance reporting subsystem is not yet implemented"
 PERSISTENT_STORAGE_NOT_IMPLEMENTED = "Persistent audit storage is not yet implemented"
 TAMPER_DETECTION_NOT_IMPLEMENTED = "Tamper-detection is not yet implemented"
+FAKE_AUDIT_API_KEY = (
+    "sk-ant-canary-DO-NOT-USE-123456789abcdef"  # pragma: allowlist secret
+)
 
 
 class TestAuditEvent:
@@ -280,6 +283,35 @@ class TestAuditLogger:
 
         # Event should be queued for processing
         assert not audit_logger.event_queue.empty()
+
+    def test_log_event_redacts_sensitive_payloads_before_storage(self):
+        """Audit events should not store raw PII or credential-like values."""
+        audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
+
+        event = audit_logger.log_event(
+            event_type=AuditEventType.DATA_READ,
+            user_id="alice@example.com",
+            session_id="session-4111111111111234",
+            tenant_id="tenant-123-45-6789",
+            resource_id=FAKE_AUDIT_API_KEY,
+            message="Bearer canary.jwt.header.payload.signature",
+            details={
+                "email": "alice@example.com",
+                "api_key": FAKE_AUDIT_API_KEY,
+            },
+        )
+
+        event_blob = str(event.to_dict())
+        assert "alice@example.com" not in event_blob
+        assert "4111111111111234" not in event_blob
+        assert "123-45-6789" not in event_blob
+        assert FAKE_AUDIT_API_KEY not in event_blob
+        assert "canary.jwt.header.payload.signature" not in event_blob
+        assert "[REDACTED:email]" in event_blob
+        assert "[REDACTED:credit_card]" in event_blob
+        assert "[REDACTED:ssn]" in event_blob
+        assert "[REDACTED:api_key]" in event_blob
+        assert "[REDACTED:bearer_token]" in event_blob
 
     def test_log_authentication_events(self):
         """Test logging authentication events"""

--- a/tests/unit/security/test_audit.py
+++ b/tests/unit/security/test_audit.py
@@ -297,6 +297,7 @@ class TestAuditLogger:
             message="Bearer canary.jwt.header.payload.signature",
             details={
                 "email": "alice@example.com",
+                "ssn": "123-45-6789",
                 "api_key": FAKE_AUDIT_API_KEY,
             },
         )
@@ -312,6 +313,30 @@ class TestAuditLogger:
         assert "[REDACTED:ssn]" in event_blob
         assert "[REDACTED:api_key]" in event_blob
         assert "[REDACTED:bearer_token]" in event_blob
+
+    def test_email_user_filter_matches_only_the_original_redacted_identifier(self):
+        """Email user IDs should stay filterable without storing raw addresses."""
+        audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
+        alice_event = audit_logger.log_event(
+            event_type=AuditEventType.DATA_READ,
+            user_id="alice@example.com",
+            message="Alice event",
+        )
+        bob_event = audit_logger.log_event(
+            event_type=AuditEventType.DATA_READ,
+            user_id="bob@example.com",
+            message="Bob event",
+        )
+
+        alice_events = audit_logger.storage.get_events(user_id="alice@example.com")
+        redacted_bucket_events = audit_logger.storage.get_events(
+            user_id="[REDACTED:email]"
+        )
+
+        assert alice_events == [alice_event]
+        assert bob_event not in alice_events
+        assert redacted_bucket_events == []
+        assert "alice@example.com" not in str(alice_event.to_dict())
 
     def test_log_authentication_events(self):
         """Test logging authentication events"""
@@ -534,6 +559,32 @@ class TestComplianceReporter:
 
         with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
             reporter.generate_gdpr_report(start_date, end_date)
+
+    def test_tenant_period_filter_matches_redacted_sensitive_identifier(self):
+        """Tenant filters should work when stored tenant IDs are pseudonymized."""
+        audit_logger = AuditLogger(STRONG_AUDIT_SECRET)
+        reporter = ComplianceReporter(audit_logger)
+        tenant_id = "tenant-123-45-6789"
+        matching_event = audit_logger.log_event(
+            event_type=AuditEventType.DATA_READ,
+            tenant_id=tenant_id,
+            message="Tenant event",
+        )
+        other_event = audit_logger.log_event(
+            event_type=AuditEventType.DATA_READ,
+            tenant_id="tenant-987-65-4321",
+            message="Other tenant event",
+        )
+        start_date = datetime.now(UTC) - timedelta(minutes=1)
+        end_date = datetime.now(UTC) + timedelta(minutes=1)
+
+        events = reporter._get_events_for_period(
+            start_date, end_date, tenant_id=tenant_id
+        )
+
+        assert events == [matching_event]
+        assert other_event not in events
+        assert tenant_id not in str(matching_event.to_dict())
 
     def test_security_incident_analysis_fails_loud(self):
         """Incident compliance analysis fails loudly instead of faking resolution."""

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -244,9 +245,9 @@ def _build_success_trial_metadata(
     }
 
     example_results = getattr(eval_result, "example_results", None)
-    if example_results:
+    if isinstance(example_results, list) and example_results:
         trial_metadata["example_results"] = redact_sensitive_data(
-            _to_redactable_payloads(list(example_results))
+            _to_redactable_payloads(example_results)
         )
 
     if examples_attempted is not None:
@@ -342,7 +343,7 @@ def build_success_result(
 
     trial_result = TrialResult(
         trial_id=trial_id,
-        config=redact_sensitive_data(evaluation_config),
+        config=copy.deepcopy(evaluation_config),
         metrics=getattr(eval_result, "metrics", {}) or {},
         status=TrialStatus.COMPLETED,
         duration=duration,
@@ -485,7 +486,7 @@ def build_pruned_result(
 
     return TrialResult(
         trial_id=trial_id,
-        config=redact_sensitive_data(evaluation_config),
+        config=copy.deepcopy(evaluation_config),
         metrics=metrics,
         status=TrialStatus.PRUNED,
         duration=duration,
@@ -509,7 +510,6 @@ def build_failed_result(
     error_details = TrialError.from_exception(error, config=evaluation_config)
     error_details.message = redact_sensitive_text(error_details.message)
     error_details.traceback = redact_sensitive_text(error_details.traceback)
-    error_details.config = redact_sensitive_data(error_details.config)
 
     metadata: dict[str, Any] = (
         {"optuna_trial_id": optuna_trial_id} if optuna_trial_id is not None else {}
@@ -546,7 +546,7 @@ def build_failed_result(
 
     return TrialResult(
         trial_id=trial_id,
-        config=redact_sensitive_data(evaluation_config),
+        config=copy.deepcopy(evaluation_config),
         metrics=metrics,
         status=TrialStatus.FAILED,
         duration=duration,

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -38,7 +38,7 @@ from traigent.observability.dtos import (
     TraceRecord,
     utc_now,
 )
-from traigent.security.redaction import redact_sensitive_text
+from traigent.security.redaction import redact_sensitive_data, redact_sensitive_text
 from traigent.utils.exceptions import (
     AuthenticationError,
     ClientError,
@@ -881,7 +881,7 @@ class ObservabilityClient:
             state = self._trace_states.get(trace_id)
             if state is None or self._closed:
                 return
-            payload = state.to_payload()
+            payload = cast(dict[str, Any], redact_sensitive_data(state.to_payload()))
         submitted = self._transport.submit(trace_id, payload)
         if not submitted:
             stats = self._transport.get_stats()

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -33,6 +33,17 @@ _TAMPER_DETECTION_NOT_IMPLEMENTED = (
 )
 
 
+def _redact_filterable_identifier(value: str | None, label: str) -> str | None:
+    """Redact sensitive identifiers while preserving exact-match filtering."""
+    if value is None:
+        return None
+    redacted = redact_sensitive_text(value)
+    if redacted == value:
+        return value
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+    return f"[REDACTED:{label}:{digest}]"
+
+
 class AuditSeverity(Enum):
     """Audit event severity levels."""
 
@@ -254,9 +265,9 @@ class AuditLogger:
             event_id=secrets.token_urlsafe(16),
             event_type=event_type,
             timestamp=datetime.now(UTC),
-            user_id=redact_sensitive_text(user_id),
+            user_id=_redact_filterable_identifier(user_id, "user_id"),
             session_id=redact_sensitive_text(session_id),
-            tenant_id=redact_sensitive_text(tenant_id),
+            tenant_id=_redact_filterable_identifier(tenant_id, "tenant_id"),
             message=redact_sensitive_text(message) or "",
             resource_id=redact_sensitive_text(resource_id),
             resource_type=redact_sensitive_text(resource_type),
@@ -283,7 +294,9 @@ class AuditLogger:
         )  # Store in AuditStorage (thread-safe internally)
         self.event_queue.put(event)  # Add to queue for async processing (thread-safe)
 
-        actor = redact_sensitive_text(user_id) if user_id else "system"
+        actor = (
+            _redact_filterable_identifier(user_id, "user_id") if user_id else "system"
+        )
         logger.info("Audit event logged: %s by %s", event_type.value, actor)
         return event
 
@@ -583,7 +596,8 @@ class ComplianceReporter:
         ]
 
         if tenant_id:
-            events = [e for e in events if e.tenant_id == tenant_id]
+            normalized_tenant_id = _redact_filterable_identifier(tenant_id, "tenant_id")
+            events = [e for e in events if e.tenant_id == normalized_tenant_id]
 
         return events
 
@@ -748,7 +762,10 @@ class AuditStorage:
         if end_time:
             filtered_events = [e for e in filtered_events if e.timestamp <= end_time]
         if user_id:
-            filtered_events = [e for e in filtered_events if e.user_id == user_id]
+            normalized_user_id = _redact_filterable_identifier(user_id, "user_id")
+            filtered_events = [
+                e for e in filtered_events if e.user_id == normalized_user_id
+            ]
         if event_types:
             filtered_events = [
                 e for e in filtered_events if e.event_type in event_types

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Any
 
 from ..utils.logging import get_logger
+from .redaction import redact_sensitive_data, redact_sensitive_text
 
 logger = get_logger(__name__)
 
@@ -253,19 +254,19 @@ class AuditLogger:
             event_id=secrets.token_urlsafe(16),
             event_type=event_type,
             timestamp=datetime.now(UTC),
-            user_id=user_id,
-            session_id=session_id,
-            tenant_id=tenant_id,
-            message=message,
-            resource_id=resource_id,
-            resource_type=resource_type,
-            resource=resource,  # Add resource field
-            action=action,
+            user_id=redact_sensitive_text(user_id),
+            session_id=redact_sensitive_text(session_id),
+            tenant_id=redact_sensitive_text(tenant_id),
+            message=redact_sensitive_text(message) or "",
+            resource_id=redact_sensitive_text(resource_id),
+            resource_type=redact_sensitive_text(resource_type),
+            resource=redact_sensitive_text(resource),  # Add resource field
+            action=redact_sensitive_text(action),
             result=result,
-            ip_address=final_ip,
-            source_ip=final_ip,  # Set both for compatibility
-            user_agent=user_agent,
-            details=details or {},
+            ip_address=redact_sensitive_text(final_ip),
+            source_ip=redact_sensitive_text(final_ip),  # Set both for compatibility
+            user_agent=redact_sensitive_text(user_agent),
+            details=redact_sensitive_data(details or {}),
             severity=severity,
             compliance_tags=compliance_tags or [],
         )
@@ -282,7 +283,8 @@ class AuditLogger:
         )  # Store in AuditStorage (thread-safe internally)
         self.event_queue.put(event)  # Add to queue for async processing (thread-safe)
 
-        logger.info(f"Audit event logged: {event_type.value} by {user_id or 'system'}")
+        actor = redact_sensitive_text(user_id) if user_id else "system"
+        logger.info("Audit event logged: %s by %s", event_type.value, actor)
         return event
 
     def _calculate_checksum(self, event: AuditEvent) -> str:

--- a/traigent/security/auth/helpers.py
+++ b/traigent/security/auth/helpers.py
@@ -19,7 +19,7 @@ EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
 # Regex pattern for validating role names. Enterprise IdPs commonly emit
 # separators such as "api:read", "team.member", and "org/admin".
-ROLE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_:/.-]{0,49}$")
+ROLE_PATTERN = re.compile(r"^[a-z0-9_-][a-z0-9_:/.-]{0,49}$")
 
 # Security constant: Delay to prevent timing attacks on authentication.
 # This intentionally blocks to ensure constant-time failure responses.

--- a/traigent/security/auth/helpers.py
+++ b/traigent/security/auth/helpers.py
@@ -17,8 +17,9 @@ _CONTROL_CHARS_PATTERN = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 # Regex pattern for validating email addresses (RFC 5322 simplified)
 EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
-# Regex pattern for validating role names (lowercase alphanumeric with dash/underscore)
-ROLE_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+# Regex pattern for validating role names. Enterprise IdPs commonly emit
+# separators such as "api:read", "team.member", and "org/admin".
+ROLE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_:/.-]{0,49}$")
 
 # Security constant: Delay to prevent timing attacks on authentication.
 # This intentionally blocks to ensure constant-time failure responses.


### PR DESCRIPTION
Follow-up to #958 for remaining P0/P1 review findings.\n\nChanges:\n- Redact observability trace payloads before transport submission.\n- Exercise audit and observability sinks in the PII canary test instead of leaving placeholder scanners.\n- Preserve raw TrialResult.config in memory for replay/apply while serialized exports redact.\n- Redact AuditLogger event payload fields before storage/logging.\n- Accept common enterprise IdP role separators (:, ., /) in strict role claims while still rejecting malformed whitespace/non-string claims.\n\nLocal verification:\n- uv run --extra dev ruff format --check <touched files>\n- uv run --extra dev ruff check <touched files>\n- pytest -o addopts='' tests/security/test_pii_canary_leak.py tests/unit/observability/test_observability_client.py tests/unit/security/test_audit.py tests/unit/core/test_trial_result_factory.py tests/unit/security/auth/test_role_sanitization.py -q (105 passed)