### PR TITLE
fix: close SDK redaction boundaries

### DIFF
--- a/tests/unit/api/test_trial_serialization.py
+++ b/tests/unit/api/test_trial_serialization.py
@@ -9,6 +9,10 @@ import pytest
 from traigent import serialize_trials
 from traigent.api.types import ExampleResult, TrialError, TrialResult, TrialStatus
 
+FAKE_TRIAL_API_KEY = (
+    "sk-ant-canary-DO-NOT-USE-trial-123456789abcdef"  # pragma: allowlist secret
+)
+
 
 class _NestedTimestampedPayload:
     """Test helper exposing a no-arg ``to_dict`` with nested datetimes."""
@@ -122,6 +126,50 @@ def test_trial_result_to_dict_serializes_structured_error_context() -> None:
         "model": "gpt-4o-mini",
         "temperature": 0.2,
     }
+
+
+def test_trial_result_to_dict_redacts_config_and_repr_hides_payloads() -> None:
+    trial = TrialResult(
+        trial_id="trial-redaction",
+        config={"api_key": FAKE_TRIAL_API_KEY},
+        metrics={"accuracy": 1.0},
+        status=TrialStatus.COMPLETED,
+        duration=0.1,
+        timestamp=datetime(2026, 3, 13, 12, 1, tzinfo=UTC),
+        metadata={"owner_email": "alice@example.com"},
+    )
+
+    assert trial.config["api_key"] == FAKE_TRIAL_API_KEY
+
+    serialized = trial.to_dict()
+    serialized_blob = str(serialized)
+
+    assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
+    assert serialized["metadata"]["owner_email"] == "[REDACTED:email]"
+    assert FAKE_TRIAL_API_KEY not in serialized_blob
+    assert "alice@example.com" not in serialized_blob
+    assert FAKE_TRIAL_API_KEY not in repr(trial)
+    assert "alice@example.com" not in repr(trial)
+    assert FAKE_TRIAL_API_KEY not in str(trial)
+    assert "alice@example.com" not in str(trial)
+
+
+def test_trial_error_to_dict_redacts_raw_config_directly() -> None:
+    error = TrialError(
+        message="Provider failed",
+        error_type="ProviderError",
+        traceback="Traceback omitted",
+        timestamp=datetime(2026, 3, 13, 12, 2, tzinfo=UTC),
+        config={"api_key": FAKE_TRIAL_API_KEY},
+    )
+
+    assert error.config["api_key"] == FAKE_TRIAL_API_KEY
+
+    serialized = error.to_dict()
+
+    assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
+    assert FAKE_TRIAL_API_KEY not in str(serialized)
+    assert FAKE_TRIAL_API_KEY not in repr(error)
 
 
 def test_trial_result_to_dict_serializes_nested_to_dict_datetimes() -> None:

--- a/tests/unit/api/test_trial_serialization.py
+++ b/tests/unit/api/test_trial_serialization.py
@@ -133,9 +133,10 @@ def test_trial_result_to_dict_redacts_config_and_repr_hides_payloads() -> None:
         trial_id="trial-redaction",
         config={"api_key": FAKE_TRIAL_API_KEY},
         metrics={"accuracy": 1.0},
-        status=TrialStatus.COMPLETED,
+        status=TrialStatus.FAILED,
         duration=0.1,
         timestamp=datetime(2026, 3, 13, 12, 1, tzinfo=UTC),
+        error_message=f"Provider returned {FAKE_TRIAL_API_KEY}",
         metadata={"owner_email": "alice@example.com"},
     )
 
@@ -145,6 +146,7 @@ def test_trial_result_to_dict_redacts_config_and_repr_hides_payloads() -> None:
     serialized_blob = str(serialized)
 
     assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
+    assert serialized["error_message"] == "Provider returned [REDACTED:api_key]"
     assert serialized["metadata"]["owner_email"] == "[REDACTED:email]"
     assert FAKE_TRIAL_API_KEY not in serialized_blob
     assert "alice@example.com" not in serialized_blob
@@ -154,11 +156,11 @@ def test_trial_result_to_dict_redacts_config_and_repr_hides_payloads() -> None:
     assert "alice@example.com" not in str(trial)
 
 
-def test_trial_error_to_dict_redacts_raw_config_directly() -> None:
+def test_trial_error_to_dict_redacts_raw_strings_and_config_directly() -> None:
     error = TrialError(
-        message="Provider failed",
+        message=f"Provider failed for {FAKE_TRIAL_API_KEY}",
         error_type="ProviderError",
-        traceback="Traceback omitted",
+        traceback=f"Traceback included alice@example.com and {FAKE_TRIAL_API_KEY}",
         timestamp=datetime(2026, 3, 13, 12, 2, tzinfo=UTC),
         config={"api_key": FAKE_TRIAL_API_KEY},
     )
@@ -167,8 +169,14 @@ def test_trial_error_to_dict_redacts_raw_config_directly() -> None:
 
     serialized = error.to_dict()
 
+    assert serialized["message"] == "Provider failed for [REDACTED:api_key]"
+    assert (
+        serialized["traceback"]
+        == "Traceback included [REDACTED:email] and [REDACTED:api_key]"
+    )
     assert serialized["config"]["api_key"] == "[REDACTED:api_key]"
     assert FAKE_TRIAL_API_KEY not in str(serialized)
+    assert "alice@example.com" not in str(serialized)
     assert FAKE_TRIAL_API_KEY not in repr(error)
 
 

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -239,6 +239,42 @@ def test_observability_client_redacts_trace_payloads_before_submit():
     assert "[REDACTED:bearer_token]" in payload_blob
 
 
+def test_sync_batch_transport_redacts_direct_submitted_payloads():
+    """Direct transport submissions must be scrubbed before buffering and sending."""
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    transport = _SyncBatchTransport(
+        sender=sender,
+        batch_size=100,
+        max_buffer_age=999.0,
+        max_queue_size=10,
+        max_batch_bytes=10_000,
+    )
+
+    accepted = transport.submit(
+        "trace_direct",
+        {
+            "id": "trace_direct",
+            "user_id": "alice@example.com",
+            "metadata": {"api_key": FAKE_TRACE_API_KEY},
+        },
+    )
+
+    result = transport.flush()
+    transport.close()
+
+    payload_blob = str(sent_batches)
+    assert accepted is True
+    assert result.success is True
+    assert "alice@example.com" not in payload_blob
+    assert FAKE_TRACE_API_KEY not in payload_blob
+    assert "[REDACTED:email]" in payload_blob
+    assert "[REDACTED:api_key]" in payload_blob
+
+
 def test_observability_client_close_flushes_active_trace_payloads_without_explicit_flush():
     sent_batches: list[list[dict]] = []
 

--- a/tests/unit/security/test_audit.py
+++ b/tests/unit/security/test_audit.py
@@ -334,6 +334,7 @@ class TestAuditLogger:
         assert "123-45-6789" not in event_blob
         assert FAKE_AUDIT_API_KEY not in event_blob
         assert "canary.jwt.header.payload.signature" not in event_blob
+        assert event.message == "[REDACTED:bearer_token]"
         assert "[REDACTED:email]" in event_blob
         assert "[REDACTED:credit_card]" in event_blob
         assert "[REDACTED:ssn]" in event_blob

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -274,6 +274,16 @@ class TrialError:
             ),
         }
 
+    def __repr__(self) -> str:
+        return (
+            "TrialError("
+            "message='<redacted>', "
+            f"error_type={self.error_type!r}, "
+            f"timestamp={self.timestamp!r}, "
+            "config='<redacted>'"
+            ")"
+        )
+
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> TrialError:
         """Reconstruct a structured trial error from a dictionary."""
@@ -331,6 +341,21 @@ class TrialResult:
     def error_traceback(self) -> str | None:
         """Get the formatted traceback for a failed trial, when available."""
         return self.error.traceback if self.error else None
+
+    def __repr__(self) -> str:
+        return (
+            "TrialResult("
+            f"trial_id={self.trial_id!r}, "
+            "config='<redacted>', "
+            f"metrics={self.metrics!r}, "
+            f"status={self.status!r}, "
+            f"duration={self.duration!r}, "
+            f"timestamp={self.timestamp!r}, "
+            "error_message='<redacted>', "
+            "metadata='<redacted>', "
+            f"error_type={self.error_type!r}"
+            ")"
+        )
 
     def to_dict(
         self,

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from traigent.security.redaction import redact_sensitive_data
+from traigent.security.redaction import redact_sensitive_data, redact_sensitive_text
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -263,9 +263,9 @@ class TrialError:
     ) -> dict[str, Any]:
         """Convert structured error details to a JSON-ready dictionary."""
         return {
-            "message": self.message,
+            "message": redact_sensitive_text(self.message),
             "error_type": self.error_type,
-            "traceback": self.traceback,
+            "traceback": redact_sensitive_text(self.traceback),
             "timestamp": _serialize_datetime(
                 self.timestamp, datetime_format=datetime_format
             ),
@@ -380,7 +380,7 @@ class TrialResult:
             "timestamp": _serialize_datetime(
                 self.timestamp, datetime_format=datetime_format
             ),
-            "error_message": self.error_message,
+            "error_message": redact_sensitive_text(self.error_message),
             "error": _json_safe_trial_value(
                 self.error, datetime_format=datetime_format
             ),

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -138,7 +138,8 @@ class _SyncBatchTransport:
                 )
                 return False
 
-            self._buffer[item_id] = copy.deepcopy(payload)
+            redacted_payload = cast(dict[str, Any], redact_sensitive_data(payload))
+            self._buffer[item_id] = copy.deepcopy(redacted_payload)
             self._stats["submitted_items"] += 1
             self._stats["pending_items"] = len(self._buffer)
 

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -138,6 +138,7 @@ class _SyncBatchTransport:
                 )
                 return False
 
+            # Direct transport callers bypass ObservabilityClient's trace redaction.
             redacted_payload = cast(dict[str, Any], redact_sensitive_data(payload))
             self._buffer[item_id] = copy.deepcopy(redacted_payload)
             self._stats["submitted_items"] += 1

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -260,6 +260,7 @@ class AuditLogger:
 
         # Handle source_ip alias
         final_ip = ip_address or source_ip
+        redacted_message = redact_sensitive_text(message)
 
         event = AuditEvent(
             event_id=secrets.token_urlsafe(16),
@@ -268,7 +269,7 @@ class AuditLogger:
             user_id=_redact_filterable_identifier(user_id, "user_id"),
             session_id=redact_sensitive_text(session_id),
             tenant_id=_redact_filterable_identifier(tenant_id, "tenant_id"),
-            message=redact_sensitive_text(message) or "",
+            message=redacted_message if redacted_message is not None else "",
             resource_id=redact_sensitive_text(resource_id),
             resource_type=redact_sensitive_text(resource_type),
             resource=redact_sensitive_text(resource),  # Add resource field


### PR DESCRIPTION
Closes the remaining SDK redaction review blockers after the prior follow-up PRs were merged. Adds direct TrialResult/TrialError serialization coverage, redacts observability payloads at the sync transport boundary, preserves fully-redacted audit message markers, and prevents TrialResult/TrialError repr/str from exposing raw config or metadata payloads. Local evidence: ruff format --check, ruff check, and pytest -o addopts='' tests/security/test_pii_canary_leak.py tests/unit/observability/test_observability_client.py tests/unit/security/test_audit.py tests/unit/core/test_trial_result_factory.py tests/unit/security/auth/test_role_sanitization.py tests/unit/api/test_trial_serialization.py -q passed with 120 tests.