### PR TITLE
fix(security): credential storage fails closed in production (closes #896)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,27 @@ TRAIGENT_BACKEND_URL=http://localhost:5000
 TRAIGENT_RESULTS_FOLDER=~/.traigent
 
 # =============================================================================
+# Production: Credential Encryption (REQUIRED in production)
+# =============================================================================
+# TRAIGENT_ENCRYPTION_KEY is REQUIRED for any deployment that does NOT set
+# TRAIGENT_ENV to development/dev/test/local. Without it, the SDK will fail
+# to initialize credential storage with a RuntimeError (SDK#896 fix —
+# previously the SDK silently fell back to base64-only credential storage,
+# which is not encryption).
+#
+# Generate a secure 32+ character random key for production:
+#     python -c "import secrets; print(secrets.token_hex(32))"
+#
+# In local development, leave this unset and set TRAIGENT_ENV=development
+# to opt into the ephemeral-key fallback (warns at startup; encrypted data
+# is lost across restarts).
+# TRAIGENT_ENCRYPTION_KEY=
+
+# Environment classifier — defaults to "production" if unset.
+# Recognized non-prod values: development, dev, test, local.
+# TRAIGENT_ENV=development
+
+# =============================================================================
 # Optional: Logging Configuration
 # =============================================================================
 # TRAIGENT_LOG_LEVEL=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       - TRAIGENT_MOCK_LLM=true
       - TRAIGENT_OFFLINE_MODE=true
       - TRAIGENT_LOG_LEVEL=DEBUG
+      # Local-dev opt-out of the production-fail-closed credential check
+      # (SDK#896). Production deployments MUST instead set
+      # TRAIGENT_ENCRYPTION_KEY and leave TRAIGENT_ENV unset.
+      - TRAIGENT_ENV=development
     command: ["bash"]
     stdin_open: true
     tty: true

--- a/tests/unit/security/test_crypto_utils.py
+++ b/tests/unit/security/test_crypto_utils.py
@@ -788,3 +788,40 @@ class TestProductionFailClosed_SDK896:
 
         storage = get_credential_storage()
         assert storage is not None
+
+    def test_production_without_cryptography_library_raises(self, monkeypatch):
+        """Codex Q4 of PR #964: when `CRYPTOGRAPHY_AVAILABLE=False`
+        in production, `get_credential_storage()` must raise instead
+        of silently using `FallbackCredentialStorage` (base64 only)."""
+        import traigent.security.crypto_utils as crypto_module
+
+        monkeypatch.delenv("TRAIGENT_ENV", raising=False)
+        monkeypatch.delenv("TRAIGENT_ENVIRONMENT", raising=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("TRAIGENT_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setattr(crypto_module, "CRYPTOGRAPHY_AVAILABLE", False)
+
+        with pytest.raises(RuntimeError, match="cryptography library is required"):
+            get_credential_storage()
+
+    def test_environment_classification_consistent_between_init_and_factory(
+        self, monkeypatch
+    ):
+        """Codex Q3 of PR #964: __init__ and the factory's classifier
+        helper must agree on environment normalization (whitespace,
+        case). Previously __init__ did `.lower()` only, while the
+        helper did `.strip().lower()`, so `" test "` would be
+        classified as non-prod by the factory but prod by __init__.
+        Now both go through `_is_non_production_environment()`."""
+        import traigent.security.crypto_utils as crypto_module
+
+        # Whitespace-padded value: must be treated as non-prod by both
+        # paths since they share the helper.
+        monkeypatch.setenv("TRAIGENT_ENV", "  test  ")
+        monkeypatch.delenv("TRAIGENT_ENCRYPTION_KEY", raising=False)
+        # If the two checks disagree, this would either raise from
+        # __init__ (treating as prod) OR succeed silently with the
+        # factory falling back to FallbackCredentialStorage. With
+        # the shared helper, both classify as non-prod → no raise.
+        storage = get_credential_storage()
+        assert storage is not None

--- a/tests/unit/security/test_crypto_utils.py
+++ b/tests/unit/security/test_crypto_utils.py
@@ -825,3 +825,20 @@ class TestProductionFailClosed_SDK896:
         # the shared helper, both classify as non-prod → no raise.
         storage = get_credential_storage()
         assert storage is not None
+
+    def test_factory_tail_guard_fails_closed_if_singleton_remains_unset(
+        self, monkeypatch
+    ):
+        """Greptile PR #964: the terminal guard must not silently return
+        FallbackCredentialStorage if a future refactor leaves the singleton
+        unset after the lock body."""
+        import traigent.security.crypto_utils as crypto_module
+
+        monkeypatch.setenv("TRAIGENT_ENV", "development")
+        monkeypatch.setattr(crypto_module, "CRYPTOGRAPHY_AVAILABLE", True)
+        monkeypatch.setattr(crypto_module, "SecureCredentialStorage", lambda: None)
+
+        with pytest.raises(
+            RuntimeError, match="Credential storage initialization failed"
+        ):
+            get_credential_storage()

--- a/tests/unit/security/test_crypto_utils.py
+++ b/tests/unit/security/test_crypto_utils.py
@@ -720,3 +720,71 @@ class TestSecurityProperties:
         # Only base64 encoded data should be present
         assert encrypted["salt"] in encrypted_str
         assert encrypted["data"] in encrypted_str
+
+
+class TestProductionFailClosed_SDK896:
+    """SDK#896 anti-regression: get_credential_storage() must fail closed
+    in production rather than silently dropping to base64-only fallback.
+
+    The pre-fix behavior caught any RuntimeError from
+    SecureCredentialStorage.__init__ and returned a
+    FallbackCredentialStorage. That silently base64-encoded credentials
+    on a host where TRAIGENT_ENCRYPTION_KEY was unset — exactly the
+    "fail-open in production" pattern Codex review flagged.
+
+    These tests pin both directions: production must raise; explicit
+    dev environments may still use fallback.
+    """
+
+    def setup_method(self):
+        """Reset the singleton before each test (other tests cache it)."""
+        import traigent.security.crypto_utils as crypto_module
+
+        crypto_module._credential_storage_instance = None
+
+    def test_production_without_encryption_key_raises(self, monkeypatch):
+        """Production env (default if no env var is set) + no
+        TRAIGENT_ENCRYPTION_KEY must raise RuntimeError. Previously this
+        silently returned base64-only FallbackCredentialStorage."""
+        # Force production semantics by clearing all env classifiers.
+        monkeypatch.delenv("TRAIGENT_ENV", raising=False)
+        monkeypatch.delenv("TRAIGENT_ENVIRONMENT", raising=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("TRAIGENT_ENCRYPTION_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="TRAIGENT_ENCRYPTION_KEY"):
+            get_credential_storage()
+
+    def test_production_with_encryption_key_returns_secure(self, monkeypatch):
+        """Production env + TRAIGENT_ENCRYPTION_KEY set returns the real
+        SecureCredentialStorage (not the fallback)."""
+        monkeypatch.delenv("TRAIGENT_ENV", raising=False)
+        monkeypatch.delenv("TRAIGENT_ENVIRONMENT", raising=False)
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("TRAIGENT_ENCRYPTION_KEY", "x" * 64)
+
+        storage = get_credential_storage()
+        assert isinstance(storage, SecureCredentialStorage)
+
+    def test_development_without_encryption_key_falls_back(self, monkeypatch):
+        """In an explicit dev environment, missing key still allows the
+        fallback (preserves local-dev workflow). The fallback is the
+        ONLY thing that changed direction in SDK#896 — production is
+        now strict, dev is unchanged."""
+        monkeypatch.setenv("TRAIGENT_ENV", "development")
+        monkeypatch.delenv("TRAIGENT_ENCRYPTION_KEY", raising=False)
+
+        storage = get_credential_storage()
+        # In dev with cryptography available, SecureCredentialStorage's
+        # __init__ generates an ephemeral key with a warning — and that's
+        # what we accept here. The point is no RuntimeError.
+        assert storage is not None
+
+    def test_test_env_without_encryption_key_does_not_raise(self, monkeypatch):
+        """`TRAIGENT_ENV=test` is the env pytest uses for security tests
+        themselves — must not raise so the test suite can run."""
+        monkeypatch.setenv("TRAIGENT_ENV", "test")
+        monkeypatch.delenv("TRAIGENT_ENCRYPTION_KEY", raising=False)
+
+        storage = get_credential_storage()
+        assert storage is not None

--- a/traigent/security/crypto_utils.py
+++ b/traigent/security/crypto_utils.py
@@ -63,14 +63,10 @@ class SecureCredentialStorage:
         import warnings
 
         env_password = os.environ.get("TRAIGENT_ENCRYPTION_KEY")
-        # Use canonical environment flags; default to production for safety
-        environment = (
-            os.environ.get("TRAIGENT_ENVIRONMENT")
-            or os.environ.get("TRAIGENT_ENV")
-            or os.environ.get("ENVIRONMENT")
-            or "production"
-        ).lower()
-        is_non_prod = environment in {"development", "dev", "test", "local"}
+        # Defer to the shared classifier so __init__ and the factory can
+        # never disagree on environment normalization (Codex Q3 P2 of
+        # PR #964 caught a `.strip()` drift between the two).
+        is_non_prod = _is_non_production_environment()
 
         if password:
             self.password = password

--- a/traigent/security/crypto_utils.py
+++ b/traigent/security/crypto_utils.py
@@ -485,21 +485,79 @@ _credential_storage_instance: (
 _credential_storage_lock = threading.Lock()
 
 
+def _is_non_production_environment() -> bool:
+    """Mirror SecureCredentialStorage.__init__'s environment classification.
+
+    Non-production iff one of the canonical environment flags is set to
+    a known dev/test/local value. Default (no flag set) is production —
+    matches the SDK-wide safety convention that an unset env defaults
+    to the strict path. Keep this in sync with the equivalent block at
+    the top of `SecureCredentialStorage.__init__`.
+    """
+    environment = (
+        (
+            os.environ.get("TRAIGENT_ENVIRONMENT")
+            or os.environ.get("TRAIGENT_ENV")
+            or os.environ.get("ENVIRONMENT")
+            or "production"
+        )
+        .strip()
+        .lower()
+    )
+    return environment in {"development", "dev", "test", "local"}
+
+
 def get_credential_storage() -> SecureCredentialStorage | FallbackCredentialStorage:
-    """Get appropriate credential storage implementation (thread-safe)."""
+    """Get appropriate credential storage implementation (thread-safe).
+
+    Production safety contract (SDK#896 fix):
+      * In production (no `TRAIGENT_ENV*` flag set, or set to anything
+        other than dev/test/local), the SDK MUST use real AES-256
+        encryption. If `cryptography` is unavailable OR
+        `SecureCredentialStorage.__init__` cannot construct (e.g.,
+        `TRAIGENT_ENCRYPTION_KEY` missing), this function raises
+        `RuntimeError` rather than silently returning the base64-only
+        `FallbackCredentialStorage`. Silent fallback was the
+        production-credential-storage fail-open Codex review of the
+        2026-05-13 audit pass identified as SDK#896.
+      * In non-production (`TRAIGENT_ENV=development|dev|test|local`),
+        the previous fallback behavior is preserved so local
+        development without `cryptography` installed still works.
+
+    The legacy `FallbackCredentialStorage` class is kept for those
+    non-production paths and for decrypting any historical
+    base64-stored credentials a developer may have on disk; production
+    callers will never see it from this factory function.
+    """
     global _credential_storage_instance
 
     if _credential_storage_instance is None:
         with _credential_storage_lock:
             # Double-checked locking pattern
             if _credential_storage_instance is None:
-                if CRYPTOGRAPHY_AVAILABLE:
+                non_prod = _is_non_production_environment()
+                if not CRYPTOGRAPHY_AVAILABLE:
+                    if not non_prod:
+                        raise RuntimeError(
+                            "cryptography library is required in production for "
+                            "credential storage. The base64 fallback is dev-only "
+                            "(SDK#896). Install with: pip install cryptography, or "
+                            "set TRAIGENT_ENV=development to opt into the local "
+                            "fallback for development."
+                        )
+                    _credential_storage_instance = FallbackCredentialStorage()
+                else:
                     try:
                         _credential_storage_instance = SecureCredentialStorage()
                     except RuntimeError:
+                        # SecureCredentialStorage already raised the production-
+                        # safety RuntimeError (e.g. TRAIGENT_ENCRYPTION_KEY
+                        # missing). DO NOT swallow it in production — that was
+                        # the SDK#896 fail-open. Only fall back when the caller
+                        # has explicitly opted into a non-production environment.
+                        if not non_prod:
+                            raise
                         _credential_storage_instance = FallbackCredentialStorage()
-                else:
-                    _credential_storage_instance = FallbackCredentialStorage()
 
     if _credential_storage_instance is None:
         return FallbackCredentialStorage()

--- a/traigent/security/crypto_utils.py
+++ b/traigent/security/crypto_utils.py
@@ -33,6 +33,27 @@ except ImportError:
 PBKDF2_ITERATIONS = 100000  # OWASP/NIST recommended minimum for key derivation
 
 
+def _is_non_production_environment() -> bool:
+    """Return whether the current environment explicitly opts into dev behavior.
+
+    Non-production iff one of the canonical environment flags is set to
+    a known dev/test/local value. Default (no flag set) is production —
+    matches the SDK-wide safety convention that an unset env defaults
+    to the strict path.
+    """
+    environment = (
+        (
+            os.environ.get("TRAIGENT_ENVIRONMENT")
+            or os.environ.get("TRAIGENT_ENV")
+            or os.environ.get("ENVIRONMENT")
+            or "production"
+        )
+        .strip()
+        .lower()
+    )
+    return environment in {"development", "dev", "test", "local"}
+
+
 class CredentialEncryptionError(Exception):
     """Error during credential encryption."""
 
@@ -481,28 +502,6 @@ _credential_storage_instance: (
 _credential_storage_lock = threading.Lock()
 
 
-def _is_non_production_environment() -> bool:
-    """Mirror SecureCredentialStorage.__init__'s environment classification.
-
-    Non-production iff one of the canonical environment flags is set to
-    a known dev/test/local value. Default (no flag set) is production —
-    matches the SDK-wide safety convention that an unset env defaults
-    to the strict path. Keep this in sync with the equivalent block at
-    the top of `SecureCredentialStorage.__init__`.
-    """
-    environment = (
-        (
-            os.environ.get("TRAIGENT_ENVIRONMENT")
-            or os.environ.get("TRAIGENT_ENV")
-            or os.environ.get("ENVIRONMENT")
-            or "production"
-        )
-        .strip()
-        .lower()
-    )
-    return environment in {"development", "dev", "test", "local"}
-
-
 def get_credential_storage() -> SecureCredentialStorage | FallbackCredentialStorage:
     """Get appropriate credential storage implementation (thread-safe).
 
@@ -556,7 +555,11 @@ def get_credential_storage() -> SecureCredentialStorage | FallbackCredentialStor
                         _credential_storage_instance = FallbackCredentialStorage()
 
     if _credential_storage_instance is None:
-        return FallbackCredentialStorage()
+        raise RuntimeError(
+            "Credential storage initialization failed without selecting a secure "
+            "or explicitly non-production storage backend. Refusing to fall back "
+            "silently (SDK#896)."
+        )
     return _credential_storage_instance
 
 


### PR DESCRIPTION
## Summary

Closes #896.

\`get_credential_storage()\` was silently catching \`RuntimeError\` from \`SecureCredentialStorage.__init__\` and returning a base64-only \`FallbackCredentialStorage\` — nullifying the production safety check the constructor was supposed to enforce.

## Codex consultation

Ranked **#1** actionable production-credential risk by Codex consultation (\`ops/_validation/runs/codex-review-2026-05-14/urgency-consultation.output.md\`):

> \`SecureCredentialStorage\` correctly requires \`TRAIGENT_ENCRYPTION_KEY\` in production, but \`get_credential_storage()\` catches that \`RuntimeError\` and silently returns \`FallbackCredentialStorage\`, which base64-encodes secrets. […] In production/staging, never instantiate fallback storage; raise.

## Fix

Two-part guard in \`get_credential_storage()\`:
1. If \`cryptography\` library isn't installed AND we're in production, raise \`RuntimeError\` with a migration message.
2. If \`SecureCredentialStorage()\` raises and we're in production, re-raise. Only fall back when the caller explicitly set \`TRAIGENT_ENV\` to \`development\`/\`dev\`/\`test\`/\`local\`.

Added \`_is_non_production_environment()\` helper that mirrors \`SecureCredentialStorage.__init__\`'s environment classification.

## Tests

\`TestProductionFailClosed_SDK896\` with 4 regression tests:
- \`test_production_without_encryption_key_raises\` — pins the production-without-key path raises (was silent base64 fallback)
- \`test_production_with_encryption_key_returns_secure\` — pins production-with-key returns the real \`SecureCredentialStorage\`
- \`test_development_without_encryption_key_falls_back\` — pins explicit-dev-without-key still works
- \`test_test_env_without_encryption_key_does_not_raise\` — pins \`TRAIGENT_ENV=test\` doesn't break the test suite

41/41 tests pass.

## ⚠️ Migration notes

Production deployments missing \`TRAIGENT_ENCRYPTION_KEY\` will now fail to start with:
\`\`\`
RuntimeError: TRAIGENT_ENCRYPTION_KEY environment variable is required in production. ...
\`\`\`

This is intended — silently storing credentials as base64 was the bug.

## Test plan

- [x] Unit tests 41/41 pass
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)