### PR TITLE
fix(security): enterprise health checks + backups fail loud (closes #918)

### DIFF
--- a/tests/unit/security/test_deployment.py
+++ b/tests/unit/security/test_deployment.py
@@ -521,34 +521,49 @@ class TestHealthCheckerCheckServiceHealth:
         """Create test health checker instance."""
         return HealthChecker()
 
-    def test_check_service_health_database(self, checker: HealthChecker) -> None:
-        """Test health check for database service."""
+    def test_check_service_health_database_reports_unknown_when_no_probe_wired(
+        self, checker: HealthChecker
+    ) -> None:
+        """SDK#918 anti-regression: previously this returned
+        `HealthStatus.HEALTHY` with fabricated `connections=45`
+        details. Now it returns `UNKNOWN` with a `reason` field
+        indicating no real probe is wired."""
         health = checker.check_service_health("database")
 
         assert health.service == "database"
-        assert health.status == HealthStatus.HEALTHY
-        assert health.response_time_ms > 0
-        assert health.details["connections"] == 45
-        assert health.details["query_time_avg_ms"] == 12
+        assert health.status == HealthStatus.UNKNOWN
+        assert health.response_time_ms >= 0
+        assert "reason" in health.details
+        assert "No real health probe configured" in health.details["reason"]
+        assert "database" in health.details["reason"]
         assert isinstance(health.timestamp, datetime)
+        # Fabricated metrics MUST be gone.
+        assert "connections" not in health.details
+        assert "query_time_avg_ms" not in health.details
 
-    def test_check_service_health_api(self, checker: HealthChecker) -> None:
-        """Test health check for API service."""
+    def test_check_service_health_api_reports_unknown_when_no_probe_wired(
+        self, checker: HealthChecker
+    ) -> None:
+        """SDK#918 anti-regression for the api service slot."""
         health = checker.check_service_health("api")
 
         assert health.service == "api"
-        assert health.status == HealthStatus.HEALTHY
-        assert health.details["active_requests"] == 23
-        assert health.details["queue_length"] == 2
+        assert health.status == HealthStatus.UNKNOWN
+        assert "reason" in health.details
+        assert "active_requests" not in health.details
+        assert "queue_length" not in health.details
 
-    def test_check_service_health_optimizer(self, checker: HealthChecker) -> None:
-        """Test health check for optimizer service."""
+    def test_check_service_health_optimizer_reports_unknown_when_no_probe_wired(
+        self, checker: HealthChecker
+    ) -> None:
+        """SDK#918 anti-regression for the optimizer service slot."""
         health = checker.check_service_health("optimizer")
 
         assert health.service == "optimizer"
-        assert health.status == HealthStatus.HEALTHY
-        assert health.details["active_optimizations"] == 5
-        assert health.details["cpu_usage"] == 67
+        assert health.status == HealthStatus.UNKNOWN
+        assert "reason" in health.details
+        assert "active_optimizations" not in health.details
+        assert "cpu_usage" not in health.details
 
     def test_check_service_health_unknown_service(self, checker: HealthChecker) -> None:
         """Test health check for unknown service returns UNKNOWN status."""
@@ -556,7 +571,10 @@ class TestHealthCheckerCheckServiceHealth:
 
         assert health.service == "unknown-service"
         assert health.status == HealthStatus.UNKNOWN
-        assert health.details == {}
+        # Unknown service still has a reason field; previously this
+        # returned an empty dict, but the new code surfaces the
+        # "Unrecognized service name" reason for honest reporting.
+        assert "reason" in health.details
 
     def test_check_service_health_stores_in_history(
         self, checker: HealthChecker
@@ -568,16 +586,18 @@ class TestHealthCheckerCheckServiceHealth:
         assert len(checker.health_history) == 2
 
     @patch("traigent.security.deployment.logger")
-    def test_check_service_health_logs_debug(
+    def test_check_service_health_logs_warning(
         self, mock_logger: MagicMock, checker: HealthChecker
     ) -> None:
-        """Test health check logs debug message."""
+        """SDK#918: probes for recognized services that have no real
+        implementation now log a warning instead of debug, so monitoring
+        catches the call. Previously logged debug + fake `healthy` status."""
         checker.check_service_health("database")
 
-        mock_logger.debug.assert_called_once()
-        log_message = mock_logger.debug.call_args[0][0]
-        assert "Health check for database" in log_message
-        assert "healthy" in log_message
+        mock_logger.warning.assert_called_once()
+        log_message = mock_logger.warning.call_args[0][0]
+        assert "no real probe is configured" in log_message
+        assert "SDK#918" in log_message
 
     @patch("traigent.security.deployment.time.time")
     def test_check_service_health_measures_response_time(
@@ -647,14 +667,22 @@ class TestHealthCheckerGetSystemHealth:
         assert "storage" in services
 
     def test_get_system_health_service_details(self, checker: HealthChecker) -> None:
-        """Test system health includes service details."""
+        """Test system health includes service details.
+
+        SDK#918 fix: database used to report `status=healthy` with
+        fabricated `connections=45`. Now it reports `unknown` with a
+        `reason` field. The structural shape (status / response_time
+        / details) is preserved so consumers don't crash.
+        """
         result = checker.get_system_health()
 
         db_health = result["services"]["database"]
-        assert db_health["status"] == "healthy"
+        assert db_health["status"] == "unknown"
         assert "response_time_ms" in db_health
         assert "details" in db_health
-        assert db_health["details"]["connections"] == 45
+        # Honest signal — no fabricated metrics:
+        assert "connections" not in db_health["details"]
+        assert "reason" in db_health["details"]
 
     def test_get_system_health_creates_health_history(
         self, checker: HealthChecker
@@ -746,75 +774,79 @@ class TestBackupManagerCreateBackup:
         """Create test backup manager instance."""
         return BackupManager()
 
-    def test_create_backup_with_default_type(self, manager: BackupManager) -> None:
-        """Test creating backup with default full type."""
+    def test_create_backup_reports_unsupported(self, manager: BackupManager) -> None:
+        """SDK#918 anti-regression: previously this returned
+        `status="completed"` with a fabricated backup_id and
+        size_gb=2.5 despite doing no work. Now it must report
+        `unsupported` with no backup_id and a `reason` mentioning
+        the missing executor."""
         backup = manager.create_backup()
 
         assert backup["type"] == "full"
-        assert backup["status"] == "completed"
-        assert backup["size_gb"] == 2.5
-        assert "backup_id" in backup
-        assert backup["backup_id"].startswith("backup_")
+        assert backup["status"] == "unsupported"
+        assert "reason" in backup
+        assert "BackupExecutor" not in backup["reason"] or "real backup" in backup["reason"]
+        assert "NO DATA WAS PERSISTED" in backup["reason"]
+        # Fabricated fields MUST be gone:
+        assert "backup_id" not in backup
+        assert "size_gb" not in backup
+        assert "retention_until" not in backup
+        # Honest fields:
         assert "created_at" in backup
-        assert "retention_until" in backup
 
     def test_create_backup_with_custom_type(self, manager: BackupManager) -> None:
-        """Test creating backup with custom type."""
+        """Custom type passes through but status is still unsupported."""
         backup = manager.create_backup(backup_type="incremental")
 
         assert backup["type"] == "incremental"
+        assert backup["status"] == "unsupported"
 
-    def test_create_backup_stores_in_backups_list(self, manager: BackupManager) -> None:
-        """Test created backup is stored in backups list."""
+    def test_create_backup_does_not_store_in_backups_list_when_unsupported(
+        self, manager: BackupManager
+    ) -> None:
+        """SDK#918 anti-regression: previously a fabricated backup
+        was appended to `self.backups`, polluting the list with
+        non-existent backups. Now no append happens because no real
+        backup occurred."""
         manager.create_backup()
 
-        assert len(manager.backups) == 1
-        assert manager.backups[0]["type"] == "full"
-
-    def test_create_backup_multiple_backups(self, manager: BackupManager) -> None:
-        """Test creating multiple backups."""
-        manager.create_backup(backup_type="full")
-        manager.create_backup(backup_type="incremental")
-
-        assert len(manager.backups) == 2
-
-    @patch("traigent.security.deployment.time.time")
-    def test_create_backup_unique_ids(
-        self, mock_time: MagicMock, manager: BackupManager
-    ) -> None:
-        """Test each backup gets unique ID."""
-        # Use an unbounded counter so unrelated background calls to time.time
-        # in this module do not exhaust side effects and cause StopIteration.
-        mock_time.side_effect = (float(ts) for ts in count(start=1000, step=1))
-
-        backup1 = manager.create_backup()
-        backup2 = manager.create_backup()
-
-        assert backup1["backup_id"] != backup2["backup_id"]
-        assert backup1["backup_id"].startswith("backup_")
-        assert backup2["backup_id"].startswith("backup_")
-
-    def test_create_backup_retention_period(self, manager: BackupManager) -> None:
-        """Test backup retention period is set correctly."""
-        backup = manager.create_backup()
-
-        created_at = datetime.fromisoformat(backup["created_at"])
-        retention_until = datetime.fromisoformat(backup["retention_until"])
-        expected_retention = created_at + timedelta(days=30)
-
-        # Allow small time difference due to processing
-        assert abs((retention_until - expected_retention).total_seconds()) < 1
+        assert len(manager.backups) == 0
 
     @patch("traigent.security.deployment.logger")
-    def test_create_backup_logs_info(
+    def test_create_backup_logs_error(
         self, mock_logger: MagicMock, manager: BackupManager
     ) -> None:
-        """Test backup creation logs informational message."""
+        """SDK#918: the no-op backup must log an error (not info), so
+        monitoring catches the call."""
         manager.create_backup(backup_type="full")
 
-        mock_logger.info.assert_called_once()
-        log_message = mock_logger.info.call_args[0][0]
-        assert "Created full backup" in log_message
+        mock_logger.error.assert_called_once()
+        log_message = mock_logger.error.call_args[0][0]
+        assert "no backup executor is configured" in log_message
+        assert "no data was persisted" in log_message.lower()
+
+
+def _synthetic_backup_entry(
+    backup_id: str = "backup_synth",
+    *,
+    expired: bool = False,
+    backup_type: str = "full",
+) -> dict[str, Any]:
+    """Insert a hand-built backup record for tests of list/restore/cleanup
+    methods that previously relied on `create_backup()` populating the
+    list. After SDK#918, `create_backup()` no longer fabricates a
+    completed backup — tests of the OTHER backup methods now build
+    their own synthetic records directly."""
+    now = datetime.now(UTC)
+    retention = now - timedelta(days=1) if expired else now + timedelta(days=30)
+    return {
+        "backup_id": backup_id,
+        "type": backup_type,
+        "created_at": (now - timedelta(days=60 if expired else 0)).isoformat(),
+        "size_gb": 2.5,
+        "status": "completed",
+        "retention_until": retention.isoformat(),
+    }
 
 
 class TestBackupManagerListBackups:
@@ -831,32 +863,21 @@ class TestBackupManagerListBackups:
         assert backups == []
 
     def test_list_backups_with_valid_backups(self, manager: BackupManager) -> None:
-        """Test listing valid backups."""
-        manager.create_backup()
-        manager.create_backup()
+        """Test listing valid backups (built directly post-SDK#918)."""
+        manager.backups.append(_synthetic_backup_entry("backup_a"))
+        manager.backups.append(_synthetic_backup_entry("backup_b"))
 
         backups = manager.list_backups()
         assert len(backups) == 2
 
     def test_list_backups_filters_expired(self, manager: BackupManager) -> None:
         """Test list filters out expired backups."""
-        # Create expired backup
-        expired_backup = {
-            "backup_id": "backup_expired",
-            "type": "full",
-            "created_at": (datetime.now(UTC) - timedelta(days=60)).isoformat(),
-            "size_gb": 2.5,
-            "status": "completed",
-            "retention_until": (datetime.now(UTC) - timedelta(days=1)).isoformat(),
-        }
-        manager.backups.append(expired_backup)
-
-        # Create valid backup
-        manager.create_backup()
+        manager.backups.append(_synthetic_backup_entry("backup_expired", expired=True))
+        manager.backups.append(_synthetic_backup_entry("backup_valid"))
 
         backups = manager.list_backups()
         assert len(backups) == 1
-        assert backups[0]["backup_id"] != "backup_expired"
+        assert backups[0]["backup_id"] == "backup_valid"
 
 
 class TestBackupManagerRestoreBackup:
@@ -868,13 +889,12 @@ class TestBackupManagerRestoreBackup:
         return BackupManager()
 
     def test_restore_backup_existing(self, manager: BackupManager) -> None:
-        """Test restoring from existing backup."""
-        backup = manager.create_backup()
-        backup_id = backup["backup_id"]
+        """Test restoring from existing backup (synthetic record post-SDK#918)."""
+        manager.backups.append(_synthetic_backup_entry("backup_synth"))
 
-        restore = manager.restore_backup(backup_id)
+        restore = manager.restore_backup("backup_synth")
 
-        assert restore["backup_id"] == backup_id
+        assert restore["backup_id"] == "backup_synth"
         assert restore["status"] == "in_progress"
         assert restore["estimated_duration_minutes"] == 30
         assert "restore_started_at" in restore
@@ -891,11 +911,11 @@ class TestBackupManagerRestoreBackup:
         self, mock_logger: MagicMock, manager: BackupManager
     ) -> None:
         """Test restore operation logs informational message."""
-        backup = manager.create_backup()
-        manager.restore_backup(backup["backup_id"])
+        manager.backups.append(_synthetic_backup_entry("backup_synth"))
+        manager.restore_backup("backup_synth")
 
         mock_logger.info.assert_called()
-        # Find the restore log message (not the create backup message)
+        # Find the restore log message
         restore_log_found = False
         for call in mock_logger.info.call_args_list:
             log_message = call[0][0]
@@ -914,9 +934,9 @@ class TestBackupManagerCleanupExpiredBackups:
         return BackupManager()
 
     def test_cleanup_expired_backups_none_expired(self, manager: BackupManager) -> None:
-        """Test cleanup when no backups are expired."""
-        manager.create_backup()
-        manager.create_backup()
+        """Test cleanup when no backups are expired (synthetic post-SDK#918)."""
+        manager.backups.append(_synthetic_backup_entry("backup_a"))
+        manager.backups.append(_synthetic_backup_entry("backup_b"))
 
         cleaned = manager.cleanup_expired_backups()
 
@@ -925,25 +945,14 @@ class TestBackupManagerCleanupExpiredBackups:
 
     def test_cleanup_expired_backups_some_expired(self, manager: BackupManager) -> None:
         """Test cleanup removes only expired backups."""
-        # Create expired backup
-        expired_backup = {
-            "backup_id": "backup_expired",
-            "type": "full",
-            "created_at": (datetime.now(UTC) - timedelta(days=60)).isoformat(),
-            "size_gb": 2.5,
-            "status": "completed",
-            "retention_until": (datetime.now(UTC) - timedelta(days=1)).isoformat(),
-        }
-        manager.backups.append(expired_backup)
-
-        # Create valid backup
-        manager.create_backup()
+        manager.backups.append(_synthetic_backup_entry("backup_expired", expired=True))
+        manager.backups.append(_synthetic_backup_entry("backup_valid"))
 
         cleaned = manager.cleanup_expired_backups()
 
         assert cleaned == 1
         assert len(manager.backups) == 1
-        assert manager.backups[0]["backup_id"] != "backup_expired"
+        assert manager.backups[0]["backup_id"] == "backup_valid"
 
     def test_cleanup_expired_backups_all_expired(self, manager: BackupManager) -> None:
         """Test cleanup when all backups are expired."""
@@ -992,10 +1001,16 @@ class TestBackupManagerCleanupExpiredBackups:
     def test_cleanup_expired_backups_no_log_when_none_cleaned(
         self, mock_logger: MagicMock, manager: BackupManager
     ) -> None:
-        """Test cleanup doesn't log when no backups are cleaned."""
-        manager.create_backup()
+        """Test cleanup doesn't log when no backups are cleaned.
+
+        SDK#918 update: previously this counted 1 logger.info call from
+        the (now-removed) fabricated create_backup info log. With the
+        synthetic entry inserted directly there are zero info calls.
+        """
+        manager.backups.append(_synthetic_backup_entry("backup_a"))
 
         manager.cleanup_expired_backups()
 
-        # Should not call logger.info for cleanup (only for create_backup)
-        assert mock_logger.info.call_count == 1  # Only from create_backup
+        # No backups expired → cleanup should not log info.
+        # No call to create_backup → no fabricated info log.
+        assert mock_logger.info.call_count == 0

--- a/tests/unit/security/test_enterprise.py
+++ b/tests/unit/security/test_enterprise.py
@@ -423,7 +423,11 @@ class TestEnterpriseDeploymentManager:
 
         health_check = manager.perform_health_check()
 
-        assert health_check["overall_status"] in ["healthy", "unhealthy"]
+        # SDK#918 fix: with database + external_services reporting
+        # `unsupported` (no real probes wired), overall_status is now
+        # `degraded` instead of the previous fabricated `healthy`. May
+        # still be `unhealthy` if the system metrics check fails.
+        assert health_check["overall_status"] in ["healthy", "unhealthy", "degraded"]
         assert "timestamp" in health_check
         assert "checks" in health_check
 
@@ -432,28 +436,44 @@ class TestEnterpriseDeploymentManager:
         assert "database" in checks
         assert "external_services" in checks
 
-        # System check should have status and score
+        # System check should have status and score (real probe)
         assert "status" in checks["system"]
         if checks["system"]["status"] != "error":
             assert "score" in checks["system"]
             assert "details" in checks["system"]
 
-    def test_create_backup(self):
-        """Test backup creation"""
+        # SDK#918 anti-regression: database + external_services must NOT
+        # report a fabricated `healthy` status. They must surface the
+        # missing-probe condition honestly.
+        assert checks["database"]["status"] == "unsupported"
+        assert "reason" in checks["database"]
+        assert "DatabaseHealthProbe" in checks["database"]["reason"]
+        assert checks["external_services"]["status"] == "unsupported"
+        assert "reason" in checks["external_services"]
+        assert "ExternalServiceHealthProbe" in checks["external_services"]["reason"]
+
+    def test_create_backup_reports_unsupported_when_no_executor_wired(self):
+        """SDK#918 anti-regression: `create_backup()` previously
+        returned `status="completed"` with a fabricated backup_id and
+        size despite doing no work. Now it must report `unsupported`
+        with no fake backup_id, so callers (and monitoring) see the
+        truth."""
         manager = EnterpriseDeploymentManager(DeploymentMode.ON_PREMISE)
 
         backup_info = manager.create_backup()
 
-        assert "backup_id" in backup_info
-        assert backup_info["backup_id"].startswith("backup_")
-        assert "timestamp" in backup_info
+        # The previous "success" shape is GONE: no backup_id, no
+        # size_bytes, no retention_until.
+        assert "backup_id" not in backup_info
+        assert "size_bytes" not in backup_info
+        assert "retention_until" not in backup_info
+        # The honest shape MUST be present.
+        assert backup_info["status"] == "unsupported"
+        assert "reason" in backup_info
+        assert "BackupExecutor" in backup_info["reason"]
+        assert "NO DATA WAS PERSISTED" in backup_info["reason"]
         assert backup_info["deployment_mode"] == DeploymentMode.ON_PREMISE.value
-        assert backup_info["status"] == "completed"
-        assert backup_info["size_bytes"] > 0
-        assert "retention_until" in backup_info
-
-        # Retention should be based on deployment config
-        assert manager.config["backup_retention_days"] == 365  # On-premise default
+        assert "timestamp" in backup_info
 
     @patch("traigent.security.enterprise.psutil")
     def test_enterprise_dashboard(self, mock_psutil):

--- a/traigent/security/deployment.py
+++ b/traigent/security/deployment.py
@@ -195,23 +195,46 @@ class HealthChecker:
         self.check_interval = 60  # seconds
 
     def check_service_health(self, service_name: str) -> HealthCheck:
-        """Check health of a specific service."""
+        """Check health of a specific service.
+
+        Honest-status contract (SDK#918 fix): the previous body returned
+        hardcoded `HealthStatus.HEALTHY` for `database`, `api`, and
+        `optimizer` with fabricated metric values (`connections: 45`,
+        `active_requests: 23`, etc.). The source comment said
+        `# Simulate health check (replace with actual checks)`. Operators
+        querying this method got a green light regardless of whether the
+        underlying services were running.
+
+        This implementation now returns `HealthStatus.UNKNOWN` for every
+        recognized service name with a `details["reason"]` explaining
+        that no real probe is configured. Subclasses (or callers) must
+        wire real probes by overriding this method. A logger.warning
+        fires so monitoring catches the call.
+        """
         start_time = time.time()
 
         try:
-            # Simulate health check (replace with actual checks)
-            if service_name == "database":
-                status = HealthStatus.HEALTHY
-                details: dict[str, Any] = {"connections": 45, "query_time_avg_ms": 12}
-            elif service_name == "api":
-                status = HealthStatus.HEALTHY
-                details = {"active_requests": 23, "queue_length": 2}
-            elif service_name == "optimizer":
-                status = HealthStatus.HEALTHY
-                details = {"active_optimizations": 5, "cpu_usage": 67}
+            if service_name in {"database", "api", "optimizer"}:
+                # Recognized service slot but no real probe wired.
+                status = HealthStatus.UNKNOWN
+                details: dict[str, Any] = {
+                    "reason": (
+                        f"No real health probe configured for "
+                        f"'{service_name}'. Override "
+                        f"HealthChecker.check_service_health in a subclass "
+                        f"to wire a real probe (SDK#918)."
+                    ),
+                }
+                logger.warning(
+                    "HealthChecker.check_service_health('%s') returned UNKNOWN "
+                    "because no real probe is configured (SDK#918).",
+                    service_name,
+                )
             else:
                 status = HealthStatus.UNKNOWN
-                details = {}
+                details = {
+                    "reason": f"Unrecognized service name '{service_name}'.",
+                }
 
             response_time = (time.time() - start_time) * 1000  # Convert to ms
 
@@ -270,23 +293,43 @@ class BackupManager:
         self.retention_days = 30
 
     def create_backup(self, backup_type: str = "full") -> dict[str, Any]:
-        """Create system backup."""
-        backup_id = f"backup_{int(time.time())}"
+        """Create system backup.
 
-        backup_info = {
-            "backup_id": backup_id,
+        Honest-status contract (SDK#918 fix): this method previously
+        returned `status="completed"` with a fabricated `backup_id`
+        and a fake `size_gb=2.5` — without performing any backup work.
+        Operators calling `create_backup()` got a "completed" status
+        and a backup_id they could record as proof of backup, then
+        would discover during disaster recovery that no backup data
+        existed.
+
+        This implementation now returns `status="unsupported"` (no
+        `backup_id`, no fake size) with a `reason` explaining how to
+        wire a real backup. A logger.error fires so monitoring catches
+        the call. Callers that previously checked `status == "completed"`
+        will now correctly see the failure.
+
+        Override `BackupManager.create_backup` in a subclass to provide
+        a real backup implementation; `self.backups` is left untouched
+        when no real backup occurs.
+        """
+        logger.error(
+            "BackupManager.create_backup(%r) called but no backup executor "
+            "is configured. Returning status='unsupported'; no data was "
+            "persisted. See SDK#918 for the migration path.",
+            backup_type,
+        )
+        return {
             "type": backup_type,
+            "status": "unsupported",
+            "reason": (
+                "No real backup implementation is wired. The SDK does not "
+                "ship a default BackupExecutor. Override "
+                "BackupManager.create_backup in a subclass to provide one. "
+                "NO DATA WAS PERSISTED."
+            ),
             "created_at": datetime.now(UTC).isoformat(),
-            "size_gb": 2.5,  # Simulated
-            "status": "completed",
-            "retention_until": (
-                datetime.now(UTC) + timedelta(days=self.retention_days)
-            ).isoformat(),
         }
-
-        self.backups.append(backup_info)
-        logger.info(f"Created {backup_type} backup: {backup_id}")
-        return backup_info
 
     def list_backups(self) -> list[dict[str, Any]]:
         """List available backups."""

--- a/traigent/security/enterprise.py
+++ b/traigent/security/enterprise.py
@@ -729,10 +729,30 @@ class EnterpriseDeploymentManager:
         return status
 
     def perform_health_check(self) -> dict[str, Any]:
-        """Perform comprehensive health check"""
-        health_checks = {}
+        """Perform comprehensive health check.
 
-        # System health
+        Honest-status contract (SDK#918 fix): the per-service probes
+        for `database` and `external_services` were previously
+        hardcoded to `"healthy"` (the source comments said `(mock)`).
+        Operators integrating with this method got a green light even
+        when the underlying components were absent or unconfigured.
+
+        The system-metrics check IS real (driven by
+        `metrics_collector.collect_system_metrics()`) and continues
+        to report its actual status. The two stubbed sub-checks now
+        report `status="unsupported"` with a `reason` explaining
+        what's missing, so monitoring/dashboards see the gap. Overall
+        status downgrades to `"degraded"` when any sub-check is
+        `unsupported`, so an alerting pipeline that key-checks
+        `overall_status == "healthy"` will (correctly) not page on
+        the system-metrics half but also won't claim everything is
+        fine.
+
+        Wire real probes by overriding this method in a subclass.
+        """
+        health_checks: dict[str, dict[str, Any]] = {}
+
+        # System health — real probe via metrics_collector.
         try:
             metrics = self.metrics_collector.collect_system_metrics()
             health_checks["system"] = {
@@ -743,56 +763,111 @@ class EnterpriseDeploymentManager:
         except Exception as e:
             health_checks["system"] = {"status": "error", "error": str(e)}
 
-        # Database connectivity (mock)
-        health_checks["database"] = {"status": "healthy", "response_time_ms": 5}
-
-        # External services (mock)
-        health_checks["external_services"] = {
-            "status": "healthy",
-            "services_checked": ",".join(
-                [
-                    "auth_service",
-                    "billing_service",
-                    "notification_service",
-                ]
+        # Database connectivity — no real probe configured. Honest
+        # response so monitoring sees the gap.
+        health_checks["database"] = {
+            "status": "unsupported",
+            "reason": (
+                "DatabaseHealthProbe not configured; the SDK does not ship "
+                "a default DB connectivity check. Override "
+                "perform_health_check in a subclass to wire a real probe."
             ),
         }
 
-        # Overall status
+        # External services — same: no built-in probes.
+        health_checks["external_services"] = {
+            "status": "unsupported",
+            "reason": (
+                "ExternalServiceHealthProbe not configured; the SDK does "
+                "not ship default reachability checks for "
+                "auth_service/billing_service/notification_service."
+            ),
+            "services_listed": [
+                "auth_service",
+                "billing_service",
+                "notification_service",
+            ],
+        }
+
+        # Overall status: only "healthy" iff every check says so. Any
+        # `unsupported` (or other non-healthy) drops the rollup so
+        # monitoring catches the unconfigured probes.
         all_healthy = all(
             check.get("status") == "healthy" for check in health_checks.values()
         )
+        any_unsupported = any(
+            check.get("status") == "unsupported" for check in health_checks.values()
+        )
+        any_bad = any(
+            check.get("status") in {"unhealthy", "error"}
+            for check in health_checks.values()
+        )
+        if all_healthy:
+            overall = "healthy"
+        elif any_bad:
+            overall = "unhealthy"
+        elif any_unsupported:
+            overall = "degraded"
+        else:
+            overall = "unhealthy"
+
+        if any_unsupported:
+            unsupported_count = sum(
+                1 for c in health_checks.values() if c.get("status") == "unsupported"
+            )
+            logger.warning(
+                "EnterpriseManager.perform_health_check: %d sub-check(s) "
+                "report 'unsupported' — see returned `reason` fields.",
+                unsupported_count,
+            )
 
         return {
-            "overall_status": "healthy" if all_healthy else "unhealthy",
+            "overall_status": overall,
             "timestamp": datetime.now(UTC).isoformat(),
             "checks": health_checks,
         }
 
     def create_backup(self) -> dict[str, Any]:
-        """Create system backup"""
-        backup_id = f"backup_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}"
+        """Create system backup.
 
-        # In production, this would:
-        # - Backup database
-        # - Backup configuration files
-        # - Backup user data
-        # - Store in secure location
+        Honest-status contract (SDK#918 fix): this method previously
+        returned `status="completed"` with a fabricated `backup_id`,
+        a fake `size_bytes=100MB`, and a fake `retention_until` —
+        without doing any actual backup work. Source comments said
+        `# In production, this would: backup database / config / user
+        data / store in secure location`.
 
-        backup_info = {
-            "backup_id": backup_id,
+        That was catastrophically misleading: an operator calling
+        `create_backup()` got a "completed" status and a backup_id
+        they could record as proof of backup, then would discover
+        during disaster recovery that no backup data existed.
+
+        This method now returns `status="unsupported"` (no
+        `backup_id`, no fake size, no fake retention) with a
+        `reason` explaining how to wire a real backup implementation.
+        Callers that previously checked `status == "completed"` will
+        now correctly see the failure. A logger.error fires so
+        monitoring catches the call.
+
+        Override this method in a subclass to provide a real backup
+        implementation.
+        """
+        logger.error(
+            "EnterpriseManager.create_backup called but no backup executor "
+            "is configured. Returning status='unsupported'; no data was "
+            "persisted. See SDK#918 for the migration path."
+        )
+        return {
+            "status": "unsupported",
+            "reason": (
+                "BackupExecutor not configured; the SDK does not ship a "
+                "default backup implementation. Override "
+                "EnterpriseManager.create_backup in a subclass. "
+                "NO DATA WAS PERSISTED."
+            ),
             "timestamp": datetime.now(UTC).isoformat(),
             "deployment_mode": self.deployment_mode.value,
-            "size_bytes": 1024 * 1024 * 100,  # Mock 100MB
-            "retention_until": (
-                datetime.now(UTC)
-                + timedelta(days=self.config.get("backup_retention_days", 30))
-            ).isoformat(),
-            "status": "completed",
         }
-
-        logger.info(f"Created backup {backup_id}")
-        return backup_info
 
     def get_enterprise_dashboard(self) -> dict[str, Any]:
         """Get enterprise dashboard data"""


### PR DESCRIPTION
## Summary

Closes #918.

\`EnterpriseManager.perform_health_check\`, \`EnterpriseManager.create_backup\`, \`HealthChecker.check_service_health\`, and \`BackupManager.create_backup\` all returned fabricated success status without doing the work the method name implied. Source comments said \`# (mock)\`, \`# Simulate health check (replace with actual checks)\`, and \`# In production, this would: backup database / config / user data\`.

The catastrophic case is \`create_backup()\`: an operator calling it got a \`status='completed'\` response and a \`backup_id\` they could record as proof of backup, then would discover during disaster recovery that no backup data existed.

## Codex consultation

Ranked top-3 by Codex (\`ops/_validation/runs/codex-review-2026-05-14/urgency-consultation.output.md\`):

> Database/external service health is hardcoded healthy, and backup APIs return completed/in-progress without doing backup/restore work. **Recommended action: fail-closed or de-export.** Return \`NotImplementedError\`/\`unsupported\` unless real probes/backends are configured.

## Fix

Honest-status pattern: every stub-method now returns \`status='unsupported'\` (or \`HealthStatus.UNKNOWN\` for the typed deployment.py case) with a \`reason\` field explaining what's missing and how to wire a real implementation. Structural shape preserved so callers don't crash.

| Method | Before | After |
|---|---|---|
| \`EnterpriseManager.perform_health_check\` | database + external_services hardcoded \`healthy\` | both report \`unsupported\` with \`reason\`; overall status downgrades to \`degraded\`; logs warning |
| \`EnterpriseManager.create_backup\` | \`status='completed'\`, fake \`backup_id\`, \`size_bytes=100MB\` | \`status='unsupported'\`, no backup_id, no size; logs error; \"NO DATA WAS PERSISTED\" in reason |
| \`HealthChecker.check_service_health(database/api/optimizer)\` | \`HealthStatus.HEALTHY\` + fake metrics (connections=45, etc.) | \`HealthStatus.UNKNOWN\` + reason field; logs warning |
| \`BackupManager.create_backup\` | \`status='completed'\`, fake \`size_gb=2.5\`, appended fake entry to \`self.backups\` | \`status='unsupported'\`; **no longer pollutes \`self.backups\` with non-existent records** |

System-metrics check (\`metrics_collector.collect_system_metrics()\`) IS real and continues to work unchanged.

## Migration

Callers checking \`status == 'completed'\` will now correctly see the failure. Operators must override the methods in a subclass to provide real implementations. Structural shape (dict response, expected keys) preserved so non-status checks still work.

## Tests

- Updated 6 existing tests to assert the new honest behavior (no fabricated \`backup_id\` / \`size_gb\` / \`connections\`).
- Added explicit anti-regression assertions: fabricated fields MUST be absent.
- Added \`_synthetic_backup_entry\` helper for tests of list/restore/cleanup methods that previously relied on \`create_backup\` populating \`self.backups\` — they now build synthetic records directly, separating the test of OTHER methods from the (now-broken) create_backup behavior.

99/99 tests pass in \`test_enterprise.py\` + \`test_deployment.py\`.

## Test plan

- [x] Tests 99/99 pass
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)