### PR TITLE
fix(security): stop fabricating refresh_token + drop JWT-as-API-key fallback (closes #908)

### DIFF
--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -417,9 +417,16 @@ class TraigentAuthCLI:
         # We'll need to extract it from the initial auth response
         user_info: dict[str, str] = {}
 
+        # SDK#908 fix: do NOT fabricate `refresh_token = jwt_token`. The
+        # backend's auth response did not return a real refresh token,
+        # so storing the JWT under that key was misleading — downstream
+        # callers (e.g. `auth_commands.py:_perform_token_refresh`) would
+        # try to use the JWT as a refresh token at the auth server,
+        # which fails. The honest behavior: omit the field entirely.
+        # Refresh-needing flows already gracefully degrade to "please
+        # re-login" when no refresh_token is present (see line 772).
         return {
             "jwt_token": jwt_token,
-            "refresh_token": jwt_token,  # Use same token as refresh for now
             "api_key": api_key,
             "user": user_info,
             "backend_url": self.backend_url,

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -51,13 +51,31 @@ class CredentialManager:
         # Check for CLI stored credentials
         stored_creds = cls._load_cli_credentials()
         if stored_creds:
-            # Prefer API key over JWT
             if stored_creds.get("api_key"):
                 logger.debug("Using API key from CLI credentials")
                 return cast(str, stored_creds["api_key"])
-            elif stored_creds.get("jwt_token"):
-                logger.debug("Using JWT token from CLI credentials")
-                return cast(str, stored_creds["jwt_token"])
+            # SDK#908 fix: previously this fell back to using the
+            # stored `jwt_token` as if it were an API key. JWTs expire
+            # within minutes; using one as a long-lived API key leaks
+            # an expired token into request headers, which the
+            # backend's auth middleware then has to reject. The
+            # symptom is "401 unauthorized after the JWT expires" —
+            # impossible for the user to diagnose because the SDK
+            # claimed it had valid credentials.
+            #
+            # Honest behavior: if the user has only a JWT (no API
+            # key), we don't have a long-lived credential. Returning
+            # None forces the caller down the unauthenticated path,
+            # which surfaces the missing-credential condition
+            # immediately instead of after the JWT expires.
+            if stored_creds.get("jwt_token"):
+                logger.warning(
+                    "CLI credentials have a stored jwt_token but no "
+                    "api_key. JWT tokens are short-lived and unsafe to "
+                    "use as a long-lived API key. Run "
+                    "'traigent auth login' to refresh and create an "
+                    "API key (SDK#908)."
+                )
 
         # Development fallback. The dev-mode credential is no longer hard-coded
         # in source: the operator must explicitly set TRAIGENT_DEV_API_KEY when

--- a/traigent/cloud/credential_manager.py
+++ b/traigent/cloud/credential_manager.py
@@ -74,7 +74,7 @@ class CredentialManager:
                     "api_key. JWT tokens are short-lived and unsafe to "
                     "use as a long-lived API key. Run "
                     "'traigent auth login' to refresh and create an "
-                    "API key (SDK#908)."
+                    "API key."
                 )
 
         # Development fallback. The dev-mode credential is no longer hard-coded


### PR DESCRIPTION
## Summary

Closes #908.

Two real correctness/security issues addressed in this PR:

### 1. \`auth_commands.py:422\` — bogus \`refresh_token = jwt_token\`

The CLI was returning:
\`\`\`python
\"refresh_token\": jwt_token,  # Use same token as refresh for now
\`\`\`

The auth backend's response did not include a refresh token, so the CLI synthesized one by stuffing the JWT under the \`refresh_token\` key. Downstream \`_perform_token_refresh()\` then tried to use the JWT as a refresh token at the auth server, which fails.

**Fix:** omit \`refresh_token\` from the returned dict entirely. The refresh-needing code path (\`auth_commands.py:772\`) already gracefully degrades to \"please re-login\" when no refresh_token is present.

### 2. \`credential_manager.py:56-58\` — JWT-as-API-key fallback

If stored CLI credentials had no \`api_key\` but had a \`jwt_token\`, \`get_api_key()\` returned the JWT and used it as a long-lived API key. JWTs expire within minutes; using one as an API key leaks an expired token into request headers, which the backend's auth middleware then has to reject.

The symptom is **\"401 unauthorized after the JWT expires\"** — impossible for the user to diagnose because the SDK claimed it had valid credentials.

**Fix:** don't return JWT from \`get_api_key()\`. Log a warning telling the user to run \`traigent auth login\`, then return None (forces the caller down the unauthenticated path, surfacing the missing-credential condition immediately).

## Codex consultation

Ranked Top 3 by Codex consultation (\`ops/_validation/runs/codex-review-2026-05-14/urgency-consultation.output.md\`):

> Recommended action: new code / fail-closed. Stop storing JWT/refresh tokens; persist only through encrypted/keychain-backed storage, or make env-only persistence explicit. Remove the \"cat credentials.json\" guidance.

**Note:** the encrypted-storage half of Codex's recommendation is **already implemented** — \`_save_credentials\` uses \`get_secure_credential_store()\`, with the legacy plaintext fallback gated behind \`TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS=true\`. This PR addresses the remaining two bugs Codex named.

## Test plan

- [x] Existing \`test_does_not_return_jwt_when_no_api_key\` already pinned the expected behavior; this PR makes the implementation match
- [x] Impacted test suites pass (175 tests, 2 pre-existing failures unrelated to this PR)
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)