### PR TITLE
fix(security): stop fabricating billing permission on local APIKey (closes #920, addresses #937)

### DIFF
--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -1482,3 +1482,93 @@ class TestPasswordAuthentication:
         assert result.success is False
         assert result.status == AuthStatus.INVALID
         assert "Backend unavailable" in result.error_message
+
+
+# ---------------------------------------------------------------------------
+# SDK#920 anti-regression: APIKey instances created from local credentials
+# (CLI auth response, env vars, secure storage) must NOT fabricate
+# `billing: True` or any admin-tier permission. The SDK has no way to
+# know what the backend actually granted; pretending it does is forgery.
+# ---------------------------------------------------------------------------
+
+
+class TestSDK920_NoFabricatedBillingPermission:
+    """Pin: locally-constructed APIKey objects use the safe default
+    permissions (billing=False) — they do not invent admin claims."""
+
+    def test_apikey_default_post_init_has_billing_false(self):
+        """The dataclass default permissions must explicitly deny
+        billing. Was true on develop already; this test pins it so
+        a future refactor can't quietly flip the default."""
+        from datetime import UTC, datetime
+
+        from traigent.cloud.auth import APIKey
+
+        api_key = APIKey(key="test", name="t", created_at=datetime.now(UTC))
+        assert api_key.permissions is not None
+        assert api_key.permissions.get("billing") is False, (
+            "APIKey default permissions must NOT grant billing locally"
+        )
+
+    def test_api_key_manager_set_credentials_does_not_grant_billing(self):
+        """Pin: APIKeyManager.set_credentials_for_environment (or
+        equivalent local-credential constructor) does NOT explicitly
+        override permissions to grant billing. Pre-fix it set
+        `permissions={"optimize": True, "analytics": True, "billing": True}`
+        — the SDK can't know what the backend granted."""
+        import inspect
+
+        from traigent.cloud import api_key_manager
+
+        source = inspect.getsource(api_key_manager)
+        # The exact bug-line literal must not be present anywhere in
+        # the module.
+        assert '"billing": True' not in source, (
+            "api_key_manager.py must not hard-code `billing: True` in "
+            "any APIKey construction (SDK#920)"
+        )
+
+    def test_authmanager_apply_token_data_does_not_grant_billing(self):
+        """Pin: AuthManager.apply_token_data (or equivalent) does NOT
+        construct an APIKey with `billing: True`. Pre-fix it did."""
+        import inspect
+
+        from traigent.cloud import auth
+
+        source = inspect.getsource(auth)
+        # The pre-fix literal MUST NOT appear in auth.py.
+        assert '"billing": True' not in source, (
+            "auth.py must not hard-code `billing: True` in any APIKey "
+            "construction (SDK#920)"
+        )
+
+    def test_get_info_for_env_keyed_path_returns_empty_permissions(self):
+        """SDK#920: when reporting info for an env-keyed source (the
+        SDK never received an APIKey object from the backend), the
+        permissions field must be `{}` not the previously-fabricated
+        `{"optimize": True, "analytics": True}`. Empty dict is the
+        honest answer — caller checking specific permissions gets a
+        clear `False` for whatever they ask."""
+        from unittest.mock import patch
+
+        from traigent.cloud.api_key_manager import APIKeyManager
+        from traigent.cloud.auth import UnifiedAuthConfig
+
+        config = UnifiedAuthConfig(
+            api_key_default_ttl_days=30,
+            api_key_warning_days=14,
+            api_key_critical_days=7,
+        )
+        manager = APIKeyManager(config)
+        # Force the env-keyed path by giving no in-memory APIKey
+        # object and mocking the env-key reader to return a valid key.
+        with patch.object(manager, "get_key_for_internal_use", return_value="tg_envkey"), \
+             patch.object(manager, "validate_format", return_value=True):
+            info = manager.get_info()
+
+        assert info is not None
+        assert info["name"] == "environment"
+        # The honest empty answer:
+        assert info["permissions"] == {}, (
+            f"env-keyed permissions must be {{}}, got {info['permissions']}"
+        )

--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -1521,9 +1521,14 @@ class TestSDK920_NoFabricatedBillingPermission:
         from traigent.cloud import api_key_manager
 
         source = inspect.getsource(api_key_manager)
-        # The exact bug-line literal must not be present anywhere in
-        # the module.
-        assert '"billing": True' not in source, (
+        # Greptile P2 of PR #967: regex-based check tolerates quote
+        # variants (single vs double) and whitespace differences (no
+        # space after colon). The previous string-equality test would
+        # silently miss `'billing': True` (single quotes) or
+        # `"billing":True` (no space).
+        import re
+
+        assert not re.search(r"""['"]billing['"]\s*:\s*True""", source), (
             "api_key_manager.py must not hard-code `billing: True` in "
             "any APIKey construction (SDK#920)"
         )
@@ -1532,12 +1537,14 @@ class TestSDK920_NoFabricatedBillingPermission:
         """Pin: AuthManager.apply_token_data (or equivalent) does NOT
         construct an APIKey with `billing: True`. Pre-fix it did."""
         import inspect
+        import re
 
         from traigent.cloud import auth
 
         source = inspect.getsource(auth)
-        # The pre-fix literal MUST NOT appear in auth.py.
-        assert '"billing": True' not in source, (
+        # Greptile P2 of PR #967: regex pattern tolerates quote/spacing
+        # variants — see the sister assertion above.
+        assert not re.search(r"""['"]billing['"]\s*:\s*True""", source), (
             "auth.py must not hard-code `billing: True` in any APIKey "
             "construction (SDK#920)"
         )

--- a/traigent/cloud/api_key_manager.py
+++ b/traigent/cloud/api_key_manager.py
@@ -422,11 +422,15 @@ class APIKeyManager:
                 name="default",
                 created_at=now,
                 expires_at=now + timedelta(days=365),
-                permissions={
-                    "optimize": True,
-                    "analytics": True,
-                    "billing": True,
-                },
+                # SDK#920 fix: do not fabricate `billing: True` (or any
+                # admin-tier permission) locally. The SDK has no way to
+                # know what the backend actually granted this credential.
+                # Falling through to `APIKey.__post_init__` defaults
+                # gives `optimize: True, analytics: True, billing: False`
+                # — the SDK's normal capabilities, with no claimed
+                # billing rights. Authorization for sensitive operations
+                # is the backend's responsibility; the SDK should never
+                # pretend to have rights it cannot prove.
             )
 
     def get_info(self) -> dict[str, Any] | None:
@@ -451,11 +455,18 @@ class APIKeyManager:
         api_key_value = self.get_key_for_internal_use()
 
         if api_key_value and self.validate_format(api_key_value):
+            # SDK#920 fix: report `permissions={}` for the env-key
+            # path. Previously this fabricated `{optimize: True,
+            # analytics: True}` even though the SDK has no way to
+            # know what the backend actually granted this key.
+            # Empty dict is the honest answer — callers checking
+            # specific permissions get a clear "no claimed rights"
+            # response and the backend remains authoritative.
             return {
                 "name": "environment",
                 "created_at": None,
                 "expires_at": None,
-                "permissions": {"optimize": True, "analytics": True},
+                "permissions": {},
                 "is_valid": True,
                 "preview": self.get_preview(),
             }

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1796,11 +1796,18 @@ class AuthManager:
         # AuthManager-specific: update _api_key if present
         api_key = token_data.get("api_key") or token_data.get("apiKey")
         if api_key and self._validate_key_format(api_key):
+            # SDK#920 fix: do not fabricate `billing: True` (or any
+            # admin-tier permission) locally. The auth response payload
+            # does not include real backend-granted permissions, so we
+            # let `APIKey.__post_init__` default to the safer
+            # `{optimize: True, analytics: True, billing: False}`.
+            # Authorization for sensitive operations is the backend's
+            # responsibility; the SDK must never claim rights it
+            # cannot prove.
             self._api_key = APIKey(
                 key=api_key,
                 name="cli",
                 created_at=datetime.now(UTC),
-                permissions={"optimize": True, "analytics": True, "billing": True},
             )
 
         return credentials


### PR DESCRIPTION
## Summary

Closes #920. Partial fix for #937.

Two call sites locally constructed APIKey objects with \`permissions={\"optimize\":True, \"analytics\":True, \"billing\":True}\` overriding the safer dataclass default. The SDK has no way to know what permissions the backend actually granted these credentials — fabricating \`billing:True\` makes consumers believe the SDK has admin-tier billing rights when it cannot prove that.

## Codex consultation

Ranked **#1 in Tier 2** by Codex consultation (\`ops/_validation/runs/codex-review-2026-05-14/tier2-consultation.output.md\`):

> SDK#920 — P1 — persisted API key state invents billing permission claims. Do not synthesize permission claims locally; use backend-returned permissions only, or default to empty/non-billing.

## Fix

| Site | Before | After |
|---|---|---|
| \`api_key_manager.py:425\` (CLI-credential path) | explicit \`{optimize:True, analytics:True, billing:True}\` | drops override; falls through to \`APIKey.__post_init__\` default \`{optimize:True, analytics:True, billing:False}\` |
| \`auth.py:1799\` (AuthManager.apply_token_data) | same | same fix |
| \`api_key_manager.py:454\` (env-keyed get_info) | \`{optimize:True, analytics:True}\` | \`{}\` — honest \"no claimed rights\" |

The \`APIKey.__post_init__\` default at \`auth.py:185\` is unchanged — it already correctly defaults billing to False.

## Tests

\`TestSDK920_NoFabricatedBillingPermission\` with 4 anti-regression tests:
- default APIKey post_init has billing=False
- \`api_key_manager.py\` source contains no \`'billing': True\` literal
- \`auth.py\` source contains no \`'billing': True\` literal
- env-keyed get_info path returns \`permissions={}\`

The two source-string tests are the strongest anti-regression: any future commit that reintroduces hardcoded billing permission in either file will fail CI.

95/95 tests pass in \`tests/unit/cloud/test_cloud_authentication.py\` (91 existing + 4 new).

## Test plan

- [x] Tests 95/95 pass
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)