### PR TITLE
fix(security): block local plan upgrade — fail-closed on tier escalation (closes #924)

### DIFF
--- a/tests/unit/cloud/test_billing.py
+++ b/tests/unit/cloud/test_billing.py
@@ -576,15 +576,52 @@ class TestBillingManager:
 
         asyncio.run(run_test())
 
-    def test_upgrade_plan_success(self):
-        """Test successful plan upgrade."""
+    def test_upgrade_plan_rejects_local_upgrade_to_paid_tier(self):
+        """SDK#924: post-fix, locally upgrading from `free` to a paid
+        tier (`standard`/`professional`/`enterprise`) must raise
+        ConfigurationError. The SDK has no authority to grant itself
+        a higher subscription tier — that has to be a backend/billing-
+        portal action.
+
+        Pre-fix this returned True and silently set
+        `self.current_plan = "professional"`, granting the SDK
+        professional-tier quotas (10k credits + 500 max trials)
+        without any server-side validation."""
+        from traigent.utils.exceptions import ConfigurationError
+
         tracker = UsageTracker()
         manager = BillingManager(tracker)
 
-        result = manager.upgrade_plan("professional")
+        for upgrade_target in ("standard", "professional", "enterprise"):
+            with pytest.raises(ConfigurationError, match="SDK#924"):
+                manager.upgrade_plan(upgrade_target)
+            assert manager.current_plan == "free", (
+                f"upgrade_plan('{upgrade_target}') must not mutate "
+                f"current_plan when it raises"
+            )
 
+    def test_upgrade_plan_allows_downgrade(self):
+        """SDK#924: downgrades are allowed — a user can cap themselves
+        to a lower tier (uses LESS quota, never more)."""
+        tracker = UsageTracker()
+        manager = BillingManager(tracker)
+        # Simulate a user already on professional via the backend (set
+        # the field directly to skip the upgrade-block).
+        manager.current_plan = "professional"
+
+        for downgrade_target in ("standard", "free"):
+            result = manager.upgrade_plan(downgrade_target)
+            assert result is True
+            assert manager.current_plan == downgrade_target
+            manager.current_plan = "professional"
+
+    def test_upgrade_plan_no_op_same_tier_succeeds(self):
+        """SDK#924: same-tier set must succeed (idempotent reconcile)."""
+        tracker = UsageTracker()
+        manager = BillingManager(tracker)
+        result = manager.upgrade_plan("free")
         assert result is True
-        assert manager.current_plan == "professional"
+        assert manager.current_plan == "free"
 
     def test_upgrade_plan_invalid(self):
         """Test plan upgrade with invalid plan."""

--- a/tests/unit/cloud/test_billing.py
+++ b/tests/unit/cloud/test_billing.py
@@ -623,6 +623,46 @@ class TestBillingManager:
         assert result is True
         assert manager.current_plan == "free"
 
+    def test_upgrade_plan_unknown_target_in_billing_plans_but_missing_tier_order_raises(self):
+        """Greptile P1 of PR #968: a plan registered in billing_plans
+        but absent from _TIER_ORDER must raise ConfigurationError.
+        Pre-fix this fell back to index 0 (free) and silently allowed
+        the change — re-opening the upgrade bypass for any future
+        tier added without an _TIER_ORDER update."""
+        from traigent.cloud.billing import BillingPlan
+        from traigent.utils.exceptions import ConfigurationError
+
+        tracker = UsageTracker()
+        # Inject a fictitious tier into billing_plans WITHOUT updating
+        # _TIER_ORDER (simulating the maintenance gap Greptile flagged).
+        tracker.billing_plans["super_secret_unlimited"] = BillingPlan(
+            name="Super Secret",
+            monthly_credits=999_999_999,
+            cost_per_credit=0.0,
+            max_trials_per_optimization=-1,
+            max_dataset_size=-1,
+        )
+        manager = BillingManager(tracker)
+
+        with pytest.raises(ConfigurationError, match="_TIER_ORDER"):
+            manager.upgrade_plan("super_secret_unlimited")
+
+    def test_upgrade_plan_current_plan_not_in_tier_order_raises(self):
+        """Greptile P1 of PR #968 (symmetric case): if current_plan is
+        somehow set to a value missing from _TIER_ORDER (e.g., a
+        legitimate plan added to billing_plans but not yet ordered),
+        upgrade_plan must raise instead of misclassifying as free."""
+        from traigent.utils.exceptions import ConfigurationError
+
+        tracker = UsageTracker()
+        manager = BillingManager(tracker)
+        # Force current_plan to a non-ordered value (skipping the
+        # upgrade-block by direct attribute assignment).
+        manager.current_plan = "unknown_legacy_tier"
+
+        with pytest.raises(ConfigurationError, match="_TIER_ORDER"):
+            manager.upgrade_plan("free")
+
     def test_upgrade_plan_invalid(self):
         """Test plan upgrade with invalid plan."""
         tracker = UsageTracker()

--- a/traigent/cloud/billing.py
+++ b/traigent/cloud/billing.py
@@ -21,6 +21,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from traigent.utils.exceptions import ConfigurationError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -609,23 +610,41 @@ class BillingManager:
 
         Raises:
             ConfigurationError: if `new_plan` is a known plan but
-                represents an upgrade above the current tier.
+                represents an upgrade above the current tier, OR if
+                either current_plan or new_plan exists in
+                `billing_plans` but is missing from `_TIER_ORDER`
+                (Greptile P1 of PR #968: silent fallback to "free"
+                index re-opened the bypass for any future tier added
+                without an _TIER_ORDER update).
         """
-        from traigent.utils.exceptions import ConfigurationError
-
         if new_plan not in self.usage_tracker.billing_plans:
             logger.error(f"Unknown billing plan: {new_plan}")
             return False
 
         old_plan = self.current_plan
+        # Greptile P1#1 of PR #968: do NOT fall back to free index for
+        # unknown tiers. Either tier missing from _TIER_ORDER is a
+        # configuration error — fail-closed means raising, not
+        # silently treating it as "free".
         try:
             old_idx = self._TIER_ORDER.index(old_plan)
-        except ValueError:
-            old_idx = 0  # Unknown current plan → treat as free
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"Current plan '{old_plan}' is not in the known tier "
+                f"ordering (SDK#924). Cannot evaluate upgrade direction. "
+                f"Add '{old_plan}' to BillingManager._TIER_ORDER if it is "
+                f"a legitimate plan."
+            ) from exc
         try:
             new_idx = self._TIER_ORDER.index(new_plan)
-        except ValueError:
-            new_idx = 0  # Unknown target plan → treat as free for ordering
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"Target plan '{new_plan}' is in billing_plans but absent "
+                f"from BillingManager._TIER_ORDER (SDK#924). Update "
+                f"_TIER_ORDER to include this plan in the correct position "
+                f"before allowing it to be applied — silently allowing "
+                f"unknown-position plans would re-open the upgrade bypass."
+            ) from exc
 
         if new_idx > old_idx:
             raise ConfigurationError(

--- a/traigent/cloud/billing.py
+++ b/traigent/cloud/billing.py
@@ -569,23 +569,77 @@ class BillingManager:
             - current_month_stats["total_credits"],
         }
 
-    def upgrade_plan(self, new_plan: str) -> bool:
-        """Upgrade to a new billing plan.
+    # Tier ordering for upgrade-direction enforcement (SDK#924). Higher
+    # index = higher quota. `upgrade_plan` rejects any change that
+    # increases the index, since the SDK has no authority to grant
+    # itself a higher tier — that has to be a backend/billing-portal
+    # action, validated against the user's actual subscription.
+    _TIER_ORDER: tuple[str, ...] = ("free", "standard", "professional", "enterprise")
 
-        Args:
-            new_plan: Name of new billing plan
+    def upgrade_plan(self, new_plan: str) -> bool:
+        """Change to a different billing plan locally.
+
+        Honest semantics (SDK#924 fix):
+          * Downgrades are allowed — a user can locally cap themselves
+            to a lower tier (e.g. "use the free quota for this run
+            even though I'm on professional"). Caps the user's own
+            usage; never grants additional rights.
+          * Upgrades are REJECTED — locally bumping `current_plan`
+            from `free` to `enterprise` would let the SDK claim
+            unlimited credits / max trials / etc. with no server-side
+            validation, bypassing whatever subscription the user
+            actually has.
+
+        Pre-fix: this method blindly set `self.current_plan = new_plan`
+        for any known plan, granting a free SDK process enterprise
+        quotas (100k monthly_credits + unlimited trials). Codex
+        consultation (#924) flagged this as a billing-bypass:
+
+            > Local plan upgrade grants enterprise quota.
+            > Recommended action: fail-closed/de-export. Remove public
+            > local upgrade authority; derive tier from validated
+            > server/account state.
+
+        Real plan upgrades happen via the backend portal; the SDK
+        learns about them by re-authenticating, not by self-mutation.
 
         Returns:
-            True if upgrade successful
+            True iff the change was applied (a downgrade or no-op).
+            False if the requested plan is unknown.
+
+        Raises:
+            ConfigurationError: if `new_plan` is a known plan but
+                represents an upgrade above the current tier.
         """
+        from traigent.utils.exceptions import ConfigurationError
+
         if new_plan not in self.usage_tracker.billing_plans:
             logger.error(f"Unknown billing plan: {new_plan}")
             return False
 
         old_plan = self.current_plan
-        self.current_plan = new_plan
+        try:
+            old_idx = self._TIER_ORDER.index(old_plan)
+        except ValueError:
+            old_idx = 0  # Unknown current plan → treat as free
+        try:
+            new_idx = self._TIER_ORDER.index(new_plan)
+        except ValueError:
+            new_idx = 0  # Unknown target plan → treat as free for ordering
 
-        logger.info(f"Upgraded billing plan: {old_plan} → {new_plan}")
+        if new_idx > old_idx:
+            raise ConfigurationError(
+                f"Cannot upgrade billing plan locally: '{old_plan}' → "
+                f"'{new_plan}' (SDK#924). Plan upgrades must happen via "
+                f"the backend billing portal and be reflected in the "
+                f"user's authenticated state — the SDK has no authority "
+                f"to grant itself a higher tier. Re-authenticate after "
+                f"completing the upgrade in the portal."
+            )
+
+        # Downgrade or no-op: allowed.
+        self.current_plan = new_plan
+        logger.info(f"Changed billing plan: {old_plan} → {new_plan}")
         return True
 
     def get_current_plan_info(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Closes #924.

\`BillingManager.upgrade_plan(new_plan)\` blindly set \`self.current_plan = new_plan\` for any known plan, including the enterprise tier with **100,000 monthly_credits and unlimited trials**. A free-tier SDK process could call \`manager.upgrade_plan(\"enterprise\")\` and grant itself enterprise quotas — no server-side validation, no billing event, just a local mutation.

## Codex consultation

Ranked **#2 in Tier 2** by Codex consultation (\`ops/_validation/runs/codex-review-2026-05-14/tier2-consultation.output.md\`):

> SDK#924 — P1 — local plan upgrade grants enterprise quota. Recommended action: fail-closed/de-export. Remove public local upgrade authority; derive tier from validated server/account state.

## Fix

\`upgrade_plan\` is now direction-aware. Plans are ordered: \`free < standard < professional < enterprise\`.

| Direction | Result |
|---|---|
| Upgrade | raises \`ConfigurationError\` with SDK#924 ref |
| Downgrade | applied (user caps own usage to less quota) |
| Same-tier no-op | applied (idempotent reconcile) |
| Unknown new_plan | returns \`False\` (unchanged) |

Real plan upgrades happen via the backend billing portal; the SDK learns about them by re-authenticating, not by self-mutation.

## Tests

Replaced \`test_upgrade_plan_success\` (which tested the bug) with 3 new tests:
- \`test_upgrade_plan_rejects_local_upgrade_to_paid_tier\` — pins standard/professional/enterprise upgrades all raise + don't mutate state
- \`test_upgrade_plan_allows_downgrade\` — pins downgrade direction still works
- \`test_upgrade_plan_no_op_same_tier_succeeds\` — pins idempotent reconcile

37/37 tests pass.

## Test plan

- [x] Tests 37/37 pass
- [ ] CI green
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)