### PR TITLE
fix(auth): fail closed on omitted API key permissions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -692,84 +692,84 @@
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
         "is_verified": false,
-        "line_number": 288
+        "line_number": 290
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44c08d71fbe20d2cf9c5842af590dda096bee6f9",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 304
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "801f9bf378fc57a61f95a66e2465a02ed3092d7e",
         "is_verified": false,
-        "line_number": 303
+        "line_number": 305
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "c6e454d960df4845f9d69eb11377c8b23882715b",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 326
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 543
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 570
+        "line_number": 573
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "827ba56f5549ed55e91dc9fb84327b0148c01a5e",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 634
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 775
+        "line_number": 778
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
         "is_verified": false,
-        "line_number": 1102
+        "line_number": 1105
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ad6ed643d097938d8f82b0945077efdc93928614",
         "is_verified": false,
-        "line_number": 1111
+        "line_number": 1114
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 1213
+        "line_number": 1216
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
-        "line_number": 1283
+        "line_number": 1286
       }
     ],
     "tests/unit/cloud/test_cloud_client_validation.py": [
@@ -1249,5 +1249,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T09:00:55Z"
+  "generated_at": "2026-05-14T11:45:17Z"
 }

--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -75,11 +75,13 @@ class TestAPIKey:
         assert api_key.usage_limit == 1000
 
     def test_api_key_default_permissions(self):
-        """Test APIKey with default permissions."""
+        """Missing APIKey permissions fail closed."""
         api_key = APIKey(key="test_key", name="test", created_at=datetime.now(UTC))
 
-        expected_permissions = {"optimize": True, "analytics": True, "billing": False}
-        assert api_key.permissions == expected_permissions
+        assert api_key.permissions == {}
+        assert api_key.has_permission("optimize") is False
+        assert api_key.has_permission("analytics") is False
+        assert api_key.has_permission("billing") is False
 
     def test_api_key_is_valid_not_expired(self):
         """Test API key validity when not expired."""
@@ -392,7 +394,8 @@ class TestDemoAuthManager:
         with _mock_backend_validate():
             await manager.authenticate()
         assert manager._api_key is not None
-        assert manager._api_key.has_permission("optimize") is True
+        assert manager._api_key.permissions == {}
+        assert manager._api_key.has_permission("optimize") is False
 
     @pytest.mark.asyncio
     async def test_demo_auth_headers(self):
@@ -1485,72 +1488,81 @@ class TestPasswordAuthentication:
 
 
 # ---------------------------------------------------------------------------
-# SDK#920 anti-regression: APIKey instances created from local credentials
-# (CLI auth response, env vars, secure storage) must NOT fabricate
-# `billing: True` or any admin-tier permission. The SDK has no way to
-# know what the backend actually granted; pretending it does is forgery.
+# SDK#937 anti-regression: APIKey instances created from local credentials
+# (CLI auth response, env vars, secure storage) must NOT fabricate any
+# permission grants. The SDK has no way to know what the backend actually
+# granted; pretending it does is forgery.
 # ---------------------------------------------------------------------------
 
 
-class TestSDK920_NoFabricatedBillingPermission:
-    """Pin: locally-constructed APIKey objects use the safe default
-    permissions (billing=False) — they do not invent admin claims."""
+class TestSDK937_NoFabricatedPermissionGrants:
+    """Locally-constructed APIKey objects do not invent claims."""
 
-    def test_apikey_default_post_init_has_billing_false(self):
-        """The dataclass default permissions must explicitly deny
-        billing. Was true on develop already; this test pins it so
-        a future refactor can't quietly flip the default."""
+    @staticmethod
+    def _assert_no_hardcoded_api_key_permission_grants(module) -> None:
+        """Inspect APIKey(...) calls, ignoring comments/docstrings."""
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(module))
+        forbidden_permissions = {"optimize", "analytics", "billing"}
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Name) or node.func.id != "APIKey":
+                continue
+            permissions_kw = next(
+                (kw for kw in node.keywords if kw.arg == "permissions"),
+                None,
+            )
+            if permissions_kw is None or not isinstance(permissions_kw.value, ast.Dict):
+                continue
+            for key_node, value_node in zip(
+                permissions_kw.value.keys,
+                permissions_kw.value.values,
+                strict=False,
+            ):
+                if not isinstance(key_node, ast.Constant):
+                    continue
+                if key_node.value not in forbidden_permissions:
+                    continue
+                if isinstance(value_node, ast.Constant) and value_node.value is True:
+                    pytest.fail(
+                        f"{module.__name__} must not hard-code "
+                        f"{key_node.value}: True in APIKey permissions (SDK#937)"
+                    )
+
+    def test_apikey_default_post_init_has_empty_permissions(self):
+        """The dataclass default must not grant local permissions."""
         from datetime import UTC, datetime
 
         from traigent.cloud.auth import APIKey
 
         api_key = APIKey(key="test", name="t", created_at=datetime.now(UTC))
-        assert api_key.permissions is not None
-        assert api_key.permissions.get("billing") is False, (
-            "APIKey default permissions must NOT grant billing locally"
-        )
+        assert api_key.permissions == {}
+        assert api_key.has_permission("optimize") is False
+        assert api_key.has_permission("analytics") is False
+        assert api_key.has_permission("billing") is False
 
-    def test_api_key_manager_set_credentials_does_not_grant_billing(self):
+    def test_api_key_manager_set_credentials_does_not_grant_permissions(self):
         """Pin: APIKeyManager.set_credentials_for_environment (or
         equivalent local-credential constructor) does NOT explicitly
-        override permissions to grant billing. Pre-fix it set
-        `permissions={"optimize": True, "analytics": True, "billing": True}`
-        — the SDK can't know what the backend granted."""
-        import inspect
-
+        override permissions to grant capabilities. The SDK can't know
+        what the backend granted."""
         from traigent.cloud import api_key_manager
 
-        source = inspect.getsource(api_key_manager)
-        # Greptile P2 of PR #967: regex-based check tolerates quote
-        # variants (single vs double) and whitespace differences (no
-        # space after colon). The previous string-equality test would
-        # silently miss `'billing': True` (single quotes) or
-        # `"billing":True` (no space).
-        import re
+        self._assert_no_hardcoded_api_key_permission_grants(api_key_manager)
 
-        assert not re.search(r"""['"]billing['"]\s*:\s*True""", source), (
-            "api_key_manager.py must not hard-code `billing: True` in "
-            "any APIKey construction (SDK#920)"
-        )
-
-    def test_authmanager_apply_token_data_does_not_grant_billing(self):
+    def test_authmanager_apply_token_data_does_not_grant_permissions(self):
         """Pin: AuthManager.apply_token_data (or equivalent) does NOT
-        construct an APIKey with `billing: True`. Pre-fix it did."""
-        import inspect
-        import re
-
+        construct an APIKey with local permission grants."""
         from traigent.cloud import auth
 
-        source = inspect.getsource(auth)
-        # Greptile P2 of PR #967: regex pattern tolerates quote/spacing
-        # variants — see the sister assertion above.
-        assert not re.search(r"""['"]billing['"]\s*:\s*True""", source), (
-            "auth.py must not hard-code `billing: True` in any APIKey "
-            "construction (SDK#920)"
-        )
+        self._assert_no_hardcoded_api_key_permission_grants(auth)
 
     def test_get_info_for_env_keyed_path_returns_empty_permissions(self):
-        """SDK#920: when reporting info for an env-keyed source (the
+        """SDK#937: when reporting info for an env-keyed source (the
         SDK never received an APIKey object from the backend), the
         permissions field must be `{}` not the previously-fabricated
         `{"optimize": True, "analytics": True}`. Empty dict is the

--- a/traigent/cloud/api_key_manager.py
+++ b/traigent/cloud/api_key_manager.py
@@ -422,15 +422,11 @@ class APIKeyManager:
                 name="default",
                 created_at=now,
                 expires_at=now + timedelta(days=365),
-                # SDK#920 fix: do not fabricate `billing: True` (or any
-                # admin-tier permission) locally. The SDK has no way to
-                # know what the backend actually granted this credential.
-                # Falling through to `APIKey.__post_init__` defaults
-                # gives `optimize: True, analytics: True, billing: False`
-                # — the SDK's normal capabilities, with no claimed
-                # billing rights. Authorization for sensitive operations
-                # is the backend's responsibility; the SDK should never
-                # pretend to have rights it cannot prove.
+                # SDK#937 fix: do not fabricate any permission grants
+                # locally. The SDK has no way to know what the backend
+                # actually granted this credential, so the APIKey default
+                # is an empty permission set and has_permission() fails
+                # closed unless authoritative claims are supplied.
             )
 
     def get_info(self) -> dict[str, Any] | None:
@@ -455,7 +451,7 @@ class APIKeyManager:
         api_key_value = self.get_key_for_internal_use()
 
         if api_key_value and self.validate_format(api_key_value):
-            # SDK#920 fix: report `permissions={}` for the env-key
+            # SDK#937 fix: report `permissions={}` for the env-key
             # path. Previously this fabricated `{optimize: True,
             # analytics: True}` even though the SDK has no way to
             # know what the backend actually granted this key.

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -183,9 +183,9 @@ class APIKey:
     usage_limit: int | None = None
 
     def __post_init__(self) -> None:
-        """Initialise default permissions when not provided."""
+        """Initialise missing permissions to no local grants."""
         if self.permissions is None:
-            self.permissions = {"optimize": True, "analytics": True, "billing": False}
+            self.permissions = {}
 
         # Normalise date fields to timezone-aware datetime instances.
         self.created_at = self._coerce_datetime(self.created_at, "created_at")
@@ -1796,14 +1796,10 @@ class AuthManager:
         # AuthManager-specific: update _api_key if present
         api_key = token_data.get("api_key") or token_data.get("apiKey")
         if api_key and self._validate_key_format(api_key):
-            # SDK#920 fix: do not fabricate `billing: True` (or any
-            # admin-tier permission) locally. The auth response payload
-            # does not include real backend-granted permissions, so we
-            # let `APIKey.__post_init__` default to the safer
-            # `{optimize: True, analytics: True, billing: False}`.
-            # Authorization for sensitive operations is the backend's
-            # responsibility; the SDK must never claim rights it
-            # cannot prove.
+            # SDK#937 fix: do not fabricate any permission grants from
+            # locally available credentials. If the backend does not
+            # return authoritative claims, APIKey.__post_init__ keeps
+            # permissions empty and has_permission() fails closed.
             self._api_key = APIKey(
                 key=api_key,
                 name="cli",


### PR DESCRIPTION
## Summary
- Default locally constructed APIKey permissions to an empty dict instead of granting optimize and analytics when claims are omitted.
- Keep explicit caller/backend permissions working, but make has_permission fail closed for omitted claims.
- Update API-key auth regression tests so local credentials cannot fabricate optimize, analytics, or billing grants.

Closes #937.

## Validation
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m ruff check traigent/cloud/auth.py traigent/cloud/api_key_manager.py tests/unit/cloud/test_cloud_authentication.py
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts= -p no:rerunfailures tests/unit/cloud/test_cloud_authentication.py -q (95 passed)
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts= -p no:rerunfailures tests/unit/cloud/test_api_key_manager.py tests/unit/cloud/test_authentication_security.py -q (67 passed, 1 skipped)
- Commit hooks passed: isort, black, ruff, detect-secrets, trailing whitespace, EOF, merge conflict, private key, bandit, mypy, TVL specs, strict cost guardrails, dependency floor drift, ignored files