### PR TITLE
fix(auth): require explicit mock password auth opt-in

### DIFF
--- a/tests/unit/cloud/test_password_auth_handler.py
+++ b/tests/unit/cloud/test_password_auth_handler.py
@@ -95,8 +95,8 @@ async def test_invalid_credentials_propagate_even_in_dev_mode():
 
 
 @pytest.mark.asyncio
-async def test_dev_mode_still_falls_back_on_backend_outage():
-    """Explicit dev mode may still use mock tokens for non-auth backend failures."""
+async def test_dev_mode_backend_outage_fails_without_mock_opt_in():
+    """Dev mode alone must not turn backend outages into authenticated tokens."""
     handler = PasswordAuthHandler()
     credentials = {
         "email": "dev@example.com",
@@ -112,5 +112,58 @@ async def test_dev_mode_still_falls_back_on_backend_outage():
     ):
         token_data = await handler._perform_authentication(credentials)
 
+    assert token_data is None
+
+
+@pytest.mark.asyncio
+async def test_dev_mode_mock_auth_requires_explicit_opt_in():
+    """Mock password auth is allowed only after explicit local opt-in."""
+    handler = PasswordAuthHandler()
+    credentials = {
+        "email": "dev@example.com",
+        "password": "password123",  # pragma: allowlist secret
+    }
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH": "true"},  # pragma: allowlist secret
+            clear=True,
+        ),
+        patch.object(handler, "_is_dev_mode_enabled", return_value=True),
+        patch(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            new=AsyncMock(side_effect=RuntimeError("backend down")),
+        ),
+    ):
+        token_data = await handler._perform_authentication(credentials)
+
+    assert token_data is not None
     assert token_data["dev_mode"] is True
     assert token_data["user"]["email"] == credentials["email"]
+
+
+@pytest.mark.asyncio
+async def test_mock_auth_opt_in_is_ignored_outside_dev_mode():
+    """The mock-auth escape hatch must still require dev/local mode."""
+    handler = PasswordAuthHandler()
+    credentials = {
+        "email": "dev@example.com",
+        "password": "password123",  # pragma: allowlist secret
+    }
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH": "true"},  # pragma: allowlist secret
+            clear=True,
+        ),
+        patch.object(handler, "_is_dev_mode_enabled", return_value=False),
+        patch(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            new=AsyncMock(side_effect=RuntimeError("backend down")),
+        ),
+    ):
+        token_data = await handler._perform_authentication(credentials)
+
+    assert token_data is None

--- a/traigent/cloud/password_auth_handler.py
+++ b/traigent/cloud/password_auth_handler.py
@@ -37,7 +37,7 @@ class PasswordAuthHandler:
     - Email/password validation
     - Rate limiting of login attempts
     - Backend authentication calls
-    - Development mode mocking
+    - Explicit development-only mock fallback
     """
 
     def __init__(self) -> None:
@@ -166,8 +166,7 @@ class PasswordAuthHandler:
         """Validate email/password credentials without logging sensitive values."""
         if self._is_dev_mode_enabled():
             logger.warning(
-                "Development mode enabled - backend outage fallback is allowed, "
-                "but credential format is still enforced"
+                "Development mode enabled - credential format is still enforced"
             )
 
         required_fields = {"email", "password"}
@@ -211,6 +210,17 @@ class PasswordAuthHandler:
             logger.debug(f"Could not check local backend status: {e}")
 
         return False
+
+    def _is_mock_auth_fallback_enabled(self) -> bool:
+        """Return True only for explicit development mock-auth fallback."""
+        if not self._is_dev_mode_enabled():
+            return False
+        return os.getenv("TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
 
     def _validated_backend_api_url(self, backend_api_url: str) -> str:
         """Validate the backend login target before sending credentials."""
@@ -323,9 +333,9 @@ class PasswordAuthHandler:
         except InvalidCredentialsError:
             raise
         except Exception as exc:
-            if self._is_dev_mode_enabled():
+            if self._is_mock_auth_fallback_enabled():
                 logger.warning(
-                    "Dev mode enabled - using mock tokens because backend login failed: %s",
+                    "Explicit mock password auth enabled - using mock tokens because backend login failed: %s",
                     exc,
                 )
                 return self._build_dev_token_payload(credentials)


### PR DESCRIPTION
## Summary
- Stop treating development/local mode alone as permission to fabricate password-auth mock tokens after backend outages.
- Add an explicit TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH=true opt-in, and keep it gated behind dev/local mode.
- Preserve invalid-credential propagation and local URL allowances while making backend outages fail unauthenticated by default.

Closes #925.

## Validation
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m ruff check traigent/cloud/password_auth_handler.py tests/unit/cloud/test_password_auth_handler.py tests/unit/cloud/test_cloud_authentication.py tests/unit/test_secure_auth.py
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts= -p no:rerunfailures tests/unit/cloud/test_password_auth_handler.py tests/unit/cloud/test_cloud_authentication.py tests/unit/test_secure_auth.py -q (126 passed)
- /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts= -p no:rerunfailures tests/unit/cloud/test_password_auth_handler.py -q (10 passed)
- Commit hooks passed: isort, black, ruff, detect-secrets, trailing whitespace, EOF, merge conflict, private key, bandit, mypy, TVL specs, strict cost guardrails, dependency floor drift, ignored files