### PR TITLE
fix(security): close SDK token refresh fail-open gaps

### DIFF
--- a/tests/unit/cloud/test_authentication_security.py
+++ b/tests/unit/cloud/test_authentication_security.py
@@ -100,9 +100,9 @@ class TestCredentialSecurity:
             # Check file permissions (should be 0o600)
             if cache_file.exists():
                 file_mode = cache_file.stat().st_mode & 0o777
-                assert (
-                    file_mode == 0o600
-                ), f"Cache file has insecure permissions: {oct(file_mode)}"
+                assert file_mode == 0o600, (
+                    f"Cache file has insecure permissions: {oct(file_mode)}"
+                )
 
     def test_weak_credential_encryption_detection(self):
         """Test detection of weak credential encryption."""
@@ -254,9 +254,9 @@ class TestCredentialSecurity:
                     f"Development mode: JWT validation may be permissive for token: {token[:50]}..."
                 )
             # Ensure result is an AuthResult object regardless of success/failure
-            assert hasattr(
-                result, "success"
-            ), f"Invalid result type for token: {token[:50]}..."
+            assert hasattr(result, "success"), (
+                f"Invalid result type for token: {token[:50]}..."
+            )
 
     def test_session_fixation_prevention(self):
         """Test prevention of session fixation attacks."""

--- a/tests/unit/cloud/test_token_manager.py
+++ b/tests/unit/cloud/test_token_manager.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE
 from traigent.cloud.auth import (
     AuthCredentials,
     AuthMode,
@@ -427,6 +428,97 @@ class TestRefreshAccessToken:
             await token_manager.refresh_access_token()
 
         assert token_manager.last_refresh_attempt >= before
+
+
+class TestRefreshSecurity:
+    """Security regressions around token refresh network boundaries."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_oauth2_rejects_private_cloud_base_url_in_production(
+        self, token_manager
+    ):
+        credentials = AuthCredentials(
+            mode=AuthMode.OAUTH2,
+            refresh_token="test_refresh_token_12345",
+            client_id="client-id",
+            client_secret="client-secret",  # pragma: allowlist secret
+        )
+        token_manager.set_callbacks(
+            get_credentials=lambda: credentials,
+            set_credentials=MagicMock(),
+            cache_credentials=AsyncMock(),
+            auth_lock=asyncio.Lock(),
+        )
+        token_manager.config.cloud_base_url = "https://127.0.0.1:5000"
+
+        with patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=True):
+            result = await token_manager.refresh_oauth2()
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
+        assert "private or loopback" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_refresh_jwt_secure_rejects_private_backend_url_in_production(
+        self, token_manager
+    ):
+        token_manager.config.backend_base_url = "https://127.0.0.1:5000"
+
+        with patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=True):
+            result = await token_manager.refresh_jwt_secure("test_refresh_token_12345")
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
+        assert "private or loopback" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_refresh_jwt_secure_redacts_unexpected_server_errors(
+        self, token_manager, monkeypatch
+    ):
+        if not AIOHTTP_AVAILABLE:
+            pytest.skip("aiohttp unavailable")
+
+        async def _raise_sensitive_error(*_args, **_kwargs):
+            raise RuntimeError("upstream leaked token=secret-value")
+
+        monkeypatch.setattr(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            _raise_sensitive_error,
+        )
+
+        result = await token_manager.refresh_jwt_secure("test_refresh_token_12345")
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
+        assert result.error_message == "Token refresh failed"
+
+    @pytest.mark.asyncio
+    async def test_refresh_access_token_redacts_unexpected_refresh_errors(
+        self, token_manager
+    ):
+        credentials = AuthCredentials(
+            mode=AuthMode.JWT_TOKEN,
+            jwt_token="test_token_12345",
+            refresh_token="test_refresh_token_12345",
+        )
+        token_manager.set_callbacks(
+            get_credentials=lambda: credentials,
+            set_credentials=MagicMock(),
+            cache_credentials=AsyncMock(),
+            auth_lock=asyncio.Lock(),
+        )
+
+        with patch.object(
+            token_manager,
+            "refresh_jwt_secure",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("upstream leaked token=secret-value"),
+        ):
+            result = await token_manager.refresh_access_token()
+
+        assert result.success is False
+        assert result.status == AuthStatus.INVALID
+        assert result.error_message == "Token refresh failed"
 
 
 class TestBuildCredentialsFromTokenData:

--- a/tests/unit/cloud/test_url_security.py
+++ b/tests/unit/cloud/test_url_security.py
@@ -1,0 +1,102 @@
+"""Tests for cloud URL safety validation."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from traigent.cloud.url_security import (
+    validate_cloud_base_url,
+    validate_cloud_base_url_async,
+)
+
+
+def test_validate_cloud_base_url_normalizes_safe_public_url() -> None:
+    with patch(
+        "socket.getaddrinfo",
+        return_value=[
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                ("93.184.216.34", 443),
+            )
+        ],
+    ):
+        assert (
+            validate_cloud_base_url("https://auth.example.com/base/")
+            == "https://auth.example.com/base"
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://auth.example.com",
+        "https://user:pass@auth.example.com",  # pragma: allowlist secret
+        "https://auth.example.com?token=secret",  # pragma: allowlist secret
+        "https://auth.example.com/../admin",
+        "https://auth.example.com/%2e%2e/admin",
+        "https://auth.example.com/safe%2f..%2fadmin",
+    ],
+)
+def test_validate_cloud_base_url_rejects_malformed_urls(url: str) -> None:
+    with pytest.raises(ValueError):
+        validate_cloud_base_url(url)
+
+
+def test_validate_cloud_base_url_fails_closed_when_env_is_unset() -> None:
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="private or loopback"):
+            validate_cloud_base_url("https://127.0.0.1:5000")
+
+
+def test_validate_cloud_base_url_rejects_private_ip_in_production() -> None:
+    with patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=True):
+        with pytest.raises(ValueError, match="private or loopback"):
+            validate_cloud_base_url("https://127.0.0.1:5000")
+
+
+def test_validate_cloud_base_url_fails_closed_on_dns_failure() -> None:
+    with (
+        patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=True),
+        patch("socket.getaddrinfo", side_effect=socket.gaierror),
+    ):
+        with pytest.raises(ValueError, match="could not be resolved"):
+            validate_cloud_base_url("https://unresolvable.example")
+
+
+@pytest.mark.asyncio
+async def test_validate_cloud_base_url_async_uses_thread_for_dns_work() -> None:
+    with patch(
+        "traigent.cloud.url_security.asyncio.to_thread",
+        new=AsyncMock(return_value="https://auth.example.com"),
+    ) as mock_to_thread:
+        assert (
+            await validate_cloud_base_url_async(
+                "https://auth.example.com", purpose="async test"
+            )
+            == "https://auth.example.com"
+        )
+
+    mock_to_thread.assert_called_once()
+
+
+def test_validate_cloud_base_url_allows_localhost_in_development() -> None:
+    with patch.dict("os.environ", {"TRAIGENT_ENV": "development"}, clear=True):
+        assert (
+            validate_cloud_base_url("http://localhost:5000/") == "http://localhost:5000"
+        )
+
+
+def test_validate_cloud_base_url_production_signal_wins_over_dev_signal() -> None:
+    with patch.dict(
+        "os.environ",
+        {"ENVIRONMENT": "production", "TRAIGENT_ENV": "development"},
+        clear=True,
+    ):
+        with pytest.raises(ValueError, match="must use https in production"):
+            validate_cloud_base_url("http://localhost:5000")

--- a/tests/unit/core/test_ci_approval.py
+++ b/tests/unit/core/test_ci_approval.py
@@ -9,7 +9,7 @@ import json
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -212,7 +212,7 @@ class TestValidateHmacToken:
         assert _validate_hmac_token(token) is False
 
     def test_no_secret_with_valid_expiry(self) -> None:
-        """When secret is not set, token is accepted if not expired (with warning)."""
+        """When the secret is not set, HMAC tokens fail closed."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
         token = {
             "approver": "ci-bot",
@@ -222,7 +222,7 @@ class TestValidateHmacToken:
         }
         env = {k: v for k, v in os.environ.items() if k != "TRAIGENT_APPROVAL_SECRET"}
         with patch.dict(os.environ, env, clear=True):
-            assert _validate_hmac_token(token) is True
+            assert _validate_hmac_token(token) is False
 
     def test_no_secret_with_expired_token(self) -> None:
         past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
@@ -283,11 +283,7 @@ class TestCheckCiApproval:
         config = MagicMock()
         config.is_edge_analytics_mode.return_value = True
         config.get_local_storage_path.return_value = str(tmp_path)
-        env = {
-            k: v
-            for k, v in os.environ.items()
-            if k != "TRAIGENT_RUN_APPROVED"
-        }
+        env = {k: v for k, v in os.environ.items() if k != "TRAIGENT_RUN_APPROVED"}
         env["TRAIGENT_MOCK_LLM"] = "true"
         with (
             patch("traigent.core.ci_approval._is_ci_environment", return_value=True),

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -31,6 +31,7 @@ from traigent.cloud.api_key_manager import APIKeyManager
 from traigent.cloud.credential_resolver import CredentialResolver
 from traigent.cloud.password_auth_handler import PasswordAuthHandler
 from traigent.cloud.token_manager import TokenManager
+from traigent.cloud.url_security import validate_cloud_base_url_async
 from traigent.core.constants import MAX_RETRIES
 from traigent.utils.exceptions import AuthenticationError as TraigentAuthenticationError
 
@@ -1580,7 +1581,10 @@ class AuthManager:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp not available for OAuth2 flow") from None
 
-        token_url = f"{self.config.cloud_base_url}/oauth/token"
+        cloud_base_url = await validate_cloud_base_url_async(
+            self.config.cloud_base_url, purpose="OAuth2 client credentials"
+        )
+        token_url = f"{cloud_base_url}/oauth/token"
 
         data = {
             "grant_type": "client_credentials",
@@ -1598,9 +1602,9 @@ class AuthManager:
                 if response.status == 200:
                     return cast(dict[str, Any], await response.json())
                 else:
-                    error_text = await response.text()
+                    await response.text()
                     raise RuntimeError(
-                        f"OAuth2 flow failed: {response.status} {error_text}"
+                        f"OAuth2 flow failed with status {response.status}"
                     )
 
     async def _refresh_token(self) -> AuthResult:
@@ -1698,8 +1702,11 @@ class AuthManager:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.build_api_base(
-            self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
+        backend_api_url = await validate_cloud_base_url_async(
+            BackendConfig.build_api_base(
+                self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
+            ),
+            purpose="password authentication",
         )
         login_url = f"{backend_api_url}/auth/login"
 
@@ -1726,15 +1733,17 @@ class AuthManager:
                     if response.status == 401:
                         raise InvalidCredentialsError("Invalid credentials")
                     if response.status == 429:
-                        error_msg = await response.text()
-                        raise Exception(f"429 Rate Limited: {error_msg}")
+                        await response.text()
+                        raise RuntimeError("Backend authentication rate limited")
                     if response.status != 200:
-                        error_text = await response.text()
-                        raise Exception(f"{response.status}: {error_text}")
+                        await response.text()
+                        raise RuntimeError(
+                            f"Backend authentication failed with status {response.status}"
+                        )
 
                     data = await response.json()
                     if not data.get("success"):
-                        raise ValueError(data.get("error", "Authentication failed"))
+                        raise ValueError("Authentication failed")
 
                     token_data = data.get("data", {})
                     access_token = token_data.get("access_token", "")
@@ -1760,21 +1769,21 @@ class AuthManager:
                 perform_login, operation_name="backend_authentication"
             )
         except InvalidCredentialsError:
-            if self._is_dev_mode_enabled():
+            if self._password_auth_handler._is_mock_auth_fallback_enabled():
                 logger.warning(
-                    "Dev mode enabled - returning mock tokens despite invalid credentials"
+                    "Explicit mock password auth enabled - returning mock tokens despite invalid credentials"
                 )
                 return self._build_dev_token_payload(credentials)
             raise
         except Exception as exc:
-            if self._is_dev_mode_enabled():
+            if self._password_auth_handler._is_mock_auth_fallback_enabled():
                 logger.warning(
-                    "Dev mode enabled - using mock tokens because backend login failed: %s",
-                    exc,
+                    "Explicit mock password auth enabled - using mock tokens because backend login failed: %s",
+                    type(exc).__name__,
                 )
                 return self._build_dev_token_payload(credentials)
 
-            logger.error(f"Authentication error: {exc}")
+            logger.error("Authentication error: %s", type(exc).__name__)
             return None
 
     async def _refresh_jwt_token_secure(self, refresh_token_value: str) -> AuthResult:

--- a/traigent/cloud/token_manager.py
+++ b/traigent/cloud/token_manager.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
+from traigent.cloud.url_security import validate_cloud_base_url_async
 from traigent.core.constants import MAX_RETRIES
 
 if TYPE_CHECKING:
@@ -298,9 +299,11 @@ class TokenManager:
                 )
 
             except Exception as exc:
-                logger.error(f"Token refresh failed: {exc}")
+                logger.error("Token refresh failed: %s", type(exc).__name__)
                 return AuthResult(
-                    success=False, status=AuthStatus.INVALID, error_message=str(exc)
+                    success=False,
+                    status=AuthStatus.INVALID,
+                    error_message="Token refresh failed",
                 )
 
     async def refresh_jwt_secure(self, refresh_token_value: str) -> AuthResult:
@@ -320,9 +323,22 @@ class TokenManager:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.build_api_base(
-            self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
-        )
+        try:
+            backend_api_url = await validate_cloud_base_url_async(
+                BackendConfig.build_api_base(
+                    self.config.backend_base_url
+                    or BackendConfig.get_cloud_backend_url()
+                ),
+                purpose="JWT token refresh",
+            )
+        except ValueError as exc:
+            logger.warning("Rejected JWT token refresh URL: %s", exc)
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message=str(exc),
+            )
+
         refresh_url = f"{backend_api_url}/auth/refresh"
 
         client = ResilientClient(
@@ -343,15 +359,17 @@ class TokenManager:
                     if response.status == 401:
                         raise ValueError("Refresh token invalid or expired")
                     if response.status == 429:
-                        error_msg = await response.text()
-                        raise Exception(f"429 Rate Limited: {error_msg}")
+                        await response.text()
+                        raise RuntimeError("Backend token refresh rate limited")
                     if response.status != 200:
-                        error_text = await response.text()
-                        raise Exception(f"{response.status}: {error_text}")
+                        await response.text()
+                        raise RuntimeError(
+                            f"Backend token refresh failed with status {response.status}"
+                        )
 
                     data = await response.json()
                     if not data.get("success"):
-                        raise ValueError(data.get("error", "Token refresh failed"))
+                        raise ValueError("Token refresh failed")
 
                     payload = data.get("data", {})
                     if "refresh_token" not in payload or not payload["refresh_token"]:
@@ -404,11 +422,11 @@ class TokenManager:
                 error_message=str(exc),
             )
         except Exception as exc:
-            logger.error(f"Token refresh error: {type(exc).__name__}: {exc}")
+            logger.error("Token refresh error: %s", type(exc).__name__)
             return AuthResult(
                 success=False,
                 status=AuthStatus.INVALID,
-                error_message=str(exc),
+                error_message="Token refresh failed",
             )
 
     async def refresh_oauth2(self) -> AuthResult:
@@ -430,7 +448,19 @@ class TokenManager:
                 error_message="No refresh token available",
             )
 
-        token_url = f"{self.config.cloud_base_url}/oauth/token"
+        try:
+            cloud_base_url = await validate_cloud_base_url_async(
+                self.config.cloud_base_url, purpose="OAuth2 token refresh"
+            )
+        except ValueError as exc:
+            logger.warning("Rejected OAuth2 token refresh URL: %s", exc)
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message=str(exc),
+            )
+
+        token_url = f"{cloud_base_url}/oauth/token"
 
         if credentials.client_id is None or credentials.client_secret is None:
             return AuthResult(
@@ -446,37 +476,54 @@ class TokenManager:
             "client_secret": credentials.client_secret,
         }
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(token_url, data=data) as response:
-                if response.status == 200:
-                    token_data = await response.json()
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(token_url, data=data) as response:
+                    if response.status == 200:
+                        token_data = await response.json()
 
-                    # Update credentials
-                    credentials.jwt_token = token_data["access_token"]
-                    if "refresh_token" in token_data:
-                        credentials.refresh_token = token_data["refresh_token"]
-                    credentials.expires_at = time.time() + token_data.get(
-                        "expires_in", 3600
+                        # Update credentials
+                        credentials.jwt_token = token_data["access_token"]
+                        if "refresh_token" in token_data:
+                            credentials.refresh_token = token_data["refresh_token"]
+                        credentials.expires_at = time.time() + token_data.get(
+                            "expires_in", 3600
+                        )
+
+                        if self._set_credentials_fn:
+                            self._set_credentials_fn(
+                                credentials, AuthStatus.AUTHENTICATED
+                            )
+
+                        # Cache updated credentials
+                        if self.config.cache_credentials and self._cache_credentials_fn:
+                            await self._cache_credentials_fn(credentials)
+
+                        return AuthResult(
+                            success=True,
+                            status=AuthStatus.AUTHENTICATED,
+                            credentials=credentials,
+                            expires_in=token_data.get("expires_in", 3600),
+                        )
+
+                    await response.text()
+                    logger.warning(
+                        "OAuth2 token refresh failed with status %s", response.status
                     )
-
-                    if self._set_credentials_fn:
-                        self._set_credentials_fn(credentials, AuthStatus.AUTHENTICATED)
-
-                    # Cache updated credentials
-                    if self.config.cache_credentials and self._cache_credentials_fn:
-                        await self._cache_credentials_fn(credentials)
-
                     return AuthResult(
-                        success=True,
-                        status=AuthStatus.AUTHENTICATED,
-                        credentials=credentials,
-                        expires_in=token_data.get("expires_in", 3600),
+                        success=False,
+                        status=AuthStatus.INVALID,
+                        error_message=(
+                            f"OAuth2 token refresh failed with status {response.status}"
+                        ),
                     )
-                else:
-                    error_text = await response.text()
-                    raise RuntimeError(
-                        f"Token refresh failed: {response.status} {error_text}"
-                    )
+        except Exception as exc:
+            logger.error("OAuth2 token refresh failed: %s", type(exc).__name__)
+            return AuthResult(
+                success=False,
+                status=AuthStatus.INVALID,
+                error_message="OAuth2 token refresh failed",
+            )
 
     def build_credentials_from_token_data(
         self, token_data: dict[str, Any]

--- a/traigent/cloud/url_security.py
+++ b/traigent/cloud/url_security.py
@@ -1,0 +1,132 @@
+"""URL validation helpers for cloud-facing SDK HTTP calls."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import os
+import socket
+from urllib.parse import unquote, urlparse, urlunparse
+
+_DEVELOPMENT_ENV_NAMES = {"dev", "development", "local", "test", "testing"}
+_PRODUCTION_ENV_NAMES = {"prod", "production", "stage", "staging"}
+_ENV_KEYS = ("TRAIGENT_ENV", "ENVIRONMENT", "APP_ENV", "FLASK_ENV")
+
+
+def _is_development_environment() -> bool:
+    """Return True for explicit/local SDK development environments."""
+    for key in _ENV_KEYS:
+        value = os.getenv(key)
+        if value and value.strip().lower() in _PRODUCTION_ENV_NAMES:
+            return False
+
+    for key in _ENV_KEYS:
+        value = os.getenv(key)
+        if value and value.strip().lower() in _DEVELOPMENT_ENV_NAMES:
+            return True
+    return False
+
+
+def _reject_unsafe_hostname(hostname: str, *, allow_local: bool) -> None:
+    normalized = hostname.strip("[]").rstrip(".").lower()
+    if not normalized:
+        raise ValueError("Cloud base URL must include a hostname") from None
+
+    if normalized in {"localhost", "localhost.localdomain"} or normalized.endswith(
+        (".localhost", ".local")
+    ):
+        if allow_local:
+            return
+        raise ValueError("Cloud base URL host is not allowed in production") from None
+
+    try:
+        host_ip = ipaddress.ip_address(normalized)
+    except ValueError:
+        host_ip = None
+
+    if host_ip is not None:
+        if not allow_local and not host_ip.is_global:
+            raise ValueError(
+                "Cloud base URL must not target private or loopback IPs"
+            ) from None
+        return
+
+    if allow_local:
+        return
+
+    try:
+        addr_infos = socket.getaddrinfo(normalized, None)
+    except socket.gaierror:
+        raise ValueError("Cloud base URL host could not be resolved") from None
+
+    for _family, _socktype, _proto, _canonname, sockaddr in addr_infos:
+        try:
+            resolved_ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if not resolved_ip.is_global:
+            raise ValueError(
+                "Cloud base URL must not resolve to private or loopback IPs"
+            ) from None
+
+
+def validate_cloud_base_url(base_url: str, *, purpose: str = "cloud request") -> str:
+    """Validate and normalize a cloud base URL before sending credentials.
+
+    Production calls must use a public HTTP(S) host. Localhost and private
+    networks are allowed only in explicit development/test environments.
+    """
+    candidate = (base_url or "").strip().rstrip("/")
+    if not candidate:
+        raise ValueError(f"{purpose} base URL cannot be empty") from None
+
+    if any(ord(ch) < 32 or ch.isspace() for ch in candidate):
+        raise ValueError(f"{purpose} base URL contains unsafe whitespace") from None
+
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"{purpose} base URL must be http(s) with a host") from None
+    if parsed.username or parsed.password:
+        raise ValueError(f"{purpose} base URL must not include credentials") from None
+    if parsed.params or parsed.query or parsed.fragment:
+        raise ValueError(
+            f"{purpose} base URL must not include params, query, or fragment"
+        ) from None
+
+    allow_local = _is_development_environment()
+    if not allow_local and parsed.scheme != "https":
+        raise ValueError(f"{purpose} base URL must use https in production") from None
+
+    decoded_path = parsed.path
+    for _ in range(2):
+        next_path = unquote(decoded_path)
+        if next_path == decoded_path:
+            break
+        decoded_path = next_path
+
+    path_segments = [part for part in decoded_path.split("/") if part]
+    if any(part in {".", ".."} for part in path_segments):
+        raise ValueError(
+            f"{purpose} base URL must not contain path traversal"
+        ) from None
+
+    hostname = parsed.hostname
+    if hostname is None:
+        raise ValueError(f"{purpose} base URL must include a hostname") from None
+    _reject_unsafe_hostname(hostname, allow_local=allow_local)
+
+    clean_path = parsed.path.rstrip("/")
+    return urlunparse(
+        parsed._replace(path=clean_path, params="", query="", fragment="")
+    )
+
+
+async def validate_cloud_base_url_async(
+    base_url: str, *, purpose: str = "cloud request"
+) -> str:
+    """Validate a cloud URL without blocking the event loop on DNS resolution."""
+    return await asyncio.to_thread(
+        validate_cloud_base_url,
+        base_url,
+        purpose=purpose,
+    )

--- a/traigent/core/ci_approval.py
+++ b/traigent/core/ci_approval.py
@@ -89,22 +89,7 @@ def _validate_hmac_token(token_data: dict[str, Any]) -> bool:
 
     secret = os.getenv("TRAIGENT_APPROVAL_SECRET", "").encode()
     if not secret:
-        logger.warning(
-            "TRAIGENT_APPROVAL_SECRET not set, cannot validate token signature"
-        )
-        try:
-            expires_at = datetime.fromisoformat(
-                token_data["expires_iso"].replace("Z", _UTC_TIMEZONE_SUFFIX)
-            )
-            now = datetime.now(UTC) if expires_at.tzinfo else datetime.now()
-            if expires_at > now:
-                logger.warning(
-                    "Token approved by %s (signature not verified)",
-                    _sanitize_for_log(token_data.get("approver", "unknown")),
-                )
-                return True
-        except (ValueError, KeyError):
-            pass
+        logger.warning("TRAIGENT_APPROVAL_SECRET not set; refusing unsigned token")
         return False
 
     # Compute expected signature


### PR DESCRIPTION
## Summary
- fail closed when HMAC CI approval tokens cannot be verified because TRAIGENT_APPROVAL_SECRET is unset
- add shared cloud URL validation and apply it before OAuth/password credential flows send secrets
- redact token/auth refresh failures so raw upstream bodies are not returned or logged

## Verification
- uv run --extra dev ruff format --check traigent/core/ci_approval.py traigent/cloud/token_manager.py traigent/cloud/auth.py traigent/cloud/url_security.py tests/unit/core/test_ci_approval.py tests/unit/cloud/test_token_manager.py tests/unit/cloud/test_url_security.py
- uv run --extra dev ruff check traigent/core/ci_approval.py traigent/cloud/token_manager.py traigent/cloud/auth.py traigent/cloud/url_security.py tests/unit/core/test_ci_approval.py tests/unit/cloud/test_token_manager.py tests/unit/cloud/test_url_security.py
- pytest -o addopts='' tests/unit/cloud/test_password_auth_handler.py tests/unit/cloud/test_token_manager.py tests/unit/cloud/test_url_security.py tests/unit/core/test_ci_approval.py -q

Refs Traigent/Traigent#846