### PR TITLE
fix: close high-priority runtime contract gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`langgraph-checkpoint` 3.x → 4.x:** the 4.0 release drops default deserialization of payloads serialized with the legacy `"json"` serde mode. Users running `langgraph` with a persistent checkpoint saver (SQLite, Postgres, Redis, etc.) whose stored state contains JSON-format blobs will see deserialization failures unless they configure `serde` with an explicit `allowed_json_modules` list. Traigent does not bind `langgraph-checkpoint` directly — it arrives transitively through the `langgraph` dependency — so this only affects projects that also use `langgraph` checkpointers in their own code. See [CVE-2026-27794](https://github.com/langchain-ai/langgraph/security/advisories) for the underlying RCE that motivated removing the default.
 
 ### Changed
+- Agent platform helpers now distinguish executable platforms from configuration-mapping-only platforms: `get_supported_platforms()` reports only executor-backed platforms, while `get_mapping_platforms()` returns all registered mappings.
+- Agent executors without real cost-estimation support now raise `NotImplementedError` instead of returning an authoritative-looking zero-cost estimate.
+- Langfuse trace metrics now include an `observations_partial` numeric flag in `to_measures_dict()` when observation pagination returns incomplete metrics.
 - Cost enforcement invariant checks now treat the cost-limit bound as an admission-time permit rule. `assert_invariants()` still detects stranded permits and reservation drift, but it no longer flags valid post-trial actual-cost overruns while other admitted permits remain in flight.
 - `metric_limit` in parallel mode is evaluated after each batch and may overshoot by up to `parallel_trials - 1` trials; use `cost_limit` when a hard spend bound is required.
 - Deprecated `budget_limit` stop-condition aliases now report `OptimizationResult.stop_reason="metric_limit"` instead of `"cost_limit"`. Use `cost_limit` for hard USD spend control and `metric_limit` with `metric_name` for soft cumulative metric stopping.
 - Built-in hypervolume convergence now reports `OptimizationResult.stop_reason="convergence"`; arbitrary custom stop conditions still report the generic `"condition"` reason unless explicitly mapped.
+
+### Fixed
+- Trial tenants now pass quota checks until `trial_ends_at` and are blocked after expiry.
+- Unsupported hybrid keep-alive now marks the session status as `unsupported` instead of treating every tracked session as alive.
 
 ## [0.11.2] - 2026-04-01
 

--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -519,7 +519,7 @@ response = await client.optimize_agent(
 
 1. **"Platform not supported"**
 
-   - Check available platforms: `get_supported_platforms()`
+   - Check executable platforms with `get_supported_platforms()`; use `get_mapping_platforms()` when you need mapping-only targets.
    - Register custom platform if needed
 
 2. **"Configuration validation failed"**

--- a/tests/unit/agents/test_agent_config_mapper.py
+++ b/tests/unit/agents/test_agent_config_mapper.py
@@ -7,6 +7,7 @@ from traigent.agents.config_mapper import (
     ParameterMapping,
     PlatformMapping,
     apply_config_to_agent,
+    get_mapping_platforms,
     get_supported_platforms,
     register_platform_mapping,
     validate_config_compatibility,
@@ -150,7 +151,7 @@ class TestConfigurationMapper:
         mapper = ConfigurationMapper()
         mapper.register_platform_mapping(custom_platform_mapping)
 
-        platforms = mapper.get_supported_platforms()
+        platforms = mapper.get_mapping_platforms()
         assert "custom" in platforms
 
         retrieved = mapper.get_platform_mapping("custom")
@@ -408,9 +409,10 @@ class TestModuleFunctions:
         # Register the mapping
         register_platform_mapping(custom_platform_mapping)
 
-        # Should be available in supported platforms
-        platforms = get_supported_platforms()
+        # Should be available in mapping platforms without becoming executable.
+        platforms = get_mapping_platforms()
         assert "custom" in platforms
+        assert "custom" not in get_supported_platforms()
 
     def test_get_supported_platforms(self):
         """Test get_supported_platforms function."""

--- a/tests/unit/agents/test_agent_config_mapper_platforms.py
+++ b/tests/unit/agents/test_agent_config_mapper_platforms.py
@@ -11,6 +11,7 @@ from traigent.agents.config_mapper import (
     ParameterMapping,
     PlatformMapping,
     apply_config_to_agent,
+    get_mapping_platforms,
     get_supported_platforms,
     register_platform_mapping,
     validate_config_compatibility,
@@ -81,7 +82,7 @@ class TestConfigMapperPlatforms:
 
     def test_anthropic_platform_mapping_exists(self, config_mapper):
         """Test that Anthropic platform mapping is registered by default."""
-        platforms = config_mapper.get_supported_platforms()
+        platforms = config_mapper.get_mapping_platforms()
         assert "anthropic" in platforms
 
         mapping = config_mapper.get_platform_mapping("anthropic")
@@ -90,7 +91,7 @@ class TestConfigMapperPlatforms:
 
     def test_cohere_platform_mapping_exists(self, config_mapper):
         """Test that Cohere platform mapping is registered by default."""
-        platforms = config_mapper.get_supported_platforms()
+        platforms = config_mapper.get_mapping_platforms()
         assert "cohere" in platforms
 
         mapping = config_mapper.get_platform_mapping("cohere")
@@ -99,7 +100,7 @@ class TestConfigMapperPlatforms:
 
     def test_huggingface_platform_mapping_exists(self, config_mapper):
         """Test that HuggingFace platform mapping is registered by default."""
-        platforms = config_mapper.get_supported_platforms()
+        platforms = config_mapper.get_mapping_platforms()
         assert "huggingface" in platforms
 
         mapping = config_mapper.get_platform_mapping("huggingface")
@@ -384,7 +385,7 @@ class TestConfigMapperPlatforms:
         config_mapper.register_platform_mapping(custom_mapping)
 
         # Verify it was registered
-        assert "custom_llm" in config_mapper.get_supported_platforms()
+        assert "custom_llm" in config_mapper.get_mapping_platforms()
         assert config_mapper.get_platform_mapping("custom_llm") is not None
 
         # Test using the custom mapping
@@ -544,15 +545,16 @@ class TestConfigMapperPlatforms:
         )
         assert validation_result["compatible"] is True
 
-        # Test get_supported_platforms
+        # Test executable and mapping platform lists stay separated
         platforms = get_supported_platforms()
-        assert "anthropic" in platforms
-        assert "cohere" in platforms
-        assert "huggingface" in platforms
         assert "openai" in platforms
         assert "langchain" in platforms
+        mapping_platforms = get_mapping_platforms()
+        assert "anthropic" in mapping_platforms
+        assert "cohere" in mapping_platforms
+        assert "huggingface" in mapping_platforms
 
         # Test register_platform_mapping
         test_mapping = PlatformMapping(platform="test_global")
         register_platform_mapping(test_mapping)
-        assert "test_global" in get_supported_platforms()
+        assert "test_global" in get_mapping_platforms()

--- a/tests/unit/agents/test_executor.py
+++ b/tests/unit/agents/test_executor.py
@@ -293,12 +293,8 @@ class TestAgentExecutor:
         """Test cost estimation."""
         input_data = {"query": "test"}
 
-        # Default implementation returns zero cost
-        estimate = await mock_executor.estimate_cost(sample_agent_spec, input_data)
-
-        assert estimate["estimated_cost"] == 0.0
-        assert estimate["estimated_tokens"] == 0
-        assert estimate["confidence"] == 0.0
+        with pytest.raises(NotImplementedError, match="cost estimation"):
+            await mock_executor.estimate_cost(sample_agent_spec, input_data)
 
     @pytest.mark.asyncio
     async def test_cleanup(self, mock_executor):

--- a/tests/unit/agents/test_platforms.py
+++ b/tests/unit/agents/test_platforms.py
@@ -395,6 +395,14 @@ class TestLangChainAgentExecutor:
         assert "async" in capabilities
 
     @pytest.mark.asyncio
+    async def test_estimate_cost_fails_closed(self, langchain_agent_spec):
+        """LangChain must not inherit a fake zero-cost estimate."""
+        executor = LangChainAgentExecutor()
+
+        with pytest.raises(NotImplementedError, match="cost estimation"):
+            await executor.estimate_cost(langchain_agent_spec, {"question": "test"})
+
+    @pytest.mark.asyncio
     async def test_execute_without_langchain(self, langchain_agent_spec):
         """Test execution when LangChain is not available."""
         executor = LangChainAgentExecutor()
@@ -708,6 +716,9 @@ class TestPlatformRegistry:
 
         assert "langchain" in platforms
         assert "openai" in platforms
+        assert "anthropic" not in platforms
+        assert "cohere" not in platforms
+        assert "huggingface" not in platforms
 
     def test_get_executor_for_platform(self):
         """Test getting executor instance."""

--- a/tests/unit/hybrid/test_lifecycle.py
+++ b/tests/unit/hybrid/test_lifecycle.py
@@ -236,3 +236,33 @@ class TestAgentLifecycleManager:
             assert info.keep_alive_status == "unsupported"
 
         await manager.release()
+
+    @pytest.mark.asyncio
+    async def test_keep_alive_not_supported_marks_all_sessions_in_one_pass(
+        self,
+        mock_transport: MagicMock,
+    ) -> None:
+        """Unsupported keep-alive must process every active session in one pass."""
+        mock_transport.keep_alive = AsyncMock(side_effect=NotImplementedError)
+
+        manager = AgentLifecycleManager(
+            transport=mock_transport,
+            heartbeat_interval=3600.0,
+        )
+
+        manager._sessions = {
+            "session-1": SessionInfo(session_id="session-1"),
+            "session-2": SessionInfo(session_id="session-2"),
+        }
+        manager._missed_heartbeats = {"session-1": 0, "session-2": 0}
+
+        await manager._send_heartbeats()
+
+        assert mock_transport.keep_alive.await_count == 2
+        for session_id in ("session-1", "session-2"):
+            info = manager.get_session_info(session_id)
+            assert info is not None
+            assert info.is_alive is False
+            assert info.keep_alive_status == "unsupported"
+
+        await manager.release()

--- a/tests/unit/hybrid/test_lifecycle.py
+++ b/tests/unit/hybrid/test_lifecycle.py
@@ -17,6 +17,7 @@ class TestSessionInfo:
         assert info.session_id == "test"
         assert info.is_alive is True
         assert info.heartbeat_count == 0
+        assert info.keep_alive_status == "alive"
 
 
 class TestAgentLifecycleManager:
@@ -183,6 +184,7 @@ class TestAgentLifecycleManager:
         info = manager.get_session_info("test")
         assert info is not None
         assert info.is_alive is False
+        assert info.keep_alive_status == "dead"
 
         await manager.release()
 
@@ -191,7 +193,7 @@ class TestAgentLifecycleManager:
         self,
         mock_transport: MagicMock,
     ) -> None:
-        """Test behavior when keep-alive not supported."""
+        """Unsupported keep-alive is unknown, not a positive alive signal."""
         mock_transport.keep_alive = AsyncMock(side_effect=NotImplementedError)
 
         manager = AgentLifecycleManager(
@@ -202,9 +204,35 @@ class TestAgentLifecycleManager:
         await manager.register("test")
         await asyncio.sleep(0.1)
 
-        # Session should still be considered alive
         info = manager.get_session_info("test")
         assert info is not None
-        assert info.is_alive is True
+        assert info.is_alive is False
+        assert info.keep_alive_status == "unsupported"
+        assert not manager.is_session_alive("test")
+
+        await manager.release()
+
+    @pytest.mark.asyncio
+    async def test_keep_alive_not_supported_does_not_mark_other_sessions_alive(
+        self,
+        mock_transport: MagicMock,
+    ) -> None:
+        """Unsupported keep-alive should not rewrite unrelated sessions to alive."""
+        mock_transport.keep_alive = AsyncMock(side_effect=NotImplementedError)
+
+        manager = AgentLifecycleManager(
+            transport=mock_transport,
+            heartbeat_interval=0.05,
+        )
+
+        await manager.register("session-1")
+        await manager.register("session-2")
+        await asyncio.sleep(0.16)
+
+        for session_id in ("session-1", "session-2"):
+            info = manager.get_session_info(session_id)
+            assert info is not None
+            assert info.is_alive is False
+            assert info.keep_alive_status == "unsupported"
 
         await manager.release()

--- a/tests/unit/integrations/langfuse/test_langfuse_client.py
+++ b/tests/unit/integrations/langfuse/test_langfuse_client.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from traigent.integrations.langfuse import client as langfuse_client_module
 from traigent.integrations.langfuse.client import (
     AIOHTTP_AVAILABLE,
     REQUESTS_AVAILABLE,
@@ -128,8 +129,20 @@ class TestLangfuseTraceMetrics:
         assert "total_cost" in measures
         assert "total_latency_ms" in measures
         assert "total_tokens" in measures
+        assert measures["observations_partial"] == 0
         assert measures["total_cost"] == 0.01
         assert measures["total_latency_ms"] == 2000.0
+
+    def test_to_measures_dict_flags_partial_observations(self):
+        """Partial observation metrics must be visible to callers."""
+        metrics = LangfuseTraceMetrics(
+            trace_id="trace-partial",
+            observations_partial=True,
+        )
+
+        measures = metrics.to_measures_dict(prefix="lf_")
+
+        assert measures["lf_observations_partial"] == 1
 
     def test_to_measures_dict_per_agent_metrics(
         self, sample_metrics: LangfuseTraceMetrics
@@ -692,12 +705,33 @@ class TestLangfuseClientErrorHandling:
 
     @pytest.mark.skipif(not REQUESTS_AVAILABLE, reason="requests not installed")
     def test_get_observations_http_handles_request_exception(self, client):
-        """Test that observations HTTP errors return partial results."""
+        """HTTP errors must mark returned observations as partial."""
         import requests
 
         with patch("requests.get", side_effect=requests.exceptions.Timeout("Timeout")):
             result = client._get_observations_http("trace-123")
             assert result == []
+            assert client._observations_partial_by_trace["trace-123"] is True
+
+    @pytest.mark.skipif(not REQUESTS_AVAILABLE, reason="requests not installed")
+    def test_get_observations_http_marks_accumulated_results_partial(self, client):
+        """A later page failure must not look like complete metrics."""
+        import requests
+
+        first_page = MagicMock()
+        first_page.json.return_value = {
+            "data": [{"id": "obs-1", "name": "llm-call", "type": "GENERATION"}],
+            "meta": {"totalItems": 2},
+        }
+
+        with patch(
+            "requests.get",
+            side_effect=[first_page, requests.exceptions.Timeout("Timeout")],
+        ):
+            result = client._get_observations_http("trace-123")
+
+        assert len(result) == 1
+        assert client._observations_partial_by_trace["trace-123"] is True
 
 
 class TestLangfuseClientGetTrace:
@@ -765,6 +799,17 @@ class TestLangfuseClientMetricsAggregation:
             mock_get_obs.return_value = []
             client._extract_metrics_from_trace(trace_data)
             mock_get_obs.assert_called_once_with("trace-123")
+
+    def test_extract_metrics_carries_partial_observation_flag(self, client):
+        """Fetched partial observations must be surfaced on aggregate metrics."""
+        trace_data = {"id": "trace-123", "name": "test"}  # No observations key
+        client._observations_partial_by_trace["trace-123"] = True
+
+        with patch.object(client, "get_observations_for_trace", return_value=[]):
+            metrics = client._extract_metrics_from_trace(trace_data)
+
+        assert metrics.observations_partial is True
+        assert metrics.to_measures_dict()["observations_partial"] == 1
 
     def test_aggregate_multiple_agents_accumulates(self, client):
         """Test that metrics accumulate correctly for same agent."""
@@ -924,6 +969,70 @@ class TestLangfuseClientAsync:
                 is True
             )
 
+    @pytest.mark.skipif(not AIOHTTP_AVAILABLE, reason="aiohttp not installed")
+    @pytest.mark.asyncio
+    async def test_get_observations_async_marks_accumulated_results_partial(
+        self, client
+    ):
+        """A later async page failure must mark accumulated observations partial."""
+
+        class AsyncResponse:
+            def __init__(self, payload=None, exc=None):
+                self.payload = payload or {}
+                self.exc = exc
+
+            async def __aenter__(self):
+                if self.exc:
+                    raise self.exc
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def raise_for_status(self):
+                return None
+
+            async def json(self):
+                return self.payload
+
+        class AsyncSession:
+            def __init__(self):
+                self.calls = 0
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def get(self, *_args, **_kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return AsyncResponse(
+                        {
+                            "data": [
+                                {
+                                    "id": "obs-1",
+                                    "name": "llm-call",
+                                    "type": "GENERATION",
+                                }
+                            ],
+                            "meta": {"totalItems": 2},
+                        }
+                    )
+                return AsyncResponse(
+                    exc=langfuse_client_module.aiohttp.ClientError("timeout")
+                )
+
+        with patch(
+            "traigent.integrations.langfuse.client.aiohttp.ClientSession",
+            new=AsyncSession,
+        ):
+            result = await client.get_observations_for_trace_async("trace-123")
+
+        assert len(result) == 1
+        assert client._observations_partial_by_trace["trace-123"] is True
+
 
 class TestLangfuseClientSDK:
     """Test SDK integration paths."""
@@ -970,6 +1079,7 @@ class TestLangfuseClientSDK:
 
         result = client.get_observations_for_trace("trace-123")
         assert len(result) == 1
+        assert client._observations_partial_by_trace["trace-123"] is False
         mock_sdk.get_observations.assert_called_once()
 
     def test_get_observations_for_trace_sdk_exception(self, client):

--- a/tests/unit/security/test_tenant.py
+++ b/tests/unit/security/test_tenant.py
@@ -4,7 +4,7 @@ Tests for multi-tenant support systems
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -303,6 +303,48 @@ class TestTenant:
         assert not tenant.check_quota("optimizations_per_month", 1)
         assert not tenant.consume_quota("optimizations_per_month", 1)
 
+    def test_trial_tenant_has_quota_until_expiry(self):
+        """Trial tenants should behave as active until trial_ends_at."""
+        tenant = Tenant(
+            tenant_id="tenant123",
+            name="Trial Tenant",
+            contact_email="trial@test.com",
+            status=TenantStatus.TRIAL,
+            trial_ends_at=datetime.now(UTC) + timedelta(days=1),
+        )
+
+        assert tenant.is_active()
+        assert not tenant.is_trial_expired()
+        assert tenant.check_quota("optimizations_per_month", 1)
+
+    def test_expired_trial_tenant_is_blocked(self):
+        """Expired trials must not continue consuming quotas."""
+        tenant = Tenant(
+            tenant_id="tenant123",
+            name="Expired Trial",
+            contact_email="trial@test.com",
+            status=TenantStatus.TRIAL,
+            trial_ends_at=datetime.now(UTC) - timedelta(seconds=1),
+        )
+
+        assert not tenant.is_active()
+        assert tenant.is_trial_expired()
+        assert not tenant.check_quota("optimizations_per_month", 1)
+        assert not tenant.consume_quota("optimizations_per_month", 1)
+
+    def test_trial_tenant_accepts_naive_expiry_datetimes(self):
+        """Naive trial expiries should be interpreted as UTC."""
+        tenant = Tenant(
+            tenant_id="tenant123",
+            name="Naive Trial",
+            contact_email="trial@test.com",
+            status=TenantStatus.TRIAL,
+            trial_ends_at=datetime.now() + timedelta(days=1),
+        )
+
+        assert tenant.is_active()
+        assert not tenant.is_trial_expired()
+
     def test_tenant_serialization(self):
         """Test tenant serialization"""
         tenant = Tenant(
@@ -415,6 +457,22 @@ class TestTenantManager:
         # Should be stored in manager
         retrieved_tenant = manager.get_tenant(tenant.tenant_id)
         assert retrieved_tenant == tenant
+
+    def test_create_trial_tenant_is_active_until_expiry(self):
+        """TenantManager-created trial tenants should pass quota checks."""
+        manager = TenantManager()
+
+        tenant = manager.create_tenant(
+            name="Trial Company",
+            contact_email="trial@testcompany.com",
+            status=TenantStatus.TRIAL,
+        )
+
+        assert tenant.trial_ends_at is not None
+        assert tenant.is_active()
+        assert manager.check_quota(
+            "optimizations_per_month", tenant_id=tenant.tenant_id
+        )
 
     def test_list_tenants(self):
         """Test listing tenants with filters"""

--- a/traigent/agents/__init__.py
+++ b/traigent/agents/__init__.py
@@ -15,6 +15,7 @@ from .config_mapper import (
     ParameterMapping,
     PlatformMapping,
     apply_config_to_agent,
+    get_mapping_platforms,
     get_supported_platforms,
     register_platform_mapping,
     validate_config_compatibility,
@@ -52,6 +53,7 @@ __all__ = [
     "validate_config_compatibility",
     "register_platform_mapping",
     "get_supported_platforms",
+    "get_mapping_platforms",
 ]
 
 # Only include platform-specific exports if platforms are available

--- a/traigent/agents/config_mapper.py
+++ b/traigent/agents/config_mapper.py
@@ -124,11 +124,21 @@ class ConfigurationMapper:
             ) from e
 
     def get_supported_platforms(self) -> list[str]:
-        """Get list of supported platforms.
+        """Get executable platforms that can run through the agent registry.
 
         Returns:
-            List of platform names
+            List of executable platform names.
         """
+        from traigent.agents.platforms import PlatformRegistry
+
+        return [
+            platform
+            for platform in self._platform_mappings
+            if platform in PlatformRegistry.list_platforms()
+        ]
+
+    def get_mapping_platforms(self) -> list[str]:
+        """Get all platforms with configuration mappings, including mapping-only."""
         return list(self._platform_mappings.keys())
 
     def get_platform_mapping(self, platform: str) -> PlatformMapping | None:
@@ -646,9 +656,14 @@ def register_platform_mapping(mapping: PlatformMapping) -> None:
 
 
 def get_supported_platforms() -> list[str]:
-    """Get list of supported platforms.
+    """Get executable platforms.
 
     Returns:
-        List of platform names
+        List of executable platform names.
     """
     return config_mapper.get_supported_platforms()
+
+
+def get_mapping_platforms() -> list[str]:
+    """Get all mapping platforms, including mapping-only targets."""
+    return config_mapper.get_mapping_platforms()

--- a/traigent/agents/executor.py
+++ b/traigent/agents/executor.py
@@ -290,10 +290,10 @@ class AgentExecutor(ABC):
         Returns:
             Cost estimation dictionary
         """
-        # Default implementation - platforms can override with async operations
-        # Add minimal async operation to satisfy linter
         await asyncio.sleep(0)
-        return {"estimated_cost": 0.0, "estimated_tokens": 0, "confidence": 0.0}
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement cost estimation"
+        )
 
     async def validate_configuration(self, config: dict[str, Any]) -> dict[str, Any]:
         """Validate configuration for the platform.

--- a/traigent/agents/executor.py
+++ b/traigent/agents/executor.py
@@ -290,7 +290,6 @@ class AgentExecutor(ABC):
         Returns:
             Cost estimation dictionary
         """
-        await asyncio.sleep(0)
         raise NotImplementedError(
             f"{self.__class__.__name__} does not implement cost estimation"
         )

--- a/traigent/hybrid/lifecycle.py
+++ b/traigent/hybrid/lifecycle.py
@@ -244,7 +244,7 @@ class AgentLifecycleManager:
                 info.is_alive = False
                 info.keep_alive_status = "unsupported"
                 self._missed_heartbeats[session_id] = 0
-                return
+                continue
 
             except Exception as e:
                 self._handle_heartbeat_failure(session_id, info, str(e))

--- a/traigent/hybrid/lifecycle.py
+++ b/traigent/hybrid/lifecycle.py
@@ -33,6 +33,7 @@ class SessionInfo:
         last_heartbeat: Timestamp of last successful heartbeat
         heartbeat_count: Number of successful heartbeats
         is_alive: Whether session is currently alive
+        keep_alive_status: Last keep-alive status: alive, dead, or unsupported
     """
 
     session_id: str
@@ -40,6 +41,7 @@ class SessionInfo:
     last_heartbeat: float = 0.0
     heartbeat_count: int = 0
     is_alive: bool = True
+    keep_alive_status: str = "alive"
 
 
 class AgentLifecycleManager:
@@ -225,6 +227,7 @@ class AgentLifecycleManager:
                 if alive:
                     info.last_heartbeat = asyncio.get_event_loop().time()
                     info.heartbeat_count += 1
+                    info.keep_alive_status = "alive"
                     self._missed_heartbeats[session_id] = 0
                     logger.debug(
                         f"Heartbeat success for session {session_id} "
@@ -238,10 +241,10 @@ class AgentLifecycleManager:
                 logger.debug(
                     f"Keep-alive not supported, skipping heartbeat for {session_id}"
                 )
-                # Mark all sessions as needing no heartbeat
-                for s_info in self._sessions.values():
-                    s_info.is_alive = True  # Assume alive
-                return  # No point continuing
+                info.is_alive = False
+                info.keep_alive_status = "unsupported"
+                self._missed_heartbeats[session_id] = 0
+                return
 
             except Exception as e:
                 self._handle_heartbeat_failure(session_id, info, str(e))
@@ -271,6 +274,7 @@ class AgentLifecycleManager:
 
         if missed >= self._max_missed_heartbeats:
             info.is_alive = False
+            info.keep_alive_status = "dead"
             logger.error(
                 f"Session {session_id} marked as dead after {missed} missed heartbeats"
             )

--- a/traigent/integrations/langfuse/client.py
+++ b/traigent/integrations/langfuse/client.py
@@ -137,6 +137,7 @@ class LangfuseTraceMetrics:
     trace_metadata: dict[str, Any] = field(default_factory=dict)
     session_id: str | None = None
     user_id: str | None = None
+    observations_partial: bool = False
 
     def to_measures_dict(
         self,
@@ -160,6 +161,7 @@ class LangfuseTraceMetrics:
             f"{prefix}total_input_tokens": self.total_input_tokens,
             f"{prefix}total_output_tokens": self.total_output_tokens,
             f"{prefix}total_tokens": self.total_tokens,
+            f"{prefix}observations_partial": int(self.observations_partial),
         }
 
         if include_per_agent:
@@ -229,6 +231,7 @@ class LangfuseClient:
         )
         self.host = resolved_host.rstrip("/")
         self.timeout = timeout
+        self._observations_partial_by_trace: dict[str, bool] = {}
 
         # Initialize SDK client if available
         self._sdk_client: LangfuseType | None = None
@@ -343,6 +346,7 @@ class LangfuseClient:
                 # SDK method to get observations
                 observations = self._sdk_client.get_observations(trace_id=trace_id)
                 if observations:
+                    self._observations_partial_by_trace[trace_id] = False
                     return [
                         self._observation_to_model(obs) for obs in observations.data
                     ]
@@ -369,6 +373,7 @@ class LangfuseClient:
 
         observations: list[LangfuseObservation] = []
         page = 1
+        self._observations_partial_by_trace[trace_id] = False
 
         try:
             while page <= max_pages:
@@ -402,10 +407,12 @@ class LangfuseClient:
                     f"Hit max_pages limit ({max_pages}) fetching observations "
                     f"for trace {trace_id}. Some observations may be missing."
                 )
+                self._observations_partial_by_trace[trace_id] = True
 
             return observations
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to get observations for trace {trace_id}: {e}")
+            self._observations_partial_by_trace[trace_id] = True
             return observations  # Return what we have so far
 
     def wait_for_trace(
@@ -496,6 +503,7 @@ class LangfuseClient:
 
         observations: list[LangfuseObservation] = []
         page = 1
+        self._observations_partial_by_trace[trace_id] = False
 
         try:
             async with aiohttp.ClientSession() as session:
@@ -534,10 +542,12 @@ class LangfuseClient:
                     f"Hit max_pages limit ({max_pages}) fetching observations "
                     f"for trace {trace_id}. Some observations may be missing."
                 )
+                self._observations_partial_by_trace[trace_id] = True
 
             return observations
         except aiohttp.ClientError as e:
             logger.error(f"Failed to get observations for trace {trace_id}: {e}")
+            self._observations_partial_by_trace[trace_id] = True
             return observations  # Return what we have so far
 
     async def wait_for_trace_async(
@@ -715,12 +725,19 @@ class LangfuseClient:
 
         # Get observations (may be embedded or need separate fetch)
         observations: list[LangfuseObservation] = []
+        observations_partial = bool(
+            trace_data.get("observations_partial")
+            or trace_data.get("observationsPartial")
+        )
         if "observations" in trace_data:
             for obs_data in trace_data["observations"]:
                 observations.append(self._dict_to_observation(obs_data))
         else:
             # Fetch observations separately
             observations = self.get_observations_for_trace(trace_id)
+            observations_partial = self._observations_partial_by_trace.get(
+                trace_id, False
+            )
 
         # Aggregate metrics
         total_cost = 0.0
@@ -773,6 +790,7 @@ class LangfuseClient:
             trace_metadata=trace_metadata,
             session_id=session_id,
             user_id=user_id,
+            observations_partial=observations_partial,
         )
 
 

--- a/traigent/security/tenant.py
+++ b/traigent/security/tenant.py
@@ -301,7 +301,31 @@ class Tenant:
 
     def is_active(self) -> bool:
         """Check if tenant is active."""
-        return self.status == TenantStatus.ACTIVE
+        if self.status == TenantStatus.ACTIVE:
+            return True
+        if self.status != TenantStatus.TRIAL:
+            return False
+        trial_ends_at = self._trial_ends_at_utc()
+        if trial_ends_at is None:
+            return False
+        return datetime.now(UTC) <= trial_ends_at
+
+    def is_trial_expired(self) -> bool:
+        """Check whether a trial tenant has passed its configured end time."""
+        if self.status != TenantStatus.TRIAL:
+            return False
+        trial_ends_at = self._trial_ends_at_utc()
+        if trial_ends_at is None:
+            return True
+        return datetime.now(UTC) > trial_ends_at
+
+    def _trial_ends_at_utc(self) -> datetime | None:
+        """Return trial expiry as an aware UTC datetime."""
+        if self.trial_ends_at is None:
+            return None
+        if self.trial_ends_at.tzinfo is None:
+            return self.trial_ends_at.replace(tzinfo=UTC)
+        return self.trial_ends_at.astimezone(UTC)
 
     def check_quota(self, resource_type: str, amount: int = 1) -> bool:
         """Check if tenant has quota for resource."""


### PR DESCRIPTION
## Summary
- fail closed for unsupported agent cost estimation and split executable agent platforms from mapping-only platforms
- add partial-observation signaling to Langfuse trace metrics
- stop treating unsupported hybrid keep-alive as alive and enforce trial tenant expiry in quota checks
- document the public contract changes in the changelog and agent guide

Fixes #945
Fixes #944
Fixes #943
Fixes #940
Fixes #938

## Verification
- pytest -o addopts='' tests/unit/agents/test_executor.py tests/unit/agents/test_platforms.py tests/unit/agents/test_agent_config_mapper.py tests/unit/agents/test_agent_config_mapper_platforms.py -q
- pytest -o addopts='' tests/unit/integrations/langfuse/test_langfuse_client.py tests/unit/hybrid/test_lifecycle.py tests/unit/security/test_tenant.py -q
- uv run --extra dev ruff check traigent/agents/executor.py traigent/agents/config_mapper.py traigent/agents/__init__.py traigent/integrations/langfuse/client.py traigent/hybrid/lifecycle.py traigent/security/tenant.py tests/unit/agents/test_executor.py tests/unit/agents/test_platforms.py tests/unit/agents/test_agent_config_mapper.py tests/unit/agents/test_agent_config_mapper_platforms.py tests/unit/integrations/langfuse/test_langfuse_client.py tests/unit/hybrid/test_lifecycle.py tests/unit/security/test_tenant.py
- git diff --check
- commit hooks: isort, black, ruff, detect-secrets, trim trailing whitespace, merge-conflict/private-key checks, bandit, mypy, strict-cost guardrails