### PR TITLE
fix(security): harden auth fallback paths on main

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -660,21 +660,21 @@
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "25b5a7e454ccbe4974ee239749935c9e32b887e1",
         "is_verified": false,
-        "line_number": 317
+        "line_number": 318
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "b3215fe1d22a64a131c0f9c09718c5b8860911ad",
         "is_verified": false,
-        "line_number": 350
+        "line_number": 351
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "495289ab973afae18fc84235f33dadc07a9608c4",
         "is_verified": false,
-        "line_number": 381
+        "line_number": 382
       }
     ],
     "tests/unit/cloud/test_backend_bridges_security.py": [
@@ -1256,5 +1256,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-10T15:13:48Z"
+  "generated_at": "2026-05-14T13:14:08Z"
 }

--- a/tests/unit/cloud/test_authentication_security.py
+++ b/tests/unit/cloud/test_authentication_security.py
@@ -18,6 +18,7 @@ from traigent.cloud.auth import (
     AuthCredentials,
     AuthManager,
     AuthMode,
+    InvalidCredentialsError,
     UnifiedAuthConfig,
 )
 from traigent.utils.logging import get_logger
@@ -100,9 +101,9 @@ class TestCredentialSecurity:
             # Check file permissions (should be 0o600)
             if cache_file.exists():
                 file_mode = cache_file.stat().st_mode & 0o777
-                assert (
-                    file_mode == 0o600
-                ), f"Cache file has insecure permissions: {oct(file_mode)}"
+                assert file_mode == 0o600, (
+                    f"Cache file has insecure permissions: {oct(file_mode)}"
+                )
 
     def test_weak_credential_encryption_detection(self):
         """Test detection of weak credential encryption."""
@@ -254,9 +255,9 @@ class TestCredentialSecurity:
                     f"Development mode: JWT validation may be permissive for token: {token[:50]}..."
                 )
             # Ensure result is an AuthResult object regardless of success/failure
-            assert hasattr(
-                result, "success"
-            ), f"Invalid result type for token: {token[:50]}..."
+            assert hasattr(result, "success"), (
+                f"Invalid result type for token: {token[:50]}..."
+            )
 
     def test_session_fixation_prevention(self):
         """Test prevention of session fixation attacks."""
@@ -721,6 +722,162 @@ class TestEnvironmentSecurity:
                 os.environ[test_env_key] = original_value
             else:
                 os.environ.pop(test_env_key, None)
+
+
+class TestAuthManagerLegacyAuthSecurity:
+    """Regression coverage for legacy AuthManager auth helpers."""
+
+    @pytest.mark.asyncio
+    async def test_oauth2_client_credentials_rejects_private_cloud_base_url(self):
+        manager = AuthManager(
+            UnifiedAuthConfig(cloud_base_url="https://127.0.0.1:5000")
+        )
+        credentials = AuthCredentials(
+            mode=AuthMode.OAUTH2,
+            client_id="client-id",
+            client_secret="client-secret",  # pragma: allowlist secret
+        )
+
+        with pytest.raises(RuntimeError, match="cloud_base_url is not allowed"):
+            await manager._oauth2_client_credentials_flow(credentials)
+
+    @pytest.mark.asyncio
+    async def test_oauth2_client_credentials_success_uses_validated_url(self):
+        manager = AuthManager(UnifiedAuthConfig(cloud_base_url="https://auth.example"))
+        credentials = AuthCredentials(
+            mode=AuthMode.OAUTH2,
+            client_id="client-id",
+            client_secret="client-secret",  # pragma: allowlist secret
+            scopes=["read"],
+        )
+        token_data = {"access_token": "access-token", "expires_in": 3600}
+        captured: dict[str, object] = {}
+
+        class _Response:
+            status = 200
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def json(self):
+                return token_data
+
+        class _Session:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def post(self, url, data):
+                captured["url"] = url
+                captured["data"] = data
+                return _Response()
+
+        with patch("traigent.cloud.auth.aiohttp.ClientSession", new=_Session):
+            result = await manager._oauth2_client_credentials_flow(credentials)
+
+        assert result == token_data
+        assert captured["url"] == "https://auth.example/oauth/token"
+
+    @pytest.mark.asyncio
+    async def test_oauth2_client_credentials_error_redacts_response_body(self):
+        manager = AuthManager(UnifiedAuthConfig(cloud_base_url="https://auth.example"))
+        credentials = AuthCredentials(
+            mode=AuthMode.OAUTH2,
+            client_id="client-id",
+            client_secret="client-secret",  # pragma: allowlist secret
+        )
+
+        class _Response:
+            status = 503
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def text(self):
+                return "upstream leaked token=secret-value"
+
+        class _Session:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def post(self, *_args, **_kwargs):
+                return _Response()
+
+        with patch("traigent.cloud.auth.aiohttp.ClientSession", new=_Session):
+            with pytest.raises(RuntimeError) as exc_info:
+                await manager._oauth2_client_credentials_flow(credentials)
+
+        assert str(exc_info.value) == "OAuth2 flow failed with HTTP 503"
+
+    @pytest.mark.asyncio
+    async def test_legacy_password_auth_does_not_mock_without_explicit_opt_in(self):
+        manager = AuthManager(UnifiedAuthConfig())
+
+        async def _raise_invalid_credentials(*_args, **_kwargs):
+            raise InvalidCredentialsError("Invalid credentials")
+
+        with (
+            patch.dict("os.environ", {"TRAIGENT_ENV": "development"}, clear=True),
+            patch(
+                "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+                new=_raise_invalid_credentials,
+            ),
+        ):
+            with pytest.raises(InvalidCredentialsError):
+                await manager._perform_password_authentication(
+                    {
+                        "email": "user@example.com",
+                        "password": "password123",  # pragma: allowlist secret
+                    }
+                )
+
+    @pytest.mark.asyncio
+    async def test_legacy_password_auth_mock_requires_explicit_opt_in(self):
+        manager = AuthManager(UnifiedAuthConfig())
+
+        async def _raise_backend_outage(*_args, **_kwargs):
+            raise RuntimeError("backend down")
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "TRAIGENT_ENV": "development",
+                    "TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH": "1",
+                },
+                clear=True,
+            ),
+            patch(
+                "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+                new=_raise_backend_outage,
+            ),
+        ):
+            token_data = await manager._perform_password_authentication(
+                {
+                    "email": "user@example.com",
+                    "password": "password123",  # pragma: allowlist secret
+                }
+            )
+
+        assert token_data is not None
+        assert token_data["dev_mode"] is True
 
 
 if __name__ == "__main__":

--- a/tests/unit/cloud/test_password_auth_handler.py
+++ b/tests/unit/cloud/test_password_auth_handler.py
@@ -36,6 +36,17 @@ def test_explicit_local_backend_still_enables_dev_mode():
         assert handler._is_dev_mode_enabled() is True
 
 
+def test_mock_auth_fallback_still_requires_dev_mode():
+    """Mock auth opt-in must not bypass the non-production guard."""
+    handler = PasswordAuthHandler()
+
+    with (
+        patch.dict("os.environ", {"TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH": "1"}),
+        patch.object(handler, "_is_dev_mode_enabled", return_value=False),
+    ):
+        assert handler._is_mock_auth_fallback_enabled() is False
+
+
 @pytest.mark.asyncio
 async def test_invalid_credentials_propagate_even_in_dev_mode():
     """Wrong credentials should fail loudly instead of returning mock tokens."""
@@ -57,8 +68,8 @@ async def test_invalid_credentials_propagate_even_in_dev_mode():
 
 
 @pytest.mark.asyncio
-async def test_dev_mode_still_falls_back_on_backend_outage():
-    """Explicit dev mode may still use mock tokens for non-auth backend failures."""
+async def test_dev_mode_does_not_fall_back_on_backend_outage_without_opt_in():
+    """Dev mode alone should not produce mock tokens for backend failures."""
     handler = PasswordAuthHandler()
     credentials = {
         "email": "dev@example.com",
@@ -74,5 +85,167 @@ async def test_dev_mode_still_falls_back_on_backend_outage():
     ):
         token_data = await handler._perform_authentication(credentials)
 
+    assert token_data is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_mock_auth_opt_in_falls_back_on_backend_outage():
+    """Explicit dev mock-auth opt-in may use mock tokens for backend failures."""
+    handler = PasswordAuthHandler()
+    credentials = {
+        "email": "dev@example.com",
+        "password": "password123",  # pragma: allowlist secret
+    }
+
+    with (
+        patch.dict("os.environ", {"TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH": "1"}),
+        patch.object(handler, "_is_dev_mode_enabled", return_value=True),
+        patch(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            new=AsyncMock(side_effect=RuntimeError("backend down")),
+        ),
+    ):
+        token_data = await handler._perform_authentication(credentials)
+
+    assert token_data is not None
     assert token_data["dev_mode"] is True
     assert token_data["user"]["email"] == credentials["email"]
+
+
+@pytest.mark.asyncio
+async def test_password_auth_rejects_private_backend_url_outside_dev():
+    """Production password auth must reject private backend URLs before POSTing."""
+    handler = PasswordAuthHandler()
+    credentials = {
+        "email": "dev@example.com",
+        "password": "password123",  # pragma: allowlist secret
+    }
+
+    with (
+        patch.object(handler, "_is_dev_mode_enabled", return_value=False),
+        patch(
+            "traigent.config.backend_config.BackendConfig.get_cloud_api_url",
+            return_value="http://127.0.0.1:5000/api/v1",
+        ),
+    ):
+        token_data = await handler._perform_authentication(credentials)
+
+    assert token_data is None
+
+
+@pytest.mark.asyncio
+async def test_password_auth_success_uses_validated_backend_url():
+    """Successful backend auth should still execute through the validated URL."""
+    handler = PasswordAuthHandler()
+    credentials = {
+        "email": "dev@example.com",
+        "password": "password123",  # pragma: allowlist secret
+    }
+    captured: dict[str, object] = {}
+
+    class _Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def json(self):
+            return {
+                "success": True,
+                "data": {
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_in": 3600,
+                },
+            }
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def post(self, url, json, headers, timeout):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _Response()
+
+    async def _execute(_self, fn, **_kwargs):
+        return await fn()
+
+    with (
+        patch(
+            "traigent.config.backend_config.BackendConfig.get_cloud_api_url",
+            return_value="https://api.example.com/api/v1",
+        ),
+        patch(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            new=_execute,
+        ),
+        patch(
+            "traigent.cloud.password_auth_handler.aiohttp.ClientSession", new=_Session
+        ),
+    ):
+        token_data = await handler._perform_authentication(credentials)
+
+    assert token_data is not None
+    assert token_data["access_token"] == "access-token"
+    assert captured["url"] == "https://api.example.com/api/v1/auth/login"
+
+
+@pytest.mark.asyncio
+async def test_password_auth_backend_error_redacts_response_body():
+    """Backend error bodies should not be returned or logged by the handler."""
+    handler = PasswordAuthHandler()
+    credentials = {
+        "email": "dev@example.com",
+        "password": "password123",  # pragma: allowlist secret
+    }
+
+    class _Response:
+        status = 500
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def text(self):
+            return "upstream leaked token=secret-value"
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def post(self, *_args, **_kwargs):
+            return _Response()
+
+    async def _execute(_self, fn, **_kwargs):
+        return await fn()
+
+    with (
+        patch(
+            "traigent.config.backend_config.BackendConfig.get_cloud_api_url",
+            return_value="https://api.example.com/api/v1",
+        ),
+        patch(
+            "traigent.cloud.resilient_client.ResilientClient.execute_with_retry",
+            new=_execute,
+        ),
+        patch(
+            "traigent.cloud.password_auth_handler.aiohttp.ClientSession", new=_Session
+        ),
+    ):
+        token_data = await handler._perform_authentication(credentials)
+
+    assert token_data is None

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -9,7 +9,6 @@ secure token management, and resilient HTTP client integration.
 from __future__ import annotations
 
 import asyncio
-import base64
 import hashlib
 import hmac
 import inspect
@@ -31,8 +30,8 @@ from traigent.cloud.api_key_manager import APIKeyManager
 from traigent.cloud.credential_resolver import CredentialResolver
 from traigent.cloud.password_auth_handler import PasswordAuthHandler
 from traigent.cloud.token_manager import TokenManager
-from traigent.core.constants import MAX_RETRIES
 from traigent.utils.exceptions import AuthenticationError as TraigentAuthenticationError
+from traigent.utils.url_security import UnsafeUrlError, validate_outbound_url
 
 logger = logging.getLogger(__name__)
 
@@ -1578,7 +1577,17 @@ class AuthManager:
         if not AIOHTTP_AVAILABLE:
             raise RuntimeError("aiohttp not available for OAuth2 flow") from None
 
-        token_url = f"{self.config.cloud_base_url}/oauth/token"
+        try:
+            cloud_base_url = validate_outbound_url(
+                self.config.cloud_base_url,
+                purpose="OAuth2 cloud_base_url",
+                allow_private_hosts=False,
+            )
+        except UnsafeUrlError as exc:
+            logger.warning("Rejected unsafe OAuth2 cloud_base_url: %s", exc)
+            raise RuntimeError("OAuth2 cloud_base_url is not allowed") from None
+
+        token_url = f"{cloud_base_url}/oauth/token"
 
         data = {
             "grant_type": "client_credentials",
@@ -1595,11 +1604,8 @@ class AuthManager:
             async with session.post(token_url, data=data) as response:
                 if response.status == 200:
                     return cast(dict[str, Any], await response.json())
-                else:
-                    error_text = await response.text()
-                    raise RuntimeError(
-                        f"OAuth2 flow failed: {response.status} {error_text}"
-                    )
+                await response.text()  # drain body; do not propagate upstream content
+                raise RuntimeError(f"OAuth2 flow failed with HTTP {response.status}")
 
     async def _refresh_token(self) -> AuthResult:
         """Refresh authentication token.
@@ -1689,91 +1695,8 @@ class AuthManager:
     async def _perform_password_authentication(
         self, credentials: dict[str, str]
     ) -> dict[str, Any] | None:
-        """Perform backend authentication using resilient HTTP client."""
-        if not AIOHTTP_AVAILABLE:
-            raise RuntimeError("aiohttp not available for authentication") from None
-
-        from traigent.cloud.resilient_client import ResilientClient
-        from traigent.config.backend_config import BackendConfig
-
-        backend_api_url = BackendConfig.build_api_base(
-            self.config.backend_base_url or BackendConfig.get_cloud_backend_url()
-        )
-        login_url = f"{backend_api_url}/auth/login"
-
-        client = ResilientClient(
-            max_retries=MAX_RETRIES,
-            base_delay=1.0,
-            max_delay=10.0,
-            jitter_factor=0.1,
-        )
-
-        async def perform_login():
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=30)
-            ) as session:
-                async with session.post(
-                    login_url,
-                    json={
-                        "email": credentials["email"],
-                        "password": credentials["password"],
-                    },
-                    headers={"Content-Type": "application/json"},
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as response:
-                    if response.status == 401:
-                        raise InvalidCredentialsError("Invalid credentials")
-                    if response.status == 429:
-                        error_msg = await response.text()
-                        raise Exception(f"429 Rate Limited: {error_msg}")
-                    if response.status != 200:
-                        error_text = await response.text()
-                        raise Exception(f"{response.status}: {error_text}")
-
-                    data = await response.json()
-                    if not data.get("success"):
-                        raise ValueError(data.get("error", "Authentication failed"))
-
-                    token_data = data.get("data", {})
-                    access_token = token_data.get("access_token", "")
-                    expires_in = token_data.get("expires_in", 3600)
-
-                    if access_token and "." in access_token:
-                        try:
-                            parts = access_token.split(".")
-                            if len(parts) >= 2:
-                                payload = parts[1] + "=" * (4 - len(parts[1]) % 4)
-                                decoded = base64.urlsafe_b64decode(payload)
-                                jwt_data = json.loads(decoded)
-                                if "exp" in jwt_data:
-                                    expires_in = max(0, jwt_data["exp"] - time.time())
-                        except Exception as exc:
-                            logger.debug(f"Failed to parse JWT expiry: {exc}")
-
-                    token_data["expires_in"] = expires_in
-                    return token_data
-
-        try:
-            return await client.execute_with_retry(
-                perform_login, operation_name="backend_authentication"
-            )
-        except InvalidCredentialsError:
-            if self._is_dev_mode_enabled():
-                logger.warning(
-                    "Dev mode enabled - returning mock tokens despite invalid credentials"
-                )
-                return self._build_dev_token_payload(credentials)
-            raise
-        except Exception as exc:
-            if self._is_dev_mode_enabled():
-                logger.warning(
-                    "Dev mode enabled - using mock tokens because backend login failed: %s",
-                    exc,
-                )
-                return self._build_dev_token_payload(credentials)
-
-            logger.error(f"Authentication error: {exc}")
-            return None
+        """Perform backend authentication via the hardened password handler."""
+        return await self._password_auth_handler._perform_authentication(credentials)
 
     async def _refresh_jwt_token_secure(self, refresh_token_value: str) -> AuthResult:
         """Refresh JWT access token using secure stored refresh token.

--- a/traigent/cloud/password_auth_handler.py
+++ b/traigent/cloud/password_auth_handler.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
 from traigent.core.constants import MAX_RETRIES
+from traigent.utils.url_security import UnsafeUrlError, validate_outbound_url
 
 if TYPE_CHECKING:
     from traigent.cloud.auth import AuthResult
@@ -210,6 +211,17 @@ class PasswordAuthHandler:
 
         return False
 
+    def _is_mock_auth_fallback_enabled(self) -> bool:
+        """Return True only for explicit development mock-auth fallback."""
+        if not self._is_dev_mode_enabled():
+            return False
+        return os.getenv("TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
     async def _perform_authentication(
         self, credentials: dict[str, str]
     ) -> dict[str, Any] | None:
@@ -222,7 +234,18 @@ class PasswordAuthHandler:
         from traigent.cloud.resilient_client import ResilientClient
         from traigent.config.backend_config import BackendConfig
 
-        backend_api_url = BackendConfig.get_cloud_api_url()
+        try:
+            backend_api_url = validate_outbound_url(
+                BackendConfig.get_cloud_api_url(),
+                purpose="password authentication backend_url",
+                allow_private_hosts=self._is_dev_mode_enabled(),
+            )
+        except UnsafeUrlError as exc:
+            logger.warning(
+                "Rejected unsafe password authentication backend_url: %s", exc
+            )
+            return None
+
         login_url = f"{backend_api_url}/auth/login"
 
         client = ResilientClient(
@@ -246,15 +269,17 @@ class PasswordAuthHandler:
                     if response.status == 401:
                         raise InvalidCredentialsError("Invalid credentials")
                     if response.status == 429:
-                        error_msg = await response.text()
-                        raise Exception(f"429 Rate Limited: {error_msg}")
+                        await response.text()
+                        raise RuntimeError("Backend authentication rate limited")
                     if response.status != 200:
-                        error_text = await response.text()
-                        raise Exception(f"{response.status}: {error_text}")
+                        await response.text()
+                        raise RuntimeError(
+                            f"Backend authentication failed with HTTP {response.status}"
+                        )
 
                     data = await response.json()
                     if not data.get("success"):
-                        raise ValueError(data.get("error", "Authentication failed"))
+                        raise ValueError("Authentication failed")
 
                     token_data = data.get("data", {})
                     access_token = token_data.get("access_token", "")
@@ -282,14 +307,14 @@ class PasswordAuthHandler:
         except InvalidCredentialsError:
             raise
         except Exception as exc:
-            if self._is_dev_mode_enabled():
+            if self._is_mock_auth_fallback_enabled():
                 logger.warning(
-                    "Dev mode enabled - using mock tokens because backend login failed: %s",
-                    exc,
+                    "Explicit mock password auth enabled - using mock tokens because backend login failed: %s",
+                    type(exc).__name__,
                 )
                 return self._build_dev_token_payload(credentials)
 
-            logger.error(f"Authentication error: {exc}")
+            logger.error("Authentication error: %s", type(exc).__name__)
             return None
 
     def _build_dev_token_payload(


### PR DESCRIPTION
## Summary
- validate OAuth/password auth outbound URLs before sending credentials
- stop raw upstream auth/OAuth response bodies from being returned in exceptions
- require explicit `TRAIGENT_ALLOW_MOCK_PASSWORD_AUTH` opt-in before password auth returns mock dev tokens

## Notes
- `main` already had the CI approval fail-closed behavior and token-manager URL hardening, so this is a smaller main-specific backport than #973.

## Verification
- `uv run --extra dev ruff format --check traigent/cloud/auth.py traigent/cloud/password_auth_handler.py tests/unit/cloud/test_authentication_security.py tests/unit/cloud/test_password_auth_handler.py`
- `uv run --extra dev ruff check traigent/cloud/auth.py traigent/cloud/password_auth_handler.py tests/unit/cloud/test_authentication_security.py tests/unit/cloud/test_password_auth_handler.py`
- `pytest -o addopts='' tests/unit/cloud/test_token_manager.py tests/unit/core/test_ci_approval.py tests/unit/cloud/test_password_auth_handler.py tests/unit/cloud/test_authentication_security.py tests/unit/utils/test_url_security.py -q`
- commit hook passed isort, black, ruff, detect-secrets, bandit, mypy, and project guardrails

Refs Traigent/Traigent#846
Companion develop PR: #973
