### PR TITLE
ci: add concurrency cancel-in-progress to install-smoke + publish

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -17,6 +17,13 @@ on:
       - ".github/workflows/install-smoke.yml"
   workflow_dispatch:
 
+# Cancel in-flight runs when a new commit lands on the same ref.
+# Pattern matches existing concurrency blocks in
+# validation-spine-pr.yml, release-review.yml, sonarcloud.yml.
+concurrency:
+  group: install-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,14 @@ on:
         default: false
         type: boolean
 
+# Cancel in-flight runs when a new commit lands on the same ref.
+# Mostly defensive: this workflow fires on tag pushes which are rare,
+# but back-to-back retags or workflow_dispatch invocations shouldn't
+# stack.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Mirrors [TraigentBackend#457](https://github.com/Traigent/TraigentBackend/pull/457) and the equivalent TraigentFrontend PR. Adds the existing `concurrency: { group, cancel-in-progress: true }` pattern (already used in `validation-spine-pr.yml`, `release-review.yml`, `sonarcloud.yml`) to the 2 workflows that fire automatically and don't already have it.

## Workflows patched

| Workflow | Trigger | Concurrency before / after |
|----------|---------|----------------------------|
| `install-smoke.yml` | push + PR to main/develop (path-filtered) | 0 → 1 |
| `publish.yml` | tag push `v*` + manual | 0 → 1 |

## Why this scope is small

The Traigent SDK has 15 workflows but **13 of them are `workflow_dispatch:`-only** (manual fire — no PR/push churn): `architecture-analysis`, `docs-links`, `documentation`, `example-auto-tune` (+ secure variant), `examples-smoke`, `quality`, `release-review`, `sonarcloud`, `tests`, `traigent-ci-gates`, `typed-session-smoke`. Those don't need concurrency because they don't auto-trigger.

The two patched here are the only ones that auto-fire and could stack.

## What's intentionally not in this PR

The high 14-day clone count for this repo (~17K clones / 1.1K unique cloners) is **external traffic** (package managers, external CI, researchers cloning the SDK), not internal CI. Concurrency on internal workflows can't help with that. If reducing external clone traffic matters, that's a separate conversation (cache headers, CDN, release-tarball strategy).

## Diff size

15 lines added across 2 files, 0 lines removed.

## PR checklist

1. **Worst-case prod path** — `publish.yml` cancellation: if back-to-back tag pushes happen, only the latest tag's publish runs. Earlier tag still has its commit on the branch but no published artifact for that exact tag. Mitigation: workflow_dispatch is still available to manually re-trigger.
2. **Production-branch test** — n/a (workflow config only).
3. **Contract regeneration** — none.
4. **Public surface delta** — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)