### PR TITLE
ci: pin artifact retention windows

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -112,6 +112,7 @@ jobs:
         name: diagnostic-report-${{ matrix.python-version }}
         path: traigent_diagnostic_report.json
 
+        retention-days: 30
   quick-validation:
     name: Quick Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -111,8 +111,8 @@ jobs:
       with:
         name: diagnostic-report-${{ matrix.python-version }}
         path: traigent_diagnostic_report.json
-
         retention-days: 30
+
   quick-validation:
     name: Quick Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -143,6 +143,7 @@ jobs:
         path: |
           bandit-report.json
           safety-report.json
+        retention-days: 30
 
   documentation-quality:
     runs-on: ubuntu-latest
@@ -267,3 +268,4 @@ jobs:
         name: dependency-reports
         path: |
           pip-audit-report.json
+        retention-days: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,8 +120,8 @@ jobs:
         path: |
           safety-report.json
           bandit-report.json
-
         retention-days: 30
+
   build-test:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,7 @@ jobs:
           safety-report.json
           bandit-report.json
 
+        retention-days: 30
   build-test:
     runs-on: ubuntu-latest
     needs: test
@@ -156,3 +157,4 @@ jobs:
       with:
         name: dist-packages
         path: dist/
+        retention-days: 30

--- a/.github/workflows/traigent-ci-gates.yml
+++ b/.github/workflows/traigent-ci-gates.yml
@@ -157,6 +157,7 @@ jobs:
             work/results-ci/
             work/examples/integrations/ci-cd/math-qa/saved_config.json
 
+          retention-days: 30
       - name: Comment on PR
         if: failure()
         continue-on-error: true  # Don't fail the workflow if PR comment fails (permissions issue on forks)


### PR DESCRIPTION
## Summary
- add explicit retention-days to upload-artifact steps that were using GitHub's default retention
- keep the validation-spine PR artifacts on their existing 14-day policy
- avoid surprise artifact-storage growth as validation snapshots become more frequent

## Validation
- parsed changed workflow YAML with PyYAML
- audited all upload-artifact blocks for explicit retention-days