### PR TITLE
[codex] fix examples onboarding mock mode

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -137,6 +137,10 @@ jobs:
         python examples/quickstart/01_simple_qa.py || true
         echo "Quick validation passed"
 
+    - name: Run bare simple-prompt tutorial
+      run: |
+        python examples/core/simple-prompt/run.py
+
   lint-check:
     runs-on: ubuntu-latest
 

--- a/docs/examples/LEARNING_ROADMAP.md
+++ b/docs/examples/LEARNING_ROADMAP.md
@@ -8,7 +8,7 @@ A concise path from first run to production-ready evaluations.
 - Researcher (3-4 hours): advanced playbooks, metrics, RAG evaluation.
 
 ## Week 1: Foundations (beginner)
-1. Sanity check: `TRAIGENT_MOCK_LLM=true python examples/core/simple-prompt/run.py`
+1. Sanity check: `python examples/core/simple-prompt/run.py`
 2. RAG toggle: `TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py`
 3. Few-shot prompts: `TRAIGENT_MOCK_LLM=true python examples/core/few-shot-classification/run.py`
 4. Trade-offs: `TRAIGENT_MOCK_LLM=true python examples/core/multi-objective-tradeoff/run_anthropic.py`

--- a/docs/examples/QUICK_REFERENCE.md
+++ b/docs/examples/QUICK_REFERENCE.md
@@ -7,8 +7,7 @@ Everything you need to run and adapt examples quickly.
 # Install from repo root (includes example deps)
 pip install -e ".[examples]"
 
-# Mock mode (no keys)
-export TRAIGENT_MOCK_LLM=true
+# Auto-mocks when ANTHROPIC_API_KEY is unset
 python examples/core/simple-prompt/run.py
 
 # With real LLMs

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -37,7 +37,7 @@ examples/
 ## Core examples at a glance
 | Example | Optimizes | Run (mock mode) |
 | --- | --- | --- |
-| simple-prompt | Model, temperature, prompt style | `TRAIGENT_MOCK_LLM=true python examples/core/simple-prompt/run.py` |
+| simple-prompt | Model, temperature, prompt style | `python examples/core/simple-prompt/run.py` |
 | rag-optimization | RAG toggle, model, top_k | `TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py` |
 | few-shot-classification | Example count/strategy | `TRAIGENT_MOCK_LLM=true python examples/core/few-shot-classification/run.py` |
 | multi-objective-tradeoff | Accuracy, cost, latency | `TRAIGENT_MOCK_LLM=true python examples/core/multi-objective-tradeoff/run_anthropic.py` |
@@ -58,8 +58,7 @@ pip install -e ".[examples]"
 python -m http.server 8000
 # Open http://localhost:8000/examples/
 
-# Mock mode (recommended)
-export TRAIGENT_MOCK_LLM=true
+# Auto-mocks when ANTHROPIC_API_KEY is unset
 python examples/core/simple-prompt/run.py
 
 # Real APIs (set keys you need)

--- a/docs/examples/START_HERE.md
+++ b/docs/examples/START_HERE.md
@@ -3,7 +3,7 @@
 Pick an example in under a minute.
 
 ## Quick picks
-- 2 min: `TRAIGENT_MOCK_LLM=true python examples/core/simple-prompt/run.py`
+- 2 min: `python examples/core/simple-prompt/run.py`
 - 5 min: `TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py`
 - 8 min: `TRAIGENT_MOCK_LLM=true python examples/core/few-shot-classification/run.py`
 - 10 min: `TRAIGENT_MOCK_LLM=true python examples/core/multi-objective-tradeoff/run_anthropic.py`
@@ -64,7 +64,6 @@ examples/
 ```bash
 cd /path/to/Traigent
 pip install -e ".[examples]"
-export TRAIGENT_MOCK_LLM=true
 python examples/core/simple-prompt/run.py
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -254,8 +254,7 @@ cd Traigent
 # Install Traigent
 pip install -e .
 
-# Run any example in mock mode (no API keys)
-export TRAIGENT_MOCK_LLM=true
+# Run the first example. It auto-mocks when ANTHROPIC_API_KEY is unset.
 python examples/core/simple-prompt/run.py
 ```
 
@@ -409,7 +408,6 @@ See our [Contributing Guide](../CONTRIBUTING.md) for more details.
 **Ready to get started?** Run your first example:
 
 ```bash
-export TRAIGENT_MOCK_LLM=true
 python examples/core/simple-prompt/run.py
 ```
 

--- a/examples/core/simple-prompt/README.md
+++ b/examples/core/simple-prompt/README.md
@@ -20,8 +20,7 @@ We want to summarize short text snippets. We are optimizing:
 ## Quick Start
 
 ```bash
-# Run in mock mode (no API key needed)
-export TRAIGENT_MOCK_LLM=true
+# Runs in local mock mode automatically when ANTHROPIC_API_KEY is unset.
 python examples/core/simple-prompt/run.py
 ```
 

--- a/examples/core/simple-prompt/index.html
+++ b/examples/core/simple-prompt/index.html
@@ -30,8 +30,7 @@
                     </div>
                     <aside class="hero-panel">
                         <div class="hero-panel-label">Quick Start</div>
-                        <pre class="hero-code"><code># Run in mock mode (no API key needed)
-export TRAIGENT_MOCK_LLM=true
+                        <pre class="hero-code"><code># Auto-mocks when ANTHROPIC_API_KEY is unset
 python examples/core/simple-prompt/run.py</code></pre>
                     </aside>
                 </section>
@@ -59,8 +58,7 @@ python examples/core/simple-prompt/run.py</code></pre>
                         <h2>Quick Start</h2>
                     </header>
                     <div class="detail-section-body">
-                        <pre class="detail-code"><code class="language-bash"># Run in mock mode (no API key needed)
-export TRAIGENT_MOCK_LLM=true
+                        <pre class="detail-code"><code class="language-bash"># Auto-mocks when ANTHROPIC_API_KEY is unset
 python examples/core/simple-prompt/run.py</code></pre>
                     </div>
                 </section><section class="detail-section" id="simple-prompt-expected-output">

--- a/examples/core/simple-prompt/run.py
+++ b/examples/core/simple-prompt/run.py
@@ -14,23 +14,34 @@ import sys
 from pathlib import Path
 
 os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
-
-
-def _prepare_mock_paths(base: Path) -> None:
-    """
-    Use a writable local directory for mock runs to avoid permission issues.
-    """
-    results_dir = base / ".traigent_local"
-    os.environ.setdefault("HOME", str(base))
-    results_dir.mkdir(parents=True, exist_ok=True)
-    os.environ.setdefault("TRAIGENT_RESULTS_FOLDER", str(results_dir))
-
-
-# --- Setup for local development/testing ---
-MOCK = str(os.getenv("TRAIGENT_MOCK_LLM", "")).lower() in {"1", "true", "yes", "y"}
 BASE = Path(__file__).parent
-if MOCK:
-    _prepare_mock_paths(BASE)
+MODULE_PATH = Path(__file__).resolve()
+
+
+def _env_flag(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+_mock_env_flag = _env_flag(os.environ.get("TRAIGENT_MOCK_LLM"))
+if _mock_env_flag is True or (
+    _mock_env_flag is not False and not os.environ.get("ANTHROPIC_API_KEY", "").strip()
+):
+    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+_sdk_path = os.environ.get("TRAIGENT_SDK_PATH")
+if _sdk_path:
+    sys.path.insert(0, _sdk_path)
+else:
+    repo_root = MODULE_PATH.parents[3]
+    if (repo_root / "traigent" / "__init__.py").exists():
+        sys.path.insert(0, str(repo_root))
 
 # --- Import Traigent ---
 try:
@@ -38,17 +49,16 @@ try:
 except ImportError:
     import importlib
 
-    _sdk = os.environ.get("TRAIGENT_SDK_PATH")
-    if _sdk:
-        sys.path.insert(0, _sdk)
-    else:
-        module_path = Path(__file__).resolve()
-        for depth in (2, 3):
-            try:
-                sys.path.append(str(module_path.parents[depth]))
-            except IndexError:
-                continue
     traigent = importlib.import_module("traigent")
+
+from traigent.examples.tutorial_bootstrap import configure_tutorial_mock_mode
+
+# --- Setup for local development/testing ---
+MOCK = configure_tutorial_mock_mode(
+    provider_env_keys=("ANTHROPIC_API_KEY",),
+    tutorial_name="Simple Prompt Optimization",
+    results_base=BASE,
+)
 
 # --- Configuration ---
 DATA_ROOT = Path(__file__).resolve().parents[2] / "datasets" / "simple-prompt"
@@ -104,6 +114,32 @@ def _mock_summarize_text(text: str) -> str:
     return "Summary of input text."
 
 
+def _print_results_summary(result) -> None:
+    rows = []
+    for trial in result.trials:
+        metrics = trial.metrics or {}
+        rows.append(
+            [
+                str(trial.config.get("model", "")),
+                str(trial.config.get("temperature", "")),
+                str(trial.config.get("prompt_style", "")),
+                f"{float(metrics.get('accuracy', 0.0)):.3f}",
+                f"{float(metrics.get('cost', 0.0)):.6f}",
+            ]
+        )
+
+    headers = ["model", "temperature", "prompt_style", "accuracy", "cost"]
+    widths = []
+    for index, header in enumerate(headers):
+        widths.append(max([len(header), *(len(row[index]) for row in rows)]))
+
+    print("\nResults Summary:")
+    print(" | ".join(header.ljust(widths[index]) for index, header in enumerate(headers)))
+    print("-+-".join("-" * width for width in widths))
+    for row in rows:
+        print(" | ".join(value.ljust(widths[index]) for index, value in enumerate(row)))
+
+
 @traigent.optimize(
     # 1. The dataset to evaluate against
     eval_dataset=DATASET,
@@ -150,7 +186,10 @@ def summarize_text(text: str) -> str:
     from langchain_core.messages import HumanMessage
 
     if not os.getenv("ANTHROPIC_API_KEY"):
-        raise ValueError("Please set ANTHROPIC_API_KEY or use TRAIGENT_MOCK_LLM=true")
+        raise ValueError(
+            "Please set ANTHROPIC_API_KEY or use TRAIGENT_MOCK_LLM=true. "
+            "For the no-key tutorial path, leave TRAIGENT_MOCK_LLM unset."
+        )
 
     prompt = f"Please summarize the following text. Style: {style}.\n\nText: {text}"
 
@@ -173,14 +212,7 @@ if __name__ == "__main__":
                 print(f"Best Score: {result.best_score}")
                 print(f"Best Configuration: {result.best_config}")
 
-                # Show a summary table
-                df = result.to_aggregated_dataframe()
-                print("\nResults Summary:")
-                print(
-                    df[
-                        ["model", "temperature", "prompt_style", "accuracy", "cost"]
-                    ].to_string(index=False)
-                )
+                _print_results_summary(result)
             except Exception as e:
                 import traceback
 

--- a/examples/gallery/index.html
+++ b/examples/gallery/index.html
@@ -96,7 +96,7 @@
     </ul>
 </div>
             <div class="run-command-row">
-                <span class="run-label">Run:</span><code class="run-command">TRAIGENT_MOCK_LLM=true python examples/core/simple-prompt/run.py</code>
+                <span class="run-label">Run:</span><code class="run-command">python examples/core/simple-prompt/run.py</code>
             </div>
             <a class="example-link" href="../core/simple-prompt/index.html" aria-label="Open primary documentation for Simple Prompt Optimization">View Example</a>
         </article>

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -967,11 +967,13 @@ class TestOptimizedFunction:
             mock_orchestrator = Mock()
             mock_orchestrator_class.return_value = mock_orchestrator
             mock_orchestrator.optimize = AsyncMock(
-                side_effect=OptimizationError("Optimization failed")
+                side_effect=OptimizationError("Provider key missing")
             )
 
-            with pytest.raises(OptimizationError, match="Optimization failed"):
+            with pytest.raises(OptimizationError) as exc_info:
                 await opt_func.optimize(algorithm="random")
+
+            assert str(exc_info.value) == "Provider key missing"
 
     @pytest.mark.asyncio
     async def test_optimize_with_configuration_error(

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -754,8 +754,10 @@ class TestOptimizationOrchestrator:
 
         orchestrator.optimizer.suggest_next_trial = failing_suggest
 
-        with pytest.raises(OptimizationError):
+        with pytest.raises(OptimizationError) as exc_info:
             await orchestrator.optimize(mock_function, sample_dataset)
+
+        assert str(exc_info.value) == "Optimizer failure"
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)

--- a/tests/unit/examples/test_tutorial_bootstrap.py
+++ b/tests/unit/examples/test_tutorial_bootstrap.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from traigent.examples.tutorial_bootstrap import (
+    configure_tutorial_mock_mode,
+    should_auto_enable_mock_mode,
+)
+from traigent.testing import _reset_for_tests, is_mock_mode_enabled
+
+
+@pytest.fixture(autouse=True)
+def reset_mock_mode() -> None:
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def test_auto_enables_mock_mode_when_provider_key_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    env: dict[str, str] = {}
+
+    enabled = configure_tutorial_mock_mode(
+        provider_env_keys=("ANTHROPIC_API_KEY",),
+        tutorial_name="Simple Prompt Optimization",
+        results_base=tmp_path,
+        env=env,
+    )
+
+    assert enabled is True
+    assert is_mock_mode_enabled() is True
+    assert env["TRAIGENT_OFFLINE_MODE"] == "true"
+    assert env["HOME"] == str(tmp_path)
+    assert env["TRAIGENT_RESULTS_FOLDER"] == str(tmp_path / ".traigent_local")
+    assert "TRAIGENT_MOCK_LLM" not in env
+    assert "local mock mode" in capsys.readouterr().err
+
+
+def test_mock_tutorial_defaults_offline_even_with_portal_key() -> None:
+    env = {"TRAIGENT_API_KEY": "test-traigent-key"}  # pragma: allowlist secret
+
+    enabled = configure_tutorial_mock_mode(
+        provider_env_keys=("ANTHROPIC_API_KEY",),
+        tutorial_name="Simple Prompt Optimization",
+        env=env,
+    )
+
+    assert enabled is True
+    assert env["TRAIGENT_OFFLINE_MODE"] == "true"
+    assert "TRAIGENT_API_KEY" not in env
+
+
+def test_explicit_offline_false_allows_mock_tutorial_sync() -> None:
+    env = {
+        "TRAIGENT_API_KEY": "test-traigent-key",  # pragma: allowlist secret
+        "TRAIGENT_OFFLINE_MODE": "false",
+    }
+
+    enabled = configure_tutorial_mock_mode(
+        provider_env_keys=("ANTHROPIC_API_KEY",),
+        tutorial_name="Simple Prompt Optimization",
+        env=env,
+    )
+
+    assert enabled is True
+    assert env["TRAIGENT_OFFLINE_MODE"] == "false"
+
+
+def test_provider_key_keeps_real_mode() -> None:
+    env = {"ANTHROPIC_API_KEY": "test-anthropic-key"}  # pragma: allowlist secret
+
+    enabled = configure_tutorial_mock_mode(
+        provider_env_keys=("ANTHROPIC_API_KEY",),
+        tutorial_name="Simple Prompt Optimization",
+        env=env,
+    )
+
+    assert enabled is False
+    assert is_mock_mode_enabled() is False
+    assert "TRAIGENT_OFFLINE_MODE" not in env
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+def test_explicit_mock_false_is_respected(value: str) -> None:
+    env = {"TRAIGENT_MOCK_LLM": value}
+
+    assert should_auto_enable_mock_mode(("ANTHROPIC_API_KEY",), env=env) is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on"])
+def test_explicit_mock_true_is_respected_even_with_provider_key(value: str) -> None:
+    env = {
+        "TRAIGENT_MOCK_LLM": value,
+        "ANTHROPIC_API_KEY": "test-anthropic-key",  # pragma: allowlist secret
+    }
+
+    assert should_auto_enable_mock_mode(("ANTHROPIC_API_KEY",), env=env) is True
+
+
+def test_production_guard_still_blocks_auto_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    with pytest.raises(RuntimeError, match="ENVIRONMENT=production"):
+        configure_tutorial_mock_mode(
+            provider_env_keys=("ANTHROPIC_API_KEY",),
+            tutorial_name="Simple Prompt Optimization",
+            env={},
+        )

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1843,6 +1843,8 @@ class OptimizedFunction:
                 effective_config_space=effective_config_space,
                 save_to=save_to,
             )
+        except OptimizationError:
+            raise
         except Exception as e:
             logger.error(f"Optimization failed: {e}")
             raise OptimizationError(f"Optimization failed: {e}") from e

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2263,6 +2263,9 @@ class OptimizationOrchestrator:
             await self._finalize_optimization(result, session_id, session_span)
             return result
 
+        except OptimizationError:
+            self._status = OptimizationStatus.FAILED
+            raise
         except Exception as e:
             self._status = OptimizationStatus.FAILED
             logger.error(f"Optimization {self._optimization_id} failed: {e}")

--- a/traigent/examples/tutorial_bootstrap.py
+++ b/traigent/examples/tutorial_bootstrap.py
@@ -1,0 +1,83 @@
+"""Bootstrap helpers for bundled tutorial examples.
+
+These helpers are intentionally scoped to examples shipped with the repo.
+The SDK should not silently turn arbitrary user code into a mock run just
+because a provider key is missing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import MutableMapping, Sequence
+from pathlib import Path
+
+from traigent.testing import enable_mock_mode_for_quickstart
+
+_FALSEY = {"0", "false", "no", "off"}
+_TRUTHY = {"1", "true", "yes", "on"}
+_PORTAL_SIGNUP_URL = "https://app.traigent.ai"
+
+
+def _normalized_env_flag(value: str | None) -> bool | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSEY:
+        return False
+    return None
+
+
+def should_auto_enable_mock_mode(
+    provider_env_keys: Sequence[str],
+    *,
+    env: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Return whether a bundled tutorial should run with mocked LLM calls."""
+    active_env = os.environ if env is None else env
+    explicit_mock_mode = _normalized_env_flag(active_env.get("TRAIGENT_MOCK_LLM"))
+    if explicit_mock_mode is not None:
+        return explicit_mock_mode
+
+    return not any(active_env.get(key, "").strip() for key in provider_env_keys)
+
+
+def configure_tutorial_mock_mode(
+    *,
+    provider_env_keys: Sequence[str],
+    tutorial_name: str,
+    results_base: Path | None = None,
+    env: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Enable safe mock/offline defaults for bundled tutorial code.
+
+    Returns ``True`` when mock mode is active for this tutorial. If a user
+    explicitly sets ``TRAIGENT_MOCK_LLM=false``, this helper leaves real-provider
+    execution alone so missing API keys still fail loudly.
+    """
+    active_env = os.environ if env is None else env
+    if not should_auto_enable_mock_mode(provider_env_keys, env=active_env):
+        return False
+
+    enable_mock_mode_for_quickstart()
+
+    if results_base is not None:
+        results_dir = results_base / ".traigent_local"
+        active_env.setdefault("HOME", str(results_base))
+        results_dir.mkdir(parents=True, exist_ok=True)
+        active_env.setdefault("TRAIGENT_RESULTS_FOLDER", str(results_dir))
+
+    offline_mode = _normalized_env_flag(active_env.get("TRAIGENT_OFFLINE_MODE"))
+    if offline_mode is not False:
+        print(
+            f"[traigent] {tutorial_name} is running in local mock mode. "
+            "Set TRAIGENT_OFFLINE_MODE=false and TRAIGENT_API_KEY "
+            f"(get one at {_PORTAL_SIGNUP_URL}) to sync results to the portal.",
+            file=sys.stderr,
+        )
+        active_env["TRAIGENT_OFFLINE_MODE"] = "true"
+        active_env.pop("TRAIGENT_API_KEY", None)
+
+    return True


### PR DESCRIPTION
## Summary
- Add a reusable tutorial bootstrap helper that enables mock/offline mode only for bundled examples, not arbitrary SDK user code.
- Wire `examples/core/simple-prompt/run.py` so the catalog Hello World runs bare when `ANTHROPIC_API_KEY` is unset, avoids backend auth noise by default, and no longer requires pandas just to print results.
- Preserve existing `OptimizationError` instances in the orchestrator/optimized-function layers so errors no longer render as `Optimization failed: Optimization failed: ...`.
- Update simple-prompt docs/gallery commands and add a PR quick-validation step for the bare tutorial command.

## Why
The first developer journey had one sharp papercut: the packaged quickstart auto-mocked correctly, while the catalog Hello World required `TRAIGENT_MOCK_LLM=true` or crashed on missing Anthropic credentials. This keeps the safe auto-mock behavior scoped to tutorial code while preserving fail-loud behavior for real user applications.

## Validation
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m ruff check traigent/examples/tutorial_bootstrap.py examples/core/simple-prompt/run.py tests/unit/examples/test_tutorial_bootstrap.py tests/unit/core/test_optimized_function.py tests/unit/core/test_orchestrator.py`
- `python3 -m pytest -o addopts='' tests/unit/examples/test_tutorial_bootstrap.py tests/unit/examples/test_quickstart_entry.py tests/unit/core/test_optimized_function.py::TestOptimizedFunction::test_optimize_with_optimization_error tests/unit/core/test_orchestrator.py::TestOptimizationOrchestrator::test_optimize_optimizer_exception -q`
- `env -u TRAIGENT_MOCK_LLM -u TRAIGENT_OFFLINE_MODE -u TRAIGENT_API_KEY -u ANTHROPIC_API_KEY python3 examples/core/simple-prompt/run.py`
- Commit hooks passed: isort, black, ruff, detect-secrets, yaml checks, bandit, mypy, strict cost guardrails.

Note: the push hook attempted a SonarQube scan but skipped because `sonar-scanner` is not installed locally.