### PR TITLE
[codex] fix JWT refresh-token fallback

### DIFF
--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -379,6 +379,138 @@ class TestCliAuthPayload:
         # Verify result
         assert result["api_key"] == "tg_created_key"  # pragma: allowlist secret
 
+    @pytest.mark.asyncio
+    async def test_key_creation_failure_does_not_reuse_access_token_as_refresh_token(
+        self,
+    ):
+        """JWT fallback must not persist an access token under refresh_token."""
+        from traigent.cli.auth_commands import TraigentAuthCLI
+
+        login_response = AsyncMock()
+        login_response.status = 200
+        login_response.text = AsyncMock(
+            return_value=json.dumps(
+                {"success": True, "data": {"access_token": "fake_jwt"}}
+            )
+        )
+        login_response.headers = {}
+
+        key_response = AsyncMock()
+        key_response.status = 500
+        key_response.text = AsyncMock(return_value=json.dumps({"error": "down"}))
+        key_response.headers = {}
+
+        class FakeCtxManager:
+            def __init__(self, resp):
+                self.resp = resp
+
+            async def __aenter__(self):
+                return self.resp
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeSession:
+            def __init__(self):
+                self._call_idx = 0
+
+            def post(self, _url, **_kwargs):
+                resp = login_response if self._call_idx == 0 else key_response
+                self._call_idx += 1
+                return FakeCtxManager(resp)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_TENANT_ID": "tenant_acme"},
+                clear=True,
+            ),
+            patch("aiohttp.ClientSession", return_value=FakeSession()),
+        ):
+            cli = object.__new__(TraigentAuthCLI)
+            cli.backend_api_url = "http://test/api/v1"
+            cli.backend_url = "http://test"
+            result = await cli._authenticate_with_backend("a@b.com", "pass123")
+
+        assert result["jwt_token"] == "fake_jwt"
+        assert result["api_key"] is None
+        assert "refresh_token" not in result
+
+    @pytest.mark.asyncio
+    async def test_key_creation_preserves_backend_refresh_token(self):
+        """A real backend refresh token should still be persisted."""
+        from traigent.cli.auth_commands import TraigentAuthCLI
+
+        login_response = AsyncMock()
+        login_response.status = 200
+        login_response.text = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "success": True,
+                    "data": {
+                        "access_token": "fake_jwt",
+                        "refresh_token": "real_refresh_token",
+                    },
+                }
+            )
+        )
+        login_response.headers = {}
+
+        key_response = AsyncMock()
+        key_response.status = 201
+        key_response.text = AsyncMock(
+            return_value=json.dumps({"data": {"key": "tg_created_key"}})
+        )
+        key_response.headers = {}
+
+        class FakeCtxManager:
+            def __init__(self, resp):
+                self.resp = resp
+
+            async def __aenter__(self):
+                return self.resp
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeSession:
+            def __init__(self):
+                self._call_idx = 0
+
+            def post(self, _url, **_kwargs):
+                resp = login_response if self._call_idx == 0 else key_response
+                self._call_idx += 1
+                return FakeCtxManager(resp)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_TENANT_ID": "tenant_acme"},
+                clear=True,
+            ),
+            patch("aiohttp.ClientSession", return_value=FakeSession()),
+        ):
+            cli = object.__new__(TraigentAuthCLI)
+            cli.backend_api_url = "http://test/api/v1"
+            cli.backend_url = "http://test"
+            result = await cli._authenticate_with_backend("a@b.com", "pass123")
+
+        assert result["jwt_token"] == "fake_jwt"
+        assert result["refresh_token"] == "real_refresh_token"
+        assert result["api_key"] == "tg_created_key"  # pragma: allowlist secret
+
 
 class TestCliAuthEnvFileGuard:
     """CLI should only write API keys to a local .env file."""
@@ -430,6 +562,6 @@ class TestCentralizedCredentialHints:
         ):
             BackendConfig.get_api_key()
 
-        assert any(SIGNUP_URL in msg for msg in caplog.messages), (
-            f"Expected {SIGNUP_URL!r} in warning messages: {caplog.messages}"
-        )
+        assert any(
+            SIGNUP_URL in msg for msg in caplog.messages
+        ), f"Expected {SIGNUP_URL!r} in warning messages: {caplog.messages}"

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -278,6 +278,7 @@ class TraigentAuthCLI:
 
                 token_data = login_data.get("data", {})
                 jwt_token = token_data.get("access_token")
+                refresh_token = token_data.get("refresh_token")
 
                 if not jwt_token:
                     console.print(BACKEND_RESPONSE_HEADER)
@@ -359,13 +360,16 @@ class TraigentAuthCLI:
         # We'll need to extract it from the initial auth response
         user_info: dict[str, str] = {}
 
-        return {
+        credentials = {
             "jwt_token": jwt_token,
-            "refresh_token": jwt_token,  # Use same token as refresh for now
             "api_key": api_key,
             "user": user_info,
             "backend_url": self.backend_url,
         }
+        if refresh_token:
+            credentials["refresh_token"] = refresh_token
+
+        return credentials
 
     async def _check_stored_api_key(self) -> bool:
         """Check if stored API key is valid.
@@ -636,7 +640,14 @@ class TraigentAuthCLI:
         # Check if token needs refresh
         if creds.get("jwt_token") and not creds.get("api_key"):
             console.print("[yellow]ℹ️  Using JWT token authentication[/yellow]")
-            console.print("JWT tokens expire and need periodic refresh.\n")
+            if creds.get("refresh_token"):
+                console.print("JWT tokens expire and need periodic refresh.\n")
+            else:
+                console.print(
+                    "No refresh token is available. Run "
+                    "[cyan]traigent auth login[/cyan] again before the JWT expires, "
+                    "or create an API key for long-lived authentication.\n"
+                )
 
         return True
 
@@ -708,7 +719,11 @@ class TraigentAuthCLI:
         # Check for refresh token
         if not creds.get("refresh_token"):
             console.print("[red]❌ No refresh token available[/red]")
-            console.print(MSG_RUN_LOGIN_AGAIN)
+            console.print(
+                "This login only stored a short-lived JWT access token. "
+                "Run [cyan]traigent auth login[/cyan] again or create an API key "
+                "for long-lived authentication.\n"
+            )
             return False
 
         try:


### PR DESCRIPTION
## Summary
- Stop storing a JWT access token under `refresh_token` when API-key creation fails during `traigent auth login`.
- Preserve a backend-provided refresh token when one is actually returned.
- Make `auth status` and `auth refresh` explain the JWT-only/no-refresh-token state instead of implying refresh will work.
- Add regression coverage for the fallback path and the real-refresh-token path.

Fixes #910.

## Root Cause
The CLI login flow always wrote `"refresh_token": jwt_token` after receiving an access token. Later refresh flows treated that persisted access token as a refresh token and sent it to `/auth/refresh`.

## Validation
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m ruff check traigent/cli/auth_commands.py tests/unit/config/test_backend_config_stored_creds.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m black --check traigent/cli/auth_commands.py tests/unit/config/test_backend_config_stored_creds.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts='' tests/unit/config/test_backend_config_stored_creds.py::TestCliAuthPayload -q`
- Commit hooks passed: isort, black, ruff, detect-secrets, whitespace, YAML/JSON/TOML checks, merge conflict/private-key checks, bandit, mypy, strict cost guardrails.

Note: the push hook skipped SonarQube because `sonar-scanner` is not installed locally.