### PR TITLE
[codex] sanitize backend bridge metadata

### DIFF
--- a/tests/unit/cloud/test_backend_bridges.py
+++ b/tests/unit/cloud/test_backend_bridges.py
@@ -460,6 +460,61 @@ class TestSDKBackendBridge:
         )
         assert "difficulty:easy" in first_example["tags"]
 
+    def test_convert_dataset_to_examples_filters_sensitive_metadata_tags(
+        self, sdk_bridge
+    ):
+        """Bridge example tags should use the shared backend metadata sanitizer."""
+        dataset = Dataset(
+            examples=[
+                EvaluationExample(
+                    input_data={"query": "safe input"},
+                    expected_output="safe output",
+                    metadata={
+                        "difficulty": "easy",
+                        "api_key": "tg_secret_value",  # pragma: allowlist secret
+                        "password": "super-secret",  # pragma: allowlist secret
+                        "auth token": "jwt-secret",  # pragma: allowlist secret
+                        "unsafe key\x00": "hello,\x01world",
+                        "nested": {"skip": "dict"},
+                    },
+                )
+            ],
+            name="sensitive_metadata_dataset",
+        )
+
+        examples = sdk_bridge._convert_dataset_to_examples(dataset)
+        tags = examples[0]["tags"]
+
+        assert "difficulty:easy" in tags
+        assert "unsafe_key:hello  world" in tags
+        assert not any("api_key" in tag for tag in tags)
+        assert not any("password" in tag for tag in tags)
+        assert not any("token" in tag for tag in tags)
+        assert not any("nested" in tag for tag in tags)
+        assert not any("\x00" in tag or "\x01" in tag or "," in tag for tag in tags)
+
+    def test_optimization_request_metadata_is_filtered_before_backend(
+        self, sdk_bridge, optimization_request
+    ):
+        """Bridge experiment metadata should not forward sensitive raw keys."""
+        optimization_request.metadata = {
+            "experiment type": "trial",
+            "api_key": "tg_secret_value",  # pragma: allowlist secret
+            "password": "super-secret",  # pragma: allowlist secret
+            "authorization": "Bearer secret",  # pragma: allowlist secret
+            "unsafe key\x00": "hello,\x01world",
+            "nested": {"skip": "dict"},
+        }
+
+        backend_request = sdk_bridge.optimization_request_to_backend(
+            optimization_request
+        )
+
+        assert backend_request.metadata == {
+            "experiment_type": "trial",
+            "unsafe_key": "hello  world",
+        }
+
     def test_serialize_input_data(self, sdk_bridge):
         """Test input data serialization."""
         # Test string input

--- a/traigent/cloud/backend_bridges.py
+++ b/traigent/cloud/backend_bridges.py
@@ -14,6 +14,10 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, cast
 
+from traigent.cloud.dataset_converter import (
+    metadata_to_backend_tags,
+    sanitize_backend_metadata,
+)
 from traigent.evaluators.base import Dataset
 from traigent.utils.hashing import generate_benchmark_hash, generate_experiment_hash
 from traigent.utils.logging import get_logger
@@ -159,7 +163,7 @@ class SDKBackendBridge:
             model_parameters_data=model_parameters_data,
             measures=measures,
             experiment_parameters=experiment_parameters,
-            metadata=request.metadata,
+            metadata=sanitize_backend_metadata(request.metadata),
         )
 
     def session_creation_to_backend_run(
@@ -545,9 +549,7 @@ Response:"""
 
                 # Add metadata as tags if available
                 if hasattr(example, "metadata") and example.metadata:
-                    backend_example["tags"] = [
-                        f"{k}:{v}" for k, v in example.metadata.items()
-                    ]
+                    backend_example["tags"] = metadata_to_backend_tags(example.metadata)
 
                 examples.append(backend_example)
 

--- a/traigent/cloud/dataset_converter.py
+++ b/traigent/cloud/dataset_converter.py
@@ -51,6 +51,57 @@ _SENSITIVE_METADATA_KEY_PATTERN = re.compile(
 )
 _TAG_KEY_SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
 _TAG_CONTROL_CHARS_PATTERN = re.compile(r"[\x00-\x1f\x7f]+")
+_METADATA_TAG_VALUE_TYPES = (str, int, float, bool)
+
+
+def is_sensitive_metadata_key(key: str) -> bool:
+    """Return True when metadata should not be exposed to backend surfaces."""
+    normalized = key.strip().lower()
+    return bool(_SENSITIVE_METADATA_KEY_PATTERN.search(normalized))
+
+
+def sanitize_metadata_key(key: str) -> str:
+    """Normalize metadata keys to safe backend keys."""
+    normalized = _TAG_CONTROL_CHARS_PATTERN.sub("", key).strip()
+    normalized = _TAG_KEY_SANITIZE_PATTERN.sub("_", normalized)
+    return normalized.strip("._-")[:64]
+
+
+def sanitize_metadata_value(value: Any) -> str:
+    """Normalize metadata values for backend-safe metadata and tags."""
+    normalized = _TAG_CONTROL_CHARS_PATTERN.sub(" ", str(value))
+    normalized = normalized.replace(",", " ").strip()
+    return normalized[:160]
+
+
+def sanitize_backend_metadata(
+    metadata: dict[str, Any] | None,
+    privacy_mode: bool = False,
+) -> dict[str, str]:
+    """Filter sensitive metadata and normalize keys/values for backend payloads."""
+    if privacy_mode or not metadata:
+        return {}
+
+    sanitized: dict[str, str] = {}
+    for key, value in metadata.items():
+        if not isinstance(value, _METADATA_TAG_VALUE_TYPES):
+            continue
+        if is_sensitive_metadata_key(str(key)):
+            continue
+        safe_key = sanitize_metadata_key(str(key))
+        safe_value = sanitize_metadata_value(value)
+        if safe_key and safe_value:
+            sanitized[safe_key] = safe_value
+    return sanitized
+
+
+def metadata_to_backend_tags(
+    metadata: dict[str, Any] | None,
+    privacy_mode: bool = False,
+) -> list[str]:
+    """Convert metadata to backend tags while filtering sensitive keys."""
+    sanitized = sanitize_backend_metadata(metadata, privacy_mode=privacy_mode)
+    return [f"{key}:{value}" for key, value in sanitized.items()]
 
 
 @dataclass
@@ -186,41 +237,23 @@ class DatasetConverter:
     @staticmethod
     def _is_sensitive_metadata_key(key: str) -> bool:
         """Return True when metadata should not be exposed as backend tags."""
-        normalized = key.strip().lower()
-        return bool(_SENSITIVE_METADATA_KEY_PATTERN.search(normalized))
+        return is_sensitive_metadata_key(key)
 
     @staticmethod
     def _sanitize_tag_key(key: str) -> str:
         """Normalize metadata keys to safe backend tag keys."""
-        normalized = _TAG_CONTROL_CHARS_PATTERN.sub("", key).strip()
-        normalized = _TAG_KEY_SANITIZE_PATTERN.sub("_", normalized)
-        return normalized.strip("._-")[:64]
+        return sanitize_metadata_key(key)
 
     @staticmethod
     def _sanitize_tag_value(value: Any) -> str:
         """Normalize metadata values for CSV/tag-safe backend transport."""
-        normalized = _TAG_CONTROL_CHARS_PATTERN.sub(" ", str(value))
-        normalized = normalized.replace(",", " ").strip()
-        return normalized[:160]
+        return sanitize_metadata_value(value)
 
     def _metadata_to_tags(
         self, metadata: dict[str, Any], privacy_mode: bool = False
     ) -> list[str]:
         """Convert metadata to backend tags while filtering sensitive keys."""
-        if privacy_mode or not metadata:
-            return []
-
-        tags: list[str] = []
-        for key, value in metadata.items():
-            if not isinstance(value, (str, int, float, bool)):
-                continue
-            if self._is_sensitive_metadata_key(str(key)):
-                continue
-            safe_key = self._sanitize_tag_key(str(key))
-            safe_value = self._sanitize_tag_value(value)
-            if safe_key and safe_value:
-                tags.append(f"{safe_key}:{safe_value}")
-        return tags
+        return metadata_to_backend_tags(metadata, privacy_mode=privacy_mode)
 
     # SDK Dataset to Backend Example Set Conversion
 


### PR DESCRIPTION
## Summary
- Share the dataset converter's sensitive-metadata filtering and tag sanitization as backend metadata helpers.
- Sanitize `OptimizationRequest.metadata` before constructing backend experiment requests.
- Convert bridge example metadata to backend tags through the same sensitive-key filter and key/value sanitizer.
- Add bridge-level tests covering `api_key`, `password`, `token`/`authorization`, nested metadata, commas, and control characters.

Fixes #901.

## Root Cause
`SDKBackendBridge` bypassed `dataset_converter`'s protected metadata path: request metadata was copied directly, and example metadata was converted with raw `f"{key}:{value}"` tags.

## Validation
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m ruff check traigent/cloud/backend_bridges.py traigent/cloud/dataset_converter.py tests/unit/cloud/test_backend_bridges.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m black --check traigent/cloud/backend_bridges.py traigent/cloud/dataset_converter.py tests/unit/cloud/test_backend_bridges.py`
- `/home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python -m pytest -o addopts='' tests/unit/cloud/test_backend_bridges.py -q`
- Commit hooks passed: isort, black, ruff, detect-secrets, whitespace, YAML/JSON/TOML checks, merge conflict/private-key checks, bandit, mypy, strict cost guardrails.

Note: the push hook skipped SonarQube because `sonar-scanner` is not installed locally.