### PR TITLE
fix(optimizers): RemoteOptimizer fails closed without a remote_client (closes #872)

### DIFF
--- a/tests/unit/optimizers/test_remote_optimizer.py
+++ b/tests/unit/optimizers/test_remote_optimizer.py
@@ -2,13 +2,48 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
+from traigent.optimizers.registry import get_optimizer, list_optimizers
 from traigent.optimizers.remote import MockRemoteSuggestionClient, RemoteOptimizer
+from traigent.utils.exceptions import OptimizationError
 
 
-def test_remote_optimizer_fallback_sync():
-    opt = RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=False)
-    cfg = opt.suggest_next_trial([])
-    assert cfg in [{"x": 1}, {"x": 2}]
+def test_remote_optimizer_fail_loud_without_client_and_without_remote_enabled():
+    """Issue #872 regression: constructing without a remote_client used to
+    silently fall back to local random search, masquerading as 'remote'.
+    The construction now MUST fail loud with a migration message instead.
+    """
+    with pytest.raises(OptimizationError) as exc_info:
+        RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=False)
+    msg = str(exc_info.value)
+    assert "remote_client" in msg
+    assert "algorithm='random'" in msg
+    assert "execution_mode='hybrid'" in msg
+
+
+def test_remote_optimizer_fail_loud_with_remote_enabled_but_no_client():
+    """remote_enabled=True without a client is still invalid — same gate."""
+    with pytest.raises(OptimizationError) as exc_info:
+        RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=True)
+    assert "remote_client" in str(exc_info.value)
+
+
+def test_remote_still_registered_so_users_get_a_clear_error_not_keyerror():
+    """We keep "remote" in the registry so users who pass algorithm='remote'
+    receive the OptimizationError migration message via construction, not
+    a confusing KeyError from a missing registry entry.
+    """
+    assert "remote" in list_optimizers()
+
+    # The registry path (algorithm='remote' in @traigent.optimize) instantiates
+    # via get_optimizer(); that path must surface the same migration message.
+    with pytest.raises(OptimizationError) as exc_info:
+        get_optimizer("remote", {"x": [1, 2]}, ["accuracy"])
+    # get_optimizer re-wraps; the original migration text is preserved in the chain.
+    assert "remote_client" in str(exc_info.value) or "remote_client" in str(
+        exc_info.value.__cause__ or ""
+    )
 
 
 def test_remote_optimizer_uses_remote_single_suggestion():

--- a/tests/unit/optimizers/test_remote_optimizer.py
+++ b/tests/unit/optimizers/test_remote_optimizer.py
@@ -18,6 +18,7 @@ def test_remote_optimizer_fail_loud_without_client_and_without_remote_enabled():
         RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=False)
     msg = str(exc_info.value)
     assert "remote_client" in msg
+    assert "remote_enabled=True" in msg
     assert "algorithm='random'" in msg
     assert "execution_mode='hybrid'" in msg
 
@@ -27,6 +28,18 @@ def test_remote_optimizer_fail_loud_with_remote_enabled_but_no_client():
     with pytest.raises(OptimizationError) as exc_info:
         RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=True)
     assert "remote_client" in str(exc_info.value)
+
+
+def test_remote_optimizer_fail_loud_with_client_but_remote_not_enabled():
+    """A client alone is not enough; the opt-in flag must be explicit too."""
+    client = MockRemoteSuggestionClient()
+
+    with pytest.raises(OptimizationError) as exc_info:
+        RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_client=client)
+
+    msg = str(exc_info.value)
+    assert "remote_client" in msg
+    assert "remote_enabled=True" in msg
 
 
 def test_remote_still_registered_so_users_get_a_clear_error_not_keyerror():
@@ -65,6 +78,21 @@ def test_remote_optimizer_uses_remote_single_suggestion():
         client_used.last_context
         and client_used.last_context.get("privacy_enabled") is True
     )
+
+
+def test_remote_optimizer_sync_suggestion_fails_loud_instead_of_random_fallback():
+    client = MockRemoteSuggestionClient()
+    opt = RemoteOptimizer(
+        {"x": [1, 2]}, ["accuracy"], remote_enabled=True, remote_client=client
+    )
+
+    with pytest.raises(OptimizationError) as exc_info:
+        opt.suggest_next_trial([])
+
+    msg = str(exc_info.value)
+    assert "does not support synchronous suggestions" in msg
+    assert "algorithm='random'" in msg
+    assert client.calls["single"] == 0
 
 
 def test_remote_optimizer_uses_remote_batch_suggestions():

--- a/traigent/optimizers/remote.py
+++ b/traigent/optimizers/remote.py
@@ -25,10 +25,10 @@ logger = get_logger(__name__)
 
 
 _NO_REMOTE_CLIENT_MSG = (
-    "RemoteOptimizer requires a remote suggestion client. Remote optimization "
-    "is not yet implemented as a first-party service, so constructing this "
-    "optimizer without injecting a remote_client used to silently fall back "
-    "to local random search — making the result mislabeled as 'remote'. "
+    "RemoteOptimizer requires both a remote_client and remote_enabled=True. "
+    "Remote optimization is not yet implemented as a first-party service, so "
+    "constructing this optimizer without both arguments used to silently fall "
+    "back to local random search — making the result mislabeled as 'remote'. "
     "If you want random search, pass algorithm='random'. "
     "If you want portal-tracked local execution, pass execution_mode='hybrid' "
     "with one of the supported algorithms (grid, random, bayesian, optuna_*). "
@@ -92,9 +92,16 @@ class RemoteOptimizer(BaseOptimizer):
         self._remote_client = remote_client
 
     def suggest_next_trial(self, history: list[Any]) -> dict[str, Any]:
-        """Suggest the next configuration (fallback path)."""
-        # For now, just use the local fallback. Remote path will be added later.
-        return self._fallback.suggest_next_trial(history)
+        """Remote suggestions require the async API.
+
+        The old sync implementation delegated to local random search, which
+        recreated the fake "remote" completion bug for sync callers.
+        """
+        raise OptimizationError(
+            "RemoteOptimizer does not support synchronous suggestions. "
+            "Use suggest_next_trial_async(), generate_candidates_async(), or "
+            "choose algorithm='random' for local random search."
+        )
 
     async def suggest_next_trial_async(
         self, history: list[Any], remote_context: dict[str, Any] | None = None
@@ -143,8 +150,10 @@ class RemoteOptimizer(BaseOptimizer):
             except Exception as e:
                 logger.warning(f"Remote batch suggestion failed, falling back: {e}")
 
-        # Fallback to base implementation
-        return await super().generate_candidates_async(
+        # Runtime fallback remains explicit: use the local optimizer object,
+        # not RemoteOptimizer.suggest_next_trial(), which intentionally fails
+        # loud for sync callers.
+        return await self._fallback.generate_candidates_async(
             max_candidates, remote_context=remote_context
         )
 

--- a/traigent/optimizers/remote.py
+++ b/traigent/optimizers/remote.py
@@ -18,20 +18,41 @@ from typing import Any, cast
 from traigent.optimizers.base import BaseOptimizer
 from traigent.optimizers.random import RandomSearchOptimizer
 from traigent.optimizers.registry import register_optimizer
+from traigent.utils.exceptions import OptimizationError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-class RemoteOptimizer(BaseOptimizer):
-    """Optimizer that can request suggestions from a remote service.
+_NO_REMOTE_CLIENT_MSG = (
+    "RemoteOptimizer requires a remote suggestion client. Remote optimization "
+    "is not yet implemented as a first-party service, so constructing this "
+    "optimizer without injecting a remote_client used to silently fall back "
+    "to local random search — making the result mislabeled as 'remote'. "
+    "If you want random search, pass algorithm='random'. "
+    "If you want portal-tracked local execution, pass execution_mode='hybrid' "
+    "with one of the supported algorithms (grid, random, bayesian, optuna_*). "
+    "If you are wiring a remote suggestion backend, pass it explicitly via "
+    "remote_client=... and remote_enabled=True."
+)
 
-    Note: Remote optimization is not implemented yet. This optimizer currently
-    uses a local RandomSearchOptimizer as a placeholder.
+
+class RemoteOptimizer(BaseOptimizer):
+    """Optimizer that requests suggestions from an injected remote service.
+
+    Note: Remote optimization is not implemented as a first-party service yet.
+    To use this optimizer you MUST inject a ``remote_client`` and set
+    ``remote_enabled=True``; otherwise construction raises ``OptimizationError``.
+    There is no longer a silent local-random-search fallback at construction
+    time — that path masqueraded a local run as a remote one and was the
+    surface flagged by issue #872.
 
     - Async suggestion APIs are provided to align with remote access patterns.
-    - Privacy: call sites can pass `remote_context={"privacy_enabled": True}` to
-      indicate indices-only behavior for any remote integration.
+    - Privacy: call sites can pass ``remote_context={"privacy_enabled": True}``
+      to indicate indices-only behavior for any remote integration.
+    - Runtime fallback: when the injected client raises at suggest-time, the
+      optimizer emits a WARNING and falls back to local random search for
+      that single suggestion. This is logged, not silent.
     """
 
     def __init__(
@@ -43,6 +64,12 @@ class RemoteOptimizer(BaseOptimizer):
         remote_enabled: bool = False,
         **kwargs: Any,
     ) -> None:
+        # Fail closed: without a real remote_client, this optimizer cannot do
+        # what its name advertises. See module docstring and issue #872.
+        remote_client = kwargs.get("remote_client")
+        if remote_client is None or not remote_enabled:
+            raise OptimizationError(_NO_REMOTE_CLIENT_MSG)
+
         super().__init__(
             config_space,
             objectives,
@@ -52,7 +79,8 @@ class RemoteOptimizer(BaseOptimizer):
         )
         self.remote_enabled = remote_enabled
 
-        # Fallback local optimizer
+        # Runtime fallback (only used when the remote client raises mid-call;
+        # never as a substitute for a missing client — see __init__ guard).
         self._fallback = RandomSearchOptimizer(
             config_space=config_space,
             objectives=objectives,
@@ -61,8 +89,7 @@ class RemoteOptimizer(BaseOptimizer):
             **kwargs,
         )
 
-        # Lightweight mockable remote client; real client to be injected later
-        self._remote_client = kwargs.get("remote_client")
+        self._remote_client = remote_client
 
     def suggest_next_trial(self, history: list[Any]) -> dict[str, Any]:
         """Suggest the next configuration (fallback path)."""


### PR DESCRIPTION
## Summary

Closes #872. `algorithm="remote"` was registered with the orchestrator but constructing `RemoteOptimizer` without injecting a `remote_client` silently fell through to local `RandomSearchOptimizer`. Users who selected `algorithm="remote"` believed they were getting remote-guided optimization while actually running random search — public-surface fake-completion (workspace `Traigent/CLAUDE.md` rule #2).

## Fix

`RemoteOptimizer.__init__` now fail-closes: if `remote_client is None` or `remote_enabled=False`, raise `OptimizationError` with migration text pointing at `algorithm='random'`, `execution_mode='hybrid'`, or explicit `remote_client=...` injection.

`"remote"` stays in the registry so `get_optimizer("remote", ...)` surfaces the migration error at construction, not a confusing KeyError.

Runtime fallback (injected client raises mid-call → local for one call with WARNING) is preserved — that's the legitimate "client present but currently failing" branch.

## Test plan

- [x] Replaced `test_remote_optimizer_fallback_sync` (which asserted the silent-fallback bug) with 3 regression tests covering construction paths and registry lookup.
- [x] 5 tests pass: 3 remote_optimizer + 2 hybrid_async integration tests.
- [ ] CI green on PR.

## Production-safety checklist

1. **Worst-case prod path.** Users passing `algorithm="remote"` and getting silently-random results now get `OptimizationError` at construction. Previous behavior was silent failure (mislabeled results). **Fail-closed.**
2. **Production-branch test.** `test_remote_optimizer_fail_loud_without_client_and_without_remote_enabled` asserts the production migration message.
3. **Contract regeneration.** No schema changes. Public class signature unchanged.
4. **Public surface delta.** `RemoteOptimizer` remains in `optimizers.__all__`; `"remote"` remains in `list_optimizers()`. Behavior change: constructing without `remote_client` now raises (used to silently fall through to random).
5. **Review threads resolved.** N/A.
6. **Quality gates not relaxed.** Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)