### PR TITLE
test(sdk): replace `or True` and implementation-dependent assertions (closes #887)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -660,21 +660,21 @@
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "25b5a7e454ccbe4974ee239749935c9e32b887e1",
         "is_verified": false,
-        "line_number": 318
+        "line_number": 319
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "b3215fe1d22a64a131c0f9c09718c5b8860911ad",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 352
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_authentication_security.py",
         "hashed_secret": "495289ab973afae18fc84235f33dadc07a9608c4",
         "is_verified": false,
-        "line_number": 382
+        "line_number": 383
       }
     ],
     "tests/unit/cloud/test_backend_bridges_security.py": [
@@ -1256,5 +1256,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T13:14:08Z"
+  "generated_at": "2026-05-21T14:03:26Z"
 }

--- a/tests/unit/api/decorator_tests/test_decorator_advanced.py
+++ b/tests/unit/api/decorator_tests/test_decorator_advanced.py
@@ -234,8 +234,11 @@ class TestOptimizationScenarios(DecoratorTestBase):
         def test_func(text: str) -> str:
             return f"Response: {text}"
 
-        # Should support constrained optimization
-        assert hasattr(test_func, "_constraints") or True  # Depends on implementation
+        # The contract being asserted: @optimize accepts a constraints= kwarg
+        # without raising, and returns a callable wrapper. The internal
+        # storage of the constraint list (attribute name, location) is
+        # implementation detail and intentionally not asserted here.
+        assert callable(test_func)
 
     def test_cloud_execution_mode(self):
         """Test optimization when execution_mode is cloud."""

--- a/tests/unit/api/decorator_tests/test_decorator_advanced.py
+++ b/tests/unit/api/decorator_tests/test_decorator_advanced.py
@@ -235,10 +235,11 @@ class TestOptimizationScenarios(DecoratorTestBase):
             return f"Response: {text}"
 
         # The contract being asserted: @optimize accepts a constraints= kwarg
-        # without raising, and returns a callable wrapper. The internal
-        # storage of the constraint list (attribute name, location) is
-        # implementation detail and intentionally not asserted here.
+        # without raising, returns a callable wrapper, and the wrapper can run.
+        # The internal storage of the constraint list (attribute name,
+        # location) is implementation detail and intentionally not asserted.
         assert callable(test_func)
+        assert test_func("hello") == "Response: hello"
 
     def test_cloud_execution_mode(self):
         """Test optimization when execution_mode is cloud."""

--- a/tests/unit/cloud/test_authentication_security.py
+++ b/tests/unit/cloud/test_authentication_security.py
@@ -286,11 +286,12 @@ class TestCredentialSecurity:
 
         headers2 = asyncio.run(auth_manager.get_auth_headers())
 
-        # Headers should be different (if session tokens are used)
-        # This test may need adjustment based on actual implementation
-        assert (
-            headers1 == headers2 or True
-        )  # Currently always passes due to stateless auth
+        # Contract: stateless API-key auth produces stable headers across
+        # logout/re-authenticate cycles (the bearer is the same API key).
+        # When session-token auth is introduced, this assertion must be
+        # split per credential type — until then, equality is the documented
+        # behavior and should be asserted, not muted.
+        assert headers1 == headers2
 
     def test_credential_injection_attempts(self):
         """Test prevention of credential injection attacks."""

--- a/tests/unit/integrations/test_integration_base.py
+++ b/tests/unit/integrations/test_integration_base.py
@@ -592,12 +592,15 @@ class TestErrorHandling:
             framework_key, broken_constructor
         )
 
-        # Wrapper should handle the exception
+        # Wrapper should handle the exception in ONE of two valid ways:
+        # (a) return None to signal failure, or (b) propagate the original
+        # RuntimeError. The test asserts no other failure mode (e.g., a
+        # truthy zombie instance) leaks out.
         try:
             instance = wrapper()
-            assert instance is None or True  # Implementation dependent
+            assert instance is None
         except RuntimeError:
-            # May propagate exception depending on implementation
+            # Propagation is the other valid branch.
             pass
 
     def test_method_override_with_broken_method(self, base_manager):
@@ -612,12 +615,14 @@ class TestErrorHandling:
 
         wrapper = base_manager.create_overridden_method(method_key, broken_method)
 
-        # Wrapper should handle the exception
+        # Wrapper should handle the exception in ONE of two valid ways:
+        # (a) return None to signal failure, or (b) propagate the original
+        # ValueError. The test asserts no other return value leaks out.
         try:
             result = wrapper("test")
-            assert result is None or True  # Implementation dependent
+            assert result is None
         except ValueError:
-            # May propagate exception depending on implementation
+            # Propagation is the other valid branch.
             pass
 
     def test_concurrent_access_safety(self, base_manager):
@@ -657,12 +662,13 @@ class TestErrorHandling:
         for thread in threads:
             thread.join()
 
-        # Check results
+        # Check results: each worker either returned the bool from
+        # is_constructor_overridden() (the happy path) or stashed an
+        # Exception it caught. Anything else (e.g., a zombie object) would
+        # signal a thread-safety leak.
         assert len(results) == 10
         for result in results.values():
-            assert (
-                not isinstance(result, Exception) or True
-            )  # Some exceptions may be expected
+            assert isinstance(result, (bool, Exception))
 
 
 class TestCTDScenarios:

--- a/tests/unit/integrations/test_integration_base.py
+++ b/tests/unit/integrations/test_integration_base.py
@@ -662,13 +662,12 @@ class TestErrorHandling:
         for thread in threads:
             thread.join()
 
-        # Check results: each worker either returned the bool from
-        # is_constructor_overridden() (the happy path) or stashed an
-        # Exception it caught. Anything else (e.g., a zombie object) would
-        # signal a thread-safety leak.
+        # Check results: each worker either returned the strict bool promised
+        # by is_constructor_overridden() or stashed an Exception it caught.
+        # Sentinel values like 0/1/None are contract regressions here.
         assert len(results) == 10
         for result in results.values():
-            assert isinstance(result, (bool, Exception))
+            assert result is True or result is False or isinstance(result, Exception)
 
 
 class TestCTDScenarios:

--- a/tests/unit/integrations/test_integration_discovery.py
+++ b/tests/unit/integrations/test_integration_discovery.py
@@ -802,4 +802,7 @@ class TestCTDScenarios:
         if mappings:
             avg_confidence = sum(confidence.values()) / len(confidence)
             accepted = avg_confidence >= confidence_threshold
-            assert accepted == expected_acceptance or True  # Implementation dependent
+            # Parametrize cases are deterministic — each (mapping_quality,
+            # threshold) tuple has a fixed expected_acceptance. The previous
+            # `or True` muted real regressions in generate_mapping_confidence.
+            assert accepted == expected_acceptance


### PR DESCRIPTION
## Summary

Closes #887. Six public-surface tests ended in `... or True`, making the assert always pass regardless of behavior. Workspace `Traigent/CLAUDE.md` rule #2 forbids this — tautological tests don't protect any contract.

## Sites fixed

| File:line | Was | Now |
|---|---|---|
| decorator_advanced.py:238 | `assert hasattr(test_func, "_constraints") or True` | `assert callable(test_func)` |
| test_integration_base.py:598 | `assert instance is None or True` | `assert instance is None` (other branch is `except RuntimeError`) |
| test_integration_base.py:618 | `assert result is None or True` | `assert result is None` (other branch is `except ValueError`) |
| test_integration_base.py:664 | `not isinstance(result, Exception) or True` | `isinstance(result, (bool, Exception))` |
| test_integration_discovery.py:805 | `accepted == expected_acceptance or True` | `accepted == expected_acceptance` |
| test_authentication_security.py:292 | `headers1 == headers2 or True` | `headers1 == headers2` |

## Test plan

- [x] 36 tests across the four files pass against the tightened assertions — no hidden bugs surfaced.
- [x] `grep -rn " or True" tests/` returns no matches.
- [ ] CI green on PR.

## Production-safety checklist

1. **Worst-case prod path.** N/A — test-only change. Strictly tightens regression coverage; nothing in `traigent/` is touched.
2. **Production-branch test.** The PR IS the production-branch test fix.
3. **Contract regeneration.** No schema changes.
4. **Public surface delta.** None. Tests now protect the documented contract instead of muting it.
5. **Review threads resolved.** N/A.
6. **Quality gates not relaxed.** All 36 affected tests still pass with tighter assertions — no test was deleted or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)