### PR TITLE
fix: backport fake-completion gaps to develop

### DIFF
--- a/tests/unit/api/decorator_tests/test_decorator_advanced.py
+++ b/tests/unit/api/decorator_tests/test_decorator_advanced.py
@@ -234,10 +234,12 @@ class TestOptimizationScenarios(DecoratorTestBase):
         def test_func(text: str) -> str:
             return f"Response: {text}"
 
-        # Documented contract: @optimize(constraints=[...]) returns a callable
-        # wrapper. Internal storage on `_constraints` is an implementation detail
-        # — assert only the documented surface to avoid coupling to private attrs.
+        # The contract being asserted: @optimize accepts a constraints= kwarg
+        # without raising, returns a callable wrapper, and the wrapper can run.
+        # The internal storage of the constraint list (attribute name,
+        # location) is implementation detail and intentionally not asserted.
         assert callable(test_func)
+        assert test_func("hello") == "Response: hello"
 
     def test_cloud_execution_mode(self):
         """Test optimization when execution_mode is cloud."""

--- a/tests/unit/api/decorator_tests/test_decorator_advanced.py
+++ b/tests/unit/api/decorator_tests/test_decorator_advanced.py
@@ -234,8 +234,10 @@ class TestOptimizationScenarios(DecoratorTestBase):
         def test_func(text: str) -> str:
             return f"Response: {text}"
 
-        # Should support constrained optimization
-        assert hasattr(test_func, "_constraints") or True  # Depends on implementation
+        # Documented contract: @optimize(constraints=[...]) returns a callable
+        # wrapper. Internal storage on `_constraints` is an implementation detail
+        # — assert only the documented surface to avoid coupling to private attrs.
+        assert callable(test_func)
 
     def test_cloud_execution_mode(self):
         """Test optimization when execution_mode is cloud."""

--- a/tests/unit/integrations/test_integration_base.py
+++ b/tests/unit/integrations/test_integration_base.py
@@ -592,12 +592,14 @@ class TestErrorHandling:
             framework_key, broken_constructor
         )
 
-        # Wrapper should handle the exception
+        # Documented contract: when the wrapped constructor raises, the wrapper
+        # either swallows and returns None, OR re-raises the original
+        # RuntimeError. Any other return (e.g. a zombie partially-constructed
+        # instance) is a regression.
         try:
             instance = wrapper()
-            assert instance is None or True  # Implementation dependent
+            assert instance is None
         except RuntimeError:
-            # May propagate exception depending on implementation
             pass
 
     def test_method_override_with_broken_method(self, base_manager):
@@ -612,12 +614,14 @@ class TestErrorHandling:
 
         wrapper = base_manager.create_overridden_method(method_key, broken_method)
 
-        # Wrapper should handle the exception
+        # Documented contract: when the wrapped method raises, the wrapper
+        # either swallows and returns None, OR re-raises the original
+        # ValueError. Anything else (e.g. a fabricated default value) is a
+        # regression.
         try:
             result = wrapper("test")
-            assert result is None or True  # Implementation dependent
+            assert result is None
         except ValueError:
-            # May propagate exception depending on implementation
             pass
 
     def test_concurrent_access_safety(self, base_manager):
@@ -657,12 +661,13 @@ class TestErrorHandling:
         for thread in threads:
             thread.join()
 
-        # Check results
+        # Check results: every worker_thread either reports the
+        # is_constructor_overridden bool, or stores the captured Exception.
+        # Anything else (None, a partially-constructed object, a string)
+        # would indicate a thread-safety regression in worker_thread itself.
         assert len(results) == 10
         for result in results.values():
-            assert (
-                not isinstance(result, Exception) or True
-            )  # Some exceptions may be expected
+            assert isinstance(result, (bool, Exception))
 
 
 class TestCTDScenarios:

--- a/tests/unit/integrations/test_integration_base.py
+++ b/tests/unit/integrations/test_integration_base.py
@@ -661,13 +661,12 @@ class TestErrorHandling:
         for thread in threads:
             thread.join()
 
-        # Check results: every worker_thread either reports the
-        # is_constructor_overridden bool, or stores the captured Exception.
-        # Anything else (None, a partially-constructed object, a string)
-        # would indicate a thread-safety regression in worker_thread itself.
+        # Check results: each worker either returned the strict bool promised
+        # by is_constructor_overridden() or stashed an Exception it caught.
+        # Sentinel values like 0/1/None are contract regressions here.
         assert len(results) == 10
         for result in results.values():
-            assert isinstance(result, (bool, Exception))
+            assert result is True or result is False or isinstance(result, Exception)
 
 
 class TestCTDScenarios:

--- a/tests/unit/integrations/test_integration_discovery.py
+++ b/tests/unit/integrations/test_integration_discovery.py
@@ -802,4 +802,8 @@ class TestCTDScenarios:
         if mappings:
             avg_confidence = sum(confidence.values()) / len(confidence)
             accepted = avg_confidence >= confidence_threshold
-            assert accepted == expected_acceptance or True  # Implementation dependent
+            # The parametrize cases below are deterministic: known mappings
+            # with the perfect/good/poor confidence_threshold MUST produce
+            # the expected_acceptance value. `or True` was masking
+            # regressions in generate_mapping_confidence.
+            assert accepted == expected_acceptance

--- a/tests/unit/optimizers/test_remote_optimizer.py
+++ b/tests/unit/optimizers/test_remote_optimizer.py
@@ -2,13 +2,48 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
+from traigent.optimizers.registry import get_optimizer, list_optimizers
 from traigent.optimizers.remote import MockRemoteSuggestionClient, RemoteOptimizer
+from traigent.utils.exceptions import OptimizationError
 
 
-def test_remote_optimizer_fallback_sync():
-    opt = RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=False)
-    cfg = opt.suggest_next_trial([])
-    assert cfg in [{"x": 1}, {"x": 2}]
+def test_remote_optimizer_fail_loud_without_client_and_without_remote_enabled():
+    """Issue #872 regression: constructing without a remote_client used to
+    silently fall back to local random search, masquerading as 'remote'.
+    The construction now MUST fail loud with a migration message instead.
+    """
+    with pytest.raises(OptimizationError) as exc_info:
+        RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=False)
+    msg = str(exc_info.value)
+    assert "remote_client" in msg
+    assert "algorithm='random'" in msg
+    assert "execution_mode='hybrid'" in msg
+
+
+def test_remote_optimizer_fail_loud_with_remote_enabled_but_no_client():
+    """remote_enabled=True without a client is still invalid — same gate."""
+    with pytest.raises(OptimizationError) as exc_info:
+        RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=True)
+    assert "remote_client" in str(exc_info.value)
+
+
+def test_remote_still_registered_so_users_get_a_clear_error_not_keyerror():
+    """We keep "remote" in the registry so users who pass algorithm='remote'
+    receive the OptimizationError migration message via construction, not
+    a confusing KeyError from a missing registry entry.
+    """
+    assert "remote" in list_optimizers()
+
+    # The registry path (algorithm='remote' in @traigent.optimize) instantiates
+    # via get_optimizer(); that path must surface the same migration message.
+    with pytest.raises(OptimizationError) as exc_info:
+        get_optimizer("remote", {"x": [1, 2]}, ["accuracy"])
+    # get_optimizer re-wraps; the original migration text is preserved in the chain.
+    assert "remote_client" in str(exc_info.value) or "remote_client" in str(
+        exc_info.value.__cause__ or ""
+    )
 
 
 def test_remote_optimizer_uses_remote_single_suggestion():

--- a/tests/unit/optimizers/test_remote_optimizer.py
+++ b/tests/unit/optimizers/test_remote_optimizer.py
@@ -18,6 +18,7 @@ def test_remote_optimizer_fail_loud_without_client_and_without_remote_enabled():
         RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=False)
     msg = str(exc_info.value)
     assert "remote_client" in msg
+    assert "remote_enabled=True" in msg
     assert "algorithm='random'" in msg
     assert "execution_mode='hybrid'" in msg
 
@@ -27,6 +28,18 @@ def test_remote_optimizer_fail_loud_with_remote_enabled_but_no_client():
     with pytest.raises(OptimizationError) as exc_info:
         RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_enabled=True)
     assert "remote_client" in str(exc_info.value)
+
+
+def test_remote_optimizer_fail_loud_with_client_but_remote_not_enabled():
+    """A client alone is not enough; the opt-in flag must be explicit too."""
+    client = MockRemoteSuggestionClient()
+
+    with pytest.raises(OptimizationError) as exc_info:
+        RemoteOptimizer({"x": [1, 2]}, ["accuracy"], remote_client=client)
+
+    msg = str(exc_info.value)
+    assert "remote_client" in msg
+    assert "remote_enabled=True" in msg
 
 
 def test_remote_still_registered_so_users_get_a_clear_error_not_keyerror():
@@ -65,6 +78,21 @@ def test_remote_optimizer_uses_remote_single_suggestion():
         client_used.last_context
         and client_used.last_context.get("privacy_enabled") is True
     )
+
+
+def test_remote_optimizer_sync_suggestion_fails_loud_instead_of_random_fallback():
+    client = MockRemoteSuggestionClient()
+    opt = RemoteOptimizer(
+        {"x": [1, 2]}, ["accuracy"], remote_enabled=True, remote_client=client
+    )
+
+    with pytest.raises(OptimizationError) as exc_info:
+        opt.suggest_next_trial([])
+
+    msg = str(exc_info.value)
+    assert "does not support synchronous suggestions" in msg
+    assert "algorithm='random'" in msg
+    assert client.calls["single"] == 0
 
 
 def test_remote_optimizer_uses_remote_batch_suggestions():

--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -921,6 +921,7 @@ class TestProductionMCPClientFallback:
         """Test fallback for create_experiment tool."""
         response = await self.client._fallback_operation("create_experiment", {})
         assert response.success is True
+        assert response.is_fallback is True
         assert "experiment_id" in response.data
         assert "fallback_exp_" in response.data["experiment_id"]
 
@@ -929,6 +930,7 @@ class TestProductionMCPClientFallback:
         """Test fallback for start_experiment_run tool."""
         response = await self.client._fallback_operation("start_experiment_run", {})
         assert response.success is True
+        assert response.is_fallback is True
         assert "experiment_run_id" in response.data
 
     @pytest.mark.asyncio
@@ -936,6 +938,7 @@ class TestProductionMCPClientFallback:
         """Test fallback for create_configuration_run tool."""
         response = await self.client._fallback_operation("create_configuration_run", {})
         assert response.success is True
+        assert response.is_fallback is True
         assert "config_run_id" in response.data
 
     @pytest.mark.asyncio
@@ -943,6 +946,7 @@ class TestProductionMCPClientFallback:
         """Test fallback for create_agent tool."""
         response = await self.client._fallback_operation("create_agent", {})
         assert response.success is True
+        assert response.is_fallback is True
         assert "agent_id" in response.data
 
     @pytest.mark.asyncio
@@ -950,6 +954,7 @@ class TestProductionMCPClientFallback:
         """Test fallback for upload_example_set tool."""
         response = await self.client._fallback_operation("upload_example_set", {})
         assert response.success is True
+        assert response.is_fallback is True
         assert "example_set_id" in response.data
 
     @pytest.mark.asyncio
@@ -957,7 +962,23 @@ class TestProductionMCPClientFallback:
         """Test fallback for unknown tool."""
         response = await self.client._fallback_operation("unknown_tool", {})
         assert response.success is False
+        # Even on unknown-tool failure, is_fallback must be True so callers
+        # can distinguish "MCP server returned this error" from "we never
+        # reached the server and locally synthesized this response."
+        assert response.is_fallback is True
         assert "No fallback available" in response.error_message
+
+    def test_mcpresponse_default_is_fallback_is_false(self):
+        """Regression for issue #898: a real MCPResponse (constructed at the
+        MCP-server result boundary) must default to is_fallback=False so
+        the synthetic-vs-real distinction is unambiguous.
+        """
+        from traigent.cloud.production_mcp_client import MCPResponse
+
+        real_response = MCPResponse(
+            success=True, data={"experiment_id": "real-backend-uuid-1234"}
+        )
+        assert real_response.is_fallback is False
 
 
 class TestProductionMCPClientHealthCheck:

--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -968,6 +968,26 @@ class TestProductionMCPClientFallback:
         assert response.is_fallback is True
         assert "No fallback available" in response.error_message
 
+    @pytest.mark.asyncio
+    async def test_call_tool_unknown_tool_returns_failed_fallback_marker(self):
+        """Unknown-tool fallback failures keep the fallback marker at call_tool."""
+
+        async def mock_execute(func):
+            return Mock(
+                success=False, last_exception=RuntimeError("server down"), result=None
+            )
+
+        self.client._retry_handler.execute_async = mock_execute
+
+        response = await self.client.call_tool("unknown_tool", {}, "op-unknown")
+
+        assert response.success is False
+        assert response.is_fallback is True
+        assert response.request_id == "op-unknown"
+        assert "server down" in response.error_message
+        assert "No fallback available" in response.error_message
+        assert self.client._operation_results["op-unknown"] is response
+
     def test_mcpresponse_default_is_fallback_is_false(self):
         """Regression for issue #898: a real MCPResponse (constructed at the
         MCP-server result boundary) must default to is_fallback=False so

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -132,12 +132,22 @@ class MCPServerConfig:
 
 @dataclass
 class MCPResponse:
-    """Response from MCP server operations."""
+    """Response from MCP server operations.
+
+    The ``is_fallback`` flag indicates the response was constructed locally
+    by ``_fallback_operation`` because the MCP server was unavailable. Any
+    ``data`` IDs in a fallback response (``fallback_exp_*`` etc.) are
+    synthetic local placeholders, not real backend resources. Callers MUST
+    check ``is_fallback`` before treating IDs as durable backend references
+    (e.g. before quoting them in user-facing UI or backend reconciliation).
+    See issue #898.
+    """
 
     success: bool
     data: dict[str, Any] | None = None
     error_message: str | None = None
     request_id: str | None = None
+    is_fallback: bool = False
 
 
 class ProductionMCPClient:
@@ -794,16 +804,21 @@ class ProductionMCPClient:
     ) -> MCPResponse:
         """Fallback operation when MCP server unavailable.
 
-        Args:
-            tool_name: Tool name
-            arguments: Tool arguments
-
-        Returns:
-            Fallback response
+        Returns a response with ``is_fallback=True`` so callers can disambiguate
+        synthetic local IDs (``fallback_exp_*`` etc.) from real backend IDs.
+        Per workspace ``Traigent/CLAUDE.md`` rule #2, fallback responses MUST
+        be distinguishable from real backend responses on the public surface
+        — see issue #898.
         """
-        logger.info(f"Using fallback for MCP tool: {tool_name}")
+        logger.warning(
+            "MCP server unavailable; using fallback for tool %r. "
+            "Response.is_fallback will be True and IDs are synthetic.",
+            tool_name,
+        )
 
-        # Simple fallback responses for testing
+        # Synthetic IDs prefixed with `fallback_*` are intentional so a log
+        # grep or backend reconciliation job can detect them, but callers
+        # MUST treat `response.is_fallback` as the authoritative signal.
         fallback_responses = {
             "create_experiment": {
                 "experiment_id": f"fallback_exp_{int(time.time())}",
@@ -828,11 +843,16 @@ class ProductionMCPClient:
         }
 
         if tool_name in fallback_responses:
-            return MCPResponse(success=True, data=fallback_responses[tool_name])
+            return MCPResponse(
+                success=True,
+                data=fallback_responses[tool_name],
+                is_fallback=True,
+            )
         else:
             return MCPResponse(
                 success=False,
                 error_message=f"No fallback available for tool: {tool_name}",
+                is_fallback=True,
             )
 
     # Utility Methods

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -420,8 +420,17 @@ class ProductionMCPClient:
                     fallback_response = await self._fallback_operation(
                         tool_name, arguments
                     )
-                    if fallback_response.success:
-                        return fallback_response
+                    fallback_response.request_id = operation_id
+                    if (
+                        not fallback_response.success
+                        and fallback_response.error_message
+                    ):
+                        fallback_response.error_message = (
+                            f"{response.error_message}; fallback failed: "
+                            f"{fallback_response.error_message}"
+                        )
+                    self._operation_results[operation_id] = fallback_response
+                    return fallback_response
 
                 self._operation_results[operation_id] = response
                 return response  # type: ignore[no-any-return]

--- a/traigent/optimizers/remote.py
+++ b/traigent/optimizers/remote.py
@@ -25,10 +25,10 @@ logger = get_logger(__name__)
 
 
 _NO_REMOTE_CLIENT_MSG = (
-    "RemoteOptimizer requires a remote suggestion client. Remote optimization "
-    "is not yet implemented as a first-party service, so constructing this "
-    "optimizer without injecting a remote_client used to silently fall back "
-    "to local random search — making the result mislabeled as 'remote'. "
+    "RemoteOptimizer requires both a remote_client and remote_enabled=True. "
+    "Remote optimization is not yet implemented as a first-party service, so "
+    "constructing this optimizer without both arguments used to silently fall "
+    "back to local random search — making the result mislabeled as 'remote'. "
     "If you want random search, pass algorithm='random'. "
     "If you want portal-tracked local execution, pass execution_mode='hybrid' "
     "with one of the supported algorithms (grid, random, bayesian, optuna_*). "
@@ -92,9 +92,16 @@ class RemoteOptimizer(BaseOptimizer):
         self._remote_client = remote_client
 
     def suggest_next_trial(self, history: list[Any]) -> dict[str, Any]:
-        """Suggest the next configuration (fallback path)."""
-        # For now, just use the local fallback. Remote path will be added later.
-        return self._fallback.suggest_next_trial(history)
+        """Remote suggestions require the async API.
+
+        The old sync implementation delegated to local random search, which
+        recreated the fake "remote" completion bug for sync callers.
+        """
+        raise OptimizationError(
+            "RemoteOptimizer does not support synchronous suggestions. "
+            "Use suggest_next_trial_async(), generate_candidates_async(), or "
+            "choose algorithm='random' for local random search."
+        )
 
     async def suggest_next_trial_async(
         self, history: list[Any], remote_context: dict[str, Any] | None = None
@@ -143,8 +150,10 @@ class RemoteOptimizer(BaseOptimizer):
             except Exception as e:
                 logger.warning(f"Remote batch suggestion failed, falling back: {e}")
 
-        # Fallback to base implementation
-        return await super().generate_candidates_async(
+        # Runtime fallback remains explicit: use the local optimizer object,
+        # not RemoteOptimizer.suggest_next_trial(), which intentionally fails
+        # loud for sync callers.
+        return await self._fallback.generate_candidates_async(
             max_candidates, remote_context=remote_context
         )
 

--- a/traigent/optimizers/remote.py
+++ b/traigent/optimizers/remote.py
@@ -18,20 +18,41 @@ from typing import Any, cast
 from traigent.optimizers.base import BaseOptimizer
 from traigent.optimizers.random import RandomSearchOptimizer
 from traigent.optimizers.registry import register_optimizer
+from traigent.utils.exceptions import OptimizationError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-class RemoteOptimizer(BaseOptimizer):
-    """Optimizer that can request suggestions from a remote service.
+_NO_REMOTE_CLIENT_MSG = (
+    "RemoteOptimizer requires a remote suggestion client. Remote optimization "
+    "is not yet implemented as a first-party service, so constructing this "
+    "optimizer without injecting a remote_client used to silently fall back "
+    "to local random search — making the result mislabeled as 'remote'. "
+    "If you want random search, pass algorithm='random'. "
+    "If you want portal-tracked local execution, pass execution_mode='hybrid' "
+    "with one of the supported algorithms (grid, random, bayesian, optuna_*). "
+    "If you are wiring a remote suggestion backend, pass it explicitly via "
+    "remote_client=... and remote_enabled=True."
+)
 
-    Note: Remote optimization is not implemented yet. This optimizer currently
-    uses a local RandomSearchOptimizer as a placeholder.
+
+class RemoteOptimizer(BaseOptimizer):
+    """Optimizer that requests suggestions from an injected remote service.
+
+    Note: Remote optimization is not implemented as a first-party service yet.
+    To use this optimizer you MUST inject a ``remote_client`` and set
+    ``remote_enabled=True``; otherwise construction raises ``OptimizationError``.
+    There is no longer a silent local-random-search fallback at construction
+    time — that path masqueraded a local run as a remote one and was the
+    surface flagged by issue #872.
 
     - Async suggestion APIs are provided to align with remote access patterns.
-    - Privacy: call sites can pass `remote_context={"privacy_enabled": True}` to
-      indicate indices-only behavior for any remote integration.
+    - Privacy: call sites can pass ``remote_context={"privacy_enabled": True}``
+      to indicate indices-only behavior for any remote integration.
+    - Runtime fallback: when the injected client raises at suggest-time, the
+      optimizer emits a WARNING and falls back to local random search for
+      that single suggestion. This is logged, not silent.
     """
 
     def __init__(
@@ -43,6 +64,12 @@ class RemoteOptimizer(BaseOptimizer):
         remote_enabled: bool = False,
         **kwargs: Any,
     ) -> None:
+        # Fail closed: without a real remote_client, this optimizer cannot do
+        # what its name advertises. See module docstring and issue #872.
+        remote_client = kwargs.get("remote_client")
+        if remote_client is None or not remote_enabled:
+            raise OptimizationError(_NO_REMOTE_CLIENT_MSG)
+
         super().__init__(
             config_space,
             objectives,
@@ -52,7 +79,8 @@ class RemoteOptimizer(BaseOptimizer):
         )
         self.remote_enabled = remote_enabled
 
-        # Fallback local optimizer
+        # Runtime fallback (only used when the remote client raises mid-call;
+        # never as a substitute for a missing client — see __init__ guard).
         self._fallback = RandomSearchOptimizer(
             config_space=config_space,
             objectives=objectives,
@@ -61,8 +89,7 @@ class RemoteOptimizer(BaseOptimizer):
             **kwargs,
         )
 
-        # Lightweight mockable remote client; real client to be injected later
-        self._remote_client = kwargs.get("remote_client")
+        self._remote_client = remote_client
 
     def suggest_next_trial(self, history: list[Any]) -> dict[str, Any]:
         """Suggest the next configuration (fallback path)."""


### PR DESCRIPTION
Closes #872.
Closes #887.
Closes #898.

Changes:
- Makes RemoteOptimizer fail closed when no real remote client is configured, while preserving runtime fallback after remote execution errors.
- Marks MCP fallback responses explicitly with is_fallback=true and logs fallback operations at warning level.
- Replaces tautological test assertions with concrete behavior checks.

Verification:
- uv run pytest -o addopts="" tests/unit/optimizers/test_remote_optimizer.py tests/unit/test_mcp_production_client.py tests/unit/api/decorator_tests/test_decorator_advanced.py tests/unit/integrations/test_integration_base.py tests/unit/integrations/test_integration_discovery.py -q
- pre-commit hooks from git commit