### PR TITLE
fix: remove remote client from fallback kwargs

### DIFF
--- a/traigent/optimizers/remote.py
+++ b/traigent/optimizers/remote.py
@@ -66,7 +66,7 @@ class RemoteOptimizer(BaseOptimizer):
     ) -> None:
         # Fail closed: without a real remote_client, this optimizer cannot do
         # what its name advertises. See module docstring and issue #872.
-        remote_client = kwargs.get("remote_client")
+        remote_client = kwargs.pop("remote_client", None)
         if remote_client is None or not remote_enabled:
             raise OptimizationError(_NO_REMOTE_CLIENT_MSG)
 


### PR DESCRIPTION
## Summary
- pop remote_client before passing kwargs into BaseOptimizer and RandomSearchOptimizer fallback
- keeps the Greptile review fix from #993 on develop after the original PR merged before this one-line cleanup

## Tests
- uv run pytest -o addopts='' tests/unit/optimizers/test_remote_optimizer.py -q