### PR TITLE
fix(config): preserve execution mode in partial merges

### DIFF
--- a/tests/optimizer_validation/dimensions/test_execution_modes.py
+++ b/tests/optimizer_validation/dimensions/test_execution_modes.py
@@ -1,8 +1,8 @@
 """Tests for execution mode configurations.
 
-Tests execution modes. Note: only edge_analytics is currently supported.
-cloud and hybrid raise ConfigurationError (not yet supported).
-privacy and standard raise ConfigurationError (removed).
+Tests execution modes. edge_analytics and hybrid are supported today.
+cloud raises ConfigurationError because remote cloud execution is reserved.
+privacy and standard raise ConfigurationError in the validation helper.
 """
 
 from __future__ import annotations
@@ -17,11 +17,11 @@ from tests.optimizer_validation.specs import (
 )
 from traigent.utils.exceptions import ConfigurationError
 
-# Only edge_analytics is currently supported
-SUPPORTED_EXECUTION_MODES = ["edge_analytics"]
+# Supported local execution modes.
+SUPPORTED_EXECUTION_MODES = ["edge_analytics", "hybrid"]
 
 # Modes that raise ConfigurationError
-UNSUPPORTED_MODES = ["cloud", "hybrid"]  # Not yet supported
+UNSUPPORTED_MODES = ["cloud"]  # Not yet supported
 REMOVED_MODES = ["privacy", "standard"]  # Removed
 
 
@@ -68,7 +68,7 @@ class TestExecutionModeMatrix:
         execution_mode: str,
     ) -> None:
         """Test that unsupported modes raise ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="not yet supported"):
+        with pytest.raises(ConfigurationError, match="not available yet"):
             from traigent.config.types import validate_execution_mode
 
             validate_execution_mode(execution_mode)
@@ -208,15 +208,14 @@ class TestPrivacyMode:
 
 
 class TestHybridMode:
-    """Tests for HYBRID execution mode - not yet supported."""
+    """Tests for HYBRID execution mode."""
 
     @pytest.mark.unit
-    def test_hybrid_mode_raises_configuration_error(self) -> None:
-        """Test hybrid mode raises ConfigurationError (not yet supported)."""
-        from traigent.config.types import validate_execution_mode
+    def test_hybrid_mode_is_supported(self) -> None:
+        """Hybrid is the supported portal-tracked local execution mode."""
+        from traigent.config.types import ExecutionMode, validate_execution_mode
 
-        with pytest.raises(ConfigurationError, match="not yet supported"):
-            validate_execution_mode("hybrid")
+        assert validate_execution_mode("hybrid") is ExecutionMode.HYBRID
 
 
 class TestStandardMode:
@@ -239,7 +238,7 @@ class TestCloudMode:
         """Test cloud mode raises ConfigurationError (not yet supported)."""
         from traigent.config.types import validate_execution_mode
 
-        with pytest.raises(ConfigurationError, match="not yet supported"):
+        with pytest.raises(ConfigurationError, match="not available yet"):
             validate_execution_mode("cloud")
 
 

--- a/tests/unit/config/test_types.py
+++ b/tests/unit/config/test_types.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from traigent.config.types import TraigentConfig, validate_execution_mode
+from traigent.config.types import (
+    ExecutionMode,
+    TraigentConfig,
+    resolve_execution_mode,
+    validate_execution_mode,
+)
 from traigent.utils.exceptions import ConfigurationError, ValidationError
 
 
@@ -92,7 +97,6 @@ class TestTraigentConfig:
         expected = {
             "model": "GPT-4o",
             "temperature": 0.7,
-            "execution_mode": "edge_analytics",
             "custom_key": "custom_value",
         }
         assert result == expected
@@ -105,6 +109,11 @@ class TestTraigentConfig:
         assert "model" in result
         assert "temperature" not in result
         assert "max_tokens" not in result
+
+    def test_to_dict_excludes_default_execution_mode(self):
+        """Default edge_analytics must not leak into partial config merges."""
+        assert TraigentConfig().to_dict() == {}
+        assert TraigentConfig(model="GPT-4o").to_dict() == {"model": "GPT-4o"}
 
     def test_from_dict(self):
         """Test creating config from dictionary."""
@@ -142,6 +151,26 @@ class TestTraigentConfig:
         assert merged.temperature == 0.8
         assert merged.max_tokens == 1000
 
+    def test_merge_partial_config_preserves_execution_mode(self):
+        """A default-valued override must not reset a hybrid base config."""
+        base = TraigentConfig(execution_mode="hybrid", privacy_enabled=True)
+        override = TraigentConfig(model="GPT-4o")
+
+        merged = base.merge(override)
+
+        assert merged.model == "GPT-4o"
+        assert merged.execution_mode == "hybrid"
+        assert merged.privacy_enabled is True
+
+    def test_merge_dict_can_explicitly_reset_execution_mode_to_default(self):
+        """Dict overrides preserve explicitly supplied default values."""
+        base = TraigentConfig(execution_mode="hybrid", privacy_enabled=True)
+
+        merged = base.merge({"execution_mode": "edge_analytics"})
+
+        assert merged.execution_mode == "edge_analytics"
+        assert merged.privacy_enabled is True
+
     def test_repr(self):
         """Test string representation."""
         config = TraigentConfig(model="GPT-4o", temperature=0.7)
@@ -166,6 +195,14 @@ class TestTraigentConfig:
 
 class TestValidateExecutionMode:
     """Tests for validate_execution_mode function."""
+
+    def test_resolve_execution_mode_none_defaults_to_edge_analytics(self) -> None:
+        """Omitted execution mode follows the public SDK default."""
+        assert resolve_execution_mode(None) is ExecutionMode.EDGE_ANALYTICS
+
+    def test_validate_execution_mode_none_defaults_to_edge_analytics(self) -> None:
+        """Validation should accept the omitted-mode public default."""
+        assert validate_execution_mode(None) is ExecutionMode.EDGE_ANALYTICS
 
     def test_invalid_mode_string_raises_configuration_error(self) -> None:
         """Invalid mode string should raise ConfigurationError, not ValueError."""

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -353,9 +353,8 @@ class SeamlessParameterProvider(ConfigurationProvider):
 
             # Only merge context config when a context has been explicitly set.
             # When no context is set, config_context.get() returns None and
-            # get_config() synthesises a default TraigentConfig whose to_dict()
-            # returns {'execution_mode': 'edge_analytics'} — a truthy dict that
-            # would pollute active_config with irrelevant defaults.
+            # get_config() synthesises a default TraigentConfig. That default
+            # should not pollute active_config with irrelevant values.
             raw_ctx = _config_context.get(None)
             if raw_ctx is not None:
                 current_config = get_config()

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -40,7 +40,7 @@ class ExecutionMode(StrEnum):
 def resolve_execution_mode(
     mode: ExecutionMode | str | None,
     *,
-    default: ExecutionMode = ExecutionMode.CLOUD,
+    default: ExecutionMode = ExecutionMode.EDGE_ANALYTICS,
 ) -> ExecutionMode:
     """Normalize user-provided execution mode values into an ExecutionMode enum."""
 
@@ -267,7 +267,7 @@ class TraigentConfig:
 
         # Define default values to exclude
         defaults = {
-            "execution_mode": "cloud",
+            "execution_mode": "edge_analytics",
             "minimal_logging": True,
             "auto_sync": False,
             "privacy_enabled": False,
@@ -345,14 +345,27 @@ class TraigentConfig:
         Returns:
             New TraigentConfig with merged values (other takes precedence)
         """
+        explicit_override_keys: set[str] = set()
         if isinstance(other, dict):
+            explicit_override_keys = set(other)
             other = self.from_dict(other)
 
-        # Start with current values
+        # Start with current values.
         merged_dict = self.to_dict()
 
-        # Override with other values
-        merged_dict.update(other.to_dict())
+        # Override with non-default values from the other config. For dict
+        # inputs, preserve explicitly supplied defaults such as
+        # {"execution_mode": "edge_analytics"} so callers can intentionally
+        # reset a value without default leakage from TraigentConfig().
+        override_dict = other.to_dict()
+        dataclass_fields = getattr(self, "__dataclass_fields__", {})
+        for key in explicit_override_keys:
+            if key in dataclass_fields and key != "custom_params":
+                value = getattr(other, key)
+                if value is not None:
+                    override_dict[key] = value
+
+        merged_dict.update(override_dict)
 
         return self.from_dict(merged_dict)
 


### PR DESCRIPTION
## Summary

Closes #906.
Closes #902.
Refs #911 without closing it.

- Align `TraigentConfig.to_dict()` default filtering with the actual public default `execution_mode="edge_analytics"`, so default configs no longer serialize an execution mode and poison partial merges.
- Preserve explicit dict overrides for default-valued fields, so `base.merge({"execution_mode":"edge_analytics"})` can intentionally reset a hybrid config while `base.merge(TraigentConfig(model="..."))` does not.
- Update the optimizer-validation execution-mode dimension so `hybrid` is tested as supported and only reserved `cloud` is treated as unavailable.
- Update the stale seamless-provider comment now that default configs serialize to `{}`.

## Claude pre-PR review

Ran Claude Code with Opus 4.7, xhigh effort, against the uncommitted diff before opening this PR. Result: no merge-blocking findings. Low-risk notes were documented: object-form `TraigentConfig(execution_mode="edge_analytics")` cannot prove explicit default intent, `resolve_execution_mode(None)` overlaps with broader #911 and should not be overclaimed, and backend-tracking behavior for hybrid remains a future deeper test.

I added direct tests for `resolve_execution_mode(None)` and `validate_execution_mode(None)` after that review.

## Verification

- `uv run pytest -o addopts="" tests/unit/config/test_types.py -q` → 17 passed
- `uv run --extra dev python` with `TRAIGENT_COST_APPROVED=true`, running `tests/unit/config/test_types.py` and `tests/optimizer_validation/dimensions/test_execution_modes.py` → 36 passed, 22 deprecation warnings
- git commit hooks passed: isort, black, ruff, detect-secrets, bandit, mypy, guardrail checks

## Production-safety checklist

1. **Worst-case prod path.** Partial config merges stop resetting hybrid runs to edge analytics. Explicit dict resets still work. No policy surface is relaxed.
2. **Production-branch test.** `tests/unit/config/test_types.py` covers default serialization, hybrid merge preservation, explicit dict reset, and omitted-mode validation defaults.
3. **Contract regeneration.** No schema or API contract regeneration required.
4. **Public surface delta.** `resolve_execution_mode(None)` now follows the documented public SDK default (`edge_analytics`) instead of reserved `cloud`. This is deliberately not claimed as closing #911.
5. **Review threads resolved.** None at PR creation; will resolve all before merge.
6. **Quality gates not relaxed.** No thresholds changed.