### PR TITLE
fix(cloud): fail closed on backend accounting

### DIFF
--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -934,6 +934,7 @@ class TestUtilityMethods:
 
         session_id = "session_submit"
         created_at = datetime.now(UTC)
+        backend_client.enable_fallback = False
 
         backend_client._active_sessions[session_id] = OptimizationSession(
             session_id=session_id,
@@ -956,6 +957,46 @@ class TestUtilityMethods:
         session = backend_client._active_sessions[session_id]
         assert session.completed_trials == 1
         assert session.updated_at is not None
+
+    def test_submit_result_does_not_increment_when_fallback_persistence_fails(
+        self, backend_client
+    ):
+        """submit_result should not count a trial when fallback persistence fails."""
+
+        from datetime import datetime
+
+        from traigent.cloud.models import OptimizationSession
+
+        session_id = "session_failed_fallback"
+        created_at = datetime.now(UTC)
+        backend_client.enable_fallback = True
+        backend_client.local_storage = MagicMock()
+        backend_client.local_storage.add_trial_result.side_effect = RuntimeError(
+            "disk write failed"
+        )
+
+        backend_client._active_sessions[session_id] = OptimizationSession(
+            session_id=session_id,
+            function_name="test_func",
+            configuration_space={"param": [1, 2]},
+            objectives=["accuracy"],
+            max_trials=5,
+            status=OptimizationSessionStatus.ACTIVE,
+            created_at=created_at,
+            updated_at=created_at,
+        )
+
+        backend_client.submit_result(
+            session_id=session_id,
+            config={"param": 2},
+            score=0.75,
+            metadata={"source": "local"},
+        )
+
+        session = backend_client._active_sessions[session_id]
+        assert session.completed_trials == 0
+        assert session.updated_at == created_at
+        backend_client.local_storage.add_trial_result.assert_called_once()
 
     def test_submit_result_local_storage_fallback(self, backend_client):
         """submit_result should persist results to local storage when enabled."""

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -195,6 +195,45 @@ class TestMeasuresDictValidationInSubmission:
         mock_client._normalize_execution_mode.assert_called_once_with("hybrid")
 
     @pytest.mark.asyncio
+    async def test_invalid_configuration_run_submission_does_not_post(self) -> None:
+        """Schema validation failure must stop trial result network submission."""
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://api.example.com"
+        mock_client.backend_config.api_base_url = "https://api.example.com"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="completed")
+        mock_client._normalize_execution_mode = Mock(return_value="edge_analytics")
+        mock_client._sanitize_error_message = Mock(return_value="")
+
+        ops = TrialOperations(mock_client)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+                side_effect=ValueError("invalid payload"),
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            result = await ops.submit_trial_result_via_session(
+                session_id="test-session",
+                trial_id="test-trial",
+                config={"model": "gpt-4"},
+                metrics={"accuracy": 0.95},
+                status="completed",
+            )
+
+        assert result is False
+        mock_client.auth_manager.augment_headers.assert_not_awaited()
+        mock_aiohttp.ClientSession.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_invalid_metric_key_logs_warning_and_submits_unvalidated(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -351,6 +390,97 @@ class TestMeasuresDictValidationInSubmission:
             call_args = ops._handle_trial_success_response.call_args
             assert call_args is not None
             assert call_args.args[5] == {"accuracy": 0.95}
+
+
+class TestSummaryStatsValidation:
+    """Tests for fail-closed summary_stats submission validation."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_summary_stats_submission_does_not_post(self) -> None:
+        """Schema validation failure must stop summary stats network submission."""
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://api.example.com"
+        mock_client.backend_config.api_base_url = "https://api.example.com"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="completed")
+
+        ops = TrialOperations(mock_client)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+                side_effect=ValueError("invalid summary"),
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            result = await ops.submit_summary_stats(
+                session_id="test-session",
+                trial_id="test-trial",
+                config={"model": "gpt-4"},
+                summary_stats={"metrics": {"accuracy": 0.95}},
+                status="completed",
+            )
+
+        assert result is False
+        mock_client.auth_manager.augment_headers.assert_not_awaited()
+        mock_aiohttp.ClientSession.assert_not_called()
+
+
+class TestWeightedScoreUpdates:
+    """Tests for weighted-score backend update accounting."""
+
+    @pytest.mark.asyncio
+    async def test_missing_configuration_run_is_not_counted_as_update(self) -> None:
+        """Backend not-found responses should not report an applied update."""
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://api.example.com"
+        mock_client.backend_config.api_base_url = "https://api.example.com"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+
+        ops = TrialOperations(mock_client)
+
+        mock_response = Mock()
+        mock_response.status = 400
+        mock_response.text = AsyncMock(return_value="Configuration run not found")
+
+        mock_put_ctx = AsyncMock()
+        mock_put_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_put_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.put = Mock(return_value=mock_put_ctx)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+
+            result = await ops.update_trial_weighted_scores(
+                trial_id="trial-missing",
+                weighted_score=0.73,
+            )
+
+        assert result is False
+        mock_session.put.assert_called_once()
 
 
 class TestSummaryStatsLogging:

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -758,7 +758,7 @@ class TestStatisticalSignificanceWiring:
         """Significance metadata propagates to backend submit_result call."""
         # Non-edge config so submit_session_aggregation actually submits
         config = TraigentConfig()
-        config.execution_mode = "standard"
+        config.execution_mode = "hybrid"
 
         manager = BackendSessionManager(
             backend_client=mock_backend_client,
@@ -811,7 +811,7 @@ class TestStatisticalSignificanceWiring:
     ):
         """Aggregation still works when no significance data is present."""
         config = TraigentConfig()
-        config.execution_mode = "standard"
+        config.execution_mode = "hybrid"
 
         manager = BackendSessionManager(
             backend_client=mock_backend_client,
@@ -887,9 +887,9 @@ class TestHandleSessionCreationResult:
 
         assert session_id == "local_test"
         assert not manager.backend_tracking_enabled
-        assert any(SIGNUP_URL in msg for msg in caplog.messages), (
-            f"Expected {SIGNUP_URL!r} in warning: {caplog.messages}"
-        )
+        assert any(
+            SIGNUP_URL in msg for msg in caplog.messages
+        ), f"Expected {SIGNUP_URL!r} in warning: {caplog.messages}"
         warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert len(warning_records) == 1
 
@@ -961,9 +961,9 @@ class TestHandleSessionCreationResult:
             manager.handle_session_creation_result(result)
 
         warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warning_records) == 1, (
-            f"Expected exactly 1 warning, got {len(warning_records)}"
-        )
+        assert (
+            len(warning_records) == 1
+        ), f"Expected exactly 1 warning, got {len(warning_records)}"
 
     def test_success_logs_info(
         self, traigent_config, objective_schema, mock_optimizer, caplog

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -379,7 +379,7 @@ class BackendIntegratedClient:
             session_token = secrets.token_urlsafe(32)
 
         self._session_credentials[session_id] = session_token
-        return session_token
+        return cast(str, session_token)
 
     def _revoke_security_session(self, session_id: str) -> None:
         """Revoke a session from the security manager and clear cached token."""
@@ -543,13 +543,16 @@ class BackendIntegratedClient:
     ) -> tuple[str, str, str]:
         """Create privacy-first optimization session.
         Delegates to privacy_operations module."""
-        return await self._privacy_ops.create_privacy_optimization_session(
-            function_name,
-            configuration_space,
-            objectives,
-            dataset_metadata,
-            max_trials,
-            user_id,
+        return cast(
+            tuple[str, str, str],
+            await self._privacy_ops.create_privacy_optimization_session(
+                function_name,
+                configuration_space,
+                objectives,
+                dataset_metadata,
+                max_trials,
+                user_id,
+            ),
         )
 
     async def _deprecated_create_privacy_optimization_session(
@@ -597,8 +600,11 @@ class BackendIntegratedClient:
     ) -> bool:
         """Submit trial results for privacy-first optimization.
         Delegates to privacy_operations module."""
-        return await self._privacy_ops.submit_privacy_trial_results(
-            session_id, trial_id, config, metrics, duration, error_message
+        return cast(
+            bool,
+            await self._privacy_ops.submit_privacy_trial_results(
+                session_id, trial_id, config, metrics, duration, error_message
+            ),
         )
 
     # Reserved Cloud Operations
@@ -652,19 +658,28 @@ class BackendIntegratedClient:
     ) -> tuple[str, str, str]:
         """Create a hybrid execution session.
         Delegates to session_operations module."""
-        return await self._session_ops.create_hybrid_session(
-            problem_statement, search_space, optimization_config, metadata
+        return cast(
+            tuple[str, str, str],
+            await self._session_ops.create_hybrid_session(
+                problem_statement, search_space, optimization_config, metadata
+            ),
         )
 
     async def get_hybrid_session_status(self, session_id: str) -> dict[str, Any]:
         """Get status of a hybrid session.
         Delegates to session_operations module."""
-        return await self._session_ops.get_hybrid_session_status(session_id)
+        return cast(
+            dict[str, Any],
+            await self._session_ops.get_hybrid_session_status(session_id),
+        )
 
     async def finalize_hybrid_session(self, session_id: str) -> dict[str, Any]:
         """Finalize hybrid session and get results.
         Delegates to session_operations module."""
-        return await self._session_ops.finalize_hybrid_session(session_id)
+        return cast(
+            dict[str, Any],
+            await self._session_ops.finalize_hybrid_session(session_id),
+        )
 
     async def finalize_session(
         self, session_id: str, include_full_history: bool = False
@@ -678,7 +693,7 @@ class BackendIntegratedClient:
     async def delete_session(self, session_id: str, cascade: bool = True) -> bool:
         """Delete optimization session and optionally related data.
         Delegates to session_operations module."""
-        return await self._session_ops.delete_session(session_id, cascade)
+        return cast(bool, await self._session_ops.delete_session(session_id, cascade))
 
     def finalize_session_sync(
         self, session_id: str, include_full_history: bool = False
@@ -690,12 +705,14 @@ class BackendIntegratedClient:
     def delete_session_sync(self, session_id: str, cascade: bool = True) -> bool:
         """Synchronous wrapper for delete_session.
         Delegates to session_operations module."""
-        return self._session_ops.delete_session_sync(session_id, cascade)
+        return cast(bool, self._session_ops.delete_session_sync(session_id, cascade))
 
     def get_active_sessions(self) -> dict[str, OptimizationSession]:
         """Get all active optimization sessions.
         Delegates to session_operations module."""
-        return self._session_ops.get_active_sessions()
+        return cast(
+            dict[str, OptimizationSession], self._session_ops.get_active_sessions()
+        )
 
     def get_session_mapping(self, session_id: str) -> SessionExperimentMapping | None:
         """Get session to experiment mapping.
@@ -817,8 +834,11 @@ class BackendIntegratedClient:
             f"{parsed.path.rstrip('/')}/analytics/example-scoring/"
             f"{encoded_run_id}/features"
         )
-        return urlunparse(
-            parsed._replace(path=upload_path, params="", query="", fragment="")
+        return cast(
+            str,
+            urlunparse(
+                parsed._replace(path=upload_path, params="", query="", fragment="")
+            ),
         )
 
     def upload_example_features(
@@ -932,7 +952,7 @@ class BackendIntegratedClient:
 
         from traigent.utils.hashing import generate_trial_hash
 
-        return generate_trial_hash(session_id, config, "")
+        return cast(str, generate_trial_hash(session_id, config, ""))
 
     async def _submit_trial_result_via_session(
         self,
@@ -988,11 +1008,6 @@ class BackendIntegratedClient:
 
         logger.debug("submit_result called for session=%s score=%s", session_id, score)
 
-        session = self._active_sessions.get(session_id)
-        if session:
-            session.completed_trials += 1
-            session.updated_at = datetime.now(UTC)
-
         if self.enable_fallback and self.local_storage:
             try:
                 self.local_storage.add_trial_result(
@@ -1003,12 +1018,18 @@ class BackendIntegratedClient:
                 )
             except Exception as exc:
                 logger.debug("Local storage trial result fallback failed: %s", exc)
+                return
+
+        session = self._active_sessions.get(session_id)
+        if session:
+            session.completed_trials += 1
+            session.updated_at = datetime.now(UTC)
 
     # API Operations
     def _map_to_backend_status(self, status: str) -> str:
         """Map Traigent status values to backend-expected values.
         Delegates to api_operations module."""
-        return self._api_ops.map_to_backend_status(status)
+        return cast(str, self._api_ops.map_to_backend_status(status))
 
     def _normalize_execution_mode(self, execution_mode: str | None) -> str:
         """Translate SDK execution modes to backend-supported values."""
@@ -1032,19 +1053,25 @@ class BackendIntegratedClient:
     def _sanitize_error_message(self, error_message: str | None) -> str | None:
         """Sanitize error message for transmission.
         Delegates to api_operations module."""
-        return self._api_ops.sanitize_error_message(error_message)
+        return cast(str | None, self._api_ops.sanitize_error_message(error_message))
 
     async def _create_traigent_session_via_api(
         self, session_request: SessionCreationRequest
     ) -> tuple[str, str, str]:
         """Create a Traigent optimization session using the new session endpoints.
         Delegates to api_operations module."""
-        return await self._api_ops.create_traigent_session_via_api(session_request)
+        return cast(
+            tuple[str, str, str],
+            await self._api_ops.create_traigent_session_via_api(session_request),
+        )
 
     async def _update_config_run_status(self, config_run_id: str, status: str) -> bool:
         """Update configuration run status in the backend.
         Delegates to api_operations module."""
-        return await self._api_ops.update_config_run_status(config_run_id, status)
+        return cast(
+            bool,
+            await self._api_ops.update_config_run_status(config_run_id, status),
+        )
 
     async def _update_config_run_measures(
         self,
@@ -1054,8 +1081,11 @@ class BackendIntegratedClient:
     ) -> bool:
         """Update configuration run measures in the backend.
         Delegates to api_operations module."""
-        return await self._api_ops.update_config_run_measures(
-            config_run_id, metrics, execution_time
+        return cast(
+            bool,
+            await self._api_ops.update_config_run_measures(
+                config_run_id, metrics, execution_time
+            ),
         )
 
     async def _update_experiment_run_status_on_completion(
@@ -1108,7 +1138,10 @@ class BackendIntegratedClient:
         self, session_request: SessionCreationRequest
     ) -> tuple[str, str]:
         """DEPRECATED: Use session endpoints only."""
-        return await self._api_ops.create_backend_experiment_tracking(session_request)
+        return cast(
+            tuple[str, str],
+            await self._api_ops.create_backend_experiment_tracking(session_request),
+        )
 
     async def _create_backend_experiment_via_api(
         self, *args: Any, **kwargs: Any
@@ -1167,8 +1200,11 @@ class BackendIntegratedClient:
         max_trials: int,
     ) -> tuple[str, str]:
         """DEPRECATED: Use session endpoints only."""
-        return await self._api_ops.create_backend_agent_experiment(
-            agent_spec, dataset, configuration_space, objectives, max_trials
+        return cast(
+            tuple[str, str],
+            await self._api_ops.create_backend_agent_experiment(
+                agent_spec, dataset, configuration_space, objectives, max_trials
+            ),
         )
 
 

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -575,11 +575,13 @@ class TrialOperations:
                 result_data["summary_stats"] = summary_stats
             self._log_summary_stats_debug(trial_id, summary_stats)
 
-            # Validate the submission data
+            # Validate the submission data. Schema validation is authoritative;
+            # invalid payloads must not be posted to the backend.
             try:
                 validate_configuration_run_submission(result_data)
             except ValueError as e:
                 logger.error(f"Invalid configuration run submission: {e}")
+                return False
 
             if error_message:
                 result_data["error"] = self.client._sanitize_error_message(
@@ -718,13 +720,14 @@ class TrialOperations:
                 "summary_stats": summary_stats,
             }
 
-            # Validate the submission data
+            # Validate the submission data. Schema validation is authoritative;
+            # invalid payloads must not be posted to the backend.
             try:
                 validate_configuration_run_submission(submission_data)
                 logger.debug("✅ Summary stats submission validated successfully")
             except ValueError as e:
                 logger.error(f"Invalid summary stats submission: {e}")
-                # Still try to send but log the validation error
+                return False
 
             logger.debug(
                 "Submitting summary_stats with keys: %s",
@@ -866,12 +869,9 @@ class TrialOperations:
                             if "Configuration run not found" in error_msg:
                                 logger.debug(
                                     f"Configuration run not found for trial {trial_id}. "
-                                    "This is expected in standard mode with mock execution. "
-                                    "Skipping weighted score update."
+                                    "Skipping weighted score update without counting it as applied."
                                 )
-                                # Return True to prevent the error from propagating
-                                # The weighted scores won't be updated but the optimization can continue
-                                return True
+                                return False
                             else:
                                 # Auth failures: instance-scoped dedup at DEBUG
                                 if response.status in (401, 403):


### PR DESCRIPTION
## Summary

Closes #914
Closes #927
Closes #929

Makes backend accounting fail closed instead of reporting success after dropped writes or invalid payloads:

- stop posting trial result and summary_stats payloads when schema validation fails
- return false for weighted-score updates when the backend says the configuration run is missing
- increment BackendIntegratedClient.submit_result completed_trials only after fallback local storage accepts the result
- add regression coverage for validation-failure no-POST behavior, missing weighted-score targets, and fallback persistence failure accounting
- update two backend-session tests from removed standard mode to supported hybrid mode after the execution-mode contract merge

## Review

Claude Code review was run before PR creation with claude-opus-4-7 and xhigh effort in no-tools mode against the final diff. Result: no blockers found.

## Validation

- focused pytest run: 108 passed
- ruff check on touched files
- black --check on touched files
- mypy on traigent/cloud/trial_operations.py and traigent/cloud/backend_client.py
- git diff --check
- pre-commit on commit: isort, black, ruff, detect-secrets, whitespace/EOF, merge-conflict checks, private-key check, bandit, mypy, strict cost accounting guardrails

## Notes

The backend_session_manager test edits are stale execution-mode cleanup from #998: standard is now rejected, so those tests use hybrid for the non-edge backend-submission path.
