### PR TITLE
fix(cloud): fail closed backend synchronizer

### DIFF
--- a/tests/unit/cloud/test_backend_synchronizer.py
+++ b/tests/unit/cloud/test_backend_synchronizer.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from traigent.cloud.backend_synchronizer import BackendSynchronizer
+from traigent.utils.exceptions import NonRetryableError
 from traigent.utils.exceptions import ValidationError as ValidationException
 
 
@@ -33,6 +34,69 @@ def test_backend_synchronizer_initializes_with_valid_values():
         enable_auto_sync=False,
     )
     assert sync.max_concurrent_syncs == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_session_state_fails_closed_without_backend_transport():
+    sync = BackendSynchronizer(enable_auto_sync=False, sync_interval=0.1)
+
+    result = await sync.sync_session_state(
+        "session-1",
+        {
+            "status": "completed",
+            "function_name": "test_function",
+            "objectives": ["accuracy"],
+        },
+    )
+
+    assert result.success is False
+    assert result.items_synced == 0
+    assert result.retries == 0
+    assert result.error_message is not None
+    assert "not implemented" in result.error_message
+    assert "unexpected keyword argument" not in result.error_message
+    assert sync._stats["failed_syncs"] == 1
+    assert sync._stats["successful_syncs"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_trial_states_fails_closed_without_backend_transport():
+    sync = BackendSynchronizer(enable_auto_sync=False, sync_interval=0.1)
+
+    result = await sync.sync_trial_states(
+        "session-1",
+        [{"trial_id": "trial-1", "status": "completed"}],
+    )
+
+    assert result.success is False
+    assert result.items_synced == 0
+    assert result.retries == 0
+    assert result.error_message is not None
+    assert "not implemented" in result.error_message
+    assert "unexpected keyword argument" not in result.error_message
+    assert sync._stats["failed_syncs"] == 1
+    assert sync._stats["successful_syncs"] == 0
+
+
+@pytest.mark.asyncio
+async def test_private_sync_methods_do_not_fabricate_backend_success():
+    sync = BackendSynchronizer(enable_auto_sync=False, sync_interval=0.1)
+
+    with pytest.raises(NonRetryableError, match="session sync is not implemented"):
+        await sync._sync_session_to_backend(
+            "session-1",
+            {
+                "status": "completed",
+                "function_name": "test_function",
+                "objectives": ["accuracy"],
+            },
+        )
+
+    with pytest.raises(NonRetryableError, match="trial sync is not implemented"):
+        await sync._sync_trials_to_backend(
+            "session-1",
+            [{"trial_id": "trial-1", "status": "completed"}],
+        )
 
 
 @pytest.mark.asyncio

--- a/traigent/cloud/backend_synchronizer.py
+++ b/traigent/cloud/backend_synchronizer.py
@@ -16,6 +16,7 @@ from enum import Enum
 from threading import Lock
 from typing import Any, cast
 
+from traigent.utils.exceptions import NonRetryableError
 from traigent.utils.exceptions import ValidationError as ValidationException
 from traigent.utils.logging import get_logger
 from traigent.utils.retry import CLOUD_API_RETRY_CONFIG, RetryHandler
@@ -173,7 +174,6 @@ class BackendSynchronizer:
                     self._sync_session_to_backend,
                     session_id,
                     session_payload,
-                    operation_id=f"sync_session_{session_id}",
                 )
 
                 if result.success:
@@ -264,7 +264,6 @@ class BackendSynchronizer:
                         self._sync_trials_to_backend,
                         session_id,
                         batch,
-                        operation_id=f"sync_trials_{session_id}_{i}",
                     )
 
                     if result.success:
@@ -372,49 +371,31 @@ class BackendSynchronizer:
     async def _sync_session_to_backend(
         self, session_id: str, session_data: dict[str, Any]
     ) -> dict[str, Any]:
-        """Internal method to sync session to backend.
-
-        This is a placeholder implementation. In production, this would
-        make actual API calls to the backend service.
-        """
-        # Simulate API call delay
-        await asyncio.sleep(0.1)
-
-        # Validate required fields
+        """Fail closed until a real backend session-sync transport exists."""
         required_fields = ["status", "function_name", "objectives"]
         for field in required_fields:
             if field not in session_data:
                 raise ValueError(f"Missing required field: {field}") from None
 
-        # Simulate success/failure based on session data
-        if session_data.get("status") == "invalid":
-            raise RuntimeError("Invalid session status")
-
-        logger.debug(f"Synced session {session_id} to backend")
-        return {"status": "synced", "backend_id": f"backend_{session_id}"}
+        raise NonRetryableError(
+            "BackendSynchronizer session sync is not implemented; "
+            "no backend transport was called."
+        )
 
     async def _sync_trials_to_backend(
         self, session_id: str, trial_batch: list[dict[str, Any]]
     ) -> dict[str, Any]:
-        """Internal method to sync trials to backend.
-
-        This is a placeholder implementation. In production, this would
-        make actual API calls to the backend service.
-        """
-        # Simulate API call delay
-        await asyncio.sleep(0.05 * len(trial_batch))
-
-        # Validate trial data
+        """Fail closed until a real backend trial-sync transport exists."""
         for trial in trial_batch:
             if "trial_id" not in trial:
                 raise ValueError("Trial missing trial_id")
             if "status" not in trial:
                 raise ValueError("Trial missing status")
 
-        logger.debug(
-            f"Synced {len(trial_batch)} trials for session {session_id} to backend"
+        raise NonRetryableError(
+            "BackendSynchronizer trial sync is not implemented; "
+            "no backend transport was called."
         )
-        return {"status": "synced", "trials_synced": len(trial_batch)}
 
     @staticmethod
     def _clone_payload(data: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Closes #913

Makes BackendSynchronizer fail closed instead of reporting fabricated backend sync success:

- removes operation_id kwargs from RetryHandler calls so operation metadata is not forwarded into target sync methods
- replaces placeholder session/trial backend sync implementations with NonRetryableError fail-closed gates
- adds real RetryHandler-path tests proving public sync methods now fail with not implemented instead of unexpected keyword argument
- adds direct tests that private sync methods no longer return synthetic synced payloads

## Review

Claude Code review was run before PR creation with claude-opus-4-7 and xhigh effort in no-tools mode against the full diff. Result: no blockers found.

## Validation

- uv run pytest -o addopts= tests/unit/cloud/test_backend_synchronizer.py -q -> 10 passed
- ruff check on touched files
- black --check on touched files
- mypy on traigent/cloud/backend_synchronizer.py
- git diff --check
- pre-commit on commit: isort, black, ruff, detect-secrets, whitespace/EOF, merge-conflict checks, private-key check, bandit, mypy, strict cost accounting guardrails
