### PR TITLE
fix(cloud): fail closed cloud service scaffold

### DIFF
--- a/tests/unit/cloud/test_cloud_service.py
+++ b/tests/unit/cloud/test_cloud_service.py
@@ -1,10 +1,11 @@
 """Tests for Traigent Cloud Service."""
 
 import time
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 
+from traigent.cloud.client import CloudRemoteExecutionUnavailableError
 from traigent.cloud.service import (
     OptimizationRequest,
     OptimizationResponse,
@@ -364,32 +365,17 @@ class TestTraigentCloudService:
 
         asyncio.run(run_test())
 
-    def test_run_enhanced_optimization_professional_tier(
+    def test_run_enhanced_optimization_fails_closed(
         self, cloud_service, sample_dataset
     ):
-        """Test enhanced optimization for professional tier."""
+        """The cloud service scaffold must not fabricate local optimization."""
 
         async def run_test():
-            with (
-                patch("traigent.cloud.service.get_optimizer") as mock_get_optimizer,
-                patch("traigent.cloud.service.LocalEvaluator") as mock_evaluator_class,
+            with pytest.raises(
+                CloudRemoteExecutionUnavailableError,
+                match="Cloud remote execution is not available yet",
             ):
-
-                # Mock Bayesian optimizer
-                mock_optimizer = MagicMock()
-                mock_optimizer.optimize = AsyncMock(
-                    return_value=MagicMock(
-                        best_config={"param": "value"},
-                        best_metrics={"accuracy": 0.9},
-                        trials=[MagicMock() for _ in range(30)],  # 30 trials
-                    )
-                )
-                mock_get_optimizer.return_value = mock_optimizer
-
-                # Mock evaluator
-                mock_evaluator_class.return_value = MagicMock()
-
-                result = await cloud_service._run_enhanced_optimization(
+                await cloud_service._run_enhanced_optimization(
                     dataset=sample_dataset,
                     configuration_space={"param": [1, 2, 3]},
                     objectives=["accuracy"],
@@ -397,220 +383,53 @@ class TestTraigentCloudService:
                     billing_tier="professional",
                 )
 
-                # Verify Bayesian optimizer was requested
-                mock_get_optimizer.assert_called_with(
-                    "bayesian",
-                    {"param": [1, 2, 3]},
-                    ["accuracy"],
-                    max_trials=30,
-                )
-
-                # Verify max_trials was adjusted (1.5x for professional)
-                optimize_call = mock_optimizer.optimize.call_args
-                assert optimize_call[1]["max_trials"] == 30  # 20 * 1.5
-
-                # Verify result
-                assert result["best_config"] == {"param": "value"}
-                assert result["best_metrics"] == {"accuracy": 0.9}
-                assert result["trials_count"] == 30
-
         import asyncio
 
         asyncio.run(run_test())
 
-    def test_run_enhanced_optimization_standard_tier(
-        self, cloud_service, sample_dataset
+    def test_process_optimization_request_reports_unavailable_service(
+        self, cloud_service, optimization_request
     ):
-        """Test enhanced optimization for standard tier."""
+        """Real requests get an explicit unavailable response, not AttributeError."""
 
         async def run_test():
             with (
-                patch("traigent.cloud.service.get_optimizer") as mock_get_optimizer,
-                patch("traigent.cloud.service.LocalEvaluator") as mock_evaluator_class,
+                patch.object(
+                    cloud_service.billing_manager, "check_usage_limits"
+                ) as mock_limits,
+                patch.object(
+                    cloud_service.subset_selector, "select_optimal_subset"
+                ) as mock_subset,
+                patch.object(
+                    cloud_service.usage_tracker, "record_optimization"
+                ) as mock_record,
             ):
+                mock_limits.return_value = {
+                    "allowed": True,
+                    "estimated_cost": 5.0,
+                    "remaining_credits": 95.0,
+                }
+                mock_subset.return_value = optimization_request.dataset
 
-                # Mock random optimizer
-                mock_optimizer = MagicMock()
-                mock_optimizer.optimize = AsyncMock(
-                    return_value=MagicMock(
-                        best_config={"param": "value"},
-                        best_metrics={"accuracy": 0.8},
-                        trials=[MagicMock() for _ in range(25)],
-                    )
-                )
-                mock_get_optimizer.return_value = mock_optimizer
-                mock_evaluator_class.return_value = MagicMock()
-
-                await cloud_service._run_enhanced_optimization(
-                    dataset=sample_dataset,
-                    configuration_space={"param": [1, 2, 3]},
-                    objectives=["accuracy"],
-                    max_trials=25,
-                    billing_tier="standard",
+                response = await cloud_service.process_optimization_request(
+                    optimization_request
                 )
 
-                # Verify random optimizer was used
-                mock_get_optimizer.assert_called_with(
-                    "random",
-                    {"param": [1, 2, 3]},
-                    ["accuracy"],
-                    max_trials=25,
+                assert response.status == "failed_unavailable"
+                assert response.best_config == {}
+                assert response.best_metrics == {}
+                assert response.trials_count == 0
+                assert (
+                    response.billing_info["error_type"]
+                    == "CloudRemoteExecutionUnavailableError"
                 )
-
-                # Verify max_trials not adjusted (1.0x for standard)
-                optimize_call = mock_optimizer.optimize.call_args
-                assert optimize_call[1]["max_trials"] == 25
-
-        import asyncio
-
-        asyncio.run(run_test())
-
-    def test_run_enhanced_optimization_enterprise_tier(
-        self, cloud_service, sample_dataset
-    ):
-        """Test enhanced optimization for enterprise tier."""
-
-        async def run_test():
-            with (
-                patch("traigent.cloud.service.get_optimizer") as mock_get_optimizer,
-                patch("traigent.cloud.service.LocalEvaluator") as mock_evaluator_class,
-            ):
-
-                mock_optimizer = MagicMock()
-                mock_optimizer.optimize = AsyncMock(
-                    return_value=MagicMock(
-                        best_config={"param": "value"},
-                        best_metrics={"accuracy": 0.95},
-                        trials=[MagicMock() for _ in range(40)],
-                    )
+                assert (
+                    "object has no attribute 'optimize'"
+                    not in response.billing_info["error"]
                 )
-                mock_get_optimizer.return_value = mock_optimizer
-                mock_evaluator_class.return_value = MagicMock()
-
-                await cloud_service._run_enhanced_optimization(
-                    dataset=sample_dataset,
-                    configuration_space={"param": [1, 2, 3]},
-                    objectives=["accuracy"],
-                    max_trials=20,
-                    billing_tier="enterprise",
-                )
-
-                # Verify Bayesian optimizer was requested
-                mock_get_optimizer.assert_called_with(
-                    "bayesian",
-                    {"param": [1, 2, 3]},
-                    ["accuracy"],
-                    max_trials=40,
-                )
-
-                # Verify max_trials was adjusted (2.0x for enterprise)
-                optimize_call = mock_optimizer.optimize.call_args
-                assert optimize_call[1]["max_trials"] == 40  # 20 * 2.0
-
-        import asyncio
-
-        asyncio.run(run_test())
-
-    def test_run_enhanced_optimization_free_tier(self, cloud_service, sample_dataset):
-        """Test enhanced optimization for free tier."""
-
-        async def run_test():
-            with (
-                patch("traigent.cloud.service.get_optimizer") as mock_get_optimizer,
-                patch("traigent.cloud.service.LocalEvaluator") as mock_evaluator_class,
-            ):
-
-                mock_optimizer = MagicMock()
-                mock_optimizer.optimize = AsyncMock(
-                    return_value=MagicMock(
-                        best_config={"param": "value"},
-                        best_metrics={"accuracy": 0.75},
-                        trials=[MagicMock() for _ in range(10)],
-                    )
-                )
-                mock_get_optimizer.return_value = mock_optimizer
-                mock_evaluator_class.return_value = MagicMock()
-
-                await cloud_service._run_enhanced_optimization(
-                    dataset=sample_dataset,
-                    configuration_space={"param": [1, 2, 3]},
-                    objectives=["accuracy"],
-                    max_trials=20,
-                    billing_tier="free",
-                )
-
-                # Verify random optimizer was used
-                mock_get_optimizer.assert_called_with(
-                    "random",
-                    {"param": [1, 2, 3]},
-                    ["accuracy"],
-                    max_trials=10,
-                )
-
-                # Verify max_trials was adjusted (0.5x for free)
-                optimize_call = mock_optimizer.optimize.call_args
-                assert optimize_call[1]["max_trials"] == 10  # 20 * 0.5
-
-        import asyncio
-
-        asyncio.run(run_test())
-
-    def test_run_enhanced_optimization_fallback_optimizer(
-        self, cloud_service, sample_dataset
-    ):
-        """Test fallback to random optimizer when Bayesian fails."""
-
-        async def run_test():
-            with (
-                patch("traigent.cloud.service.get_optimizer") as mock_get_optimizer,
-                patch("traigent.cloud.service.LocalEvaluator") as mock_evaluator_class,
-            ):
-
-                # First call (Bayesian) raises exception, second call (random) succeeds
-                mock_optimizer = MagicMock()
-                mock_optimizer.optimize = AsyncMock(
-                    return_value=MagicMock(
-                        best_config={"param": "fallback"},
-                        best_metrics={"accuracy": 0.8},
-                        trials=[MagicMock() for _ in range(15)],
-                    )
-                )
-
-                mock_get_optimizer.side_effect = [
-                    Exception("Bayesian not available"),
-                    mock_optimizer,
-                ]
-                mock_evaluator_class.return_value = MagicMock()
-
-                result = await cloud_service._run_enhanced_optimization(
-                    dataset=sample_dataset,
-                    configuration_space={"param": [1, 2, 3]},
-                    objectives=["accuracy"],
-                    max_trials=10,
-                    billing_tier="professional",  # Should try Bayesian first
-                )
-
-                # Verify both optimizer calls
-                assert mock_get_optimizer.call_count == 2
-                mock_get_optimizer.assert_has_calls(
-                    [
-                        call(
-                            "bayesian",
-                            {"param": [1, 2, 3]},
-                            ["accuracy"],
-                            max_trials=15,
-                        ),
-                        call(
-                            "random",
-                            {"param": [1, 2, 3]},
-                            ["accuracy"],
-                            max_trials=15,
-                        ),
-                    ]
-                )
-
-                # Verify result from fallback optimizer
-                assert result["best_config"] == {"param": "fallback"}
+                assert cloud_service.total_optimizations == 0
+                assert cloud_service.total_cost_savings == 0.0
+                mock_record.assert_not_called()
 
         import asyncio
 
@@ -626,14 +445,14 @@ class TestTraigentCloudService:
 
             health = await cloud_service.get_service_health()
 
-            assert health["status"] == "healthy"
+            assert health["status"] == "unavailable"
             assert health["total_optimizations"] == 5
             assert health["average_cost_reduction"] == 50.0  # 2.5/5 * 100
             assert health["service_version"] == "1.0.0"
-            assert "random" in health["available_algorithms"]
-            assert "grid" in health["available_algorithms"]
-            assert "bayesian" in health["available_algorithms"]
-            assert "accuracy" in health["supported_objectives"]
+            assert health["remote_execution_available"] is False
+            assert "not available yet" in health["unavailable_reason"]
+            assert health["available_algorithms"] == []
+            assert health["supported_objectives"] == []
             assert health["max_dataset_size"] == 10000
             assert health["max_trials"] == 1000
             assert "uptime_hours" in health
@@ -924,22 +743,13 @@ class TestEdgeCases:
 
         asyncio.run(run_test())
 
-    def test_optimization_unknown_billing_tier(self, cloud_service, sample_dataset):
-        """Test optimization with unknown billing tier."""
+    def test_run_enhanced_optimization_unknown_billing_tier_also_fails_closed(
+        self, cloud_service, sample_dataset
+    ):
+        """Unknown direct billing-tier calls do not reach optimizer selection."""
 
         async def run_test():
-            with (
-                patch("traigent.cloud.service.get_optimizer") as mock_get_optimizer,
-                patch("traigent.cloud.service.LocalEvaluator") as mock_evaluator_class,
-            ):
-
-                mock_optimizer = MagicMock()
-                mock_optimizer.optimize = AsyncMock(
-                    return_value=MagicMock(best_config={}, best_metrics={}, trials=[])
-                )
-                mock_get_optimizer.return_value = mock_optimizer
-                mock_evaluator_class.return_value = MagicMock()
-
+            with pytest.raises(CloudRemoteExecutionUnavailableError):
                 await cloud_service._run_enhanced_optimization(
                     dataset=sample_dataset,
                     configuration_space={"param": [1, 2, 3]},
@@ -947,10 +757,6 @@ class TestEdgeCases:
                     max_trials=20,
                     billing_tier="unknown_tier",
                 )
-
-                # Should use standard tier multiplier (1.0) for unknown tier
-                optimize_call = mock_optimizer.optimize.call_args
-                assert optimize_call[1]["max_trials"] == 20  # 20 * 1.0
 
         import asyncio
 

--- a/traigent/cloud/service.py
+++ b/traigent/cloud/service.py
@@ -1,8 +1,8 @@
-"""In-process optimization service scaffold.
+"""Cloud optimization service scaffold.
 
-This helper is not the SDK ``execution_mode="cloud"`` remote execution path.
-It runs locally inside the current process and exists for service experiments
-around subset selection, billing, and orchestration shapes.
+Remote cloud optimization is not implemented yet. This module retains request,
+response, billing, and history scaffolding, but execution fails closed until a
+real backend optimization transport exists.
 """
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID REQ-CLOUD-009 SYNC-CloudHybrid
@@ -13,9 +13,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from traigent.cloud.client import CloudRemoteExecutionUnavailableError
 from traigent.evaluators.base import Dataset, EvaluationExample
-from traigent.evaluators.local import LocalEvaluator
-from traigent.optimizers.registry import get_optimizer
 from traigent.utils.exceptions import ValidationError as ValidationException
 from traigent.utils.logging import get_logger
 from traigent.utils.validation import CoreValidators, validate_or_raise
@@ -56,7 +55,7 @@ class OptimizationResponse:
 
 
 class TraigentCloudService:
-    """Local scaffold for service-style optimization experiments."""
+    """Cloud service scaffold that fails closed for execution."""
 
     def __init__(self) -> None:
         """Initialize the local service scaffold."""
@@ -225,6 +224,23 @@ class TraigentCloudService:
                 status="completed",
             )
 
+        except CloudRemoteExecutionUnavailableError as e:
+            logger.error(f"Cloud service unavailable for request {request_id}: {e}")
+            return OptimizationResponse(
+                request_id=request_id,
+                best_config={},
+                best_metrics={},
+                trials_count=0,
+                optimization_time=time.time() - start_time,
+                cost_reduction=0.0,
+                subset_used=False,
+                billing_info={
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                },
+                status="failed_unavailable",
+            )
+
         except Exception as e:
             logger.error(f"Optimization failed for request {request_id}: {e}")
             return OptimizationResponse(
@@ -247,79 +263,16 @@ class TraigentCloudService:
         max_trials: int,
         billing_tier: str,
     ) -> dict[str, Any]:
-        """Run optimization with enhanced algorithms based on billing tier.
+        """Fail closed until this scaffold has a real optimization driver.
 
-        Args:
-            dataset: Evaluation dataset
-            configuration_space: Parameter search space
-            objectives: Optimization objectives
-            max_trials: Maximum number of trials
-            billing_tier: User's billing tier
-
-        Returns:
-            Dict with optimization results
+        OptimizationRequest does not include a callable to evaluate, and the
+        optimizer interface exposes suggest_next_trial / observe_trial rather
+        than a monolithic optimize method. Returning a fabricated success here
+        would hide that the service path is not implemented.
         """
-        # Adjust max_trials based on billing tier before optimizer selection
-        tier_multipliers = {
-            "free": 0.5,
-            "standard": 1.0,
-            "professional": 1.5,
-            "enterprise": 2.0,
-        }
-
-        multiplier = tier_multipliers.get(billing_tier)
-        if multiplier is None:
-            logger.warning("Unknown billing tier; falling back to standard multiplier")
-            multiplier = 1.0
-
-        adjusted_max_trials = int(max_trials * multiplier)
-
-        # Choose optimizer based on billing tier
-        if billing_tier in ["professional", "enterprise"]:
-            # Use advanced algorithms for premium tiers
-            try:
-                optimizer = get_optimizer(
-                    "bayesian",
-                    configuration_space,
-                    objectives,
-                    max_trials=adjusted_max_trials,
-                )
-                logger.info("Using Bayesian optimization for premium tier")
-            except (ImportError, ValueError, Exception):
-                optimizer = get_optimizer(
-                    "random",
-                    configuration_space,
-                    objectives,
-                    max_trials=adjusted_max_trials,
-                )
-                logger.info("Fallback to random optimization")
-        else:
-            # Use standard algorithms for free/standard tiers
-            optimizer = get_optimizer(
-                "random",
-                configuration_space,
-                objectives,
-                max_trials=adjusted_max_trials,
-            )
-            logger.info("Using random optimization for standard tier")
-
-        # Enhanced evaluator with cloud-specific optimizations
-        evaluator = LocalEvaluator()
-
-        # Run optimization
-        optimization_result = await optimizer.optimize(  # type: ignore[attr-defined]
-            configuration_space=configuration_space,
-            evaluator=evaluator,
-            dataset=dataset,
-            objectives=objectives,
-            max_trials=adjusted_max_trials,
+        raise CloudRemoteExecutionUnavailableError(
+            "TraigentCloudService._run_enhanced_optimization"
         )
-
-        return {
-            "best_config": optimization_result.best_config,
-            "best_metrics": optimization_result.best_metrics,
-            "trials_count": len(optimization_result.trials),
-        }
 
     async def get_service_health(self) -> dict[str, Any]:
         """Get service health and status information.
@@ -336,19 +289,19 @@ class TraigentCloudService:
             else 0.0
         )
 
+        unavailable = CloudRemoteExecutionUnavailableError(
+            "TraigentCloudService._run_enhanced_optimization"
+        )
         return {
-            "status": "healthy",
+            "status": "unavailable",
             "uptime_hours": round(uptime_hours, 2),
             "total_optimizations": self.total_optimizations,
             "average_cost_reduction": round(avg_cost_reduction * 100, 1),
             "service_version": "1.0.0",
-            "available_algorithms": ["random", "grid", "bayesian"],
-            "supported_objectives": [
-                "accuracy",
-                "success_rate",
-                "error_rate",
-                "avg_execution_time",
-            ],
+            "remote_execution_available": False,
+            "unavailable_reason": str(unavailable),
+            "available_algorithms": [],
+            "supported_objectives": [],
             "max_dataset_size": 10000,
             "max_trials": 1000,
         }


### PR DESCRIPTION
## Summary

Closes #922

Fails closed the exported TraigentCloudService scaffold instead of routing through a nonexistent optimizer.optimize method:

- removes the broken optimizer.optimize path from _run_enhanced_optimization
- raises CloudRemoteExecutionUnavailableError until a real backend optimization transport exists
- reports failed_unavailable from process_optimization_request with a typed error payload instead of generic AttributeError-derived failure
- updates health metadata so the scaffold no longer advertises available optimization algorithms while execution is unavailable
- rewrites cloud-service tests around the fail-closed contract

## Review

Claude Code review was run before PR creation with claude-opus-4-7 and xhigh effort in no-tools mode against the full diff. Result: no blockers found.

## Validation

- uv run pytest -o addopts= tests/unit/cloud/test_cloud_service.py tests/unit/cloud/test_cloud_service_validation.py -q -> 28 passed
- ruff check on touched files
- black --check on touched files
- mypy on traigent/cloud/service.py
- git diff --check
- pre-commit on commit: isort, black, ruff, detect-secrets, whitespace/EOF, merge-conflict checks, private-key check, bandit, mypy, strict cost accounting guardrails

## Notes

A quick grep found no live consumer of TraigentCloudService.get_service_health outside its own SDK tests. Generic backend/hybrid health endpoints still use their own healthy/degraded/unhealthy contracts and are unchanged.
