### PR TITLE
fix(api): ParetoFront.plot_trade_offs raises with actionable message (closes #893)

### DIFF
--- a/tests/unit/api/test_api_types.py
+++ b/tests/unit/api/test_api_types.py
@@ -793,7 +793,12 @@ class TestParetoFront:
             pareto.plot_trade_offs("accuracy", "cost")
         msg = str(exc_info.value)
         assert "experimental" in msg.lower()
-        for field_name in ("configurations", "objective_values", "objectives"):
+        for field_name in (
+            "configurations",
+            "objective_values",
+            "objectives",
+            "is_maximized",
+        ):
             assert field_name in msg
 
 

--- a/tests/unit/api/test_api_types.py
+++ b/tests/unit/api/test_api_types.py
@@ -789,9 +789,12 @@ class TestParetoFront:
             is_maximized=[True, False],
         )
 
-        # Method is not implemented, just check it exists and doesn't raise
-        result = pareto.plot_trade_offs("accuracy", "cost")
-        assert result is None  # Method returns None
+        with pytest.raises(NotImplementedError) as exc_info:
+            pareto.plot_trade_offs("accuracy", "cost")
+        msg = str(exc_info.value)
+        assert "experimental" in msg.lower()
+        for field_name in ("configurations", "objective_values", "objectives"):
+            assert field_name in msg
 
 
 class TestStrategyConfig:

--- a/tests/unit/api/test_types.py
+++ b/tests/unit/api/test_types.py
@@ -755,7 +755,12 @@ class TestParetoFront:
             pareto.plot_trade_offs("accuracy", "cost")
         msg = str(exc_info.value)
         assert "experimental" in msg.lower()
-        for field_name in ("configurations", "objective_values", "objectives"):
+        for field_name in (
+            "configurations",
+            "objective_values",
+            "objectives",
+            "is_maximized",
+        ):
             assert field_name in msg
 
 

--- a/tests/unit/api/test_types.py
+++ b/tests/unit/api/test_types.py
@@ -737,8 +737,13 @@ class TestParetoFront:
         best = pareto.get_best_balanced_config()
         assert best["id"] == "B"  # Highest accuracy
 
-    def test_plot_trade_offs(self):
-        """Test plot_trade_offs method (placeholder test)."""
+    def test_plot_trade_offs_raises_with_actionable_message(self):
+        """Regression for issue #893: the previous placeholder method was a
+        public no-op (just ``pass``). A no-op visualization API is
+        indistinguishable from a render bug. It now raises
+        NotImplementedError with a message that names the public data
+        fields users can pipe into matplotlib/plotly directly.
+        """
         pareto = ParetoFront(
             configurations=[{"model": "A"}],
             objective_values=np.array([[0.8, 0.2]]),
@@ -746,9 +751,12 @@ class TestParetoFront:
             is_maximized=[True, False],
         )
 
-        # Method is not implemented, just check it exists and doesn't raise
-        result = pareto.plot_trade_offs("accuracy", "cost")
-        assert result is None  # Method returns None
+        with pytest.raises(NotImplementedError) as exc_info:
+            pareto.plot_trade_offs("accuracy", "cost")
+        msg = str(exc_info.value)
+        assert "experimental" in msg.lower()
+        for field_name in ("configurations", "objective_values", "objectives"):
+            assert field_name in msg
 
 
 class TestStrategyConfig:

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1755,7 +1755,6 @@ class ParetoFront:
             itself raises ``NotImplementedError`` until first-party plotting
             ships.
         """
-        _ = (x_objective, y_objective)
         raise NotImplementedError(
             "ParetoFront.plot_trade_offs() is an experimental visualization "
             "scaffold and has not shipped yet. To render a Pareto trade-off "

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1743,9 +1743,27 @@ class ParetoFront:
         return self.configurations[best_idx]  # type: ignore[no-any-return]
 
     def plot_trade_offs(self, x_objective: str, y_objective: str) -> None:
-        """Plot trade-offs between two objectives."""
-        # Implementation would use matplotlib/plotly
-        pass
+        """Plot trade-offs between two objectives.
+
+        .. note::
+            Multi-objective plotting is an experimental scaffold that has
+            not shipped yet. The data backing the plot — ``configurations``,
+            ``objective_values``, ``objectives``, ``is_maximized`` — is real
+            and can be passed to any plotting library directly. To render a
+            Pareto trade-off chart today, use that data with matplotlib,
+            plotly, or your visualization library of choice. ``plot_trade_offs``
+            itself raises ``NotImplementedError`` until first-party plotting
+            ships.
+        """
+        _ = (x_objective, y_objective)
+        raise NotImplementedError(
+            "ParetoFront.plot_trade_offs() is an experimental visualization "
+            "scaffold and has not shipped yet. To render a Pareto trade-off "
+            "chart today, read the public fields (configurations, "
+            "objective_values, objectives, is_maximized) and pass them to "
+            "matplotlib/plotly directly. "
+            "Tracking: https://github.com/Traigent/Traigent/issues/893"
+        )
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Closes #893. `ParetoFront.plot_trade_offs()` was a bare `pass` — a silent no-op visualization API indistinguishable from a render bug. Two test files asserted the placeholder behavior (`result is None`), locking in the SDK's "no fake completion" rule violation.

## Fix

Same "experimental gate" pattern used for `OptimizationJob.wait()` (#875): raise `NotImplementedError` with a message that names the public dataclass fields callers can pipe into matplotlib/plotly directly. The data backing the plot (`configurations`, `objective_values`, `objectives`, `is_maximized`) is all real — only the rendering itself is gated.

## Test plan

- [x] Both existing tautological tests replaced with contract tests asserting the message includes "experimental" and lists the public field names.
- [x] 10 ParetoFront tests pass.
- [x] **Codex-xhigh review: APPROVE** (gpt-5.5 xhigh reasoning).
- [ ] CI green on PR.

## Production-safety checklist

1. **Worst-case prod path.** Users calling `.plot_trade_offs()` previously got no plot and no error — they now get an explicit `NotImplementedError` with remediation. Strictly better than silent failure. **Fail-closed.**
2. **Production-branch test.** `test_plot_trade_offs_raises_with_actionable_message` (in both test_types.py and test_api_types.py).
3. **Contract regeneration.** No schema changes. Public method signature unchanged.
4. **Public surface delta.** `ParetoFront` remains in `__all__`. `plot_trade_offs` signature unchanged. Behavior change: `None` return → `NotImplementedError` raise.
5. **Review threads resolved.** N/A.
6. **Quality gates not relaxed.** Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)