### PR TITLE
docs(api): mark set_strategy/StrategyConfig as construction-only + fix decorator doc drift (closes #933)

### DIFF
--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -1635,15 +1635,21 @@ def optimize(  # NOSONAR(S107)
             legacy: Adapter for the legacy decorator signature. Accepts either a
                 LegacyOptimizeArgs instance or a dict with the historic keyword
                 arguments. Values provided here merge with the explicit parameters.
-            **runtime_overrides: Runtime overrides such as ``algorithm``, ``max_trials``,
-                ``timeout``, ``cache_policy``, or stop-condition knobs like
-                ``metric_limit`` (deprecated alias: ``budget_limit``), ``plateau_window``,
-                ``cost_limit``, and ``cost_approved``.
-                Tuned-variable detection controls are also available via runtime
-                overrides: ``auto_detect_tvars`` (bool), ``auto_detect_tvars_mode``
-                (``off|suggest|apply``), ``auto_detect_tvars_min_confidence``
-                (``high|medium|low``), and optional include/exclude filters via
-                ``auto_detect_tvars_include`` / ``auto_detect_tvars_exclude``.
+            **runtime_overrides: Stop-condition and budget knobs accepted by
+                the decorator. The currently supported keys are:
+                ``metric_limit`` (deprecated alias: ``budget_limit``),
+                ``metric_name``, ``metric_include_pruned``,
+                ``budget_limit``, ``budget_metric``,
+                ``budget_include_pruned``, ``plateau_window``,
+                ``plateau_epsilon``, ``cost_limit``, ``cost_approved``,
+                ``tie_breakers``, and ``tvl_parameter_agents``.
+                Note: ``algorithm`` and ``max_trials`` are first-class
+                parameters of this decorator (not in ``**runtime_overrides``);
+                ``timeout`` is supported on
+                ``OptimizedFunction.optimize(timeout=...)`` at call time,
+                not on the decorator. Tuned-variable detection controls
+                (``auto_detect_tvars`` and friends) are available as
+                first-class parameters.
 
     Warning:
         Optimization runs multiple LLM calls. Use

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -1637,9 +1637,10 @@ def optimize(  # NOSONAR(S107)
                 arguments. Values provided here merge with the explicit parameters.
             **runtime_overrides: Stop-condition and budget knobs accepted by
                 the decorator. The currently supported keys are:
-                ``metric_limit`` (deprecated alias: ``budget_limit``),
-                ``metric_name``, ``metric_include_pruned``,
-                ``budget_limit``, ``budget_metric``,
+                ``metric_limit``, ``metric_name``,
+                ``metric_include_pruned``,
+                ``budget_limit`` (deprecated alias for ``metric_limit``),
+                ``budget_metric``,
                 ``budget_include_pruned``, ``plateau_window``,
                 ``plateau_epsilon``, ``cost_limit``, ``cost_approved``,
                 ``tie_breakers``, and ``tvl_parameter_agents``.

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -712,31 +712,43 @@ def set_strategy(
     parallel_workers: int | None = None,
     resource_limits: dict[str, Any] | None = None,
 ) -> StrategyConfig:
-    """Configure optimization strategy and execution parameters.
+    """Build a validated ``StrategyConfig`` container.
+
+    .. warning::
+        This helper currently only **constructs and validates** a
+        ``StrategyConfig`` object — the returned config is not yet
+        consumed by the optimization runtime. To configure runtime
+        behavior today, use the supported entry points:
+
+        - algorithm: pass directly as
+          ``@traigent.optimize(algorithm=...)`` or
+          ``OptimizedFunction.optimize(algorithm=...)``.
+        - parallel_workers: pass via
+          ``traigent.configure(parallel_workers=...)`` (and use
+          ``parallel_config=`` for mode / trial_concurrency /
+          example_concurrency / thread_workers).
+        - resource_limits: no supported runtime equivalent yet for
+          structured limits. For coarse cost/time bounds, use
+          ``cost_limit=...`` / ``TRAIGENT_RUN_COST_LIMIT`` on the
+          decorator and ``OptimizedFunction.optimize(timeout=...)``
+          at call time. Structured ``resource_limits`` ship with the
+          #933 wiring follow-up.
+
+        First-party wiring of ``StrategyConfig`` into the optimization
+        pipeline is tracked in issue #933.
 
     Args:
         algorithm: Optimization algorithm ("tpe", "random", "grid", "bayesian").
             Default is "tpe" (Tree-structured Parzen Estimator) which is always
             available with Optuna. "bayesian" (Gaussian Process) requires
             the traigent-advanced-algorithms plugin.
-        algorithm_config: Algorithm-specific parameters
-        parallel_workers: Number of parallel evaluation workers
-        resource_limits: Memory, time, and compute constraints
+        algorithm_config: Algorithm-specific parameters.
+        parallel_workers: Number of parallel evaluation workers.
+        resource_limits: Memory, time, and compute constraints.
 
     Returns:
-        StrategyConfig object for use with optimization
-
-    Example::
-
-        strategy = traigent.set_strategy(
-            algorithm="tpe",
-            algorithm_config={
-                "n_startup_trials": 10,
-                "multivariate": True
-            },
-            parallel_workers=4
-        )
-        results = my_agent.optimize(strategy=strategy)
+        Validated ``StrategyConfig``. Holding this object does not change
+        optimization behavior; see the warning above for runtime entry points.
     """
     # Validate algorithm
     available_algorithms = get_available_strategies()

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -731,11 +731,11 @@ def set_strategy(
           structured limits. For coarse cost/time bounds, use
           ``cost_limit=...`` / ``TRAIGENT_RUN_COST_LIMIT`` on the
           decorator and ``OptimizedFunction.optimize(timeout=...)``
-          at call time. Structured ``resource_limits`` ship with the
-          #933 wiring follow-up.
+          at call time. Structured ``resource_limits`` are not wired
+          into the runtime yet.
 
-        First-party wiring of ``StrategyConfig`` into the optimization
-        pipeline is tracked in issue #933.
+        Future first-party wiring would need to connect
+        ``StrategyConfig`` to the optimization pipeline.
 
     Args:
         algorithm: Optimization algorithm ("tpe", "random", "grid", "bayesian").

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1750,7 +1750,33 @@ class ParetoFront:
 
 @dataclass
 class StrategyConfig:
-    """Configuration for optimization strategy."""
+    """Configuration container for optimization strategy parameters.
+
+    .. note::
+        This is a **construction utility** — the fields below are
+        validated and stored, but they are not yet consumed by the
+        SDK's optimization runtime. To configure runtime execution
+        today, use the equivalent supported entry points:
+
+        - ``algorithm``: pass via ``@traigent.optimize(algorithm=...)``
+          or ``OptimizedFunction.optimize(algorithm=...)``.
+        - ``parallel_workers``: pass via
+          ``traigent.configure(parallel_workers=...)`` (which also accepts
+          a ``parallel_config`` for mode / trial_concurrency /
+          example_concurrency / thread_workers).
+        - ``resource_limits``: there is **no supported runtime equivalent
+          yet** for structured resource limits. For coarse cost/time
+          bounds today, use ``cost_limit=...`` /
+          ``TRAIGENT_RUN_COST_LIMIT`` on the decorator and
+          ``OptimizedFunction.optimize(timeout=...)`` at call time.
+          Structured ``resource_limits`` plumbing is part of the #933
+          wiring follow-up.
+
+        First-party wiring of ``StrategyConfig`` into the optimization
+        pipeline is tracked separately. Holding this object does not
+        change optimization behavior. See issue #933 for the wiring
+        plan.
+    """
 
     algorithm: str
     algorithm_config: dict[str, Any] = field(default_factory=dict)

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1769,13 +1769,12 @@ class StrategyConfig:
           bounds today, use ``cost_limit=...`` /
           ``TRAIGENT_RUN_COST_LIMIT`` on the decorator and
           ``OptimizedFunction.optimize(timeout=...)`` at call time.
-          Structured ``resource_limits`` plumbing is part of the #933
-          wiring follow-up.
+          Structured ``resource_limits`` are not wired into the
+          runtime yet.
 
-        First-party wiring of ``StrategyConfig`` into the optimization
-        pipeline is tracked separately. Holding this object does not
-        change optimization behavior. See issue #933 for the wiring
-        plan.
+        Future first-party wiring would need to connect
+        ``StrategyConfig`` to the optimization pipeline. Holding this
+        object does not change optimization behavior.
     """
 
     algorithm: str


### PR DESCRIPTION
## Summary

Closes #933. `set_strategy()` / `StrategyConfig` were exposed publicly but no fields flowed into the runtime. The original docstring even showed `my_agent.optimize(strategy=strategy)` — a kwarg that doesn't exist in the SDK.

This PR takes the documented "construction-only" path from the issue and also fixes adjacent decorator doc drift caught during codex review.

## Changes

1. `StrategyConfig` / `set_strategy()` docstrings now name the object as a construction-only container, with accurate runtime equivalents for each field.
2. Dropped the misleading `optimize(strategy=...)` example.
3. Bonus (caught during codex review): `decorators.py:1638-1646` advertised `algorithm`, `max_trials`, `timeout`, `cache_policy` in `**runtime_overrides`. Only `_ALLOWED_RUNTIME_OVERRIDE_KEYS` are actually accepted; that docstring now lists exactly those keys with correct routing notes for the off-list ones.

## Test plan

- [x] 59 affected tests pass (test_functions_additional, test_types, test_decorators).
- [x] **Codex-xhigh: APPROVE** after 4 iterations — caught and fixed two real doc-drift items beyond #933's stated scope.
- [ ] CI green on PR.

## Production-safety checklist

1. **Worst-case prod path.** Doc-only — no runtime behavior change. **Strictly improves accuracy of user-facing docs.**
2. **Production-branch test.** N/A (doc-only).
3. **Contract regeneration.** No schema changes. Public signatures, return types, and field defaults unchanged.
4. **Public surface delta.** None. Only docstring text.
5. **Review threads resolved.** N/A.
6. **Quality gates not relaxed.** Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)