### PR TITLE
fix(agents): fail closed on LangChain tool specs

### DIFF
--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -35,7 +35,9 @@ agent_spec = AgentSpecification(
     },
     persona="helpful assistant",
     guidelines=["Be concise", "Be accurate"],
-    custom_tools=["search", "calculator"]  # Optional
+    # Tool execution is not available in the local LangChain executor yet;
+    # tool-bearing specs fail closed instead of running as plain LLM calls.
+    custom_tools=None
 )
 ```
 
@@ -366,8 +368,8 @@ agent_spec = generator.from_optimized_function(
 
 ### LangChain Platform
 
-- Supports various LLM backends
-- Additional features: tools, memory, chains
+- Supports conversational and task-style LLM execution
+- Tool-bearing specs are rejected until LangChain tool invocation is implemented
 - Requires langchain package installation
 
 ### Custom Platforms

--- a/tests/unit/agents/platforms/test_platform_override.py
+++ b/tests/unit/agents/platforms/test_platform_override.py
@@ -193,7 +193,7 @@ class TestFrameworkOverride:
         # Verify expected capabilities
         assert "conversational" in capabilities
         assert "task" in capabilities
-        assert "tools" in capabilities
+        assert "tools" not in capabilities
         assert "async" in capabilities
 
         # Test capability checking logic

--- a/tests/unit/agents/test_platforms.py
+++ b/tests/unit/agents/test_platforms.py
@@ -391,7 +391,7 @@ class TestLangChainAgentExecutor:
 
         assert "conversational" in capabilities
         assert "task" in capabilities
-        assert "tools" in capabilities
+        assert "tools" not in capabilities
         assert "async" in capabilities
 
     @pytest.mark.asyncio
@@ -419,6 +419,43 @@ class TestLangChainAgentExecutor:
         assert result.error is not None
         # Check for expected error indicating LangChain is not available
         assert "langchain not available" in result.error.lower()
+
+    @pytest.mark.parametrize("agent_type", ["task", "conversational"])
+    @pytest.mark.asyncio
+    async def test_agent_with_custom_tools_fails_closed_before_langchain_import(
+        self, monkeypatch, agent_type
+    ):
+        """Tool-bearing specs must not import LangChain and run as plain LLM calls."""
+
+        def fail_import(self):
+            raise AssertionError(
+                "tool-bearing specs should fail before LangChain import"
+            )
+
+        monkeypatch.setattr(
+            LangChainAgentExecutor, "_import_langchain_components", fail_import
+        )
+
+        executor = LangChainAgentExecutor()
+        await executor.initialize()
+        executor._langchain_available = True
+        spec = AgentSpecification(
+            id="tool-agent",
+            name="Tool Agent",
+            agent_type=agent_type,
+            agent_platform="langchain",
+            prompt_template="Answer: {question}",
+            model_parameters={"model": "gpt-4o-mini"},
+            custom_tools=["search", "calculator"],
+        )
+
+        result = await executor.execute(spec, {"question": "What is AI?"})
+
+        assert result.output is None
+        assert result.error is not None
+        assert "custom tool execution is not implemented" in result.error
+        assert "search, calculator" in result.error
+        assert result.metadata == {"error_type": "AgentExecutionError"}
 
 
 class TestOpenAIAgentExecutor:

--- a/traigent/agents/platforms.py
+++ b/traigent/agents/platforms.py
@@ -81,6 +81,9 @@ class LangChainAgentExecutor(AgentExecutor):
         if not self._langchain_available:
             raise AgentExecutionError("LangChain not available")
 
+        if agent_spec.custom_tools:
+            return await self._execute_with_tools(agent_spec.custom_tools)
+
         chat_openai_cls, human_message_cls, modern_lc = (
             self._import_langchain_components()
         )
@@ -93,10 +96,6 @@ class LangChainAgentExecutor(AgentExecutor):
                 llm, human_message_cls, model_name, prompt_text
             )
         elif agent_spec.agent_type == "task":
-            if agent_spec.custom_tools:
-                return await self._execute_with_tools(
-                    llm, prompt_text, agent_spec.custom_tools
-                )
             return await self._execute_langchain_task(
                 llm, human_message_cls, prompt_text
             )
@@ -205,37 +204,15 @@ class LangChainAgentExecutor(AgentExecutor):
             ),
         }
 
-    async def _execute_with_tools(
-        self, llm: Any, prompt: str, tools: list[str]
-    ) -> dict[str, Any]:
-        """Execute agent with tools."""
-        # Simplified tool execution - in production, integrate actual tools
-        logger.info(f"Executing with tools: {tools}")
-
-        # For now, just execute without tools
-        try:
-            from langchain_core.messages import HumanMessage
-        except Exception:
-            from langchain.schema import HumanMessage
-
-        if hasattr(llm, "ainvoke"):
-            ai_message = await llm.ainvoke([HumanMessage(content=prompt)])
-            return {
-                "output": getattr(ai_message, "content", None) or str(ai_message),
-                "tokens_used": None,
-                "metadata": {"tools_available": tools},
-            }
-        else:
-            response = await llm.agenerate([[HumanMessage(content=prompt)]])
-            return {
-                "output": response.generations[0][0].text,
-                "tokens_used": (
-                    response.llm_output.get("token_usage", {}).get("total_tokens")
-                    if hasattr(response, "llm_output") and response.llm_output
-                    else None
-                ),
-                "metadata": {"tools_available": tools},
-            }
+    async def _execute_with_tools(self, tools: list[str]) -> dict[str, Any]:
+        """Reject tool-bearing specs until LangChain tool invocation is implemented."""
+        configured_tools = ", ".join(tools)
+        detail = f" Configured custom_tools: {configured_tools}." if tools else ""
+        raise AgentExecutionError(
+            "LangChain custom tool execution is not implemented yet."
+            f"{detail} Remove custom_tools or use a custom AgentExecutor that "
+            "invokes tools explicitly."
+        )
 
     def _validate_platform_spec(self, agent_spec: AgentSpecification) -> None:
         """Validate LangChain-specific requirements."""
@@ -296,7 +273,7 @@ class LangChainAgentExecutor(AgentExecutor):
 
     def _get_platform_capabilities(self) -> list[str]:
         """Get LangChain capabilities."""
-        return ["conversational", "task", "tools", "memory", "streaming", "async"]
+        return ["conversational", "task", "memory", "streaming", "async"]
 
     def _extract_llm_kwargs(self, config: dict[str, Any]) -> dict[str, Any]:
         """Extract additional LLM kwargs from config with validation."""


### PR DESCRIPTION
## Summary
- fail closed for LangChain `custom_tools` specs before LangChain import/client construction
- remove `tools` from LangChain executor capabilities until real tool invocation exists
- align agent optimization docs and regression tests with unsupported tool execution

Closes #930

## Verification
- Claude Opus 4.7 xhigh review: no blockers; final review said "Ship it."
- `uv run --extra dev pytest tests/unit/agents/test_platforms.py::TestLangChainAgentExecutor tests/unit/agents/platforms/test_platform_override.py::TestFrameworkOverride::test_platform_capability_checking tests/unit/agents/test_platforms_usage_metadata.py tests/unit/test_coverage_improvements.py::test_langchain_task_agent_type` (13 passed)
- `uv run --extra dev pytest tests/unit/agents` (147 passed)
- `uv run --extra dev black traigent/agents/platforms.py tests/unit/agents/test_platforms.py tests/unit/agents/platforms/test_platform_override.py`
- `uv run --extra dev ruff check traigent/agents/platforms.py tests/unit/agents/test_platforms.py tests/unit/agents/platforms/test_platform_override.py`
- `uv run --extra dev mypy traigent/agents/platforms.py`
- `git diff --check`

## Production safety checklist
1. Worst-case prod path — tool-bearing LangChain specs now fail closed with `AgentExecutionError`; no plain LLM execution pretends tools ran.
2. Production-branch test — not a production/env branch. Regression coverage in `tests/unit/agents/test_platforms.py` verifies `task` and `conversational` tool specs fail before LangChain import/client construction.
3. Contract regeneration — no schema/OpenAPI/DTO contract changes.
4. Public surface delta — LangChain capabilities no longer advertise `tools`; docs updated to match runtime.
5. Review threads resolved — no PR review threads yet; will resolve all before merge.
6. Quality gates not relaxed — no thresholds or gates changed.
