### PR TITLE
fix(api): gate repetition options at ExecutionOptions boundary (closes #931)

### DIFF
--- a/tests/unit/api/decorator_tests/test_decorator_error_handling.py
+++ b/tests/unit/api/decorator_tests/test_decorator_error_handling.py
@@ -9,12 +9,10 @@ Tests error scenarios including:
 """
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
 
-from traigent.api.decorators import optimize
-from traigent.utils.exceptions import (
-    ConfigurationError,
-    ValidationError,
-)
+from traigent.api.decorators import ExecutionOptions, optimize
+from traigent.utils.exceptions import ConfigurationError, ValidationError
 
 from .test_base import DecoratorTestBase
 
@@ -283,11 +281,36 @@ class TestEdgeCases(DecoratorTestBase):
 
 
 class TestEnterpriseGatedFeatures(DecoratorTestBase):
-    """Test enterprise-gated features raise NotImplementedError."""
+    """Test enterprise-gated reps options are rejected at construction time.
 
-    def test_reps_per_trial_raises_not_implemented(self):
-        """Test that reps_per_trial raises NotImplementedError."""
-        with pytest.raises(NotImplementedError) as exc:
+    See issue #931: ``reps_per_trial`` and ``reps_aggregation`` were documented
+    as public configuration but raised ``NotImplementedError`` late in
+    ``_resolve_execution_bundle_options``. The contract is now enforced at the
+    ``ExecutionOptions`` Pydantic boundary so users learn about the gate before
+    the decorator runs.
+    """
+
+    def test_reps_per_trial_rejected_at_construction(self):
+        """ExecutionOptions(reps_per_trial!=1) fails at construction."""
+        with pytest.raises(PydanticValidationError) as exc:
+            ExecutionOptions(reps_per_trial=3)
+
+        message = str(exc.value)
+        assert "reps_per_trial" in message
+        assert "Traigent Enterprise" in message
+
+    def test_reps_aggregation_rejected_at_construction(self):
+        """ExecutionOptions(reps_aggregation!='mean') fails at construction."""
+        with pytest.raises(PydanticValidationError) as exc:
+            ExecutionOptions(reps_aggregation="median")
+
+        message = str(exc.value)
+        assert "reps_aggregation" in message
+        assert "Traigent Enterprise" in message
+
+    def test_reps_per_trial_dict_rejected_at_decoration(self):
+        """Passing reps_per_trial via execution={...} fails at decoration."""
+        with pytest.raises(PydanticValidationError) as exc:
 
             @optimize(
                 configuration_space={"model": ["gpt-3.5", "gpt-4"]},
@@ -296,12 +319,13 @@ class TestEnterpriseGatedFeatures(DecoratorTestBase):
             def test_func(text: str) -> str:
                 return text
 
-        assert "reps_per_trial is not available" in str(exc.value)
-        assert "Traigent Enterprise" in str(exc.value)
+        message = str(exc.value)
+        assert "reps_per_trial" in message
+        assert "Traigent Enterprise" in message
 
-    def test_reps_aggregation_raises_not_implemented(self):
-        """Test that reps_aggregation raises NotImplementedError."""
-        with pytest.raises(NotImplementedError) as exc:
+    def test_reps_aggregation_dict_rejected_at_decoration(self):
+        """Passing reps_aggregation via execution={...} fails at decoration."""
+        with pytest.raises(PydanticValidationError) as exc:
 
             @optimize(
                 configuration_space={"model": ["gpt-3.5", "gpt-4"]},
@@ -310,8 +334,9 @@ class TestEnterpriseGatedFeatures(DecoratorTestBase):
             def test_func(text: str) -> str:
                 return text
 
-        assert "reps_aggregation is not available" in str(exc.value)
-        assert "Traigent Enterprise" in str(exc.value)
+        message = str(exc.value)
+        assert "reps_aggregation" in message
+        assert "Traigent Enterprise" in message
 
     def test_default_reps_values_work(self):
         """Test that default reps values (1, 'mean') work fine."""
@@ -326,3 +351,21 @@ class TestEnterpriseGatedFeatures(DecoratorTestBase):
         # Should not raise - defaults are allowed
         result = test_func("hello")
         assert result == "hello"
+
+    def test_default_reps_construction_succeeds(self):
+        """ExecutionOptions() and explicit defaults must still construct."""
+        # Implicit defaults
+        ExecutionOptions()
+        # Explicit defaults
+        ExecutionOptions(reps_per_trial=1, reps_aggregation="mean")
+
+    def test_reps_assignment_rejected_after_construction(self):
+        """Assignment validation preserves the enterprise gate after construction."""
+        options = ExecutionOptions()
+
+        with pytest.raises(PydanticValidationError) as exc:
+            options.reps_per_trial = 3
+
+        message = str(exc.value)
+        assert "reps_per_trial" in message
+        assert "Traigent Enterprise" in message

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -169,14 +169,23 @@ class ExecutionOptions(BaseModel):
         cloud_fallback_policy: Legacy/future cloud fallback behavior. It does
             not enable ``execution_mode="cloud"`` today; cloud remote execution
             is not available yet.
-        reps_per_trial: Number of repetitions per configuration for statistical stability.
-            Running multiple repetitions helps account for LLM non-determinism.
-            Default is 1 (no repetition). Set to 3-5 for noisy evaluations.
-        reps_aggregation: How to aggregate metrics across repetitions.
-            Options: "mean" (default), "median", "min", "max".
+        reps_per_trial: Number of repetitions per configuration for statistical
+            stability. Only the default ``1`` (no repetition) is available in the
+            OSS SDK; passing any other value raises ``pydantic.ValidationError`` at
+            construction time. Per-configuration repetition requires Traigent
+            Enterprise (contact ``sales@traigent.ai``).
+        reps_aggregation: How to aggregate metrics across repetitions. Only the
+            default ``"mean"`` is available in the OSS SDK; passing any other
+            value raises ``pydantic.ValidationError`` at
+            construction time. Per-configuration repetition aggregation
+            requires Traigent Enterprise (contact ``sales@traigent.ai``).
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="forbid",
+        validate_assignment=True,
+    )
 
     execution_mode: str = "edge_analytics"
     local_storage_path: str | None = None
@@ -200,6 +209,31 @@ class ExecutionOptions(BaseModel):
     hybrid_api_auth_header: str | None = None
     hybrid_api_auto_discover_tvars: bool = False
     cloud_fallback_policy: str | None = None
+
+    @field_validator("reps_per_trial")
+    @classmethod
+    def _reject_non_default_reps_per_trial(cls, v: int) -> int:
+        # Per-configuration repetition is enterprise-gated; fail at the contract
+        # boundary (construction) instead of late at runtime so callers see the
+        # gate before the @optimize decorator is applied. See issue #931.
+        if v != 1:
+            raise ValueError(
+                "reps_per_trial != 1 is not available in this version. "
+                "Per-configuration repetitions for statistical stability "
+                "require Traigent Enterprise. Contact sales@traigent.ai."
+            )
+        return v
+
+    @field_validator("reps_aggregation")
+    @classmethod
+    def _reject_non_default_reps_aggregation(cls, v: str) -> str:
+        if v != "mean":
+            raise ValueError(
+                "reps_aggregation != 'mean' is not available in this version. "
+                "Per-configuration repetition aggregation requires Traigent "
+                "Enterprise. Contact sales@traigent.ai."
+            )
+        return v
 
 
 class MockModeOptions(BaseModel):
@@ -927,23 +961,14 @@ def _resolve_execution_bundle_options(
     base_options: ResolvedExecutionOptions,
     defaults: dict[str, Any],
 ) -> ResolvedExecutionOptions:
-    """Resolve execution options from bundle and validate enterprise features."""
+    """Resolve execution options from bundle.
+
+    Enterprise-gated fields (``reps_per_trial``, ``reps_aggregation``) are
+    rejected at ``ExecutionOptions`` construction time via field validators
+    (see issue #931), so this resolver only handles option merging.
+    """
     if execution_bundle is None:
         return base_options
-
-    # Validate enterprise-gated features
-    if execution_bundle.reps_per_trial != 1:
-        raise NotImplementedError(
-            "reps_per_trial is not available in this version. "
-            "This feature requires Traigent Enterprise. "
-            "Contact sales@traigent.ai for more information."
-        )
-    if execution_bundle.reps_aggregation != "mean":
-        raise NotImplementedError(
-            "reps_aggregation is not available in this version. "
-            "This feature requires Traigent Enterprise. "
-            "Contact sales@traigent.ai for more information."
-        )
 
     return ResolvedExecutionOptions(
         execution_mode=_resolve_option(

--- a/traigent/skills/traigent-decorator-setup/SKILL.md
+++ b/traigent/skills/traigent-decorator-setup/SKILL.md
@@ -198,8 +198,8 @@ Configure where and how optimization runs execute.
         execution_mode="edge_analytics",  # Local execution
         local_storage_path="./results",
         privacy_enabled=True,
-        reps_per_trial=3,              # Repeat each config 3 times
-        reps_aggregation="mean",        # Average across repetitions
+        # reps_per_trial / reps_aggregation are enterprise-only in this SDK
+        # release. Non-default values raise ValidationError at construction.
     ),
     configuration_space={"model": ["gpt-3.5-turbo", "gpt-4"]},
 )
@@ -271,8 +271,7 @@ def exact_match(prediction: str, expected: str) -> float:
     execution=ExecutionOptions(
         execution_mode="edge_analytics",
         local_storage_path="./optimization_results",
-        reps_per_trial=3,
-        reps_aggregation="mean",
+        # reps_per_trial / reps_aggregation are enterprise-only; keep defaults.
     ),
     objectives=["accuracy", "cost"],
     configuration_space={

--- a/traigent/skills/traigent-decorator-setup/references/execution-modes.md
+++ b/traigent/skills/traigent-decorator-setup/references/execution-modes.md
@@ -21,12 +21,12 @@ from traigent.api.decorators import ExecutionOptions
 | `samples_include_pruned` | `bool` | `True` | Whether pruned trials count toward sample limits. |
 | `cloud_fallback_policy` | `str \| None` | `None` | Legacy setting for future cloud execution. `cloud` is not available yet and fails closed. |
 
-### Repetition Fields
+### Repetition Fields (enterprise-only)
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `reps_per_trial` | `int` | `1` | Number of times to repeat each configuration. Useful for noisy LLM evaluations. Set to 3-5 for statistical stability. |
-| `reps_aggregation` | `str` | `"mean"` | How to aggregate metrics across repetitions: `"mean"`, `"median"`, `"min"`, or `"max"`. |
+| `reps_per_trial` | `int` | `1` | **Enterprise-only.** Number of times to repeat each configuration. Only `1` is accepted in the OSS SDK; any other value raises `ValidationError` at `ExecutionOptions` construction. Per-configuration repetition requires Traigent Enterprise (contact `sales@traigent.ai`). |
+| `reps_aggregation` | `str` | `"mean"` | **Enterprise-only.** How to aggregate metrics across repetitions. Only `"mean"` is accepted in the OSS SDK; any other value raises `ValidationError`. Per-configuration repetition aggregation requires Traigent Enterprise. |
 
 ### Hybrid API Fields
 
@@ -141,28 +141,27 @@ def my_func(query: str) -> str:
     return call_llm(model=cfg["model"], prompt=query)
 ```
 
-## Repetitions for Statistical Stability
+## Repetitions for Statistical Stability (enterprise-only)
 
-LLM outputs are non-deterministic. Use `reps_per_trial` to repeat each configuration multiple times and aggregate the results:
+LLM outputs are non-deterministic. Per-configuration repetition aggregation is
+an **enterprise-only** feature in the current OSS SDK release. Constructing
+`ExecutionOptions` with any non-default value for `reps_per_trial` or
+`reps_aggregation` raises a `pydantic.ValidationError` at construction time
+(see issue #931) - the gate is enforced at the contract boundary instead of
+late in the optimization run.
 
 ```python
-@traigent.optimize(
-    execution=ExecutionOptions(
-        reps_per_trial=5,          # Run each config 5 times
-        reps_aggregation="median", # Use median score (robust to outliers)
-    ),
-    configuration_space={"temperature": [0.0, 0.3, 0.7, 1.0]},
-)
-def my_func(query: str) -> str:
-    cfg = traigent.get_config()
-    return call_llm(temperature=cfg["temperature"], prompt=query)
+# Enterprise-only - raises ValidationError in the OSS SDK:
+# ExecutionOptions(reps_per_trial=5, reps_aggregation="median")
 ```
 
-Aggregation options:
+Aggregation options shipped with Traigent Enterprise:
 
 | Method | Use When |
 |---|---|
-| `"mean"` | Default. Good for normally distributed scores. |
-| `"median"` | Robust to outliers. Good for noisy evaluations. |
-| `"min"` | Worst-case analysis. Conservative. |
-| `"max"` | Best-case analysis. Optimistic. |
+| `"mean"` | Default. Good for normally distributed scores. Only value accepted by the OSS SDK. |
+| `"median"` | Enterprise-only. Robust to outliers; good for noisy evaluations. |
+| `"min"` | Enterprise-only. Worst-case analysis; conservative. |
+| `"max"` | Enterprise-only. Best-case analysis; optimistic. |
+
+Contact `sales@traigent.ai` to unlock per-configuration repetitions.

--- a/traigent/skills/traigent-run-optimization/SKILL.md
+++ b/traigent/skills/traigent-run-optimization/SKILL.md
@@ -306,8 +306,9 @@ def exact_match(prediction: str, expected: str) -> float:
             trial_concurrency=2,
             example_concurrency=4,
         ),
-        reps_per_trial=3,
-        reps_aggregation="mean",
+        # NOTE: reps_per_trial / reps_aggregation are enterprise-only in this
+        # SDK release. Passing non-default values raises a ValidationError at
+        # ExecutionOptions construction. Defaults (1 / "mean") are required.
     ),
     objectives=["accuracy"],
     configuration_space={


### PR DESCRIPTION
## Summary

Closes #931. ExecutionOptions.reps_per_trial and reps_aggregation were public-looking configuration fields, but non-default values were not implemented in the OSS SDK. This PR makes the gate explicit at the contract boundary and updates the shipped docs so OSS users do not copy unsupported repetition settings.

## Changes

- Add ExecutionOptions Pydantic validators for reps_per_trial and reps_aggregation so non-default values fail at construction with a Traigent Enterprise remediation.
- Enable assignment validation on ExecutionOptions so post-construction mutation cannot bypass the same gate.
- Remove the later _resolve_execution_bundle_options NotImplementedError branch now that the model boundary owns validation.
- Update SDK docstrings and shipped skill docs to describe repetition controls as enterprise-only in OSS.
- Expand regressions for direct construction, decorator dict input, assignment mutation, and explicit default values.

## Review

- Claude Code Opus 4.7 xhigh review: no blockers, ship.
- Earlier review noted assignment mutation as a non-blocking seam; this PR now includes validate_assignment=True and a regression for that path.

## Validation

- uv run --extra dev pytest tests/unit/api/decorator_tests/test_decorator_error_handling.py::TestEnterpriseGatedFeatures
- uv run --extra dev black --check traigent/api/decorators.py tests/unit/api/decorator_tests/test_decorator_error_handling.py
- uv run --extra dev ruff check traigent/api/decorators.py tests/unit/api/decorator_tests/test_decorator_error_handling.py
- git diff --cached --check before commit
- pre-commit hooks on commit: passed

## Production-Safety Checklist

- Worst-case prod path: unsupported repetition options now fail at the public options boundary instead of later in optimization.
- Production-branch test: targeted unit regressions cover the gate and defaults.
- Contract regeneration: no schema or generated contract changes.
- Public surface delta: same fields remain present, but non-default OSS behavior is now explicit and tested.
- Review threads resolved before merge: pending PR review.
- Quality gates not relaxed.