### PR TITLE
[claude-session-1] Fix #889: count privacy completions on accepted results

### DIFF
--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -440,8 +440,10 @@ class TestPrivacyFirstOptimization:
                 # Verify trial mapping (no backend config run creation anymore)
                 mock_bridge.add_trial_mapping.assert_called_once()
 
-                # Verify session update
-                assert backend_client._active_sessions[session_id].completed_trials == 1
+                # Regression for #889: receiving a suggestion is NOT a
+                # completion. The completed_trials counter advances on
+                # accepted result submission, not on suggestion receipt.
+                assert backend_client._active_sessions[session_id].completed_trials == 0
 
         import asyncio
 

--- a/tests/unit/cloud/test_privacy_operations.py
+++ b/tests/unit/cloud/test_privacy_operations.py
@@ -104,4 +104,87 @@ async def test_get_next_privacy_trial_updates_session_with_lock(monkeypatch):
     suggestion = await ops.get_next_privacy_trial("session-1", None)
     assert suggestion is not None
     assert lock.enter_count == 1  # Lock entered exactly once for trial retrieval
+    # Regression for #889: receiving a suggestion is NOT a completion.
+    # completed_trials must NOT advance here. The counter advances only in
+    # submit_privacy_trial_results when the result is accepted.
+    assert client._active_sessions["session-1"].completed_trials == 0
+
+
+@pytest.mark.asyncio
+async def test_submit_privacy_trial_results_increments_completed_trials():
+    """Regression for #889: completed_trials advances exactly once per
+    accepted result, not at suggestion time.
+    """
+    lock = FakeLock()
+    client = DummyClient(lock)
+    ops = PrivacyOperations(client)
+
+    client._active_sessions["session-1"] = OptimizationSession(
+        session_id="session-1",
+        function_name="test",
+        configuration_space={},
+        objectives=["accuracy"],
+        max_trials=5,
+        status=OptimizationSessionStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    success = await ops.submit_privacy_trial_results(
+        session_id="session-1",
+        trial_id="trial-1",
+        config={"x": 1},
+        metrics={"accuracy": 0.9},
+        duration=1.0,
+    )
+
+    assert success is True
     assert client._active_sessions["session-1"].completed_trials == 1
+
+    # Submit a second result; counter advances to 2 (exactly once per submit).
+    success = await ops.submit_privacy_trial_results(
+        session_id="session-1",
+        trial_id="trial-2",
+        config={"x": 2},
+        metrics={"accuracy": 0.8},
+        duration=1.0,
+    )
+    assert success is True
+    assert client._active_sessions["session-1"].completed_trials == 2
+
+
+@pytest.mark.asyncio
+async def test_submit_privacy_trial_results_does_not_increment_on_backend_failure():
+    """If the backend submission fails, completed_trials must not advance.
+    Closes the symmetric concern to #889 on the submission side.
+    """
+    lock = FakeLock()
+    client = DummyClient(lock)
+
+    # Make backend submission fail.
+    async def failing_submit(*args, **kwargs):
+        return False
+
+    client._submit_trial_result_via_session = failing_submit  # type: ignore[method-assign]
+    ops = PrivacyOperations(client)
+
+    client._active_sessions["session-1"] = OptimizationSession(
+        session_id="session-1",
+        function_name="test",
+        configuration_space={},
+        objectives=["accuracy"],
+        max_trials=5,
+        status=OptimizationSessionStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    success = await ops.submit_privacy_trial_results(
+        session_id="session-1",
+        trial_id="trial-1",
+        config={"x": 1},
+        metrics={"accuracy": 0.9},
+        duration=1.0,
+    )
+    assert success is False
+    assert client._active_sessions["session-1"].completed_trials == 0

--- a/tests/unit/cloud/test_privacy_operations.py
+++ b/tests/unit/cloud/test_privacy_operations.py
@@ -140,6 +140,8 @@ async def test_submit_privacy_trial_results_increments_completed_trials():
 
     assert success is True
     assert client._active_sessions["session-1"].completed_trials == 1
+    # Submit checks the session under lock, then increments under lock.
+    assert lock.enter_count == 2
 
     # Submit a second result; counter advances to 2 (exactly once per submit).
     success = await ops.submit_privacy_trial_results(
@@ -151,6 +153,7 @@ async def test_submit_privacy_trial_results_increments_completed_trials():
     )
     assert success is True
     assert client._active_sessions["session-1"].completed_trials == 2
+    assert lock.enter_count == 4
 
 
 @pytest.mark.asyncio
@@ -188,3 +191,4 @@ async def test_submit_privacy_trial_results_does_not_increment_on_backend_failur
     )
     assert success is False
     assert client._active_sessions["session-1"].completed_trials == 0
+    assert lock.enter_count == 1

--- a/traigent/cloud/privacy_operations.py
+++ b/traigent/cloud/privacy_operations.py
@@ -316,6 +316,12 @@ class PrivacyOperations:
                 if session:
                     session.completed_trials += 1
                     session.updated_at = datetime.now(UTC)
+                else:
+                    logger.warning(
+                        "Session %s accepted by backend but not found locally; "
+                        "completed_trials not incremented",
+                        session_id,
+                    )
 
             return True
 

--- a/traigent/cloud/privacy_operations.py
+++ b/traigent/cloud/privacy_operations.py
@@ -218,11 +218,16 @@ class PrivacyOperations:
                         response.suggestion.trial_id,  # Trial ID is the config run ID
                     )
 
-                # Update session status
+                # Touch the session's updated_at so progress UIs reflect activity,
+                # but do NOT increment completed_trials — a suggestion is not a
+                # completion. The completion count advances in
+                # submit_privacy_trial_results when the result is accepted.
+                # See issue #889 for the reasoning (overcount on abandoned /
+                # failed-before-result suggestions distorted progress, billing,
+                # and stop conditions).
                 with self.client._active_sessions_lock:
                     session = self.client._active_sessions.get(session_id)
                     if session:
-                        session.completed_trials += 1
                         session.updated_at = datetime.now(UTC)
 
             return response.suggestion
@@ -303,6 +308,14 @@ class PrivacyOperations:
                     f"Failed to submit trial results for session {session_id}, trial {trial_id}"
                 )
                 return False
+
+            # Advance the completion counter exactly once, on result acceptance.
+            # Moved here from get_next_privacy_trial per issue #889.
+            with self.client._active_sessions_lock:
+                session = self.client._active_sessions.get(session_id)
+                if session:
+                    session.completed_trials += 1
+                    session.updated_at = datetime.now(UTC)
 
             return True
 


### PR DESCRIPTION
## Summary

Closes #889. `get_next_privacy_trial()` was incrementing `completed_trials` on suggestion receipt — meaning abandoned / failed-before-result suggestions still counted as completions, distorting progress, finalization summaries, billing, and stop conditions.

## Fix

- Remove `completed_trials += 1` from `get_next_privacy_trial`; suggestion receipt only updates `updated_at`.
- Add the increment to `submit_privacy_trial_results` on backend-accepted submission. Counter advances exactly once per accept; backend-rejected submit leaves it unchanged.

## Test plan

- [x] 12 affected tests pass.
- [x] Existing assertion in `test_privacy_operations` updated to `== 0` after suggestion (was `== 1`).
- [x] Existing assertion in `test_backend_client.py` updated to `== 0` (caught in codex review).
- [x] New regression test asserts counter advances once per accepted submit, and zero on backend rejection.
- [x] **Codex-xhigh: APPROVE** after 2 iterations.
- [ ] CI green on PR.

## Production-safety checklist

1. **Worst-case prod path.** Before this PR: progress, billing, stop-conditions over-counted by 1 per abandoned suggestion. After: counter reflects only accepted backend results. **Strictly improves accounting accuracy.** Fail-closed: backend failure no longer ghost-completes.
2. **Production-branch test.** `test_submit_privacy_trial_results_does_not_increment_on_backend_failure` covers the production-branch behavior.
3. **Contract regeneration.** No schema changes; OptimizationSession fields unchanged.
4. **Public surface delta.** None — internal counter ordering only.
5. **Review threads resolved.** N/A.
6. **Quality gates not relaxed.** Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)