### PR TITLE
fix(cloud): preserve backend session-finalization summary payload (closes #890)

### DIFF
--- a/tests/unit/cloud/test_session_finalization.py
+++ b/tests/unit/cloud/test_session_finalization.py
@@ -73,6 +73,7 @@ class TestSessionFinalization:
             # Backend returned no summary → flag must be False so callers
             # don't treat the empty best_config / best_metrics as truth.
             assert response.metadata["summary_available"] is False
+            assert response.metadata["summary_fields"] == []
             assert response.best_config == {}
             assert response.best_metrics == {}
 
@@ -126,6 +127,16 @@ class TestSessionFinalization:
         assert response.session_id == session_id
         assert response.metadata["finalized_via_api"] is True
         assert response.metadata["summary_available"] is True
+        assert set(response.metadata["summary_fields"]) == {
+            "best_config",
+            "best_metrics",
+            "total_trials",
+            "successful_trials",
+            "total_duration",
+            "cost_savings",
+            "stop_reason",
+            "convergence_history",
+        }
 
         # Backend payload fields preserved verbatim
         assert response.best_config == {"model": "gpt-4o", "temperature": 0.2}
@@ -139,6 +150,90 @@ class TestSessionFinalization:
             {"trial": 1, "score": 0.7},
             {"trial": 2, "score": 0.81},
         ]
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_partial_summary_lists_preserved_fields(
+        self, client
+    ):
+        """summary_available can be true for partial summaries without
+        implying best_config or best_metrics were returned.
+        """
+        session_id = "test-session-partial"
+        experiment_run_id = "run-partial"
+
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-partial",
+            experiment_run_id=experiment_run_id,
+            function_name="partial_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"stop_reason": "timeout"})
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        assert response.metadata["finalized_via_api"] is True
+        assert response.metadata["summary_available"] is True
+        assert response.metadata["summary_fields"] == ["stop_reason"]
+        assert response.stop_reason == "timeout"
+        assert response.best_config == {}
+        assert response.best_metrics == {}
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_malformed_summary_field_is_unavailable(
+        self, client
+    ):
+        """Malformed values that are dropped must not set summary_available."""
+        session_id = "test-session-malformed"
+        experiment_run_id = "run-malformed"
+
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-malformed",
+            experiment_run_id=experiment_run_id,
+            function_name="malformed_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "stop_reason": 408,
+                "total_trials": True,
+                "cost_savings": False,
+            }
+        )
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        assert response.metadata["finalized_via_api"] is True
+        assert response.metadata["summary_available"] is False
+        assert response.metadata["summary_fields"] == []
+        assert response.stop_reason is None
+        assert response.total_trials == 0
+        assert response.cost_savings == 0.0
 
     @pytest.mark.asyncio
     async def test_finalize_session_legacy_payload_marks_summary_unavailable(
@@ -187,6 +282,7 @@ class TestSessionFinalization:
         # callers don't read the empty best_config / best_metrics as truth.
         assert response.metadata["finalized_via_api"] is True
         assert response.metadata["summary_available"] is False
+        assert response.metadata["summary_fields"] == []
         assert response.best_config == {}
         assert response.best_metrics == {}
 
@@ -226,6 +322,7 @@ class TestSessionFinalization:
 
         assert response.metadata["finalized_via_api"] is False
         assert response.metadata["summary_available"] is False
+        assert response.metadata["summary_fields"] == []
 
     @pytest.mark.asyncio
     async def test_finalize_session_via_api_not_available(self, client):

--- a/tests/unit/cloud/test_session_finalization.py
+++ b/tests/unit/cloud/test_session_finalization.py
@@ -41,9 +41,15 @@ class TestSessionFinalization:
             objectives=["maximize"],
         )
 
-        # Mock the HTTP response
+        # Mock the HTTP response — backend returns no JSON body (legacy
+        # path). The SDK should still treat finalization as successful but
+        # mark summary_available=False because the backend didn't return
+        # any summary fields. See #890.
         mock_response = AsyncMock()
         mock_response.status = 200
+        mock_response.json = AsyncMock(
+            side_effect=Exception("no JSON body in legacy response")
+        )
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 
@@ -64,6 +70,162 @@ class TestSessionFinalization:
             # Verify response metadata
             assert response.session_id == session_id
             assert response.metadata["finalized_via_api"] is True
+            # Backend returned no summary → flag must be False so callers
+            # don't treat the empty best_config / best_metrics as truth.
+            assert response.metadata["summary_available"] is False
+            assert response.best_config == {}
+            assert response.best_metrics == {}
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_preserves_backend_summary(self, client):
+        """Regression for #890: when the backend returns a full summary
+        payload, the SDK response must preserve best_config, best_metrics,
+        total_trials, duration, savings, stop_reason, and convergence_history
+        verbatim — and summary_available must be True.
+        """
+        session_id = "test-session-summary"
+        experiment_run_id = "run-summary"
+
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-summary",
+            experiment_run_id=experiment_run_id,
+            function_name="summary_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+
+        backend_payload = {
+            "best_config": {"model": "gpt-4o", "temperature": 0.2},
+            "best_metrics": {"accuracy": 0.91},
+            "total_trials": 12,
+            "successful_trials": 10,
+            "total_duration": 42.5,
+            "cost_savings": 1.23,
+            "stop_reason": "max_trials_reached",
+            "convergence_history": [
+                {"trial": 1, "score": 0.7},
+                {"trial": 2, "score": 0.81},
+            ],
+        }
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=backend_payload)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        assert response.session_id == session_id
+        assert response.metadata["finalized_via_api"] is True
+        assert response.metadata["summary_available"] is True
+
+        # Backend payload fields preserved verbatim
+        assert response.best_config == {"model": "gpt-4o", "temperature": 0.2}
+        assert response.best_metrics == {"accuracy": 0.91}
+        assert response.total_trials == 12
+        assert response.successful_trials == 10
+        assert response.total_duration == 42.5
+        assert response.cost_savings == 1.23
+        assert response.stop_reason == "max_trials_reached"
+        assert response.convergence_history == [
+            {"trial": 1, "score": 0.7},
+            {"trial": 2, "score": 0.81},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_legacy_payload_marks_summary_unavailable(
+        self, client
+    ):
+        """Regression for #890: a backend response whose shape doesn't
+        include any of the documented summary fields (e.g. a legacy
+        {best_trial, all_results} response) MUST NOT set
+        summary_available=True. Otherwise callers would treat the SDK's
+        fallback empty best_config/best_metrics as authoritative.
+        """
+        session_id = "test-session-legacy"
+        experiment_run_id = "run-legacy"
+
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-legacy",
+            experiment_run_id=experiment_run_id,
+            function_name="legacy_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+
+        legacy_payload = {
+            "best_trial": {"trial_id": "t1", "metrics": {"accuracy": 0.9}},
+            "all_results": [{"trial_id": "t1"}],
+            "metadata": {"some": "value"},
+        }
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=legacy_payload)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        # Finalize call succeeded (200), but the payload didn't include any
+        # documented summary fields → summary_available must be False so
+        # callers don't read the empty best_config / best_metrics as truth.
+        assert response.metadata["finalized_via_api"] is True
+        assert response.metadata["summary_available"] is False
+        assert response.best_config == {}
+        assert response.best_metrics == {}
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_endpoint_unavailable_marks_summary_unavailable(
+        self, client
+    ):
+        """Regression for #890: when the backend finalize endpoint is
+        unavailable (404 etc.), summary_available must be False so callers
+        don't treat empty best_config/best_metrics as backend-authoritative.
+        """
+        session_id = "test-session-unavail"
+        experiment_run_id = "run-unavail"
+
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-unavail",
+            experiment_run_id=experiment_run_id,
+            function_name="unavail_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_response.text = AsyncMock(return_value="Not found")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        assert response.metadata["finalized_via_api"] is False
+        assert response.metadata["summary_available"] is False
 
     @pytest.mark.asyncio
     async def test_finalize_session_via_api_not_available(self, client):

--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -113,7 +113,9 @@ async def test_finalize_session_uses_lock(monkeypatch):
     client._active_sessions["session-1"] = session
 
     ops = SessionOperations(client)
-    monkeypatch.setattr(ops, "_finalize_session_via_api", AsyncMock(return_value=False))
+    # _finalize_session_via_api now returns dict|None; None = endpoint
+    # unavailable (formerly False under the dropped bool contract).
+    monkeypatch.setattr(ops, "_finalize_session_via_api", AsyncMock(return_value=None))
 
     await ops.finalize_session("session-1")
     assert lock.enter_count == 1  # Lock entered exactly once for finalization

--- a/tests/unit/core/test_robustness_cherrypicks.py
+++ b/tests/unit/core/test_robustness_cherrypicks.py
@@ -164,7 +164,10 @@ class TestSessionMappingRecovery:
         with client._active_sessions_lock:
             client._active_sessions[session_id] = active_session
 
-        client._session_ops._finalize_session_via_api = AsyncMock(return_value=True)
+        # _finalize_session_via_api now returns dict|None (was bool); empty
+        # dict represents "finalized successfully, backend returned no body"
+        # — the contract documented for issue #890.
+        client._session_ops._finalize_session_via_api = AsyncMock(return_value={})
 
         assert client.session_bridge.get_session_mapping(session_id) is None
 
@@ -195,7 +198,10 @@ class TestSessionMappingRecovery:
         with client._active_sessions_lock:
             client._active_sessions[session_id] = active_session
 
-        client._session_ops._finalize_session_via_api = AsyncMock(return_value=True)
+        # _finalize_session_via_api now returns dict|None (was bool); empty
+        # dict represents "finalized successfully, backend returned no body"
+        # — the contract documented for issue #890.
+        client._session_ops._finalize_session_via_api = AsyncMock(return_value={})
 
         await client._session_ops.finalize_session(session_id)
 

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -795,80 +795,105 @@ class SessionOperations:
         backend_convergence_history = backend_summary.get("convergence_history")
         backend_full_history = backend_summary.get("full_history")
 
-        # summary_available=True only when the backend actually included at
-        # least one of the documented summary fields. A non-empty payload
-        # that uses a different shape (e.g. legacy {best_trial, all_results}
-        # responses) MUST NOT mark summary_available=True, otherwise callers
-        # would treat the SDK's fallback empty best_config/best_metrics as
-        # authoritative — recreating the original #890 ambiguity.
-        summary_available = any(
-            v is not None
-            for v in (
-                backend_best_config,
-                backend_best_metrics,
-                backend_total_trials,
-                backend_successful_trials,
-                backend_total_duration,
-                backend_cost_savings,
-                backend_stop_reason,
-                backend_convergence_history,
-                backend_full_history,
-            )
+        summary_fields: list[str] = []
+
+        def _is_real_number(value: Any) -> bool:
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+        response_best_config = (
+            backend_best_config if isinstance(backend_best_config, dict) else {}
         )
+        if isinstance(backend_best_config, dict):
+            summary_fields.append("best_config")
+
+        response_best_metrics = (
+            backend_best_metrics if isinstance(backend_best_metrics, dict) else {}
+        )
+        if isinstance(backend_best_metrics, dict):
+            summary_fields.append("best_metrics")
+
+        response_total_trials = (
+            int(cast(int | float, backend_total_trials))
+            if _is_real_number(backend_total_trials)
+            else completed_trials
+        )
+        if _is_real_number(backend_total_trials):
+            summary_fields.append("total_trials")
+
+        response_successful_trials = (
+            int(cast(int | float, backend_successful_trials))
+            if _is_real_number(backend_successful_trials)
+            else completed_trials
+        )
+        if _is_real_number(backend_successful_trials):
+            summary_fields.append("successful_trials")
+
+        response_total_duration = (
+            float(cast(int | float, backend_total_duration))
+            if _is_real_number(backend_total_duration)
+            else 0.0
+        )
+        if _is_real_number(backend_total_duration):
+            summary_fields.append("total_duration")
+
+        response_cost_savings = (
+            float(cast(int | float, backend_cost_savings))
+            if _is_real_number(backend_cost_savings)
+            else 0.0
+        )
+        if _is_real_number(backend_cost_savings):
+            summary_fields.append("cost_savings")
+
+        response_stop_reason = (
+            str(backend_stop_reason) if isinstance(backend_stop_reason, str) else None
+        )
+        if isinstance(backend_stop_reason, str):
+            summary_fields.append("stop_reason")
+
+        response_convergence_history = (
+            backend_convergence_history
+            if isinstance(backend_convergence_history, list)
+            else []
+        )
+        if isinstance(backend_convergence_history, list):
+            summary_fields.append("convergence_history")
+
+        response_full_history = (
+            backend_full_history
+            if include_full_history and isinstance(backend_full_history, list)
+            else ([] if include_full_history else None)
+        )
+        if include_full_history and isinstance(backend_full_history, list):
+            summary_fields.append("full_history")
+
+        # summary_available=True only when at least one documented backend
+        # summary field was type-valid and preserved in the SDK response. A
+        # legacy or malformed payload must not mark a synthetic fallback value
+        # as backend-authoritative. Callers that require specific fields should
+        # inspect metadata["summary_fields"].
+        summary_available = bool(summary_fields)
 
         response = OptimizationFinalizationResponse(
             session_id=session_id,
-            best_config=(
-                backend_best_config if isinstance(backend_best_config, dict) else {}
-            ),
-            best_metrics=(
-                backend_best_metrics if isinstance(backend_best_metrics, dict) else {}
-            ),
-            total_trials=(
-                int(backend_total_trials)
-                if isinstance(backend_total_trials, (int, float))
-                else completed_trials
-            ),
-            successful_trials=(
-                int(backend_successful_trials)
-                if isinstance(backend_successful_trials, (int, float))
-                else completed_trials
-            ),
-            total_duration=(
-                float(backend_total_duration)
-                if isinstance(backend_total_duration, (int, float))
-                else 0.0
-            ),
-            cost_savings=(
-                float(backend_cost_savings)
-                if isinstance(backend_cost_savings, (int, float))
-                else 0.0
-            ),
-            stop_reason=(
-                str(backend_stop_reason)
-                if isinstance(backend_stop_reason, str)
-                else None
-            ),
-            convergence_history=(
-                backend_convergence_history
-                if isinstance(backend_convergence_history, list)
-                else []
-            ),
-            full_history=(
-                backend_full_history
-                if include_full_history and isinstance(backend_full_history, list)
-                else ([] if include_full_history else None)
-            ),
+            best_config=response_best_config,
+            best_metrics=response_best_metrics,
+            total_trials=response_total_trials,
+            successful_trials=response_successful_trials,
+            total_duration=response_total_duration,
+            cost_savings=response_cost_savings,
+            stop_reason=response_stop_reason,
+            convergence_history=response_convergence_history,
+            full_history=response_full_history,
             metadata={
                 "finalized_at": time.time(),
                 "experiment_run_id": mapping.experiment_run_id if mapping else None,
                 "finalized_via_api": finalized_via_api,
-                # summary_available=True iff the backend payload included
-                # at least one of the documented summary fields (best_config,
-                # best_metrics, total_trials, …). Callers should treat
-                # best_config / best_metrics as authoritative only when this
-                # flag is True.
+                # summary_available=True iff at least one documented backend
+                # summary field was type-valid and preserved. It does not
+                # imply any specific field is present; inspect summary_fields
+                # before treating best_config/best_metrics as authoritative.
                 "summary_available": summary_available,
+                "summary_fields": summary_fields,
             },
         )
 

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -741,17 +741,21 @@ class SessionOperations:
                         session_id,
                     )
 
-        # Try to finalize via backend API endpoint (POST /sessions/{id}/finalize)
-        finalized_via_api = False
+        # Try to finalize via backend API endpoint (POST /sessions/{id}/finalize).
+        # backend_payload is dict on 2xx (possibly empty if the backend gave us
+        # no summary), or None when the endpoint was unavailable/failed. See #890.
+        backend_payload: dict[str, Any] | None = None
         if mapping:
             try:
-                finalized_via_api = await self._finalize_session_via_api(
+                backend_payload = await self._finalize_session_via_api(
                     session_id, mapping.experiment_run_id
                 )
             except CloudServiceError:
                 raise
             except Exception as e:
                 logger.debug(f"Backend finalization API not available: {e}")
+
+        finalized_via_api = backend_payload is not None
 
         # If backend finalization not available, the session may already be auto-finalized
         # Just log this - no need to fail
@@ -775,21 +779,96 @@ class SessionOperations:
         # Revoke security session
         self.client._revoke_security_session(session_id)
 
-        # Create finalization response (simplified version)
+        # Build finalization response. When the backend returned a summary
+        # payload, preserve its fields verbatim. Otherwise mark the summary
+        # as unavailable so callers don't treat empty best_config/best_metrics
+        # as an authoritative "empty optimization" result (per issue #890).
+        backend_summary = backend_payload or {}
+
+        backend_best_config = backend_summary.get("best_config")
+        backend_best_metrics = backend_summary.get("best_metrics")
+        backend_total_trials = backend_summary.get("total_trials")
+        backend_successful_trials = backend_summary.get("successful_trials")
+        backend_total_duration = backend_summary.get("total_duration")
+        backend_cost_savings = backend_summary.get("cost_savings")
+        backend_stop_reason = backend_summary.get("stop_reason")
+        backend_convergence_history = backend_summary.get("convergence_history")
+        backend_full_history = backend_summary.get("full_history")
+
+        # summary_available=True only when the backend actually included at
+        # least one of the documented summary fields. A non-empty payload
+        # that uses a different shape (e.g. legacy {best_trial, all_results}
+        # responses) MUST NOT mark summary_available=True, otherwise callers
+        # would treat the SDK's fallback empty best_config/best_metrics as
+        # authoritative — recreating the original #890 ambiguity.
+        summary_available = any(
+            v is not None
+            for v in (
+                backend_best_config,
+                backend_best_metrics,
+                backend_total_trials,
+                backend_successful_trials,
+                backend_total_duration,
+                backend_cost_savings,
+                backend_stop_reason,
+                backend_convergence_history,
+                backend_full_history,
+            )
+        )
+
         response = OptimizationFinalizationResponse(
             session_id=session_id,
-            best_config={},
-            best_metrics={},
-            total_trials=completed_trials,
-            successful_trials=completed_trials,
-            total_duration=0.0,
-            cost_savings=0.0,
-            convergence_history=[],
-            full_history=[] if include_full_history else None,
+            best_config=(
+                backend_best_config if isinstance(backend_best_config, dict) else {}
+            ),
+            best_metrics=(
+                backend_best_metrics if isinstance(backend_best_metrics, dict) else {}
+            ),
+            total_trials=(
+                int(backend_total_trials)
+                if isinstance(backend_total_trials, (int, float))
+                else completed_trials
+            ),
+            successful_trials=(
+                int(backend_successful_trials)
+                if isinstance(backend_successful_trials, (int, float))
+                else completed_trials
+            ),
+            total_duration=(
+                float(backend_total_duration)
+                if isinstance(backend_total_duration, (int, float))
+                else 0.0
+            ),
+            cost_savings=(
+                float(backend_cost_savings)
+                if isinstance(backend_cost_savings, (int, float))
+                else 0.0
+            ),
+            stop_reason=(
+                str(backend_stop_reason)
+                if isinstance(backend_stop_reason, str)
+                else None
+            ),
+            convergence_history=(
+                backend_convergence_history
+                if isinstance(backend_convergence_history, list)
+                else []
+            ),
+            full_history=(
+                backend_full_history
+                if include_full_history and isinstance(backend_full_history, list)
+                else ([] if include_full_history else None)
+            ),
             metadata={
                 "finalized_at": time.time(),
                 "experiment_run_id": mapping.experiment_run_id if mapping else None,
                 "finalized_via_api": finalized_via_api,
+                # summary_available=True iff the backend payload included
+                # at least one of the documented summary fields (best_config,
+                # best_metrics, total_trials, …). Callers should treat
+                # best_config / best_metrics as authoritative only when this
+                # flag is True.
+                "summary_available": summary_available,
             },
         )
 
@@ -797,7 +876,7 @@ class SessionOperations:
 
     async def _finalize_session_via_api(
         self, session_id: str, experiment_run_id: str
-    ) -> bool:
+    ) -> dict[str, Any] | None:
         """Call backend session finalization endpoint.
 
         Args:
@@ -805,11 +884,16 @@ class SessionOperations:
             experiment_run_id: Associated experiment run ID
 
         Returns:
-            True if successfully finalized via API, False otherwise
+            Parsed backend response payload (may be ``{}`` if the backend
+            returned 2xx with an empty body) when finalization succeeded;
+            ``None`` when the endpoint was unavailable, returned a non-2xx
+            status, or failed locally. Per issue #890, callers use this
+            return shape to distinguish "backend gave us a summary" from
+            "backend just accepted the finalize call with no payload".
         """
         if not AIOHTTP_AVAILABLE:
             logger.debug("aiohttp not available, skipping API finalization")
-            return False
+            return None
 
         try:
             # Prepare headers with API key
@@ -839,7 +923,20 @@ class SessionOperations:
                         logger.info(
                             f"✅ Finalized session {session_id} via backend API"
                         )
-                        return True
+                        try:
+                            payload = await response.json()
+                            if not isinstance(payload, dict):
+                                logger.debug(
+                                    "Backend finalize returned non-dict body: %r",
+                                    type(payload).__name__,
+                                )
+                                return {}
+                            return payload
+                        except Exception:
+                            # Backend returned 2xx but body wasn't JSON or
+                            # was empty — finalize succeeded but no summary
+                            # payload to preserve.
+                            return {}
                     elif response.status == 403:
                         error_text = await response.text()
                         self._raise_ownership_error(
@@ -856,10 +953,10 @@ class SessionOperations:
                         logger.debug(
                             f"Backend finalization endpoint returned HTTP {response.status}: {error_text}"
                         )
-                        return False
+                        return None
         except Exception as e:
             logger.debug(f"Error calling backend finalization API: {e}")
-            return False
+            return None
 
     async def delete_session(self, session_id: str, cascade: bool = True) -> bool:
         """Delete optimization session and optionally related data.


### PR DESCRIPTION
## Summary

Closes #890. `_finalize_session_via_api` returned a bool, so the backend's actual finalize response payload was discarded and `finalize_session` synthesized an `OptimizationFinalizationResponse` with empty/zero summary fields — making a successful cloud finalization look like an empty optimization result.

## Fix

- `_finalize_session_via_api` now returns `dict | None` instead of `bool`.
- `finalize_session` populates response fields verbatim from the payload.
- New `metadata['summary_available']` flag is True iff the backend payload included at least one documented summary field — so callers can distinguish 'backend gave us a summary' from 'finalize accepted with no/legacy body'.

## Test plan

- [x] Existing `test_finalize_session_via_api_success` updated to assert summary_available=False on no-body responses.
- [x] **New** test preserves full backend payload verbatim with summary_available=True.
- [x] **New** test for legacy `{best_trial, all_results}` shape → summary_available=False (codex catch).
- [x] **New** test for 404 endpoint → summary_available=False.
- [x] 3 downstream test mocks migrated to dict|None contract.
- [x] 15 tests pass.
- [x] **Codex-xhigh: APPROVE** after 3 iterations.
- [ ] CI green on PR.

## Production-safety checklist

1. **Worst-case prod path.** Previously: callers received empty best_config/best_metrics indistinguishable from "empty optimization". Now: `summary_available` makes that distinction explicit. **Fail-closed** (no synthetic summary).
2. **Production-branch test.** `test_finalize_session_legacy_payload_marks_summary_unavailable` covers the production-relevant case where the SDK and backend disagree on payload shape.
3. **Contract regeneration.** No schema changes; `OptimizationFinalizationResponse` shape unchanged. New metadata key is additive.
4. **Public surface delta.** Private `_finalize_session_via_api` return type changed from bool to dict|None — internal only, but 3 test mocks were updated.
5. **Review threads resolved.** N/A.
6. **Quality gates not relaxed.** Pre-commit hooks pass.

## Cross-SDK note

The summary_available pattern should propagate to `traigent-js` if/when it has a finalize path — flag for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)