### PR TITLE
fix(cloud): privacy trial suggestion propagates remote-unavailable signal (closes #888)

### DIFF
--- a/tests/integration/test_backend_integration.py
+++ b/tests/integration/test_backend_integration.py
@@ -7,6 +7,10 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from traigent.cloud.backend_bridges import SessionExperimentMapping, bridge
+from traigent.cloud.client import (
+    CloudRemoteExecutionUnavailableError,
+    CloudServiceError,
+)
 from traigent.cloud.dataset_converter import converter
 from traigent.cloud.integration_manager import (
     IntegrationConfig,
@@ -639,6 +643,51 @@ class TestIntegrationManager:
                         {"accuracy": 0.9},
                         1.5,
                         None,
+                    )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("exc_type", "exc"),
+        [
+            (
+                CloudRemoteExecutionUnavailableError,
+                CloudRemoteExecutionUnavailableError("get_cloud_trial_suggestion"),
+            ),
+            (CloudServiceError, CloudServiceError("backend unavailable")),
+        ],
+        ids=["cloud-unavailable", "cloud-service-error"],
+    )
+    async def test_get_next_trial_propagates_typed_cloud_errors(
+        self, integration_config, exc_type, exc
+    ):
+        """IntegrationManager must not collapse typed cloud errors to None."""
+        with patch("traigent.cloud.integration_manager.get_production_mcp_client"):
+            with patch(
+                "traigent.cloud.integration_manager.get_backend_client"
+            ) as mock_backend_client:
+                with patch(
+                    "traigent.cloud.integration_manager.lifecycle_manager"
+                ) as mock_lifecycle:
+                    mock_session_state = Mock()
+                    mock_session_state.session.session_id = "session_456"
+                    mock_lifecycle.get_session_state.return_value = mock_session_state
+
+                    mock_backend = Mock()
+                    mock_backend.get_next_privacy_trial = AsyncMock(side_effect=exc)
+                    mock_backend_client.return_value = mock_backend
+
+                    manager = IntegrationManager(integration_config)
+                    await manager.initialize()
+                    manager._active_integrations["test_int"] = {
+                        "mode": IntegrationMode.PRIVACY.value,
+                        "result": Mock(session_id="session_456"),
+                    }
+
+                    with pytest.raises(exc_type):
+                        await manager.get_next_trial("session_456")
+
+                    mock_backend.get_next_privacy_trial.assert_awaited_once_with(
+                        "session_456", None
                     )
 
     def test_integration_statistics(self, integration_config):

--- a/tests/unit/cloud/test_privacy_operations.py
+++ b/tests/unit/cloud/test_privacy_operations.py
@@ -6,6 +6,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from traigent.cloud.client import (
+    CloudRemoteExecutionUnavailableError,
+    CloudServiceError,
+)
 from traigent.cloud.models import OptimizationSession, OptimizationSessionStatus
 from traigent.cloud.privacy_operations import PrivacyOperations
 
@@ -192,3 +196,120 @@ async def test_submit_privacy_trial_results_does_not_increment_on_backend_failur
     assert success is False
     assert client._active_sessions["session-1"].completed_trials == 0
     assert lock.enter_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_next_privacy_trial_propagates_cloud_unavailable():
+    """Regression for #888: when the cloud remote suggestion service raises
+    CloudRemoteExecutionUnavailableError, the public method must re-raise it,
+    not swallow into None. Callers MUST be able to distinguish capability
+    unavailability from optimization completion.
+    """
+    lock = FakeLock()
+    client = DummyClient(lock)
+
+    async def raise_unavailable(request):
+        raise CloudRemoteExecutionUnavailableError("get_cloud_trial_suggestion")
+
+    client._get_cloud_trial_suggestion = raise_unavailable  # type: ignore[method-assign]
+
+    ops = PrivacyOperations(client)
+    client._active_sessions["session-1"] = OptimizationSession(
+        session_id="session-1",
+        function_name="test",
+        configuration_space={},
+        objectives=["accuracy"],
+        max_trials=5,
+        status=OptimizationSessionStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    with pytest.raises(CloudRemoteExecutionUnavailableError):
+        await ops.get_next_privacy_trial("session-1", None)
+
+
+@pytest.mark.asyncio
+async def test_get_next_privacy_trial_propagates_cloud_service_error():
+    """Companion to the #888 fix: other typed CloudServiceError subclasses
+    (auth/transient) also propagate, not silently None.
+    """
+    lock = FakeLock()
+    client = DummyClient(lock)
+
+    async def raise_cse(request):
+        raise CloudServiceError("auth failed")
+
+    client._get_cloud_trial_suggestion = raise_cse  # type: ignore[method-assign]
+
+    ops = PrivacyOperations(client)
+    client._active_sessions["session-1"] = OptimizationSession(
+        session_id="session-1",
+        function_name="test",
+        configuration_space={},
+        objectives=["accuracy"],
+        max_trials=5,
+        status=OptimizationSessionStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    with pytest.raises(CloudServiceError):
+        await ops.get_next_privacy_trial("session-1", None)
+
+
+@pytest.mark.asyncio
+async def test_get_next_privacy_trial_returns_none_on_no_suggestion():
+    """Companion to the #888 fix: when the backend explicitly returns no
+    suggestion, the method returns None as before — that's the
+    optimization-complete sentinel and distinct from capability failure.
+    """
+    lock = FakeLock()
+    client = DummyClient(lock)
+
+    async def empty_suggestion(request):
+        return SimpleNamespace(suggestion=None)
+
+    client._get_cloud_trial_suggestion = empty_suggestion  # type: ignore[method-assign]
+
+    ops = PrivacyOperations(client)
+    client._active_sessions["session-1"] = OptimizationSession(
+        session_id="session-1",
+        function_name="test",
+        configuration_space={},
+        objectives=["accuracy"],
+        max_trials=5,
+        status=OptimizationSessionStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    result = await ops.get_next_privacy_trial("session-1", None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_next_privacy_trial_returns_none_on_unexpected_error():
+    """Unexpected internal errors keep the legacy None fallback."""
+    lock = FakeLock()
+    client = DummyClient(lock)
+
+    async def raise_unexpected(request):
+        raise RuntimeError("boom")
+
+    client._get_cloud_trial_suggestion = raise_unexpected  # type: ignore[method-assign]
+
+    ops = PrivacyOperations(client)
+    client._active_sessions["session-1"] = OptimizationSession(
+        session_id="session-1",
+        function_name="test",
+        configuration_space={},
+        objectives=["accuracy"],
+        max_trials=5,
+        status=OptimizationSessionStatus.ACTIVE,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    result = await ops.get_next_privacy_trial("session-1", None)
+    assert result is None

--- a/traigent/cloud/integration_manager.py
+++ b/traigent/cloud/integration_manager.py
@@ -25,6 +25,7 @@ from traigent.utils.validation import CoreValidators, validate_or_raise
 
 from .backend_bridges import SessionExperimentMapping
 from .backend_client import BackendClientConfig, get_backend_client
+from .client import CloudRemoteExecutionUnavailableError, CloudServiceError
 from .dataset_converter import converter
 from .models import (
     OptimizationRequest,
@@ -553,6 +554,10 @@ class IntegrationManager:
             return cast(TrialSuggestion | None, suggestion)
 
         except asyncio.CancelledError:
+            raise
+        except (CloudRemoteExecutionUnavailableError, CloudServiceError):
+            # Typed cloud failures are public signals. Do not collapse them into
+            # None, which means "no suggestion / optimization complete" here.
             raise
         except Exception as e:
             logger.error(f"Failed to get next trial for session {session_id}: {e}")

--- a/traigent/cloud/privacy_operations.py
+++ b/traigent/cloud/privacy_operations.py
@@ -252,7 +252,10 @@ class PrivacyOperations:
             return response.suggestion
 
         except CloudRemoteExecutionUnavailableError:
-            # Remote suggestion capability is intentionally not implemented yet.
+            # This subclass would also propagate through CloudServiceError below;
+            # keep the explicit arm so the public capability-gap contract is
+            # visible to readers and grep-able in tests. Remote suggestion
+            # capability is intentionally not implemented yet.
             # This is structurally different from "no more trials" or a
             # transient backend failure — callers MUST be able to tell them
             # apart so they can route to a local optimizer instead of

--- a/traigent/cloud/privacy_operations.py
+++ b/traigent/cloud/privacy_operations.py
@@ -9,7 +9,10 @@ remains local and only metrics are transmitted to the backend session API.
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from traigent.cloud.client import CloudServiceError
+from traigent.cloud.client import (
+    CloudRemoteExecutionUnavailableError,
+    CloudServiceError,
+)
 from traigent.cloud.models import (
     NextTrialRequest,
     OptimizationSession,
@@ -193,7 +196,23 @@ class PrivacyOperations:
             previous_results: Previous trial results (metrics only, no data)
 
         Returns:
-            Next trial suggestion with configuration and dataset subset indices
+            A :class:`TrialSuggestion` when the backend returned one; ``None``
+            when the backend explicitly returned no suggestion (e.g. the
+            optimization is complete or no more trials are needed) **or** when
+            an unexpected internal error occurred (logged and swallowed).
+
+        Raises:
+            CloudRemoteExecutionUnavailableError: When the cloud remote
+                suggestion service is not implemented yet for this
+                deployment. Callers MUST distinguish this from a ``None``
+                return — capability unavailability is a structurally
+                different state from "no suggestion available" and should
+                route to a local optimizer or surface to the user. See
+                issue #888.
+            CloudServiceError: For other typed backend failures (auth,
+                transient remote errors). Callers should treat these as
+                non-final and may retry or fail loud, but MUST NOT treat
+                them as optimization completion.
         """
         logger.debug(f"Getting next trial for privacy session {session_id}")
 
@@ -232,7 +251,25 @@ class PrivacyOperations:
 
             return response.suggestion
 
+        except CloudRemoteExecutionUnavailableError:
+            # Remote suggestion capability is intentionally not implemented yet.
+            # This is structurally different from "no more trials" or a
+            # transient backend failure — callers MUST be able to tell them
+            # apart so they can route to a local optimizer instead of
+            # silently treating optimization as complete. Re-raise the typed
+            # exception so the public boundary surfaces the capability gap.
+            # See issue #888.
+            raise
+        except CloudServiceError:
+            # Other typed cloud failures (auth, transient remote errors) are
+            # already documented public exceptions; re-raise them too so
+            # callers can distinguish them from `None == optimization complete`.
+            raise
         except Exception as e:
+            # Genuinely unexpected error: log and return None as the legacy
+            # "no suggestion" sentinel. Anything that should be visible at
+            # the public boundary should have a typed CloudServiceError
+            # subclass and propagate via the branches above.
             logger.error(f"Failed to get next trial for session {session_id}: {e}")
             return None
 


### PR DESCRIPTION
## Summary

Closes #888. Privacy trial suggestion code swallowed typed cloud capability failures into None, making remote-unavailable indistinguishable from no more trials.

## Fix

- PrivacyOperations.get_next_privacy_trial re-raises CloudRemoteExecutionUnavailableError and CloudServiceError.
- IntegrationManager.get_next_trial also re-raises those typed cloud failures before its broad unexpected-error fallback, so the main production path preserves the signal.
- The None return remains reserved for no suggestion or unexpected internal fallback.
- Docstrings/comments describe the distinct states.

## Validation

- uv run --extra dev pytest tests/unit/cloud/test_privacy_operations.py -q -> 8 passed
- uv run --extra dev pytest tests/integration/test_backend_integration.py::TestIntegrationManager::test_trial_management tests/integration/test_backend_integration.py::TestIntegrationManager::test_get_next_trial_propagates_typed_cloud_errors -q -> 4 passed
- uv run --extra dev pytest tests/unit/cloud/test_backend_client.py::TestPrivacyFirstOptimization::test_get_next_privacy_trial -q -> 1 passed
- uv run --extra dev black --check touched files -> passed
- uv run --extra dev ruff check touched files -> passed
- uv run --extra dev isort --check-only touched files -> passed
- git diff --check -> passed
- Claude Code Opus 4.7 xhigh review: no logic blockers after import-order fix
- GitHub checks green

## Production-Safety Checklist

- Worst-case prod path: capability unavailability now propagates as a typed exception instead of looking like optimization completion.
- Production-branch test: IntegrationManager coverage proves the main path preserves typed cloud errors.
- Contract regeneration: no schema changes.
- Public surface delta: existing typed cloud exceptions are no longer swallowed at this boundary.
- Review threads resolved before merge: yes.
- Quality gates not relaxed.