### PR TITLE
docs(mock-mode): mark MockModeOptions inert + align mock-mode docs (closes #874)

### DIFF
--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -85,7 +85,7 @@ def my_agent(question: str) -> str:
 | `evaluation` | `EvaluationOptions \| dict \| None` | Bundle for `eval_dataset`, `custom_evaluator`, `scoring_function`, and `metric_functions`. |
 | `injection` | `InjectionOptions \| dict \| None` | Bundle for `injection_mode`, `config_param`, `auto_override_frameworks`, and `framework_targets`. |
 | `execution` | `ExecutionOptions \| dict \| None` | Bundle for execution settings including `execution_mode`, `local_storage_path`, `parallel_config`, `privacy_enabled`, and `max_total_examples`. |
-| `mock` | `MockModeOptions \| dict \| None` | Bundle for mock-mode settings: `enabled`, `override_evaluator`, `base_accuracy`, `variance`. |
+| `mock` | `MockModeOptions \| dict \| None` | **Deprecated — all fields inert.** Retained on the schema for backwards compatibility (config round-trip). Mock mode is enabled via the `TRAIGENT_MOCK_LLM` environment variable, not via this object. See issue #874. |
 
 **ExecutionOptions Fields** (open-source builds run in `edge_analytics` only; other modes are roadmap-compatible but not currently provisioned)
 
@@ -109,7 +109,7 @@ def my_agent(question: str) -> str:
 **Usage Notes**
 
 - The default execution mode is `"edge_analytics"`. Use `"hybrid"` for portal-tracked optimization with local trial execution.
-- Prefer the grouped option classes (`EvaluationOptions`, `InjectionOptions`, `ExecutionOptions`, `MockModeOptions`) when you need to adjust several related knobs. Import them from `traigent.api.decorators` and pass either instances or plain dicts.
+- Prefer the grouped option classes (`EvaluationOptions`, `InjectionOptions`, `ExecutionOptions`) when you need to adjust several related knobs. Import them from `traigent.api.decorators` and pass either instances or plain dicts. `MockModeOptions` is **deprecated** (all fields inert; see the `mock` row above and issue #874) — do not use it for new code.
 - `parallel_config=ParallelConfig(...)` remains the primary way to control concurrency. Set global defaults via `traigent.configure(parallel_config=...)`, override them in the decorator, and fine-tune per `.optimize()` call. Later scopes override earlier ones field-by-field.
 - `ParallelConfig` lives in `traigent.config.parallel`. You can pass either an instance or a simple `dict` with the same keys.
 - `privacy_enabled=True` applies in local and hybrid contexts. `cloud` remote execution is not available yet.

--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -85,7 +85,7 @@ def my_agent(question: str) -> str:
 | `evaluation` | `EvaluationOptions \| dict \| None` | Bundle for `eval_dataset`, `custom_evaluator`, `scoring_function`, and `metric_functions`. |
 | `injection` | `InjectionOptions \| dict \| None` | Bundle for `injection_mode`, `config_param`, `auto_override_frameworks`, and `framework_targets`. |
 | `execution` | `ExecutionOptions \| dict \| None` | Bundle for execution settings including `execution_mode`, `local_storage_path`, `parallel_config`, `privacy_enabled`, and `max_total_examples`. |
-| `mock` | `MockModeOptions \| dict \| None` | **Deprecated — all fields inert.** Retained on the schema for backwards compatibility (config round-trip). Mock mode is enabled via the `TRAIGENT_MOCK_LLM` environment variable, not via this object. See issue #874. |
+| `mock` | `MockModeOptions \| dict \| None` | **Deprecated — all fields inert.** Retained on the schema for backwards compatibility (config round-trip). Mock mode is enabled by calling `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial or test code, not via this object. The legacy `TRAIGENT_MOCK_LLM=true` env var remains available outside production for shell fixtures and backwards compatibility but emits `DeprecationWarning` when users set it directly. See issue #874. |
 
 **ExecutionOptions Fields** (open-source builds run in `edge_analytics` only; other modes are roadmap-compatible but not currently provisioned)
 

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -485,23 +485,30 @@ from traigent.config.parallel import ParallelConfig
 ```python
 from traigent.api.decorators import MockModeOptions
 
+# DEPRECATED: MockModeOptions and its fields are inert in the current SDK.
+# They round-trip cleanly for backwards compatibility but do not affect
+# runtime behavior. Mock mode is enabled via the TRAIGENT_MOCK_LLM
+# environment variable. See issue #874.
 @traigent.optimize(
-    mock=MockModeOptions(
-        enabled=True,
-        override_evaluator=True,
-        base_accuracy=0.75,
-        variance=0.25,
-    ),
+    mock=MockModeOptions(enabled=True),  # inert; kept for config round-trip
     ...
 )
 ```
 
-**MockModeOptions Fields**:
+**MockModeOptions Fields (DEPRECATED — all inert)**:
 
-- `enabled`: Enable mock mode
-- `override_evaluator`: Use mock evaluator
-- `base_accuracy`: Base accuracy for mock results
-- `variance`: Variance in mock results
+The fields below are kept on the schema for backwards compatibility but
+are ignored at runtime. Mock mode is controlled by the
+`TRAIGENT_MOCK_LLM` environment variable. In mock mode the LLM call
+layer is intercepted with canned responses; evaluator scoring (built-in
+or custom) is unchanged — there is no fabricated random-score path.
+
+- `enabled`: Inert. Use `TRAIGENT_MOCK_LLM=true` to enable mock mode.
+- `override_evaluator`: Inert. The SDK no longer ships a mock evaluator
+  override; custom and local evaluators always run their real scoring
+  logic.
+- `base_accuracy`: Inert. No baseline-accuracy fabrication path remains.
+- `variance`: Inert. No score-variance fabrication path remains.
 
 ### Runtime Overrides
 

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -487,8 +487,10 @@ from traigent.api.decorators import MockModeOptions
 
 # DEPRECATED: MockModeOptions and its fields are inert in the current SDK.
 # They round-trip cleanly for backwards compatibility but do not affect
-# runtime behavior. Mock mode is enabled via the TRAIGENT_MOCK_LLM
-# environment variable. See issue #874.
+# runtime behavior. Enable mock mode in local tutorial or test code by
+# calling traigent.testing.enable_mock_mode_for_quickstart(). The legacy
+# TRAIGENT_MOCK_LLM=true env var remains for shell fixtures only and
+# emits DeprecationWarning when users set it directly. See issue #874.
 @traigent.optimize(
     mock=MockModeOptions(enabled=True),  # inert; kept for config round-trip
     ...
@@ -498,12 +500,12 @@ from traigent.api.decorators import MockModeOptions
 **MockModeOptions Fields (DEPRECATED — all inert)**:
 
 The fields below are kept on the schema for backwards compatibility but
-are ignored at runtime. Mock mode is controlled by the
-`TRAIGENT_MOCK_LLM` environment variable. In mock mode the LLM call
+are ignored at runtime. Mock mode is enabled by calling
+`traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial or test code. The legacy `TRAIGENT_MOCK_LLM=true` env var remains available outside production for shell fixtures and backwards compatibility but emits `DeprecationWarning` when users set it directly. In mock mode the LLM call
 layer is intercepted with canned responses; evaluator scoring (built-in
 or custom) is unchanged — there is no fabricated random-score path.
 
-- `enabled`: Inert. Use `TRAIGENT_MOCK_LLM=true` to enable mock mode.
+- `enabled`: Inert. Use `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial or test code to enable mock mode.
 - `override_evaluator`: Inert. The SDK no longer ships a mock evaluator
   override; custom and local evaluators always run their real scoring
   logic.

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -17,10 +17,11 @@ pip install -e ".[dev]"
 ### Run Tests
 
 ```bash
-# Run all tests (mock mode to avoid API costs)
+# Run all tests through the legacy shell fixture path
+# (may emit DeprecationWarning; prefer enable_mock_mode_for_quickstart() in code)
 TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true pytest
 
-# Run with coverage
+# Run with coverage through the same legacy shell fixture path
 TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true pytest --cov=traigent --cov-report=html
 
 # Run all unit tests with repo-default ignores
@@ -101,16 +102,18 @@ Use the generated report (`coverage.xml` or `htmlcov/`) to track current coverag
 
 ## Mock Mode Testing
 
-Traigent includes a mock mode for testing without real API calls:
+Traigent includes a mock mode for testing without real API calls. In local tutorial or test code, use the in-code helper:
+
+```python
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
+```
+
+For shell-only fixtures and older scripts, the legacy env var still works outside production, but direct user-set activation emits `DeprecationWarning`:
 
 ```bash
-# Enable mock mode
-export TRAIGENT_MOCK_LLM=true
-
-# Run tests with mock mode
 TRAIGENT_MOCK_LLM=true pytest tests/
-
-# Run specific example in mock mode
 TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py
 ```
 
@@ -126,8 +129,11 @@ TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py
 > Note: The legacy `MockModeOptions` fields (`enabled`,
 > `override_evaluator`, `base_accuracy`, `variance`) are kept on the
 > schema for backwards compatibility but are inert — mock mode is
-> controlled by `TRAIGENT_MOCK_LLM`, not by passing `mock=...`. See
-> issue #874.
+> activated by `traigent.testing.enable_mock_mode_for_quickstart()`
+> in local code, not by passing `mock=...`. The legacy
+> `TRAIGENT_MOCK_LLM=true` env var remains for shell fixtures and
+> backwards compatibility, but emits `DeprecationWarning` when users set
+> it directly. See issue #874.
 
 ## Development Testing Workflow
 
@@ -150,10 +156,10 @@ pip install -e ".[dev]"
 ### 2. Run Tests Before Committing
 
 ```bash
-# Run all tests
+# Run all tests through the legacy shell fixture path
 TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true pytest
 
-# Run with coverage
+# Run with coverage through the same legacy shell fixture path
 TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true pytest --cov=traigent --cov-report=term-missing
 
 # Run linters
@@ -245,12 +251,16 @@ grep -A 5 'tool.pytest' pyproject.toml
 ### Mock Mode Not Working
 
 ```bash
-# Verify environment variable
+# Legacy shell fixture path only
 echo $TRAIGENT_MOCK_LLM
+```
 
-# Set explicitly in test
-import os
-os.environ["TRAIGENT_MOCK_LLM"] = "true"
+Preferred explicit activation in local tutorial or test code:
+
+```python
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
 ```
 
 ## 📈 Continuous Integration

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -115,10 +115,19 @@ TRAIGENT_MOCK_LLM=true python examples/core/rag-optimization/run.py
 ```
 
 **Mock Mode Features:**
-- No API keys required
-- Realistic accuracy scores (0.75 +/- 0.25)
-- Fast execution
-- Deterministic results when you set `mock={"random_seed": 123}`
+- No API keys required.
+- Fast execution — LLM calls are intercepted and replaced with canned
+  responses so trials don't hit the network.
+- Evaluator scoring is unchanged — your `metric_functions`, custom
+  evaluator, or the built-in `LocalEvaluator` accuracy calculator runs
+  the same scoring logic in both mock and real modes. There is no
+  fabricated random-score path.
+
+> Note: The legacy `MockModeOptions` fields (`enabled`,
+> `override_evaluator`, `base_accuracy`, `variance`) are kept on the
+> schema for backwards compatibility but are inert — mock mode is
+> controlled by `TRAIGENT_MOCK_LLM`, not by passing `mock=...`. See
+> issue #874.
 
 ## Development Testing Workflow
 

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -175,7 +175,7 @@ def strict_agent(query: str) -> str:
 
 ### 5) Mock mode
 
-`TRAIGENT_MOCK_LLM=true` skips external LLM/API calls and synthesizes metrics—ideal for CI, demos, and budget-safe smoke tests.
+`TRAIGENT_MOCK_LLM=true` intercepts external LLM/API calls and replaces them with canned/deterministic responses. Your evaluator (custom or the built-in `LocalEvaluator`) still scores those canned responses with its real scoring logic — the SDK no longer synthesizes metrics. Ideal for CI, demos, and budget-safe smoke tests.
 
 ```bash
 export TRAIGENT_MOCK_LLM=true

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -76,7 +76,7 @@ What this does:
 
 ### 1) Default semantic similarity
 
-- Embedding-based comparison (OpenAI embeddings by default); set `OPENAI_API_KEY` unless running in `TRAIGENT_MOCK_LLM`.
+- Embedding-based comparison (OpenAI embeddings by default); set `OPENAI_API_KEY` unless local mock mode is enabled.
 - Great for natural language tasks where paraphrasing is fine.
 
 ```python
@@ -175,12 +175,15 @@ def strict_agent(query: str) -> str:
 
 ### 5) Mock mode
 
-`TRAIGENT_MOCK_LLM=true` intercepts external LLM/API calls and replaces them with canned/deterministic responses. Your evaluator (custom or the built-in `LocalEvaluator`) still scores those canned responses with its real scoring logic — the SDK no longer synthesizes metrics. Ideal for CI, demos, and budget-safe smoke tests.
+Call `traigent.testing.enable_mock_mode_for_quickstart()` near the top of local tutorial or test code to intercept external LLM/API calls and replace them with canned/deterministic responses. Your evaluator (custom or the built-in `LocalEvaluator`) still scores those canned responses with its real scoring logic - the SDK no longer synthesizes metrics. Ideal for CI, demos, and budget-safe smoke tests.
 
-```bash
-export TRAIGENT_MOCK_LLM=true
-python your_optimization_script.py
+```python
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
 ```
+
+For shell-only fixtures, `TRAIGENT_MOCK_LLM=true` remains available outside production for backwards compatibility, but direct user-set activation emits `DeprecationWarning`.
 
 ## Troubleshooting
 
@@ -396,8 +399,10 @@ Best accuracy: 0.00
    ```
 
 3. **Use Mock Mode for Testing**
-   ```bash
-   export TRAIGENT_MOCK_LLM=true
+   ```python
+   from traigent.testing import enable_mock_mode_for_quickstart
+
+   enable_mock_mode_for_quickstart()
    ```
 
 ### Issue: Out of Memory

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -23,9 +23,23 @@ export TRAIGENT_MOCK_LLM=true
 
 ## What to expect
 
-Each script prints trial results to the console. In mock mode, scores are random — the point is to see the full pipeline run without errors.
+Each script prints trial results to the console. In mock mode the SDK
+intercepts the LLM call layer with canned/deterministic responses; the
+walkthrough scripts themselves use a helper called `get_mock_accuracy`
+to produce illustrative accuracy numbers (the helper is example-only,
+not part of the SDK runtime).
 
-When you're ready for real optimization, remove `TRAIGENT_MOCK_LLM` and set your API keys.
+When you switch to real LLMs (remove `TRAIGENT_MOCK_LLM`, set your API
+keys, and run the `walkthrough/real/*` scripts), your custom evaluator
+or the built-in `LocalEvaluator` accuracy calculator scores the real
+LLM outputs end-to-end — the SDK does not fabricate evaluator scores
+in either mode.
+
+> Note: The legacy `MockModeOptions` knobs (`enabled`,
+> `override_evaluator`, `base_accuracy`, `variance`) are retained on the
+> schema for backwards compatibility but are **all inert** — mock mode
+> is enabled via the `TRAIGENT_MOCK_LLM` environment variable, not via
+> that object. See issue #874.
 
 ## Optional Extras
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -1,12 +1,18 @@
-# Walkthrough — 8 Runnable Examples
+# Walkthrough - 8 Runnable Examples
 
-Step through Traigent's features with 8 progressive examples. All run in mock mode — no API keys, no cost.
+Step through Traigent's features with 8 progressive examples. All run in mock mode - no API keys, no cost.
 
 ## Setup
 
-```bash
-export TRAIGENT_MOCK_LLM=true
+The bundled `walkthrough/mock/*` scripts self-select mock behavior for local demos. For your own tutorial code, prefer the in-code helper:
+
+```python
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
 ```
+
+The legacy `TRAIGENT_MOCK_LLM=true` env var remains available outside production for shell fixtures and backwards compatibility, but direct user-set activation emits `DeprecationWarning`.
 
 ## Steps
 
@@ -29,8 +35,7 @@ walkthrough scripts themselves use a helper called `get_mock_accuracy`
 to produce illustrative accuracy numbers (the helper is example-only,
 not part of the SDK runtime).
 
-When you switch to real LLMs (remove `TRAIGENT_MOCK_LLM`, set your API
-keys, and run the `walkthrough/real/*` scripts), your custom evaluator
+When you switch to real LLMs (do not call the helper, unset the legacy `TRAIGENT_MOCK_LLM` env var if present, set your API keys, and run the `walkthrough/real/*` scripts), your custom evaluator
 or the built-in `LocalEvaluator` accuracy calculator scores the real
 LLM outputs end-to-end — the SDK does not fabricate evaluator scores
 in either mode.
@@ -38,8 +43,10 @@ in either mode.
 > Note: The legacy `MockModeOptions` knobs (`enabled`,
 > `override_evaluator`, `base_accuracy`, `variance`) are retained on the
 > schema for backwards compatibility but are **all inert** — mock mode
-> is enabled via the `TRAIGENT_MOCK_LLM` environment variable, not via
-> that object. See issue #874.
+> is activated by `traigent.testing.enable_mock_mode_for_quickstart()`
+> in local code, not via that object. The legacy `TRAIGENT_MOCK_LLM=true`
+> env var remains for shell fixtures and backwards compatibility, but emits
+> `DeprecationWarning` when users set it directly. See issue #874.
 
 ## Optional Extras
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -203,14 +203,35 @@ class ExecutionOptions(BaseModel):
 
 
 class MockModeOptions(BaseModel):
-    """Fine-grained configuration for mock mode behaviour."""
+    """Fine-grained configuration for mock mode behaviour.
+
+    .. deprecated::
+        **All MockModeOptions fields are inert in the current SDK.**
+        Mock mode is enabled via the ``TRAIGENT_MOCK_LLM=true`` environment
+        variable (or the equivalent runtime detection in bundled example
+        bootstraps), not via this object. ``enabled``,
+        ``override_evaluator``, ``base_accuracy``, and ``variance`` are
+        retained on the schema for backwards compatibility so existing
+        serialized configs round-trip without breaking, but the
+        optimization pipeline ignores all of them. In mock mode the LLM
+        call layer is intercepted with canned/deterministic responses;
+        the scoring path (built-in metrics, custom evaluators, and the
+        ``LocalEvaluator`` accuracy calculator) is unchanged — there is
+        no random-score fabrication. Walkthrough scripts under
+        ``walkthrough/mock/`` use their own helper ``get_mock_accuracy``
+        for example scoring; that helper is example-only and is not part
+        of the SDK runtime behavior.
+
+        This deprecation is doc-only. The fields will be removed in a
+        future major version. See issue #874.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     enabled: bool = True
-    override_evaluator: bool = True
-    base_accuracy: float = 0.75
-    variance: float = 0.25
+    override_evaluator: bool = True  # inert; see class docstring
+    base_accuracy: float = 0.75  # inert; see class docstring
+    variance: float = 0.25  # inert; see class docstring
 
 
 BundleModel = TypeVar("BundleModel", bound=BaseModel)
@@ -1619,8 +1640,12 @@ def optimize(  # NOSONAR(S107)
 
         Mock mode options:
             mock: Grouped mock-mode preferences (MockModeOptions or dict).
-            mock_mode_config: Dict controlling mock behaviour keys such as
-                ``enabled``, ``override_evaluator``, ``base_accuracy``, ``variance``.
+            mock_mode_config: Legacy mock-mode dict. **Inert** — the SDK
+                no longer reads ``enabled``, ``override_evaluator``,
+                ``base_accuracy``, or ``variance`` from this dict. Use the
+                ``TRAIGENT_MOCK_LLM`` environment variable to enable mock
+                mode. The parameter is retained for config round-trip;
+                see issue #874.
 
         Cost safeguards:
             cost_limit: Maximum USD spending per optimization run. Defaults to

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -207,9 +207,11 @@ class MockModeOptions(BaseModel):
 
     .. deprecated::
         **All MockModeOptions fields are inert in the current SDK.**
-        Mock mode is enabled via the ``TRAIGENT_MOCK_LLM=true`` environment
-        variable (or the equivalent runtime detection in bundled example
-        bootstraps), not via this object. ``enabled``,
+        Mock mode is enabled by calling ``traigent.testing.enable_mock_mode_for_quickstart()``
+        from local tutorial or test code, not via this object. The
+        legacy ``TRAIGENT_MOCK_LLM=true`` env var remains available outside
+        production for shell fixtures and backwards compatibility, but
+        direct user-set env-var activation emits ``DeprecationWarning``. ``enabled``,
         ``override_evaluator``, ``base_accuracy``, and ``variance`` are
         retained on the schema for backwards compatibility so existing
         serialized configs round-trip without breaking, but the
@@ -228,7 +230,7 @@ class MockModeOptions(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
-    enabled: bool = True
+    enabled: bool = True  # inert; see class docstring
     override_evaluator: bool = True  # inert; see class docstring
     base_accuracy: float = 0.75  # inert; see class docstring
     variance: float = 0.25  # inert; see class docstring
@@ -1642,9 +1644,13 @@ def optimize(  # NOSONAR(S107)
             mock: Grouped mock-mode preferences (MockModeOptions or dict).
             mock_mode_config: Legacy mock-mode dict. **Inert** — the SDK
                 no longer reads ``enabled``, ``override_evaluator``,
-                ``base_accuracy``, or ``variance`` from this dict. Use the
-                ``TRAIGENT_MOCK_LLM`` environment variable to enable mock
-                mode. The parameter is retained for config round-trip;
+                ``base_accuracy``, or ``variance`` from this dict. Use
+                ``traigent.testing.enable_mock_mode_for_quickstart()`` in
+                local tutorial or test code to enable mock mode. The legacy
+                ``TRAIGENT_MOCK_LLM`` env var remains supported outside
+                production for shell fixtures but emits ``DeprecationWarning``
+                when users set it directly. The parameter is retained for
+                config round-trip;
                 see issue #874.
 
         Cost safeguards:


### PR DESCRIPTION
Closes #874. Mock-mode public options + walkthrough/reference docs described random-score-era behavior. Now all 6 doc sites + 2 docstrings consistently say: mock mode is controlled by `TRAIGENT_MOCK_LLM`, intercepts the LLM call layer with canned responses, leaves evaluator scoring unchanged. `MockModeOptions` and its 4 fields are deprecated (inert; kept for config round-trip).

Codex-xhigh: APPROVE after 6 iterations — codex caught 6 separate drift sites across the doc tree.