### PR TITLE
docs: align injection-mode docs with v2 default (closes #871)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Provide a JSONL dataset — Traigent scores outputs using semantic similarity by
 
 | Mode | Best for | How |
 |------|----------|-----|
-| **Context** (default) | All cases | Inside the decorated function, call `traigent.get_config()` to read the active configuration (`config["key"]`). |
+| **Context** (default) | Most cases | Inside the decorated function, call `traigent.get_config()` to read the active configuration (`config.get("key", default)`). |
 | **Seamless** | Existing functions with simple local config defaults | Pass `injection_mode="seamless"`; Traigent rewrites simple local variable assignments that match configuration keys. |
 | **Parameter** | New development | Pass `injection_mode="parameter"`; the decorated function receives a `config` argument with explicit `config.get("key")` access. |
 

--- a/README.md
+++ b/README.md
@@ -342,8 +342,9 @@ Provide a JSONL dataset — Traigent scores outputs using semantic similarity by
 
 | Mode | Best for | How |
 |------|----------|-----|
-| **Seamless** (default) | Existing codebases | Traigent intercepts `ChatOpenAI`, `as_retriever`, etc. — zero code changes |
-| **Parameter** | New development | Receives `TraigentConfig` object with explicit `config.get("key")` access |
+| **Context** (default) | All cases | Inside the decorated function, call `traigent.get_config()` to read the active configuration (`config["key"]`). |
+| **Seamless** | Existing codebases with LangChain | Traigent intercepts `ChatOpenAI`, `as_retriever`, etc. — zero code changes for the supported frameworks. Pass `injection_mode="seamless"`. |
+| **Parameter** | New development | Pass `injection_mode="parameter"`; the decorated function receives a `config` argument with explicit `config.get("key")` access. |
 
 **[Injection modes guide →](docs/user-guide/injection_modes.md)**
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Provide a JSONL dataset — Traigent scores outputs using semantic similarity by
 | Mode | Best for | How |
 |------|----------|-----|
 | **Context** (default) | All cases | Inside the decorated function, call `traigent.get_config()` to read the active configuration (`config["key"]`). |
-| **Seamless** | Existing codebases with LangChain | Traigent intercepts `ChatOpenAI`, `as_retriever`, etc. — zero code changes for the supported frameworks. Pass `injection_mode="seamless"`. |
+| **Seamless** | Existing functions with simple local config defaults | Pass `injection_mode="seamless"`; Traigent rewrites simple local variable assignments that match configuration keys. |
 | **Parameter** | New development | Pass `injection_mode="parameter"`; the decorated function receives a `config` argument with explicit `config.get("key")` access. |
 
 **[Injection modes guide →](docs/user-guide/injection_modes.md)**

--- a/docs/user-guide/injection_modes.md
+++ b/docs/user-guide/injection_modes.md
@@ -556,20 +556,21 @@ def api_endpoint(query: str) -> str:
 You can use different modes for different functions:
 
 ```python
-# Seamless for simple functions
+# Context (default) — call traigent.get_config() inside the function
 @traigent.optimize()
 def preprocess(text):
-    max_length = 512
+    config = traigent.get_config()
+    max_length = config.get("max_length", 512)
     return truncate(text, max_length)
 
-# Context for complex pipelines
-@traigent.optimize(injection_mode="context")
+# Seamless — Traigent rewrites supported LangChain client kwargs
+@traigent.optimize(injection_mode="seamless")
 def pipeline(data):
-    config = traigent.get_config()  # Get config for current call
-    # Complex logic with config
+    llm = ChatOpenAI(model="gpt-4o-mini")  # injection rewrites kwargs
+    return llm.invoke(data)
 
-# Parameter for type-safe components
-@traigent.optimize(injection_mode="parameter")
+# Parameter for type-safe components — receives `config` explicitly
+@traigent.optimize(injection_mode="parameter", config_param="config")
 def train(data, config: TraigentConfig):
     # Type-safe training
 ```
@@ -594,9 +595,9 @@ def process(data):
 | Mode | Best For |
 |------|----------|
 | **Context** (default) | Most cases; dynamic config access via `get_config()` inside your function |
-| **Seamless** | Zero-code-change; existing code with matching variable names |
+| **Seamless** | Zero-code-change for LangChain code paths with matching variable names |
 | **Parameter** | Type safety; explicit dependencies; team projects |
-| **Attribute** | External monitoring; A/B testing; debugging |
+| **~~Attribute~~** | **Removed in v2.x** — see Section 4 above for migration guidance. |
 
 Choose based on your specific needs. Context mode is the default and works for most use cases.
 

--- a/docs/user-guide/injection_modes.md
+++ b/docs/user-guide/injection_modes.md
@@ -574,6 +574,7 @@ def pipeline(data):
 @traigent.optimize(injection_mode="parameter", config_param="config")
 def train(data, config: TraigentConfig):
     # Type-safe training
+    return train_model(data, config)
 ```
 
 ### Configuration Validation

--- a/docs/user-guide/injection_modes.md
+++ b/docs/user-guide/injection_modes.md
@@ -563,11 +563,12 @@ def preprocess(text):
     max_length = config.get("max_length", 512)
     return truncate(text, max_length)
 
-# Seamless — Traigent rewrites supported LangChain client kwargs
+# Seamless - Traigent rewrites simple local variable assignments
 @traigent.optimize(injection_mode="seamless")
 def pipeline(data):
-    llm = ChatOpenAI(model="gpt-4o-mini")  # injection rewrites kwargs
-    return llm.invoke(data)
+    model = "gpt-4o-mini"
+    temperature = 0.2
+    return call_llm(model=model, temperature=temperature, prompt=data)
 
 # Parameter for type-safe components — receives `config` explicitly
 @traigent.optimize(injection_mode="parameter", config_param="config")
@@ -595,7 +596,7 @@ def process(data):
 | Mode | Best For |
 |------|----------|
 | **Context** (default) | Most cases; dynamic config access via `get_config()` inside your function |
-| **Seamless** | Zero-code-change for LangChain code paths with matching variable names |
+| **Seamless** | Zero-code-change for existing functions with simple variable assignments matching configuration keys |
 | **Parameter** | Type safety; explicit dependencies; team projects |
 | **~~Attribute~~** | **Removed in v2.x** — see Section 4 above for migration guidance. |
 


### PR DESCRIPTION
Closes #871. README + user-guide injection_modes.md no longer advertise Seamless as default (Context is the v2 default). Attribute mode is consistently marked Removed in v2.x.

Codex-xhigh: APPROVE after 2 iterations.