### PR TITLE
test(cloud): cover privacy-mode trial backend calls (closes #904)

### DIFF
--- a/tests/integration/test_backend_integration.py
+++ b/tests/integration/test_backend_integration.py
@@ -565,8 +565,13 @@ class TestIntegrationManager:
                 mock_cloud.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_trial_management(self, integration_config):
-        """Test trial management through integration manager."""
+    @pytest.mark.parametrize(
+        "stored_mode",
+        [IntegrationMode.PRIVACY.value, "private"],
+        ids=["privacy", "legacy-private"],
+    )
+    async def test_trial_management(self, integration_config, stored_mode):
+        """Privacy and legacy-private modes call backend trial APIs."""
         with patch("traigent.cloud.integration_manager.get_production_mcp_client"):
             with patch(
                 "traigent.cloud.integration_manager.get_backend_client"
@@ -603,9 +608,10 @@ class TestIntegrationManager:
                     manager = IntegrationManager(integration_config)
                     await manager.initialize()
 
-                    # Add mock integration
+                    # Add mock integration with the production "privacy" mode value
+                    # or the legacy "private" spelling kept for migration reads.
                     manager._active_integrations["test_int"] = {
-                        "mode": "private",
+                        "mode": stored_mode,
                         "result": Mock(session_id="session_456"),
                     }
 
@@ -613,6 +619,9 @@ class TestIntegrationManager:
                     suggestion = await manager.get_next_trial("session_456")
                     assert suggestion is not None
                     assert suggestion.trial_id == "trial_123"
+                    mock_backend.get_next_privacy_trial.assert_awaited_once_with(
+                        "session_456", None
+                    )
 
                     # Test submitting results
                     success = await manager.submit_trial_results(
@@ -623,6 +632,14 @@ class TestIntegrationManager:
                         1.5,  # duration
                     )
                     assert success
+                    mock_backend.submit_privacy_trial_results.assert_awaited_once_with(
+                        "session_456",
+                        "trial_123",
+                        {"temp": 0.7},
+                        {"accuracy": 0.9},
+                        1.5,
+                        None,
+                    )
 
     def test_integration_statistics(self, integration_config):
         """Test integration statistics collection."""


### PR DESCRIPTION
## Summary

Closes #904. Current develop already supports both the production privacy mode string and the legacy private spelling through IntegrationManager._is_privacy_integration, but the integration test still seeded only the legacy private value. That left the original production privacy regression uncovered.

## Changes

- Parametrize TestIntegrationManager.test_trial_management over production privacy and legacy-private mode values.
- Assert get_next_privacy_trial is awaited for both mode spellings.
- Assert submit_privacy_trial_results is awaited for both mode spellings.

## Review

- Claude Code Opus 4.7 xhigh review: no blockers, ship.
- Took the optional test-id polish so CI names show privacy vs legacy-private.

## Validation

- uv run --extra dev pytest tests/integration/test_backend_integration.py::TestIntegrationManager::test_trial_management
- uv run --extra dev black --check tests/integration/test_backend_integration.py
- uv run --extra dev ruff check tests/integration/test_backend_integration.py
- git diff --check
- pre-commit hooks on commit: passed

## Production-Safety Checklist

- Worst-case prod path: regression now proves production privacy mode calls backend privacy suggestion/result APIs.
- Production-branch test: targeted integration-manager regression covers both current and legacy mode strings.
- Contract regeneration: no schema changes.
- Public surface delta: none, test-only.
- Review threads resolved before merge: pending PR review.
- Quality gates not relaxed.