### PR TITLE
fix(config-generator): constrain apply rewrite targets

### DIFF
--- a/tests/unit/config_generator/test_apply_headers.py
+++ b/tests/unit/config_generator/test_apply_headers.py
@@ -1,0 +1,173 @@
+"""Regression tests for apply_config source rewrite boundaries."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import traigent.config_generator.apply as _apply_mod
+from traigent.config_generator.apply import (
+    _find_function,
+    _find_import_insertion_point,
+    apply_config,
+)
+from traigent.config_generator.types import AutoConfigResult, ObjectiveSpec, TVarSpec
+
+
+@pytest.fixture(autouse=True)
+def _allow_tmp_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_apply_mod, "_SAFE_BASE_DIR", str(tmp_path))
+
+
+@pytest.fixture()
+def result_with_tvars() -> AutoConfigResult:
+    return AutoConfigResult(
+        tvars=(
+            TVarSpec(
+                name="temperature",
+                range_type="Range",
+                range_kwargs={"low": 0.0, "high": 1.0},
+            ),
+        ),
+        objectives=(ObjectiveSpec(name="accuracy"),),
+    )
+
+
+def test_adds_imports_after_module_docstring(
+    tmp_path: Path, result_with_tvars: AutoConfigResult
+) -> None:
+    source = textwrap.dedent('''\
+        """Agent module."""
+
+        def my_func():
+            pass
+    ''')
+    src = tmp_path / "agent.py"
+    src.write_text(source)
+
+    apply_config(src, result_with_tvars, "my_func", backup=False)
+
+    assert src.read_text().startswith(
+        '"""Agent module."""\n' "import traigent\n" "from traigent import Range\n\n"
+    )
+
+
+def test_adds_imports_after_shebang_and_encoding_comment(
+    tmp_path: Path, result_with_tvars: AutoConfigResult
+) -> None:
+    source = textwrap.dedent("""\
+        #!/usr/bin/env python3
+        # -*- coding: utf-8 -*-
+
+        def my_func():
+            pass
+    """)
+    src = tmp_path / "agent.py"
+    src.write_text(source)
+
+    apply_config(src, result_with_tvars, "my_func", backup=False)
+
+    assert src.read_text().startswith(
+        "#!/usr/bin/env python3\n"
+        "# -*- coding: utf-8 -*-\n"
+        "import traigent\n"
+        "from traigent import Range\n\n"
+    )
+
+
+def test_adds_imports_after_future_import(
+    tmp_path: Path, result_with_tvars: AutoConfigResult
+) -> None:
+    source = textwrap.dedent("""\
+        from __future__ import annotations
+
+        def my_func():
+            pass
+    """)
+    src = tmp_path / "agent.py"
+    src.write_text(source)
+
+    apply_config(src, result_with_tvars, "my_func", backup=False)
+
+    assert src.read_text().startswith(
+        "from __future__ import annotations\n"
+        "import traigent\n"
+        "from traigent import Range\n\n"
+    )
+
+
+def test_decorates_top_level_function_when_nested_name_collides(
+    tmp_path: Path, result_with_tvars: AutoConfigResult
+) -> None:
+    source = textwrap.dedent("""\
+        def outer():
+            def target():
+                pass
+
+        def target():
+            pass
+    """)
+    src = tmp_path / "agent.py"
+    src.write_text(source)
+
+    apply_config(src, result_with_tvars, "target", backup=False)
+
+    lines = src.read_text().splitlines()
+    top_level_target_idx = lines.index("def target():")
+    optimize_idx = max(
+        i
+        for i, line in enumerate(lines[:top_level_target_idx])
+        if "@traigent.optimize(" in line
+    )
+    assert lines[optimize_idx].startswith("@traigent.optimize(")
+    assert not any(line.startswith("    @traigent.optimize(") for line in lines)
+
+
+def test_nested_function_only_is_not_a_valid_target(
+    tmp_path: Path, result_with_tvars: AutoConfigResult
+) -> None:
+    src = tmp_path / "agent.py"
+    src.write_text("def outer():\n    def target():\n        pass\n")
+
+    with pytest.raises(ValueError, match="not found"):
+        apply_config(src, result_with_tvars, "target", backup=False)
+
+
+def test_find_function_ignores_nested_functions() -> None:
+    source = "def outer():\n    def target(): pass\n"
+    assert _find_function(ast.parse(source), "target") is None
+
+
+def test_find_import_insertion_point_after_module_docstring() -> None:
+    source = '"""Module docs."""\n\ndef f(): pass\n'
+    pos = _find_import_insertion_point(
+        ast.parse(source), source.splitlines(keepends=True)
+    )
+    assert pos == 1
+
+
+def test_find_import_insertion_point_after_shebang_and_encoding() -> None:
+    source = "#!/usr/bin/env python3\n# coding: utf-8\ndef f(): pass\n"
+    pos = _find_import_insertion_point(
+        ast.parse(source), source.splitlines(keepends=True)
+    )
+    assert pos == 2
+
+
+def test_find_import_insertion_point_after_future_import() -> None:
+    source = "from __future__ import annotations\n\ndef f(): pass\n"
+    pos = _find_import_insertion_point(
+        ast.parse(source), source.splitlines(keepends=True)
+    )
+    assert pos == 1
+
+
+def test_find_import_insertion_point_ignores_later_string_expression() -> None:
+    source = 'value = 1\n"not a module docstring"\ndef f(): pass\n'
+    pos = _find_import_insertion_point(
+        ast.parse(source), source.splitlines(keepends=True)
+    )
+    assert pos == 0

--- a/traigent/config_generator/apply.py
+++ b/traigent/config_generator/apply.py
@@ -10,6 +10,7 @@ import ast
 import os
 import re
 import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 from traigent.config_generator.types import AutoConfigResult
@@ -131,7 +132,7 @@ def apply_config(
     # Ensure required imports exist
     import_lines = _collect_needed_imports(decorator_code, tree)
     if import_lines:
-        insert_pos = _find_import_insertion_point(tree)
+        insert_pos = _find_import_insertion_point(tree, lines)
         for i, imp_line in enumerate(import_lines):
             lines.insert(insert_pos + i, imp_line + "\n")
 
@@ -148,10 +149,16 @@ def _find_function(
     tree: ast.Module, name: str
 ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
     """Find a top-level or class-level function by name."""
-    for node in ast.walk(tree):
+    for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             if node.name == name:
                 return node
+        elif isinstance(node, ast.ClassDef):
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if child.name == name:
+                        return child
+
     return None
 
 
@@ -273,17 +280,57 @@ def _get_existing_imports(tree: ast.Module) -> set[str]:
     return names
 
 
-def _find_import_insertion_point(tree: ast.Module) -> int:
+def _find_import_insertion_point(
+    tree: ast.Module, lines: Sequence[str] | None = None
+) -> int:
     """Find the line number (0-indexed) to insert new imports.
 
     Only considers module-level import statements to avoid inserting
-    imports inside indented blocks. Returns 0 if there are no
-    top-level imports.
+    imports inside indented blocks. If there are no imports yet, places
+    new imports after module header constructs that must stay first:
+    shebang, encoding comments, module docstring, and __future__ imports.
     """
-    last_import_line = 0
-    for node in tree.body:
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
+    insert_line = _find_source_header_end(lines)
+
+    for index, node in enumerate(tree.body):
+        if (index == 0 and _is_module_docstring_node(node)) or _is_future_import(node):
             end = getattr(node, "end_lineno", node.lineno)
-            if end > last_import_line:
-                last_import_line = end
-    return last_import_line
+            if end > insert_line:
+                insert_line = end
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            end = getattr(node, "end_lineno", node.lineno)
+            if end > insert_line:
+                insert_line = end
+    return insert_line
+
+
+def _is_module_docstring_node(node: ast.stmt) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def _is_future_import(node: ast.stmt) -> bool:
+    return isinstance(node, ast.ImportFrom) and node.module == "__future__"
+
+
+def _find_source_header_end(lines: Sequence[str] | None) -> int:
+    """Return insertion floor after shebang / encoding comments."""
+    if not lines:
+        return 0
+
+    insert_line = 0
+    if lines[0].startswith("#!"):
+        insert_line = 1
+
+    for idx in range(min(2, len(lines))):
+        if _is_encoding_comment(lines[idx]):
+            insert_line = max(insert_line, idx + 1)
+
+    return insert_line
+
+
+def _is_encoding_comment(line: str) -> bool:
+    return bool(re.match(r"^[ \t\f]*#.*coding[:=][ \t]*[-\w.]+", line))


### PR DESCRIPTION
Closes #873.

Summary:
- apply_config now inserts generated imports after source headers that must stay first: shebang, encoding comments, module docstring, future imports, and existing imports.
- function lookup now matches only top-level functions and direct class methods, so nested function name collisions no longer decorate the wrong target.
- added regression coverage in a new LF-normal test file to avoid CRLF churn in the existing test file.

Validation:
- uv run --extra dev pytest tests/unit/config_generator/test_apply.py tests/unit/config_generator/test_apply_headers.py -q -> 41 passed
- uv run --extra dev pytest tests/unit/config_generator -q -> 255 passed
- uv run --extra dev black --check traigent/config_generator/apply.py tests/unit/config_generator/test_apply_headers.py -> passed
- uv run --extra dev isort --check-only traigent/config_generator/apply.py tests/unit/config_generator/test_apply_headers.py -> passed
- uv run --extra dev ruff check traigent/config_generator/apply.py tests/unit/config_generator/test_apply_headers.py -> passed
- git diff --check -> passed
- pre-commit on commit -> passed, including mypy
- Claude Code Opus 4.7 xhigh pre-PR review -> APPROVE / no blockers

Notes:
- Nested classes are no longer searched. That is intentional and matches the documented top-level or class-level target scope.
- Existing class-method coverage still passes via test_indentation_preserved_for_method.