### PR TITLE
fix(config-generator): preserve headers and scope target lookup in apply_config (#873)

### DIFF
--- a/tests/unit/cli/test_generate_config_command.py
+++ b/tests/unit/cli/test_generate_config_command.py
@@ -263,6 +263,38 @@ class TestGenerateConfigCLI:
             bak_file = tmp_path / "agent.py.bak"
             assert not bak_file.exists()
 
+    def test_apply_inserts_imports_after_docstring(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for #873 via the public CLI path.
+
+        Ensures the ``--apply`` workflow does not insert imports before a
+        module docstring even when the source has no existing imports.
+        """
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(
+            '"""Module docstring."""\n\ndef my_agent(query: str) -> str:\n    return query\n'
+        )
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                generate_config,
+                [str(source_file), "-f", "my_agent", "--apply", "--no-backup"],
+            )
+            assert result.exit_code == 0, result.output
+
+        modified = source_file.read_text()
+        assert modified.startswith('"""Module docstring."""\n')
+        assert modified.index('"""Module docstring."""') < modified.index(
+            "import traigent"
+        )
+        assert "@traigent.optimize(" in modified
+
     def test_apply_requires_function(self, tmp_path: Path) -> None:
         source_file = tmp_path / "agent.py"
         source_file.write_text(SAMPLE_SOURCE)

--- a/tests/unit/config_generator/test_apply.py
+++ b/tests/unit/config_generator/test_apply.py
@@ -471,3 +471,334 @@ class TestHelpers:
         pos = _find_import_insertion_point(tree)
         # Should point after 'import os' (line 1), not after nested 'import json' (line 4)
         assert pos == 1
+
+
+class TestImportInsertionHeaderHandling:
+    """Regression tests for apply_config #873 — header-aware import insertion."""
+
+    def test_inserts_imports_after_module_docstring(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent('''\
+            """Module docstring stays first."""
+
+            def my_func():
+                pass
+        ''')
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        # Docstring remains the first thing in the file
+        assert modified.startswith('"""Module docstring stays first."""\n')
+        # Both imports are inserted directly after the docstring
+        docstring_idx = modified.index('"""Module docstring stays first."""')
+        import_idx = modified.index("import traigent")
+        assert docstring_idx < import_idx
+        # Decorator follows the imports
+        assert "@traigent.optimize(" in modified
+
+    def test_inserts_imports_after_shebang(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            #!/usr/bin/env python3
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert modified.startswith("#!/usr/bin/env python3\n")
+        # Imports must not be placed before the shebang
+        assert modified.index("#!/usr/bin/env python3") < modified.index(
+            "import traigent"
+        )
+
+    def test_inserts_imports_after_encoding_comment(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            # -*- coding: utf-8 -*-
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        assert modified.startswith("# -*- coding: utf-8 -*-\n")
+        assert modified.index("# -*- coding: utf-8 -*-") < modified.index(
+            "import traigent"
+        )
+
+    def test_inserts_imports_after_shebang_and_encoding(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            #!/usr/bin/env python3
+            # -*- coding: utf-8 -*-
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        modified_lines = modified.splitlines()
+        assert modified_lines[0] == "#!/usr/bin/env python3"
+        assert modified_lines[1] == "# -*- coding: utf-8 -*-"
+        # The first import lands strictly after the two-line header.
+        first_import = next(
+            i for i, line in enumerate(modified_lines) if line.startswith("import ")
+        )
+        assert first_import >= 2
+
+    def test_inserts_imports_after_future_import(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent("""\
+            from __future__ import annotations
+
+            def my_func():
+                pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        # __future__ import remains first; new imports follow it
+        future_idx = modified.index("from __future__ import annotations")
+        traigent_idx = modified.index("import traigent")
+        assert future_idx < traigent_idx
+
+    def test_inserts_imports_after_full_header_combination(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        source = textwrap.dedent('''\
+            #!/usr/bin/env python3
+            # -*- coding: utf-8 -*-
+            """Module docstring."""
+
+            from __future__ import annotations
+
+            def my_func():
+                pass
+        ''')
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified_lines = src.read_text().splitlines()
+        # Verify each header element is preserved in order before the first
+        # generated import.
+        shebang_idx = modified_lines.index("#!/usr/bin/env python3")
+        encoding_idx = modified_lines.index("# -*- coding: utf-8 -*-")
+        docstring_idx = modified_lines.index('"""Module docstring."""')
+        future_idx = modified_lines.index("from __future__ import annotations")
+        first_import_idx = next(
+            i
+            for i, line in enumerate(modified_lines)
+            if line.strip() == "import traigent"
+        )
+        assert (
+            shebang_idx < encoding_idx < docstring_idx < future_idx < first_import_idx
+        )
+
+    def test_docstring_only_module_no_existing_imports(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        """The base regression case described in issue #873."""
+        source = textwrap.dedent('''\
+            """Docstring."""
+
+            def my_func():
+                pass
+        ''')
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "my_func", backup=False)
+
+        modified = src.read_text()
+        # Should NOT start with the import — should still start with the docstring.
+        assert not modified.startswith("import traigent")
+        assert modified.startswith('"""Docstring."""')
+
+
+class TestFunctionLookupScope:
+    """Regression tests for #873 — top-level/class-method-only lookup."""
+
+    def test_nested_function_only_target_not_found(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        """A name that exists only inside another function is not a valid target."""
+        source = textwrap.dedent("""\
+            def outer():
+                def target():
+                    return 1
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        with pytest.raises(ValueError, match="not found"):
+            apply_config(src, result_with_tvars, "target", backup=False)
+
+    def test_top_level_function_preferred_over_nested_collision(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        """If a name shadows a nested name, decorate the top-level definition."""
+        source = textwrap.dedent("""\
+            def outer():
+                def target():
+                    return "nested"
+
+            def target():
+                return "top"
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "target", backup=False)
+
+        modified = src.read_text()
+        modified_lines = modified.splitlines()
+        # No decorator should be placed at indentation deeper than column 0.
+        assert not any(
+            line.startswith(" ") and "@traigent.optimize(" in line
+            for line in modified_lines
+        )
+        # The single decorator sits immediately above the top-level definition.
+        target_idx = modified_lines.index("def target():")
+        decorator_idx = next(
+            i
+            for i, line in enumerate(modified_lines)
+            if line.startswith("@traigent.optimize(")
+        )
+        assert decorator_idx < target_idx
+        # And no other top-level "def target():" appears between them.
+        between = modified_lines[decorator_idx + 1 : target_idx]
+        assert all("def target" not in line for line in between)
+
+    def test_class_methods_still_resolvable(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        """Class-level methods continue to be valid targets."""
+        source = textwrap.dedent("""\
+            class Agent:
+                def predict(self):
+                    pass
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        apply_config(src, result_with_tvars, "predict", backup=False)
+
+        modified_lines = src.read_text().splitlines()
+        decorator_idx = next(
+            i for i, line in enumerate(modified_lines) if "@traigent.optimize(" in line
+        )
+        # Decorator stays indented to match the method body.
+        assert modified_lines[decorator_idx].startswith("    @traigent.optimize(")
+
+    def test_function_inside_class_method_is_not_targeted(
+        self, tmp_path: Path, result_with_tvars: AutoConfigResult
+    ) -> None:
+        """A function nested inside a method must not be selected."""
+        source = textwrap.dedent("""\
+            class Agent:
+                def predict(self):
+                    def helper():
+                        return 1
+                    return helper()
+        """)
+        src = tmp_path / "agent.py"
+        src.write_text(source)
+
+        with pytest.raises(ValueError, match="not found"):
+            apply_config(src, result_with_tvars, "helper", backup=False)
+
+
+class TestImportInsertionHeaderHelpers:
+    """Unit-level coverage for the new helpers in apply.py."""
+
+    def test_find_import_insertion_point_after_module_docstring(self) -> None:
+        import ast
+
+        source = '"""Module docs."""\n\ndef f(): pass\n'
+        pos = _find_import_insertion_point(
+            ast.parse(source), source.splitlines(keepends=True)
+        )
+        assert pos == 1
+
+    def test_find_import_insertion_point_after_shebang_only(self) -> None:
+        import ast
+
+        source = "#!/usr/bin/env python3\n\ndef f(): pass\n"
+        pos = _find_import_insertion_point(
+            ast.parse(source), source.splitlines(keepends=True)
+        )
+        assert pos == 1
+
+    def test_find_import_insertion_point_after_shebang_and_encoding(self) -> None:
+        import ast
+
+        source = "#!/usr/bin/env python3\n# coding: utf-8\ndef f(): pass\n"
+        pos = _find_import_insertion_point(
+            ast.parse(source), source.splitlines(keepends=True)
+        )
+        assert pos == 2
+
+    def test_find_import_insertion_point_after_future_import(self) -> None:
+        import ast
+
+        source = "from __future__ import annotations\n\ndef f(): pass\n"
+        pos = _find_import_insertion_point(
+            ast.parse(source), source.splitlines(keepends=True)
+        )
+        assert pos == 1
+
+    def test_find_import_insertion_point_ignores_later_string_expression(self) -> None:
+        """A bare string after code is not a module docstring."""
+        import ast
+
+        source = 'value = 1\n"not a module docstring"\ndef f(): pass\n'
+        pos = _find_import_insertion_point(
+            ast.parse(source), source.splitlines(keepends=True)
+        )
+        assert pos == 0
+
+    def test_find_import_insertion_point_empty_file(self) -> None:
+        import ast
+
+        pos = _find_import_insertion_point(ast.parse(""), [])
+        assert pos == 0
+
+    def test_find_function_ignores_nested(self) -> None:
+        import ast
+
+        source = "def outer():\n    def target():\n        pass\n"
+        assert _find_function(ast.parse(source), "target") is None
+
+    def test_find_function_finds_method_in_class(self) -> None:
+        import ast
+
+        source = "class C:\n    def m(self):\n        pass\n"
+        node = _find_function(ast.parse(source), "m")
+        assert node is not None
+        assert node.name == "m"

--- a/traigent/config_generator/apply.py
+++ b/traigent/config_generator/apply.py
@@ -10,9 +10,13 @@ import ast
 import os
 import re
 import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 from traigent.config_generator.types import AutoConfigResult
+
+# PEP 263 encoding declaration. May appear on the first or second source line.
+_ENCODING_COMMENT_RE = re.compile(r"^[ \t\f]*#.*coding[:=][ \t]*[-\w.]+")
 
 # Optional base directory override for path containment checks (S2083).
 # If unset, the current working directory is treated as the trusted base.
@@ -131,7 +135,7 @@ def apply_config(
     # Ensure required imports exist
     import_lines = _collect_needed_imports(decorator_code, tree)
     if import_lines:
-        insert_pos = _find_import_insertion_point(tree)
+        insert_pos = _find_import_insertion_point(tree, lines)
         for i, imp_line in enumerate(import_lines):
             lines.insert(insert_pos + i, imp_line + "\n")
 
@@ -147,11 +151,27 @@ def apply_config(
 def _find_function(
     tree: ast.Module, name: str
 ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
-    """Find a top-level or class-level function by name."""
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            if node.name == name:
-                return node
+    """Find a top-level or class-level function by name.
+
+    Searches only direct children of the module and direct children of
+    top-level classes. Functions nested inside other functions (closures,
+    locally-defined helpers) are intentionally not considered so that an
+    inner ``def target()`` cannot be silently decorated when the user
+    meant a top-level ``target``.
+    """
+    for node in tree.body:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            return node
+        if isinstance(node, ast.ClassDef):
+            for child in node.body:
+                if (
+                    isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and child.name == name
+                ):
+                    return child
     return None
 
 
@@ -273,17 +293,55 @@ def _get_existing_imports(tree: ast.Module) -> set[str]:
     return names
 
 
-def _find_import_insertion_point(tree: ast.Module) -> int:
+def _find_import_insertion_point(
+    tree: ast.Module, lines: Sequence[str] | None = None
+) -> int:
     """Find the line number (0-indexed) to insert new imports.
 
-    Only considers module-level import statements to avoid inserting
-    imports inside indented blocks. Returns 0 if there are no
-    top-level imports.
+    The returned index is suitable for ``list.insert(index, ...)``. New
+    imports are placed after every leading construct that must stay at
+    the top of the file:
+
+    - Shebang line (``#!...``) on line 1.
+    - PEP 263 encoding declarations on line 1 or 2.
+    - The module docstring (only when it is the very first statement).
+    - All top-level imports, including ``from __future__ import ...``.
+
+    When the module has no imports the function still respects shebang,
+    encoding, and docstring, so generated imports never land before
+    them.
     """
-    last_import_line = 0
-    for node in tree.body:
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
+    insertion_line = _skip_source_header(lines or ())
+
+    for index, node in enumerate(tree.body):
+        if index == 0 and _is_module_docstring(node):
             end = getattr(node, "end_lineno", node.lineno)
-            if end > last_import_line:
-                last_import_line = end
-    return last_import_line
+            insertion_line = max(insertion_line, end)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            end = getattr(node, "end_lineno", node.lineno)
+            insertion_line = max(insertion_line, end)
+
+    return insertion_line
+
+
+def _skip_source_header(lines: Sequence[str]) -> int:
+    """Return the line index after shebang/encoding header comments."""
+    if not lines:
+        return 0
+    position = 0
+    if lines[0].startswith("#!"):
+        position = 1
+    # PEP 263 limits the encoding declaration to the first two lines.
+    for idx in range(min(2, len(lines))):
+        if _ENCODING_COMMENT_RE.match(lines[idx]):
+            position = max(position, idx + 1)
+    return position
+
+
+def _is_module_docstring(node: ast.stmt) -> bool:
+    """True if ``node`` is a string expression that can be a module docstring."""
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )


### PR DESCRIPTION
## Issue addressed
Closes #873 — `bug(config-generator): apply_config can insert imports before module docstrings and target nested functions`.

## Summary of changes
- `traigent/config_generator/apply.py`
  - `_find_import_insertion_point()` now respects shebangs, PEP 263 encoding declarations, module docstrings, and `__future__` imports. When the module has no existing imports, generated imports are placed after the header instead of at line 0.
  - `_find_function()` no longer uses `ast.walk()`; it iterates only `tree.body` and the direct children of top-level `ClassDef` nodes. Nested functions cannot be silently selected.
  - Two private helpers (`_skip_source_header`, `_is_module_docstring`) and a compiled PEP 263 regex were added.
- `tests/unit/config_generator/test_apply.py` — added three new test classes (`TestImportInsertionHeaderHandling`, `TestFunctionLookupScope`, `TestImportInsertionHeaderHelpers`) covering every acceptance-criterion scenario plus helper-level unit coverage.
- `tests/unit/cli/test_generate_config_command.py` — added `test_apply_inserts_imports_after_docstring`, a CLI-level regression covering the public `--apply` path against a docstring-only source file.

## Acceptance criteria and evidence
| Criterion | Evidence |
|---|---|
| Insert imports after module docstring | `test_inserts_imports_after_module_docstring`, `test_docstring_only_module_no_existing_imports`, CLI `test_apply_inserts_imports_after_docstring` |
| Insert imports after shebang | `test_inserts_imports_after_shebang` |
| Insert imports after encoding comment | `test_inserts_imports_after_encoding_comment` |
| Insert imports after `__future__` imports | `test_inserts_imports_after_future_import` |
| Full header combination preserved in order | `test_inserts_imports_after_full_header_combination` |
| Limit lookup to top-level / class methods | `test_nested_function_only_target_not_found`, `test_top_level_function_preferred_over_nested_collision`, `test_function_inside_class_method_is_not_targeted` |
| Class methods still resolvable | `test_class_methods_still_resolvable` |

## Tests run
Locally with `.venv` from a sibling worktree (Python 3.14):

```
pytest tests/unit/config_generator/test_apply.py            -> 50 passed
pytest tests/unit/cli/test_generate_config_command.py       -> 17 passed (+1 new)
pytest tests/unit/config_generator/ tests/unit/cli/         -> 411 passed
ruff check                                                  -> All checks passed
ruff format --check                                         -> 3 files already formatted
mypy traigent/config_generator/apply.py                     -> Success
```

Pre-commit hooks (isort, black, ruff, mypy, bandit, detect-secrets, etc.) all passed on commit.

## CI status
Pending on PR creation.

## Spine artifacts updated
- `ops/_validation/runs/issue-management-20260522-batch2/issue-873.md`

## Known risks and assumptions
- The PEP 263 encoding regex is intentionally permissive (matches the CPython tokenizer's behavior). A comment like `# my coding=utf-8 example` on line 1 or 2 will also be treated as an encoding declaration; the only consequence is leaving the comment above the inserted imports.
- Function lookup is now strict: requesting a nested-only target raises `ValueError("Function '...' not found in ...")`. This is a behavior change from "silently rewrote a nested target" to "refuses to operate", which matches the helper's docstring contract and the issue's acceptance criteria.
- `_find_import_insertion_point()` gained an optional `lines` argument with a backwards-compatible default, so existing callers (and the existing test that passes only `tree`) continue to work.

## Follow-up issues
None identified.

## Codex final-review status
pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)