### PR TITLE
fix(cloud): align MCP create_agent payload with bridge schema (#900)

### DIFF
--- a/tests/unit/cloud/test_backend_bridges.py
+++ b/tests/unit/cloud/test_backend_bridges.py
@@ -335,7 +335,13 @@ class TestSDKBackendBridge:
         assert backend_agent["name"] == "Test Agent"
         assert backend_agent["description"] == "Agent generated from SDK specification"
         assert backend_agent["agent_type_id"] == "agent-type-1"  # conversational
+        # Issue #900: agent_platform + model_parameters must reach the backend.
+        assert backend_agent["agent_platform"] == "openai"
         assert backend_agent["prompt_template"] == "Test prompt: {input}"
+        assert backend_agent["model_parameters"] == {
+            "temperature": 0.7,
+            "max_tokens": 150,
+        }
         assert backend_agent["reasoning"] == "chain-of-thought"
         assert backend_agent["style"] == "professional"
         assert backend_agent["tone"] == "helpful"
@@ -344,7 +350,28 @@ class TestSDKBackendBridge:
         assert backend_agent["guidelines"] == ["be accurate", "be helpful"]
         assert backend_agent["response_validation"] is True
         assert backend_agent["custom_tools"] == ["calculator"]
-        assert backend_agent["metadata"] == {"agent_version": "1.0"}
+        # user_id is folded into metadata for downstream auditing.
+        assert backend_agent["metadata"] == {
+            "agent_version": "1.0",
+            "user_id": "test_user",
+        }
+
+    def test_agent_specification_to_backend_uses_spec_description(self, sdk_bridge):
+        """User-provided AgentSpecification.description must not be overwritten."""
+        spec = AgentSpecification(
+            id="agent_desc",
+            name="Custom Agent",
+            agent_type="task",
+            agent_platform="openai",
+            prompt_template="prompt",
+            model_parameters={},
+            description="Bespoke description supplied by user",
+        )
+
+        backend_agent = sdk_bridge.agent_specification_to_backend(spec)
+
+        assert backend_agent["description"] == "Bespoke description supplied by user"
+        assert backend_agent["agent_type_id"] == "agent-type-2"  # task
 
     def test_agent_type_mapping(self, sdk_bridge):
         """Test agent type mapping logic."""

--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -328,12 +328,12 @@ class TestMCPRequestHandling:
 
                 # The client handles timeout gracefully - returns MCPResponse with success=False
                 result = await self.client.call_tool("test_tool", {})
-                assert (
-                    result.success is False
-                ), "Timeout should result in failed response"
-                assert (
-                    "timeout" in result.error_message.lower()
-                ), "Error message should mention timeout"
+                assert result.success is False, (
+                    "Timeout should result in failed response"
+                )
+                assert "timeout" in result.error_message.lower(), (
+                    "Error message should mention timeout"
+                )
 
 
 class TestMCPRetryMechanism:
@@ -1781,6 +1781,106 @@ class TestCreateAgent:
             assert result.success is True
             mock_call_tool.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_create_agent_payload_matches_bridge_schema(self):
+        """create_agent must forward the bridge schema verbatim (issue #900).
+
+        Regression: the MCP client previously read ``agent_type`` / ``platform``
+        / ``model_parameters`` from the bridge output, none of which exist
+        there, so bridge fields were silently dropped. This test asserts the
+        exact ``call_tool("create_agent", arguments)`` payload.
+        """
+        from traigent.cloud.models import AgentSpecification
+        from traigent.cloud.production_mcp_client import MCPResponse
+
+        agent_spec = AgentSpecification(
+            id="agent_xyz",
+            name="QA Agent",
+            agent_type="conversational",
+            agent_platform="openai",
+            prompt_template="Answer: {input}",
+            model_parameters={"model": "gpt-4o", "temperature": 0.3},
+            reasoning="chain-of-thought",
+            style="professional",
+            tone="helpful",
+            format="structured",
+            persona="expert",
+            guidelines=["be accurate"],
+            response_validation=True,
+            custom_tools=["calculator"],
+            metadata={"version": "1.0"},
+            description="user-supplied description",
+        )
+
+        with patch.object(
+            self.client, "call_tool", new_callable=AsyncMock
+        ) as mock_call_tool:
+            mock_call_tool.return_value = MCPResponse(
+                success=True, data={"agent_id": "agent_xyz"}
+            )
+
+            await self.client.create_agent(agent_spec)
+
+        assert mock_call_tool.call_count == 1
+        (tool_name, arguments), _kwargs = (
+            mock_call_tool.call_args.args,
+            mock_call_tool.call_args.kwargs,
+        )
+        assert tool_name == "create_agent"
+        assert arguments == {
+            "name": "QA Agent",
+            # ``agent_type`` maps via the bridge into ``agent_type_id`` —
+            # the canonical backend field. Issue #900 fixes the drop of this
+            # mapping in the MCP client.
+            "agent_type_id": "agent-type-1",
+            "description": "user-supplied description",
+            "agent_platform": "openai",
+            "prompt_template": "Answer: {input}",
+            "model_parameters": {"model": "gpt-4o", "temperature": 0.3},
+            "reasoning": "chain-of-thought",
+            "style": "professional",
+            "tone": "helpful",
+            "format": "structured",
+            "persona": "expert",
+            "guidelines": ["be accurate"],
+            "response_validation": True,
+            "custom_tools": ["calculator"],
+            "metadata": {"version": "1.0"},
+            "agent_id": "agent_xyz",
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_agent_payload_with_defaults(self):
+        """Defaults from AgentSpecification.__post_init__ flow through cleanly."""
+        from traigent.cloud.models import AgentSpecification
+        from traigent.cloud.production_mcp_client import MCPResponse
+
+        # All fields default — exercises the ``or "default"`` fallback in the
+        # bridge and ensures we still emit ``agent_type_id`` (never
+        # ``agent_type``) downstream.
+        agent_spec = AgentSpecification()
+
+        with patch.object(
+            self.client, "call_tool", new_callable=AsyncMock
+        ) as mock_call_tool:
+            mock_call_tool.return_value = MCPResponse(
+                success=True, data={"agent_id": "test-agent"}
+            )
+
+            await self.client.create_agent(agent_spec)
+
+        tool_name, arguments = mock_call_tool.call_args.args
+        assert tool_name == "create_agent"
+        # Unknown ``agent_type='test'`` falls back to the default mapping.
+        assert arguments["agent_type_id"] == "agent-type-1"
+        assert arguments["agent_platform"] == "test"
+        assert arguments["prompt_template"] == "Test prompt"
+        assert arguments["model_parameters"] == {}
+        assert arguments["response_validation"] is False
+        # No spurious legacy keys.
+        assert "agent_type" not in arguments
+        assert "platform" not in arguments
+
 
 class TestUploadDataset:
     """Test upload_dataset method."""
@@ -2033,9 +2133,11 @@ class TestCreateOptimizationWorkflow:
                             success=True, data={"experiment_run_id": "run_123"}
                         )
 
-                        agent_id, exp_id, run_id = (
-                            await self.client.create_optimization_workflow(request)
-                        )
+                        (
+                            agent_id,
+                            exp_id,
+                            run_id,
+                        ) = await self.client.create_optimization_workflow(request)
                         assert agent_id == "agent_123"
                         assert exp_id == "exp_123"
                         assert run_id == "run_123"

--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -328,12 +328,12 @@ class TestMCPRequestHandling:
 
                 # The client handles timeout gracefully - returns MCPResponse with success=False
                 result = await self.client.call_tool("test_tool", {})
-                assert result.success is False, (
-                    "Timeout should result in failed response"
-                )
-                assert "timeout" in result.error_message.lower(), (
-                    "Error message should mention timeout"
-                )
+                assert (
+                    result.success is False
+                ), "Timeout should result in failed response"
+                assert (
+                    "timeout" in result.error_message.lower()
+                ), "Error message should mention timeout"
 
 
 class TestMCPRetryMechanism:
@@ -1880,6 +1880,46 @@ class TestCreateAgent:
         # No spurious legacy keys.
         assert "agent_type" not in arguments
         assert "platform" not in arguments
+        # Issue #900 / Codex review on PR #1016: ``AgentSpecification.__post_init__``
+        # fills ``id`` with the synthetic sentinel ``"test-agent"`` when unset.
+        # We must NOT forward that placeholder as ``agent_id`` — doing so would
+        # cause backend ID collisions across every default-spec caller.
+        assert "agent_id" not in arguments
+
+    @pytest.mark.asyncio
+    async def test_create_agent_payload_omits_synthetic_default_id(self):
+        """Default AgentSpecification() must not forward the synthetic ``test-agent`` id.
+
+        Regression guard for the Codex finding on PR #1016: forwarding the
+        ``__post_init__`` placeholder id would collide on the backend for every
+        caller that did not supply an explicit id.
+        """
+        from traigent.cloud.models import AgentSpecification
+        from traigent.cloud.production_mcp_client import MCPResponse
+
+        # Default spec — id resolves to "test-agent" via __post_init__.
+        default_spec = AgentSpecification()
+        assert default_spec.id == "test-agent"
+
+        with patch.object(
+            self.client, "call_tool", new_callable=AsyncMock
+        ) as mock_call_tool:
+            mock_call_tool.return_value = MCPResponse(success=True, data={})
+            await self.client.create_agent(default_spec)
+
+        _, arguments = mock_call_tool.call_args.args
+        assert "agent_id" not in arguments
+
+        # Now verify that an explicit user-supplied id IS forwarded.
+        explicit_spec = AgentSpecification(id="agent_xyz")
+        with patch.object(
+            self.client, "call_tool", new_callable=AsyncMock
+        ) as mock_call_tool:
+            mock_call_tool.return_value = MCPResponse(success=True, data={})
+            await self.client.create_agent(explicit_spec)
+
+        _, arguments = mock_call_tool.call_args.args
+        assert arguments.get("agent_id") == "agent_xyz"
 
 
 class TestUploadDataset:

--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -1789,6 +1789,14 @@ class TestCreateAgent:
         / ``model_parameters`` from the bridge output, none of which exist
         there, so bridge fields were silently dropped. This test asserts the
         exact ``call_tool("create_agent", arguments)`` payload.
+
+        ``agent_id`` is deliberately absent: the backend MCP ``create_agent``
+        tool does not accept it (see
+        ``TraigentBackend/src/mcp/tools/agent_tools.create_agent`` — its
+        payload is built from a fixed key set and drops ``**kwargs``), and
+        ``AgentSpecification.__post_init__`` cannot distinguish a default
+        ``id`` from a caller explicitly passing ``id="test-agent"``. Letting
+        the backend allocate the id matches the pre-#900 SDK behavior.
         """
         from traigent.cloud.models import AgentSpecification
         from traigent.cloud.production_mcp_client import MCPResponse
@@ -1846,8 +1854,8 @@ class TestCreateAgent:
             "response_validation": True,
             "custom_tools": ["calculator"],
             "metadata": {"version": "1.0"},
-            "agent_id": "agent_xyz",
         }
+        assert "agent_id" not in arguments
 
     @pytest.mark.asyncio
     async def test_create_agent_payload_with_defaults(self):
@@ -1880,46 +1888,52 @@ class TestCreateAgent:
         # No spurious legacy keys.
         assert "agent_type" not in arguments
         assert "platform" not in arguments
-        # Issue #900 / Codex review on PR #1016: ``AgentSpecification.__post_init__``
-        # fills ``id`` with the synthetic sentinel ``"test-agent"`` when unset.
-        # We must NOT forward that placeholder as ``agent_id`` — doing so would
-        # cause backend ID collisions across every default-spec caller.
+        # Issue #900 / Codex review on PR #1016: ``agent_id`` is NEVER
+        # forwarded from the MCP client. The backend tool does not accept it,
+        # and the SDK-side ``id`` cannot be disambiguated from the synthetic
+        # ``__post_init__`` placeholder. The backend allocates the id.
         assert "agent_id" not in arguments
 
     @pytest.mark.asyncio
-    async def test_create_agent_payload_omits_synthetic_default_id(self):
-        """Default AgentSpecification() must not forward the synthetic ``test-agent`` id.
+    async def test_create_agent_never_forwards_agent_id(self):
+        """``agent_id`` is never forwarded from create_agent, regardless of caller intent.
 
-        Regression guard for the Codex finding on PR #1016: forwarding the
-        ``__post_init__`` placeholder id would collide on the backend for every
-        caller that did not supply an explicit id.
+        Codex review on PR #1016: the prior conditional that suppressed only
+        the synthetic ``"test-agent"`` placeholder could not distinguish a
+        default ``AgentSpecification()`` from a caller that explicitly passed
+        ``id="test-agent"``. Combined with the backend MCP tool dropping
+        ``agent_id`` from its ``**kwargs`` anyway, the safe minimal fix is to
+        not forward ``agent_id`` from the SDK at all and let the backend
+        allocate. This regression guard pins that behavior for every spec
+        shape callers can construct.
         """
         from traigent.cloud.models import AgentSpecification
         from traigent.cloud.production_mcp_client import MCPResponse
 
-        # Default spec — id resolves to "test-agent" via __post_init__.
+        # The default __post_init__ placeholder.
         default_spec = AgentSpecification()
         assert default_spec.id == "test-agent"
 
-        with patch.object(
-            self.client, "call_tool", new_callable=AsyncMock
-        ) as mock_call_tool:
-            mock_call_tool.return_value = MCPResponse(success=True, data={})
-            await self.client.create_agent(default_spec)
+        # A user explicitly passing the same string as the placeholder. The
+        # prior suppression logic would have silently dropped this even though
+        # the caller intended it. We now drop the field for both shapes, which
+        # is a no-op on the wire (backend doesn't accept agent_id).
+        explicit_same_as_placeholder = AgentSpecification(id="test-agent")
 
-        _, arguments = mock_call_tool.call_args.args
-        assert "agent_id" not in arguments
+        # A user-supplied unique id.
+        explicit_unique = AgentSpecification(id="agent_xyz")
 
-        # Now verify that an explicit user-supplied id IS forwarded.
-        explicit_spec = AgentSpecification(id="agent_xyz")
-        with patch.object(
-            self.client, "call_tool", new_callable=AsyncMock
-        ) as mock_call_tool:
-            mock_call_tool.return_value = MCPResponse(success=True, data={})
-            await self.client.create_agent(explicit_spec)
+        for spec in (default_spec, explicit_same_as_placeholder, explicit_unique):
+            with patch.object(
+                self.client, "call_tool", new_callable=AsyncMock
+            ) as mock_call_tool:
+                mock_call_tool.return_value = MCPResponse(success=True, data={})
+                await self.client.create_agent(spec)
 
-        _, arguments = mock_call_tool.call_args.args
-        assert arguments.get("agent_id") == "agent_xyz"
+            _, arguments = mock_call_tool.call_args.args
+            assert "agent_id" not in arguments, (
+                f"create_agent must not forward agent_id (spec.id={spec.id!r})"
+            )
 
 
 class TestUploadDataset:

--- a/traigent/cloud/backend_bridges.py
+++ b/traigent/cloud/backend_bridges.py
@@ -297,21 +297,35 @@ class SDKBackendBridge:
     ) -> dict[str, Any]:
         """Convert SDK AgentSpecification to backend agent data.
 
+        The returned payload matches the Traigent backend's ``create_agent``
+        MCP tool / ``POST /agents`` schema (see ``TraigentBackend`` ``agent_dal.create_agent``
+        and ``src/mcp/tools/agent_tools.create_agent``): ``agent_type_id`` and
+        ``agent_platform`` are the canonical field names (not ``agent_type`` /
+        ``platform``). ``model_parameters`` is preserved so callers that forward
+        the payload through MCP's ``**kwargs`` retain trial configuration intent.
+
         Args:
             agent_spec: SDK agent specification
-            user_id: Optional user identifier
+            user_id: Optional user identifier (included in metadata when set)
 
         Returns:
             Backend agent creation data
         """
+        metadata: dict[str, Any] = dict(agent_spec.metadata or {})
+        if user_id is not None and "user_id" not in metadata:
+            metadata["user_id"] = user_id
+
         return {
             "agent_id": agent_spec.id,
             "name": agent_spec.name,
-            "description": "Agent generated from SDK specification",
+            "description": agent_spec.description
+            or "Agent generated from SDK specification",
             "agent_type_id": self._agent_type_mappings.get(
                 agent_spec.agent_type or "default", self._agent_type_mappings["default"]
             ),
+            "agent_platform": agent_spec.agent_platform,
             "prompt_template": agent_spec.prompt_template,
+            "model_parameters": agent_spec.model_parameters,
             "reasoning": agent_spec.reasoning,
             "style": agent_spec.style,
             "tone": agent_spec.tone,
@@ -320,7 +334,7 @@ class SDKBackendBridge:
             "guidelines": agent_spec.guidelines,
             "response_validation": agent_spec.response_validation,
             "custom_tools": agent_spec.custom_tools,
-            "metadata": agent_spec.metadata,
+            "metadata": metadata,
         }
 
     def create_session_mapping(

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -63,6 +63,10 @@ _DEFAULT_MCP_SERVER_CANDIDATES = (
     "traigent_backend.mcp.server",
     "optigen_backend.mcp.server",
 )
+# Synthetic placeholder used by ``AgentSpecification.__post_init__`` when no
+# id is supplied. Must match ``traigent.cloud.models.AgentSpecification`` —
+# kept in sync via tests that exercise the default-spec path. See issue #900.
+_SYNTHETIC_AGENT_ID = "test-agent"
 
 
 def resolve_default_mcp_server_module() -> str:
@@ -668,8 +672,13 @@ class ProductionMCPClient:
             "custom_tools": backend_agent.get("custom_tools"),
             "metadata": backend_agent.get("metadata") or {},
         }
-        if backend_agent.get("agent_id") is not None:
-            arguments["agent_id"] = backend_agent["agent_id"]
+        # Only forward an explicit user-supplied agent_id. ``AgentSpecification.__post_init__``
+        # fills ``id`` with the synthetic sentinel ``"test-agent"`` when unset, which would
+        # cause backend ID collisions across default-spec callers if we forwarded it
+        # unconditionally. See issue #900 / Codex review on PR #1016.
+        spec_id = backend_agent.get("agent_id")
+        if spec_id is not None and spec_id != _SYNTHETIC_AGENT_ID:
+            arguments["agent_id"] = spec_id
 
         return await self.call_tool("create_agent", arguments)
 

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -63,10 +63,6 @@ _DEFAULT_MCP_SERVER_CANDIDATES = (
     "traigent_backend.mcp.server",
     "optigen_backend.mcp.server",
 )
-# Synthetic placeholder used by ``AgentSpecification.__post_init__`` when no
-# id is supplied. Must match ``traigent.cloud.models.AgentSpecification`` —
-# kept in sync via tests that exercise the default-spec path. See issue #900.
-_SYNTHETIC_AGENT_ID = "test-agent"
 
 
 def resolve_default_mcp_server_module() -> str:
@@ -653,6 +649,17 @@ class ProductionMCPClient:
         # ``agent_platform``, ``prompt_template``, ``model_parameters``,
         # etc.), so we forward it as-is rather than re-mapping to field
         # names that the bridge does not produce. See issue #900.
+        #
+        # ``agent_id`` is intentionally NOT forwarded: the backend MCP
+        # ``create_agent`` tool does not accept it (see
+        # ``TraigentBackend/src/mcp/tools/agent_tools.create_agent`` — its
+        # payload is built from a fixed key set and ``**kwargs`` is dropped),
+        # so the backend always allocates the id. Forwarding the SDK-side id
+        # would also be ambiguous because ``AgentSpecification.__post_init__``
+        # fills an unset ``id`` with the placeholder ``"test-agent"`` which is
+        # indistinguishable from a caller explicitly passing ``id="test-agent"``.
+        # Letting the backend assign the id matches the pre-#900 SDK behavior
+        # and removes the collision risk altogether.
         backend_agent = bridge.agent_specification_to_backend(agent_spec)
 
         arguments: dict[str, Any] = {
@@ -670,15 +677,8 @@ class ProductionMCPClient:
             "guidelines": backend_agent.get("guidelines"),
             "response_validation": backend_agent.get("response_validation", False),
             "custom_tools": backend_agent.get("custom_tools"),
-            "metadata": backend_agent.get("metadata") or {},
+            "metadata": backend_agent.get("metadata", {}),
         }
-        # Only forward an explicit user-supplied agent_id. ``AgentSpecification.__post_init__``
-        # fills ``id`` with the synthetic sentinel ``"test-agent"`` when unset, which would
-        # cause backend ID collisions across default-spec callers if we forwarded it
-        # unconditionally. See issue #900 / Codex review on PR #1016.
-        spec_id = backend_agent.get("agent_id")
-        if spec_id is not None and spec_id != _SYNTHETIC_AGENT_ID:
-            arguments["agent_id"] = spec_id
 
         return await self.call_tool("create_agent", arguments)
 

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -644,17 +644,32 @@ class ProductionMCPClient:
                 "agent_spec must be an AgentSpecification instance"
             )
 
-        # Convert to backend format
+        # Convert to backend format. The bridge output already matches the
+        # backend MCP ``create_agent`` schema (``agent_type_id``,
+        # ``agent_platform``, ``prompt_template``, ``model_parameters``,
+        # etc.), so we forward it as-is rather than re-mapping to field
+        # names that the bridge does not produce. See issue #900.
         backend_agent = bridge.agent_specification_to_backend(agent_spec)
 
-        arguments = {
-            "name": backend_agent.get("name"),
-            "agent_type": backend_agent.get("agent_type"),
-            "platform": backend_agent.get("platform"),
+        arguments: dict[str, Any] = {
+            "name": backend_agent["name"],
+            "agent_type_id": backend_agent["agent_type_id"],
+            "description": backend_agent.get("description"),
+            "agent_platform": backend_agent.get("agent_platform"),
             "prompt_template": backend_agent.get("prompt_template"),
             "model_parameters": backend_agent.get("model_parameters"),
-            "metadata": backend_agent.get("metadata", {}),
+            "reasoning": backend_agent.get("reasoning"),
+            "style": backend_agent.get("style"),
+            "tone": backend_agent.get("tone"),
+            "format": backend_agent.get("format"),
+            "persona": backend_agent.get("persona"),
+            "guidelines": backend_agent.get("guidelines"),
+            "response_validation": backend_agent.get("response_validation", False),
+            "custom_tools": backend_agent.get("custom_tools"),
+            "metadata": backend_agent.get("metadata") or {},
         }
+        if backend_agent.get("agent_id") is not None:
+            arguments["agent_id"] = backend_agent["agent_id"]
 
         return await self.call_tool("create_agent", arguments)
 


### PR DESCRIPTION
## Issue addressed

Partially addresses #900. `ProductionMCPClient.create_agent()` was reading field
names that the SDK bridge does not produce (`agent_type`, `platform`, and stale
`model_parameters` handling), so important agent semantics could be sent as
`None` or omitted. This PR aligns the SDK bridge and MCP client payload on the
canonical backend field names.

This is **not** full end-to-end production-path closure of #900: the backend MCP
tool currently accepts `**kwargs` but does not forward the rich agent fields into
`POST /agents`. That backend gap is tracked separately at
TraigentBackend#528.

## Summary of changes

- `agent_specification_to_backend()` now emits `agent_platform` and
  `model_parameters`, preserves a caller-supplied description, and folds
  `user_id` into `metadata`.
- `ProductionMCPClient.create_agent()` now forwards the canonical bridge fields:
  `agent_type_id`, `agent_platform`, `prompt_template`, `model_parameters`,
  `reasoning`, `style`, `tone`, `format`, `persona`, `guidelines`,
  `response_validation`, `custom_tools`, and `metadata`.
- `create_agent()` intentionally does **not** forward `agent_id`.
  Pre-#900 SDK behavior did not forward it; the backend MCP tool does not accept
  it; and `AgentSpecification.__post_init__` fills an unset id with the
  placeholder `"test-agent"`, which cannot be distinguished from a caller
  explicitly passing `id="test-agent"`. Letting the backend allocate the id is
  the least ambiguous scoped behavior.
- Payload tests now pin the exact `call_tool("create_agent", arguments)` shape
  and assert that legacy keys and `agent_id` are absent.

## Acceptance criteria and evidence

- [x] SDK bridge and MCP client share one explicit schema.
- [x] Canonical backend field decision recorded: `agent_type_id` is used rather
      than legacy `agent_type`.
- [x] `agent_platform` and `model_parameters` are emitted by the bridge and
      forwarded by the MCP client.
- [x] Exact payload tests guard the MCP wire shape, including absence of
      `agent_type`, `platform`, and `agent_id`.
- [x] Scope remains limited to the Traigent SDK side; #899 remains out of scope.
- [ ] End-to-end production MCP path closure is blocked on TraigentBackend#528.

## Known limitation

`TraigentBackend/src/mcp/tools/agent_tools.py` accepts `**kwargs` but currently
drops them when constructing the `POST /agents` payload. Until
TraigentBackend#528 lands, agents created through the production MCP path will
still lose `agent_platform`, `prompt_template`, `model_parameters`, `reasoning`,
`style`, `tone`, `format`, `persona`, `guidelines`, `custom_tools`, and
`metadata` at the backend MCP layer.

The REST path is not part of this PR; direct `POST /agents` already reaches the
backend route/DAL contract.

## Tests run

```text
uv run pytest -o addopts= \
  tests/unit/test_mcp_production_client.py \
  tests/unit/cloud/test_backend_bridges.py \
  tests/unit/cloud/test_production_mcp_client_validation.py \
  tests/unit/cloud/test_backend_bridges_security.py \
  tests/unit/cloud/test_backend_client.py -q

# 189 passed, 1 skipped
```

Pre-commit hooks passed on the pushed commits.

## Spine artifacts updated

`ops/_validation/runs/issue-management-20260522-batch2/issue-900.md` in the
ops spine workspace records the SDK-side fix, Codex review iterations, and the
backend follow-up requirement.

## Follow-up issues

- TraigentBackend#528: backend MCP `create_agent` must forward canonical agent
  fields into `POST /agents` before #900 can be fully closed.
- #899 intentionally remains separate because it touches adjacent MCP workflow
  bridge behavior.

## Codex final-review status

Pending captain decision. This PR should be treated as a scoped SDK-side
prerequisite, not as complete production-path closure of #900.
