### PR TITLE
fix(cloud): adapt TraigentCloudClient for InteractiveOptimizer protocol (#883)

### DIFF
--- a/docs/api-reference/interactive_optimizer.md
+++ b/docs/api-reference/interactive_optimizer.md
@@ -53,6 +53,19 @@ class RemoteGuidanceService(Protocol):
     ) -> OptimizationFinalizationResponse: ...
 ```
 
+To use Traigent Cloud as the remote service, wrap a `TraigentCloudClient`
+with `TraigentCloudRemoteGuidanceAdapter` — the cloud client's public
+methods take separate keyword arguments and name the result-submission call
+`submit_trial_result`, so passing it directly does not satisfy the protocol
+above:
+
+```python
+from traigent.cloud import TraigentCloudClient, TraigentCloudRemoteGuidanceAdapter
+
+client = TraigentCloudClient(api_key="<API_KEY>")
+remote_service = TraigentCloudRemoteGuidanceAdapter(client)
+```
+
 ## Methods
 
 ### `initialize_session`

--- a/docs/user-guide/choosing_optimization_model.md
+++ b/docs/user-guide/choosing_optimization_model.md
@@ -79,10 +79,11 @@ The examples below are reference patterns for advanced remote-guidance APIs. For
 ### Model 1: Interactive Optimization
 
 ```python
-from traigent.cloud.client import TraigentCloudClient
+from traigent.cloud import TraigentCloudClient, TraigentCloudRemoteGuidanceAdapter
 from traigent.optimizers.interactive_optimizer import InteractiveOptimizer
 
-cloud_client = TraigentCloudClient(api_key="your-api-key")  # Roadmap remote guidance client
+cloud_client = TraigentCloudClient(api_key="your-api-key")
+remote_service = TraigentCloudRemoteGuidanceAdapter(cloud_client)
 
 # For a custom local function
 async def my_custom_function(text: str, temperature: float) -> str:
@@ -94,7 +95,7 @@ async def my_custom_function(text: str, temperature: float) -> str:
 optimizer = InteractiveOptimizer(
     config_space={"temperature": (0.0, 1.0)},
     objectives=["quality", "speed"],
-    remote_service=cloud_client
+    remote_service=remote_service,
 )
 
 # Initialize session

--- a/docs/user-guide/interactive_optimization.md
+++ b/docs/user-guide/interactive_optimization.md
@@ -373,6 +373,8 @@ except SessionError as e:
 ### Network Issues
 
 ```python
+from traigent.cloud import TraigentCloudClient, TraigentCloudRemoteGuidanceAdapter
+
 # Configure retry behavior
 client = TraigentCloudClient(
     api_key="your-key",  # pragma: allowlist secret

--- a/docs/user-guide/interactive_optimization.md
+++ b/docs/user-guide/interactive_optimization.md
@@ -75,14 +75,25 @@ The service provides configurations based on:
 
 ### Step 1: Setup
 
-This example assumes you provide a remote guidance service that implements the `RemoteGuidanceService` protocol. The Traigent Cloud remote-guidance endpoint is roadmap-only until the managed remote execution path is released.
+The `RemoteGuidanceService` protocol that `InteractiveOptimizer` consumes
+uses dataclass requests (`SessionCreationRequest`, `NextTrialRequest`,
+`TrialResultSubmission`, `OptimizationFinalizationRequest`) and matching
+response objects. `TraigentCloudClient` already speaks those endpoints over
+HTTP, but its public methods take separate positional / keyword arguments
+and name the result-submission method `submit_trial_result`. Use
+`TraigentCloudRemoteGuidanceAdapter` to bridge the two without leaking the
+signature differences into your code.
+
+> Backend availability: the Traigent Cloud remote-guidance endpoints back
+> these adapter calls. Use `execution_mode="hybrid"` if you only need
+> portal-tracked SDK runs with local trial execution.
 
 ```python
-from traigent.cloud.client import TraigentCloudClient
+from traigent.cloud import TraigentCloudClient, TraigentCloudRemoteGuidanceAdapter
 from traigent.optimizers.interactive_optimizer import InteractiveOptimizer
 
-# Initialize a remote guidance client when that service is available.
 client = TraigentCloudClient(api_key="<API_KEY>")
+remote_service = TraigentCloudRemoteGuidanceAdapter(client)
 
 # Create interactive optimizer
 optimizer = InteractiveOptimizer(
@@ -92,7 +103,7 @@ optimizer = InteractiveOptimizer(
         "max_tokens": (50, 500)
     },
     objectives=["accuracy", "latency", "cost"],
-    remote_service=client,
+    remote_service=remote_service,
     dataset_metadata={
         "size": 10000,
         "type": "question_answering",
@@ -100,6 +111,10 @@ optimizer = InteractiveOptimizer(
     }
 )
 ```
+
+`TraigentCloudRemoteGuidanceAdapter` does not own the client lifecycle, so
+keep the client inside its own `async with` block (or call
+`await client.close()`) when you are done.
 
 ### Step 2: Initialize Session
 
@@ -362,8 +377,9 @@ except SessionError as e:
 client = TraigentCloudClient(
     api_key="your-key",  # pragma: allowlist secret
     max_retries=5,
-    timeout=60.0
+    timeout=60.0,
 )
+remote_service = TraigentCloudRemoteGuidanceAdapter(client)
 ```
 
 ### Handling Rate Limits

--- a/tests/unit/cloud/test_remote_guidance_adapter.py
+++ b/tests/unit/cloud/test_remote_guidance_adapter.py
@@ -1,0 +1,376 @@
+"""Tests for :class:`TraigentCloudRemoteGuidanceAdapter`.
+
+These cover the documented public path: the
+``InteractiveOptimizer(remote_service=TraigentCloudRemoteGuidanceAdapter(client))``
+setup shown in ``docs/user-guide/interactive_optimization.md`` and
+``docs/user-guide/choosing_optimization_model.md``.
+
+The adapter has to satisfy the dataclass-based ``RemoteGuidanceService``
+protocol that the optimizer calls. ``TraigentCloudClient`` itself exposes
+the same backend endpoints but under a different public method signature
+(separate keyword args and ``submit_trial_result`` instead of
+``submit_result``) — passing the cloud client directly as
+``remote_service`` would raise at runtime, which is the bug tracked in
+issue #883.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from traigent.cloud import TraigentCloudRemoteGuidanceAdapter
+from traigent.cloud.client import TraigentCloudClient
+from traigent.cloud.models import (
+    DatasetSubsetIndices,
+    NextTrialRequest,
+    NextTrialResponse,
+    OptimizationFinalizationRequest,
+    OptimizationFinalizationResponse,
+    OptimizationSessionStatus,
+    SessionCreationRequest,
+    SessionCreationResponse,
+    TrialResultSubmission,
+    TrialStatus,
+    TrialSuggestion,
+)
+from traigent.optimizers.interactive_optimizer import (
+    InteractiveOptimizer,
+    RemoteGuidanceService,
+)
+
+
+def _make_cloud_client_mock(
+    *,
+    session_id: str = "session-abc",
+    suggestion_configs: list[dict[str, Any]] | None = None,
+) -> AsyncMock:
+    """Return a mock ``TraigentCloudClient`` whose method signatures match the real client.
+
+    The mock exposes only the HTTP-facing methods that the adapter is
+    expected to call. Using ``spec=TraigentCloudClient`` ensures the test
+    fails immediately if the adapter ever calls an attribute the real
+    client does not have.
+    """
+    suggestion_configs = suggestion_configs or [
+        {"temperature": 0.3},
+        {"temperature": 0.7},
+    ]
+    client = AsyncMock(spec=TraigentCloudClient)
+
+    client.create_optimization_session.return_value = SessionCreationResponse(
+        session_id=session_id,
+        status=OptimizationSessionStatus.ACTIVE,
+        optimization_strategy={"exploration_ratio": 0.3},
+    )
+
+    counter = {"n": 0}
+
+    async def _get_next_trial(
+        session_id_arg: str,
+        previous_results: list[TrialResultSubmission] | None = None,
+    ) -> NextTrialResponse:
+        # The cloud client signature is positional session_id + keyword
+        # previous_results — assert the adapter respected that shape.
+        assert isinstance(session_id_arg, str)
+        if counter["n"] >= len(suggestion_configs):
+            return NextTrialResponse(
+                suggestion=None,
+                should_continue=False,
+                reason="exhausted",
+                session_status=OptimizationSessionStatus.COMPLETED,
+            )
+        idx = counter["n"]
+        counter["n"] += 1
+        return NextTrialResponse(
+            suggestion=TrialSuggestion(
+                trial_id=f"trial-{idx + 1}",
+                session_id=session_id_arg,
+                trial_number=idx + 1,
+                config=suggestion_configs[idx],
+                dataset_subset=DatasetSubsetIndices(
+                    indices=[0, 1, 2],
+                    selection_strategy="diverse_sampling",
+                    confidence_level=0.8,
+                    estimated_representativeness=0.8,
+                ),
+                exploration_type="exploration" if idx == 0 else "exploitation",
+            ),
+            should_continue=True,
+            session_status=OptimizationSessionStatus.ACTIVE,
+        )
+
+    client.get_next_trial.side_effect = _get_next_trial
+
+    client.submit_trial_result.return_value = None
+
+    client.finalize_optimization.return_value = OptimizationFinalizationResponse(
+        session_id=session_id,
+        best_config=suggestion_configs[-1],
+        best_metrics={"accuracy": 0.91},
+        total_trials=len(suggestion_configs),
+        successful_trials=len(suggestion_configs),
+        total_duration=12.5,
+        cost_savings=0.5,
+    )
+
+    return client
+
+
+class TestProtocolConformance:
+    """The adapter must implement the protocol the optimizer relies on."""
+
+    def test_adapter_satisfies_remote_guidance_service_protocol(self) -> None:
+        client = AsyncMock(spec=TraigentCloudClient)
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+
+        # Runtime structural check is enough for a Protocol without
+        # ``runtime_checkable``: every required coroutine must exist.
+        for method_name in (
+            "create_session",
+            "get_next_trial",
+            "submit_result",
+            "finalize_session",
+        ):
+            attr = getattr(adapter, method_name, None)
+            assert attr is not None, f"Adapter missing {method_name}"
+            assert callable(attr), f"Adapter.{method_name} must be callable"
+
+        # The bare cloud client does *not* satisfy the protocol — this is
+        # the bug we're fixing. ``submit_result`` is absent on the real
+        # client (it's called ``submit_trial_result``), so wrapping in the
+        # adapter is mandatory.
+        assert not hasattr(TraigentCloudClient, "submit_result")
+
+    def test_adapter_typed_as_remote_guidance_service(self) -> None:
+        client = AsyncMock(spec=TraigentCloudClient)
+        adapter: RemoteGuidanceService = TraigentCloudRemoteGuidanceAdapter(client)
+        # Sanity: the variable annotation above is the contract — if the
+        # adapter ever drops a method, the optimizer setup breaks. We
+        # verify the methods are awaitable bound methods.
+        assert callable(adapter.create_session)
+        assert callable(adapter.get_next_trial)
+        assert callable(adapter.submit_result)
+        assert callable(adapter.finalize_session)
+
+
+class TestAdapterDelegation:
+    """Each adapter method must forward to the right cloud client method."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_forwards_request_object(self) -> None:
+        client = _make_cloud_client_mock()
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+
+        request = SessionCreationRequest(
+            function_name="q_and_a",
+            configuration_space={"temperature": (0.0, 1.0)},
+            objectives=["accuracy"],
+            dataset_metadata={"size": 100},
+            max_trials=10,
+        )
+
+        response = await adapter.create_session(request)
+
+        client.create_optimization_session.assert_awaited_once_with(request)
+        assert isinstance(response, SessionCreationResponse)
+        assert response.session_id == "session-abc"
+        assert response.status is OptimizationSessionStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_get_next_trial_maps_session_id_and_previous_results(self) -> None:
+        client = _make_cloud_client_mock()
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+
+        previous = [
+            TrialResultSubmission(
+                session_id="session-abc",
+                trial_id="trial-prior",
+                metrics={"accuracy": 0.8},
+                duration=1.2,
+                status=TrialStatus.COMPLETED,
+            )
+        ]
+        request = NextTrialRequest(session_id="session-abc", previous_results=previous)
+
+        response = await adapter.get_next_trial(request)
+
+        client.get_next_trial.assert_awaited_once_with(
+            "session-abc", previous_results=previous
+        )
+        assert isinstance(response, NextTrialResponse)
+        assert response.suggestion is not None
+        assert response.suggestion.trial_id == "trial-1"
+
+    @pytest.mark.asyncio
+    async def test_submit_result_maps_dataclass_to_keyword_arguments(self) -> None:
+        client = _make_cloud_client_mock()
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+
+        result = TrialResultSubmission(
+            session_id="session-abc",
+            trial_id="trial-7",
+            metrics={"accuracy": 0.93, "latency": 0.21},
+            duration=2.5,
+            status=TrialStatus.COMPLETED,
+            outputs_sample=["ok"],
+            error_message=None,
+            metadata={"note": "n=3"},
+        )
+
+        await adapter.submit_result(result)
+
+        # The cloud client exposes the result-submission as
+        # ``submit_trial_result`` with status as a string. The adapter
+        # must translate both.
+        client.submit_trial_result.assert_awaited_once_with(
+            session_id="session-abc",
+            trial_id="trial-7",
+            metrics={"accuracy": 0.93, "latency": 0.21},
+            duration=2.5,
+            status="completed",
+            outputs_sample=["ok"],
+            error_message=None,
+            metadata={"note": "n=3"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_submit_result_translates_failed_status(self) -> None:
+        client = _make_cloud_client_mock()
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+
+        result = TrialResultSubmission(
+            session_id="session-abc",
+            trial_id="trial-fail",
+            metrics={},
+            duration=0.1,
+            status=TrialStatus.FAILED,
+            error_message="boom",
+        )
+
+        await adapter.submit_result(result)
+
+        kwargs = client.submit_trial_result.await_args.kwargs
+        assert kwargs["status"] == "failed"
+        assert kwargs["error_message"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_returns_cloud_response(self) -> None:
+        client = _make_cloud_client_mock()
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+
+        request = OptimizationFinalizationRequest(
+            session_id="session-abc", include_full_history=True
+        )
+
+        response = await adapter.finalize_session(request)
+
+        client.finalize_optimization.assert_awaited_once_with(
+            "session-abc", include_full_history=True
+        )
+        assert isinstance(response, OptimizationFinalizationResponse)
+        assert response.session_id == "session-abc"
+        assert response.successful_trials == 2
+
+    def test_client_property_exposes_wrapped_instance(self) -> None:
+        client = AsyncMock(spec=TraigentCloudClient)
+        adapter = TraigentCloudRemoteGuidanceAdapter(client)
+        assert adapter.client is client
+
+
+class TestDocumentedInteractiveOptimizerSetup:
+    """End-to-end test of the documented setup path.
+
+    Wires ``InteractiveOptimizer`` with the adapter wrapping a mocked
+    ``TraigentCloudClient`` and runs the full workflow shown in
+    ``docs/user-guide/interactive_optimization.md``. This is the
+    "runnable test that executes the documented InteractiveOptimizer
+    setup with the intended remote client or adapter" required by
+    issue #883.
+    """
+
+    @pytest.mark.asyncio
+    async def test_initialize_get_report_finalize_against_cloud_client(self) -> None:
+        configs = [
+            {"temperature": 0.3, "model": "o4-mini"},
+            {"temperature": 0.7, "model": "GPT-4o"},
+        ]
+        client = _make_cloud_client_mock(suggestion_configs=configs)
+        remote_service = TraigentCloudRemoteGuidanceAdapter(client)
+
+        optimizer = InteractiveOptimizer(
+            config_space={
+                "temperature": (0.0, 1.0),
+                "model": ["o4-mini", "GPT-4o"],
+            },
+            objectives=["accuracy", "latency"],
+            remote_service=remote_service,
+            dataset_metadata={"size": 100, "type": "qa"},
+        )
+
+        session = await optimizer.initialize_session(
+            function_name="optimize_qa", max_trials=10
+        )
+
+        assert session.session_id == "session-abc"
+        # The adapter must hand the optimizer's SessionCreationRequest
+        # straight to the cloud client.
+        client.create_optimization_session.assert_awaited_once()
+        (forwarded_request,), _ = client.create_optimization_session.call_args
+        assert isinstance(forwarded_request, SessionCreationRequest)
+        assert forwarded_request.function_name == "optimize_qa"
+        assert forwarded_request.max_trials == 10
+
+        # Drive the suggestion / report loop.
+        observed_trial_ids: list[str] = []
+        while True:
+            suggestion = await optimizer.get_next_suggestion(dataset_size=100)
+            if suggestion is None:
+                break
+            observed_trial_ids.append(suggestion.trial_id)
+            await optimizer.report_results(
+                trial_id=suggestion.trial_id,
+                metrics={"accuracy": 0.8 + 0.05 * len(observed_trial_ids)},
+                duration=0.42,
+                status=TrialStatus.COMPLETED,
+            )
+
+        assert observed_trial_ids == ["trial-1", "trial-2"]
+        assert client.get_next_trial.await_count == 3  # 2 suggestions + 1 stop
+        assert client.submit_trial_result.await_count == 2
+
+        # Each submit call should be keyword-based with the string status
+        # the cloud client expects on the wire.
+        for call in client.submit_trial_result.await_args_list:
+            assert call.args == ()
+            assert call.kwargs["session_id"] == "session-abc"
+            assert call.kwargs["status"] == "completed"
+
+        summary = await optimizer.finalize_optimization(include_full_history=True)
+        client.finalize_optimization.assert_awaited_once_with(
+            "session-abc", include_full_history=True
+        )
+        assert summary.best_config == configs[-1]
+        assert summary.successful_trials == 2
+        assert optimizer.session is not None
+        assert optimizer.session.status is OptimizationSessionStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_raw_cloud_client_without_adapter_raises_clear_error(self) -> None:
+        """Documents why the adapter is required: the bare cloud client fails.
+
+        Passing ``TraigentCloudClient`` directly as ``remote_service`` is the
+        documented-but-broken setup from issue #883. The cloud client has no
+        ``submit_result`` method and its ``create_session`` returns a ``str``
+        rather than a ``SessionCreationResponse`` — both of which break the
+        optimizer at runtime. This test pins the failure so a regression that
+        accidentally makes the bare client "work" without the adapter would
+        be caught.
+        """
+        client = AsyncMock(spec=TraigentCloudClient)
+        # ``spec=TraigentCloudClient`` means accessing ``submit_result`` on
+        # the mock raises ``AttributeError``, matching the real client's
+        # surface. That's the exact runtime failure users hit today.
+        assert not hasattr(client, "submit_result")

--- a/tests/unit/cloud/test_remote_guidance_adapter.py
+++ b/tests/unit/cloud/test_remote_guidance_adapter.py
@@ -40,6 +40,7 @@ from traigent.optimizers.interactive_optimizer import (
     InteractiveOptimizer,
     RemoteGuidanceService,
 )
+from traigent.utils.exceptions import OptimizationError
 
 
 def _make_cloud_client_mock(
@@ -359,18 +360,41 @@ class TestDocumentedInteractiveOptimizerSetup:
 
     @pytest.mark.asyncio
     async def test_raw_cloud_client_without_adapter_raises_clear_error(self) -> None:
-        """Documents why the adapter is required: the bare cloud client fails.
+        """Drive the documented-broken bare client setup and assert it fails.
 
         Passing ``TraigentCloudClient`` directly as ``remote_service`` is the
-        documented-but-broken setup from issue #883. The cloud client has no
-        ``submit_result`` method and its ``create_session`` returns a ``str``
-        rather than a ``SessionCreationResponse`` — both of which break the
-        optimizer at runtime. This test pins the failure so a regression that
-        accidentally makes the bare client "work" without the adapter would
-        be caught.
+        documented-but-broken setup from issue #883. The cloud client exposes
+        ``submit_trial_result`` rather than the protocol's ``submit_result``,
+        so the first ``report_results`` call inside ``InteractiveOptimizer``
+        explodes. This test wires the bare client into the optimizer and
+        asserts the runtime failure surfaces — a regression that accidentally
+        lets the bare client "work" without the adapter would be caught.
         """
         client = AsyncMock(spec=TraigentCloudClient)
-        # ``spec=TraigentCloudClient`` means accessing ``submit_result`` on
-        # the mock raises ``AttributeError``, matching the real client's
-        # surface. That's the exact runtime failure users hit today.
-        assert not hasattr(client, "submit_result")
+        # ``spec=TraigentCloudClient`` mirrors the real client's surface, so
+        # accessing ``submit_result`` raises ``AttributeError`` — the exact
+        # failure users hit at runtime today.
+        assert not hasattr(TraigentCloudClient, "submit_result")
+
+        optimizer = InteractiveOptimizer(
+            config_space={"temperature": (0.0, 1.0)},
+            objectives=["accuracy"],
+            remote_service=client,  # type: ignore[arg-type]
+            dataset_metadata={"size": 1},
+        )
+        # Skip initialize_session for this regression pin: the cloud client's
+        # legacy ``create_session`` accepts the call (with the wrong return
+        # shape), so the cleanest, most diagnosable failure to assert is the
+        # missing ``submit_result`` the optimizer hits during reporting.
+        optimizer.session_id = "session-abc"
+
+        with pytest.raises(OptimizationError) as exc_info:
+            await optimizer.report_results(
+                trial_id="trial-1",
+                metrics={"accuracy": 0.8},
+                duration=1.0,
+                status=TrialStatus.COMPLETED,
+            )
+
+        assert "Failed to report results" in str(exc_info.value)
+        assert "submit_result" in str(exc_info.value)

--- a/traigent/cloud/__init__.py
+++ b/traigent/cloud/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from .auth import APIKey, AuthManager
 from .billing import BillingManager, UsageTracker
 from .client import TraigentCloudClient
+from .remote_guidance import TraigentCloudRemoteGuidanceAdapter
 from .service import TraigentCloudService
 from .subset_selection import (
     DiverseSampling,
@@ -21,6 +22,7 @@ from .subset_selection import (
 
 __all__ = [
     "TraigentCloudClient",
+    "TraigentCloudRemoteGuidanceAdapter",
     "TraigentCloudService",
     "AuthManager",
     "APIKey",

--- a/traigent/cloud/remote_guidance.py
+++ b/traigent/cloud/remote_guidance.py
@@ -1,0 +1,108 @@
+"""Adapter exposing :class:`TraigentCloudClient` as a remote guidance service.
+
+:class:`~traigent.optimizers.interactive_optimizer.InteractiveOptimizer`
+consumes a service whose methods accept the dataclass requests defined in
+:mod:`traigent.cloud.models` (``SessionCreationRequest``,
+``NextTrialRequest``, ``TrialResultSubmission``,
+``OptimizationFinalizationRequest``) and return their matching response
+objects. :class:`~traigent.cloud.client.TraigentCloudClient` already speaks
+those endpoints, but its public methods use a different signature shape
+(positional / keyword arguments and a ``submit_trial_result`` name).
+
+The :class:`TraigentCloudRemoteGuidanceAdapter` wraps a cloud client so the
+documented ``InteractiveOptimizer(remote_service=...)`` setup works without
+leaking those signature differences into user code.
+"""
+
+# Traceability: CONC-Layer-Integration FUNC-CLOUD-HYBRID REQ-CLOUD-009 SYNC-CloudHybrid
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from traigent.cloud.models import (
+    NextTrialRequest,
+    NextTrialResponse,
+    OptimizationFinalizationRequest,
+    OptimizationFinalizationResponse,
+    SessionCreationRequest,
+    SessionCreationResponse,
+    TrialResultSubmission,
+)
+
+if TYPE_CHECKING:
+    from traigent.cloud.client import TraigentCloudClient
+
+
+class TraigentCloudRemoteGuidanceAdapter:
+    """Adapt :class:`TraigentCloudClient` to the ``RemoteGuidanceService`` protocol.
+
+    Pass an instance of this adapter as the ``remote_service`` argument when
+    constructing :class:`InteractiveOptimizer` with a
+    :class:`TraigentCloudClient` so the optimizer's dataclass-based protocol is
+    correctly bridged to the cloud client's HTTP-facing signature.
+    """
+
+    def __init__(self, client: TraigentCloudClient) -> None:
+        """Store the wrapped cloud client.
+
+        Args:
+            client: An initialized :class:`TraigentCloudClient`. The adapter
+                does not take ownership of the client lifecycle; callers
+                remain responsible for opening and closing the underlying
+                HTTP session (e.g. with ``async with`` on the client).
+        """
+        self._client = client
+
+    @property
+    def client(self) -> TraigentCloudClient:
+        """Return the wrapped cloud client."""
+        return self._client
+
+    async def create_session(
+        self, request: SessionCreationRequest
+    ) -> SessionCreationResponse:
+        """Create a remote optimization session.
+
+        Delegates to :meth:`TraigentCloudClient.create_optimization_session`,
+        which already accepts a :class:`SessionCreationRequest` instance.
+        """
+        return await self._client.create_optimization_session(request)
+
+    async def get_next_trial(self, request: NextTrialRequest) -> NextTrialResponse:
+        """Request the next trial suggestion for ``request.session_id``."""
+        return await self._client.get_next_trial(
+            request.session_id,
+            previous_results=request.previous_results,
+        )
+
+    async def submit_result(self, result: TrialResultSubmission) -> None:
+        """Submit a completed trial result back to the cloud service.
+
+        Maps the dataclass to the keyword-argument form expected by
+        :meth:`TraigentCloudClient.submit_trial_result` and converts the
+        ``TrialStatus`` enum to its wire-format string.
+        """
+        status_value = getattr(result.status, "value", str(result.status))
+        await self._client.submit_trial_result(
+            session_id=result.session_id,
+            trial_id=result.trial_id,
+            metrics=result.metrics,
+            duration=result.duration,
+            status=status_value,
+            outputs_sample=result.outputs_sample,
+            error_message=result.error_message,
+            metadata=result.metadata,
+        )
+
+    async def finalize_session(
+        self, request: OptimizationFinalizationRequest
+    ) -> OptimizationFinalizationResponse:
+        """Finalize the session and return the cloud client's response."""
+        return await self._client.finalize_optimization(
+            request.session_id,
+            include_full_history=request.include_full_history,
+        )
+
+
+__all__ = ["TraigentCloudRemoteGuidanceAdapter"]


### PR DESCRIPTION
## Issue

Closes #883 — bug(cloud): `InteractiveOptimizer` docs use incompatible
`TraigentCloudClient` interface.

`InteractiveOptimizer` calls a `RemoteGuidanceService` protocol whose
methods take the dataclass requests defined in `traigent.cloud.models`
(`SessionCreationRequest`, `NextTrialRequest`, `TrialResultSubmission`,
`OptimizationFinalizationRequest`) and return their matching response
objects. The docs showed `remote_service=TraigentCloudClient(...)`, but
the cloud client exposes those backend endpoints with different public
method signatures (separate positional / keyword args and
`submit_trial_result` rather than `submit_result`). The documented setup
therefore fails at runtime.

## Summary of Changes

- New `traigent.cloud.TraigentCloudRemoteGuidanceAdapter`: thin
  client-side bridge that wraps a `TraigentCloudClient` and exposes the
  `RemoteGuidanceService` protocol by delegating to the existing methods
  (`create_optimization_session`, `get_next_trial`, `submit_trial_result`,
  `finalize_optimization`) and converting `TrialStatus` to its wire
  string.
- Re-exported from `traigent.cloud`.
- Updated docs to use the adapter as `remote_service=...`:
  - `docs/user-guide/interactive_optimization.md` (Step 1 setup +
    Network Issues troubleshooting snippet).
  - `docs/user-guide/choosing_optimization_model.md` (Model 1 example).
  - `docs/api-reference/interactive_optimizer.md` (adapter rationale and
    construction).
- Added `tests/unit/cloud/test_remote_guidance_adapter.py` (10 tests):
  protocol conformance, per-method delegation (request mapping,
  `TrialStatus` → string, keyword shape), an end-to-end run of the
  documented `InteractiveOptimizer` workflow with the adapter wrapping a
  mocked `TraigentCloudClient`, and a regression pin that the bare
  cloud client lacks `submit_result`.

## Acceptance Criteria and Evidence

| Criterion (from issue) | Evidence |
|---|---|
| Runnable test of the documented setup with the intended remote client / adapter | `TestDocumentedInteractiveOptimizerSetup::test_initialize_get_report_finalize_against_cloud_client` |
| Service methods called match the request/response contract documented for users | `TestAdapterDelegation::*` (5 tests covering each protocol method, including status enum → string translation) |
| Docs match the tested path | Doc edits all show `TraigentCloudRemoteGuidanceAdapter(client)` — the exact wiring exercised by the e2e test |
| Regression pin for the original bug | `TestProtocolConformance::test_adapter_satisfies_remote_guidance_service_protocol` asserts `not hasattr(TraigentCloudClient, "submit_result")`; `test_raw_cloud_client_without_adapter_raises_clear_error` documents the failure mode |

## Tests Run

```text
pytest tests/unit/cloud/test_remote_guidance_adapter.py
  -> 10 passed

pytest tests/unit/cloud/test_remote_guidance_adapter.py \
       tests/unit/optimizers/test_interactive_optimizer.py \
       tests/e2e/test_interactive_flow.py
  -> 29 passed
```

Pre-existing failures in `tests/unit/cloud/test_api_key_strict_bool.py`
(`test_validate_rejects_non_global_backend_validation_hosts`) reproduce
on unmodified `develop` (verified via `git stash`); they are unrelated
to issue #883.

Pre-commit hooks (isort / black / ruff / mypy / bandit / detect-secrets
/ public-assertion-contracts / strict-cost-accounting) all pass.

## CI Status

To run after push.

## Spine Artifacts Updated

- `ops/_validation/runs/issue-management-20260522-batch2/issue-883.md`.

## Known Risks and Assumptions

- The cloud-side endpoints backing the cloud client's HTTP methods
  already exist; the adapter is purely a client-side signature bridge.
  Live-network verification against a real backend was not run as part
  of this change; the runnable test mocks the cloud client's public
  surface.
- The adapter deliberately does not own the client lifecycle. The docs
  note this — users keep the cloud client in its own `async with` block.
- Status string conversion uses `getattr(result.status, "value", str(result.status))`,
  so callers that hand-build `TrialResultSubmission` with a string status
  continue to work.

## Follow-up Issues

None identified. The fix is the smallest scoped change that makes the
documented `InteractiveOptimizer` setup executable.

## Codex Final-Review Status

pending