### PR TITLE
fix(cloud): thread MCP workflow resource IDs

### DIFF
--- a/tests/unit/test_mcp_production_client.py
+++ b/tests/unit/test_mcp_production_client.py
@@ -1931,9 +1931,9 @@ class TestCreateAgent:
                 await self.client.create_agent(spec)
 
             _, arguments = mock_call_tool.call_args.args
-            assert "agent_id" not in arguments, (
-                f"create_agent must not forward agent_id (spec.id={spec.id!r})"
-            )
+            assert (
+                "agent_id" not in arguments
+            ), f"create_agent must not forward agent_id (spec.id={spec.id!r})"
 
 
 class TestUploadDataset:
@@ -2195,6 +2195,156 @@ class TestCreateOptimizationWorkflow:
                         assert agent_id == "agent_123"
                         assert exp_id == "exp_123"
                         assert run_id == "run_123"
+
+    @pytest.mark.asyncio
+    async def test_create_optimization_workflow_threads_real_ids_to_create_experiment(
+        self,
+    ):
+        """Regression test for issue #899: create_optimization_workflow must
+        forward the agent_id and example_set_id returned by create_agent and
+        upload_dataset into create_experiment via explicit parameters, not
+        dynamic attrs that the bridge silently ignores.
+        """
+        from traigent.cloud.models import AgentSpecification, OptimizationRequest
+        from traigent.cloud.production_mcp_client import MCPResponse
+        from traigent.evaluators.base import Dataset, EvaluationExample
+
+        example = EvaluationExample(
+            input_data={"test": "input"}, expected_output="output"
+        )
+        request = OptimizationRequest(
+            function_name="test_function",
+            dataset=Dataset(name="test", examples=[example]),
+            configuration_space={"param": [1, 2, 3]},
+            objectives=["maximize"],
+            max_trials=10,
+            agent_specification=AgentSpecification(name="test", agent_type="opt"),
+            metadata={},
+        )
+
+        real_agent_id = "agent_real_uuid_abc"
+        real_example_set_id = "set_real_uuid_xyz"
+
+        with (
+            patch.object(
+                self.client, "create_agent", new_callable=AsyncMock
+            ) as mock_create_agent,
+            patch.object(
+                self.client, "upload_dataset", new_callable=AsyncMock
+            ) as mock_upload,
+            patch.object(
+                self.client, "create_experiment", new_callable=AsyncMock
+            ) as mock_create_exp,
+            patch.object(
+                self.client, "start_experiment_run", new_callable=AsyncMock
+            ) as mock_start_run,
+        ):
+            mock_create_agent.return_value = MCPResponse(
+                success=True, data={"agent_id": real_agent_id}
+            )
+            mock_upload.return_value = MCPResponse(
+                success=True, data={"example_set_id": real_example_set_id}
+            )
+            mock_create_exp.return_value = MCPResponse(
+                success=True, data={"experiment_id": "exp_123"}
+            )
+            mock_start_run.return_value = MCPResponse(
+                success=True, data={"experiment_run_id": "run_123"}
+            )
+
+            await self.client.create_optimization_workflow(request)
+
+            mock_create_exp.assert_called_once()
+            call_args = mock_create_exp.call_args
+            # The real IDs must be threaded through explicit kwargs, not
+            # silently set as attributes on the request object.
+            assert call_args.kwargs.get("agent_id") == real_agent_id
+            assert call_args.kwargs.get("example_set_id") == real_example_set_id
+
+    @pytest.mark.asyncio
+    async def test_create_experiment_tool_args_contain_real_backend_ids(self):
+        """Regression test for issue #899: when create_experiment is called
+        with explicit agent_id / example_set_id, the underlying create_experiment
+        MCP tool arguments must contain exactly those IDs (not bridge-generated
+        placeholders).
+        """
+        from traigent.cloud.models import OptimizationRequest
+        from traigent.cloud.production_mcp_client import MCPResponse
+        from traigent.evaluators.base import Dataset, EvaluationExample
+
+        example = EvaluationExample(
+            input_data={"test": "input"}, expected_output="output"
+        )
+        dataset = Dataset(name="test", examples=[example])
+        request = OptimizationRequest(
+            function_name="test_function",
+            dataset=dataset,
+            configuration_space={"param": [1, 2, 3]},
+            objectives=["maximize"],
+            max_trials=10,
+        )
+
+        real_agent_id = "agent_real_uuid_abc"
+        real_example_set_id = "set_real_uuid_xyz"
+
+        with patch.object(
+            self.client, "call_tool", new_callable=AsyncMock
+        ) as mock_call_tool:
+            mock_call_tool.return_value = MCPResponse(
+                success=True, data={"experiment_id": "exp_123"}
+            )
+
+            result = await self.client.create_experiment(
+                request,
+                agent_id=real_agent_id,
+                example_set_id=real_example_set_id,
+            )
+
+            assert result.success is True
+            mock_call_tool.assert_called_once()
+            tool_name, tool_args = mock_call_tool.call_args.args
+            assert tool_name == "create_experiment"
+            assert tool_args["agent_id"] == real_agent_id
+            assert tool_args["example_set_id"] == real_example_set_id
+
+    @pytest.mark.asyncio
+    async def test_create_experiment_falls_back_to_bridge_ids_when_unspecified(
+        self,
+    ):
+        """When create_experiment is called without explicit IDs (legacy path),
+        it falls back to the bridge-generated IDs so existing callers keep
+        working.
+        """
+        from traigent.cloud.models import OptimizationRequest
+        from traigent.cloud.production_mcp_client import MCPResponse
+        from traigent.evaluators.base import Dataset, EvaluationExample
+
+        example = EvaluationExample(
+            input_data={"test": "input"}, expected_output="output"
+        )
+        dataset = Dataset(name="test", examples=[example])
+        request = OptimizationRequest(
+            function_name="test_function",
+            dataset=dataset,
+            configuration_space={"param": [1, 2, 3]},
+            objectives=["maximize"],
+            max_trials=10,
+        )
+
+        with patch.object(
+            self.client, "call_tool", new_callable=AsyncMock
+        ) as mock_call_tool:
+            mock_call_tool.return_value = MCPResponse(
+                success=True, data={"experiment_id": "exp_123"}
+            )
+
+            await self.client.create_experiment(request)
+
+            tool_name, tool_args = mock_call_tool.call_args.args
+            assert tool_name == "create_experiment"
+            # Bridge fills agent_id from function name, example_set_id from uuid.
+            assert tool_args["agent_id"] == "test_function"
+            assert tool_args["example_set_id"]  # non-empty fallback
 
 
 class TestSessionUnavailableAfterConnect:

--- a/traigent/cloud/production_mcp_client.py
+++ b/traigent/cloud/production_mcp_client.py
@@ -495,12 +495,22 @@ class ProductionMCPClient:
     # Backend Integration Operations
 
     async def create_experiment(
-        self, optimization_request: OptimizationRequest
+        self,
+        optimization_request: OptimizationRequest,
+        agent_id: str | None = None,
+        example_set_id: str | None = None,
     ) -> MCPResponse:
         """Create experiment via MCP backend.
 
         Args:
             optimization_request: SDK optimization request
+            agent_id: Optional backend agent ID returned by ``create_agent``.
+                When provided, this ID is sent to the backend instead of the
+                bridge-generated agent_id, so the experiment is linked to the
+                real backend agent resource (issue #899).
+            example_set_id: Optional backend example-set ID returned by
+                ``upload_dataset``. When provided, this ID is sent to the
+                backend instead of the bridge-generated example_set_id.
 
         Returns:
             MCP response with experiment details
@@ -516,24 +526,41 @@ class ProductionMCPClient:
             self._validate_mapping(
                 optimization_request.metadata, "optimization_request.metadata"
             )
+        if agent_id is not None:
+            self._validate_identifier(agent_id, "agent_id")
+        if example_set_id is not None:
+            self._validate_identifier(example_set_id, "example_set_id")
 
         # Convert to backend format
         backend_request = bridge.optimization_request_to_backend(optimization_request)
 
-        # Prepare tool arguments
-        arguments = {
-            "name": backend_request.name,
-            "description": backend_request.description,
-            "agent_id": (
+        # Prefer the real backend IDs returned by upstream create_agent /
+        # upload_dataset calls. Fall back to bridge-generated IDs only when
+        # the caller did not supply them (e.g. standalone create_experiment).
+        resolved_agent_id = (
+            agent_id
+            if agent_id is not None
+            else (
                 backend_request.agent_data.get("agent_id")
                 if hasattr(backend_request, "agent_data")
                 else None
-            ),
-            "example_set_id": (
+            )
+        )
+        resolved_example_set_id = (
+            example_set_id
+            if example_set_id is not None
+            else (
                 backend_request.example_set_data.get("example_set_id")
                 if hasattr(backend_request, "example_set_data")
                 else None
-            ),
+            )
+        )
+
+        arguments = {
+            "name": backend_request.name,
+            "description": backend_request.description,
+            "agent_id": resolved_agent_id,
+            "example_set_id": resolved_example_set_id,
             "measures": backend_request.measures,
             "metadata": backend_request.metadata,
         }
@@ -785,12 +812,15 @@ class ProductionMCPClient:
             )
             example_set_id = (dataset_data or {}).get("example_set_id")
 
-            # Step 3: Create experiment
-            # Update optimization request with backend IDs
-            optimization_request.agent_id = agent_id  # type: ignore[attr-defined]
-            optimization_request.example_set_id = example_set_id  # type: ignore[attr-defined]
-
-            experiment_response = await self.create_experiment(optimization_request)
+            # Step 3: Create experiment, threading through the real backend
+            # IDs returned by create_agent / upload_dataset (issue #899).
+            # Passing them as explicit parameters ensures the bridge-generated
+            # placeholder IDs do not silently win over the live resources.
+            experiment_response = await self.create_experiment(
+                optimization_request,
+                agent_id=str(agent_id) if agent_id else None,
+                example_set_id=str(example_set_id) if example_set_id else None,
+            )
             if not experiment_response.success:
                 raise RuntimeError(
                     f"Failed to create experiment: {experiment_response.error_message}"


### PR DESCRIPTION
Closes #899.\n\nFixes create_optimization_workflow so the real agent_id returned by create_agent and example_set_id returned by upload_dataset are passed into create_experiment as explicit parameters. This prevents bridge-generated placeholder IDs from being sent to the backend when real resources were just created.\n\nChanges:\n- Adds optional agent_id/example_set_id parameters to ProductionMCPClient.create_experiment.\n- create_optimization_workflow forwards the real backend IDs returned by the previous workflow steps.\n- Adds regression coverage for exact ID forwarding, tool arguments, and legacy fallback behavior.\n\nValidation:\n- uv run pytest tests/unit/test_mcp_production_client.py\n- Claude worker also ran tests/unit/cloud/: 1264 passed, 2 skipped, 4 pre-existing failures unrelated to this diff (test_api_key_strict_bool/test_subset_selection family).