### PR TITLE
Add runtime best config resolution

### DIFF
--- a/tests/unit/core/test_best_config_runtime.py
+++ b/tests/unit/core/test_best_config_runtime.py
@@ -17,6 +17,7 @@ from traigent.core.best_config_runtime import (
     CloudPublishUnavailableReason,
     canonical_json,
     compute_spec_hash,
+    load_best_config_spec,
     resolve_cloud_cache_best_config,
     resolve_repo_best_config,
     sha256_digest,
@@ -90,9 +91,7 @@ def test_forward_compat_ignores_non_sensitive_unknown_keys():
         forward_compat=True,
     )
 
-    snapshot = snapshot_from_spec(
-        spec, configuration_space={"temperature": [0.1, 0.2]}
-    )
+    snapshot = snapshot_from_spec(spec, configuration_space={"temperature": [0.1, 0.2]})
 
     assert thaw_config(snapshot.config) == {"temperature": 0.2}
 
@@ -160,7 +159,9 @@ def test_repo_manifest_round_trip(tmp_path, monkeypatch):
 def test_repo_invalid_hash_warns_or_raises(tmp_path, monkeypatch):
     repo_root = tmp_path
     config_dir = repo_root / ".traigent" / "best-configs"
-    write_repo_best_config(config_dir, config_id="answerer", config={"temperature": 0.2})
+    write_repo_best_config(
+        config_dir, config_id="answerer", config={"temperature": 0.2}
+    )
 
     manifest_path = config_dir / "manifest.json"
     manifest = json.loads(manifest_path.read_text())
@@ -169,11 +170,22 @@ def test_repo_invalid_hash_warns_or_raises(tmp_path, monkeypatch):
 
     monkeypatch.chdir(repo_root)
     assert (
-        resolve_repo_best_config(config_id="answerer", repo_root=repo_root, strict=False)
+        resolve_repo_best_config(
+            config_id="answerer", repo_root=repo_root, strict=False
+        )
         is None
     )
     with pytest.raises(ConfigurationError, match="spec_hash mismatch"):
         resolve_repo_best_config(config_id="answerer", repo_root=repo_root, strict=True)
+
+
+def test_load_best_config_spec_non_strict_ignores_file_errors(tmp_path):
+    missing_path = tmp_path / "missing.json"
+
+    assert load_best_config_spec(missing_path, strict=False) is None
+
+    with pytest.raises(ConfigurationError, match="Failed to load best config"):
+        load_best_config_spec(missing_path, strict=True)
 
 
 def test_config_id_rejects_path_traversal(tmp_path):
@@ -203,7 +215,9 @@ def test_manifest_path_traversal_is_rejected(tmp_path):
                     "answerer": {
                         "path": "../outside.json",
                         "spec_hash": compute_spec_hash(outside_spec),
-                        "config_hash": sha256_digest(canonical_json(outside_spec["config"])),
+                        "config_hash": sha256_digest(
+                            canonical_json(outside_spec["config"])
+                        ),
                     }
                 },
             }

--- a/tests/unit/core/test_best_config_runtime.py
+++ b/tests/unit/core/test_best_config_runtime.py
@@ -1,0 +1,319 @@
+"""Tests for runtime best-config specs and snapshots."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import MappingProxyType
+
+import pytest
+
+from traigent.core.best_config_runtime import (
+    BEST_CONFIG_MANIFEST_SCHEMA_VERSION,
+    BEST_CONFIG_SCHEMA_VERSION,
+    BestConfigSnapshot,
+    BestConfigSource,
+    CloudPublishUnavailable,
+    CloudPublishUnavailableReason,
+    canonical_json,
+    compute_spec_hash,
+    resolve_cloud_cache_best_config,
+    resolve_repo_best_config,
+    sha256_digest,
+    snapshot_from_spec,
+    source_order_for_mode,
+    thaw_config,
+    write_repo_best_config,
+)
+from traigent.utils.exceptions import ConfigurationError
+
+
+def spec_for(config_id: str = "answerer", **overrides):
+    spec = {
+        "schema_version": BEST_CONFIG_SCHEMA_VERSION,
+        "config_id": config_id,
+        "config": {"model": "gpt-4o-mini", "temperature": 0.2},
+    }
+    spec.update(overrides)
+    return spec
+
+
+def test_canonical_json_and_hash_are_stable():
+    first = canonical_json({"b": 1, "a": ["x", True]})
+    second = canonical_json({"a": ["x", True], "b": 1})
+
+    assert first == second == '{"a":["x",true],"b":1}'
+    assert sha256_digest(first).startswith("sha256:")
+
+
+def test_canonical_json_rejects_non_json_native_values():
+    with pytest.raises(ConfigurationError, match="non-JSON-native"):
+        canonical_json({"bad": object()})
+
+    circular = {}
+    circular["self"] = circular
+    with pytest.raises(ConfigurationError, match="circular"):
+        canonical_json(circular)
+
+
+def test_snapshot_deep_freezes_config():
+    snapshot = BestConfigSnapshot.from_config(
+        {"nested": {"values": [1, 2]}},
+        config_id="frozen",
+        source="test",
+    )
+
+    assert isinstance(snapshot.config, MappingProxyType)
+    assert thaw_config(snapshot.config) == {"nested": {"values": [1, 2]}}
+
+    with pytest.raises(TypeError):
+        snapshot.config["x"] = 1  # type: ignore[index]
+    with pytest.raises(TypeError):
+        snapshot.config["nested"]["values"] = []  # type: ignore[index]
+
+
+def test_unknown_top_level_spec_keys_reject():
+    with pytest.raises(ConfigurationError, match="Unknown top-level"):
+        snapshot_from_spec(spec_for(extra=True))
+
+
+def test_unknown_config_keys_reject_when_config_space_known():
+    spec = spec_for(config={"temperature": 0.2, "unexpected": 1})
+
+    with pytest.raises(ConfigurationError, match="Unknown best config keys"):
+        snapshot_from_spec(spec, configuration_space={"temperature": [0.1, 0.2]})
+
+
+def test_forward_compat_ignores_non_sensitive_unknown_keys():
+    spec = spec_for(
+        config={"temperature": 0.2, "display_label": "fast"},
+        forward_compat=True,
+    )
+
+    snapshot = snapshot_from_spec(
+        spec, configuration_space={"temperature": [0.1, 0.2]}
+    )
+
+    assert thaw_config(snapshot.config) == {"temperature": 0.2}
+
+
+def test_forward_compat_does_not_ignore_safety_sensitive_unknown_keys():
+    spec = spec_for(
+        config={"temperature": 0.2, "model": "gpt-4o-mini"},
+        forward_compat=True,
+    )
+
+    with pytest.raises(ConfigurationError, match="safety-sensitive"):
+        snapshot_from_spec(spec, configuration_space={"temperature": [0.1, 0.2]})
+
+
+def test_source_order_modes_never_touch_cloud_for_off_or_repo():
+    assert source_order_for_mode("off") == ()
+    assert source_order_for_mode("repo") == (BestConfigSource.REPO,)
+    assert source_order_for_mode("cloud") == (
+        BestConfigSource.CLOUD_CACHE,
+        BestConfigSource.CLOUD_FETCH,
+    )
+    assert source_order_for_mode("repo_then_cloud") == (
+        BestConfigSource.REPO,
+        BestConfigSource.CLOUD_CACHE,
+        BestConfigSource.CLOUD_FETCH,
+    )
+    assert source_order_for_mode("cloud_then_repo") == (
+        BestConfigSource.CLOUD_CACHE,
+        BestConfigSource.CLOUD_FETCH,
+        BestConfigSource.REPO,
+    )
+
+
+def test_repo_manifest_round_trip(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    config_dir = repo_root / ".traigent" / "best-configs"
+
+    spec_path = write_repo_best_config(
+        config_dir,
+        config_id="answerer",
+        config={"temperature": 0.2},
+        function_ref="pkg.mod:answer",
+        provenance={"source": "unit"},
+    )
+
+    assert spec_path.exists()
+    manifest = json.loads((config_dir / "manifest.json").read_text())
+    assert "spec_hash" in manifest["configs"]["answerer"]
+    assert "config_hash" in manifest["configs"]["answerer"]
+
+    monkeypatch.chdir(repo_root)
+    snapshot = resolve_repo_best_config(
+        config_id="answerer",
+        repo_root=repo_root,
+        configuration_space={"temperature": [0.1, 0.2]},
+        expected_function_ref="pkg.mod:answer",
+        strict=True,
+    )
+
+    assert snapshot is not None
+    assert snapshot.source == BestConfigSource.REPO.value
+    assert thaw_config(snapshot.config) == {"temperature": 0.2}
+
+
+def test_repo_invalid_hash_warns_or_raises(tmp_path, monkeypatch):
+    repo_root = tmp_path
+    config_dir = repo_root / ".traigent" / "best-configs"
+    write_repo_best_config(config_dir, config_id="answerer", config={"temperature": 0.2})
+
+    manifest_path = config_dir / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["configs"]["answerer"]["spec_hash"] = "sha256:bad"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.chdir(repo_root)
+    assert (
+        resolve_repo_best_config(config_id="answerer", repo_root=repo_root, strict=False)
+        is None
+    )
+    with pytest.raises(ConfigurationError, match="spec_hash mismatch"):
+        resolve_repo_best_config(config_id="answerer", repo_root=repo_root, strict=True)
+
+
+def test_config_id_rejects_path_traversal(tmp_path):
+    with pytest.raises(ConfigurationError, match="path separators"):
+        write_repo_best_config(
+            tmp_path / ".traigent" / "best-configs",
+            config_id="../outside",
+            config={"temperature": 0.2},
+        )
+
+    with pytest.raises(ConfigurationError, match="path separators"):
+        snapshot_from_spec(spec_for(config_id="nested/answerer"))
+
+
+def test_manifest_path_traversal_is_rejected(tmp_path):
+    repo_root = tmp_path
+    config_dir = repo_root / ".traigent" / "best-configs"
+    config_dir.mkdir(parents=True)
+    outside_path = repo_root / ".traigent" / "outside.json"
+    outside_spec = spec_for("answerer", config={"temperature": 0.2})
+    outside_path.write_text(json.dumps(outside_spec), encoding="utf-8")
+    (config_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": BEST_CONFIG_MANIFEST_SCHEMA_VERSION,
+                "configs": {
+                    "answerer": {
+                        "path": "../outside.json",
+                        "spec_hash": compute_spec_hash(outside_spec),
+                        "config_hash": sha256_digest(canonical_json(outside_spec["config"])),
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert resolve_repo_best_config(config_id="answerer", repo_root=repo_root) is None
+    with pytest.raises(ConfigurationError, match="inside its directory"):
+        resolve_repo_best_config(
+            config_id="answerer",
+            repo_root=repo_root,
+            strict=True,
+        )
+
+
+def test_cloud_cache_ttl_behavior(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    spec = spec_for("answerer", config={"temperature": 0.2})
+    spec_hash = compute_spec_hash(spec)
+    config_hash = sha256_digest(canonical_json(spec["config"]))
+    (cache_dir / "answerer.json").write_text(json.dumps(spec), encoding="utf-8")
+    (cache_dir / "answerer.metadata.json").write_text(
+        json.dumps(
+            {
+                "spec_hash": spec_hash,
+                "config_hash": config_hash,
+                "etag": "v1",
+                "loaded_at": "2026-05-22T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot = resolve_cloud_cache_best_config(
+        config_id="answerer",
+        cache_dir=cache_dir,
+        ttl_seconds=60,
+        now=datetime(2026, 5, 22, 0, 0, 30, tzinfo=UTC),
+        strict=True,
+    )
+    assert snapshot is not None
+    assert snapshot.source == BestConfigSource.CLOUD_CACHE.value
+
+    stale = resolve_cloud_cache_best_config(
+        config_id="answerer",
+        cache_dir=cache_dir,
+        ttl_seconds=60,
+        now=datetime(2026, 5, 22, 0, 2, 0, tzinfo=UTC),
+        strict=True,
+    )
+    assert stale is None
+
+
+def test_cloud_cache_stale_ok_ttl_allows_offline_reuse(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    spec = spec_for("answerer", config={"temperature": 0.2})
+    (cache_dir / "answerer.json").write_text(json.dumps(spec), encoding="utf-8")
+    (cache_dir / "answerer.metadata.json").write_text(
+        json.dumps(
+            {
+                "spec_hash": compute_spec_hash(spec),
+                "config_hash": sha256_digest(canonical_json(spec["config"])),
+                "version": "v1",
+                "loaded_at": "2026-05-22T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot = resolve_cloud_cache_best_config(
+        config_id="answerer",
+        cache_dir=cache_dir,
+        ttl_seconds=60,
+        stale_ok_ttl_seconds=int(timedelta(hours=1).total_seconds()),
+        now=datetime(2026, 5, 22, 0, 30, 0, tzinfo=UTC),
+        strict=True,
+    )
+
+    assert snapshot is not None
+
+
+def test_cloud_publish_unavailable_exposes_reason():
+    exc = CloudPublishUnavailable(
+        CloudPublishUnavailableReason.BACKEND_NOT_IMPLEMENTED,
+        "Cloud publish not enabled",
+    )
+
+    assert exc.reason is CloudPublishUnavailableReason.BACKEND_NOT_IMPLEMENTED
+    assert exc.details["reason"] == "backend_not_implemented"
+
+
+def test_forward_compat_manifest_hashes_bind_raw_spec_before_filtering():
+    spec = spec_for(
+        config={"temperature": 0.2, "display_label": "fast"},
+        forward_compat=True,
+    )
+    manifest_entry = {
+        "spec_hash": compute_spec_hash(spec),
+        "config_hash": sha256_digest(canonical_json(spec["config"])),
+    }
+
+    snapshot = snapshot_from_spec(
+        spec,
+        configuration_space={"temperature": [0.1, 0.2]},
+        manifest_entry=manifest_entry,
+    )
+
+    assert thaw_config(snapshot.config) == {"temperature": 0.2}
+    assert snapshot.spec_hash == manifest_entry["spec_hash"]
+    assert snapshot.config_hash == sha256_digest(canonical_json({"temperature": 0.2}))

--- a/tests/unit/core/test_best_config_runtime_integration.py
+++ b/tests/unit/core/test_best_config_runtime_integration.py
@@ -8,7 +8,14 @@ import pytest
 
 import traigent
 from traigent.api.decorators import optimize
+from traigent.api.types import (
+    OptimizationResult,
+    OptimizationStatus,
+    TrialResult,
+    TrialStatus,
+)
 from traigent.core.best_config_runtime import (
+    BestConfigSnapshot,
     BestConfigSource,
     CloudPublishUnavailable,
     CloudPublishUnavailableReason,
@@ -113,6 +120,31 @@ def test_set_config_sticky_until_clear_override(tmp_path, monkeypatch):
     assert opt_func.clear_override() is False
 
 
+def test_auto_load_does_not_overwrite_override_set_during_resolution(monkeypatch):
+    opt_func = OptimizedFunction(
+        func=context_answer,
+        config_space={"temperature": [0.1, 0.3, 0.8]},
+        config_id="answerer",
+        default_config={"temperature": 0.1},
+    )
+    resolved_snapshot = BestConfigSnapshot.from_config(
+        {"temperature": 0.3},
+        config_id="answerer",
+        source=BestConfigSource.REPO.value,
+    )
+
+    def resolve_after_override():
+        opt_func.set_config({"temperature": 0.8})
+        return resolved_snapshot
+
+    monkeypatch.setattr(opt_func._csm, "_resolve_mode_snapshot", resolve_after_override)
+
+    opt_func._csm.maybe_auto_load_config()
+
+    assert opt_func.current_config["temperature"] == 0.8
+    assert opt_func.best_config_snapshot.source == BestConfigSource.OVERRIDE.value
+
+
 def test_off_source_does_not_read_repo_or_cloud(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     write_repo_best_config(
@@ -133,6 +165,27 @@ def test_off_source_does_not_read_repo_or_cloud(tmp_path, monkeypatch):
 
     assert opt_func.current_config["temperature"] == 0.1
     assert opt_func.best_config_snapshot.source == BestConfigSource.DEFAULT.value
+
+
+def test_cloud_fetch_unimplemented_falls_back_with_warning(tmp_path, monkeypatch):
+    warnings = []
+    monkeypatch.setattr(
+        "traigent.core.config_state_manager.logger.warning",
+        lambda message, *args: warnings.append(message % args if args else message),
+    )
+
+    opt_func = OptimizedFunction(
+        func=plain_answer,
+        config_space={"temperature": [0.1, 0.3]},
+        config_id="answerer",
+        best_config_source="cloud",
+        best_config_cache_dir=str(tmp_path / "missing-cache"),
+        default_config={"temperature": 0.1},
+    )
+
+    assert opt_func.current_config["temperature"] == 0.1
+    assert opt_func.best_config_snapshot.source == BestConfigSource.DEFAULT.value
+    assert any("Cloud best-config fetch is not implemented" in item for item in warnings)
 
 
 def test_invocation_does_not_re_resolve_repo(tmp_path, monkeypatch):
@@ -313,3 +366,60 @@ async def test_repo_best_config_source_supports_async_streaming(tmp_path, monkey
         values.append(value)
 
     assert values == ["hello:0.8"]
+
+
+@pytest.mark.asyncio
+async def test_optimization_completion_refreshes_best_config_snapshot():
+    opt_func = OptimizedFunction(
+        func=context_answer,
+        config_space={"temperature": [0.1, 0.9]},
+        default_config={"temperature": 0.1},
+    )
+
+    class RuntimeConfig:
+        @staticmethod
+        def is_edge_analytics_mode():
+            return False
+
+    opt_func.traigent_config = RuntimeConfig()
+    result = OptimizationResult(
+        trials=[
+            TrialResult(
+                trial_id="trial-1",
+                config={"temperature": 0.9},
+                metrics={"accuracy": 1.0},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=None,
+                metadata={},
+            )
+        ],
+        best_config={"temperature": 0.9},
+        best_score=1.0,
+        optimization_id="opt-1",
+        duration=0.1,
+        convergence_info={},
+        status=OptimizationStatus.COMPLETED,
+        objectives=["accuracy"],
+        algorithm="unit",
+        timestamp=None,
+        metadata={},
+    )
+
+    class FakeOrchestrator:
+        async def optimize(self, *, func, dataset):
+            return result
+
+    await opt_func._run_and_finalize_optimization(
+        FakeOrchestrator(),
+        dataset=object(),
+        effective_config_space={"temperature": [0.1, 0.9]},
+        save_to=None,
+    )
+
+    assert opt_func("hello") == "hello:0.9"
+    assert (
+        opt_func.best_config_snapshot.source
+        == BestConfigSource.APPLY_BEST_CONFIG.value
+    )
+    assert dict(opt_func.best_config_snapshot.config) == {"temperature": 0.9}

--- a/tests/unit/core/test_best_config_runtime_integration.py
+++ b/tests/unit/core/test_best_config_runtime_integration.py
@@ -1,0 +1,315 @@
+"""Integration tests for best-config runtime resolution on OptimizedFunction."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import traigent
+from traigent.api.decorators import optimize
+from traigent.core.best_config_runtime import (
+    BestConfigSource,
+    CloudPublishUnavailable,
+    CloudPublishUnavailableReason,
+    function_ref_for,
+    write_repo_best_config,
+)
+from traigent.core.optimized_function import OptimizedFunction
+
+
+def plain_answer(text: str, **kwargs):
+    return f"{text}:{kwargs.get('temperature', 'missing')}"
+
+
+def context_answer(text: str):
+    config = traigent.get_config()
+    return f"{text}:{config.get('temperature')}"
+
+
+def test_load_from_beats_env_path(tmp_path, monkeypatch):
+    explicit = tmp_path / "explicit.json"
+    env = tmp_path / "env.json"
+    explicit.write_text(json.dumps({"config": {"temperature": 0.2}}), encoding="utf-8")
+    env.write_text(json.dumps({"config": {"temperature": 0.9}}), encoding="utf-8")
+    monkeypatch.setenv("TRAIGENT_CONFIG_PATH", str(env))
+
+    opt_func = OptimizedFunction(
+        func=plain_answer,
+        config_space={"temperature": [0.2, 0.9]},
+        load_from=str(explicit),
+        default_config={"temperature": 0.1},
+    )
+
+    assert opt_func.current_config["temperature"] == 0.2
+    assert opt_func.best_config_snapshot.source == BestConfigSource.LOAD_FROM.value
+
+
+def test_load_from_canonical_config_id_mismatch_does_not_legacy_fallback(tmp_path):
+    spec_path = write_repo_best_config(
+        tmp_path,
+        config_id="other-answerer",
+        config={"temperature": 0.9},
+        function_ref=function_ref_for(plain_answer),
+    )
+
+    opt_func = OptimizedFunction(
+        func=plain_answer,
+        config_space={"temperature": [0.1, 0.9]},
+        config_id="expected-answerer",
+        load_from=str(spec_path),
+        default_config={"temperature": 0.1},
+    )
+
+    assert opt_func.current_config["temperature"] == 0.1
+    assert opt_func.best_config_snapshot.source == BestConfigSource.DEFAULT.value
+
+
+def test_repo_best_config_source_loads_at_init(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="answerer",
+        config={"temperature": 0.3},
+        function_ref=function_ref_for(context_answer),
+    )
+
+    opt_func = OptimizedFunction(
+        func=context_answer,
+        config_space={"temperature": [0.1, 0.3]},
+        config_id="answerer",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )
+
+    assert opt_func.current_config["temperature"] == 0.3
+    assert opt_func("hello") == "hello:0.3"
+    assert opt_func.best_config_snapshot.source == BestConfigSource.REPO.value
+
+
+def test_set_config_sticky_until_clear_override(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="answerer",
+        config={"temperature": 0.3},
+        function_ref=function_ref_for(context_answer),
+    )
+    opt_func = OptimizedFunction(
+        func=context_answer,
+        config_space={"temperature": [0.1, 0.3, 0.8]},
+        config_id="answerer",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )
+
+    opt_func.set_config({"temperature": 0.8})
+
+    assert opt_func.current_config["temperature"] == 0.8
+    assert opt_func.best_config_snapshot.source == BestConfigSource.OVERRIDE.value
+
+    assert opt_func.clear_override() is True
+    assert opt_func.current_config["temperature"] == 0.3
+    assert opt_func.clear_override() is False
+
+
+def test_off_source_does_not_read_repo_or_cloud(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="answerer",
+        config={"temperature": 0.3},
+        function_ref=function_ref_for(plain_answer),
+    )
+
+    opt_func = OptimizedFunction(
+        func=plain_answer,
+        config_space={"temperature": [0.1, 0.3]},
+        config_id="answerer",
+        best_config_source="off",
+        best_config_cache_dir=str(tmp_path / "cache"),
+        default_config={"temperature": 0.1},
+    )
+
+    assert opt_func.current_config["temperature"] == 0.1
+    assert opt_func.best_config_snapshot.source == BestConfigSource.DEFAULT.value
+
+
+def test_invocation_does_not_re_resolve_repo(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="answerer",
+        config={"temperature": 0.3},
+        function_ref=function_ref_for(context_answer),
+    )
+    opt_func = OptimizedFunction(
+        func=context_answer,
+        config_space={"temperature": [0.1, 0.3]},
+        config_id="answerer",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )
+
+    # If invocation re-read disk, deleting the repo spec would change or break it.
+    (tmp_path / ".traigent" / "best-configs" / "answerer.json").unlink()
+
+    assert opt_func("hello") == "hello:0.3"
+
+
+def test_export_best_config_writes_repo_spec(tmp_path):
+    opt_func = OptimizedFunction(
+        func=plain_answer,
+        config_space={"temperature": [0.1, 0.3]},
+        config_id="answerer",
+    )
+    opt_func.set_config({"temperature": 0.3})
+
+    spec_path = opt_func.export_best_config(tmp_path / ".traigent" / "best-configs")
+
+    assert spec_path.name == "answerer.json"
+    assert (spec_path.parent / "manifest.json").exists()
+
+
+def test_publish_best_config_fails_closed_by_mode():
+    opt_func = OptimizedFunction(
+        func=plain_answer,
+        config_space={"temperature": [0.1, 0.3]},
+        best_config_source="repo",
+    )
+
+    with pytest.raises(CloudPublishUnavailable) as exc_info:
+        opt_func.publish_best_config()
+
+    assert exc_info.value.reason is CloudPublishUnavailableReason.DISABLED_BY_CONFIG
+
+
+def test_decorator_passes_best_config_runtime_options(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    def decorated_target(text: str):
+        config = traigent.get_config()
+        return f"{text}:{config.get('temperature')}"
+
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="decorated",
+        config={"temperature": 0.4},
+        function_ref=function_ref_for(decorated_target),
+    )
+
+    wrapped = optimize(
+        configuration_space={"temperature": [0.1, 0.4]},
+        config_id="decorated",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )(decorated_target)
+
+    assert wrapped.current_config["temperature"] == 0.4
+    assert wrapped("ok") == "ok:0.4"
+
+
+def test_decorator_passes_cloud_cache_ttl_options(tmp_path):
+    cache_dir = tmp_path / "cache"
+    write_repo_best_config(
+        cache_dir,
+        config_id="decorated-cache",
+        config={"temperature": 0.4},
+        function_ref=function_ref_for(context_answer),
+    )
+    metadata_path = cache_dir / "manifest.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["configs"]["decorated-cache"]["etag"] = "v1"
+    metadata["configs"]["decorated-cache"]["loaded_at"] = "2026-05-22T00:00:00+00:00"
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    wrapped = optimize(
+        configuration_space={"temperature": [0.1, 0.4]},
+        config_id="decorated-cache",
+        best_config_source="cloud",
+        best_config_cache_dir=str(cache_dir),
+        best_config_cache_ttl_seconds=1,
+        best_config_stale_ok_ttl_seconds=60 * 60 * 24 * 365,
+        default_config={"temperature": 0.1},
+    )(context_answer)
+
+    assert wrapped.current_config["temperature"] == 0.4
+    assert wrapped.best_config_snapshot.source == BestConfigSource.CLOUD_CACHE.value
+
+
+def streaming_context_answer(text: str):
+    config = traigent.get_config()
+    yield f"{text}:{config.get("temperature")}"
+
+
+async def async_context_answer(text: str):
+    config = traigent.get_config()
+    return f"{text}:{config.get("temperature")}"
+
+
+async def async_streaming_context_answer(text: str):
+    config = traigent.get_config()
+    yield f"{text}:{config.get("temperature")}"
+
+
+def test_repo_best_config_source_survives_stream_iteration(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="streaming-answerer",
+        config={"temperature": 0.6},
+        function_ref=function_ref_for(streaming_context_answer),
+    )
+    opt_func = OptimizedFunction(
+        func=streaming_context_answer,
+        config_space={"temperature": [0.1, 0.6]},
+        config_id="streaming-answerer",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )
+
+    assert list(opt_func("hello")) == ["hello:0.6"]
+
+
+@pytest.mark.asyncio
+async def test_repo_best_config_source_supports_async_invocation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="async-answerer",
+        config={"temperature": 0.7},
+        function_ref=function_ref_for(async_context_answer),
+    )
+    opt_func = OptimizedFunction(
+        func=async_context_answer,
+        config_space={"temperature": [0.1, 0.7]},
+        config_id="async-answerer",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )
+
+    assert await opt_func("hello") == "hello:0.7"
+
+
+@pytest.mark.asyncio
+async def test_repo_best_config_source_supports_async_streaming(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="async-streaming-answerer",
+        config={"temperature": 0.8},
+        function_ref=function_ref_for(async_streaming_context_answer),
+    )
+    opt_func = OptimizedFunction(
+        func=async_streaming_context_answer,
+        config_space={"temperature": [0.1, 0.8]},
+        config_id="async-streaming-answerer",
+        best_config_source="repo",
+        default_config={"temperature": 0.1},
+    )
+
+    values = []
+    async for value in opt_func("hello"):
+        values.append(value)
+
+    assert values == ["hello:0.8"]

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -426,6 +426,13 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     # Config persistence (Phase 1 of optimization-persistency feature)
     "auto_load_best": False,  # Auto-load best config on decoration
     "load_from": None,  # Explicit path to load config from
+    "config_id": None,  # Stable best-config identifier
+    "best_config_source": "off",  # off|repo|cloud|repo_then_cloud|cloud_then_repo
+    "best_config_strict": False,  # Fail startup/refresh on invalid active source
+    "best_config_cache_dir": None,  # Local cloud best-config cache
+    "best_config_cache_ttl_seconds": 24 * 60 * 60,  # Fresh cache window
+    "best_config_stale_ok_ttl_seconds": None,  # Offline stale-cache reuse window
+    "enable_auto_load_dev_logs": None,  # Back-compat dev-log auto-load toggle
     # Tuned variable auto-detection
     "auto_detect_tvars": False,  # Log suggestions when no configuration_space is set
     "auto_detect_tvars_mode": None,  # "off" | "suggest" | "apply"
@@ -528,6 +535,13 @@ class LegacyOptimizeArgs:
     # Config persistence
     auto_load_best: bool | None = None
     load_from: str | None = None
+    config_id: str | None = None
+    best_config_source: str | None = None
+    best_config_strict: bool | None = None
+    best_config_cache_dir: str | None = None
+    best_config_cache_ttl_seconds: int | None = None
+    best_config_stale_ok_ttl_seconds: int | None = None
+    enable_auto_load_dev_logs: bool | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -607,6 +621,13 @@ class LegacyOptimizeArgs:
             ("global_measures", self.global_measures),
             ("auto_load_best", self.auto_load_best),
             ("load_from", self.load_from),
+            ("config_id", self.config_id),
+            ("best_config_source", self.best_config_source),
+            ("best_config_strict", self.best_config_strict),
+            ("best_config_cache_dir", self.best_config_cache_dir),
+            ("best_config_cache_ttl_seconds", self.best_config_cache_ttl_seconds),
+            ("best_config_stale_ok_ttl_seconds", self.best_config_stale_ok_ttl_seconds),
+            ("enable_auto_load_dev_logs", self.enable_auto_load_dev_logs),
         ]
 
 
@@ -1572,6 +1593,13 @@ def optimize(  # NOSONAR(S107)
     # Config persistence
     auto_load_best: bool = False,
     load_from: str | None = None,
+    config_id: str | None = None,
+    best_config_source: str = "off",
+    best_config_strict: bool = False,
+    best_config_cache_dir: str | None = None,
+    best_config_cache_ttl_seconds: int = 24 * 60 * 60,
+    best_config_stale_ok_ttl_seconds: int | None = None,
+    enable_auto_load_dev_logs: bool | None = None,
     legacy: LegacyOptimizeArgs | dict[str, Any] | None = None,
     **runtime_overrides: Any,
 ) -> Callable[
@@ -1849,6 +1877,13 @@ def optimize(  # NOSONAR(S107)
         "global_measures": global_measures,
         "auto_load_best": auto_load_best,
         "load_from": load_from,
+        "config_id": config_id,
+        "best_config_source": best_config_source,
+        "best_config_strict": best_config_strict,
+        "best_config_cache_dir": best_config_cache_dir,
+        "best_config_cache_ttl_seconds": best_config_cache_ttl_seconds,
+        "best_config_stale_ok_ttl_seconds": best_config_stale_ok_ttl_seconds,
+        "enable_auto_load_dev_logs": enable_auto_load_dev_logs,
     }
     for key, value in direct_inputs.items():
         record_option(key, value, "optimize parameter")
@@ -1931,6 +1966,17 @@ def optimize(  # NOSONAR(S107)
     # Config persistence
     auto_load_best_config = combined_settings["auto_load_best"]
     load_from_config = combined_settings["load_from"]
+    config_id_value = combined_settings["config_id"]
+    best_config_source_value = combined_settings["best_config_source"]
+    best_config_strict_value = combined_settings["best_config_strict"]
+    best_config_cache_dir_value = combined_settings["best_config_cache_dir"]
+    best_config_cache_ttl_seconds_value = combined_settings[
+        "best_config_cache_ttl_seconds"
+    ]
+    best_config_stale_ok_ttl_seconds_value = combined_settings[
+        "best_config_stale_ok_ttl_seconds"
+    ]
+    enable_auto_load_dev_logs_value = combined_settings["enable_auto_load_dev_logs"]
     algorithm_value = combined_settings["algorithm"]
     # Optimizer limits
     max_trials_value = combined_settings["max_trials"]
@@ -2212,6 +2258,13 @@ def optimize(  # NOSONAR(S107)
             # Config persistence
             auto_load_best=auto_load_best_config,
             load_from=load_from_config,
+            config_id=config_id_value,
+            best_config_source=best_config_source_value,
+            best_config_strict=best_config_strict_value,
+            best_config_cache_dir=best_config_cache_dir_value,
+            best_config_cache_ttl_seconds=best_config_cache_ttl_seconds_value,
+            best_config_stale_ok_ttl_seconds=best_config_stale_ok_ttl_seconds_value,
+            enable_auto_load_dev_logs=enable_auto_load_dev_logs_value,
             # TVL promotion gate for statistical best-config selection
             promotion_gate=promotion_gate,
             # Optimizer limits (extracted from combined_settings)

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -160,18 +160,19 @@ class ContextBasedProvider(ConfigurationProvider):
     ) -> Callable[..., Any]:
         """Inject configuration using context variables."""
 
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            # Merge with existing context
-            merged_config = merge_with_context(config)
+        if inspect.isasyncgenfunction(func):
 
-            # Set context for function execution
-            from traigent.config.context import ConfigurationContext
+            @wraps(func)
+            async def async_gen_wrapper(*args: Any, **kwargs: Any):
+                merged_config = merge_with_context(config)
+                from traigent.config.context import ConfigurationContext
 
-            with ConfigurationContext(merged_config):
-                return func(*args, **kwargs)
+                with ConfigurationContext(merged_config):
+                    async for item in func(*args, **kwargs):
+                        yield item
 
-        # For async functions
+            return async_gen_wrapper
+
         if inspect.iscoroutinefunction(func):
 
             @wraps(func)
@@ -183,6 +184,30 @@ class ContextBasedProvider(ConfigurationProvider):
                     return await func(*args, **kwargs)
 
             return async_wrapper
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            merged_config = merge_with_context(config)
+            from traigent.config.context import ConfigurationContext
+
+            if inspect.isgeneratorfunction(func):
+
+                def iter_with_context():
+                    with ConfigurationContext(merged_config):
+                        yield from func(*args, **kwargs)
+
+                return iter_with_context()
+
+            with ConfigurationContext(merged_config):
+                result = func(*args, **kwargs)
+                if inspect.isgenerator(result):
+
+                    def iter_result_with_context():
+                        with ConfigurationContext(merged_config):
+                            yield from result
+
+                    return iter_result_with_context()
+                return result
 
         return wrapper
 

--- a/traigent/core/best_config_runtime.py
+++ b/traigent/core/best_config_runtime.py
@@ -1,0 +1,757 @@
+"""Runtime loading and validation for promoted best configs."""
+
+# Traceability: CONC-Layer-Core FUNC-ORCH-LIFECYCLE REQ-ORCH-003 REQ-STOR-007
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import inspect
+import json
+import math
+import unicodedata
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from traigent.utils.exceptions import ConfigurationError
+from traigent.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+BEST_CONFIG_SCHEMA_VERSION = "traigent.best_config.v1"
+BEST_CONFIG_MANIFEST_SCHEMA_VERSION = "traigent.best_config_manifest.v1"
+DEFAULT_BEST_CONFIG_CACHE_TTL_SECONDS = 24 * 60 * 60
+
+_SPEC_REQUIRED_KEYS = {"schema_version", "config_id", "config"}
+_SPEC_OPTIONAL_KEYS = {
+    "function_ref",
+    "environment",
+    "provenance",
+    "validation",
+    "forward_compat",
+}
+_SPEC_ALLOWED_KEYS = _SPEC_REQUIRED_KEYS | _SPEC_OPTIONAL_KEYS
+_SPEC_HASH_KEYS = (
+    "schema_version",
+    "config_id",
+    "function_ref",
+    "environment",
+    "config",
+    "provenance",
+    "validation",
+)
+
+_SAFETY_SENSITIVE_KEYS = {
+    "model",
+    "provider",
+    "system_prompt",
+    "messages",
+    "system_messages",
+    "prompt_template",
+    "prompt_templates",
+    "tools",
+    "tool_choice",
+    "function_definitions",
+    "tool_definitions",
+    "response_format",
+    "output_schema",
+    "json_schema",
+    "temperature",
+    "top_p",
+    "max_tokens",
+    "seed",
+    "safety_filter",
+    "safety_filters",
+    "guardrails",
+    "moderation",
+    "retrieval_sources",
+    "grounding_sources",
+    "data_sources",
+    "auth",
+    "credential",
+    "credentials",
+    "tenant",
+    "account",
+    "endpoint",
+    "base_url",
+}
+_SAFETY_PREFIXES = (
+    "safety_",
+    "guard_",
+    "policy_",
+    "auth_",
+    "credential_",
+    "tenant_",
+    "tools_",
+    "tool_def_",
+    "retriev",
+    "ground",
+)
+
+
+class BestConfigSourceMode(str, Enum):
+    """Durable best-config source selection mode."""
+
+    OFF = "off"
+    REPO = "repo"
+    CLOUD = "cloud"
+    REPO_THEN_CLOUD = "repo_then_cloud"
+    CLOUD_THEN_REPO = "cloud_then_repo"
+
+
+class BestConfigSource(str, Enum):
+    """Concrete source chosen during runtime resolution."""
+
+    DEFAULT = "default"
+    OVERRIDE = "override"
+    APPLY_BEST_CONFIG = "apply_best_config"
+    LOAD_FROM = "load_from"
+    ENV = "env"
+    REPO = "repo"
+    CLOUD_CACHE = "cloud_cache"
+    CLOUD_FETCH = "cloud_fetch"
+    DEV_LOG = "dev_log"
+
+
+class CloudPublishUnavailableReason(str, Enum):
+    """Reason cloud best-config publish is unavailable."""
+
+    DISABLED_BY_CONFIG = "disabled_by_config"
+    BACKEND_NOT_IMPLEMENTED = "backend_not_implemented"
+
+
+class CloudPublishUnavailable(ConfigurationError):
+    """Raised when durable cloud best-config publishing cannot proceed."""
+
+    def __init__(self, reason: CloudPublishUnavailableReason, message: str) -> None:
+        super().__init__(message, details={"reason": reason.value})
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class BestConfigSnapshot:
+    """Immutable runtime snapshot used by invocation wrappers."""
+
+    config_id: str | None
+    config: MappingProxyType[str, Any]
+    source: str
+    schema_version: str = BEST_CONFIG_SCHEMA_VERSION
+    config_hash: str | None = None
+    spec_hash: str | None = None
+    loaded_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    expires_at: datetime | None = None
+    provenance: MappingProxyType[str, Any] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+
+    @classmethod
+    def from_config(
+        cls,
+        config: dict[str, Any],
+        *,
+        config_id: str | None,
+        source: str,
+        schema_version: str = BEST_CONFIG_SCHEMA_VERSION,
+        spec_hash: str | None = None,
+        loaded_at: datetime | None = None,
+        expires_at: datetime | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> BestConfigSnapshot:
+        """Build a deeply immutable snapshot from a mutable config dict."""
+
+        normalized_config = _normalize_json_value(copy.deepcopy(config))
+        if not isinstance(normalized_config, dict):
+            raise ConfigurationError("Best config snapshot requires a dict config")
+        frozen_config = _deep_freeze(normalized_config)
+        normalized_provenance = _normalize_json_value(copy.deepcopy(provenance or {}))
+        if not isinstance(normalized_provenance, dict):
+            raise ConfigurationError("Best config provenance must be a dict")
+
+        return cls(
+            config_id=config_id,
+            config=frozen_config,
+            source=source,
+            schema_version=schema_version,
+            config_hash=sha256_digest(canonical_json(normalized_config)),
+            spec_hash=spec_hash,
+            loaded_at=loaded_at or datetime.now(UTC),
+            expires_at=expires_at,
+            provenance=_deep_freeze(normalized_provenance),
+        )
+
+
+def canonical_json(value: Any) -> str:
+    """Return canonical JSON for hash-stable, JSON-native values."""
+
+    normalized = _normalize_json_value(value)
+    return json.dumps(
+        normalized,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def sha256_digest(value: str | bytes) -> str:
+    """Return a prefixed sha256 digest."""
+
+    data = value.encode("utf-8") if isinstance(value, str) else value
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def thaw_config(config: Any) -> Any:
+    """Convert a frozen config tree back to mutable JSON-native containers."""
+
+    if isinstance(config, MappingProxyType):
+        return {key: thaw_config(value) for key, value in config.items()}
+    if isinstance(config, tuple):
+        return [thaw_config(value) for value in config]
+    return config
+
+
+def function_ref_for(func: Any) -> str:
+    """Return canonical ``module:qualname`` for a callable after unwrapping."""
+
+    target = inspect.unwrap(func)
+    module = getattr(target, "__module__", None) or "__main__"
+    qualname = getattr(target, "__qualname__", None) or getattr(
+        target, "__name__", "unknown"
+    )
+    return f"{module}:{qualname}"
+
+
+def source_order_for_mode(
+    mode: str | BestConfigSourceMode,
+) -> tuple[BestConfigSource, ...]:
+    """Return durable source order for a best-config source mode."""
+
+    try:
+        normalized = BestConfigSourceMode(mode)
+    except ValueError as exc:
+        raise ConfigurationError(
+            f"Unknown best_config_source {mode!r}. "
+            "Use one of: off, repo, cloud, repo_then_cloud, cloud_then_repo."
+        ) from exc
+
+    if normalized is BestConfigSourceMode.OFF:
+        return ()
+    if normalized is BestConfigSourceMode.REPO:
+        return (BestConfigSource.REPO,)
+    if normalized is BestConfigSourceMode.CLOUD:
+        return (BestConfigSource.CLOUD_CACHE, BestConfigSource.CLOUD_FETCH)
+    if normalized is BestConfigSourceMode.REPO_THEN_CLOUD:
+        return (
+            BestConfigSource.REPO,
+            BestConfigSource.CLOUD_CACHE,
+            BestConfigSource.CLOUD_FETCH,
+        )
+    return (
+        BestConfigSource.CLOUD_CACHE,
+        BestConfigSource.CLOUD_FETCH,
+        BestConfigSource.REPO,
+    )
+
+
+def load_best_config_spec(
+    path: str | Path,
+    *,
+    configuration_space: dict[str, Any] | None = None,
+    expected_config_id: str | None = None,
+    expected_function_ref: str | None = None,
+    manifest_entry: dict[str, Any] | None = None,
+    source: str = BestConfigSource.REPO.value,
+    strict: bool = False,
+) -> BestConfigSnapshot:
+    """Load, validate, and freeze one canonical best-config JSON spec."""
+
+    spec_path = Path(path)
+    try:
+        with spec_path.open(encoding="utf-8") as handle:
+            spec = json.load(handle)
+        return snapshot_from_spec(
+            spec,
+            configuration_space=configuration_space,
+            expected_config_id=expected_config_id,
+            expected_function_ref=expected_function_ref,
+            manifest_entry=manifest_entry,
+            source=source,
+        )
+    except Exception as exc:
+        if strict or isinstance(exc, ConfigurationError):
+            if isinstance(exc, ConfigurationError):
+                raise
+            raise ConfigurationError(
+                f"Failed to load best config {path}: {exc}"
+            ) from exc
+        logger.warning("Ignoring invalid best config %s: %s", path, exc)
+        raise
+
+
+def snapshot_from_spec(
+    spec: dict[str, Any],
+    *,
+    configuration_space: dict[str, Any] | None = None,
+    expected_config_id: str | None = None,
+    expected_function_ref: str | None = None,
+    manifest_entry: dict[str, Any] | None = None,
+    source: str = BestConfigSource.REPO.value,
+) -> BestConfigSnapshot:
+    """Validate a decoded best-config spec and return a snapshot."""
+
+    if not isinstance(spec, dict):
+        raise ConfigurationError("Best config spec must be a JSON object")
+
+    unknown_top_level = set(spec) - _SPEC_ALLOWED_KEYS
+    if unknown_top_level:
+        raise ConfigurationError(
+            f"Unknown top-level best config fields: {sorted(unknown_top_level)}"
+        )
+
+    missing = _SPEC_REQUIRED_KEYS - set(spec)
+    if missing:
+        raise ConfigurationError(f"Best config spec missing fields: {sorted(missing)}")
+
+    if spec["schema_version"] != BEST_CONFIG_SCHEMA_VERSION:
+        raise ConfigurationError(
+            f"Unsupported best config schema_version {spec['schema_version']!r}"
+        )
+
+    config_id = _validate_config_id(spec["config_id"])
+    if expected_config_id and config_id != expected_config_id:
+        raise ConfigurationError(
+            f"Best config id mismatch: expected {expected_config_id!r}, got {config_id!r}"
+        )
+
+    function_ref = spec.get("function_ref")
+    if (
+        expected_function_ref
+        and function_ref is not None
+        and function_ref != expected_function_ref
+    ):
+        raise ConfigurationError(
+            "Best config function_ref mismatch: "
+            f"expected {expected_function_ref!r}, got {function_ref!r}"
+        )
+
+    raw_config = spec["config"]
+    if not isinstance(raw_config, dict):
+        raise ConfigurationError("Best config field 'config' must be an object")
+
+    raw_config_hash = sha256_digest(canonical_json(raw_config))
+    raw_spec_hash = compute_spec_hash(spec)
+    if manifest_entry:
+        _verify_manifest_hashes(
+            manifest_entry,
+            config_hash=raw_config_hash,
+            spec_hash=raw_spec_hash,
+        )
+
+    config = _validate_and_filter_config_keys(
+        raw_config,
+        configuration_space=configuration_space,
+        forward_compat=bool(spec.get("forward_compat", False)),
+    )
+    config_hash = sha256_digest(canonical_json(config))
+    spec_hash = raw_spec_hash
+
+    provenance = spec.get("provenance", {})
+    if not isinstance(provenance, dict):
+        raise ConfigurationError("Best config provenance must be an object")
+
+    snapshot = BestConfigSnapshot.from_config(
+        config,
+        config_id=config_id,
+        source=source,
+        spec_hash=spec_hash,
+        provenance=provenance,
+    )
+    object.__setattr__(snapshot, "config_hash", config_hash)
+    return snapshot
+
+
+def compute_spec_hash(spec: dict[str, Any]) -> str:
+    """Compute hash over the canonical self-hash-free spec payload."""
+
+    payload = {key: spec[key] for key in _SPEC_HASH_KEYS if key in spec}
+    return sha256_digest(canonical_json(payload))
+
+
+def load_manifest(directory: str | Path) -> dict[str, Any] | None:
+    """Load a best-config manifest from a directory."""
+
+    manifest_path = Path(directory) / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    with manifest_path.open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    if not isinstance(manifest, dict):
+        raise ConfigurationError("Best config manifest must be an object")
+    if manifest.get("schema_version") != BEST_CONFIG_MANIFEST_SCHEMA_VERSION:
+        raise ConfigurationError(
+            f"Unsupported best config manifest schema_version "
+            f"{manifest.get('schema_version')!r}"
+        )
+    configs = manifest.get("configs")
+    if not isinstance(configs, dict):
+        raise ConfigurationError("Best config manifest requires a configs object")
+    return manifest
+
+
+def write_repo_best_config(
+    directory: str | Path,
+    *,
+    config_id: str,
+    config: dict[str, Any],
+    function_ref: str | None = None,
+    provenance: dict[str, Any] | None = None,
+    validation: dict[str, Any] | None = None,
+    environment: str | None = None,
+) -> Path:
+    """Write a canonical repo best-config spec and update manifest."""
+
+    safe_config_id = _validate_config_id(config_id)
+    output_dir = Path(directory)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    spec: dict[str, Any] = {
+        "schema_version": BEST_CONFIG_SCHEMA_VERSION,
+        "config_id": safe_config_id,
+        "config": _normalize_json_value(copy.deepcopy(config)),
+    }
+    if function_ref:
+        spec["function_ref"] = function_ref
+    if environment:
+        spec["environment"] = environment
+    if provenance:
+        spec["provenance"] = _normalize_json_value(copy.deepcopy(provenance))
+    if validation:
+        spec["validation"] = _normalize_json_value(copy.deepcopy(validation))
+
+    config_hash = sha256_digest(canonical_json(spec["config"]))
+    spec_hash = compute_spec_hash(spec)
+    spec_path = output_dir / f"{safe_config_id}.json"
+    _write_json_atomic(spec_path, spec)
+
+    manifest_path = output_dir / "manifest.json"
+    loaded_manifest = load_manifest(output_dir) if manifest_path.exists() else None
+    manifest: dict[str, Any] = loaded_manifest or {
+        "schema_version": BEST_CONFIG_MANIFEST_SCHEMA_VERSION,
+        "configs": {},
+    }
+    configs = manifest["configs"]
+    if not isinstance(configs, dict):
+        raise ConfigurationError("Best config manifest requires a configs object")
+    configs[safe_config_id] = {
+        "path": spec_path.name,
+        "spec_hash": spec_hash,
+        "config_hash": config_hash,
+    }
+    _write_json_atomic(manifest_path, manifest)
+    return spec_path
+
+
+def resolve_repo_best_config(
+    *,
+    config_id: str | None,
+    repo_root: str | Path | None = None,
+    configuration_space: dict[str, Any] | None = None,
+    expected_function_ref: str | None = None,
+    strict: bool = False,
+) -> BestConfigSnapshot | None:
+    """Resolve a repo-local best config by config id."""
+
+    if not config_id:
+        return None
+    safe_config_id = _validate_config_id(config_id)
+    directory = Path(repo_root or Path.cwd()) / ".traigent" / "best-configs"
+    manifest_path = directory / "manifest.json"
+    if not manifest_path.exists():
+        return None
+
+    try:
+        manifest = load_manifest(directory) or {}
+        entry = manifest.get("configs", {}).get(safe_config_id)
+        if not isinstance(entry, dict):
+            return None
+        path = entry.get("path")
+        if not isinstance(path, str) or not path:
+            raise ConfigurationError(
+                f"Manifest entry for {safe_config_id!r} lacks path"
+            )
+        return load_best_config_spec(
+            _resolve_entry_path(directory, path),
+            configuration_space=configuration_space,
+            expected_config_id=safe_config_id,
+            expected_function_ref=expected_function_ref,
+            manifest_entry=entry,
+            source=BestConfigSource.REPO.value,
+            strict=True,
+        )
+    except Exception as exc:
+        if strict:
+            if isinstance(exc, ConfigurationError):
+                raise
+            raise ConfigurationError(
+                f"Failed to resolve repo best config: {exc}"
+            ) from exc
+        logger.warning(
+            "Ignoring repo best config %s after validation failure: %s",
+            safe_config_id,
+            exc,
+        )
+        return None
+
+
+def resolve_cloud_cache_best_config(
+    *,
+    config_id: str | None,
+    cache_dir: str | Path | None,
+    configuration_space: dict[str, Any] | None = None,
+    ttl_seconds: int = DEFAULT_BEST_CONFIG_CACHE_TTL_SECONDS,
+    stale_ok_ttl_seconds: int | None = None,
+    now: datetime | None = None,
+    strict: bool = False,
+) -> BestConfigSnapshot | None:
+    """Resolve a locally cached cloud best config by config id."""
+
+    if not config_id or not cache_dir:
+        return None
+    safe_config_id = _validate_config_id(config_id)
+
+    directory = Path(cache_dir)
+    if not directory.exists():
+        return None
+
+    current_time = now or datetime.now(UTC)
+    try:
+        entry = _load_cache_entry(directory, safe_config_id)
+        if entry is None:
+            return None
+        if not (entry.get("etag") or entry.get("version")):
+            raise ConfigurationError("Cloud cache metadata requires etag or version")
+
+        loaded_at = _parse_datetime(entry.get("loaded_at"))
+        max_age = (
+            stale_ok_ttl_seconds if stale_ok_ttl_seconds is not None else ttl_seconds
+        )
+        if current_time - loaded_at > timedelta(seconds=max_age):
+            logger.warning("Ignoring stale best-config cache for %s", safe_config_id)
+            return None
+
+        snapshot = load_best_config_spec(
+            _resolve_entry_path(directory, entry["path"]),
+            configuration_space=configuration_space,
+            expected_config_id=safe_config_id,
+            manifest_entry=entry,
+            source=BestConfigSource.CLOUD_CACHE.value,
+            strict=True,
+        )
+        expires_at = loaded_at + timedelta(seconds=ttl_seconds)
+        object.__setattr__(snapshot, "loaded_at", loaded_at)
+        object.__setattr__(snapshot, "expires_at", expires_at)
+        return snapshot
+    except Exception as exc:
+        if strict:
+            if isinstance(exc, ConfigurationError):
+                raise
+            raise ConfigurationError(f"Failed to resolve cloud cache: {exc}") from exc
+        logger.warning(
+            "Ignoring cloud best-config cache for %s: %s", safe_config_id, exc
+        )
+        return None
+
+
+def _validate_config_id(config_id: Any) -> str:
+    if not isinstance(config_id, str) or not config_id:
+        raise ConfigurationError("Best config config_id must be a non-empty string")
+    if "\x00" in config_id or "/" in config_id or "\\" in config_id:
+        raise ConfigurationError(
+            "Best config config_id must not contain path separators"
+        )
+    if config_id in {".", ".."}:
+        raise ConfigurationError("Best config config_id must not be a relative path")
+    return config_id
+
+
+def _resolve_entry_path(directory: Path, path: Any) -> Path:
+    if not isinstance(path, str) or not path:
+        raise ConfigurationError("Best config manifest entry lacks path")
+    relative_path = Path(path)
+    if relative_path.is_absolute() or ".." in relative_path.parts or "\\" in path:
+        raise ConfigurationError(
+            "Best config manifest path must stay inside its directory"
+        )
+    return directory / relative_path
+
+
+def _load_cache_entry(directory: Path, config_id: str) -> dict[str, Any] | None:
+    manifest_path = directory / "manifest.json"
+    if manifest_path.exists():
+        manifest = load_manifest(directory) or {}
+        entry = manifest.get("configs", {}).get(config_id)
+        return entry if isinstance(entry, dict) else None
+
+    metadata_path = directory / f"{config_id}.metadata.json"
+    spec_path = directory / f"{config_id}.json"
+    if not metadata_path.exists() or not spec_path.exists():
+        return None
+    with metadata_path.open(encoding="utf-8") as handle:
+        metadata = json.load(handle)
+    if not isinstance(metadata, dict):
+        raise ConfigurationError("Cloud cache metadata must be an object")
+    metadata.setdefault("path", spec_path.name)
+    return metadata
+
+
+def _verify_manifest_hashes(
+    manifest_entry: dict[str, Any],
+    *,
+    config_hash: str,
+    spec_hash: str,
+) -> None:
+    expected_config_hash = manifest_entry.get("config_hash")
+    expected_spec_hash = manifest_entry.get("spec_hash")
+    if expected_config_hash and expected_config_hash != config_hash:
+        raise ConfigurationError("Best config manifest config_hash mismatch")
+    if expected_spec_hash and expected_spec_hash != spec_hash:
+        raise ConfigurationError("Best config manifest spec_hash mismatch")
+
+
+def _validate_and_filter_config_keys(
+    config: dict[str, Any],
+    *,
+    configuration_space: dict[str, Any] | None,
+    forward_compat: bool,
+) -> dict[str, Any]:
+    normalized = _normalize_json_value(copy.deepcopy(config))
+    if not isinstance(normalized, dict):
+        raise ConfigurationError("Best config must be an object")
+
+    if not configuration_space:
+        return normalized
+
+    allowed = set(configuration_space)
+    unknown = set(normalized) - allowed
+    if not unknown:
+        return normalized
+
+    denylisted = sorted(key for key in unknown if _is_safety_sensitive_key(key))
+    if denylisted:
+        raise ConfigurationError(
+            f"Unknown safety-sensitive best config keys: {denylisted}"
+        )
+
+    if not forward_compat:
+        raise ConfigurationError(f"Unknown best config keys: {sorted(unknown)}")
+
+    logger.warning(
+        "Ignoring forward-compatible best config keys outside configuration_space: %s",
+        sorted(unknown),
+    )
+    return {key: value for key, value in normalized.items() if key in allowed}
+
+
+def _is_safety_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return lowered in _SAFETY_SENSITIVE_KEYS or lowered.startswith(_SAFETY_PREFIXES)
+
+
+def _normalize_json_value(value: Any, seen: set[int] | None = None) -> Any:
+    if seen is None:
+        seen = set()
+
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ConfigurationError("Best config JSON values cannot be NaN/Infinity")
+        return value
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+
+    container_id = id(value)
+    if isinstance(value, dict):
+        if container_id in seen:
+            raise ConfigurationError("Best config contains a circular reference")
+        seen.add(container_id)
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ConfigurationError("Best config JSON object keys must be strings")
+            normalized[unicodedata.normalize("NFC", key)] = _normalize_json_value(
+                item, seen
+            )
+        seen.remove(container_id)
+        return normalized
+
+    if isinstance(value, list):
+        if container_id in seen:
+            raise ConfigurationError("Best config contains a circular reference")
+        seen.add(container_id)
+        normalized_list = [_normalize_json_value(item, seen) for item in value]
+        seen.remove(container_id)
+        return normalized_list
+
+    raise ConfigurationError(
+        f"Best config contains non-JSON-native value {type(value).__name__}"
+    )
+
+
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType(
+            {key: _deep_freeze(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_deep_freeze(item) for item in value)
+    return value
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ConfigurationError("Cloud cache metadata requires loaded_at timestamp")
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True, indent=2)
+        handle.write("\n")
+        handle.flush()
+    tmp_path.replace(path)
+
+
+__all__ = [
+    "BEST_CONFIG_MANIFEST_SCHEMA_VERSION",
+    "BEST_CONFIG_SCHEMA_VERSION",
+    "BestConfigSnapshot",
+    "BestConfigSource",
+    "BestConfigSourceMode",
+    "CloudPublishUnavailable",
+    "CloudPublishUnavailableReason",
+    "canonical_json",
+    "compute_spec_hash",
+    "function_ref_for",
+    "load_best_config_spec",
+    "load_manifest",
+    "resolve_cloud_cache_best_config",
+    "resolve_repo_best_config",
+    "sha256_digest",
+    "snapshot_from_spec",
+    "source_order_for_mode",
+    "thaw_config",
+    "write_repo_best_config",
+]

--- a/traigent/core/best_config_runtime.py
+++ b/traigent/core/best_config_runtime.py
@@ -266,7 +266,7 @@ def load_best_config_spec(
     manifest_entry: dict[str, Any] | None = None,
     source: str = BestConfigSource.REPO.value,
     strict: bool = False,
-) -> BestConfigSnapshot:
+) -> BestConfigSnapshot | None:
     """Load, validate, and freeze one canonical best-config JSON spec."""
 
     spec_path = Path(path)
@@ -289,7 +289,7 @@ def load_best_config_spec(
                 f"Failed to load best config {path}: {exc}"
             ) from exc
         logger.warning("Ignoring invalid best config %s: %s", path, exc)
-        raise
+        return None
 
 
 def snapshot_from_spec(
@@ -356,7 +356,6 @@ def snapshot_from_spec(
         configuration_space=configuration_space,
         forward_compat=bool(spec.get("forward_compat", False)),
     )
-    config_hash = sha256_digest(canonical_json(config))
     spec_hash = raw_spec_hash
 
     provenance = spec.get("provenance", {})
@@ -370,7 +369,6 @@ def snapshot_from_spec(
         spec_hash=spec_hash,
         provenance=provenance,
     )
-    object.__setattr__(snapshot, "config_hash", config_hash)
     return snapshot
 
 

--- a/traigent/core/config_state_manager.py
+++ b/traigent/core/config_state_manager.py
@@ -13,7 +13,7 @@ import json
 import os
 import threading
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any
@@ -281,6 +281,8 @@ class ConfigStateManager:
                 source=source,
                 strict=True,
             )
+            if snapshot is None:
+                raise ConfigurationError(f"Failed to load best config from {path}")
             merged = {**self.default_config, **thaw_config(snapshot.config)}
             return BestConfigSnapshot.from_config(
                 merged,
@@ -339,6 +341,12 @@ class ConfigStateManager:
                     stale_ok_ttl_seconds=self.best_config_stale_ok_ttl_seconds,
                     strict=self.best_config_strict,
                 )
+            elif source is BestConfigSource.CLOUD_FETCH:
+                logger.warning(
+                    "Cloud best-config fetch is not implemented in this SDK build; "
+                    "falling through to the next configured source."
+                )
+                snapshot = None
             else:
                 snapshot = None
             if snapshot is not None:
@@ -438,8 +446,8 @@ class ConfigStateManager:
 
     def clear_override(self) -> bool:
         """Clear any sticky per-instance config override and re-resolve sources."""
-        had_override = self._override_sticky
         with self._state_lock:
+            had_override = self._override_sticky
             self._override_sticky = False
         self.maybe_auto_load_config()
         return had_override
@@ -541,8 +549,9 @@ class ConfigStateManager:
 
     def maybe_auto_load_config(self) -> None:
         """Resolve startup best config from explicit, repo, cache, or dev sources."""
-        if self._override_sticky:
-            return
+        with self._state_lock:
+            if self._override_sticky:
+                return
 
         resolved: BestConfigSnapshot | None = None
 
@@ -572,6 +581,8 @@ class ConfigStateManager:
                 )
 
         with self._state_lock:
+            if self._override_sticky:
+                return
             if resolved is None:
                 self._reset_to_default_snapshot()
             else:
@@ -721,7 +732,7 @@ class ConfigStateManager:
         if include_metadata:
             provenance = {
                 "source": self._best_config_snapshot.source,
-                "exported_at": datetime.now().isoformat(),
+                "exported_at": datetime.now(UTC).isoformat(),
             }
             if self._optimization_results:
                 provenance["optimization_id"] = (
@@ -762,7 +773,7 @@ class ConfigStateManager:
 
         if include_metadata:
             export["function_name"] = getattr(self.func, "__name__", "unknown")
-            export["exported_at"] = datetime.now().isoformat()
+            export["exported_at"] = datetime.now(UTC).isoformat()
             export["traigent_version"] = __version__
 
             if self._optimization_results and self._optimization_results.best_metrics:

--- a/traigent/core/config_state_manager.py
+++ b/traigent/core/config_state_manager.py
@@ -19,6 +19,21 @@ from pathlib import Path
 from typing import Any
 
 from traigent.api.types import OptimizationResult, OptimizationStatus
+from traigent.core.best_config_runtime import (
+    BEST_CONFIG_SCHEMA_VERSION,
+    BestConfigSnapshot,
+    BestConfigSource,
+    BestConfigSourceMode,
+    CloudPublishUnavailable,
+    CloudPublishUnavailableReason,
+    function_ref_for,
+    load_best_config_spec,
+    resolve_cloud_cache_best_config,
+    resolve_repo_best_config,
+    source_order_for_mode,
+    thaw_config,
+    write_repo_best_config,
+)
 from traigent.utils.exceptions import ConfigurationError, OptimizationStateError
 from traigent.utils.logging import get_logger
 from traigent.utils.secure_path import (
@@ -66,6 +81,13 @@ class ConfigStateManager:
         auto_load_best: bool,
         load_from: str | None,
         setup_wrapper_callback: Callable[[], None],
+        config_id: str | None = None,
+        best_config_source: str = BestConfigSourceMode.OFF.value,
+        best_config_strict: bool = False,
+        best_config_cache_dir: str | None = None,
+        best_config_cache_ttl_seconds: int = 24 * 60 * 60,
+        best_config_stale_ok_ttl_seconds: int | None = None,
+        enable_auto_load_dev_logs: bool | None = None,
         optimization_history_limit: int = DEFAULT_OPTIMIZATION_HISTORY_LIMIT,
     ) -> None:
         """Initialize config state manager.
@@ -88,6 +110,17 @@ class ConfigStateManager:
         self._auto_load_best = auto_load_best
         self._load_from = load_from
         self._setup_wrapper_callback = setup_wrapper_callback
+        self.config_id = config_id
+        self.best_config_source = best_config_source
+        self.best_config_strict = best_config_strict
+        self.best_config_cache_dir = best_config_cache_dir
+        self.best_config_cache_ttl_seconds = best_config_cache_ttl_seconds
+        self.best_config_stale_ok_ttl_seconds = best_config_stale_ok_ttl_seconds
+        self.enable_auto_load_dev_logs = (
+            auto_load_best
+            if enable_auto_load_dev_logs is None
+            else enable_auto_load_dev_logs
+        )
         if optimization_history_limit < 1:
             raise ValueError("optimization_history_limit must be >= 1")
         self._optimization_history_limit = optimization_history_limit
@@ -99,6 +132,12 @@ class ConfigStateManager:
         self._optimization_history: list[OptimizationResult] = []
         self._current_config: dict[str, Any] = default_config.copy()
         self._best_config: dict[str, Any] | None = None
+        self._best_config_snapshot: BestConfigSnapshot = BestConfigSnapshot.from_config(
+            self._current_config,
+            config_id=self.config_id,
+            source=BestConfigSource.DEFAULT.value,
+        )
+        self._override_sticky = False
 
     # -- Properties --------------------------------------------------------
 
@@ -164,14 +203,19 @@ class ConfigStateManager:
     def best_config(self, value: dict[str, Any] | None) -> None:
         self._best_config = value
 
+    @property
+    def best_config_snapshot(self) -> BestConfigSnapshot:
+        """Return the active immutable best-config snapshot."""
+        return self._best_config_snapshot
+
     # -- Query methods -----------------------------------------------------
 
     def get_best_config(self) -> dict[str, Any] | None:
-        """Get the best configuration found during optimization."""
-        if self._optimization_results:
+        """Get the best configuration found or loaded for runtime use."""
+        if self._optimization_results and self._optimization_results.best_config:
             best: dict[str, Any] = self._optimization_results.best_config
             return best
-        return None
+        return self.best_config
 
     def get_optimization_results(self) -> OptimizationResult | None:
         """Get the latest optimization results."""
@@ -192,22 +236,144 @@ class ConfigStateManager:
         """Check if optimization has been completed."""
         return self._optimization_results is not None
 
+    def _set_snapshot(
+        self,
+        snapshot: BestConfigSnapshot,
+        *,
+        best_config: dict[str, Any] | None,
+    ) -> None:
+        self._best_config_snapshot = snapshot
+        self._current_config = thaw_config(snapshot.config)
+        self._best_config = best_config.copy() if best_config else None
+
+    def _reset_to_default_snapshot(self) -> None:
+        snapshot = BestConfigSnapshot.from_config(
+            self.default_config.copy(),
+            config_id=self.config_id,
+            source=BestConfigSource.DEFAULT.value,
+        )
+        self._set_snapshot(snapshot, best_config=None)
+
+    def _snapshot_from_plain_config(
+        self,
+        config: dict[str, Any],
+        *,
+        source: str,
+    ) -> BestConfigSnapshot:
+        return BestConfigSnapshot.from_config(
+            {**self.default_config, **config},
+            config_id=self.config_id,
+            source=source,
+        )
+
+    def _load_snapshot_from_file(
+        self,
+        path: str,
+        *,
+        source: str,
+    ) -> BestConfigSnapshot | None:
+        try:
+            snapshot = load_best_config_spec(
+                path,
+                configuration_space=self.configuration_space,
+                expected_config_id=self.config_id,
+                expected_function_ref=function_ref_for(self.func),
+                source=source,
+                strict=True,
+            )
+            merged = {**self.default_config, **thaw_config(snapshot.config)}
+            return BestConfigSnapshot.from_config(
+                merged,
+                config_id=snapshot.config_id,
+                source=source,
+                spec_hash=snapshot.spec_hash,
+                provenance=thaw_config(snapshot.provenance),
+            )
+        except Exception as spec_exc:
+            if self._path_has_best_config_schema(path):
+                if self.best_config_strict:
+                    if isinstance(spec_exc, ConfigurationError):
+                        raise spec_exc
+                    raise ConfigurationError(
+                        f"Failed to load best config from {path}: {spec_exc}"
+                    ) from spec_exc
+                logger.warning(
+                    "Ignoring invalid canonical best config %s: %s",
+                    path,
+                    spec_exc,
+                )
+                return None
+
+            loaded_config = self._load_config_from_path(path)
+            if loaded_config:
+                return self._snapshot_from_plain_config(loaded_config, source=source)
+            if self.best_config_strict:
+                if isinstance(spec_exc, ConfigurationError):
+                    raise spec_exc
+                raise ConfigurationError(
+                    f"Failed to load best config from {path}: {spec_exc}"
+                ) from spec_exc
+            logger.warning(
+                "Failed to load best config from %s: %s. Function will use fallback.",
+                path,
+                spec_exc,
+            )
+            return None
+
+    def _resolve_mode_snapshot(self) -> BestConfigSnapshot | None:
+        for source in source_order_for_mode(self.best_config_source):
+            if source is BestConfigSource.REPO:
+                snapshot = resolve_repo_best_config(
+                    config_id=self.config_id,
+                    repo_root=Path.cwd(),
+                    configuration_space=self.configuration_space,
+                    expected_function_ref=function_ref_for(self.func),
+                    strict=self.best_config_strict,
+                )
+            elif source is BestConfigSource.CLOUD_CACHE:
+                snapshot = resolve_cloud_cache_best_config(
+                    config_id=self.config_id,
+                    cache_dir=self.best_config_cache_dir,
+                    configuration_space=self.configuration_space,
+                    ttl_seconds=self.best_config_cache_ttl_seconds,
+                    stale_ok_ttl_seconds=self.best_config_stale_ok_ttl_seconds,
+                    strict=self.best_config_strict,
+                )
+            else:
+                snapshot = None
+            if snapshot is not None:
+                merged = {**self.default_config, **thaw_config(snapshot.config)}
+                return BestConfigSnapshot.from_config(
+                    merged,
+                    config_id=snapshot.config_id,
+                    source=snapshot.source,
+                    spec_hash=snapshot.spec_hash,
+                    loaded_at=snapshot.loaded_at,
+                    expires_at=snapshot.expires_at,
+                    provenance=thaw_config(snapshot.provenance),
+                )
+        return None
+
     # -- State mutation methods --------------------------------------------
 
     def reset_optimization(self) -> None:
         """Reset optimization state and restore default configuration."""
         self._optimization_results = None
         self._optimization_history = []
-        self._current_config = self.default_config.copy()
-        self._best_config = None
+        self._override_sticky = False
+        self._reset_to_default_snapshot()
         self._state = OptimizationState.UNOPTIMIZED
         self._setup_wrapper_callback()
         logger.info(f"Reset optimization state for {self.func.__name__}")
 
     def set_config(self, config: dict[str, Any]) -> None:
-        """Set current configuration manually."""
+        """Set current configuration manually as a sticky override."""
         with self._state_lock:
-            self._current_config = config.copy()
+            snapshot = self._snapshot_from_plain_config(
+                config, source=BestConfigSource.OVERRIDE.value
+            )
+            self._set_snapshot(snapshot, best_config=config)
+            self._override_sticky = True
             self._setup_wrapper_callback()
         logger.debug(f"Set configuration for {self.func.__name__}: {config}")
 
@@ -244,13 +410,21 @@ class ConfigStateManager:
             old_config = self._current_config.copy()
             old_best = self._best_config.copy() if self._best_config else None
             old_wrapped_func = get_wrapped_func() if get_wrapped_func else None
+            old_snapshot = self._best_config_snapshot
+            old_override_sticky = self._override_sticky
             try:
-                self._current_config = results.best_config.copy()
-                self._best_config = results.best_config.copy()
+                snapshot = self._snapshot_from_plain_config(
+                    results.best_config,
+                    source=BestConfigSource.APPLY_BEST_CONFIG.value,
+                )
+                self._set_snapshot(snapshot, best_config=results.best_config)
+                self._override_sticky = True
                 self._setup_wrapper_callback()
             except Exception:
                 self._current_config = old_config
                 self._best_config = old_best
+                self._best_config_snapshot = old_snapshot
+                self._override_sticky = old_override_sticky
                 if set_wrapped_func and old_wrapped_func is not None:
                     set_wrapped_func(old_wrapped_func)
                 raise
@@ -261,6 +435,14 @@ class ConfigStateManager:
         )
 
         return True
+
+    def clear_override(self) -> bool:
+        """Clear any sticky per-instance config override and re-resolve sources."""
+        had_override = self._override_sticky
+        with self._state_lock:
+            self._override_sticky = False
+        self.maybe_auto_load_config()
+        return had_override
 
     # -- Persistence methods -----------------------------------------------
 
@@ -333,8 +515,14 @@ class ConfigStateManager:
             self.append_optimization_result(self._optimization_results)
 
             if self._optimization_results.best_config:
-                self._current_config = self._optimization_results.best_config.copy()
-                self._best_config = self._optimization_results.best_config.copy()
+                snapshot = self._snapshot_from_plain_config(
+                    self._optimization_results.best_config,
+                    source=BestConfigSource.APPLY_BEST_CONFIG.value,
+                )
+                self._set_snapshot(
+                    snapshot, best_config=self._optimization_results.best_config
+                )
+                self._override_sticky = True
                 self._setup_wrapper_callback()
 
             if self._optimization_results.status == OptimizationStatus.COMPLETED:
@@ -352,39 +540,48 @@ class ConfigStateManager:
     # -- Auto-load methods -------------------------------------------------
 
     def maybe_auto_load_config(self) -> None:
-        """Auto-load configuration if requested via decorator parameters or env var."""
-        config_path: str | None = None
+        """Resolve startup best config from explicit, repo, cache, or dev sources."""
+        if self._override_sticky:
+            return
+
+        resolved: BestConfigSnapshot | None = None
 
         if self._load_from:
-            config_path = self._load_from
-            logger.debug(f"Using explicit load_from path: {config_path}")
+            logger.debug("Using explicit load_from path: %s", self._load_from)
+            resolved = self._load_snapshot_from_file(
+                self._load_from, source=BestConfigSource.LOAD_FROM.value
+            )
 
-        if not config_path:
+        if resolved is None:
             env_path = os.environ.get("TRAIGENT_CONFIG_PATH")
             if env_path:
-                config_path = env_path
-                logger.debug(f"Using TRAIGENT_CONFIG_PATH: {config_path}")
-
-        if not config_path and self._auto_load_best:
-            config_path = self._find_latest_config_path()
-            if config_path:
-                logger.debug(f"Auto-found latest config: {config_path}")
-
-        if config_path:
-            try:
-                loaded_config = self._load_config_from_path(config_path)
-                if loaded_config:
-                    self._current_config = loaded_config.copy()
-                    self._best_config = loaded_config.copy()
-                    self._setup_wrapper_callback()
-                    logger.info(
-                        f"Auto-loaded config for {self.func.__name__} from {config_path}"
-                    )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to auto-load config from {config_path}: {e}. "
-                    "Function will use default configuration."
+                logger.debug("Using TRAIGENT_CONFIG_PATH: %s", env_path)
+                resolved = self._load_snapshot_from_file(
+                    env_path, source=BestConfigSource.ENV.value
                 )
+
+        if resolved is None:
+            resolved = self._resolve_mode_snapshot()
+
+        if resolved is None and self.enable_auto_load_dev_logs:
+            dev_log_path = self._find_latest_config_path()
+            if dev_log_path:
+                logger.debug("Auto-found latest dev log config: %s", dev_log_path)
+                resolved = self._load_snapshot_from_file(
+                    dev_log_path, source=BestConfigSource.DEV_LOG.value
+                )
+
+        with self._state_lock:
+            if resolved is None:
+                self._reset_to_default_snapshot()
+            else:
+                self._set_snapshot(resolved, best_config=thaw_config(resolved.config))
+            self._setup_wrapper_callback()
+            logger.debug(
+                "Resolved best config for %s from %s",
+                self.func.__name__,
+                self._best_config_snapshot.source,
+            )
 
     def _find_latest_config_path(self) -> str | None:
         """Find the most recent best_config file in optimization logs."""
@@ -419,6 +616,20 @@ class ConfigStateManager:
                         return str(config_file)
 
         return None
+
+    @staticmethod
+    def _path_has_best_config_schema(path: str) -> bool:
+        """Return True when a file declares the canonical best-config schema."""
+        try:
+            config_path = validate_user_path(path, for_write=False)
+            with open(config_path, encoding="utf-8") as f:
+                data = json.load(f)
+            return (
+                isinstance(data, dict)
+                and data.get("schema_version") == BEST_CONFIG_SCHEMA_VERSION
+            )
+        except Exception:
+            return False
 
     @staticmethod
     def _load_config_from_path(path: str) -> dict[str, Any] | None:
@@ -490,6 +701,56 @@ class ConfigStateManager:
 
         logger.info(f"Exported config for {self.func.__name__} to {output_path}")
         return output_path
+
+    def export_best_config(
+        self,
+        directory: str | Path = ".traigent/best-configs",
+        *,
+        config_id: str | None = None,
+        include_metadata: bool = True,
+    ) -> Path:
+        """Export the active best config as a canonical repo runtime spec."""
+        if not self._best_config:
+            raise ConfigurationError(
+                "No best configuration available to export. "
+                "Please run optimization first using .optimize() or load a config."
+            )
+
+        effective_config_id = config_id or self.config_id or self.func.__name__
+        provenance = None
+        if include_metadata:
+            provenance = {
+                "source": self._best_config_snapshot.source,
+                "exported_at": datetime.now().isoformat(),
+            }
+            if self._optimization_results:
+                provenance["optimization_id"] = (
+                    self._optimization_results.optimization_id
+                )
+
+        return write_repo_best_config(
+            directory,
+            config_id=effective_config_id,
+            config=self._best_config,
+            function_ref=function_ref_for(self.func),
+            provenance=provenance,
+        )
+
+    def publish_best_config(self, *, target: str = "cloud") -> None:
+        """Fail closed until durable cloud best-config publishing is implemented."""
+        if self.best_config_source in {
+            BestConfigSourceMode.OFF.value,
+            BestConfigSourceMode.REPO.value,
+        }:
+            raise CloudPublishUnavailable(
+                CloudPublishUnavailableReason.DISABLED_BY_CONFIG,
+                "Cloud best-config publish is disabled by best_config_source.",
+            )
+        raise CloudPublishUnavailable(
+            CloudPublishUnavailableReason.BACKEND_NOT_IMPLEMENTED,
+            "Cloud best-config publish is not implemented in this SDK build; "
+            "use export_best_config() to write a repo spec.",
+        )
 
     def _create_slim_export(self, include_metadata: bool) -> dict[str, Any]:
         """Create a slim export suitable for git and deployment."""

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1593,9 +1593,7 @@ class OptimizedFunction:
 
             # Update current config to best found
             if result.best_config:
-                self._current_config = result.best_config.copy()
-                self._best_config = result.best_config.copy()
-                self._setup_function_wrapper()
+                self.apply_best_config(result)
 
             # Set state to OPTIMIZED on success
             self._state = OptimizationState.OPTIMIZED
@@ -1920,9 +1918,7 @@ class OptimizedFunction:
 
             # Update current config and best config (consistent with local optimization)
             if result.best_config:
-                self._current_config = result.best_config.copy()
-                self._best_config = result.best_config.copy()
-                self._setup_function_wrapper()
+                self.apply_best_config(result)
 
             logger.info(
                 "Cloud optimization completed: %s trials, %.1f%% cost reduction",

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -284,6 +284,17 @@ class OptimizedFunction:
         # Config persistence parameters
         self._auto_load_best = kwargs.pop("auto_load_best", False)
         self._load_from = kwargs.pop("load_from", None)
+        self._config_id = kwargs.pop("config_id", None)
+        self._best_config_source = kwargs.pop("best_config_source", "off")
+        self._best_config_strict = kwargs.pop("best_config_strict", False)
+        self._best_config_cache_dir = kwargs.pop("best_config_cache_dir", None)
+        self._best_config_cache_ttl_seconds = kwargs.pop(
+            "best_config_cache_ttl_seconds", 24 * 60 * 60
+        )
+        self._best_config_stale_ok_ttl_seconds = kwargs.pop(
+            "best_config_stale_ok_ttl_seconds", None
+        )
+        self._enable_auto_load_dev_logs = kwargs.pop("enable_auto_load_dev_logs", None)
         # Store core parameters
         self._store_core_parameters(
             func,
@@ -659,6 +670,17 @@ class OptimizedFunction:
             auto_load_best=getattr(self, "_auto_load_best", False),
             load_from=getattr(self, "_load_from", None),
             setup_wrapper_callback=self._setup_function_wrapper,
+            config_id=getattr(self, "_config_id", None),
+            best_config_source=getattr(self, "_best_config_source", "off"),
+            best_config_strict=getattr(self, "_best_config_strict", False),
+            best_config_cache_dir=getattr(self, "_best_config_cache_dir", None),
+            best_config_cache_ttl_seconds=getattr(
+                self, "_best_config_cache_ttl_seconds", 24 * 60 * 60
+            ),
+            best_config_stale_ok_ttl_seconds=getattr(
+                self, "_best_config_stale_ok_ttl_seconds", None
+            ),
+            enable_auto_load_dev_logs=getattr(self, "_enable_auto_load_dev_logs", None),
             optimization_history_limit=self.optimization_history_limit,
         )
 
@@ -837,12 +859,13 @@ class OptimizedFunction:
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Make the optimized function callable."""
+        wrapped_func = self._wrapped_func
         # If framework overrides are enabled, use them during function call
         if self.auto_override_frameworks and self.framework_targets:
             with override_context(self.framework_targets):
-                return self._wrapped_func(*args, **kwargs)
+                return wrapped_func(*args, **kwargs)
         else:
-            return self._wrapped_func(*args, **kwargs)
+            return wrapped_func(*args, **kwargs)
 
     def _prepare_algorithm_kwargs(
         self, algorithm_kwargs: dict[str, Any]
@@ -2204,6 +2227,15 @@ class OptimizedFunction:
         """Set current configuration manually."""
         self._csm.set_config(config)
 
+    def clear_override(self) -> bool:
+        """Clear a sticky set_config/apply_best_config override."""
+        return self._csm.clear_override()  # type: ignore[no-any-return]
+
+    @property
+    def best_config_snapshot(self):
+        """Return the active immutable best-config snapshot."""
+        return self._csm.best_config_snapshot
+
     def apply_best_config(self, results: OptimizationResult | None = None) -> bool:
         """Apply best configuration from optimization results."""
         return self._csm.apply_best_config(  # type: ignore[no-any-return]
@@ -2223,6 +2255,22 @@ class OptimizedFunction:
         return self._csm.export_config(  # type: ignore[no-any-return]
             path, format=format, include_metadata=include_metadata
         )
+
+    def export_best_config(
+        self,
+        directory: str | Path = ".traigent/best-configs",
+        *,
+        config_id: str | None = None,
+        include_metadata: bool = True,
+    ) -> Path:
+        """Export the best configuration as a canonical repo runtime spec."""
+        return self._csm.export_best_config(  # type: ignore[no-any-return]
+            directory, config_id=config_id, include_metadata=include_metadata
+        )
+
+    def publish_best_config(self, *, target: str = "cloud") -> None:
+        """Publish the best config to a durable remote target when supported."""
+        self._csm.publish_best_config(target=target)
 
     def _load_config_from_path(self, path: str) -> dict[str, Any] | None:
         """Load config from a file path. Delegates to ConfigStateManager."""


### PR DESCRIPTION
## Summary
- Add a runtime best-config resolver for explicit files, TRAIGENT_CONFIG_PATH, repo-local specs, and local cloud cache.
- Add immutable best-config snapshots, sticky set_config/apply_best_config overrides, clear_override, canonical repo export, and fail-closed cloud publish behavior.
- Preserve invocation performance by resolving at startup/config-change time, not per call; context-mode sync, async, sync streaming, and async streaming calls use the resolved config.

## Tests
- pytest -o addopts='' tests/unit/core/test_best_config_runtime.py tests/unit/core/test_best_config_runtime_integration.py tests/unit/core/test_apply_best_config.py tests/unit/core/test_apply_best_config_injection_modes.py tests/unit/api/test_decorators.py tests/unit/config/test_providers.py tests/unit/config/test_integration.py tests/unit/api/decorator_tests/test_decorator_injection_modes.py tests/unit/core/optimized_function_tests/test_configuration_injection.py
- pre-commit hooks on commit: isort, black, ruff, detect-secrets, bandit, mypy, repo guardrails

## Notes
- Cloud service fetch/publish remains fail-closed until a backend contract exists; local cloud cache support is implemented.
- A broader local API/core sweep was attempted, but this environment is missing optional dependencies such as pandas and hypothesis and has unrelated cost/license environment failures.