### PR TITLE
docs(cloud): correct misleading OAuth2 refresh failure-branch comment

### DIFF
--- a/traigent/cloud/token_manager.py
+++ b/traigent/cloud/token_manager.py
@@ -510,10 +510,14 @@ class TokenManager:
         # refresh_oauth2 advertises an ``AuthResult`` return contract and is
         # called via delegation from AuthManager.refresh_oauth2_token (see
         # traigent/cloud/auth.py). Network errors, JSON parse errors, and
-        # non-200 responses must be reported as AuthResult(success=False) so
-        # callers can handle the failure gracefully — propagating exceptions
-        # would break that contract and skip the documented
-        # _set_credentials_fn(None, INVALID) invalidation path on failure.
+        # non-200 responses must be reported as AuthResult(success=False,
+        # status=INVALID) so callers can inspect the result and decide how
+        # to react (e.g. surface to the user, retry, or clear stored
+        # credentials). Propagating exceptions would break that contract.
+        # NOTE: this branch returns the INVALID AuthResult without actively
+        # clearing self credentials; if specific failure modes (e.g. 401
+        # invalid_grant) should also invalidate stored credentials, that
+        # behavior should be added explicitly here.
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(token_url, data=data) as response:


### PR DESCRIPTION
## Summary

Tiny docs-only follow-up to #1030. Codex round-2 review of #1030 caught that the comment I added in `ddece394` referenced an `_set_credentials_fn(None, INVALID)` invalidation path that the failure branches do **not** actually call — they return `AuthResult(INVALID)` but leave credential clearing to the caller.

This PR rewrites the comment to accurately describe what the branches do, and explicitly flags that 401 invalid_grant active-invalidation would be a separate, intentional change (out of scope for the merge reconciliation that #1030 landed).

The corresponding commit (`b904da49`) was prepared during #1030's review cycle but didn't make the merge cut. Cherry-picking it onto develop directly here.

## What changed

`traigent/cloud/token_manager.py` — comment-only change in `refresh_oauth2()`. No behavior change. No test change.

## Test plan

- [ ] CI passes (this is comment-only; tests should remain green)
- [ ] Greptile / Aikido / SonarCloud feedback addressed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)