### PR TITLE
fix(security): remove fake audit storage + enrichment (closes #894)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -916,7 +916,7 @@
         "filename": "tests/unit/security/test_audit.py",
         "hashed_secret": "4e6a5700698aa6f299f112948996c75b688f8d58",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 25
       }
     ],
     "tests/unit/security/test_codex_security_fixes_regression.py": [
@@ -1240,5 +1240,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-21T21:56:32Z"
+  "generated_at": "2026-05-23T12:58:45Z"
 }

--- a/docs/requirements.yml
+++ b/docs/requirements.yml
@@ -143,11 +143,22 @@
   title: "Security, compliance, and tenancy safeguards"
   description: >
     Provide secure credential storage, encryption utilities, JWT validation, rate limiting,
-    audit logging, tenant isolation, and security headers suitable for enterprise use.
+    in-memory audit event capture, tenant isolation, and security headers. Persistent
+    audit storage, compliance report generation (SOC 2 / ISO 27001 / GDPR), tamper
+    detection, and audit-event enrichment (geolocation, threat intelligence) are
+    scaffolding only in this release: the SDK exposes the entry points but they raise
+    NotImplementedError or EnrichmentProviderUnavailableError until a real backend or
+    provider is wired in. Do not represent these surfaces as production-ready
+    enterprise compliance features.
   acceptance_criteria:
     - Credentials stored in permission-restricted local files; secure comparison avoids leaks.
     - JWT validator enforces issuer/audience/expiry and derives defaults safely.
-    - Rate limiters and audit loggers can be configured per deployment mode/tenant.
+    - Rate limiters and the in-memory audit logger can be configured per deployment mode/tenant.
+    - AuditStorage is in-memory only and does NOT accept a storage_path parameter that
+      implies persistence; events do not survive process restarts.
+    - ComplianceReporter, AuditLogIntegrity.verify_integrity, and EventProcessor
+      geolocation/threat-intel enrichment raise on the public surface until a real
+      implementation or injected provider is available.
   tags: [security, auth, compliance]
   priority: high
   type: non-functional

--- a/tests/unit/security/test_audit.py
+++ b/tests/unit/security/test_audit.py
@@ -18,12 +18,15 @@ from traigent.security.audit import (
     AuditStorage,
     ComplianceFramework,
     ComplianceReporter,
+    EnrichmentProviderUnavailableError,
+    EventProcessor,
 )
 
 STRONG_AUDIT_SECRET = "StrongAuditSecretKey123!@#ABC4567890"
 COMPLIANCE_NOT_IMPLEMENTED = "Compliance reporting subsystem is not yet implemented"
-PERSISTENT_STORAGE_NOT_IMPLEMENTED = "Persistent audit storage is not yet implemented"
 TAMPER_DETECTION_NOT_IMPLEMENTED = "Tamper-detection is not yet implemented"
+GEOLOCATION_PROVIDER_UNAVAILABLE = "No geolocation provider configured"
+THREAT_INTEL_PROVIDER_UNAVAILABLE = "No threat intelligence provider configured"
 FAKE_AUDIT_API_KEY = (
     "sk-ant-canary-DO-NOT-USE-123456789abcdef"  # pragma: allowlist secret
 )
@@ -91,22 +94,37 @@ class TestAuditEvent:
 class TestAuditStorage:
     """Test AuditStorage class"""
 
-    def test_default_storage_path_keeps_backward_compatible_value(self):
-        """No-arg construction preserves the historical default path."""
+    def test_storage_has_no_storage_path_attribute(self):
+        """AuditStorage no longer exposes a misleading storage_path attribute.
+
+        The historical ``storage_path`` parameter implied persistence that
+        was never implemented. It has been removed so the in-memory nature
+        of this backend is honest.
+        """
         storage = AuditStorage()
 
-        assert storage.storage_path == "audit_logs"
+        assert not hasattr(storage, "storage_path")
         assert storage.events == []
 
-    def test_explicit_storage_path_is_accepted_for_compatibility(self):
-        """Explicit paths remain constructible while storage stays in-memory."""
-        storage = AuditStorage(storage_path="custom_audit_logs")
-        event = AuditEvent(event_type=AuditEventType.LOGIN_SUCCESS, user_id="user123")
+    def test_storage_rejects_storage_path_kwarg(self):
+        """Passing storage_path now fails fast instead of silently being ignored."""
+        with pytest.raises(TypeError):
+            AuditStorage(storage_path="audit_logs")
 
-        storage.store_event(event)
+    def test_events_do_not_survive_reinstantiation(self):
+        """In-memory storage is honest: events vanish on re-instantiation.
 
-        assert storage.storage_path == "custom_audit_logs"
-        assert storage.get_events() == [event]
+        This documents the lack of persistence so future callers don't
+        re-introduce a misleading storage_path parameter.
+        """
+        storage = AuditStorage()
+        storage.store_event(
+            AuditEvent(event_type=AuditEventType.LOGIN_SUCCESS, user_id="user123")
+        )
+        assert len(storage.get_events()) == 1
+
+        fresh_storage = AuditStorage()
+        assert fresh_storage.get_events() == []
 
     def test_store_and_retrieve_events(self):
         """Test storing and retrieving events"""
@@ -627,3 +645,100 @@ class TestComplianceReporter:
 
         with pytest.raises(NotImplementedError, match=COMPLIANCE_NOT_IMPLEMENTED):
             reporter._analyze_security_incidents(events)
+
+
+class TestEventProcessorEnrichment:
+    """EventProcessor enrichment surfaces must fail-loud without providers."""
+
+    def test_geolocation_without_provider_raises(self):
+        """Geolocation enrichment must not fabricate hard-coded location data."""
+        processor = EventProcessor()
+        event = AuditEvent(
+            event_type=AuditEventType.LOGIN_SUCCESS,
+            user_id="user123",
+            ip_address="8.8.8.8",
+        )
+
+        with pytest.raises(
+            EnrichmentProviderUnavailableError,
+            match=GEOLOCATION_PROVIDER_UNAVAILABLE,
+        ):
+            processor.enrich_with_geolocation(event)
+
+        assert "geolocation" not in event.details
+
+    def test_threat_intelligence_without_provider_raises(self):
+        """Threat-intel enrichment must not fabricate hard-coded reputation."""
+        processor = EventProcessor()
+        event = AuditEvent(
+            event_type=AuditEventType.LOGIN_SUCCESS,
+            user_id="user123",
+            ip_address="8.8.8.8",
+        )
+
+        with pytest.raises(
+            EnrichmentProviderUnavailableError,
+            match=THREAT_INTEL_PROVIDER_UNAVAILABLE,
+        ):
+            processor.enrich_with_threat_intelligence(event)
+
+        assert "threat_intel" not in event.details
+
+    def test_geolocation_provider_is_called_with_ip(self):
+        """When a provider is injected, geolocation is delegated to it."""
+        captured: dict[str, str] = {}
+
+        def provider(ip: str) -> dict[str, str]:
+            captured["ip"] = ip
+            return {"country": "DE", "city": "Berlin"}
+
+        processor = EventProcessor(geolocation_provider=provider)
+        event = AuditEvent(
+            event_type=AuditEventType.LOGIN_SUCCESS,
+            user_id="user123",
+            ip_address="203.0.113.5",
+        )
+
+        processor.enrich_with_geolocation(event)
+
+        assert captured == {"ip": "203.0.113.5"}
+        assert event.details["geolocation"] == {"country": "DE", "city": "Berlin"}
+
+    def test_threat_intelligence_provider_is_called_with_ip(self):
+        """When a provider is injected, threat-intel is delegated to it."""
+        captured: dict[str, str] = {}
+
+        def provider(ip: str) -> dict[str, object]:
+            captured["ip"] = ip
+            return {"malicious": True, "reputation_score": 12, "categories": ["botnet"]}
+
+        processor = EventProcessor(threat_intelligence_provider=provider)
+        event = AuditEvent(
+            event_type=AuditEventType.LOGIN_SUCCESS,
+            user_id="user123",
+            ip_address="198.51.100.7",
+        )
+
+        processor.enrich_with_threat_intelligence(event)
+
+        assert captured == {"ip": "198.51.100.7"}
+        assert event.details["threat_intel"] == {
+            "malicious": True,
+            "reputation_score": 12,
+            "categories": ["botnet"],
+        }
+
+    def test_enrichment_no_ip_still_requires_provider(self):
+        """Even without an IP, calling enrichment without a provider must fail.
+
+        Previously the code silently no-op'd when ip_address was missing, but
+        that hides the misconfiguration — the public surface still claims
+        enrichment is supported. Require a provider regardless.
+        """
+        processor = EventProcessor()
+        event = AuditEvent(event_type=AuditEventType.LOGIN_SUCCESS, user_id="u")
+
+        with pytest.raises(EnrichmentProviderUnavailableError):
+            processor.enrich_with_geolocation(event)
+        with pytest.raises(EnrichmentProviderUnavailableError):
+            processor.enrich_with_threat_intelligence(event)

--- a/traigent/security/__init__.py
+++ b/traigent/security/__init__.py
@@ -4,10 +4,14 @@
 
 from __future__ import annotations
 
-from .audit import AuditLogger, ComplianceReporter, EventProcessor, SecurityMonitor
-from .auth import (
-    MultiFactorAuth,
+from .audit import (
+    AuditLogger,
+    ComplianceReporter,
+    EnrichmentProviderUnavailableError,
+    EventProcessor,
+    SecurityMonitor,
 )
+from .auth import MultiFactorAuth
 from .deployment import BackupManager, DeploymentManager, HealthChecker, SLAMonitor
 from .encryption import DataClassifier, EncryptionManager, PIIDetector, SecureStorage
 from .tenant import (
@@ -35,6 +39,7 @@ __all__ = [
     "ComplianceReporter",
     "SecurityMonitor",
     "EventProcessor",
+    "EnrichmentProviderUnavailableError",
     # Multi-Tenancy
     "TenantManager",
     "TenantContext",

--- a/traigent/security/audit.py
+++ b/traigent/security/audit.py
@@ -10,6 +10,7 @@ import re
 import threading
 import uuid
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -23,14 +24,29 @@ logger = get_logger(__name__)
 _COMPLIANCE_NOT_IMPLEMENTED = (
     "Compliance reporting subsystem is not yet implemented; do not call in production"
 )
-_PERSISTENT_STORAGE_NOT_IMPLEMENTED = (
-    "Persistent audit storage is not yet implemented; AuditStorage accepts "
-    "storage_path for compatibility but stores events in memory"
-)
 _TAMPER_DETECTION_NOT_IMPLEMENTED = (
     "Tamper-detection is not yet implemented; verify_integrity will be available "
     "in a future release"
 )
+_GEOLOCATION_PROVIDER_UNAVAILABLE = (
+    "No geolocation provider configured. Inject one via "
+    "EventProcessor(geolocation_provider=...) — the SDK ships no default "
+    "geolocation backend."
+)
+_THREAT_INTEL_PROVIDER_UNAVAILABLE = (
+    "No threat intelligence provider configured. Inject one via "
+    "EventProcessor(threat_intelligence_provider=...) — the SDK ships no "
+    "default threat-intel backend."
+)
+
+
+class EnrichmentProviderUnavailableError(RuntimeError):
+    """Raised when an audit-event enrichment provider is not configured.
+
+    The SDK previously returned hard-coded geolocation/threat-intel data,
+    which silently produced fake compliance signal. Callers must inject a
+    real provider before invoking enrichment.
+    """
 
 
 def _redact_filterable_identifier(value: str | None, label: str) -> str | None:
@@ -677,12 +693,40 @@ class SecurityMonitor:
         return alerts
 
 
-class EventProcessor:
-    """Processes and enriches audit events."""
+GeolocationProvider = Callable[[str], dict[str, Any]]
+ThreatIntelligenceProvider = Callable[[str], dict[str, Any]]
 
-    def __init__(self) -> None:
-        """Initialize event processor."""
+
+class EventProcessor:
+    """Processes and enriches audit events.
+
+    Enrichment providers must be injected explicitly. If callers invoke
+    ``enrich_with_geolocation`` or ``enrich_with_threat_intelligence`` without
+    a configured provider, the call raises
+    :class:`EnrichmentProviderUnavailableError` instead of synthesizing fake
+    geolocation/threat data — which would otherwise feed bogus signal into
+    audit and compliance pipelines.
+    """
+
+    def __init__(
+        self,
+        geolocation_provider: GeolocationProvider | None = None,
+        threat_intelligence_provider: ThreatIntelligenceProvider | None = None,
+    ) -> None:
+        """Initialize event processor with optional enrichment providers.
+
+        Args:
+            geolocation_provider: Callable that takes an IP address string and
+                returns a dict of geolocation fields (e.g. country, region,
+                city). Required for :meth:`enrich_with_geolocation` to work.
+            threat_intelligence_provider: Callable that takes an IP address
+                string and returns a dict of threat-intel fields (e.g.
+                malicious flag, reputation score, categories). Required for
+                :meth:`enrich_with_threat_intelligence` to work.
+        """
         self.processors: list[Any] = []
+        self._geolocation_provider = geolocation_provider
+        self._threat_intelligence_provider = threat_intelligence_provider
 
     def add_processor(self, processor_func) -> None:
         """Add event processor function."""
@@ -695,41 +739,47 @@ class EventProcessor:
         return event
 
     def enrich_with_geolocation(self, event: AuditEvent) -> AuditEvent:
-        """Enrich event with geolocation data."""
+        """Enrich event with geolocation data from the injected provider.
+
+        Raises:
+            EnrichmentProviderUnavailableError: if no geolocation provider was
+                supplied at construction.
+        """
+        if self._geolocation_provider is None:
+            raise EnrichmentProviderUnavailableError(_GEOLOCATION_PROVIDER_UNAVAILABLE)
         if event.ip_address:
-            # Simplified geolocation (in production, use actual service)
-            event.details["geolocation"] = {
-                "country": "US",
-                "region": "California",
-                "city": "San Francisco",
-            }
+            event.details["geolocation"] = self._geolocation_provider(event.ip_address)
         return event
 
     def enrich_with_threat_intelligence(self, event: AuditEvent) -> AuditEvent:
-        """Enrich event with threat intelligence."""
+        """Enrich event with threat intelligence from the injected provider.
+
+        Raises:
+            EnrichmentProviderUnavailableError: if no threat-intelligence
+                provider was supplied at construction.
+        """
+        if self._threat_intelligence_provider is None:
+            raise EnrichmentProviderUnavailableError(_THREAT_INTEL_PROVIDER_UNAVAILABLE)
         if event.ip_address:
-            # Simplified threat check (in production, use actual threat feeds)
-            event.details["threat_intel"] = {
-                "malicious": False,
-                "reputation_score": 95,
-                "categories": [],
-            }
+            event.details["threat_intel"] = self._threat_intelligence_provider(
+                event.ip_address
+            )
         return event
 
 
 class AuditStorage:
     """In-memory storage backend for audit events.
 
-    ``storage_path`` is accepted for backward compatibility with callers that
-    previously constructed ``AuditStorage("audit_logs")``. This class does not
-    implement file-backed persistence yet; it records the configured path for
-    diagnostics while keeping events in memory.
+    This backend keeps events in a Python list. It does NOT persist to disk
+    or any external store, so events do not survive process restarts. The
+    historical ``storage_path`` parameter has been removed because it falsely
+    implied persistence — wire up a real persistence backend rather than
+    passing a path here.
     """
 
-    def __init__(self, storage_path: str | None = "audit_logs") -> None:
-        """Initialize storage backend."""
-        self.storage_path = storage_path
-        self.events: list[Any] = []  # In-memory storage for testing
+    def __init__(self) -> None:
+        """Initialize the in-memory storage backend."""
+        self.events: list[Any] = []
 
     def store_event(self, event: AuditEvent) -> None:
         """Store an audit event."""


### PR DESCRIPTION
## Summary

Closes #894. Removes fake-completion surfaces from \`traigent.security.audit\` per CLAUDE.md production safety rule 2.

Three concrete fixes:

1. **AuditStorage no longer pretends to persist.** The \`storage_path\` parameter falsely implied persistence on an in-memory store. Removed; callers that passed it now get a \`TypeError\` (fail-loud per the issue's "remove the persistence implication" branch).
2. **EventProcessor enrichment fails loud.** \`enrich_with_geolocation\` was hardcoding US/California/SF. \`enrich_with_threat_intelligence\` was hardcoding \`malicious=False, reputation_score=95\`. Both now raise \`EnrichmentProviderUnavailableError\` unless a \`Callable\` provider is injected via \`EventProcessor.__init__(geolocation_provider=..., threat_intelligence_provider=...)\`. Real providers (MaxMind / IPInfo / threat feeds) are separate engineering work.
3. **\`docs/requirements.yml\` REQ-SEC-010** rewritten to flag scaffolding-only status for persistent audit storage, compliance reporting, tamper detection, and audit enrichment.

## Public surface delta

- Added to \`traigent.security.__all__\`: \`EnrichmentProviderUnavailableError\`
- \`AuditStorage.__init__(self, storage_path=...)\` → \`AuditStorage.__init__(self)\`
- \`EventProcessor.__init__(self)\` → \`EventProcessor.__init__(self, geolocation_provider=None, threat_intelligence_provider=None)\`
- \`enrich_with_geolocation\` / \`enrich_with_threat_intelligence\` raise instead of returning fabricated data

## Test plan

- [x] **39 passed** — \`uv run pytest tests/unit/security/test_audit.py\` (8 new tests added)
- [x] Import smoke: all 4 classes + new exception importable from \`traigent.security\`
- [x] Pre-commit gates all pass
- [ ] CI matrix to confirm broader suite stays green

## Captain protocol

Worked under captain (Claude Opus 4.7) supervision via \`claude-session-70\` worker. Worker report at \`worktrees/issue-management/claude-session-70-Traigent/reports/claude-opus-session-70-result.md\`. Captain ran validation (sandbox blocked worker). Codex final review will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)