### PR TITLE
fix(config-generator): reject structural constraints in to_python_code (closes #869)

### DIFF
--- a/tests/unit/config_generator/test_apply.py
+++ b/tests/unit/config_generator/test_apply.py
@@ -23,6 +23,7 @@ from traigent.config_generator.types import (
     AutoConfigResult,
     ObjectiveSpec,
     SafetySpec,
+    StructuralConstraintSpec,
     TVarSpec,
 )
 
@@ -318,6 +319,47 @@ class TestApplyConfig:
         assert "old" not in modified
         assert "@traigent.optimize(" in modified
         assert "temperature" in modified
+
+    def test_rejects_structural_constraints(
+        self, tmp_path: Path, simple_source: str
+    ) -> None:
+        """apply_config must propagate the structural-constraint rejection.
+
+        Regression for #869: previously --apply silently dropped generated
+        structural constraints. Now apply_config refuses and points users
+        at the TVL export path. The source file must remain untouched.
+        """
+        src = tmp_path / "agent.py"
+        src.write_text(simple_source)
+
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            structural_constraints=(
+                StructuralConstraintSpec(
+                    description="Conservative temp for factual models",
+                    constraint_code=(
+                        "implies(model.equals('gpt-4o'), temperature.lte(1.0))"
+                    ),
+                    requires_tvars=("model", "temperature"),
+                ),
+            ),
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            apply_config(src, result, "answer_question", backup=False)
+        message = str(excinfo.value)
+        assert "tvl" in message.lower()
+        assert "structural constraint" in message.lower()
+        # Source file must NOT have been modified.
+        assert src.read_text() == simple_source
+        # No backup written either (we failed before any I/O).
+        assert not (tmp_path / "agent.py.bak").exists()
 
     def test_async_function(
         self, tmp_path: Path, result_with_tvars: AutoConfigResult

--- a/tests/unit/config_generator/test_types.py
+++ b/tests/unit/config_generator/test_types.py
@@ -357,6 +357,67 @@ class TestAutoConfigResult:
         # Ensure faithfulness does NOT get "()"
         assert "faithfulness().above" not in code
 
+    def test_to_python_code_rejects_structural_constraints(self) -> None:
+        """to_python_code() must refuse to silently drop generated constraints."""
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+            structural_constraints=(
+                StructuralConstraintSpec(
+                    description="Low temp for factual models",
+                    constraint_code="implies(model.equals('gpt-4o'), temperature.lte(1.0))",
+                    requires_tvars=("model", "temperature"),
+                ),
+            ),
+        )
+        with pytest.raises(ValueError) as excinfo:
+            result.to_python_code()
+        message = str(excinfo.value)
+        # Error must direct user to the TVL export path.
+        assert "tvl" in message.lower()
+        assert "structural constraint" in message.lower()
+        # Must report how many were dropped and include the description.
+        assert "1" in message
+        assert "Low temp for factual models" in message
+
+    def test_to_python_code_rejects_multiple_structural_constraints(self) -> None:
+        """Count and first descriptions appear in the rejection message."""
+        result = AutoConfigResult(
+            structural_constraints=tuple(
+                StructuralConstraintSpec(
+                    description=f"constraint-{i}",
+                    constraint_code=f"code-{i}",
+                )
+                for i in range(5)
+            ),
+        )
+        with pytest.raises(ValueError) as excinfo:
+            result.to_python_code()
+        message = str(excinfo.value)
+        assert "5" in message
+        # Truncates after first 3 with a "+N more" suffix.
+        assert "constraint-0" in message
+        assert "+2 more" in message
+
+    def test_to_python_code_no_constraints_still_works(self) -> None:
+        """Result without structural constraints emits decorator normally."""
+        result = AutoConfigResult(
+            tvars=(
+                TVarSpec(
+                    name="temperature",
+                    range_type="Range",
+                    range_kwargs={"low": 0.0, "high": 1.0},
+                ),
+            ),
+        )
+        code = result.to_python_code()
+        assert "@traigent.optimize(" in code
+
     def test_to_python_code_with_recommendations(self) -> None:
         result = AutoConfigResult(
             tvars=(

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -203,7 +203,20 @@ class AutoConfigResult:
         return spec
 
     def to_python_code(self) -> str:
-        """Generate copy-pasteable ``@traigent.optimize(...)`` Python code."""
+        """Generate copy-pasteable ``@traigent.optimize(...)`` Python code.
+
+        Raises
+        ------
+        ValueError
+            If ``structural_constraints`` is non-empty. The Python decorator
+            surface does not currently support structural constraints, and
+            silently dropping them would let invalid sampled configurations
+            slip through. Export to TVL (``-o tvl`` / ``to_tvl_spec()``) to
+            preserve them.
+        """
+        if self.structural_constraints:
+            raise ValueError(_structural_constraint_error(self.structural_constraints))
+
         lines: list[str] = []
         lines.append("@traigent.optimize(")
 
@@ -236,6 +249,22 @@ class AutoConfigResult:
 
         lines.append(")")
         return "\n".join(lines)
+
+
+def _structural_constraint_error(
+    constraints: tuple[StructuralConstraintSpec, ...],
+) -> str:
+    """Build the rejection message for structural constraints in Python output."""
+    count = len(constraints)
+    sample = "; ".join(sc.description or sc.constraint_code for sc in constraints[:3])
+    suffix = "" if count <= 3 else f" (+{count - 3} more)"
+    return (
+        f"Cannot emit @traigent.optimize(...) Python code: {count} generated "
+        f"structural constraint(s) would be silently dropped because the "
+        f"decorator surface does not accept them. Re-export with `-o tvl` "
+        f"(or call AutoConfigResult.to_tvl_spec()) to preserve them. "
+        f"Constraints: {sample}{suffix}"
+    )
 
 
 # Metrics in traigent.api.safety that are factory functions (need "()")


### PR DESCRIPTION
## Summary

Closes #869. \`traigent generate-config --apply\` was silently dropping generated structural constraints when emitting Python decorator code while the TVL export path preserved them. Per captain guidance (option B from the issue), \`to_python_code()\` now rejects with a clear \`ValueError\` and directs the user to TVL.

## Why option B (reject) over option A (emit DSL)

\`StructuralConstraintSpec.constraint_code\` is stored as an opaque string, not a typed AST. Faithful DSL translation would require re-parsing or rewriting the constraint representation — well outside this PR's scope. The reject path preserves the safety property (no silent constraint drop) and is fully testable in a few lines. Option A remains on the table for a future PR if/when constraint representation work happens.

## Changes

- \`traigent/config_generator/types.py:205-238\` — \`AutoConfigResult.to_python_code()\` raises \`ValueError\` when \`self.structural_constraints\` is non-empty, before emitting any decorator code.
- \`traigent/config_generator/types.py:241-254\` — new private helper \`_structural_constraint_error()\` builds the rejection message: count, first 3 descriptions, \`+N more\` suffix, explicit TVL guidance.
- \`apply.py\` / \`pipeline.py\` — **not modified**. \`apply.py\` inherits the rejection via its existing call to \`to_python_code()\` at apply.py:109, BEFORE any backup or write (apply.py:140-144). \`pipeline.py\` was already generating structural constraints correctly (bug was downstream in the Python emitter).

## Test plan

- [x] **259 passed** — \`uv run pytest tests/unit/config_generator/\`
- [x] Import smoke: \`from traigent.config_generator.apply import apply_config\` works
- [x] Pre-commit gates all pass
- [ ] CI matrix

New tests pin:
- single constraint → \`ValueError\` with TVL guidance + constraint description
- multiple constraints → \`+N more\` truncation
- no constraints → happy path still works (regression guard)
- \`apply_config()\` against real source → propagates ValueError AND source untouched AND no \`.bak\` written

## Public surface delta

- \`AutoConfigResult.to_python_code()\` previously could not fail; it now raises \`ValueError\` whenever \`structural_constraints\` is non-empty. CLI \`traigent generate-config --apply\` surfaces this error with a clear remediation pointer rather than silently producing a decorator that drops constraints.
- No \`__all__\`, schema, or wire-format changes.

## Out of scope (worth follow-up issues)

- \`to_dict_kwargs()\`/\`to_decorator_kwargs()\` silently drop structural constraints too — same reject contract should be widened there.
- CLI-layer message customization (suggesting the exact \`-o tvl\` flag) belongs in the CLI command file.

## Captain protocol

Worked under captain (Claude Opus 4.7) supervision via \`claude-session-71\` worker. Worker report at \`worktrees/issue-management/claude-session-71-Traigent/reports/claude-opus-session-71-result.md\`. Captain ran validation (sandbox blocked worker). Codex final review will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)