### PR TITLE
[codex] reduce SDK develop CI cost

### DIFF
--- a/.github/BRANCH_PROTECTION_CUTOVER.md
+++ b/.github/BRANCH_PROTECTION_CUTOVER.md
@@ -1,0 +1,9 @@
+# Branch protection cutover
+
+The Python SDK currently relies on release PR discipline more than required status checks.
+If branch protection later requires a fast gate, introduce a single stable
+`required-pr-gate` job first, let it complete successfully once on the target branch, and
+only then add it to the ruleset.
+
+Required workflows must always create the required check name. Use in-workflow change
+detection and an aggregator that accepts intentionally skipped jobs.

--- a/.github/CI_TIERS.md
+++ b/.github/CI_TIERS.md
@@ -1,0 +1,12 @@
+# CI tiers
+
+Canonical policy: `traigent-validation-spine/ops/_validation/policies/ci_tiers.md`.
+
+This SDK already keeps most deep checks manual or scheduled. Keep that shape:
+
+- T0/T1: release PRs to `main` and package/install-sensitive changes.
+- T2: cross-SDK parity and Sonar on release PRs or manual dispatch.
+- T3: weekly parity and any long-running smoke coverage.
+
+When adding a required check, use a stable aggregator job name and put change detection inside
+the workflow. Do not use top-level `paths:` filters on a branch-protection-required workflow.

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -2,7 +2,7 @@ name: Install Smoke Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "pyproject.toml"
       - "uv.lock"
@@ -11,7 +11,7 @@ on:
       - "scripts/ci/**"
       - ".github/workflows/install-smoke.yml"
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - "pyproject.toml"
       - "uv.lock"

--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -3,7 +3,7 @@ name: JS Public Parity
 on:
   pull_request:
     branches:
-      - develop
+      - main
     # Client/config file moves outside these conventional module names are still
     # caught by the weekly schedule; keep PR triggers scoped to parity-relevant
     # files so unrelated Python changes do not pay the cross-repo clone/install cost.

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Move Python SDK install-smoke, Sonar, and JS public parity PR triggers from develop to main release PRs.
- Keep weekly/manual parity coverage and package/install coverage for release qualification.
- Add repo-local CI tier and branch-protection cutover notes pointing at the canonical validation-spine policy.

## Validation
- git diff --check
- Ruby YAML parse over .github/workflows/*.yml
- pre-commit hooks during commit passed for staged workflow/doc files.

## Safety
- Quality gates were not relaxed. This PR changes when expensive gates run, not their thresholds or pass criteria.