### PR TITLE
fix(cloud): add wrapped wallet top-up packs dto

### DIFF
--- a/tests/unit/cloud/test_billing_error_dtos.py
+++ b/tests/unit/cloud/test_billing_error_dtos.py
@@ -2,6 +2,7 @@ from traigent.cloud.dtos import (
     QuotaExceededErrorDTO,
     WalletInsufficientBalanceErrorDTO,
     WalletTopUpPackDTO,
+    WalletTopUpPacksResponseDTO,
 )
 
 
@@ -43,3 +44,15 @@ def test_wallet_top_up_pack_dto_exposes_no_price_id():
     dto = WalletTopUpPackDTO(pack_id="starter", credit_usd="5.00")
 
     assert dto.to_dict() == {"pack_id": "starter", "credit_usd": "5.00"}
+
+
+def test_wallet_top_up_packs_response_dto_matches_wrapped_backend_shape():
+    dto = WalletTopUpPacksResponseDTO(
+        packs=[WalletTopUpPackDTO(pack_id="starter", credit_usd="5.00")]
+    )
+
+    assert dto.to_dict() == {
+        "success": True,
+        "message": "Success",
+        "data": {"packs": [{"pack_id": "starter", "credit_usd": "5.00"}]},
+    }

--- a/traigent/cloud/__init__.py
+++ b/traigent/cloud/__init__.py
@@ -26,6 +26,10 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
         "WalletInsufficientBalanceErrorDTO",
     ),
     "WalletTopUpPackDTO": ("traigent.cloud.dtos", "WalletTopUpPackDTO"),
+    "WalletTopUpPacksResponseDTO": (
+        "traigent.cloud.dtos",
+        "WalletTopUpPacksResponseDTO",
+    ),
     "UsageTracker": ("traigent.cloud.billing", "UsageTracker"),
     "SmartSubsetSelector": ("traigent.cloud.subset_selection", "SmartSubsetSelector"),
     "DiverseSampling": ("traigent.cloud.subset_selection", "DiverseSampling"),
@@ -49,6 +53,7 @@ __all__ = [
     "QuotaExceededErrorDTO",
     "WalletInsufficientBalanceErrorDTO",
     "WalletTopUpPackDTO",
+    "WalletTopUpPacksResponseDTO",
     "UsageTracker",
     "SmartSubsetSelector",
     "DiverseSampling",

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -102,6 +102,22 @@ class WalletTopUpPackDTO:
         return {"pack_id": self.pack_id, "credit_usd": self.credit_usd}
 
 
+@dataclass(frozen=True)
+class WalletTopUpPacksResponseDTO:
+    """Standard backend response wrapper for public wallet credit packs."""
+
+    packs: list[WalletTopUpPackDTO]
+    message: str = "Success"
+    success: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "success": self.success,
+            "message": self.message,
+            "data": {"packs": [pack.to_dict() for pack in self.packs]},
+        }
+
+
 def _get_schema_validator_class() -> Any:
     """Load the optional TraigentSchema validator lazily."""
     from traigent_schema.validator import SchemaValidator


### PR DESCRIPTION
## Summary

- Add `WalletTopUpPacksResponseDTO` for the wrapped wallet top-up packs response.
- Export the DTO from `traigent.cloud`.
- Add DTO coverage for the wrapped response contract.

## Safety / Contract Notes

- Mirrors the companion TraigentSchema response-shape correction.
- No runtime billing behavior changes in the Python SDK beyond typed DTO availability.

## Codex 5.5 Review

- Round 1 identified contract drift around wallet top-up pack response wrapping.
- This PR propagates the corrected contract to the Python SDK.

## Validation

- `pytest -n 0 tests/unit/cloud/test_billing_error_dtos.py -q`
