### PR TITLE
ci: update github-script in ci gates

### DIFF
--- a/.github/workflows/traigent-ci-gates.yml
+++ b/.github/workflows/traigent-ci-gates.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Comment on PR
         if: failure()
         continue-on-error: true  # Don't fail the workflow if PR comment fails (permissions issue on forks)
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- update the CI gates PR-comment step from `actions/github-script@v6` to `@v7`
- clear the public actionlint compatibility finding without exposing sensitive scanner details

## Verification
- pre-commit hooks from `git commit` passed
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "validated #{f}" }' .github/workflows/traigent-ci-gates.yml`\n- `git diff --check`\n- `/home/nimrodbu/Traigent_enterprise/ops/_validation/tool_plugins/workflow_integrity/actionlint/bin/actionlint -format '{{json .}}' .github/workflows/*.yml` -> `[]`\n- GPT-5.5 xhigh read-only review: no findings; reviewer noted full GitHub Actions run was not executed and `github-script@v7` may face later Node 20 deprecation pressure\n\nFixes #1047