### PR TITLE
ci: bump official workflow actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/architecture-analysis.yml
+++ b/.github/workflows/architecture-analysis.yml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Full history for comparison
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload Architecture Reports
         if: steps.check_tools.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: architecture-reports
           path: |
@@ -154,7 +154,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.check_tools.outputs.skip != 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -207,7 +207,7 @@ jobs:
     steps:
       - name: Download Reports
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
           name: architecture-reports

--- a/.github/workflows/docs-links.yml
+++ b/.github/workflows/docs-links.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.11'
 

--- a/.github/workflows/example-auto-tune-secure.yml
+++ b/.github/workflows/example-auto-tune-secure.yml
@@ -50,12 +50,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload security reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: security-reports
           path: |
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Validate configuration files
         run: |
@@ -179,12 +179,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -422,7 +422,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: auto-tuning-results
           path: |

--- a/.github/workflows/example-auto-tune.yml
+++ b/.github/workflows/example-auto-tune.yml
@@ -50,12 +50,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Needed for DVC
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -237,7 +237,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: auto-tuning-results
           path: |

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -15,15 +15,15 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -107,7 +107,7 @@ jobs:
 
     - name: Upload diagnostic report
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: diagnostic-report-${{ matrix.python-version }}
         path: traigent_diagnostic_report.json
@@ -119,10 +119,10 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: '3.11'
 
@@ -146,10 +146,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Validate documentation links
       run: |

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -41,10 +41,10 @@ jobs:
         python-version: ["3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,10 +73,10 @@ jobs:
   install-recommended-uv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 
@@ -103,10 +103,10 @@ jobs:
   install-enterprise:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 
@@ -128,10 +128,10 @@ jobs:
   pip-install-quickstart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4  # needed to build the wheel
+      - uses: actions/checkout@v6.0.2  # needed to build the wheel
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/js-public-parity.yml
+++ b/.github/workflows/js-public-parity.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Python SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           path: Traigent
 
@@ -56,7 +56,7 @@ jobs:
       # copy or the latest npm-published tag.
       - name: Checkout JS SDK
         if: steps.cross-repo-token.outputs.available == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           repository: Traigent/traigent-js
           ref: main
@@ -65,7 +65,7 @@ jobs:
 
       - name: Checkout TraigentSchema
         if: steps.cross-repo-token.outputs.available == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           repository: Traigent/TraigentSchema
           ref: main
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set up Python
         if: steps.cross-repo-token.outputs.available == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 0  # Full history for version detection
 
@@ -65,7 +65,7 @@ jobs:
         echo "Tag $GIT_REF_NAME is on main — proceeding."
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -178,7 +178,7 @@ jobs:
       run: sleep 300
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.5
       with:
         path: ~/.cache/pip
         key: ubuntu-latest-pip-quality-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml') }}
@@ -136,7 +136,7 @@ jobs:
         "
 
     - name: Upload quality reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       if: always()
       with:
         name: quality-reports
@@ -149,10 +149,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -235,10 +235,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -262,7 +262,7 @@ jobs:
         pip-audit || true
 
     - name: Upload dependency reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       if: always()
       with:
         name: dependency-reports

--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -44,8 +44,8 @@ jobs:
     outputs:
       gate_status: ${{ steps.lint_type_status.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.LINT_PYTHON_VERSION }}
       - name: Install lint and type tooling
@@ -79,8 +79,8 @@ jobs:
     outputs:
       gate_status: ${{ steps.tests_unit_status.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install test deps
@@ -111,8 +111,8 @@ jobs:
     outputs:
       gate_status: ${{ steps.tests_integration_status.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install test deps
@@ -143,8 +143,8 @@ jobs:
     outputs:
       gate_status: ${{ steps.security_status.outputs.status }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install security tooling
@@ -176,12 +176,12 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: PR dependency review
         id: dependency_review_pr
         if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@v4
-      - uses: actions/setup-python@v5
+        uses: actions/dependency-review-action@v5.0.0
+      - uses: actions/setup-python@v6.2.0
         if: github.event_name != 'pull_request'
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -232,20 +232,20 @@ jobs:
           else
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
         if: steps.codeql_capability.outputs.enabled == 'true'
       - name: Initialize CodeQL
         id: codeql_init
         continue-on-error: true
         if: steps.codeql_capability.outputs.enabled == 'true'
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4.36.0
         with:
           languages: python
       - name: Perform CodeQL analysis
         id: codeql_analyze
         continue-on-error: true
         if: steps.codeql_capability.outputs.enabled == 'true'
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4.36.0
       - name: Skip unavailable CodeQL upload
         if: steps.codeql_capability.outputs.enabled != 'true'
         run: echo "CodeQL upload is disabled for this repository until GitHub code scanning is enabled."
@@ -276,8 +276,8 @@ jobs:
       - dependency_review
       - codeql
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Detect release-review automation
@@ -392,7 +392,7 @@ jobs:
 
       - name: Upload release-review artifacts
         if: always() && steps.release_review_tools.outputs.available == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-review-${{ steps.release_id.outputs.release_id }}
           path: .release_review/runs/${{ steps.release_id.outputs.release_id }}
@@ -407,8 +407,8 @@ jobs:
       contents: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Validate required emergency fields
@@ -465,7 +465,7 @@ jobs:
           INCIDENT_ID: ${{ inputs.incident_id }}
           REASON: ${{ inputs.reason }}
           EXPIRES_AT: ${{ inputs.expires_at }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const title = `Emergency override remediation: ${context.runId}`;

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,12 +25,12 @@ jobs:
     timeout-minutes: 30  # Job-level timeout
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Shallow clones disabled for better analysis
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,15 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('**/pyproject.toml') }}
@@ -73,10 +73,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -97,10 +97,10 @@ jobs:
     needs: test
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -117,7 +117,7 @@ jobs:
         bandit -r traigent/ -f json -o bandit-report.json || true
 
     - name: Upload security scan results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       if: always()
       with:
         name: security-reports
@@ -131,10 +131,10 @@ jobs:
     needs: test
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6.2.0
       with:
         python-version: "3.11"
 
@@ -157,7 +157,7 @@ jobs:
         python -c "import traigent; print(f'Successfully imported traigent v{traigent.__version__}')"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: dist-packages
         path: dist/

--- a/.github/workflows/traigent-ci-gates.yml
+++ b/.github/workflows/traigent-ci-gates.yml
@@ -21,18 +21,18 @@ jobs:
 
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: baseline
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           path: work
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.11'
 
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ci-results
           path: |
@@ -161,7 +161,7 @@ jobs:
       - name: Comment on PR
         if: failure()
         continue-on-error: true  # Don't fail the workflow if PR comment fails (permissions issue on forks)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/typed-session-smoke.yml
+++ b/.github/workflows/typed-session-smoke.yml
@@ -12,9 +12,9 @@ jobs:
     environment: typed-session-smoke
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/validation-spine-pr.yml
+++ b/.github/workflows/validation-spine-pr.yml
@@ -55,14 +55,14 @@ jobs:
       # `_PYTHON_REPOS` are simply absent from this CI checkout, which
       # the spine handles by skipping missing dirs.
       - name: Checkout product repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
           path: Traigent
 
       - name: Checkout validation spine
         if: env.SPINE_RO_TOKEN != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           repository: Traigent/traigent-validation-spine
           ref: ${{ env.SPINE_REF }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set up Python 3.11
         if: env.SPINE_RO_TOKEN != ''
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload spine gap artifacts
         if: always() && env.SPINE_RO_TOKEN != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: validation-spine-gaps
           path: .spine-health/


### PR DESCRIPTION
## Summary
- Bump GitHub-official workflow actions to Node 24-compatible releases across 15 SDK workflows:
  - actions/checkout -> v6.0.2
  - actions/setup-python -> v6.2.0
  - actions/upload-artifact -> v7.0.1
  - actions/download-artifact -> v8.0.1
  - actions/cache -> v5.0.5
  - actions/github-script -> v9.0.0
  - github/codeql-action init/analyze -> v4.36.0
- This includes traigent-ci-gates.yml, so it resolves the validation-spine actionlint gap from #1047.
- Third-party SHA-pinned actions are intentionally out of this slice and still need separate bump-checking under #1044 if the tracker requires it.

Fixes #1047
Refs #1044

## Validation
- Resolved official action target tags through GitHub API where applicable.
- Verified target action manifests declare node24 for checkout, setup-python, upload-artifact, download-artifact, cache, github-script, and CodeQL init/analyze.
- rg found no stale official action refs from #1044/#1047 in .github/workflows.
- ruby YAML parse passed for .github/workflows/*.yml.
- actionlint returned [].
- git diff --check origin/main...HEAD passed.
- Commit pre-commit hooks passed: detect secrets, trailing whitespace, YAML, merge conflicts, private key check, strict cost-accounting guardrails, and related staged-file hooks.

## Review Protocol
Claude is unavailable under the workspace protocol, so this PR will use the documented Codex 5 xhigh fallback review gate before merge consideration.