### PR TITLE
fix(auth): preserve explicit API key permissions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -683,84 +683,84 @@
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "9250c08601c6b21a3196bb6a7e8d9ce1ae5f39be",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 301
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44c08d71fbe20d2cf9c5842af590dda096bee6f9",
         "is_verified": false,
-        "line_number": 304
+        "line_number": 315
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "801f9bf378fc57a61f95a66e2465a02ed3092d7e",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 316
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "c6e454d960df4845f9d69eb11377c8b23882715b",
         "is_verified": false,
-        "line_number": 326
+        "line_number": 337
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
         "is_verified": false,
-        "line_number": 543
+        "line_number": 554
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 573
+        "line_number": 584
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "827ba56f5549ed55e91dc9fb84327b0148c01a5e",
         "is_verified": false,
-        "line_number": 634
+        "line_number": 645
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 778
+        "line_number": 789
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ab2bf873e7a77f787d5c8b53d196c659cd146497",
         "is_verified": false,
-        "line_number": 1105
+        "line_number": 1116
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "ad6ed643d097938d8f82b0945077efdc93928614",
         "is_verified": false,
-        "line_number": 1114
+        "line_number": 1125
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "44cdfc3615970ada14420caaaa5c5745fca06002",
         "is_verified": false,
-        "line_number": 1216
+        "line_number": 1227
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/cloud/test_cloud_authentication.py",
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_verified": false,
-        "line_number": 1286
+        "line_number": 1297
       }
     ],
     "tests/unit/cloud/test_cloud_client_validation.py": [
@@ -1240,5 +1240,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-23T20:03:04Z"
+  "generated_at": "2026-05-26T11:39:35Z"
 }

--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -1572,6 +1572,23 @@ class TestSDK937_NoFabricatedPermissionGrants:
 
         self._assert_no_hardcoded_api_key_permission_grants(auth)
 
+    def test_authmanager_token_data_preserves_explicit_backend_permissions(self):
+        """Backend permission claims may be recorded when explicit and boolean."""
+        manager = AuthManager()
+
+        credentials = manager._build_credentials_from_token_data(
+            {
+                "access_token": "new_access_token_12345",
+                "expires_in": 3600,
+                "api_key": "tg_" + "p" * 61,
+                "permissions": {"optimize": True, "billing": "yes"},
+            }
+        )
+
+        assert credentials.api_key == "tg_" + "p" * 61
+        assert manager._api_key is not None
+        assert manager._api_key.permissions == {"optimize": True}
+
     def test_get_info_for_env_keyed_path_returns_empty_permissions(self):
         """SDK#937: when reporting info for an env-keyed source (the
         SDK never received an APIKey object from the backend), the

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1729,14 +1729,21 @@ class AuthManager:
         # AuthManager-specific: update _api_key if present
         api_key = token_data.get("api_key") or token_data.get("apiKey")
         if api_key and self._validate_key_format(api_key):
-            # SDK#937 fix: do not fabricate any permission grants from
-            # locally available credentials. If the backend does not
-            # return authoritative claims, APIKey.__post_init__ keeps
-            # permissions empty and has_permission() fails closed.
+            raw_permissions = token_data.get("permissions")
+            permissions = (
+                {
+                    str(permission): enabled
+                    for permission, enabled in raw_permissions.items()
+                    if isinstance(enabled, bool)
+                }
+                if isinstance(raw_permissions, dict)
+                else {}
+            )
             self._api_key = APIKey(
                 key=api_key,
                 name="cli",
                 created_at=datetime.now(UTC),
+                permissions=permissions,
             )
 
         return credentials


### PR DESCRIPTION
## Summary
- Preserve backend-provided API key permission claims only when they are explicit boolean claims.
- Keep missing or non-dict permission data fail-closed as empty permissions.
- Add regression coverage for mixed valid/invalid permission claim data.

## Validation
- pytest -n0 tests/unit/cloud/test_cloud_authentication.py -q
- ruff check traigent/cloud/auth.py tests/unit/cloud/test_cloud_authentication.py
- pre-commit hooks during commit: isort, black, ruff, detect-secrets, bandit, mypy, guardrail checks

## Notes
- Created from a clean origin/develop worktree so unrelated dirty SDK files were not included.
- .secrets.baseline changed only because detect-secrets refreshed existing line numbers after the test insertion.