### PR TITLE
fix(observability): honor offline mode for ingest

### DIFF
--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -33,6 +33,12 @@ FAKE_TRACE_API_KEY = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_observability_offline_mode(monkeypatch, jwt_development_mode):
+    del jwt_development_mode
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+
+
 def test_observability_client_flushes_trace_payloads():
     sent_batches: list[list[dict]] = []
 
@@ -109,6 +115,80 @@ def test_observability_client_flushes_trace_payloads():
     assert (
         sent_trace["observations"][0]["children"][0]["prompt_reference"]["version"] == 1
     )
+
+
+def test_observability_client_offline_mode_does_not_attempt_ingest(monkeypatch, caplog):
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
+    urlopen_calls = {"count": 0}
+
+    def fake_urlopen(*args, **kwargs):
+        urlopen_calls["count"] += 1
+        raise AssertionError("network attempted")
+
+    monkeypatch.setattr(
+        "traigent.observability.client.request.urlopen",
+        fake_urlopen,
+    )
+
+    caplog.set_level(logging.INFO, logger="traigent.observability.client")
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=1,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+            enable_atexit_flush=False,
+        )
+    )
+
+    trace_id = client.start_trace("offline-probe", trace_id="trace_offline")
+    client.record_observation(trace_id, name="offline-observation")
+    client.end_trace(trace_id)
+
+    result = client.flush()
+    assert client._post_batch_sync([{"id": "trace_manual"}]) is None
+    close_result = client.close()
+
+    assert client.config.offline_mode is True
+    assert result.success is True
+    assert result.items_sent == 0
+    assert result.items_pending == 0
+    assert result.items_dropped == 0
+    assert result.successful_batches == 0
+    assert result.failed_batches == 0
+    assert close_result.success is True
+    assert close_result.items_sent == 0
+    assert urlopen_calls["count"] == 0
+    assert caplog.text.count("Observability transport in offline mode") == 1
+
+
+def test_observability_client_offline_mode_blocks_request_api():
+    request_calls: list[tuple[str, str, dict | None]] = []
+
+    def request_sender(method: str, path: str, payload: dict | None):
+        request_calls.append((method, path, payload))
+        raise AssertionError("request sender should not be called in offline mode")
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=10,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+            enable_atexit_flush=False,
+            offline_mode=True,
+        ),
+        request_sender=request_sender,
+    )
+
+    with pytest.raises(ClientError, match="TRAIGENT_OFFLINE_MODE=true"):
+        client.list_sessions()
+
+    client.close()
+
+    assert request_calls == []
 
 
 def test_observability_client_tracks_dropped_payloads_when_buffer_is_full():
@@ -791,16 +871,20 @@ def test_observability_client_collaboration_helpers_follow_backend_contract():
             return {
                 "data": {
                     "is_bookmarked": bool(payload.get("is_bookmarked")),
-                    "bookmarked_at": "2026-03-10T14:13:00+00:00"
-                    if payload.get("is_bookmarked")
-                    else None,
-                    "bookmarked_by": "sdk-user"
-                    if payload.get("is_bookmarked")
-                    else None,
+                    "bookmarked_at": (
+                        "2026-03-10T14:13:00+00:00"
+                        if payload.get("is_bookmarked")
+                        else None
+                    ),
+                    "bookmarked_by": (
+                        "sdk-user" if payload.get("is_bookmarked") else None
+                    ),
                     "is_published": bool(payload.get("is_published")),
-                    "published_at": "2026-03-10T14:14:00+00:00"
-                    if payload.get("is_published")
-                    else None,
+                    "published_at": (
+                        "2026-03-10T14:14:00+00:00"
+                        if payload.get("is_published")
+                        else None
+                    ),
                     "published_by": "sdk-user" if payload.get("is_published") else None,
                     "comment_count": 2,
                     "feedback_summary": {"up_count": 1, "down_count": 0},

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -84,7 +84,7 @@ class _TraceState:
                 roots.append(observation)
 
         payload_trace = replace(self.trace, observations=roots)
-        return payload_trace.to_dict()
+        return cast(dict[str, Any], payload_trace.to_dict())
 
 
 class _SyncBatchTransport:
@@ -334,6 +334,7 @@ class ObservabilityClient:
         self._trace_states: dict[str, _TraceState] = {}
         self._lock = threading.RLock()
         self._closed = False
+        self._offline_notice_logged = False
         self._transport = self._create_transport()
 
         if self.config.enable_atexit_flush:
@@ -531,6 +532,9 @@ class ObservabilityClient:
 
     def flush(self, timeout: float | None = None) -> FlushResult:
         timeout = timeout or self.config.flush_timeout
+        if self.config.offline_mode:
+            self._log_offline_mode_once()
+            return self._offline_flush_result()
         with self._lock:
             trace_ids = list(self._trace_states.keys())
         for trace_id in trace_ids:
@@ -567,6 +571,10 @@ class ObservabilityClient:
                 warnings=[],
             )
 
+        if self.config.offline_mode:
+            self._log_offline_mode_once()
+            self._closed = True
+            return self._offline_flush_result()
         with self._lock:
             trace_ids = list(self._trace_states.keys())
         for trace_id in trace_ids:
@@ -747,6 +755,10 @@ class ObservabilityClient:
         return self._post_batch_sync(traces)
 
     def _post_batch_sync(self, traces: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if self.config.offline_mode:
+            self._log_offline_mode_once()
+            return None
+
         payload = json.dumps({"traces": traces}).encode("utf-8")
         http_request = request.Request(
             self.config.ingest_url,
@@ -820,6 +832,11 @@ class ObservabilityClient:
     ) -> dict[str, Any]:
         if self._closed:
             raise ClientError("Observability client is closed")
+        if self.config.offline_mode:
+            self._log_offline_mode_once()
+            raise ClientError(
+                "Observability backend request skipped because TRAIGENT_OFFLINE_MODE=true"
+            )
         if self._request_sender_override is not None:
             return cast(
                 dict[str, Any], self._request_sender_override(method, path, payload)
@@ -879,6 +896,8 @@ class ObservabilityClient:
         return data
 
     def _queue_trace_snapshot(self, trace_id: str) -> None:
+        if self.config.offline_mode:
+            return
         with self._lock:
             state = self._trace_states.get(trace_id)
             if state is None or self._closed:
@@ -895,6 +914,25 @@ class ObservabilityClient:
                 trace_id,
                 reason,
             )
+
+    def _log_offline_mode_once(self) -> None:
+        if self._offline_notice_logged:
+            return
+        self._offline_notice_logged = True
+        logger.info("Observability transport in offline mode; traces will not be sent")
+
+    @staticmethod
+    def _offline_flush_result() -> FlushResult:
+        return FlushResult(
+            success=True,
+            items_sent=0,
+            items_pending=0,
+            items_dropped=0,
+            successful_batches=0,
+            failed_batches=0,
+            errors=[],
+            warnings=[],
+        )
 
     def _build_query_string(self, **params: Any) -> str:
         serialized: dict[str, str] = {}

--- a/traigent/observability/config.py
+++ b/traigent/observability/config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env, scope_api_path
 from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
+from traigent.utils.env_config import is_backend_offline
 
 MAX_BATCH_SIZE = 10_000
 MAX_QUEUE_SIZE = 1_000_000
@@ -37,6 +38,7 @@ class ObservabilityConfig:
     flush_timeout: float = 30.0
     request_timeout: float = 10.0
     enable_atexit_flush: bool = True
+    offline_mode: bool = field(default_factory=is_backend_offline)
     default_environment: str | None = field(
         default_factory=lambda: (
             os.getenv("TRAIGENT_ENVIRONMENT") or os.getenv("ENVIRONMENT")


### PR DESCRIPTION
## Summary
- honor TRAIGENT_OFFLINE_MODE in ObservabilityConfig
- short-circuit observability ingest flush/close paths in offline mode with zero-send results
- block observability backend query helpers while offline before sender or HTTP code runs
- add regression coverage proving offline mode makes no urlopen calls and logs the offline transport notice once

## Validation
- pytest -n 0 tests/unit/observability/test_observability_client.py -q
- ruff check traigent/observability/client.py traigent/observability/config.py tests/unit/observability/test_observability_client.py
- black --check traigent/observability/client.py traigent/observability/config.py tests/unit/observability/test_observability_client.py
- mypy --ignore-missing-imports --follow-imports=skip --no-error-summary traigent/observability/client.py traigent/observability/config.py
- git diff --check

Initial plain pytest run without -n 0 hit a local xdist/asyncio-cooperative internal runner error after spawning 24 workers; the focused serial run passed.

Fixes #1051