### PR TITLE
fix(ci): harden manual workflow inputs

### DIFF
--- a/.github/workflows/example-auto-tune-secure.yml
+++ b/.github/workflows/example-auto-tune-secure.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Validate budget limits
         env:
-          INPUT_BUDGET: ${{ github.event.inputs.budget || '5.0' }}
+          INPUT_BUDGET: ${{ inputs.budget }}
         run: |
           python -c "
           import os, yaml
@@ -211,7 +211,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials via OIDC
-        if: github.event.inputs.environment != 'development' && vars.AWS_ROLE_TO_ASSUME != ''
+        if: inputs.environment != 'development' && vars.AWS_ROLE_TO_ASSUME != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
@@ -225,7 +225,7 @@ jobs:
       - name: Set environment
         id: env
         env:
-          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           echo "environment=$INPUT_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
@@ -233,8 +233,8 @@ jobs:
         id: params
         env:
           STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
-          INPUT_MAX_TRIALS: ${{ github.event.inputs.max_trials }}
-          INPUT_BUDGET: ${{ github.event.inputs.budget }}
+          INPUT_MAX_TRIALS: ${{ inputs.max_trials }}
+          INPUT_BUDGET: ${{ inputs.budget }}
         run: |
           # Set defaults based on environment with strict limits
           if [[ "$STEP_ENV_OUTPUT" == "production" ]]; then
@@ -377,7 +377,7 @@ jobs:
           fi
 
       - name: Push to DVC
-        if: success() && github.event.inputs.apply_changes == 'true'
+        if: success() && inputs.apply_changes
         run: |
           # Add optimization results to DVC
           if [ -f "optimization_results/latest.json" ]; then
@@ -392,7 +392,7 @@ jobs:
           git diff --staged --quiet || git commit -m "Update optimization results [skip ci]"
 
       - name: Create PR with improvements
-        if: success() && github.event.inputs.apply_changes == 'true' && steps.env.outputs.environment == 'staging' && !contains(github.ref, 'auto-tune/')
+        if: success() && inputs.apply_changes && steps.env.outputs.environment == 'staging' && !contains(github.ref, 'auto-tune/')
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example-auto-tune.yml
+++ b/.github/workflows/example-auto-tune.yml
@@ -20,15 +20,24 @@ on:
         description: 'Maximum number of trials'
         required: false
         default: '10'
+        type: number
       budget:
         description: 'Maximum budget in USD'
         required: false
         default: '5.0'
+        type: number
       apply_changes:
         description: 'Allow DVC push and PR creation'
         required: true
         default: false
         type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: example-auto-tune-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   auto-tune:
@@ -73,7 +82,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials via OIDC (for DVC storage)
-        if: github.event.inputs.environment != 'development' && vars.AWS_ROLE_TO_ASSUME != ''
+        if: inputs.environment != 'development' && vars.AWS_ROLE_TO_ASSUME != ''
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
@@ -88,7 +97,7 @@ jobs:
       - name: Determine environment
         id: env
         env:
-          INPUT_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           echo "environment=$INPUT_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
@@ -96,8 +105,8 @@ jobs:
         id: params
         env:
           STEP_ENV_OUTPUT: ${{ steps.env.outputs.environment }}
-          INPUT_MAX_TRIALS: ${{ github.event.inputs.max_trials }}
-          INPUT_BUDGET: ${{ github.event.inputs.budget }}
+          INPUT_MAX_TRIALS: ${{ inputs.max_trials }}
+          INPUT_BUDGET: ${{ inputs.budget }}
         run: |
           # Set defaults based on environment
           if [[ "$STEP_ENV_OUTPUT" == "production" ]]; then
@@ -191,7 +200,7 @@ jobs:
           cat report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Push to DVC
-        if: success() && github.event.inputs.apply_changes == 'true'
+        if: success() && inputs.apply_changes
         run: |
           # Add optimization results to DVC
           dvc add optimization_results/latest.json
@@ -204,7 +213,7 @@ jobs:
           git diff --staged --quiet || git commit -m "Update optimization results [skip ci]"
 
       - name: Create PR with improvements
-        if: success() && github.event.inputs.apply_changes == 'true' && steps.env.outputs.environment == 'staging'
+        if: success() && inputs.apply_changes && steps.env.outputs.environment == 'staging'
         uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5  # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     # Run if: tag push OR manual dispatch with confirmation
-    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.confirm_publish == 'true'
-    environment: ${{ (github.event_name == 'push' && 'pypi') || github.event.inputs.environment || 'pypi' }}
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.confirm_publish
+    environment: ${{ (github.event_name == 'push' && 'pypi') || inputs.environment || 'pypi' }}
     outputs:
       package_version: ${{ steps.package_version.outputs.package_version }}
     permissions:
@@ -140,7 +140,7 @@ jobs:
 
     # Publish to Test PyPI (manual dispatch only)
     - name: Publish to Test PyPI
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'testpypi'
+      if: github.event_name == 'workflow_dispatch' && inputs.environment == 'testpypi'
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
       with:
         repository-url: https://test.pypi.org/legacy/
@@ -148,7 +148,7 @@ jobs:
 
     # Publish to production PyPI (automatic on tag push, or manual dispatch)
     - name: Publish to PyPI
-      if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'pypi')
+      if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.environment == 'pypi')
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # v1.12.4
       with:
         verbose: true
@@ -156,7 +156,7 @@ jobs:
     - name: Create deployment summary
       if: always()
       env:
-        ENVIRONMENT: ${{ (github.event_name == 'push' && 'pypi (auto from tag)') || github.event.inputs.environment || 'unknown' }}
+        ENVIRONMENT: ${{ (github.event_name == 'push' && 'pypi (auto from tag)') || inputs.environment || 'unknown' }}
         TRIGGER: ${{ github.event_name }}
         REF: ${{ github.ref }}
         JOB_STATUS: ${{ job.status }}
@@ -185,7 +185,7 @@ jobs:
     - name: Test installation from PyPI
       env:
         EXPECTED_VERSION: ${{ needs.publish.outputs.package_version }}
-        PUBLISH_ENVIRONMENT: ${{ github.event.inputs.environment }}
+        PUBLISH_ENVIRONMENT: ${{ inputs.environment || 'pypi' }}
       run: |
         if [ "$PUBLISH_ENVIRONMENT" = "testpypi" ]; then
           PACKAGE_LABEL="TestPyPI"


### PR DESCRIPTION
## Summary
- Harden manual GitHub Actions inputs in the auto-tune demo and publish workflows by using typed `inputs.*` instead of raw `github.event.inputs.*`.
- Add numeric typing for the plain auto-tune demo's `max_trials` and `budget` dispatch inputs.
- Add default read-only top-level permissions and concurrency to the plain demo workflow.
- Normalize `example-auto-tune-secure.yml` from CRLF to LF so changed workflow lines pass whitespace checks.

## Spine Evidence
Addresses critical/high Aikido import gaps from the validation spine:
- `tool_plugin:spine.security.aikido_import:2dd2d353ae2f15b3`
- `tool_plugin:spine.security.aikido_import:1fd5a422ac668089`
- `tool_plugin:spine.security.aikido_import:f854b4d036cf7c9c`

These map to Aikido's workflow template-injection findings in:
- `.github/workflows/example-auto-tune-secure.yml`
- `.github/workflows/example-auto-tune.yml`
- `.github/workflows/publish.yml`

## Validation
- `/home/nimrodbu/Traigent_enterprise/ops/_validation/tool_plugins/workflow_integrity/actionlint/bin/actionlint .github/workflows/example-auto-tune.yml .github/workflows/example-auto-tune-secure.yml .github/workflows/publish.yml`
- `python3 -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/example-auto-tune.yml','.github/workflows/example-auto-tune-secure.yml','.github/workflows/publish.yml']]; print('yaml ok')"`
- `git diff --check -- .github/workflows/example-auto-tune.yml .github/workflows/example-auto-tune-secure.yml .github/workflows/publish.yml`
- `rg -n "github\\.event\\.inputs" .github/workflows/example-auto-tune.yml .github/workflows/example-auto-tune-secure.yml .github/workflows/publish.yml` returned no matches.
- Codex 5.5 xhigh review: no blocking findings; one non-blocking budget fallback note was addressed.

## Notes
- This is workflow-only; no SDK runtime code changed.
- The secure workflow has a large raw diff because the file was normalized from CRLF to LF. Ignoring CR-at-EOL, the semantic diff is limited to the input-expression hardening.
