### PR TITLE
fix(auth): accept backend-issued API key prefixes

### DIFF
--- a/docs/getting-started/portal-dev-laptop-agent.md
+++ b/docs/getting-started/portal-dev-laptop-agent.md
@@ -1,0 +1,55 @@
+# Portal-dev laptop agent setup
+
+Use this when running Traigent from this laptop against the dev backend.
+
+## Backend URL
+
+Use the API host, not the portal host:
+
+```bash
+export TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
+export TRAIGENT_API_URL=https://api-dev.traigent.ai
+export TRAIGENT_CLOUD_API_URL=https://api-dev.traigent.ai
+```
+
+`portal-dev.traigent.ai` is the browser application. SDK and agent code should call
+`api-dev.traigent.ai`.
+
+## API key
+
+Use a key that validates against `POST /api/v1/keys/validate`. Do not paste keys into shell
+history. Store them through the SDK credential helper or a hidden prompt:
+
+```bash
+python - <<'PY'
+import getpass
+import json
+from pathlib import Path
+
+path = Path.home() / ".traigent" / "credentials.json"
+path.parent.mkdir(mode=0o700, exist_ok=True)
+
+data = {
+    "backend_url": "https://api-dev.traigent.ai",
+    "api_key": getpass.getpass("Traigent API key: "),
+}
+path.write_text(json.dumps(data, indent=2) + "\n")
+path.chmod(0o600)
+print(f"Wrote {path}")
+PY
+```
+
+## Smoke checks
+
+```bash
+traigent auth whoami "$(python - <<'PY'
+import json
+from pathlib import Path
+print(json.loads((Path.home() / ".traigent" / "credentials.json").read_text())["api_key"])
+PY
+)"
+```
+
+If a newly minted key is listed in the UI but `whoami` or `/keys/validate` returns 401,
+mint a new key after the backend fix that verifies generated keys before returning them.
+Do not keep retrying an unpersisted one-time key; it cannot be recovered after creation.

--- a/tests/unit/cli/test_auth_whoami_command.py
+++ b/tests/unit/cli/test_auth_whoami_command.py
@@ -122,6 +122,27 @@ def test_whoami_valid_key_200(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "authenticated" in result.output
 
 
+@pytest.mark.parametrize("prefix", ["tg_", "uk_", "sk_", "ak_", "tk_"])
+def test_whoami_accepts_backend_issued_prefixes(
+    monkeypatch: pytest.MonkeyPatch, prefix: str
+) -> None:
+    _install_fake_aiohttp(
+        monkeypatch,
+        response=_FakeResponse(
+            status=200,
+            json_payload={
+                "valid": True,
+                "data": {"email": "dev@traigent.ai"},
+            },
+        ),
+    )
+
+    key = prefix + "a" * 43
+    result = _run_whoami(monkeypatch, api_key=key)
+    assert result.exit_code == 0
+    assert "✅ Valid" in result.output
+
+
 @pytest.mark.parametrize("status", [401, 403])
 def test_whoami_auth_failures_classified(
     monkeypatch: pytest.MonkeyPatch, status: int

--- a/tests/unit/cloud/test_api_key_manager.py
+++ b/tests/unit/cloud/test_api_key_manager.py
@@ -256,9 +256,18 @@ class TestValidateFormat:
         assert len(key) == 46  # Verify length
         assert manager.validate_format(key) is True
 
+    @pytest.mark.parametrize("prefix", ["uk_", "sk_", "ak_", "tk_"])
+    def test_validate_format_accepts_backend_issued_prefixes(
+        self, manager: APIKeyManager, prefix: str
+    ) -> None:
+        """Backend-issued API key families are 46 characters including prefix."""
+        key = prefix + "a" * 43
+        assert len(key) == 46
+        assert manager.validate_format(key) is True
+
     def test_validate_format_wrong_prefix(self, manager: APIKeyManager) -> None:
         """Test validation rejects wrong prefix."""
-        key = "ak_" + "a" * 61
+        key = "zz_" + "a" * 61
         assert manager.validate_format(key) is False
 
     def test_validate_format_wrong_length(self, manager: APIKeyManager) -> None:

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -1027,10 +1027,12 @@ def whoami(key: str) -> None:
     console.print("\n[bold blue]🔍 API Key Information[/bold blue]\n")
 
     # Validate format
-    valid_prefixes = ("tg_", "uk_")
+    valid_prefixes = ("tg_", "uk_", "sk_", "ak_", "tk_")
     if not any(key.startswith(prefix) for prefix in valid_prefixes):
         console.print("[red]❌ Invalid API key format[/red]")
-        console.print("API keys should start with 'tg_' or 'uk_'\n")
+        console.print(
+            "API keys should start with 'tg_', 'uk_', 'sk_', 'ak_', or 'tk_'\n"
+        )
         sys.exit(1)
 
     # Check with backend

--- a/traigent/cloud/api_key_manager.py
+++ b/traigent/cloud/api_key_manager.py
@@ -293,6 +293,9 @@ class APIKeyManager:
         Supported formats:
         - `tg_`: Standard Traigent API keys (64 characters total)
         - `uk_`: User/utility keys issued by the backend (46 characters total)
+        - `sk_`: Service keys issued by the backend (46 characters total)
+        - `ak_`: Admin keys issued by the backend (46 characters total)
+        - `tk_`: Temporary keys issued by the backend (46 characters total)
 
         Args:
             key: API key to validate
@@ -307,6 +310,9 @@ class APIKeyManager:
         prefix_lengths = {
             "tg_": 64,  # Standard Traigent API keys
             "uk_": 46,  # User/utility keys from backend
+            "sk_": 46,  # Service keys from backend
+            "ak_": 46,  # Admin keys from backend
+            "tk_": 46,  # Temporary keys from backend
         }
 
         # Find matching prefix


### PR DESCRIPTION
## Summary
- accept backend-issued uk/sk/ak/tk API key families in SDK format validation and auth whoami
- add laptop portal-dev agent setup instructions without embedding secrets
- cover backend-issued prefixes in SDK unit tests

## Tests
- uv run --project /tmp/traigent-sdk-api-key-prefixes pytest /tmp/traigent-sdk-api-key-prefixes/tests/unit/cloud/test_api_key_manager.py /tmp/traigent-sdk-api-key-prefixes/tests/unit/cli/test_auth_whoami_command.py -q -n 0

Note: the same SDK test selection hit a pytest xdist/asyncio-cooperative internal error under the repo's default xdist run after 41 tests had passed; rerunning single-process passed cleanly.