### PR TITLE
fix(auth): validate API keys with JSON body

### DIFF
--- a/tests/unit/cli/test_auth_whoami_command.py
+++ b/tests/unit/cli/test_auth_whoami_command.py
@@ -38,6 +38,8 @@ class _FakeResponse:
 
 
 class _FakeSession:
+    last_post_kwargs = None
+
     def __init__(
         self,
         *,
@@ -65,6 +67,11 @@ class _FakeSession:
         if self._error is not None:
             raise self._error
         assert self._response is not None
+        type(self).last_post_kwargs = {
+            "url": url,
+            "headers": headers,
+            **kwargs,
+        }
         return self._response
 
 
@@ -74,6 +81,7 @@ def _install_fake_aiohttp(
     response: _FakeResponse | None = None,
     error: Exception | None = None,
 ) -> Any:
+    _FakeSession.last_post_kwargs = None
     fake_module = types.SimpleNamespace()
 
     class _ClientError(Exception):
@@ -120,6 +128,26 @@ def test_whoami_valid_key_200(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "✅ Valid" in result.output
     assert "Category" in result.output
     assert "authenticated" in result.output
+
+
+def test_whoami_posts_json_payload_to_validate_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_key = "sk_" + "a" * 43  # pragma: allowlist secret
+    _install_fake_aiohttp(
+        monkeypatch,
+        response=_FakeResponse(status=200, json_payload={"valid": True, "data": {}}),
+    )
+
+    result = _run_whoami(monkeypatch, api_key=api_key)
+
+    assert result.exit_code == 0
+    assert _FakeSession.last_post_kwargs is not None
+    assert _FakeSession.last_post_kwargs["json"] == {"api_key": api_key}
+    assert (
+        _FakeSession.last_post_kwargs["headers"]["Content-Type"]
+        == "application/json"
+    )
 
 
 @pytest.mark.parametrize("prefix", ["tg_", "uk_", "sk_", "ak_", "tk_"])

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -52,6 +52,8 @@ class _FakeResponse:
 class _FakeSession:
     """Stub aiohttp.ClientSession returning a configurable JSON payload."""
 
+    last_post_kwargs = None
+
     def __init__(self, payload):
         self._payload = payload
 
@@ -61,12 +63,18 @@ class _FakeSession:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    def post(self, url, headers=None, allow_redirects=None):  # noqa: ARG002
+    def post(self, url, headers=None, **kwargs):
+        type(self).last_post_kwargs = {
+            "url": url,
+            "headers": headers,
+            **kwargs,
+        }
         return _FakeResponse(self._payload)
 
 
 def _patch_aiohttp(payload):
     """Patch the aiohttp surface used by ``_validate_api_key_with_backend``."""
+    _FakeSession.last_post_kwargs = None
     fake_aiohttp = MagicMock()
     fake_aiohttp.ClientSession = MagicMock(return_value=_FakeSession(payload))
     fake_aiohttp.ClientTimeout = MagicMock()
@@ -129,9 +137,28 @@ async def test_validate_accepts_strict_true_payload():
 
 
 @pytest.mark.asyncio
+async def test_validate_posts_json_payload_to_backend():
+    """Backend validation must send a JSON body, not an empty POST."""
+    manager = _auth_manager_with_public_backend()
+    api_key = "tg_" + "x" * 61  # pragma: allowlist secret
+
+    with _patch_aiohttp({"valid": True}):
+        reason = await manager._validate_api_key_with_backend(api_key)
+
+    assert reason is None
+    assert _FakeSession.last_post_kwargs is not None
+    assert _FakeSession.last_post_kwargs["json"] == {"api_key": api_key}
+    assert (
+        _FakeSession.last_post_kwargs["headers"]["Content-Type"]
+        == "application/json"
+    )
+
+
+@pytest.mark.asyncio
 async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
     """Missing aiohttp must not block API-key validation when the stdlib can call backend."""
     manager = _auth_manager_with_public_backend()
+    api_key = "tg_" + "x" * 61  # pragma: allowlist secret
 
     with (
         patch("traigent.cloud.auth.AIOHTTP_AVAILABLE", False),
@@ -140,10 +167,12 @@ async def test_validate_uses_stdlib_fallback_when_aiohttp_unavailable():
             return_value=_RequestsResponse(200, b'{"valid": true}'),
         ) as post,
     ):
-        reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
+        reason = await manager._validate_api_key_with_backend(api_key)
 
     assert reason is None
     post.assert_called_once()
+    assert post.call_args.kwargs["json"] == {"api_key": api_key}
+    assert post.call_args.kwargs["headers"]["Content-Type"] == "application/json"
     assert post.call_args.kwargs["allow_redirects"] is False
 
 

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -1104,13 +1104,21 @@ async def _check_api_key(backend_api_url: str, key: str) -> bool:
         return False
 
     url = f"{backend_api_url}/keys/validate"
-    headers = {"X-API-Key": key}
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-API-Key": key,
+    }
 
     try:
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=15)
         ) as session:
-            async with session.post(url, headers=headers) as response:
+            async with session.post(
+                url,
+                headers=headers,
+                json={"api_key": key},
+            ) as response:
                 if response.status == 200:
                     return _handle_200_response(await _safe_parse_json(response))
 

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1405,7 +1405,12 @@ class AuthManager:
         if unsafe_url_reason:
             return unsafe_url_reason
 
-        headers = {"X-API-Key": api_key}
+        validation_payload = {"api_key": api_key}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-API-Key": api_key,
+        }
 
         if not AIOHTTP_AVAILABLE:
             try:
@@ -1416,6 +1421,7 @@ class AuthManager:
                         self._validate_api_key_with_backend_sync,
                         url,
                         headers,
+                        validation_payload,
                     )
             except ImportError:
                 return "requests library not available for backend validation"
@@ -1433,6 +1439,7 @@ class AuthManager:
                 async with session.post(
                     url,
                     headers=headers,
+                    json=validation_payload,
                     allow_redirects=False,
                 ) as response:
                     if response.status == 200:
@@ -1507,6 +1514,7 @@ class AuthManager:
         self,
         url: str,
         headers: dict[str, str],
+        validation_payload: dict[str, str],
     ) -> str | None:
         """Requests fallback for backend key validation when aiohttp is unavailable."""
         import requests
@@ -1515,6 +1523,7 @@ class AuthManager:
             response = requests.post(
                 url,
                 headers=headers,
+                json=validation_payload,
                 timeout=15,
                 allow_redirects=False,
             )


### PR DESCRIPTION
## Summary
- send a JSON body plus JSON content headers when validating API keys against /keys/validate
- keep X-API-Key for compatibility with existing backend route handling
- add regressions for cloud auth and auth whoami so SDK validation cannot regress to an empty POST

## Verification
- uv run pytest tests/unit/cloud/test_api_key_strict_bool.py tests/unit/cli/test_auth_whoami_command.py -q -n 0

## Notes
- This fixes the SDK-side 400 Bad Request from backend request-format middleware. The live dev validate endpoint is currently returning 429 after repeated probes, so demo execution is blocked by rate limiting, not request shape.