### PR TITLE
chore(license): declare dual-license metadata for the Python SDK (AGPL-3.0 OR commercial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`langgraph-checkpoint` 3.x → 4.x:** the 4.0 release drops default deserialization of payloads serialized with the legacy `"json"` serde mode. Users running `langgraph` with a persistent checkpoint saver (SQLite, Postgres, Redis, etc.) whose stored state contains JSON-format blobs will see deserialization failures unless they configure `serde` with an explicit `allowed_json_modules` list. Traigent does not bind `langgraph-checkpoint` directly — it arrives transitively through the `langgraph` dependency — so this only affects projects that also use `langgraph` checkpointers in their own code. See [CVE-2026-27794](https://github.com/langchain-ai/langgraph/security/advisories) for the underlying RCE that motivated removing the default.
 
 ### Changed
+- **Dual-licensed** under `AGPL-3.0-only OR LicenseRef-Traigent-Commercial`: declared the SPDX
+  license expression in package metadata (PEP 639 via `setuptools>=77`), added `license-files`,
+  per-module SPDX headers, and `COMMERCIAL-LICENSE.md`; aligned `NOTICE`, `README`, and
+  `DISCLAIMER`. Commercial terms remain available under separate agreement; see
+  `COMMERCIAL-LICENSE.md` and `CONTRIBUTOR-LICENSING.md`. No version bump in this change.
 - Agent platform helpers now distinguish executable platforms from configuration-mapping-only platforms: `get_supported_platforms()` reports only executor-backed platforms, while `get_mapping_platforms()` returns all registered mappings.
 - Agent executors without real cost-estimation support now raise `NotImplementedError` instead of returning an authoritative-looking zero-cost estimate.
 - Langfuse trace metrics now include an `observations_partial` numeric flag in `to_measures_dict()` when observation pagination returns incomplete metrics.

--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -10,6 +10,6 @@ intended deployment or distribution model.
 Commercial rights are not granted by default through this repository. They are
 available only under a separate written agreement with Traigent.
 
-To discuss commercial licensing, contact: `sales@traigent.ai`
+To discuss commercial licensing, contact: `legal@traigent.ai`
 
 For the open-source license terms, see [LICENSE](LICENSE).

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -196,4 +196,4 @@ https://github.com/Traigent/Traigent/issues
 ---
 
 *Last updated: May 2026*
-*Licensed under GNU Affero General Public License v3.0 (AGPL-3.0-only) - See [LICENSE](LICENSE) for full terms*
+*Dual-licensed: GNU Affero General Public License v3.0 only (AGPL-3.0-only) - see [LICENSE](LICENSE) - or a Traigent commercial license under separate agreement (see [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)).*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include NOTICE
 include CHANGELOG.md
 include CONTRIBUTING.md
 include CONTRIBUTOR-LICENSING.md
-include COMMERCIAL-LICENSING.md
+include COMMERCIAL-LICENSE.md
 include SECURITY.md
 include DISCLAIMER.md
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,16 +1,18 @@
 Traigent SDK
-Copyright 2024-2026 Traigent
+Copyright 2024-2026 Traigent Ltd
 
-Open-source releases of this repository are licensed under the GNU Affero
-General Public License v3.0 only. Commercial licenses are also available from
-Traigent under separate written agreement.
+This software is dual-licensed: GNU Affero General Public License v3.0 only
+(AGPL-3.0-only) OR a Traigent commercial license under separate written
+agreement. SPDX: AGPL-3.0-only OR LicenseRef-Traigent-Commercial.
+See LICENSE and COMMERCIAL-LICENSE.md.
 
 This NOTICE file is provided for attribution and third-party notice purposes
 only. It does not modify the applicable license terms.
 
 ================================================================================
 
-This project includes code from the following third-party libraries:
+This project depends on the following notable third-party libraries
+(not vendored; each retains its own license):
 
 - Optuna (MIT License) - https://github.com/optuna/optuna
 - LangChain (MIT License) - https://github.com/langchain-ai/langchain

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ We welcome bug reports and feature requests via [GitHub Issues](https://github.c
 
 ## 📄 License
 
-This project is licensed under the GNU Affero General Public License v3.0 (AGPL-3.0-only) - see the [LICENSE](LICENSE) file for details.
+This project is **dual-licensed**: the GNU Affero General Public License v3.0 only (AGPL-3.0-only) - see [LICENSE](LICENSE) - **or** a Traigent commercial license under a separate written agreement (see [COMMERCIAL-LICENSE.md](COMMERCIAL-LICENSE.md)). SPDX: `AGPL-3.0-only OR LicenseRef-Traigent-Commercial`. Commercial inquiries: legal@traigent.ai.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=70.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]  # PEP 639 SPDX license expressions require setuptools >= 77
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,8 @@ authors = [
 ]
 description = "Enterprise-grade LLM optimization platform with advanced analytics and AI-powered insights"
 readme = "README.md"
-license = "AGPL-3.0-only"
+license = "AGPL-3.0-only OR LicenseRef-Traigent-Commercial"
+license-files = ["LICENSE", "NOTICE", "COMMERCIAL-LICENSE.md", "CONTRIBUTOR-LICENSING.md"]
 requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
+# Copyright (c) 2024-2026 Traigent Ltd. Dual-licensed: AGPL-3.0 or commercial.
 """Traigent SDK - Open-source LLM optimization toolkit.
 
 Traigent makes it effortless to optimize your LLM applications with a simple decorator.

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
+# Copyright (c) 2024-2026 Traigent Ltd. Dual-licensed: AGPL-3.0 or commercial.
 """Version information for Traigent SDK."""
 
 # Traceability: CONC-Layer-Data CONC-Quality-Maintainability FUNC-API-ENTRY REQ-API-001


### PR DESCRIPTION
## Summary
Make the Traigent Python SDK's **dual-license** posture machine-readable and
consistent with the rest of the open-core train: **AGPL-3.0-only** *or* a
**Traigent commercial license**. The SDK already documented dual licensing in
prose; this adds the SPDX metadata and aligns the docs.

**No version bump** — rides the in-flight `0.12.0` release; the note goes under
`CHANGELOG [Unreleased]`. The binding commercial grant lives in the EULA/MSA,
not this repo.

## Changes
- `pyproject.toml`: SPDX `license = "AGPL-3.0-only OR LicenseRef-Traigent-Commercial"`;
  pin `setuptools>=77.0` (PEP 639 / Metadata 2.4); add `license-files`.
- `NOTICE`: owner → Traigent Ltd; restate the dual license + SPDX; clarify deps.
- `README` + `DISCLAIMER`: state the dual license instead of AGPL-only.
- SPDX headers on the package entry points (`__init__.py`, `_version.py`).
- Standardize the commercial notice to `COMMERCIAL-LICENSE.md`; commercial contact `legal@traigent.ai`.

## Verification
- Wheel: **Metadata-Version 2.4**, `License-Expression: AGPL-3.0-only OR LicenseRef-Traigent-Commercial`,
  license docs bundled in `.dist-info/licenses/`.
- Pre-commit (black, ruff, mypy, bandit, detect-secrets, dep-floor) PASS.

## PR checklist
1. **Worst-case prod path** — none; license metadata + docs only.
2. **Production-branch test** — n/a.
3. **Contract regeneration** — none.
4. **Public surface delta** — packaging metadata + license docs; no API change.
5. **Review threads** — resolve before merge.
6. **Quality gates** — unchanged.

> ⚠️ License texts pending **counsel sign-off**; commercial grant belongs in the MSA/EULA.
