### PR TITLE
fix(auth): send API key only via X-API-Key, not Authorization: Bearer

### DIFF
--- a/tests/unit/cloud/test_authentication_headers.py
+++ b/tests/unit/cloud/test_authentication_headers.py
@@ -982,3 +982,19 @@ class TestIntegrationScenarios:
         mock_session.get.assert_called_once()
         call_kwargs = mock_session.get.call_args[1]
         assert "headers" in call_kwargs
+
+
+def test_api_key_headers_use_x_api_key_only_no_bearer(valid_api_key):
+    """API-key auth must send X-API-Key only, never Authorization: Bearer.
+
+    Regression for the SDK<->backend interop bug: emitting the API key as an
+    ``Authorization: Bearer`` token makes a backend that tries JWT auth first
+    parse the key as a JWT, fail, and reject the request before the valid
+    ``X-API-Key`` credential is considered.
+    """
+    manager = AuthManager(api_key=valid_api_key)
+
+    headers = manager._get_api_key_headers()
+
+    assert headers.get("X-API-Key") == valid_api_key
+    assert "Authorization" not in headers

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -810,12 +810,19 @@ class AuthManager:
         self._authenticated = False
 
     def _get_api_key_headers(self) -> dict[str, str]:
-        """Generate headers for API key authentication."""
+        """Generate headers for API key authentication.
+
+        Emit the API key ONLY via ``X-API-Key``. We intentionally do not also
+        set ``Authorization: Bearer <api_key>``: the ``Authorization`` scheme is
+        reserved for JWTs, and a backend that tries the Bearer credential first
+        parses the API key as a JWT, fails, and rejects the request before the
+        valid ``X-API-Key`` is considered. Sending one unambiguous credential
+        keeps API-key auth working across all routes.
+        """
         headers: dict[str, str] = {}
         api_key_value = self._get_api_key_for_internal_use()
         if api_key_value:
             headers["X-API-Key"] = api_key_value
-            headers["Authorization"] = f"Bearer {api_key_value}"
         return headers
 
     async def _get_jwt_headers(self) -> dict[str, str]:


### PR DESCRIPTION
## Problem
For API-key auth the SDK emitted **both** `X-API-Key` **and** `Authorization: Bearer <api_key>` (`_get_api_key_headers`). A backend that tries JWT auth before API-key auth parses the Bearer value as a JWT, fails, and rejects the request **before** the valid `X-API-Key` is considered.

Reproduced end-to-end against the optimization session routes:

| Headers sent | Result |
|---|---|
| `X-API-Key` only | auth passes |
| `Authorization: Bearer <api_key>` only | 401 |
| **both** (what the SDK sent) | **401** |

This blocked every API-key SDK→backend session call (surfaced by the `FR-SDK-SMART-OPTIMIZATION-V1` live SDK↔BE E2E).

## Fix
Send one unambiguous credential — `X-API-Key` only. `Authorization` is reserved for JWTs; backend key validation (`/keys/validate`) already uses `X-API-Key`.

## Verification
- New regression test `test_api_key_headers_use_x_api_key_only_no_bearer` (asserts `X-API-Key` present, `Authorization` absent).
- `tests/unit/cloud/test_authentication_headers.py`: 20 passed.
- Live Python hybrid suite (bayesian/tpe/hyperband/frontier_scout) passes against a real backend with this change.

## PR checklist (policy surface: auth)
1. **Worst-case prod path** — narrows what's sent (removes an ambiguous credential). No new auth is granted; if anything it tightens the wire contract. Fails closed unchanged (no key → no header).
2. **Production-branch test** — `tests/unit/cloud/test_authentication_headers.py::test_api_key_headers_use_x_api_key_only_no_bearer`.
3. **Contract regeneration** — no schema change. Cross-SDK parity: matching `traigent-js` fix in a sibling PR.
4. **Public surface delta** — none (`_get_api_key_headers` is private; wire behavior corrected).
5. **Review threads** — n/a at open.
6. **Quality gates** — unchanged (no gate relaxed).

Companion backend hardening (so a stray Bearer can't lock out a valid X-API-Key) tracked in a separate TraigentBackend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)