### PR TITLE
Guaranteed modes (Python SDK): request builder + fail-closed deploy guard

### DIFF
--- a/tests/unit/test_guaranteed_modes.py
+++ b/tests/unit/test_guaranteed_modes.py
@@ -1,0 +1,86 @@
+"""Fail-closed guard + request-builder tests for the SDK guaranteed-modes helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.guaranteed_modes import (
+    build_guaranteed_selection_request,
+    deployable_config,
+    is_deployable,
+)
+
+
+def _certified(cfg: str = "cfg_cheap") -> dict:
+    return {
+        "status": "CERTIFIED_SELECTION",
+        "deployable": True,
+        "selected_config": cfg,
+        "fallback_config": "cfg_base",
+        "certificate": {},
+    }
+
+
+def test_certified_result_is_deployable() -> None:
+    result = _certified()
+    assert is_deployable(result)
+    assert deployable_config(result) == "cfg_cheap"
+
+
+def test_no_decision_is_not_deployable() -> None:
+    result = {
+        "status": "NO_DECISION_BASELINE_FALLBACK",
+        "deployable": False,
+        "selected_config": None,
+        "fallback_config": "cfg_base",
+    }
+    assert not is_deployable(result)
+    assert deployable_config(result) is None
+
+
+def test_best_effort_is_not_deployable() -> None:
+    result = {
+        "status": "BEST_EFFORT_UNCERTIFIED",
+        "deployable": False,
+        "selected_config": None,
+        "fallback_config": "cfg_base",
+    }
+    assert not is_deployable(result)
+    assert deployable_config(result) is None
+
+
+def test_certified_with_false_deployable_flag_is_denied() -> None:
+    result = _certified()
+    result["deployable"] = False
+    assert not is_deployable(result)
+    assert deployable_config(result) is None
+
+
+def test_malformed_results_are_denied() -> None:
+    assert not is_deployable(None)
+    assert deployable_config(None) is None
+    assert not is_deployable(
+        {"status": "CERTIFIED_SELECTION", "deployable": True, "selected_config": ""}
+    )
+
+
+def test_request_builder_mode1_requires_baseline() -> None:
+    with pytest.raises(ValueError, match="baseline_ref"):
+        build_guaranteed_selection_request("keep_accuracy_reduce_cost", delta=0.05)
+    request = build_guaranteed_selection_request(
+        "keep_accuracy_reduce_cost", delta=0.05, baseline_ref="cfg_base"
+    )
+    assert request["selection_mode"] == "keep_accuracy_reduce_cost"
+    assert request["baseline_ref"] == "cfg_base"
+    assert request["schema_version"] == "traigent.guaranteed_selection_request.v1"
+
+
+def test_request_builder_mode2_omits_baseline() -> None:
+    request = build_guaranteed_selection_request("accuracy_then_cost", delta=0.02, epsilon=0.1)
+    assert request["selection_mode"] == "accuracy_then_cost"
+    assert "baseline_ref" not in request
+
+
+def test_request_builder_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="selection_mode"):
+        build_guaranteed_selection_request("maximize_accuracy", delta=0.05)

--- a/traigent/guaranteed_modes.py
+++ b/traigent/guaranteed_modes.py
@@ -1,0 +1,77 @@
+"""Client-side helpers for the guaranteed optimizer modes.
+
+Builds a ``guaranteed_selection`` request and applies the FAIL-CLOSED guard on the result: the
+SDK must never deploy a config the backend did not certify. :func:`is_deployable` /
+:func:`deployable_config` yield a deployable config ONLY for a ``CERTIFIED_SELECTION``; every
+other status (``NO_DECISION_*``, ``BEST_EFFORT_UNCERTIFIED``) yields no deployable config, so a
+worse-but-cheaper candidate can never be auto-applied through the SDK (legacy best-config apply
+paths included). Mirrors TraigentSchema ``guaranteed_selection_{request,result}_schema``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+CERTIFIED_STATUS = "CERTIFIED_SELECTION"
+SELECTION_MODES = frozenset({"keep_accuracy_reduce_cost", "accuracy_then_cost"})
+
+
+def build_guaranteed_selection_request(
+    selection_mode: str,
+    *,
+    delta: float,
+    epsilon: float = 0.10,
+    baseline_ref: str | None = None,
+    eta: float = 0.0,
+    epsilon_allocation: Mapping[str, float] | None = None,
+    min_pairs: int = 2,
+    cost_value_range: float | None = None,
+    allow_best_effort_uncertified: bool = False,
+) -> dict[str, Any]:
+    """Build a guaranteed_selection request payload (validated client-side)."""
+    if selection_mode not in SELECTION_MODES:
+        raise ValueError(f"unknown selection_mode: {selection_mode!r}")
+    if selection_mode == "keep_accuracy_reduce_cost" and not baseline_ref:
+        raise ValueError("keep_accuracy_reduce_cost requires baseline_ref")
+    request: dict[str, Any] = {
+        "schema_version": "traigent.guaranteed_selection_request.v1",
+        "selection_mode": selection_mode,
+        "delta": delta,
+        "epsilon": epsilon,
+        "eta": eta,
+        "min_pairs": min_pairs,
+        "allow_best_effort_uncertified": allow_best_effort_uncertified,
+    }
+    if baseline_ref is not None:
+        request["baseline_ref"] = baseline_ref
+    if epsilon_allocation is not None:
+        request["epsilon_allocation"] = dict(epsilon_allocation)
+    if cost_value_range is not None:
+        request["cost_value_range"] = cost_value_range
+    return request
+
+
+def is_deployable(result: object) -> bool:
+    """Fail-closed: True only for a CERTIFIED_SELECTION that carries a config to deploy."""
+    if not isinstance(result, Mapping):
+        return False
+    if result.get("status") != CERTIFIED_STATUS:
+        return False
+    if result.get("deployable") is not True:
+        return False
+    selected = result.get("selected_config")
+    return isinstance(selected, str) and bool(selected)
+
+
+def deployable_config(result: object) -> str | None:
+    """The config to deploy, or ``None`` when the result is not a certified selection.
+
+    The SDK must NEVER auto-apply a config from a non-certified result.
+    """
+    if not isinstance(result, Mapping):
+        return None
+    if not is_deployable(result):
+        return None
+    selected = result.get("selected_config")
+    return selected if isinstance(selected, str) else None


### PR DESCRIPTION
## What

`traigent/guaranteed_modes.py` — the client-side surface for the guaranteed optimizer modes (engine Traigent/traigent-smartopt#4, contracts Traigent/TraigentSchema#76, backend Traigent/TraigentBackend#758):

- **`build_guaranteed_selection_request()`** — builds a `guaranteed_selection` request (validated client-side; Mode 1 requires `baseline_ref`).
- **`is_deployable()` / `deployable_config()`** — the **fail-closed guard**: a config is deployable **only** for a `CERTIFIED_SELECTION`; `NO_DECISION_*` / `BEST_EFFORT_UNCERTIFIED` / malformed yield no deployable config. This is the SDK half of the poison-pill — a worse-but-cheaper candidate can never be auto-applied through the SDK.

8 tests; ruff + mypy clean. Additive (a new module); the `@traigent.optimize` integration that calls this stacks on the concurrent optimization-surface work.

## PR checklist
1. **Worst-case prod path** — auto-deploying an uncertified config. `is_deployable`/`deployable_config` are **deny-by-default**: only `CERTIFIED_SELECTION` returns a config.
2. **Production-branch test** — `tests/unit/test_guaranteed_modes.py` (poison/best-effort/malformed denied).
3. **Contract regen** — consumes the TraigentSchema request/result contracts; no contract change here.
4. **Public surface delta** — a new module; no existing API changed.
5. **Review threads / 6. Quality gates** — n/a (new PR); gates not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)