### PR TITLE
feat(logger): content-logging opt-out for optimization logs (#1069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Content-logging opt-out for optimization logs** (#1069). `TRAIGENT_LOG_EXAMPLE_CONTENT=false`
+  (or `OptimizationLogger(..., log_example_content=False)`) keeps per-trial ids and metrics on
+  disk while omitting the per-example `query` / `response` / `expected` content — without having
+  to enable full privacy mode. Defaults to on for DX. The logger now also writes a `.gitignore`
+  (`*`) into the log root (`./.traigent/optimization_logs/` by default) so prompt/response
+  content isn't accidentally committed, and `docs/api-reference/telemetry.md` documents the
+  default location, what is persisted, and that on-disk redaction covers structured PII only.
+
 ### Removed
 - **Breaking in 0.12.0:** removed Python-orchestrated JavaScript optimization through the temporary JS bridge. `ExecutionOptions.runtime`, all `ExecutionOptions.js_*` fields, `traigent.bridges.*`, and `traigent.evaluators.JSEvaluator` are no longer available. JavaScript/TypeScript users should migrate to native `@traigent/sdk` optimization with `optimize(spec)(agentFn)` and `await wrapped.optimize(...)`; see https://github.com/Traigent/traigent-js/blob/main/docs/getting-started/minimal-integration.md and https://github.com/Traigent/traigent-js/blob/main/docs/MIGRATION_FROM_PYTHON.md.
 

--- a/docs/api-reference/telemetry.md
+++ b/docs/api-reference/telemetry.md
@@ -212,6 +212,33 @@ You can customize the storage location:
 )
 ```
 
+### Per-example content in optimization logs
+
+By default, optimization runs also write per-trial logs under
+`./.traigent/optimization_logs/` (the **project working directory**, unless
+`TRAIGENT_OPTIMIZATION_LOG_DIR` / `TRAIGENT_RESULTS_FOLDER` relocate it). Each
+example record includes the input **query**, the model **response**, and the
+**expected** output as free text, alongside ids and metrics.
+
+> ⚠️ On-disk redaction covers **structured PII only** (emails, Luhn-checked
+> cards, API keys / bearer tokens, etc.). Free-text content in prompts and
+> responses (names, addresses, proprietary data) is stored **verbatim**.
+
+To keep ids and metrics while omitting that content — without enabling full
+privacy mode — disable content logging:
+
+```bash
+export TRAIGENT_LOG_EXAMPLE_CONTENT=false   # also accepts 0 / no / off
+```
+
+or per-logger via `OptimizationLogger(..., log_example_content=False)`. With it
+disabled, trial jsonl retains `example_id`, `accuracy`, `cost_usd`, `latency_ms`
+and `error`, but `query` / `response` / `expected` are `null`.
+
+Traigent writes a `.gitignore` (`*`) into the log root so this content is not
+accidentally committed, but you should still keep `.traigent/` out of version
+control and CI artifact collection in privacy-sensitive projects.
+
 ## Telemetry Listeners
 
 You can subscribe to telemetry events for your own monitoring:

--- a/tests/unit/utils/test_optimization_logger_content_optout.py
+++ b/tests/unit/utils/test_optimization_logger_content_optout.py
@@ -1,0 +1,151 @@
+"""Tests for the content-logging opt-out (Traigent/Traigent#1069).
+
+TRAIGENT_LOG_EXAMPLE_CONTENT (or `log_example_content=`) lets a user keep ids and
+metrics on disk while omitting per-example query/response/expected content, without
+enabling full privacy mode.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from traigent.api.types import TrialResult, TrialStatus
+from traigent.utils.optimization_logger import (
+    ENV_LOG_EXAMPLE_CONTENT,
+    OptimizationLogger,
+    _serialize_example_result,
+    _should_log_example_content,
+)
+
+PROMPT = "SENSITIVE_PROMPT_XYZ"
+EXPECTED = "SENSITIVE_EXPECTED_XYZ"
+
+
+def _example() -> dict:
+    return {
+        "example_id": "ex1",
+        "actual_output": {"query": PROMPT, "response": "the response"},
+        "expected_output": EXPECTED,
+        "metrics": {"accuracy": 1.0},
+        "cost_usd": 0.01,
+        "latency_ms": 5.0,
+    }
+
+
+def _logger(tmp_path: Path, **kwargs) -> OptimizationLogger:
+    return OptimizationLogger(
+        experiment_name="exp",
+        session_id="sess12345678",
+        execution_mode="edge_analytics",
+        base_path=tmp_path,
+        buffer_size=1,
+        **kwargs,
+    )
+
+
+def _trial_with_example() -> TrialResult:
+    return TrialResult(
+        trial_id="t1",
+        config={"model": "gpt-4o"},
+        metrics={"accuracy": 1.0},
+        status=TrialStatus("completed"),
+        duration=1.0,
+        timestamp=datetime(2026, 6, 2, tzinfo=UTC),
+        metadata={"example_results": [_example()]},
+    )
+
+
+# --- env switch resolution ------------------------------------------------
+
+
+def test_env_default_is_on(monkeypatch):
+    monkeypatch.delenv(ENV_LOG_EXAMPLE_CONTENT, raising=False)
+    assert _should_log_example_content() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "off", "no", "FALSE", " Off ", ""])
+def test_env_disables(monkeypatch, value):
+    monkeypatch.setenv(ENV_LOG_EXAMPLE_CONTENT, value)
+    assert _should_log_example_content() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "on", "yes"])
+def test_env_enables(monkeypatch, value):
+    monkeypatch.setenv(ENV_LOG_EXAMPLE_CONTENT, value)
+    assert _should_log_example_content() is True
+
+
+# --- serializer gating ----------------------------------------------------
+
+
+def test_serializer_omits_content_when_disabled():
+    out = _serialize_example_result(_example(), log_content=False)
+    assert out["query"] is None
+    assert out["response"] is None
+    assert out["expected"] is None
+    # ids + metrics retained
+    assert out["example_id"] == "ex1"
+    assert out["accuracy"] == 1.0
+    assert out["cost_usd"] == 0.01
+
+
+def test_serializer_keeps_content_when_enabled():
+    out = _serialize_example_result(_example(), log_content=True)
+    assert out["query"] == PROMPT
+    assert out["expected"] == EXPECTED
+
+
+# --- constructor honors env / explicit param ------------------------------
+
+
+def test_constructor_reads_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(ENV_LOG_EXAMPLE_CONTENT, "false")
+    assert _logger(tmp_path).log_example_content is False
+
+
+def test_explicit_param_overrides_env(tmp_path, monkeypatch):
+    monkeypatch.setenv(ENV_LOG_EXAMPLE_CONTENT, "false")
+    assert _logger(tmp_path, log_example_content=True).log_example_content is True
+
+
+# --- on-disk behavior (the issue's reproduction) --------------------------
+
+
+def _all_disk_text(root: Path) -> str:
+    return "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore")
+        for p in root.rglob("*")
+        if p.is_file()
+    )
+
+
+def test_content_absent_on_disk_when_disabled(tmp_path):
+    log = _logger(tmp_path / "off", log_example_content=False)
+    log.log_trial_result(_trial_with_example())
+    log._flush_trial_buffer()
+    disk = _all_disk_text(tmp_path / "off")
+    assert PROMPT not in disk
+    assert EXPECTED not in disk
+    # but the example is still recorded (id present)
+    assert "ex1" in disk
+
+
+def test_content_present_on_disk_by_default(tmp_path):
+    """Default DX behavior — content IS persisted (the gap #1069 addresses)."""
+    log = _logger(tmp_path / "on", log_example_content=True)
+    log.log_trial_result(_trial_with_example())
+    log._flush_trial_buffer()
+    assert PROMPT in _all_disk_text(tmp_path / "on")
+
+
+def test_log_dir_gitignore_written(tmp_path):
+    _logger(tmp_path / "gi")
+    assert (
+        (tmp_path / "gi" / ".gitignore")
+        .read_text(encoding="utf-8")
+        .strip()
+        .endswith("*")
+    )

--- a/traigent/utils/optimization_logger.py
+++ b/traigent/utils/optimization_logger.py
@@ -185,8 +185,33 @@ def _extract_output_text(output: Any) -> str | None:
     return None
 
 
-def _serialize_example_result(ex: Any) -> dict[str, Any]:
-    """Serialize a per-example result (dataclass or dict) for jsonl logging."""
+ENV_LOG_EXAMPLE_CONTENT = "TRAIGENT_LOG_EXAMPLE_CONTENT"
+_CONTENT_LOGGING_DISABLED_VALUES = {"0", "false", "no", "off", ""}
+
+
+def _should_log_example_content() -> bool:
+    """Whether per-example query/response/expected content is persisted to disk.
+
+    Controlled by ``TRAIGENT_LOG_EXAMPLE_CONTENT`` and enabled by default (for
+    DX). Set it to a falsey value (``0`` / ``false`` / ``no`` / ``off``) to keep
+    ids and metrics on disk but omit prompt/response/expected content — without
+    having to enable full privacy mode. Note that even with content logging on,
+    on-disk redaction covers structured PII only (emails, cards, tokens), not
+    free-text bodies.
+    """
+    raw = os.getenv(ENV_LOG_EXAMPLE_CONTENT)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in _CONTENT_LOGGING_DISABLED_VALUES
+
+
+def _serialize_example_result(ex: Any, *, log_content: bool = True) -> dict[str, Any]:
+    """Serialize a per-example result (dataclass or dict) for jsonl logging.
+
+    When ``log_content`` is False, the content-bearing ``query`` / ``response`` /
+    ``expected`` fields are emitted as ``None`` (ids and metrics are retained), so
+    no prompt/response/expected text is written to disk.
+    """
     if isinstance(ex, dict):
         metrics = ex.get("metrics", {})
         actual = ex.get("actual_output")
@@ -198,9 +223,13 @@ def _serialize_example_result(ex: Any) -> dict[str, Any]:
         )
         return {
             "example_id": ex.get("example_id"),
-            "query": actual.get("query") if isinstance(actual, dict) else None,
-            "response": _extract_output_text(actual),
-            "expected": ex.get("expected_output"),
+            "query": (
+                (actual.get("query") if isinstance(actual, dict) else None)
+                if log_content
+                else None
+            ),
+            "response": _extract_output_text(actual) if log_content else None,
+            "expected": ex.get("expected_output") if log_content else None,
             "accuracy": metrics.get("accuracy") if isinstance(metrics, dict) else None,
             "cost_usd": ex.get("cost_usd", 0.0),
             "latency_ms": ex.get("latency_ms", 0.0),
@@ -214,9 +243,13 @@ def _serialize_example_result(ex: Any) -> dict[str, Any]:
         error = getattr(ex, "error", None)
     return {
         "example_id": getattr(ex, "example_id", None),
-        "query": actual.get("query") if isinstance(actual, dict) else None,
-        "response": _extract_output_text(actual),
-        "expected": getattr(ex, "expected_output", None),
+        "query": (
+            (actual.get("query") if isinstance(actual, dict) else None)
+            if log_content
+            else None
+        ),
+        "response": _extract_output_text(actual) if log_content else None,
+        "expected": getattr(ex, "expected_output", None) if log_content else None,
         "accuracy": metrics.get("accuracy") if isinstance(metrics, dict) else None,
         "cost_usd": getattr(ex, "cost_usd", 0.0),
         "latency_ms": getattr(ex, "latency_ms", 0.0),
@@ -236,6 +269,7 @@ class OptimizationLogger:
         execution_mode: ExecutionMode | str,
         base_path: Path | None = None,
         buffer_size: int = 10,
+        log_example_content: bool | None = None,
     ) -> None:
         self.experiment_name = self._sanitize_name(experiment_name)
         self.session_id = session_id
@@ -245,6 +279,13 @@ class OptimizationLogger:
             Path(base_path) if base_path else self._resolve_default_base_path()
         )
         self.buffer_size = buffer_size
+        # Persist per-example query/response/expected content to disk? Defaults to
+        # the TRAIGENT_LOG_EXAMPLE_CONTENT env switch (on unless explicitly disabled).
+        self.log_example_content = (
+            _should_log_example_content()
+            if log_example_content is None
+            else log_example_content
+        )
 
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         session_short = session_id[:8] if len(session_id) >= 8 else session_id
@@ -311,6 +352,24 @@ class OptimizationLogger:
         ]
         for directory in directories:
             directory.mkdir(parents=True, exist_ok=True)
+        self._write_log_dir_gitignore()
+
+    def _write_log_dir_gitignore(self) -> None:
+        """Drop a ``.gitignore`` into the log root so per-example content (which
+        may contain prompts/responses) isn't one stray ``git add .`` from being
+        committed. Best-effort; never fails a run."""
+        try:
+            self.base_path.mkdir(parents=True, exist_ok=True)
+            gitignore = self.base_path / ".gitignore"
+            if not gitignore.exists():
+                gitignore.write_text(
+                    "# Auto-generated by Traigent. Optimization logs may contain\n"
+                    "# per-example prompt/response content; keep them out of git.\n"
+                    "*\n",
+                    encoding="utf-8",
+                )
+        except OSError:
+            logger.debug("Could not write .gitignore to %s", self.base_path)
 
     @contextmanager
     def _file_lock(self, file_path: Path):
@@ -491,7 +550,8 @@ class OptimizationLogger:
             )
             if example_results:
                 serialized_examples = [
-                    _serialize_example_result(ex) for ex in example_results
+                    _serialize_example_result(ex, log_content=self.log_example_content)
+                    for ex in example_results
                 ]
                 trial_data["example_results"] = serialized_examples
             self._append_jsonl(trials_file, trial_data)


### PR DESCRIPTION
Closes #1069. Adds a privacy-mode-independent switch to stop per-example **query / response / expected** content from being written to disk during optimization runs.

## Problem (data-at-rest, not egress)
By default (privacy mode off), each trial's example records — input query, model response, expected output — are written as free text to `./.traigent/optimization_logs/` (inside the project tree). The only way to suppress this today is to enable full privacy mode (a broader behavioral change). On-disk redaction catches structured PII only; free-text bodies are stored verbatim, and the default location is one stray `git add .` from being committed.

## Fix
- **`TRAIGENT_LOG_EXAMPLE_CONTENT`** env switch (default **on** for DX; accepts `0`/`false`/`no`/`off`) and an `OptimizationLogger(..., log_example_content=...)` param. When off, `_serialize_example_result` emits `query`/`response`/`expected` as `null` — `example_id` + `accuracy`/`cost_usd`/`latency_ms`/`error` retained.
- The logger writes a **`.gitignore` (`*`)** into the log root so content isn't accidentally committed (best-effort, never fails a run).
- **Docs** (`docs/api-reference/telemetry.md`): default location, what is persisted, and the structured-PII-only redaction boundary.

Acceptance criteria (all met): switch disables content without full privacy mode ✔; docs state location/content/redaction ✔; `.traigent/` protected from accidental commit ✔.

## Verification
- `pytest tests/unit/utils/test_optimization_logger_content_optout.py` → **19 passed**; full `test_optimization_logger*` → **120 passed** (no regression).
- On-disk tests assert the secret prompt/expected strings are **absent** when disabled and **present by default** (the issue's reproduction), and the `.gitignore` is written.
- pre-commit (black, isort, ruff, mypy, bandit, detect-secrets, public-test-assertion contracts) all pass. The one pre-existing mypy `no-any-return` at `generate_manifest` is unrelated and present on `develop`.

## PR checklist (privacy surface)
1. **Worst-case prod path** — default behavior is unchanged (content still logged, preserving DX); the new path only *reduces* what's written. Worst case if the switch is misread: content keeps logging (status quo), never more. Privacy-positive direction.
2. **Production-branch test** — `test_content_absent_on_disk_when_disabled` proves the disabled path writes ids/metrics but no content; `test_env_disables`/`test_constructor_reads_env` prove the switch resolves.
3. **Contract regeneration** — none; local logging behavior only, no wire/schema change.
4. **Public surface delta** — adds `TRAIGENT_LOG_EXAMPLE_CONTENT` + `log_example_content` param + a module-level `ENV_LOG_EXAMPLE_CONTENT`; documented in telemetry.md.
5. **Review threads** — none yet; will resolve all before merge.
6. **Quality gates not relaxed** — none touched; all hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)