### PR TITLE
fix(benchmark): attribute generation to the active project (#1066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 - **Breaking in 0.12.0:** removed Python-orchestrated JavaScript optimization through the temporary JS bridge. `ExecutionOptions.runtime`, all `ExecutionOptions.js_*` fields, `traigent.bridges.*`, and `traigent.evaluators.JSEvaluator` are no longer available. JavaScript/TypeScript users should migrate to native `@traigent/sdk` optimization with `optimize(spec)(agentFn)` and `await wrapped.optimize(...)`; see https://github.com/Traigent/traigent-js/blob/main/docs/getting-started/minimal-integration.md and https://github.com/Traigent/traigent-js/blob/main/docs/MIGRATION_FROM_PYTHON.md.
 
+### Fixed
+- **`BenchmarkClient` now attributes generation to the active project** (#1066). It read
+  `TRAIGENT_PROJECT_ID` but applied it to the bare `/api/v1` root, which `scope_api_path`
+  leaves unrewritten — so `generate_sync` posted to the unscoped `/api/v1/datasets/generate`
+  and the benchmark was not project-scoped (a tenancy / data-isolation gap for multi-project
+  tenants). With a project set it now targets the project-scoped backend route
+  `POST /api/v1beta/projects/{id}/benchmarks/generate` (the `/datasets/generate` alias is not
+  project-scoped on the backend; the project-scoped generate route is registered under
+  `benchmarks`). With no project set, behavior is unchanged.
+
 ### Security
 - SDK auth and security policy checks now use `treat_as_production_policy()`, which treats unset or unknown environment names as production-safe by default. Local development JWT validation and mock password auth now require an explicit non-production environment such as `ENVIRONMENT=development` or `TRAIGENT_ENV=development`.
 - Bump `litellm` floor from `>=1.83.0` to `>=1.83.7` to fix [GHSA-xqmj-j6mv-4862](https://github.com/BerriAI/litellm/security/advisories/GHSA-xqmj-j6mv-4862) — prompt-template SSTI in `POST /prompts/test` that could run arbitrary code in the LiteLLM Proxy process. 1.83.7 renders templates in a sandboxed Jinja environment.

--- a/tests/unit/cloud/test_benchmark_client_project_scope.py
+++ b/tests/unit/cloud/test_benchmark_client_project_scope.py
@@ -1,0 +1,89 @@
+"""BenchmarkClient generation is project-scoped (Traigent/Traigent#1066).
+
+With TRAIGENT_PROJECT_ID set, generation must hit the project-scoped backend
+route (POST /api/v1beta/projects/{id}/benchmarks/generate) rather than the bare,
+unscoped /api/v1/datasets/generate alias. With no project, behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import traigent.cloud.benchmark_client as bc_module
+from traigent.cloud.benchmark_client import BenchmarkClient, BenchmarkClientConfig
+
+ORIGIN = "https://api.example.test"
+
+
+def _config(project_id):
+    return BenchmarkClientConfig(
+        backend_origin=ORIGIN, api_key="k", tenant_id=None, project_id=project_id
+    )
+
+
+# --- generate_path ---------------------------------------------------------
+
+
+def test_generate_path_is_project_scoped_when_project_set():
+    assert (
+        _config("proj-123").generate_path()
+        == "/api/v1beta/projects/proj-123/benchmarks/generate"
+    )
+
+
+def test_generate_path_unchanged_when_no_project():
+    assert _config(None).generate_path() == "/api/v1/datasets/generate"
+
+
+def test_generate_path_url_encodes_project_id():
+    assert (
+        _config("a/b c").generate_path()
+        == "/api/v1beta/projects/a%2Fb%20c/benchmarks/generate"
+    )
+
+
+# --- end-to-end URL (capture the outbound Request) -------------------------
+
+
+def _capture_urlopen(monkeypatch):
+    """Patch urlopen to return a minimal benchmark response and capture the Request."""
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+    captured = {}
+    body = json.dumps(
+        {
+            "data": {
+                "examples": [],
+                "benchmark": {"id": "b1", "name": "n"},
+                "status": "ok",
+            }
+        }
+    ).encode()
+
+    def fake_urlopen(http_req, timeout=None):
+        captured["url"] = http_req.full_url
+        cm = MagicMock()
+        cm.__enter__.return_value = MagicMock(read=lambda: body)
+        cm.__exit__.return_value = False
+        return cm
+
+    patcher = patch.object(bc_module.request, "urlopen", side_effect=fake_urlopen)
+    return captured, patcher
+
+
+def test_generate_sync_targets_project_scoped_route(monkeypatch):
+    captured, patcher = _capture_urlopen(monkeypatch)
+    client = BenchmarkClient(_config("proj-123"))
+    with patcher:
+        client.generate_sync(description="qa", count=5, use_case="question-answering")
+    assert (
+        captured["url"] == f"{ORIGIN}/api/v1beta/projects/proj-123/benchmarks/generate"
+    )
+
+
+def test_generate_sync_unscoped_route_when_no_project(monkeypatch):
+    captured, patcher = _capture_urlopen(monkeypatch)
+    client = BenchmarkClient(_config(None))
+    with patcher:
+        client.generate_sync(description="qa", count=5, use_case="question-answering")
+    assert captured["url"] == f"{ORIGIN}/api/v1/datasets/generate"

--- a/traigent/cloud/benchmark_client.py
+++ b/traigent/cloud/benchmark_client.py
@@ -10,9 +10,10 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 from urllib import error, request
+from urllib.parse import quote
 
 from traigent.config.backend_config import BackendConfig
-from traigent.config.project import read_optional_project_env, scope_api_path
+from traigent.config.project import read_optional_project_env
 from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.utils.exceptions import (
@@ -32,7 +33,6 @@ class BenchmarkClientConfig:
         default_factory=lambda: read_optional_env(TENANT_ENV_VAR)
     )
     project_id: str | None = field(default_factory=read_optional_project_env)
-    api_path: str = "/api/v1"
     request_timeout: float = 120.0  # generation can be slow
 
     def __post_init__(self) -> None:
@@ -43,7 +43,21 @@ class BenchmarkClientConfig:
         self.project_id = (
             self.project_id.strip() or None if self.project_id is not None else None
         )
-        self.api_path = scope_api_path(self.api_path, self.project_id)
+
+    def generate_path(self) -> str:
+        """Origin-relative path for benchmark generation.
+
+        When a project is active, generation is attributed to it via the
+        project-scoped route. The ``/datasets/generate`` alias is NOT
+        project-scoped on the backend; the project-scoped generate route lives
+        under ``benchmarks`` (``POST /api/v1beta/projects/{id}/benchmarks/generate``),
+        registered via ``_register_project_scoped(benchmark_bp, "benchmarks")``.
+        With no project set, the unscoped alias is used unchanged.
+        """
+        if self.project_id:
+            project_segment = quote(self.project_id, safe="")
+            return f"/api/v1beta/projects/{project_segment}/benchmarks/generate"
+        return "/api/v1/datasets/generate"
 
     def build_headers(self) -> dict[str, str]:
         headers = {
@@ -127,7 +141,7 @@ class BenchmarkClient:
         if seed_examples:
             payload["seed_examples"] = seed_examples
 
-        response = self._post("/datasets/generate", payload)
+        response = self._post(self.config.generate_path(), payload)
         return self._response_to_dataset(response, description)
 
     # ------------------------------------------------------------------
@@ -135,7 +149,7 @@ class BenchmarkClient:
     # ------------------------------------------------------------------
 
     def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
-        full_url = f"{self.config.backend_origin}{self.config.api_path}{path}"
+        full_url = f"{self.config.backend_origin}{path}"
         encoded = json.dumps(payload).encode("utf-8")
         http_req = request.Request(
             full_url,


### PR DESCRIPTION
Closes #1066. `BenchmarkClient` read `TRAIGENT_PROJECT_ID` but never applied it: it used the bare `/api/v1` root, which `scope_api_path` leaves unrewritten (its branches require a trailing-slash `/api/v1/` or `/api/v1beta`). So `generate_sync` posted to the **unscoped** `/api/v1/datasets/generate` — the benchmark was not attributed to the active project (a tenancy / data-isolation gap for multi-project tenants).

## BE confirmation (the issue's required step 1)
Verified against **TraigentBackend `develop`**:
- `src/routes/api_v1beta.py` registers project-scoped routes via `_register_project_scoped(parent, bp, name)` → `/api/v1beta/projects/<project_id>{bp.url_prefix}`.
- `benchmark_bp` (url_prefix `/benchmarks`) **is** in that list → `POST /api/v1beta/projects/{id}/benchmarks/generate` exists, with `<project_id>` as a path param.
- The `dataset_bp` (`/datasets`, the alias the SDK was hitting) is **not** project-scoped → a naive rewrite of `/datasets/generate` would **404**. So the fix targets the `benchmarks` project route, not `datasets`.

## Fix
- `BenchmarkClientConfig.generate_path()` returns:
  - **project set** → `/api/v1beta/projects/{quote(id)}/benchmarks/generate`
  - **no project** → `/api/v1/datasets/generate` (unchanged)
- `generate_sync` uses it; `_post` builds an origin-relative URL. Removed the now-redundant `api_path` field + the no-op `scope_api_path` call. `scope_api_path` itself is untouched (its other clients are unaffected).

## Verification
- `pytest tests/unit/cloud/test_benchmark_client_project_scope.py` → **5 passed**: `generate_path` scoped / unset / URL-encoded, and end-to-end captured outbound request URL for both project-set and unset.
- Broader sweep (`-k "scope_api_path or benchmark"`) → 54 passed, no regression. pre-commit (black/isort/ruff/mypy/bandit/detect-secrets/public-test-assertion) all pass.

## Notes
- JS SDK is out of scope (per #1066: `@traigent/sdk` `BenchmarkClient.generate` is a no-op stub that throws — no HTTP call).
- #1068 (offline-mode egress) touches the same `benchmark_client.py` but a different method (`_post` guard); if it lands first, this branch rebases cleanly (my test sets `TRAIGENT_OFFLINE_MODE=false` defensively).

## PR checklist (tenancy / policy surface)
1. **Worst-case prod path** — before: benchmarks silently attributed to the wrong/no project (cross-project data-isolation gap). After: generation is path-scoped to the active project; unset path unchanged. No fail-open.
2. **Production-branch test** — `test_generate_sync_targets_project_scoped_route` asserts the exact project-scoped URL; `test_generate_sync_unscoped_route_when_no_project` pins the unchanged unset path.
3. **Contract regeneration** — none; uses an existing BE route. JS parity N/A (JS is a stub).
4. **Public surface delta** — `BenchmarkClientConfig` drops the internal `api_path` field and gains `generate_path()`; no client method signature change.
5. **Review threads** — none yet; will resolve all before merge.
6. **Quality gates not relaxed** — none touched; all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)