### PR TITLE
config_generator: evidence-backed structural TVar recommendations (internal MVP)

### DIFF
--- a/tests/unit/config_generator/test_presets/test_range_presets.py
+++ b/tests/unit/config_generator/test_presets/test_range_presets.py
@@ -38,11 +38,43 @@ class TestGetPresetRange:
         assert preset is not None
         assert preset["range_type"] == "IntRange"
 
+    def test_retrieval_k(self) -> None:
+        preset = get_preset_range("retrieval_k")
+        assert preset is not None
+        assert preset["range_type"] == "IntRange"
+        assert preset["kwargs"] == {"low": 1, "high": 5}
+
     def test_prompting_strategy(self) -> None:
         preset = get_preset_range("prompting_strategy")
         assert preset is not None
         assert preset["range_type"] == "Choices"
         assert "direct" in preset["kwargs"]["values"]
+
+    def test_structural_recommendation_presets(self) -> None:
+        schema = get_preset_range("schema_context")
+        assert schema is not None
+        assert schema["range_type"] == "Choices"
+        assert schema["kwargs"]["values"] == [
+            "none",
+            "full_ddl_fk",
+            "linked_top6",
+            "linked_top10",
+        ]
+
+        fewshot = get_preset_range("fewshot_k")
+        assert fewshot is not None
+        assert fewshot["range_type"] == "IntRange"
+        assert fewshot["kwargs"]["low"] == 0
+        assert fewshot["kwargs"]["high"] == 10
+
+        candidates = get_preset_range("candidate_count")
+        assert candidates is not None
+        assert candidates["range_type"] == "IntRange"
+        assert candidates["kwargs"] == {"low": 1, "high": 3}
+
+    def test_retriever_reranker_aliases(self) -> None:
+        assert get_preset_range("retriever") == get_preset_range("retriever_type")
+        assert get_preset_range("reranker") == get_preset_range("reranker_model")
 
     def test_unknown_returns_none(self) -> None:
         assert get_preset_range("unknown_variable") is None
@@ -59,9 +91,11 @@ class TestGetPresetRange:
             "chunk_overlap_ratio",
             "max_tokens",
             "k",
+            "retrieval_k",
             "chunk_size",
             "chunk_overlap",
             "few_shot_count",
+            "fewshot_k",
             "batch_size",
             "n",
             "seed",
@@ -69,8 +103,16 @@ class TestGetPresetRange:
             "model",
             "prompting_strategy",
             "context_format",
+            "schema_context",
+            "evidence_usage",
+            "fewshot_selector",
+            "generation_path",
+            "candidate_count",
+            "repair_policy",
+            "retriever",
             "retriever_type",
             "embedding_model",
+            "reranker",
             "reranker_model",
         ],
     )
@@ -86,6 +128,8 @@ class TestHasPreset:
     def test_known(self) -> None:
         assert has_preset("temperature") is True
         assert has_preset("model") is True
+        assert has_preset("retriever") is True
+        assert has_preset("reranker") is True
 
     def test_unknown(self) -> None:
         assert has_preset("nonexistent") is False

--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from contextlib import redirect_stdout
+from io import StringIO
 from unittest.mock import MagicMock
 
 from traigent.config_generator.agent_classifier import ClassificationResult
@@ -10,7 +12,20 @@ from traigent.config_generator.llm_backend import BudgetExhausted
 from traigent.config_generator.subsystems.tvar_recommendations import (
     generate_recommendations,
 )
-from traigent.config_generator.types import TVarSpec
+from traigent.config_generator.types import AutoConfigResult, TVarSpec
+
+_READY_MADE_RECS = {
+    "schema_context",
+    "evidence_usage",
+    "retrieval_k",
+    "fewshot_selector",
+    "generation_path",
+    "fewshot_k",
+    "candidate_count",
+    "repair_policy",
+}
+
+_CODE_GEN_STRUCTURAL_RECS = _READY_MADE_RECS - {"retrieval_k"}
 
 
 def _make_tvar(name: str) -> TVarSpec:
@@ -26,13 +41,16 @@ class TestGenerateRecommendations:
         names = {r.name for r in recs}
         assert "prompting_strategy" in names
 
-    def test_rag_agent_recommends_retriever_type(self) -> None:
+    def test_rag_agent_recommends_retriever(self) -> None:
         classification = ClassificationResult(
             agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
         )
         recs = generate_recommendations([], classification=classification)
         names = {r.name for r in recs}
-        assert "retriever_type" in names
+        assert "retriever" in names
+        assert "retriever_type" not in names
+        assert "reranker" in names
+        assert "reranker_model" not in names
 
     def test_existing_tvars_are_excluded(self) -> None:
         classification = ClassificationResult(
@@ -100,6 +118,126 @@ class TestGenerateRecommendations:
         recs = generate_recommendations([], classification=classification)
         names = [r.name for r in recs]
         assert len(names) == len(set(names))
+
+    def test_ready_made_structural_recommendations_present(self) -> None:
+        rag_classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        code_gen_classification = ClassificationResult(
+            agent_type="code_gen", confidence=0.9, source="heuristic", reasoning="test"
+        )
+
+        rag_recs = generate_recommendations([], classification=rag_classification)
+        code_gen_recs = generate_recommendations(
+            [], classification=code_gen_classification
+        )
+        recs_by_name = {r.name: r for r in [*rag_recs, *code_gen_recs]}
+
+        assert _READY_MADE_RECS <= set(recs_by_name)
+        for name in _READY_MADE_RECS:
+            rec = recs_by_name[name]
+            assert rec.evidence_refs, f"{name} missing evidence"
+            assert rec.apply_guidance.strip(), f"{name} missing guidance"
+            assert rec.range_type in ("Range", "IntRange", "LogRange", "Choices")
+
+    def test_sql_recommendations_are_under_code_gen(self) -> None:
+        rag_classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        code_gen_classification = ClassificationResult(
+            agent_type="code_gen", confidence=0.9, source="heuristic", reasoning="test"
+        )
+
+        rag_names = {
+            r.name for r in generate_recommendations([], classification=rag_classification)
+        }
+        code_gen_names = {
+            r.name
+            for r in generate_recommendations([], classification=code_gen_classification)
+        }
+
+        assert "retrieval_k" in rag_names
+        assert _CODE_GEN_STRUCTURAL_RECS <= code_gen_names
+        assert _CODE_GEN_STRUCTURAL_RECS.isdisjoint(rag_names)
+
+    def test_ready_made_evidence_details(self) -> None:
+        rag_classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        code_gen_classification = ClassificationResult(
+            agent_type="code_gen", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        recs = [
+            *generate_recommendations([], classification=rag_classification),
+            *generate_recommendations([], classification=code_gen_classification),
+        ]
+        recs_by_name = {r.name: r for r in recs}
+
+        schema_context = recs_by_name["schema_context"]
+        assert len(schema_context.evidence_refs) == 2
+        assert schema_context.evidence_refs[0].artifact_path == (
+            "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/"
+            "isolation/schema_context.json"
+        )
+        assert schema_context.evidence_refs[0].delta == 0.40
+        assert schema_context.evidence_refs[1].candidate == "full_ddl_fk"
+        assert schema_context.impact_estimate == "high"
+
+        retrieval_k = recs_by_name["retrieval_k"]
+        assert retrieval_k.evidence_refs[0].artifact_path == (
+            "TraigentDemo/examples/use-cases/hotpotqa-rag-optimizer/artifacts/"
+            "isolation/retrieval_k.json"
+        )
+        assert retrieval_k.evidence_refs[0].metric == "answer_em"
+        assert retrieval_k.evidence_refs[0].baseline == 1
+        assert retrieval_k.evidence_refs[0].candidate == 5
+        assert retrieval_k.impact_estimate == "medium"
+
+        fewshot_selector = recs_by_name["fewshot_selector"]
+        assert fewshot_selector.evidence_refs[0].limitations == (
+            "observational_not_causal",
+        )
+        assert fewshot_selector.impact_estimate == "medium"
+
+        generation_path = recs_by_name["generation_path"]
+        assert len(generation_path.evidence_refs) == 2
+        assert all(ref.delta == 0.0 for ref in generation_path.evidence_refs)
+        assert all(
+            ref.limitations == ("low_or_zero_in_isolation", "gains_are_joint")
+            for ref in generation_path.evidence_refs
+        )
+        assert generation_path.impact_estimate == "low"
+
+
+class TestCLIJsonRecommendationStability:
+    def test_recommendation_keys_unchanged(self) -> None:
+        from traigent.cli.generate_config_command import _output_json
+
+        classification = ClassificationResult(
+            agent_type="code_gen", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        rec = next(
+            r
+            for r in generate_recommendations([], classification=classification)
+            if r.name == "schema_context"
+        )
+        assert rec.evidence_refs
+        assert rec.apply_guidance
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            _output_json(AutoConfigResult(recommendations=(rec,)))
+
+        data = json.loads(buf.getvalue())
+        assert set(data["recommendations"][0]) == {
+            "name",
+            "range_code",
+            "category",
+            "impact",
+            "reasoning",
+        }
+        assert "evidence_refs" not in data["recommendations"][0]
+        assert "apply_guidance" not in data["recommendations"][0]
 
 
 class TestLLMEnrichment:

--- a/tests/unit/config_generator/test_types.py
+++ b/tests/unit/config_generator/test_types.py
@@ -7,6 +7,7 @@ import pytest
 from traigent.config_generator.types import (
     AutoConfigResult,
     BenchmarkSpec,
+    EvidenceRef,
     ObjectiveSpec,
     SafetySpec,
     StructuralConstraintSpec,
@@ -112,6 +113,36 @@ class TestStructuralConstraintSpec:
         assert sc.source == "template"
 
 
+class TestEvidenceRef:
+    def test_creation_defaults(self) -> None:
+        ref = EvidenceRef(
+            artifact_path="artifacts/isolation/schema_context.json",
+            run_id="run-1",
+            scope="isolation",
+            metric="execution_accuracy",
+            n=10,
+            model="bedrock/us.anthropic.claude-haiku-4-5",
+            baseline="none",
+            candidate="linked_top6",
+        )
+        assert ref.delta is None
+        assert ref.limitations == ()
+
+    def test_frozen(self) -> None:
+        ref = EvidenceRef(
+            artifact_path="artifacts/isolation/schema_context.json",
+            run_id="run-1",
+            scope="isolation",
+            metric="execution_accuracy",
+            n=10,
+            model="model",
+            baseline="none",
+            candidate="linked_top6",
+        )
+        with pytest.raises(AttributeError):
+            ref.metric = "other"  # type: ignore[misc]
+
+
 class TestTVarRecommendation:
     def test_to_range_code(self) -> None:
         rec = TVarRecommendation(
@@ -128,6 +159,31 @@ class TestTVarRecommendation:
         rec = TVarRecommendation(name="x", range_type="Range")
         assert rec.impact_estimate == "medium"
         assert rec.category == ""
+        assert rec.entry_id == ""
+        assert rec.evidence_refs == ()
+        assert rec.apply_guidance == ""
+
+    def test_with_evidence_and_guidance(self) -> None:
+        ref = EvidenceRef(
+            artifact_path="artifacts/isolation/schema_context.json",
+            run_id="run-1",
+            scope="isolation",
+            metric="execution_accuracy",
+            n=10,
+            model="model",
+            baseline="none",
+            candidate="linked_top6",
+            delta=0.4,
+            limitations=("single_slice", "not_sota"),
+        )
+        rec = TVarRecommendation(
+            name="schema_context",
+            range_type="Choices",
+            evidence_refs=(ref,),
+            apply_guidance="Manual wiring required.",
+        )
+        assert rec.evidence_refs == (ref,)
+        assert rec.apply_guidance == "Manual wiring required."
 
 
 class TestAutoConfigResult:

--- a/traigent/config_generator/presets/range_presets.py
+++ b/traigent/config_generator/presets/range_presets.py
@@ -79,6 +79,10 @@ _CANONICAL_PRESETS: dict[str, dict[str, Any]] = {
         "range_type": "IntRange",
         "kwargs": {"low": 1, "high": 10},
     },
+    "retrieval_k": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 1, "high": 5},
+    },
     "chunk_size": {
         "range_type": "IntRange",
         "kwargs": {"low": 100, "high": 1000},
@@ -90,6 +94,10 @@ _CANONICAL_PRESETS: dict[str, dict[str, Any]] = {
     "few_shot_count": {
         "range_type": "IntRange",
         "kwargs": {"low": 0, "high": 10},
+    },
+    "fewshot_k": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 0, "high": 10, "default": 3},
     },
     "batch_size": {
         "range_type": "IntRange",
@@ -126,6 +134,50 @@ _CANONICAL_PRESETS: dict[str, dict[str, Any]] = {
             "values": ["bullet", "numbered", "xml", "markdown", "json"],
         },
     },
+    "schema_context": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["none", "full_ddl_fk", "linked_top6", "linked_top10"],
+        },
+    },
+    "evidence_usage": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["off", "hint_appended"],
+        },
+    },
+    "fewshot_selector": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["random", "masked_question_similarity", "dail_selection"],
+        },
+    },
+    "generation_path": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["direct_dail", "query_plan_cot", "divide_conquer_cot"],
+        },
+    },
+    "candidate_count": {
+        "range_type": "IntRange",
+        "kwargs": {"low": 1, "high": 3},
+    },
+    "repair_policy": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": [
+                "off",
+                "sqlite_error_once",
+                "sqlite_error_or_empty_once",
+            ],
+        },
+    },
+    "retriever": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": ["similarity", "mmr", "bm25", "hybrid"],
+        },
+    },
     "retriever_type": {
         "range_type": "Choices",
         "kwargs": {
@@ -139,6 +191,17 @@ _CANONICAL_PRESETS: dict[str, dict[str, Any]] = {
                 "text-embedding-3-small",
                 "text-embedding-3-large",
                 "text-embedding-ada-002",
+            ],
+        },
+    },
+    "reranker": {
+        "range_type": "Choices",
+        "kwargs": {
+            "values": [
+                "none",
+                "cohere-rerank-v3",
+                "cross-encoder/ms-marco-MiniLM-L-6-v2",
+                "llm-rerank",
             ],
         },
     },

--- a/traigent/config_generator/subsystems/tvar_recommendations.py
+++ b/traigent/config_generator/subsystems/tvar_recommendations.py
@@ -6,10 +6,12 @@ based on agent type and what TVARs are already detected.
 
 from __future__ import annotations
 
+from typing import Any
+
 from traigent.config_generator.agent_classifier import ClassificationResult
 from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
 from traigent.config_generator.presets.range_presets import get_preset_range
-from traigent.config_generator.types import TVarRecommendation, TVarSpec
+from traigent.config_generator.types import EvidenceRef, TVarRecommendation, TVarSpec
 from traigent.utils.llm_response_parsing import extract_json_array_text
 
 
@@ -56,7 +58,25 @@ def generate_recommendations(
 # Preset recommendation catalog
 # ---------------------------------------------------------------------------
 
-_RECOMMENDATIONS: dict[str, list[dict[str, str]]] = {
+_DEMO_MODEL = "bedrock/us.anthropic.claude-haiku-4-5"
+_BIRD_ISOLATION = (
+    "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation"
+)
+_TEXT2SQL_ISOLATION = (
+    "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation"
+)
+_TEXT2SQL_SIGNIFICANCE = (
+    "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/significance"
+)
+_HOTPOTQA_ISOLATION = (
+    "TraigentDemo/examples/use-cases/hotpotqa-rag-optimizer/artifacts/isolation"
+)
+_SINGLE_SLICE_LIMITATIONS = ("single_slice", "not_sota")
+_LOW_JOINT_LIMITATIONS = ("low_or_zero_in_isolation", "gains_are_joint")
+_OBSERVATIONAL_LIMITATIONS = ("observational_not_causal",)
+
+
+_RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
     "rag": [
         {
             "name": "prompting_strategy",
@@ -65,10 +85,38 @@ _RECOMMENDATIONS: dict[str, list[dict[str, str]]] = {
             "impact": "high",
         },
         {
-            "name": "retriever_type",
+            "name": "retriever",
             "category": "retrieval",
             "reasoning": "Different retrieval methods (similarity, MMR, BM25, hybrid) affect answer quality",
             "impact": "high",
+        },
+        {
+            "name": "retrieval_k",
+            "category": "retrieval",
+            "reasoning": "Measured HotpotQA demo isolation showed answer EM improved when retrieving more context, but the slice is small.",
+            "impact": "medium",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_HOTPOTQA_ISOLATION}/retrieval_k.json",
+                    run_id="hotpotqa-rag-300-naive",
+                    scope="isolation",
+                    metric="answer_em",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline=1,
+                    candidate=5,
+                    delta=0.10,
+                    limitations=_SINGLE_SLICE_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, read "
+                "cfg['retrieval_k'] and pass it into your retriever's top-k "
+                "or limit argument for each query. Keep the existing baseline "
+                "value covered and add eval cases across the 1..5 range. "
+                "NOTE: apply_config() only inserts the decorator + imports; "
+                "it does not change retriever calls."
+            ),
         },
         {
             "name": "chunk_size",
@@ -77,7 +125,7 @@ _RECOMMENDATIONS: dict[str, list[dict[str, str]]] = {
             "impact": "medium",
         },
         {
-            "name": "reranker_model",
+            "name": "reranker",
             "category": "retrieval",
             "reasoning": "Reranking retrieved documents can improve answer quality",
             "impact": "medium",
@@ -109,6 +157,257 @@ _RECOMMENDATIONS: dict[str, list[dict[str, str]]] = {
             "category": "prompting",
             "reasoning": "Chain-of-thought and self-consistency improve code generation accuracy",
             "impact": "high",
+        },
+        {
+            "name": "schema_context",
+            "category": "structural",
+            "reasoning": "Measured BIRD and Spider demo isolation runs showed schema context can materially improve SQL execution accuracy.",
+            "impact": "high",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_BIRD_ISOLATION}/schema_context.json",
+                    run_id="bird-minidev-300-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="none",
+                    candidate="linked_top6",
+                    delta=0.40,
+                    limitations=_SINGLE_SLICE_LIMITATIONS,
+                ),
+                EvidenceRef(
+                    artifact_path=f"{_TEXT2SQL_ISOLATION}/schema_context.json",
+                    run_id="text2sql-spider-200-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="none",
+                    candidate="full_ddl_fk",
+                    delta=0.30,
+                    limitations=_SINGLE_SLICE_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, branch "
+                "on cfg['schema_context']: 'none' sends no schema; "
+                "'full_ddl_fk' injects full DDL+FK text; "
+                "'linked_top6'/'linked_top10' inject the top-k schema-linked "
+                "lines. Add eval coverage for the baseline and each branch. "
+                "NOTE: apply_config() only inserts the @traigent.optimize "
+                "decorator + imports; it does NOT wire this runtime branch - "
+                "you do."
+            ),
+        },
+        {
+            "name": "evidence_usage",
+            "category": "structural",
+            "reasoning": "Measured BIRD demo isolation showed appended evidence hints can improve execution accuracy on a small slice.",
+            "impact": "medium",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_BIRD_ISOLATION}/evidence_usage.json",
+                    run_id="bird-minidev-300-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="off",
+                    candidate="hint_appended",
+                    delta=0.10,
+                    limitations=_SINGLE_SLICE_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, branch "
+                "on cfg['evidence_usage']: 'off' leaves the prompt unchanged; "
+                "'hint_appended' appends retrieved schema or value evidence as "
+                "a hint section before generation. Add eval coverage for off "
+                "and hint_appended. NOTE: apply_config() only inserts the "
+                "decorator + imports; runtime prompt wiring remains your code."
+            ),
+        },
+        {
+            "name": "fewshot_selector",
+            "category": "prompting",
+            "reasoning": "Spider significance data indicates few-shot selection matters, but this signal is observational rather than causal.",
+            "impact": "medium",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_TEXT2SQL_SIGNIFICANCE}/importance.json",
+                    run_id="text2sql-spider-200-naive",
+                    scope="significance",
+                    metric="importance",
+                    n=200,
+                    model=_DEMO_MODEL,
+                    baseline="observational",
+                    candidate="fewshot_selector",
+                    delta=None,
+                    limitations=_OBSERVATIONAL_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, branch "
+                "on cfg['fewshot_selector']: 'random' samples examples "
+                "uniformly, 'masked_question_similarity' selects nearest "
+                "masked-question examples, and 'dail_selection' uses the DAIL "
+                "selection path. Add eval coverage for each selector because "
+                "this evidence is observational, not causal. NOTE: "
+                "apply_config() only inserts the decorator + imports; selector "
+                "implementation remains your code."
+            ),
+        },
+        {
+            "name": "generation_path",
+            "category": "prompting",
+            "reasoning": "Generation path had low or zero isolated lift in demos, but can contribute when combined with schema, examples, and repair.",
+            "impact": "low",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_BIRD_ISOLATION}/generation_path.json",
+                    run_id="bird-minidev-300-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="direct_dail",
+                    candidate="query_plan_cot",
+                    delta=0.0,
+                    limitations=_LOW_JOINT_LIMITATIONS,
+                ),
+                EvidenceRef(
+                    artifact_path=f"{_TEXT2SQL_ISOLATION}/generation_path.json",
+                    run_id="text2sql-spider-200-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="direct_dail",
+                    candidate="query_plan_cot",
+                    delta=0.0,
+                    limitations=_LOW_JOINT_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, branch "
+                "on cfg['generation_path']: 'direct_dail' uses direct SQL "
+                "generation, 'query_plan_cot' prompts for a plan before SQL, "
+                "and 'divide_conquer_cot' decomposes the question before "
+                "composing SQL. Add eval coverage for each path and interpret "
+                "isolated wins cautiously. NOTE: apply_config() only inserts "
+                "the decorator + imports; generation control flow remains "
+                "your code."
+            ),
+        },
+        {
+            "name": "fewshot_k",
+            "category": "prompting",
+            "reasoning": "Few-shot count had low or zero isolated lift in demos, but can matter jointly with selector and schema context.",
+            "impact": "low",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_BIRD_ISOLATION}/fewshot_k.json",
+                    run_id="bird-minidev-300-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline=0,
+                    candidate=3,
+                    delta=0.0,
+                    limitations=_LOW_JOINT_LIMITATIONS,
+                ),
+                EvidenceRef(
+                    artifact_path=f"{_TEXT2SQL_ISOLATION}/fewshot_k.json",
+                    run_id="text2sql-spider-200-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline=0,
+                    candidate=3,
+                    delta=0.0,
+                    limitations=_LOW_JOINT_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, read "
+                "cfg['fewshot_k'] and use it as the number of few-shot "
+                "examples emitted by whichever selector is active; 0 means no "
+                "examples. Add eval coverage for 0 and the upper range. NOTE: "
+                "apply_config() only inserts the decorator + imports; example "
+                "selection remains your code."
+            ),
+        },
+        {
+            "name": "candidate_count",
+            "category": "generation",
+            "reasoning": "Spider significance data indicates candidate count matters, but this signal is observational rather than causal.",
+            "impact": "low",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_TEXT2SQL_SIGNIFICANCE}/importance.json",
+                    run_id="text2sql-spider-200-naive",
+                    scope="significance",
+                    metric="importance",
+                    n=200,
+                    model=_DEMO_MODEL,
+                    baseline="observational",
+                    candidate="candidate_count",
+                    delta=None,
+                    limitations=_OBSERVATIONAL_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, read "
+                "cfg['candidate_count'] and generate that many candidate SQL "
+                "or program outputs before your selection or execution step; "
+                "1 preserves single-sample behavior. Add eval coverage for "
+                "1..3. NOTE: apply_config() only inserts the decorator + "
+                "imports; multi-candidate generation remains your code."
+            ),
+        },
+        {
+            "name": "repair_policy",
+            "category": "repair",
+            "reasoning": "Repair policy had low or zero isolated lift in demos, but retry behavior can help when combined with candidate generation and schema context.",
+            "impact": "low",
+            "evidence_refs": (
+                EvidenceRef(
+                    artifact_path=f"{_BIRD_ISOLATION}/repair_policy.json",
+                    run_id="bird-minidev-300-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="off",
+                    candidate="sqlite_error_or_empty_once",
+                    delta=0.0,
+                    limitations=_LOW_JOINT_LIMITATIONS,
+                ),
+                EvidenceRef(
+                    artifact_path=f"{_TEXT2SQL_ISOLATION}/repair_policy.json",
+                    run_id="text2sql-spider-200-naive",
+                    scope="isolation",
+                    metric="execution_accuracy",
+                    n=10,
+                    model=_DEMO_MODEL,
+                    baseline="off",
+                    candidate="sqlite_error_or_empty_once",
+                    delta=0.0,
+                    limitations=_LOW_JOINT_LIMITATIONS,
+                ),
+            ),
+            "apply_guidance": (
+                "Manual wiring: after `cfg = traigent.get_config()`, branch "
+                "on cfg['repair_policy']: 'off' returns the first generation, "
+                "'sqlite_error_once' retries once when SQLite reports an "
+                "error, and 'sqlite_error_or_empty_once' retries once on "
+                "error or empty result. Add eval coverage for each policy. "
+                "NOTE: apply_config() only inserts the decorator + imports; "
+                "retry handling remains your code."
+            ),
         },
     ],
     "summarization": [
@@ -175,6 +474,9 @@ def _preset_recommendations(
                 category=tmpl["category"],
                 reasoning=tmpl["reasoning"],
                 impact_estimate=tmpl["impact"],
+                entry_id=tmpl.get("entry_id", ""),
+                evidence_refs=tuple(tmpl.get("evidence_refs", ())),
+                apply_guidance=tmpl.get("apply_guidance", ""),
             )
         )
 

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -72,6 +72,22 @@ class StructuralConstraintSpec:
 
 
 @dataclass(frozen=True)
+class EvidenceRef:
+    """Reference to measured evidence supporting a recommendation."""
+
+    artifact_path: str
+    run_id: str
+    scope: str
+    metric: str
+    n: int
+    model: str
+    baseline: Any
+    candidate: Any
+    delta: float | None = None
+    limitations: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class TVarRecommendation:
     """A recommended additional TVAR the user may not have considered."""
 
@@ -81,6 +97,9 @@ class TVarRecommendation:
     category: str = ""  # "prompting" | "retrieval" | "model" | "evaluation"
     reasoning: str = ""
     impact_estimate: str = "medium"  # "high" | "medium" | "low"
+    entry_id: str = ""
+    evidence_refs: tuple[EvidenceRef, ...] = ()
+    apply_guidance: str = ""
 
     def to_range_code(self) -> str:
         """Generate Python code for the recommended range."""


### PR DESCRIPTION
## Evidence-backed structural TVar recommendations (config_generator, internal MVP)

Make Traigent optimization more seamless for AI agents: give them **ready-made, preset-backed
STRUCTURAL tuned-variable recommendations** (with measured evidence + manual-wiring guidance) so an
agent can extend an existing implementation beyond model + one prompt string. **Additive and
backward-compatible** — reuses the existing `_RECOMMENDATIONS` / `_CANONICAL_PRESETS` / pipeline
(no new package; no `apply_config()` change; CLI JSON shape unchanged).

### Changes
- **`types.py`** — new frozen `EvidenceRef(artifact_path, run_id, scope, metric, n, model, baseline,
  candidate, delta, limitations)`; optional `TVarRecommendation` fields `entry_id`, `evidence_refs`,
  `apply_guidance` (all with defaults → existing constructions unaffected).
- **`subsystems/tvar_recommendations.py`** — 8 preset-backed structural recommendations with **real
  measured `evidence_refs`** from our demo runs and honest impact tiers:
  | knob | agent_type | impact | evidence |
  |---|---|---|---|
  | schema_context | code_gen | high | BIRD +40pp, Spider +30pp |
  | evidence_usage | code_gen | medium | BIRD +10pp |
  | retrieval_k | rag | medium | HotpotQA +10pp |
  | fewshot_selector / candidate_count | code_gen | observational | Spider importance |
  | generation_path / fewshot_k / repair_policy | code_gen | low / task-dependent | ~0 alone (gains are joint) |

  `apply_guidance` is **prose for MANUAL runtime wiring** — `apply_config()` still only inserts the
  `@traigent.optimize` decorator + imports; it does not rewrite runtime branches.
- **`presets/range_presets.py`** — canonical aliases `retriever` / `reranker` (the real range names
  from `parameter_ranges.py`) + structural presets; old `retriever_type`/`reranker_model` kept for
  back-compat.
- text2SQL maps to the existing `code_gen` agent type (no new classifier type).

### Honesty
Impact tiers reflect isolation reality: only schema/evidence/retrieval move alone; most knobs are
task-dependent and the gains are **joint**. Evidence refs cite the real artifact path + run_id +
scope + n; nothing is claimed SOTA or statistically significant.

### Verification
`python3 -m pytest tests/unit/config_generator -n0` → **279 passed**. `generate-config --json`
recommendation keys unchanged (`category, impact, name, range_code, reasoning`).
Note: a local `pytest-xdist` + `asyncio_cooperative` plugin quirk errors under `-n auto` (pre-existing,
unrelated to this change); passes serially.

Targets **develop**.

### PR checklist
1. Worst-case prod path — N/A (offline config-generation helper; not in a request path).
2. Production-branch test — N/A (no policy branch).
3. Contract regeneration — none; additive dataclass fields with defaults; CLI shape unchanged.
4. Public surface delta — internal recommendation enrichment only; `--json` output unchanged (new
   fields not exposed via CLI in this PR).
5. Review threads — none yet; will resolve before merge.
6. Quality gates — none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
