### PR TITLE
feat(config_generator): catalog-backed recommendations + tvar_observation emission

### DIFF
--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -8,6 +8,11 @@ from io import StringIO
 from unittest.mock import MagicMock
 
 from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.catalog import (
+    catalog_entries,
+    entry_to_recommendation,
+    load_catalog,
+)
 from traigent.config_generator.llm_backend import BudgetExhausted
 from traigent.config_generator.subsystems.tvar_recommendations import (
     generate_recommendations,
@@ -26,6 +31,17 @@ _READY_MADE_RECS = {
 }
 
 _CODE_GEN_STRUCTURAL_RECS = _READY_MADE_RECS - {"retrieval_k"}
+
+_CATALOG_ENTRY_KINDS = {
+    "rag.retrieval_k.v1": "cardinality",
+    "code_gen.schema_context.v1": "topology",
+    "code_gen.evidence_usage.v1": "topology",
+    "code_gen.fewshot_selector.v1": "topology",
+    "code_gen.generation_path.v1": "topology",
+    "code_gen.fewshot_k.v1": "cardinality",
+    "code_gen.candidate_count.v1": "cardinality",
+    "code_gen.repair_policy.v1": "topology",
+}
 
 
 def _make_tvar(name: str) -> TVarSpec:
@@ -207,6 +223,95 @@ class TestGenerateRecommendations:
             for ref in generation_path.evidence_refs
         )
         assert generation_path.impact_estimate == "low"
+
+    def test_catalog_backed_recommendation_lists_are_stable(self) -> None:
+        rag_classification = ClassificationResult(
+            agent_type="rag", confidence=0.9, source="heuristic", reasoning="test"
+        )
+        code_gen_classification = ClassificationResult(
+            agent_type="code_gen", confidence=0.9, source="heuristic", reasoning="test"
+        )
+
+        assert [
+            rec.name
+            for rec in generate_recommendations([], classification=rag_classification)
+        ] == [
+            "prompting_strategy",
+            "retriever",
+            "retrieval_k",
+            "chunk_size",
+            "reranker",
+            "context_format",
+        ]
+        assert [
+            rec.name
+            for rec in generate_recommendations(
+                [], classification=code_gen_classification
+            )
+        ] == [
+            "prompting_strategy",
+            "schema_context",
+            "evidence_usage",
+            "fewshot_selector",
+            "generation_path",
+            "fewshot_k",
+            "candidate_count",
+            "repair_policy",
+        ]
+
+
+class TestTVarCatalog:
+    def test_catalog_loads_and_validates_all_ready_made_entries(self) -> None:
+        entries = load_catalog()
+
+        assert len(entries) == 8
+        assert {entry["entry_id"] for entry in entries} == set(_CATALOG_ENTRY_KINDS)
+        for entry in entries:
+            assert entry["kind"] == _CATALOG_ENTRY_KINDS[entry["entry_id"]]
+            assert entry["effectuation_status"] == "manual_guidance"
+            assert entry["status"] == "active"
+            assert entry["schema_version"] == "1.0.0"
+            assert entry["version"] == "1.0.0"
+            assert entry["evidence_refs"]
+            assert entry["apply_guidance"].strip()
+
+    def test_catalog_filters_by_agent_type(self) -> None:
+        assert [entry["entry_id"] for entry in catalog_entries("rag")] == [
+            "rag.retrieval_k.v1"
+        ]
+        assert {entry["entry_id"] for entry in catalog_entries("code_gen")} == (
+            set(_CATALOG_ENTRY_KINDS) - {"rag.retrieval_k.v1"}
+        )
+
+    def test_entry_to_recommendation_round_trips_catalog_fields(self) -> None:
+        entry = next(
+            entry
+            for entry in load_catalog()
+            if entry["entry_id"] == "code_gen.schema_context.v1"
+        )
+
+        rec = entry_to_recommendation(entry)
+
+        assert rec.entry_id == entry["entry_id"]
+        assert rec.name == entry["name"]
+        assert rec.category == entry["category"]
+        assert rec.reasoning == entry["reasoning"]
+        assert rec.impact_estimate == entry["impact_estimate"]
+        assert rec.apply_guidance == entry["apply_guidance"]
+        assert len(rec.evidence_refs) == len(entry["evidence_refs"])
+        assert rec.evidence_refs[0].artifact_path == entry["evidence_refs"][0][
+            "artifact_path"
+        ]
+
+    def test_count_evidence_values_keep_public_types(self) -> None:
+        entry = next(
+            entry for entry in load_catalog() if entry["entry_id"] == "rag.retrieval_k.v1"
+        )
+
+        rec = entry_to_recommendation(entry)
+
+        assert rec.evidence_refs[0].baseline == 1
+        assert rec.evidence_refs[0].candidate == 5
 
 
 class TestCLIJsonRecommendationStability:

--- a/tests/unit/tuned_variables/test_observation.py
+++ b/tests/unit/tuned_variables/test_observation.py
@@ -1,0 +1,89 @@
+"""Tests for privacy-safe TVAR observations."""
+
+from __future__ import annotations
+
+import json
+
+from traigent.tuned_variables.observation import (
+    build_tvar_observation,
+    merge_tvar_observation_metadata,
+)
+
+
+def test_build_tvar_observation_is_schema_valid_and_content_free() -> None:
+    sentinel = "RAW_PROMPT_CANARY_DO_NOT_LEAK"
+
+    observation = build_tvar_observation(
+        session_id="session-1",
+        trial_id="trial-1",
+        config={
+            "schema_context": "full_ddl_fk",
+            "fewshot_k": 3,
+            "raw_prompt": sentinel,
+            "surrounding_context": {"prompt": sentinel},
+        },
+        metrics={"accuracy": 0.91, "latency": 12, "raw_text": sentinel},
+        primary_metric="accuracy",
+        comparability={"scope": "trial", "n": 20},
+        catalog_entry_ids=("code_gen.schema_context.v1", "code_gen.fewshot_k.v1"),
+        agent_type="code_gen",
+        config_space_id="space-1",
+        sdk_version="9.9.9",
+    )
+
+    payload = json.dumps(observation, sort_keys=True)
+    assert observation["privacy"] == {"raw_content_included": False}
+    assert observation["metrics"] == {"accuracy": 0.91, "latency": 12}
+    assert observation["variables"] == [
+        {"name": "schema_context", "value": "full_ddl_fk", "kind": "topology"},
+        {"name": "fewshot_k", "value": 3, "kind": "cardinality"},
+    ]
+    assert sentinel not in payload
+
+
+def test_merge_tvar_observation_metadata_is_non_destructive() -> None:
+    observation = build_tvar_observation(
+        session_id="session-1",
+        trial_id="trial-1",
+        config={"retrieval_k": 5},
+        metrics={"answer_em": 0.4},
+        primary_metric="answer_em",
+        comparability={"scope": "trial", "n": 10},
+        catalog_entry_ids=("rag.retrieval_k.v1",),
+        agent_type="rag",
+        config_space_id="space-1",
+        sdk_version="9.9.9",
+    )
+
+    metadata = {"existing": {"value": 1}}
+    merged = merge_tvar_observation_metadata(metadata, observation)
+
+    assert merged["existing"] == {"value": 1}
+    assert merged["tvar_observation_v1"] == observation
+    assert "tvar_observation_v1" not in metadata
+
+
+def test_privacy_canary_nested_context_never_appears() -> None:
+    sentinel = "EXAMPLE_RESPONSE_SECRET_CANARY"
+
+    observation = build_tvar_observation(
+        session_id="session-2",
+        trial_id="trial-2",
+        config={
+            "candidate_count": 2,
+            "example_context": {"input": sentinel, "output": sentinel},
+            "user_response": sentinel,
+        },
+        metrics={"execution_accuracy": 1.0},
+        primary_metric="execution_accuracy",
+        comparability={"scope": "trial", "n": 1},
+        catalog_entry_ids=("code_gen.candidate_count.v1",),
+        agent_type="code_gen",
+        config_space_id="space-2",
+        sdk_version="9.9.9",
+    )
+
+    assert observation["variables"] == [
+        {"name": "candidate_count", "value": 2, "kind": "cardinality"}
+    ]
+    assert sentinel not in json.dumps(observation, sort_keys=True)

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -973,6 +973,7 @@ class BackendIntegratedClient:
         status: str,
         error_message: str | None = None,
         execution_mode: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> bool | None:
         """Submit trial results via the Traigent session endpoint.
         Delegates to trial_operations module.
@@ -981,8 +982,25 @@ class BackendIntegratedClient:
             True if submission succeeded, False if it failed,
             None if the operation was skipped (e.g. offline mode).
         """
+        if metadata is None:
+            return await self._trial_ops.submit_trial_result_via_session(
+                session_id,
+                trial_id,
+                config,
+                metrics,
+                status,
+                error_message,
+                execution_mode,
+            )
         return await self._trial_ops.submit_trial_result_via_session(
-            session_id, trial_id, config, metrics, status, error_message, execution_mode
+            session_id,
+            trial_id,
+            config,
+            metrics,
+            status,
+            error_message,
+            execution_mode,
+            metadata=metadata,
         )
 
     async def _submit_summary_stats(

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -389,17 +389,18 @@ class TrialOperations:
         clean_metrics: dict[str, Any],
         backend_status: str,
         mode: str,
+        metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Build the trial result data dict."""
+        result_metadata = dict(metadata or {})
+        result_metadata["mode"] = mode
+        result_metadata["sdk_version"] = "2.0.0"
         result_data: dict[str, Any] = {
             "trial_id": trial_id,
             "config": config,
             "metrics": clean_metrics if clean_metrics else {},
             "status": backend_status,
-            "metadata": {
-                "mode": mode,
-                "sdk_version": "2.0.0",
-            },
+            "metadata": result_metadata,
         }
         return result_data
 
@@ -514,6 +515,7 @@ class TrialOperations:
         status: str,
         error_message: str | None = None,
         execution_mode: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> bool | None:
         """Submit trial results via the Traigent session endpoint.
 
@@ -525,6 +527,7 @@ class TrialOperations:
             status: Trial status
             error_message: Optional error message
             execution_mode: Optional execution mode
+            metadata: Optional additional metadata to merge into the result payload
 
         Returns:
             True if submission succeeded, False if it failed,
@@ -567,7 +570,12 @@ class TrialOperations:
 
             # Build result data
             result_data = self._build_trial_result_data(
-                trial_id, config, validated_metrics, backend_status, mode
+                trial_id,
+                config,
+                validated_metrics,
+                backend_status,
+                mode,
+                metadata=metadata,
             )
 
             # Add measures and summary_stats at the top level if present

--- a/traigent/config_generator/catalog.py
+++ b/traigent/config_generator/catalog.py
@@ -1,0 +1,139 @@
+"""Governed TVAR recommendation catalog helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from traigent.config_generator.types import EvidenceRef, TVarRecommendation
+
+_CATALOG_DIR = Path(__file__).resolve().with_name("catalog")
+_CATALOG_PATH = _CATALOG_DIR / "tvar_catalog.v1.json"
+_CATALOG_ENTRY_SCHEMA_PATH = _CATALOG_DIR / "schemas" / "tvar_catalog_entry_schema.json"
+
+_REQUIRED_ENTRY_FIELDS = frozenset(
+    {
+        "entry_id",
+        "schema_version",
+        "name",
+        "range_type",
+        "range_kwargs",
+        "kind",
+        "effectuation_status",
+    }
+)
+_VALID_RANGE_TYPES = frozenset({"Range", "IntRange", "LogRange", "Choices"})
+_VALID_KINDS = frozenset({"value", "cardinality", "topology", "policy"})
+_VALID_EFFECTUATION = frozenset({"executable", "manual_guidance", "advisory"})
+
+
+def load_catalog() -> list[dict[str, Any]]:
+    """Load and validate all governed TVAR catalog entries."""
+    return copy.deepcopy(list(_load_catalog_cached()))
+
+
+def catalog_entries(agent_type: str | None = None) -> list[dict[str, Any]]:
+    """Return catalog entries, optionally filtered by agent type."""
+    entries = load_catalog()
+    if agent_type is None:
+        return entries
+    return [
+        entry
+        for entry in entries
+        if agent_type in {str(value) for value in entry.get("agent_types", [])}
+    ]
+
+
+def entry_to_recommendation(entry: dict[str, Any]) -> TVarRecommendation:
+    """Project a catalog entry back into the public TVarRecommendation shape."""
+    evidence_refs = tuple(
+        EvidenceRef(
+            artifact_path=str(ref["artifact_path"]),
+            run_id=str(ref["run_id"]),
+            scope=str(ref["scope"]),
+            metric=str(ref["metric"]),
+            n=int(ref["n"]),
+            model=str(ref["model"]),
+            baseline=_restore_evidence_value(ref.get("baseline")),
+            candidate=_restore_evidence_value(ref.get("candidate")),
+            delta=ref.get("delta"),
+            limitations=tuple(str(item) for item in ref.get("limitations", ())),
+        )
+        for ref in entry.get("evidence_refs", ())
+    )
+    return TVarRecommendation(
+        name=str(entry["name"]),
+        range_type=str(entry["range_type"]),
+        range_kwargs=dict(entry.get("range_kwargs", {})),
+        category=str(entry.get("category", "")),
+        reasoning=str(entry.get("reasoning", "")),
+        impact_estimate=str(entry.get("impact_estimate", "medium")),
+        entry_id=str(entry.get("entry_id", "")),
+        evidence_refs=evidence_refs,
+        apply_guidance=str(entry.get("apply_guidance", "")),
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_catalog_cached() -> tuple[dict[str, Any], ...]:
+    with _CATALOG_PATH.open(encoding="utf-8") as catalog_file:
+        payload = json.load(catalog_file)
+    if not isinstance(payload, list):
+        raise ValueError("TVAR catalog must be a JSON array of entries")
+
+    schema = _load_catalog_entry_schema()
+    entries: list[dict[str, Any]] = []
+    for index, entry in enumerate(payload):
+        if not isinstance(entry, dict):
+            raise ValueError(f"TVAR catalog entry {index} must be an object")
+        _validate_catalog_entry(entry, schema)
+        entries.append(dict(entry))
+    return tuple(entries)
+
+
+def _load_catalog_entry_schema() -> dict[str, Any]:
+    with _CATALOG_ENTRY_SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+    if not isinstance(schema, dict):
+        raise ValueError("TVAR catalog entry schema must be an object")
+    return schema
+
+
+def _validate_catalog_entry(entry: dict[str, Any], schema: dict[str, Any]) -> None:
+    try:
+        from jsonschema import validate
+        from jsonschema.exceptions import ValidationError
+    except Exception:
+        _minimal_validate_catalog_entry(entry)
+        return
+
+    try:
+        validate(instance=entry, schema=schema)
+    except ValidationError as exc:
+        entry_id = entry.get("entry_id", "<unknown>")
+        raise ValueError(
+            f"Invalid TVAR catalog entry {entry_id}: {exc.message}"
+        ) from exc
+
+
+def _minimal_validate_catalog_entry(entry: dict[str, Any]) -> None:
+    missing = sorted(_REQUIRED_ENTRY_FIELDS - set(entry))
+    if missing:
+        raise ValueError(f"TVAR catalog entry missing fields: {missing}")
+    if entry["range_type"] not in _VALID_RANGE_TYPES:
+        raise ValueError(f"Unsupported range_type: {entry['range_type']}")
+    if entry["kind"] not in _VALID_KINDS:
+        raise ValueError(f"Unsupported kind: {entry['kind']}")
+    if entry["effectuation_status"] not in _VALID_EFFECTUATION:
+        raise ValueError(
+            f"Unsupported effectuation_status: {entry['effectuation_status']}"
+        )
+
+
+def _restore_evidence_value(value: Any) -> Any:
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return value

--- a/traigent/config_generator/catalog/schemas/tvar_catalog_entry_schema.json
+++ b/traigent/config_generator/catalog/schemas/tvar_catalog_entry_schema.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "TVAR Catalog Entry Schema",
+  "description": "Defines a governed catalog entry for a ready-made tuned-variable recommendation.",
+  "version": "1.0.0",
+  "definitions": {
+    "RangeType": {
+      "type": "string",
+      "enum": ["Range", "IntRange", "LogRange", "Choices"],
+      "description": "Supported tuned-variable range constructor."
+    },
+    "CatalogKind": {
+      "type": "string",
+      "enum": ["value", "cardinality", "topology", "policy"],
+      "description": "Kind of recommendation represented by this catalog entry."
+    },
+    "EffectuationStatus": {
+      "type": "string",
+      "enum": ["executable", "manual_guidance", "advisory"],
+      "description": "Whether the recommendation can be applied automatically."
+    },
+    "ImpactEstimate": {
+      "type": "string",
+      "enum": ["high", "medium", "low"],
+      "description": "Qualitative impact estimate from the supporting evidence."
+    },
+    "CatalogStatus": {
+      "type": "string",
+      "enum": ["active", "deprecated", "experimental"],
+      "description": "Lifecycle status for this catalog entry."
+    },
+    "EvidenceRef": {
+      "type": "object",
+      "description": "Reference to supporting aggregate evidence for the recommendation.",
+      "properties": {
+        "artifact_path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024,
+          "description": "Path or URI for the evidence artifact."
+        },
+        "run_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Run identifier that produced the evidence."
+        },
+        "scope": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Evaluation scope covered by the evidence."
+        },
+        "metric": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Metric summarized by this evidence reference."
+        },
+        "n": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of trials, examples, or observations behind the evidence."
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "description": "Model or model family for which the evidence applies."
+        },
+        "baseline": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Baseline configuration or value summarized by the evidence."
+        },
+        "candidate": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Candidate configuration or value summarized by the evidence."
+        },
+        "delta": {
+          "type": ["number", "null"],
+          "description": "Observed candidate-baseline delta for the referenced metric."
+        },
+        "limitations": {
+          "type": "array",
+          "description": "Known limitations of the evidence.",
+          "items": {
+            "type": "string",
+            "maxLength": 512
+          }
+        }
+      },
+      "required": [
+        "artifact_path",
+        "run_id",
+        "scope",
+        "metric",
+        "n",
+        "model",
+        "baseline",
+        "candidate",
+        "delta",
+        "limitations"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "entry_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Stable catalog entry identifier."
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Version of this catalog entry contract."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Human-readable name for the recommendation."
+    },
+    "range_type": {
+      "$ref": "#/definitions/RangeType",
+      "description": "Range constructor used by range_kwargs."
+    },
+    "range_kwargs": {
+      "type": "object",
+      "description": "Keyword arguments for the selected range constructor.",
+      "additionalProperties": true
+    },
+    "kind": {
+      "$ref": "#/definitions/CatalogKind"
+    },
+    "effectuation_status": {
+      "$ref": "#/definitions/EffectuationStatus"
+    },
+    "effectuation_strategy": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "description": "Strategy identifier used when effectuation_status is executable."
+    },
+    "category": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "Catalog category."
+    },
+    "reasoning": {
+      "type": "string",
+      "maxLength": 4096,
+      "description": "Summary of why this recommendation exists."
+    },
+    "impact_estimate": {
+      "$ref": "#/definitions/ImpactEstimate"
+    },
+    "agent_types": {
+      "type": "array",
+      "description": "Agent types for which this recommendation is relevant.",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "description": "Evidence artifacts supporting this recommendation.",
+      "items": {
+        "$ref": "#/definitions/EvidenceRef"
+      }
+    },
+    "apply_guidance": {
+      "type": "string",
+      "maxLength": 4096,
+      "description": "Operational guidance for applying this recommendation."
+    },
+    "status": {
+      "$ref": "#/definitions/CatalogStatus",
+      "default": "active"
+    },
+    "version": {
+      "type": "string",
+      "description": "Catalog entry revision."
+    }
+  },
+  "required": [
+    "entry_id",
+    "schema_version",
+    "name",
+    "range_type",
+    "range_kwargs",
+    "kind",
+    "effectuation_status"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "required": ["effectuation_strategy"]
+      },
+      "then": {
+        "properties": {
+          "effectuation_status": {
+            "const": "executable"
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/traigent/config_generator/catalog/schemas/tvar_observation_schema.json
+++ b/traigent/config_generator/catalog/schemas/tvar_observation_schema.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "TVAR Observation Schema",
+  "description": "Defines a content-free, privacy-safe observation record emitted per optimization trial under tvar_observation_v1 result metadata.",
+  "version": "1.0.0",
+  "definitions": {
+    "VariableKind": {
+      "type": "string",
+      "enum": ["value", "cardinality", "topology", "policy"],
+      "description": "Kind of tuned variable observed in the trial."
+    },
+    "VariableValue": {
+      "description": "Observed tuned-variable value. This field is for compact scalar values only.",
+      "anyOf": [
+        {
+          "type": "string",
+          "maxLength": 512
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "Variable": {
+      "type": "object",
+      "description": "Name/value pair for a tuned variable observed during the trial.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "value": {
+          "$ref": "#/definitions/VariableValue"
+        },
+        "kind": {
+          "$ref": "#/definitions/VariableKind"
+        }
+      },
+      "required": ["name", "value"],
+      "additionalProperties": false
+    },
+    "MetricMap": {
+      "type": "object",
+      "description": "Metric name to numeric value map.",
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
+    "Comparability": {
+      "type": "object",
+      "description": "Scope and count used to compare this trial with other observations.",
+      "properties": {
+        "scope": {
+          "type": "string",
+          "enum": ["opt_mini", "heldout", "isolation", "trial"]
+        },
+        "n": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": ["scope", "n"],
+      "additionalProperties": false
+    },
+    "PolicyEventsSummary": {
+      "type": "object",
+      "description": "Aggregate policy event counts only; no per-input rows or content.",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+      },
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "PromptArtifactRef": {
+      "type": "object",
+      "description": "Hash and optional artifact reference for prompt material. Raw content is not allowed.",
+      "properties": {
+        "hash": {
+          "type": "string",
+          "pattern": "^(sha256:)?[A-Fa-f0-9]{64}$"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1024
+        }
+      },
+      "required": ["hash"],
+      "additionalProperties": false
+    },
+    "Privacy": {
+      "type": "object",
+      "description": "Privacy declaration for the observation payload.",
+      "properties": {
+        "raw_content_included": {
+          "const": false,
+          "description": "This observation contract never permits raw prompts, examples, or completions."
+        }
+      },
+      "required": ["raw_content_included"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Version of this observation contract."
+    },
+    "session_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "trial_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "config_space_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "agent_type": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "catalog_entry_ids": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 256
+      }
+    },
+    "variables": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Variable"
+      }
+    },
+    "metrics": {
+      "$ref": "#/definitions/MetricMap"
+    },
+    "primary_metric": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "comparability": {
+      "$ref": "#/definitions/Comparability"
+    },
+    "policy_events_summary": {
+      "$ref": "#/definitions/PolicyEventsSummary"
+    },
+    "prompt_artifact_refs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PromptArtifactRef"
+      }
+    },
+    "privacy": {
+      "$ref": "#/definitions/Privacy"
+    },
+    "sdk_version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    }
+  },
+  "required": ["schema_version", "session_id", "trial_id", "privacy"],
+  "additionalProperties": false
+}

--- a/traigent/config_generator/catalog/tvar_catalog.v1.json
+++ b/traigent/config_generator/catalog/tvar_catalog.v1.json
@@ -1,0 +1,380 @@
+[
+  {
+    "entry_id": "rag.retrieval_k.v1",
+    "schema_version": "1.0.0",
+    "name": "retrieval_k",
+    "range_type": "IntRange",
+    "range_kwargs": {
+      "low": 1,
+      "high": 5
+    },
+    "kind": "cardinality",
+    "effectuation_status": "manual_guidance",
+    "category": "retrieval",
+    "reasoning": "Measured HotpotQA demo isolation showed answer EM improved when retrieving more context, but the slice is small.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "rag"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/hotpotqa-rag-optimizer/artifacts/isolation/retrieval_k.json",
+        "run_id": "hotpotqa-rag-300-naive",
+        "scope": "isolation",
+        "metric": "answer_em",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "1",
+        "candidate": "5",
+        "delta": 0.1,
+        "limitations": [
+          "single_slice",
+          "not_sota"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, read cfg['retrieval_k'] and pass it into your retriever's top-k or limit argument for each query. Keep the existing baseline value covered and add eval cases across the 1..5 range. NOTE: apply_config() only inserts the decorator + imports; it does not change retriever calls.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.schema_context.v1",
+    "schema_version": "1.0.0",
+    "name": "schema_context",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "none",
+        "full_ddl_fk",
+        "linked_top6",
+        "linked_top10"
+      ]
+    },
+    "kind": "topology",
+    "effectuation_status": "manual_guidance",
+    "category": "structural",
+    "reasoning": "Measured BIRD and Spider demo isolation runs showed schema context can materially improve SQL execution accuracy.",
+    "impact_estimate": "high",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation/schema_context.json",
+        "run_id": "bird-minidev-300-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "none",
+        "candidate": "linked_top6",
+        "delta": 0.4,
+        "limitations": [
+          "single_slice",
+          "not_sota"
+        ]
+      },
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation/schema_context.json",
+        "run_id": "text2sql-spider-200-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "none",
+        "candidate": "full_ddl_fk",
+        "delta": 0.3,
+        "limitations": [
+          "single_slice",
+          "not_sota"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch on cfg['schema_context']: 'none' sends no schema; 'full_ddl_fk' injects full DDL+FK text; 'linked_top6'/'linked_top10' inject the top-k schema-linked lines. Add eval coverage for the baseline and each branch. NOTE: apply_config() only inserts the @traigent.optimize decorator + imports; it does NOT wire this runtime branch - you do.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.evidence_usage.v1",
+    "schema_version": "1.0.0",
+    "name": "evidence_usage",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "off",
+        "hint_appended"
+      ]
+    },
+    "kind": "topology",
+    "effectuation_status": "manual_guidance",
+    "category": "structural",
+    "reasoning": "Measured BIRD demo isolation showed appended evidence hints can improve execution accuracy on a small slice.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation/evidence_usage.json",
+        "run_id": "bird-minidev-300-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "off",
+        "candidate": "hint_appended",
+        "delta": 0.1,
+        "limitations": [
+          "single_slice",
+          "not_sota"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch on cfg['evidence_usage']: 'off' leaves the prompt unchanged; 'hint_appended' appends retrieved schema or value evidence as a hint section before generation. Add eval coverage for off and hint_appended. NOTE: apply_config() only inserts the decorator + imports; runtime prompt wiring remains your code.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.fewshot_selector.v1",
+    "schema_version": "1.0.0",
+    "name": "fewshot_selector",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "random",
+        "masked_question_similarity",
+        "dail_selection"
+      ]
+    },
+    "kind": "topology",
+    "effectuation_status": "manual_guidance",
+    "category": "prompting",
+    "reasoning": "Spider significance data indicates few-shot selection matters, but this signal is observational rather than causal.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/significance/importance.json",
+        "run_id": "text2sql-spider-200-naive",
+        "scope": "significance",
+        "metric": "importance",
+        "n": 200,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "observational",
+        "candidate": "fewshot_selector",
+        "delta": null,
+        "limitations": [
+          "observational_not_causal"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch on cfg['fewshot_selector']: 'random' samples examples uniformly, 'masked_question_similarity' selects nearest masked-question examples, and 'dail_selection' uses the DAIL selection path. Add eval coverage for each selector because this evidence is observational, not causal. NOTE: apply_config() only inserts the decorator + imports; selector implementation remains your code.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.generation_path.v1",
+    "schema_version": "1.0.0",
+    "name": "generation_path",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "direct_dail",
+        "query_plan_cot",
+        "divide_conquer_cot"
+      ]
+    },
+    "kind": "topology",
+    "effectuation_status": "manual_guidance",
+    "category": "prompting",
+    "reasoning": "Generation path had low or zero isolated lift in demos, but can contribute when combined with schema, examples, and repair.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation/generation_path.json",
+        "run_id": "bird-minidev-300-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "direct_dail",
+        "candidate": "query_plan_cot",
+        "delta": 0.0,
+        "limitations": [
+          "low_or_zero_in_isolation",
+          "gains_are_joint"
+        ]
+      },
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation/generation_path.json",
+        "run_id": "text2sql-spider-200-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "direct_dail",
+        "candidate": "query_plan_cot",
+        "delta": 0.0,
+        "limitations": [
+          "low_or_zero_in_isolation",
+          "gains_are_joint"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch on cfg['generation_path']: 'direct_dail' uses direct SQL generation, 'query_plan_cot' prompts for a plan before SQL, and 'divide_conquer_cot' decomposes the question before composing SQL. Add eval coverage for each path and interpret isolated wins cautiously. NOTE: apply_config() only inserts the decorator + imports; generation control flow remains your code.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.fewshot_k.v1",
+    "schema_version": "1.0.0",
+    "name": "fewshot_k",
+    "range_type": "IntRange",
+    "range_kwargs": {
+      "low": 0,
+      "high": 10,
+      "default": 3
+    },
+    "kind": "cardinality",
+    "effectuation_status": "manual_guidance",
+    "category": "prompting",
+    "reasoning": "Few-shot count had low or zero isolated lift in demos, but can matter jointly with selector and schema context.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation/fewshot_k.json",
+        "run_id": "bird-minidev-300-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "0",
+        "candidate": "3",
+        "delta": 0.0,
+        "limitations": [
+          "low_or_zero_in_isolation",
+          "gains_are_joint"
+        ]
+      },
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation/fewshot_k.json",
+        "run_id": "text2sql-spider-200-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "0",
+        "candidate": "3",
+        "delta": 0.0,
+        "limitations": [
+          "low_or_zero_in_isolation",
+          "gains_are_joint"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, read cfg['fewshot_k'] and use it as the number of few-shot examples emitted by whichever selector is active; 0 means no examples. Add eval coverage for 0 and the upper range. NOTE: apply_config() only inserts the decorator + imports; example selection remains your code.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.candidate_count.v1",
+    "schema_version": "1.0.0",
+    "name": "candidate_count",
+    "range_type": "IntRange",
+    "range_kwargs": {
+      "low": 1,
+      "high": 3
+    },
+    "kind": "cardinality",
+    "effectuation_status": "manual_guidance",
+    "category": "generation",
+    "reasoning": "Spider significance data indicates candidate count matters, but this signal is observational rather than causal.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/significance/importance.json",
+        "run_id": "text2sql-spider-200-naive",
+        "scope": "significance",
+        "metric": "importance",
+        "n": 200,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "observational",
+        "candidate": "candidate_count",
+        "delta": null,
+        "limitations": [
+          "observational_not_causal"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, read cfg['candidate_count'] and generate that many candidate SQL or program outputs before your selection or execution step; 1 preserves single-sample behavior. Add eval coverage for 1..3. NOTE: apply_config() only inserts the decorator + imports; multi-candidate generation remains your code.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.repair_policy.v1",
+    "schema_version": "1.0.0",
+    "name": "repair_policy",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "off",
+        "sqlite_error_once",
+        "sqlite_error_or_empty_once"
+      ]
+    },
+    "kind": "topology",
+    "effectuation_status": "manual_guidance",
+    "category": "repair",
+    "reasoning": "Repair policy had low or zero isolated lift in demos, but retry behavior can help when combined with candidate generation and schema context.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation/repair_policy.json",
+        "run_id": "bird-minidev-300-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "off",
+        "candidate": "sqlite_error_or_empty_once",
+        "delta": 0.0,
+        "limitations": [
+          "low_or_zero_in_isolation",
+          "gains_are_joint"
+        ]
+      },
+      {
+        "artifact_path": "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation/repair_policy.json",
+        "run_id": "text2sql-spider-200-naive",
+        "scope": "isolation",
+        "metric": "execution_accuracy",
+        "n": 10,
+        "model": "bedrock/us.anthropic.claude-haiku-4-5",
+        "baseline": "off",
+        "candidate": "sqlite_error_or_empty_once",
+        "delta": 0.0,
+        "limitations": [
+          "low_or_zero_in_isolation",
+          "gains_are_joint"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch on cfg['repair_policy']: 'off' returns the first generation, 'sqlite_error_once' retries once when SQLite reports an error, and 'sqlite_error_or_empty_once' retries once on error or empty result. Add eval coverage for each policy. NOTE: apply_config() only inserts the decorator + imports; retry handling remains your code.",
+    "status": "active",
+    "version": "1.0.0"
+  }
+]

--- a/traigent/config_generator/subsystems/tvar_recommendations.py
+++ b/traigent/config_generator/subsystems/tvar_recommendations.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 from typing import Any
 
 from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.catalog import catalog_entries, entry_to_recommendation
 from traigent.config_generator.llm_backend import BudgetExhausted, ConfigGenLLM
 from traigent.config_generator.presets.range_presets import get_preset_range
-from traigent.config_generator.types import EvidenceRef, TVarRecommendation, TVarSpec
+from traigent.config_generator.types import TVarRecommendation, TVarSpec
 from traigent.utils.llm_response_parsing import extract_json_array_text
 
 
@@ -58,25 +59,7 @@ def generate_recommendations(
 # Preset recommendation catalog
 # ---------------------------------------------------------------------------
 
-_DEMO_MODEL = "bedrock/us.anthropic.claude-haiku-4-5"
-_BIRD_ISOLATION = (
-    "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation"
-)
-_TEXT2SQL_ISOLATION = (
-    "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation"
-)
-_TEXT2SQL_SIGNIFICANCE = (
-    "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/significance"
-)
-_HOTPOTQA_ISOLATION = (
-    "TraigentDemo/examples/use-cases/hotpotqa-rag-optimizer/artifacts/isolation"
-)
-_SINGLE_SLICE_LIMITATIONS = ("single_slice", "not_sota")
-_LOW_JOINT_LIMITATIONS = ("low_or_zero_in_isolation", "gains_are_joint")
-_OBSERVATIONAL_LIMITATIONS = ("observational_not_causal",)
-
-
-_RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
+_LEGACY_RECOMMENDATION_TEMPLATES: dict[str, list[dict[str, Any]]] = {
     "rag": [
         {
             "name": "prompting_strategy",
@@ -89,34 +72,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "category": "retrieval",
             "reasoning": "Different retrieval methods (similarity, MMR, BM25, hybrid) affect answer quality",
             "impact": "high",
-        },
-        {
-            "name": "retrieval_k",
-            "category": "retrieval",
-            "reasoning": "Measured HotpotQA demo isolation showed answer EM improved when retrieving more context, but the slice is small.",
-            "impact": "medium",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_HOTPOTQA_ISOLATION}/retrieval_k.json",
-                    run_id="hotpotqa-rag-300-naive",
-                    scope="isolation",
-                    metric="answer_em",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline=1,
-                    candidate=5,
-                    delta=0.10,
-                    limitations=_SINGLE_SLICE_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, read "
-                "cfg['retrieval_k'] and pass it into your retriever's top-k "
-                "or limit argument for each query. Keep the existing baseline "
-                "value covered and add eval cases across the 1..5 range. "
-                "NOTE: apply_config() only inserts the decorator + imports; "
-                "it does not change retriever calls."
-            ),
         },
         {
             "name": "chunk_size",
@@ -158,257 +113,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "reasoning": "Chain-of-thought and self-consistency improve code generation accuracy",
             "impact": "high",
         },
-        {
-            "name": "schema_context",
-            "category": "structural",
-            "reasoning": "Measured BIRD and Spider demo isolation runs showed schema context can materially improve SQL execution accuracy.",
-            "impact": "high",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/schema_context.json",
-                    run_id="bird-minidev-300-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="none",
-                    candidate="linked_top6",
-                    delta=0.40,
-                    limitations=_SINGLE_SLICE_LIMITATIONS,
-                ),
-                EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/schema_context.json",
-                    run_id="text2sql-spider-200-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="none",
-                    candidate="full_ddl_fk",
-                    delta=0.30,
-                    limitations=_SINGLE_SLICE_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, branch "
-                "on cfg['schema_context']: 'none' sends no schema; "
-                "'full_ddl_fk' injects full DDL+FK text; "
-                "'linked_top6'/'linked_top10' inject the top-k schema-linked "
-                "lines. Add eval coverage for the baseline and each branch. "
-                "NOTE: apply_config() only inserts the @traigent.optimize "
-                "decorator + imports; it does NOT wire this runtime branch - "
-                "you do."
-            ),
-        },
-        {
-            "name": "evidence_usage",
-            "category": "structural",
-            "reasoning": "Measured BIRD demo isolation showed appended evidence hints can improve execution accuracy on a small slice.",
-            "impact": "medium",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/evidence_usage.json",
-                    run_id="bird-minidev-300-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="off",
-                    candidate="hint_appended",
-                    delta=0.10,
-                    limitations=_SINGLE_SLICE_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, branch "
-                "on cfg['evidence_usage']: 'off' leaves the prompt unchanged; "
-                "'hint_appended' appends retrieved schema or value evidence as "
-                "a hint section before generation. Add eval coverage for off "
-                "and hint_appended. NOTE: apply_config() only inserts the "
-                "decorator + imports; runtime prompt wiring remains your code."
-            ),
-        },
-        {
-            "name": "fewshot_selector",
-            "category": "prompting",
-            "reasoning": "Spider significance data indicates few-shot selection matters, but this signal is observational rather than causal.",
-            "impact": "medium",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_SIGNIFICANCE}/importance.json",
-                    run_id="text2sql-spider-200-naive",
-                    scope="significance",
-                    metric="importance",
-                    n=200,
-                    model=_DEMO_MODEL,
-                    baseline="observational",
-                    candidate="fewshot_selector",
-                    delta=None,
-                    limitations=_OBSERVATIONAL_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, branch "
-                "on cfg['fewshot_selector']: 'random' samples examples "
-                "uniformly, 'masked_question_similarity' selects nearest "
-                "masked-question examples, and 'dail_selection' uses the DAIL "
-                "selection path. Add eval coverage for each selector because "
-                "this evidence is observational, not causal. NOTE: "
-                "apply_config() only inserts the decorator + imports; selector "
-                "implementation remains your code."
-            ),
-        },
-        {
-            "name": "generation_path",
-            "category": "prompting",
-            "reasoning": "Generation path had low or zero isolated lift in demos, but can contribute when combined with schema, examples, and repair.",
-            "impact": "low",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/generation_path.json",
-                    run_id="bird-minidev-300-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="direct_dail",
-                    candidate="query_plan_cot",
-                    delta=0.0,
-                    limitations=_LOW_JOINT_LIMITATIONS,
-                ),
-                EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/generation_path.json",
-                    run_id="text2sql-spider-200-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="direct_dail",
-                    candidate="query_plan_cot",
-                    delta=0.0,
-                    limitations=_LOW_JOINT_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, branch "
-                "on cfg['generation_path']: 'direct_dail' uses direct SQL "
-                "generation, 'query_plan_cot' prompts for a plan before SQL, "
-                "and 'divide_conquer_cot' decomposes the question before "
-                "composing SQL. Add eval coverage for each path and interpret "
-                "isolated wins cautiously. NOTE: apply_config() only inserts "
-                "the decorator + imports; generation control flow remains "
-                "your code."
-            ),
-        },
-        {
-            "name": "fewshot_k",
-            "category": "prompting",
-            "reasoning": "Few-shot count had low or zero isolated lift in demos, but can matter jointly with selector and schema context.",
-            "impact": "low",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/fewshot_k.json",
-                    run_id="bird-minidev-300-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline=0,
-                    candidate=3,
-                    delta=0.0,
-                    limitations=_LOW_JOINT_LIMITATIONS,
-                ),
-                EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/fewshot_k.json",
-                    run_id="text2sql-spider-200-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline=0,
-                    candidate=3,
-                    delta=0.0,
-                    limitations=_LOW_JOINT_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, read "
-                "cfg['fewshot_k'] and use it as the number of few-shot "
-                "examples emitted by whichever selector is active; 0 means no "
-                "examples. Add eval coverage for 0 and the upper range. NOTE: "
-                "apply_config() only inserts the decorator + imports; example "
-                "selection remains your code."
-            ),
-        },
-        {
-            "name": "candidate_count",
-            "category": "generation",
-            "reasoning": "Spider significance data indicates candidate count matters, but this signal is observational rather than causal.",
-            "impact": "low",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_SIGNIFICANCE}/importance.json",
-                    run_id="text2sql-spider-200-naive",
-                    scope="significance",
-                    metric="importance",
-                    n=200,
-                    model=_DEMO_MODEL,
-                    baseline="observational",
-                    candidate="candidate_count",
-                    delta=None,
-                    limitations=_OBSERVATIONAL_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, read "
-                "cfg['candidate_count'] and generate that many candidate SQL "
-                "or program outputs before your selection or execution step; "
-                "1 preserves single-sample behavior. Add eval coverage for "
-                "1..3. NOTE: apply_config() only inserts the decorator + "
-                "imports; multi-candidate generation remains your code."
-            ),
-        },
-        {
-            "name": "repair_policy",
-            "category": "repair",
-            "reasoning": "Repair policy had low or zero isolated lift in demos, but retry behavior can help when combined with candidate generation and schema context.",
-            "impact": "low",
-            "evidence_refs": (
-                EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/repair_policy.json",
-                    run_id="bird-minidev-300-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="off",
-                    candidate="sqlite_error_or_empty_once",
-                    delta=0.0,
-                    limitations=_LOW_JOINT_LIMITATIONS,
-                ),
-                EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/repair_policy.json",
-                    run_id="text2sql-spider-200-naive",
-                    scope="isolation",
-                    metric="execution_accuracy",
-                    n=10,
-                    model=_DEMO_MODEL,
-                    baseline="off",
-                    candidate="sqlite_error_or_empty_once",
-                    delta=0.0,
-                    limitations=_LOW_JOINT_LIMITATIONS,
-                ),
-            ),
-            "apply_guidance": (
-                "Manual wiring: after `cfg = traigent.get_config()`, branch "
-                "on cfg['repair_policy']: 'off' returns the first generation, "
-                "'sqlite_error_once' retries once when SQLite reports an "
-                "error, and 'sqlite_error_or_empty_once' retries once on "
-                "error or empty result. Add eval coverage for each policy. "
-                "NOTE: apply_config() only inserts the decorator + imports; "
-                "retry handling remains your code."
-            ),
-        },
     ],
     "summarization": [
         {
@@ -448,13 +152,80 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
     ],
 }
 
+_RECOMMENDATION_ORDER: dict[str, tuple[str, ...]] = {
+    "rag": (
+        "prompting_strategy",
+        "retriever",
+        "retrieval_k",
+        "chunk_size",
+        "reranker",
+        "context_format",
+    ),
+    "chat": ("prompting_strategy", "context_format"),
+    "code_gen": (
+        "prompting_strategy",
+        "schema_context",
+        "evidence_usage",
+        "fewshot_selector",
+        "generation_path",
+        "fewshot_k",
+        "candidate_count",
+        "repair_policy",
+    ),
+    "summarization": ("prompting_strategy", "context_format"),
+    "classification": ("few_shot_count", "prompting_strategy"),
+    "general_llm": ("prompting_strategy",),
+}
+
+
+def _catalog_recommendation_templates(agent_type: str) -> list[dict[str, Any]]:
+    templates: list[dict[str, Any]] = []
+    for entry in catalog_entries(agent_type):
+        rec = entry_to_recommendation(entry)
+        templates.append(
+            {
+                "name": rec.name,
+                "category": rec.category,
+                "reasoning": rec.reasoning,
+                "impact": rec.impact_estimate,
+                "entry_id": rec.entry_id,
+                "evidence_refs": rec.evidence_refs,
+                "apply_guidance": rec.apply_guidance,
+            }
+        )
+    return templates
+
+
+def _recommendation_templates(agent_type: str) -> list[dict[str, Any]]:
+    templates = [
+        dict(template)
+        for template in _LEGACY_RECOMMENDATION_TEMPLATES.get(agent_type, ())
+    ]
+    templates.extend(_catalog_recommendation_templates(agent_type))
+
+    order = _RECOMMENDATION_ORDER.get(agent_type, ())
+    if not order:
+        return templates
+
+    order_index = {name: index for index, name in enumerate(order)}
+    return sorted(
+        templates,
+        key=lambda template: order_index.get(str(template.get("name", "")), len(order)),
+    )
+
+
+_RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
+    agent_type: _recommendation_templates(agent_type)
+    for agent_type in _RECOMMENDATION_ORDER
+}
+
 
 def _preset_recommendations(
     agent_type: str,
     existing_names: set[str],
 ) -> list[TVarRecommendation]:
     """Generate recommendations from presets."""
-    templates = _RECOMMENDATIONS.get(agent_type, [])
+    templates = _recommendation_templates(agent_type)
     recs: list[TVarRecommendation] = []
 
     for tmpl in templates:

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -475,6 +475,7 @@ class BackendSessionManager:
             primary_objective,
             self._traigent_config,
             dataset_name,
+            session_id=session_id,
         )
 
         await self._log_trial_to_backend(
@@ -639,6 +640,7 @@ class BackendSessionManager:
                 status=status,
                 error_message=trial_result.error_message,
                 execution_mode=self._traigent_config.execution_mode,
+                metadata=metadata_payload,
             )
             submitted = (
                 await submitted_result

--- a/traigent/core/metadata_helpers.py
+++ b/traigent/core/metadata_helpers.py
@@ -241,12 +241,76 @@ def _add_aggregation_summary(
         logger.debug("Failed to add aggregation summary (trial): %s", exc)
 
 
+def _metadata_string_sequence(metadata: dict[str, Any], key: str) -> tuple[str, ...]:
+    value = metadata.get(key)
+    if not isinstance(value, (list, tuple, set)):
+        return ()
+    return tuple(str(item) for item in value if item)
+
+
+def _observation_comparability(trial_metadata: dict[str, Any]) -> dict[str, Any]:
+    payload = trial_metadata.get("comparability")
+    n = 0
+    if isinstance(payload, dict):
+        for key in ("n", "examples_with_primary_metric", "total_examples"):
+            try:
+                n = int(payload.get(key, 0))
+            except (TypeError, ValueError):
+                n = 0
+            if n:
+                break
+    return {"scope": "trial", "n": max(0, n)}
+
+
+def _add_tvar_observation(
+    trial_metadata: dict[str, Any],
+    trial_result: TrialResult,
+    primary_objective: str,
+    session_id: str | None,
+) -> dict[str, Any]:
+    effective_session_id = session_id or trial_metadata.get("session_id")
+    if not effective_session_id:
+        return trial_metadata
+
+    try:
+        source_metadata = getattr(trial_result, "metadata", {}) or {}
+        if not isinstance(source_metadata, dict):
+            source_metadata = {}
+        from traigent.tuned_variables.observation import (
+            build_tvar_observation,
+            merge_tvar_observation_metadata,
+        )
+
+        observation = build_tvar_observation(
+            session_id=str(effective_session_id),
+            trial_id=str(trial_result.trial_id),
+            config=getattr(trial_result, "config", {}) or {},
+            metrics=trial_result.metrics or {},
+            primary_metric=primary_objective,
+            comparability=_observation_comparability(trial_metadata),
+            catalog_entry_ids=_metadata_string_sequence(
+                source_metadata, "catalog_entry_ids"
+            ),
+            agent_type=source_metadata.get("agent_type"),
+            config_space_id=source_metadata.get("config_space_id"),
+        )
+        return merge_tvar_observation_metadata(trial_metadata, observation)
+    except Exception as exc:
+        logger.debug(
+            "Skipping TVAR observation metadata for trial %s: %s",
+            getattr(trial_result, "trial_id", "<unknown>"),
+            exc,
+        )
+        return trial_metadata
+
+
 def build_backend_metadata(
     trial_result: TrialResult,
     primary_objective: str,
     traigent_config: TraigentConfig,
     dataset_name: str = "dataset",
     content_scores: dict[str, dict[int, float]] | None = None,
+    session_id: str | None = None,
 ) -> dict[str, Any]:
     """Build metadata dictionary for backend trial submission.
 
@@ -264,6 +328,7 @@ def build_backend_metadata(
         dataset_name: Name of the dataset (used for stable example ID generation)
         content_scores: Deprecated and ignored. Content analytics are uploaded
             once per run via the dedicated feature-upload path.
+        session_id: Optional backend session identifier for TVAR observation emission.
 
     Returns:
         Metadata dict ready for backend submission
@@ -314,7 +379,12 @@ def build_backend_metadata(
     if privacy_on and "example_results" in trial_metadata:
         trial_metadata.pop("example_results", None)
 
-    return trial_metadata
+    return _add_tvar_observation(
+        trial_metadata,
+        trial_result,
+        primary_objective,
+        session_id,
+    )
 
 
 def _extract_score_from_metrics(

--- a/traigent/optimizers/interactive_optimizer.py
+++ b/traigent/optimizers/interactive_optimizer.py
@@ -97,6 +97,13 @@ def _is_completed_status(status: TrialStatusLike) -> bool:
     return getattr(status, "value", status) == "completed"
 
 
+def _string_sequence(value: Any) -> tuple[str, ...]:
+    """Return string tuple metadata only from sequence-like values."""
+    if not isinstance(value, (list, tuple, set)):
+        return ()
+    return tuple(str(item) for item in value if item)
+
+
 class RemoteGuidanceService(Protocol):
     """Protocol for remote guidance services."""
 
@@ -323,6 +330,11 @@ class InteractiveOptimizer(BaseOptimizer):
             raise OptimizationError("No active session.")
 
         try:
+            result_metadata = self._metadata_with_tvar_observation(
+                trial_id=trial_id,
+                metrics=metrics,
+                metadata=metadata,
+            )
             result = TrialResultSubmission(
                 session_id=self.session_id,
                 trial_id=trial_id,
@@ -331,7 +343,7 @@ class InteractiveOptimizer(BaseOptimizer):
                 status=_coerce_trial_status(status),
                 outputs_sample=outputs_sample,
                 error_message=error_message,
-                metadata=metadata or {},
+                metadata=result_metadata,
             )
 
             await self.remote_service.submit_result(result)
@@ -472,3 +484,62 @@ class InteractiveOptimizer(BaseOptimizer):
             return current > best
 
         return False
+
+    def _metadata_with_tvar_observation(
+        self,
+        *,
+        trial_id: str,
+        metrics: dict[str, float],
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Attach a content-free TVAR observation when suggestion context exists."""
+        result_metadata = dict(metadata or {})
+        suggestion = self._pending_trials.get(trial_id)
+        if suggestion is None or not self.session_id:
+            return result_metadata
+
+        try:
+            from traigent.tuned_variables.observation import (
+                build_tvar_observation,
+                merge_tvar_observation_metadata,
+            )
+
+            suggestion_metadata = suggestion.metadata or {}
+            session_metadata = self.session.metadata if self.session else {}
+            catalog_entry_ids = _string_sequence(
+                suggestion_metadata.get("catalog_entry_ids")
+                or result_metadata.get("catalog_entry_ids")
+                or session_metadata.get("catalog_entry_ids")
+            )
+            primary_metric = self.objectives[0] if self.objectives else "score"
+            observation = build_tvar_observation(
+                session_id=self.session_id,
+                trial_id=trial_id,
+                config=suggestion.config,
+                metrics=metrics,
+                primary_metric=primary_metric,
+                comparability={
+                    "scope": "trial",
+                    "n": len(suggestion.dataset_subset.indices),
+                },
+                catalog_entry_ids=catalog_entry_ids,
+                agent_type=(
+                    suggestion_metadata.get("agent_type")
+                    or result_metadata.get("agent_type")
+                    or session_metadata.get("agent_type")
+                    or self.dataset_metadata.get("agent_type")
+                ),
+                config_space_id=(
+                    suggestion_metadata.get("config_space_id")
+                    or result_metadata.get("config_space_id")
+                    or session_metadata.get("config_space_id")
+                ),
+            )
+            return merge_tvar_observation_metadata(result_metadata, observation)
+        except Exception as exc:
+            logger.debug(
+                "Skipping TVAR observation metadata for trial %s: %s",
+                trial_id,
+                exc,
+            )
+            return result_metadata

--- a/traigent/tuned_variables/__init__.py
+++ b/traigent/tuned_variables/__init__.py
@@ -30,6 +30,7 @@ from .discovery import (
     discover_callables_by_decorator,
     filter_by_signature,
 )
+from .observation import build_tvar_observation, merge_tvar_observation_metadata
 
 __all__ = [
     # Callable discovery (existing)
@@ -37,6 +38,8 @@ __all__ = [
     "discover_callables",
     "discover_callables_by_decorator",
     "filter_by_signature",
+    "build_tvar_observation",
+    "merge_tvar_observation_metadata",
     # Tuned variable detection (new)
     "DataFlowDetectionStrategy",
     "ASTDetectionStrategy",

--- a/traigent/tuned_variables/observation.py
+++ b/traigent/tuned_variables/observation.py
@@ -1,0 +1,218 @@
+"""Privacy-safe TVAR observation helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+_OBSERVATION_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "config_generator"
+    / "catalog"
+    / "schemas"
+    / "tvar_observation_schema.json"
+)
+_VALID_KINDS = frozenset({"value", "cardinality", "topology", "policy"})
+_VALID_SCOPES = frozenset({"opt_mini", "heldout", "isolation", "trial"})
+_SENSITIVE_CONFIG_NAMES = frozenset(
+    {
+        "prompt",
+        "system_prompt",
+        "user_prompt",
+        "raw_prompt",
+        "example",
+        "examples",
+        "response",
+        "responses",
+        "content",
+        "input",
+        "output",
+        "text",
+        "query",
+        "answer",
+    }
+)
+_SENSITIVE_CONFIG_SUFFIXES = (
+    "_prompt",
+    "_example",
+    "_response",
+    "_content",
+    "_input",
+    "_output",
+    "_text",
+    "_query",
+    "_answer",
+)
+
+
+def build_tvar_observation(
+    *,
+    session_id: str,
+    trial_id: str,
+    config: dict[str, Any],
+    metrics: dict[str, Any],
+    primary_metric: str,
+    comparability: dict[str, Any],
+    catalog_entry_ids: tuple[str, ...] | list[str] = (),
+    agent_type: str | None = None,
+    config_space_id: str | None = None,
+    sdk_version: str | None = None,
+) -> dict[str, Any]:
+    """Build a schema-valid, content-free TVAR observation payload."""
+    observation: dict[str, Any] = {
+        "schema_version": "1.0.0",
+        "session_id": str(session_id),
+        "trial_id": str(trial_id),
+        "catalog_entry_ids": [str(entry_id) for entry_id in catalog_entry_ids],
+        "variables": _build_variables(config, catalog_entry_ids),
+        "metrics": _numeric_metrics(metrics),
+        "primary_metric": str(primary_metric),
+        "comparability": _coerce_comparability(comparability),
+        "privacy": {"raw_content_included": False},
+        "sdk_version": str(sdk_version or _sdk_version()),
+    }
+    if agent_type:
+        observation["agent_type"] = str(agent_type)
+    if config_space_id:
+        observation["config_space_id"] = str(config_space_id)
+
+    _validate_observation(observation)
+    return observation
+
+
+def merge_tvar_observation_metadata(
+    metadata: dict[str, Any] | None,
+    observation: dict[str, Any],
+) -> dict[str, Any]:
+    """Attach a TVAR observation under metadata['tvar_observation_v1']."""
+    merged = dict(metadata or {})
+    merged["tvar_observation_v1"] = copy.deepcopy(observation)
+    return merged
+
+
+def _build_variables(
+    config: dict[str, Any],
+    catalog_entry_ids: tuple[str, ...] | list[str],
+) -> list[dict[str, Any]]:
+    kind_by_name = _catalog_kind_by_name(catalog_entry_ids)
+    variables: list[dict[str, Any]] = []
+    for name, raw_value in config.items():
+        variable_name = str(name)
+        if _is_sensitive_config_name(variable_name):
+            continue
+        safe_value = _safe_variable_value(raw_value)
+        if safe_value is None:
+            continue
+        variable: dict[str, Any] = {"name": variable_name, "value": safe_value}
+        kind = kind_by_name.get(variable_name)
+        if kind in _VALID_KINDS:
+            variable["kind"] = kind
+        variables.append(variable)
+    return variables
+
+
+def _is_sensitive_config_name(name: str) -> bool:
+    normalized = name.lower().replace("-", "_")
+    return normalized in _SENSITIVE_CONFIG_NAMES or normalized.endswith(
+        _SENSITIVE_CONFIG_SUFFIXES
+    )
+
+
+def _catalog_kind_by_name(
+    catalog_entry_ids: tuple[str, ...] | list[str],
+) -> dict[str, str]:
+    if not catalog_entry_ids:
+        return {}
+    requested_ids = {str(entry_id) for entry_id in catalog_entry_ids}
+    try:
+        from traigent.config_generator.catalog import catalog_entries
+
+        return {
+            str(entry["name"]): str(entry["kind"])
+            for entry in catalog_entries()
+            if str(entry.get("entry_id")) in requested_ids
+        }
+    except Exception:
+        return {}
+
+
+def _safe_variable_value(value: Any) -> str | int | float | bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str) and len(value) <= 512:
+        return value
+    return None
+
+
+def _numeric_metrics(metrics: dict[str, Any]) -> dict[str, float | int]:
+    numeric: dict[str, float | int] = {}
+    for key, value in metrics.items():
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            continue
+        if isinstance(value, float) and not math.isfinite(value):
+            continue
+        numeric[str(key)] = value
+    return numeric
+
+
+def _coerce_comparability(comparability: dict[str, Any]) -> dict[str, Any]:
+    scope = str(comparability.get("scope", "trial"))
+    if scope not in _VALID_SCOPES:
+        scope = "trial"
+    try:
+        n = int(comparability.get("n", 0))
+    except (TypeError, ValueError):
+        n = 0
+    return {"scope": scope, "n": max(0, n)}
+
+
+def _sdk_version() -> str:
+    try:
+        from traigent._version import get_version
+
+        return get_version()
+    except Exception:
+        return "unknown"
+
+
+def _validate_observation(observation: dict[str, Any]) -> None:
+    try:
+        from jsonschema import validate
+        from jsonschema.exceptions import ValidationError
+    except Exception:
+        _minimal_validate_observation(observation)
+        return
+
+    try:
+        validate(instance=observation, schema=_observation_schema())
+    except ValidationError as exc:
+        raise ValueError(f"Invalid TVAR observation: {exc.message}") from exc
+
+
+@lru_cache(maxsize=1)
+def _observation_schema() -> dict[str, Any]:
+    with _OBSERVATION_SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+    if not isinstance(schema, dict):
+        raise ValueError("TVAR observation schema must be an object")
+    return schema
+
+
+def _minimal_validate_observation(observation: dict[str, Any]) -> None:
+    for field in ("schema_version", "session_id", "trial_id", "privacy"):
+        if field not in observation:
+            raise ValueError(f"TVAR observation missing required field: {field}")
+    privacy = observation.get("privacy")
+    if (
+        not isinstance(privacy, dict)
+        or privacy.get("raw_content_included") is not False
+    ):
+        raise ValueError("TVAR observation privacy.raw_content_included must be false")


### PR DESCRIPTION
## Catalog-backed recommendations + content-free `tvar_observation` emission

Phase 1 SDK slice of the Tuned-Variable Knowledge Layer. **Stacked on #1075** (base =
`feature/internal-structural-recommendations`) — review/merge #1075 first. Additive + backward-compatible.

- `config_generator/catalog/tvar_catalog.v1.json`: the 8 structural recs as governed catalog entries
  (`kind` value|cardinality|topology|policy; all `effectuation_status=manual_guidance`; real
  `evidence_refs` + `apply_guidance`) + vendored JSON-Schema copies for local validation.
- `config_generator/catalog.py`: load + schema-validate entries; `entry_to_recommendation` projection.
- `subsystems/tvar_recommendations.py`: recommendations now **derived from the catalog** —
  `generate-config --json` keys unchanged (`category,impact,name,range_code,reasoning`).
- `tuned_variables/observation.py`: `build_tvar_observation` (content-free; `privacy.raw_content_included=false`;
  schema-validated) + `merge_tvar_observation_metadata` (key `tvar_observation_v1`). Emission wired
  **additively + exception-safe** at the result-metadata boundaries — so trials emit a durable,
  content-free observation the BE can later learn from, **without changing the SDK result shape again**.

Verified: config_generator+tuned_variables **489 pass**, recommendations **25**, optimizers dir **554**;
**privacy canary clean** (no raw content). Pre-existing & unrelated: the `asyncio-cooperative`+xdist
cross-dir ordering cascade on the full mega-run, and `test_bayesian::test_import_error` (sklearn-env).

### PR checklist
1. Worst-case prod path — emission is additive + exception-safe + content-free; worst case = an extra
   metadata key. No policy surface.
2. Production-branch test — observation builder + privacy-canary tests; recommendations/CLI-shape tests.
3. Contract regeneration — consumes TraigentSchema #85 (vendored copy here); JS types in their own PR.
4. Public surface delta — `TVarRecommendation` now catalog-sourced (shape unchanged); new
   `catalog`/`observation` modules; CLI JSON unchanged.
5. Review threads — none yet.
6. Quality gates — none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
