### PR TITLE
feat(config_generator): recommend-with-priors (catalog + learned priors, offline-safe)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,8 @@ pytest_plugins = ["tests.fixtures.rate_limit_fixtures"]
 # Increase recursion limit to handle complex test scenarios
 sys.setrecursionlimit(2000)
 
+_ORIGINAL_ASYNCIO_SLEEP = asyncio.sleep
+
 
 @pytest_asyncio.fixture(autouse=True)
 async def cleanup_lingering_asyncio_tasks():
@@ -55,7 +57,7 @@ async def cleanup_lingering_asyncio_tasks():
 
     yield
 
-    await asyncio.sleep(0)
+    await _ORIGINAL_ASYNCIO_SLEEP(0)
 
     current = asyncio.current_task()
     pending = [

--- a/tests/unit/cloud/test_tvar_priors.py
+++ b/tests/unit/cloud/test_tvar_priors.py
@@ -1,0 +1,127 @@
+"""Tests for learned TVAR priors client support."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from traigent.cloud.client import PriorsBundle, TraigentCloudClient
+
+
+class _Response:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self.status = status
+        self._payload = payload
+        self.headers: dict[str, str] = {}
+
+    async def json(self) -> dict:
+        return self._payload
+
+    async def text(self) -> str:
+        return "error"
+
+
+class _ResponseContext:
+    def __init__(self, response: _Response) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _Response:
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_fetch_tvar_priors_parses_contract(monkeypatch) -> None:
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+    monkeypatch.delenv("TRAIGENT_EDGE_ANALYTICS_MODE", raising=False)
+    monkeypatch.delenv("TRAIGENT_EXECUTION_MODE", raising=False)
+
+    payload = {
+        "value_priors": [
+            {
+                "schema_version": "1.0.0",
+                "tvar_name": "temperature",
+                "metric": "quality_score",
+                "value_priors": [
+                    {
+                        "value": 0.2,
+                        "score": 0.87,
+                        "support_n": 96,
+                        "confidence": 0.82,
+                    }
+                ],
+                "support_n": 96,
+                "confidence": 0.82,
+            }
+        ],
+        "correlations": [
+            {
+                "schema_version": "1.0.0",
+                "kind": "agent_type_tvar",
+                "a": {"type": "agent_type", "name": "rag"},
+                "b": {"type": "tvar", "name": "temperature", "value": 0.2},
+                "metric": "quality_score",
+                "strength": 0.41,
+                "support_n": 96,
+                "confidence": 0.73,
+            }
+        ],
+        "generated_at": "2026-06-02T12:00:00Z",
+    }
+    response = _Response(payload)
+    session = Mock()
+    session.closed = False
+    session.get = Mock(return_value=_ResponseContext(response))
+
+    client = TraigentCloudClient(
+        api_key="test-key",  # pragma: allowlist secret
+        base_url="https://backend.example.com",
+    )
+    client._aio_session = session
+    client.auth.get_headers = AsyncMock(return_value={"X-API-Key": "test-key"})
+
+    bundle = await client.fetch_tvar_priors(
+        agent_type="rag",
+        metric="quality_score",
+        tvar_names=["temperature", "top_p"],
+    )
+
+    assert bundle == PriorsBundle.from_payload(payload)
+    session.get.assert_called_once()
+    assert session.get.call_args.args[0] == (
+        "https://backend.example.com/api/v1/optimization/priors"
+    )
+    assert session.get.call_args.kwargs["params"] == {
+        "agent_type": "rag",
+        "metric": "quality_score",
+        "tvar_names": "temperature,top_p",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_tvar_priors_offline_returns_empty_without_network(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
+
+    session = Mock()
+    session.closed = False
+    session.get = Mock(side_effect=AssertionError("network must not be used"))
+
+    client = TraigentCloudClient(
+        api_key="test-key",  # pragma: allowlist secret
+        base_url="https://backend.example.com",
+    )
+    client._aio_session = session
+    client.auth.get_headers = AsyncMock(
+        side_effect=AssertionError("auth headers must not be used")
+    )
+
+    bundle = await client.fetch_tvar_priors(agent_type="rag")
+
+    assert bundle == PriorsBundle.empty()
+    session.get.assert_not_called()
+    client.auth.get_headers.assert_not_awaited()

--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -288,8 +288,7 @@ class TestLearnedPriorAugmentation:
     def test_high_support_priors_reorder_and_annotate_recommended_values(
         self,
     ) -> None:
-        # Backend returns value_priors already gated AND ordered by score desc;
-        # the SDK consumes them in that server order without re-sorting.
+        # Priors are consumed in the order provided (not re-ranked by the SDK).
         bundle = PriorsBundle(
             value_priors=(
                 _value_prior_row(
@@ -328,11 +327,8 @@ class TestLearnedPriorAugmentation:
             "linked_top6",
         ]
 
-    def test_sdk_consumes_server_gated_priors_without_regating(self) -> None:
-        # Gating is server-side now: the SDK does NOT apply its own
-        # support/confidence thresholds. Whatever the backend returns (already
-        # gated) is consumed as-is. A backend that returned only this row means
-        # it passed the backend gate, so the SDK applies it.
+    def test_provided_priors_are_applied_as_is(self) -> None:
+        # The SDK applies the priors it is given without re-ranking or filtering.
         classification = _classification("code_gen")
         server_bundle = PriorsBundle(
             value_priors=(
@@ -359,7 +355,6 @@ class TestLearnedPriorAugmentation:
             priors_bundle=server_bundle,
         )
         rec = next(rec for rec in recs if rec.name == "schema_context")
-        # SDK trusts the server's gating decision; the value is applied.
         assert rec.recommended_values == ("linked_top10",)
 
     def test_no_priors_keeps_phase_one_catalog_output(self) -> None:

--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stdout
 from io import StringIO
 from unittest.mock import MagicMock
 
+from traigent.cloud.client import PriorsBundle
 from traigent.config_generator.agent_classifier import ClassificationResult
 from traigent.config_generator.catalog import (
     catalog_entries,
@@ -46,6 +47,32 @@ _CATALOG_ENTRY_KINDS = {
 
 def _make_tvar(name: str) -> TVarSpec:
     return TVarSpec(name=name, range_type="Range", range_kwargs={"low": 0, "high": 1})
+
+
+def _classification(agent_type: str) -> ClassificationResult:
+    return ClassificationResult(
+        agent_type=agent_type,
+        confidence=0.9,
+        source="heuristic",
+        reasoning="test",
+    )
+
+
+def _value_prior_row(
+    tvar_name: str,
+    values: list[dict],
+    *,
+    support_n: int = 100,
+    confidence: float = 0.9,
+) -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "tvar_name": tvar_name,
+        "metric": "accuracy",
+        "value_priors": values,
+        "support_n": support_n,
+        "confidence": confidence,
+    }
 
 
 class TestGenerateRecommendations:
@@ -260,6 +287,101 @@ class TestGenerateRecommendations:
         ]
 
 
+class TestLearnedPriorAugmentation:
+    def test_high_support_priors_reorder_and_annotate_recommended_values(
+        self,
+    ) -> None:
+        bundle = PriorsBundle(
+            value_priors=(
+                _value_prior_row(
+                    "schema_context",
+                    [
+                        {
+                            "value": "full_ddl_fk",
+                            "score": 0.52,
+                            "support_n": 75,
+                            "confidence": 0.82,
+                        },
+                        {
+                            "value": "linked_top10",
+                            "score": 0.91,
+                            "support_n": 91,
+                            "confidence": 0.87,
+                        },
+                    ],
+                ),
+            ),
+            correlations=(),
+        )
+
+        recs = generate_recommendations(
+            [],
+            classification=_classification("code_gen"),
+            priors_bundle=bundle,
+        )
+        rec = next(rec for rec in recs if rec.name == "schema_context")
+
+        assert rec.recommended_values == ("linked_top10", "full_ddl_fk")
+        assert rec.range_kwargs["values"] == [
+            "linked_top10",
+            "full_ddl_fk",
+            "none",
+            "linked_top6",
+        ]
+
+    def test_low_support_priors_are_ignored(self) -> None:
+        classification = _classification("code_gen")
+        baseline = generate_recommendations(
+            [],
+            classification=classification,
+            priors_bundle=PriorsBundle.empty(),
+        )
+        low_support_bundle = PriorsBundle(
+            value_priors=(
+                _value_prior_row(
+                    "schema_context",
+                    [
+                        {
+                            "value": "linked_top10",
+                            "score": 0.99,
+                            "support_n": 2,
+                            "confidence": 0.95,
+                        }
+                    ],
+                    support_n=2,
+                    confidence=0.95,
+                ),
+            ),
+            correlations=(),
+        )
+
+        recs = generate_recommendations(
+            [],
+            classification=classification,
+            priors_bundle=low_support_bundle,
+        )
+
+        assert recs == baseline
+        assert all(not rec.recommended_values for rec in recs)
+
+    def test_no_priors_keeps_phase_one_catalog_output(self) -> None:
+        recs = generate_recommendations(
+            [],
+            classification=_classification("rag"),
+            priors_bundle=PriorsBundle.empty(),
+        )
+
+        assert [rec.name for rec in recs] == [
+            "prompting_strategy",
+            "retriever",
+            "retrieval_k",
+            "chunk_size",
+            "reranker",
+            "context_format",
+        ]
+        assert all(not rec.recommended_values for rec in recs)
+
+
 class TestTVarCatalog:
     def test_catalog_loads_and_validates_all_ready_made_entries(self) -> None:
         entries = load_catalog()
@@ -343,6 +465,50 @@ class TestCLIJsonRecommendationStability:
         }
         assert "evidence_refs" not in data["recommendations"][0]
         assert "apply_guidance" not in data["recommendations"][0]
+
+    def test_recommendation_keys_unchanged_with_prior_hints(self) -> None:
+        from traigent.cli.generate_config_command import _output_json
+
+        bundle = PriorsBundle(
+            value_priors=(
+                _value_prior_row(
+                    "schema_context",
+                    [
+                        {
+                            "value": "linked_top10",
+                            "score": 0.91,
+                            "support_n": 91,
+                            "confidence": 0.87,
+                        }
+                    ],
+                ),
+            ),
+            correlations=(),
+        )
+        rec = next(
+            r
+            for r in generate_recommendations(
+                [],
+                classification=_classification("code_gen"),
+                priors_bundle=bundle,
+            )
+            if r.name == "schema_context"
+        )
+        assert rec.recommended_values == ("linked_top10",)
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            _output_json(AutoConfigResult(recommendations=(rec,)))
+
+        data = json.loads(buf.getvalue())
+        assert set(data["recommendations"][0]) == {
+            "name",
+            "range_code",
+            "category",
+            "impact",
+            "reasoning",
+        }
+        assert "recommended_values" not in data["recommendations"][0]
 
 
 class TestLLMEnrichment:

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import os
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -192,6 +193,63 @@ class CloudOptimizationResult:
     optimization_time: float
     subset_used: bool
     subset_size: int | None = None
+
+
+@dataclass(frozen=True)
+class PriorsBundle:
+    """Learned TVAR priors returned by ``GET /optimization/priors``."""
+
+    value_priors: tuple[dict[str, Any], ...] = ()
+    correlations: tuple[dict[str, Any], ...] = ()
+    generated_at: str | None = None
+
+    @classmethod
+    def empty(cls) -> PriorsBundle:
+        """Return an empty, offline-safe priors bundle."""
+
+        return cls()
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, Any]) -> PriorsBundle:
+        """Parse the backend response shape into immutable tuple fields."""
+
+        return cls(
+            value_priors=_dict_tuple(payload.get("value_priors")),
+            correlations=_dict_tuple(payload.get("correlations")),
+            generated_at=(
+                str(payload["generated_at"])
+                if payload.get("generated_at") is not None
+                else None
+            ),
+        )
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether the bundle carries no learned priors."""
+
+        return not self.value_priors and not self.correlations
+
+
+def _dict_tuple(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return ()
+    return tuple(dict(item) for item in value if isinstance(item, Mapping))
+
+
+def _tvar_priors_params(
+    agent_type: str | None,
+    metric: str | None,
+    tvar_names: Sequence[str] | None,
+) -> dict[str, str]:
+    params: dict[str, str] = {}
+    if agent_type:
+        params["agent_type"] = str(agent_type)
+    if metric:
+        params["metric"] = str(metric)
+    names = [str(name).strip() for name in tvar_names or () if str(name).strip()]
+    if names:
+        params["tvar_names"] = ",".join(names)
+    return params
 
 
 class _DirectResponseContext:
@@ -821,6 +879,78 @@ class TraigentCloudClient(BaseTraigentClient):
     async def get_usage_stats(self) -> dict[str, Any]:
         """Get usage statistics for current billing period."""
         return cast(dict[str, Any], await self.usage_tracker.get_usage_stats())
+
+    async def fetch_tvar_priors(
+        self,
+        agent_type: str | None = None,
+        metric: str | None = None,
+        tvar_names: Sequence[str] | None = None,
+    ) -> PriorsBundle:
+        """Fetch learned TVAR priors without ever blocking recommendations.
+
+        The recommendation system treats backend priors as optional hints. Any
+        offline mode, missing credentials, transport issue, auth failure, or
+        malformed response therefore returns an empty bundle instead of raising.
+        """
+
+        if self._should_skip_tvar_priors_fetch():
+            return PriorsBundle.empty()
+
+        try:
+            await self._ensure_session()
+            if self._aio_session is None:
+                return PriorsBundle.empty()
+
+            url = f"{self.api_base_url}/optimization/priors"
+            params = _tvar_priors_params(agent_type, metric, tvar_names)
+            request = self._aio_session.get(
+                url,
+                params=params,
+                headers=await self._get_headers(),
+            )
+            response_candidate = (
+                await request if asyncio.iscoroutine(request) else request
+            )
+            manager = (
+                response_candidate
+                if hasattr(response_candidate, "__aenter__")
+                else _DirectResponseContext(response_candidate)
+            )
+
+            async with manager as response:
+                if _get_status_code(response) != 200:
+                    return PriorsBundle.empty()
+                payload = await _get_json_response(response)
+                if not isinstance(payload, Mapping):
+                    return PriorsBundle.empty()
+                return PriorsBundle.from_payload(payload)
+        except aiohttp.ClientError as exc:
+            await self._reset_http_session("tvar_priors network error")
+            logger.debug("TVAR priors fetch failed: %s", exc)
+            return PriorsBundle.empty()
+        except Exception as exc:
+            logger.debug("TVAR priors fetch skipped after error: %s", exc)
+            return PriorsBundle.empty()
+
+    def _should_skip_tvar_priors_fetch(self) -> bool:
+        """Return True when priors fetches must stay local/offline."""
+
+        from traigent.utils.env_config import is_backend_offline
+
+        if is_backend_offline():
+            return True
+
+        edge_env_values = {
+            os.getenv("TRAIGENT_EDGE_ANALYTICS_MODE", "").strip().lower(),
+            os.getenv("TRAIGENT_EXECUTION_MODE", "").strip().lower(),
+        }
+        if edge_env_values & {"true", "1", "yes", "edge_analytics"}:
+            return True
+
+        try:
+            return not (self.auth.has_api_key() or BackendConfig.has_auth_credentials())
+        except Exception:
+            return not self.auth.has_api_key()
 
     async def check_service_status(self) -> dict[str, Any]:
         """Check Traigent backend service status."""

--- a/traigent/config_generator/subsystems/tvar_recommendations.py
+++ b/traigent/config_generator/subsystems/tvar_recommendations.py
@@ -22,9 +22,8 @@ from traigent.utils.llm_response_parsing import extract_json_array_text
 if TYPE_CHECKING:
     from traigent.cloud.client import PriorsBundle
 
-# The backend returns priors already gated (support/confidence) AND ordered by
-# score; the SDK consumes them as-is and never embeds gating policy/thresholds
-# or re-sorts (keeps the decision policy server-side, avoids client/server drift).
+# Priors returned by the optimization service are consumed as provided; the SDK
+# does not rank or filter them.
 _PRIORS_FETCH_TIMEOUT_SECONDS = 2.0
 _RECOMMENDATION_PRIORS_CACHE: dict[tuple[str, tuple[str, ...]], PriorsBundle] = {}
 
@@ -324,8 +323,7 @@ def _gated_value_priors_by_tvar(
         if not tvar_name or not isinstance(value_priors, Sequence):
             continue
 
-        # The backend already gated + ordered these; consume in server order,
-        # keeping only well-formed (value+score) items. No thresholds, no resort.
+        # Consume priors as provided, keeping only well-formed (value+score) items.
         usable: list[tuple[Any, float]] = []
         for item in value_priors:
             if not isinstance(item, Mapping) or "value" not in item:

--- a/traigent/config_generator/subsystems/tvar_recommendations.py
+++ b/traigent/config_generator/subsystems/tvar_recommendations.py
@@ -6,7 +6,11 @@ based on agent type and what TVARs are already detected.
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
 
 from traigent.config_generator.agent_classifier import ClassificationResult
 from traigent.config_generator.catalog import catalog_entries, entry_to_recommendation
@@ -15,6 +19,14 @@ from traigent.config_generator.presets.range_presets import get_preset_range
 from traigent.config_generator.types import TVarRecommendation, TVarSpec
 from traigent.utils.llm_response_parsing import extract_json_array_text
 
+if TYPE_CHECKING:
+    from traigent.cloud.client import PriorsBundle
+
+_MIN_PRIOR_SUPPORT_N = 30
+_MIN_PRIOR_CONFIDENCE = 0.60
+_PRIORS_FETCH_TIMEOUT_SECONDS = 2.0
+_RECOMMENDATION_PRIORS_CACHE: dict[tuple[str, tuple[str, ...]], PriorsBundle] = {}
+
 
 def generate_recommendations(
     tvars: list[TVarSpec],
@@ -22,6 +34,7 @@ def generate_recommendations(
     llm: ConfigGenLLM | None = None,
     source_code: str = "",
     classification: ClassificationResult | None = None,
+    priors_bundle: PriorsBundle | None = None,
 ) -> list[TVarRecommendation]:
     """Generate TVAR recommendations.
 
@@ -35,12 +48,23 @@ def generate_recommendations(
         Original source code.
     classification:
         Pre-computed agent classification.
+    priors_bundle:
+        Optional learned priors bundle. ``None`` means try the backend when
+        configured; an empty bundle keeps catalog output unchanged.
     """
     existing_names = {t.name for t in tvars}
     agent_type = classification.agent_type if classification else "general_llm"
 
     # Preset recommendations
     recs = _preset_recommendations(agent_type, existing_names)
+    recs = _augment_recommendations_with_priors(
+        recs,
+        (
+            priors_bundle
+            if priors_bundle is not None
+            else _fetch_recommendation_priors(agent_type, [rec.name for rec in recs])
+        ),
+    )
 
     # LLM enrichment
     if llm is not None:
@@ -252,6 +276,211 @@ def _preset_recommendations(
         )
 
     return recs
+
+
+def _augment_recommendations_with_priors(
+    recs: list[TVarRecommendation],
+    priors_bundle: PriorsBundle,
+) -> list[TVarRecommendation]:
+    if not recs or not getattr(priors_bundle, "value_priors", ()):
+        return recs
+
+    priors_by_name = _gated_value_priors_by_tvar(priors_bundle.value_priors)
+    if not priors_by_name:
+        return recs
+
+    augmented: list[TVarRecommendation] = []
+    for rec in recs:
+        hints = [
+            hint
+            for hint in priors_by_name.get(rec.name, ())
+            if _prior_value_allowed(rec, hint[0])
+        ]
+        if not hints:
+            augmented.append(rec)
+            continue
+
+        updated_kwargs = _range_kwargs_with_prior_order(rec, hints)
+        recommended_values = tuple(value for value, _score in hints)
+        augmented.append(
+            replace(
+                rec,
+                range_kwargs=updated_kwargs,
+                recommended_values=recommended_values,
+            )
+        )
+
+    return augmented
+
+
+def _gated_value_priors_by_tvar(
+    rows: Sequence[Mapping[str, Any]],
+) -> dict[str, tuple[tuple[Any, float], ...]]:
+    priors_by_name: dict[str, tuple[tuple[Any, float], ...]] = {}
+    for row in rows:
+        if not _passes_prior_gate(row):
+            continue
+
+        tvar_name = str(row.get("tvar_name") or "").strip()
+        value_priors = row.get("value_priors")
+        if not tvar_name or not isinstance(value_priors, Sequence):
+            continue
+
+        gated: list[tuple[Any, float]] = []
+        for item in value_priors:
+            if not isinstance(item, Mapping) or not _passes_prior_gate(item):
+                continue
+            if "value" not in item:
+                continue
+            try:
+                score = float(item["score"])
+            except (TypeError, ValueError):
+                continue
+            gated.append((item["value"], score))
+
+        ordered = _dedupe_prior_values(
+            sorted(gated, key=lambda item: item[1], reverse=True)
+        )
+        if ordered:
+            priors_by_name[tvar_name] = tuple(ordered)
+
+    return priors_by_name
+
+
+def _passes_prior_gate(item: Mapping[str, Any]) -> bool:
+    try:
+        support_n = int(item.get("support_n", 0))
+        confidence = float(item.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        return False
+    return support_n >= _MIN_PRIOR_SUPPORT_N and confidence >= _MIN_PRIOR_CONFIDENCE
+
+
+def _dedupe_prior_values(
+    hints: Sequence[tuple[Any, float]],
+) -> tuple[tuple[Any, float], ...]:
+    seen: set[tuple[str, str]] = set()
+    deduped: list[tuple[Any, float]] = []
+    for value, score in hints:
+        key = (type(value).__name__, repr(value))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((value, score))
+    return tuple(deduped)
+
+
+def _range_kwargs_with_prior_order(
+    rec: TVarRecommendation,
+    hints: Sequence[tuple[Any, float]],
+) -> dict[str, Any]:
+    if rec.range_type != "Choices":
+        return dict(rec.range_kwargs)
+
+    current_values = rec.range_kwargs.get("values")
+    if not isinstance(current_values, Sequence) or isinstance(current_values, str):
+        return dict(rec.range_kwargs)
+
+    hinted_values = [value for value, _score in hints if value in current_values]
+    if not hinted_values:
+        return dict(rec.range_kwargs)
+
+    remaining_values = [value for value in current_values if value not in hinted_values]
+    return {**rec.range_kwargs, "values": [*hinted_values, *remaining_values]}
+
+
+def _prior_value_allowed(rec: TVarRecommendation, value: Any) -> bool:
+    if rec.range_type == "Choices":
+        values = rec.range_kwargs.get("values")
+        return (
+            isinstance(values, Sequence)
+            and not isinstance(values, str)
+            and value in values
+        )
+
+    if rec.range_type == "IntRange":
+        return type(value) is int and _within_numeric_range(rec.range_kwargs, value)
+
+    if rec.range_type in {"Range", "LogRange"}:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return False
+        return _within_numeric_range(rec.range_kwargs, float(value))
+
+    return False
+
+
+def _within_numeric_range(range_kwargs: Mapping[str, Any], value: float | int) -> bool:
+    low = range_kwargs.get("low")
+    high = range_kwargs.get("high")
+    if isinstance(low, (int, float)) and value < low:
+        return False
+    if isinstance(high, (int, float)) and value > high:
+        return False
+    return True
+
+
+def _fetch_recommendation_priors(
+    agent_type: str,
+    tvar_names: Sequence[str],
+) -> PriorsBundle:
+    from traigent.cloud.client import PriorsBundle, TraigentCloudClient
+
+    names = tuple(name for name in tvar_names if name)
+    if not names or not _should_fetch_recommendation_priors():
+        return PriorsBundle.empty()
+
+    cache_key = (agent_type, names)
+    cached = _RECOMMENDATION_PRIORS_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        return PriorsBundle.empty()
+
+    async def _fetch() -> PriorsBundle:
+        client = TraigentCloudClient(timeout=_PRIORS_FETCH_TIMEOUT_SECONDS)
+        try:
+            return await client.fetch_tvar_priors(
+                agent_type=agent_type,
+                tvar_names=names,
+            )
+        finally:
+            await client.close()
+
+    try:
+        bundle = asyncio.run(_fetch())
+    except Exception:
+        bundle = PriorsBundle.empty()
+
+    _RECOMMENDATION_PRIORS_CACHE[cache_key] = bundle
+    return bundle
+
+
+def _should_fetch_recommendation_priors() -> bool:
+    from traigent.config.backend_config import BackendConfig
+    from traigent.utils.env_config import is_backend_offline
+
+    if is_backend_offline() or _edge_analytics_env_enabled():
+        return False
+
+    try:
+        if not BackendConfig.get_configured_backend_url():
+            return False
+        return BackendConfig.has_auth_credentials()
+    except Exception:
+        return False
+
+
+def _edge_analytics_env_enabled() -> bool:
+    values = {
+        os.getenv("TRAIGENT_EDGE_ANALYTICS_MODE", "").strip().lower(),
+        os.getenv("TRAIGENT_EXECUTION_MODE", "").strip().lower(),
+    }
+    return bool(values & {"true", "1", "yes", "edge_analytics"})
 
 
 _VALID_RANGE_TYPES = frozenset({"Range", "IntRange", "LogRange", "Choices"})

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -100,6 +100,7 @@ class TVarRecommendation:
     entry_id: str = ""
     evidence_refs: tuple[EvidenceRef, ...] = ()
     apply_guidance: str = ""
+    recommended_values: tuple[Any, ...] = ()
 
     def to_range_code(self) -> str:
         """Generate Python code for the recommended range."""


### PR DESCRIPTION
## recommend-with-priors: catalog + learned priors, offline-safe (P3)

Stacked on #1077 (Phase-1 catalog). The "use" half — closes the loop: recommendations are augmented by
learned priors from `GET /optimization/priors`, **gated by support+confidence**, while staying 100%
offline-safe.
- `cloud/client.py`: `PriorsBundle` + `fetch_tvar_priors(...)`; offline/edge/no-backend/any-error →
  EMPTY bundle (never raises, never blocks recommend; a test asserts **no network in offline mode**).
- `types.py`: additive `TVarRecommendation.recommended_values`.
- `tvar_recommendations.py`: catalog-derived recs reordered/annotated by prior score only when gated;
  **no priors → output equals Phase-1** (regression test). `generate-config --json` keys unchanged.

Verified: 1796 pass.

### PR checklist
1. Worst-case prod path — offline-safe + gated; worst case = no augmentation (falls back to static catalog).
2. Production-branch test — offline-no-network + gating + Phase-1 regression tests.
3. Contract regen — consumes schema priors contract.
4. Public surface — additive client method + field; CLI shape unchanged.
5. Threads — none yet. 6. Gates — none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
