### PR TITLE
feat(effectuation): executable knobs (KnobStrategy + self-consistency, opt-in)

### DIFF
--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -390,12 +390,26 @@ class TestTVarCatalog:
         assert {entry["entry_id"] for entry in entries} == set(_CATALOG_ENTRY_KINDS)
         for entry in entries:
             assert entry["kind"] == _CATALOG_ENTRY_KINDS[entry["entry_id"]]
-            assert entry["effectuation_status"] == "manual_guidance"
             assert entry["status"] == "active"
             assert entry["schema_version"] == "1.0.0"
             assert entry["version"] == "1.0.0"
             assert entry["evidence_refs"]
             assert entry["apply_guidance"].strip()
+
+        by_id = {entry["entry_id"]: entry for entry in entries}
+        assert (
+            by_id["code_gen.candidate_count.v1"]["effectuation_status"]
+            == "executable"
+        )
+        assert (
+            by_id["code_gen.candidate_count.v1"]["effectuation_strategy"]
+            == "self_consistency"
+        )
+        assert {
+            entry["entry_id"]
+            for entry in entries
+            if entry["effectuation_status"] == "manual_guidance"
+        } == set(_CATALOG_ENTRY_KINDS) - {"code_gen.candidate_count.v1"}
 
     def test_catalog_filters_by_agent_type(self) -> None:
         assert [entry["entry_id"] for entry in catalog_entries("rag")] == [

--- a/tests/unit/effectuation/test_framework_param.py
+++ b/tests/unit/effectuation/test_framework_param.py
@@ -1,0 +1,44 @@
+"""Tests for the framework_param value strategy."""
+
+from __future__ import annotations
+
+from traigent.config_generator.catalog import load_catalog
+from traigent.effectuation import get_strategy
+
+
+def test_framework_param_projects_plain_value_set_for_optimizer() -> None:
+    strategy = get_strategy("framework_param")
+    effect = strategy.compile(
+        {
+            "name": "temperature",
+            "kind": "value",
+            "value_set": [0.0, 0.5, 1.0],
+        }
+    )
+
+    assert effect.project_for_optimizer() == {"temperature": [0.0, 0.5, 1.0]}
+
+
+def test_framework_param_wrap_callable_returns_same_callable() -> None:
+    strategy = get_strategy("framework_param")
+    effect = strategy.compile(
+        {
+            "name": "model",
+            "kind": "value",
+            "value_set": ["gpt-4o-mini", "gpt-4o"],
+        }
+    )
+
+    def target() -> str:
+        return "ok"
+
+    assert effect.wrap_callable(target, plan={}) is target
+    assert effect.emit_events() == []
+
+
+def test_catalog_value_entries_are_only_marked_executable_when_strategy_exists() -> None:
+    value_entries = [entry for entry in load_catalog() if entry["kind"] == "value"]
+
+    for entry in value_entries:
+        assert entry["effectuation_status"] == "executable"
+        assert entry["effectuation_strategy"] == "framework_param"

--- a/tests/unit/effectuation/test_registry.py
+++ b/tests/unit/effectuation/test_registry.py
@@ -1,0 +1,16 @@
+"""Tests for effectuation strategy registration."""
+
+from __future__ import annotations
+
+from traigent.effectuation import STRATEGY_REGISTRY, get_strategy
+
+
+def test_builtin_strategies_register_and_resolve_by_id() -> None:
+    assert {"framework_param", "self_consistency"} <= set(STRATEGY_REGISTRY)
+    assert get_strategy("framework_param") is STRATEGY_REGISTRY["framework_param"]
+    assert get_strategy("self_consistency") is STRATEGY_REGISTRY["self_consistency"]
+
+
+def test_builtin_strategy_supported_kinds_are_correct() -> None:
+    assert get_strategy("framework_param").supported_kinds == {"value"}
+    assert get_strategy("self_consistency").supported_kinds == {"cardinality"}

--- a/tests/unit/effectuation/test_regression.py
+++ b/tests/unit/effectuation/test_regression.py
@@ -1,0 +1,110 @@
+"""Regression tests for opt-in effectuation behavior."""
+
+from __future__ import annotations
+
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+
+from traigent.config.context import ConfigurationContext
+from traigent.config_generator.agent_classifier import ClassificationResult
+from traigent.config_generator.catalog import load_catalog
+from traigent.config_generator.subsystems.tvar_recommendations import (
+    generate_recommendations,
+)
+from traigent.config_generator.types import AutoConfigResult
+from traigent.effectuation import apply_effectuation
+
+
+def test_apply_effectuation_default_disabled_returns_original_callable() -> None:
+    def target() -> str:
+        return "unchanged"
+
+    assert apply_effectuation(target, {"candidate_count": (1, 3)}) is target
+
+
+def test_apply_effectuation_enabled_runs_declared_self_consistency_knob() -> None:
+    responses = iter(["same", "different", "same"])
+
+    def target() -> str:
+        return next(responses)
+
+    wrapped = apply_effectuation(
+        target,
+        {"candidate_count": (1, 3)},
+        enabled=True,
+    )
+
+    assert wrapped is not target
+    with ConfigurationContext({"candidate_count": 3}):
+        assert wrapped() == "same"
+
+
+def test_apply_effectuation_enabled_skips_manual_structural_knobs() -> None:
+    calls: list[int] = []
+
+    def target() -> str:
+        calls.append(1)
+        return "single"
+
+    wrapped = apply_effectuation(
+        target,
+        {"schema_context": ["none", "full_ddl_fk"]},
+        enabled=True,
+    )
+
+    assert wrapped is target
+    assert wrapped() == "single"
+    assert len(calls) == 1
+
+
+def test_catalog_executable_and_manual_statuses_are_honest() -> None:
+    entries = load_catalog()
+    by_name = {entry["name"]: entry for entry in entries}
+
+    assert by_name["candidate_count"]["effectuation_status"] == "executable"
+    assert by_name["candidate_count"]["effectuation_strategy"] == "self_consistency"
+
+    manual_names = {
+        entry["name"]
+        for entry in entries
+        if entry["effectuation_status"] == "manual_guidance"
+    }
+    assert manual_names == {
+        "retrieval_k",
+        "schema_context",
+        "evidence_usage",
+        "fewshot_selector",
+        "generation_path",
+        "fewshot_k",
+        "repair_policy",
+    }
+
+
+def test_generate_config_json_recommendation_keys_remain_unchanged() -> None:
+    from traigent.cli.generate_config_command import _output_json
+
+    classification = ClassificationResult(
+        agent_type="code_gen",
+        confidence=0.9,
+        source="heuristic",
+        reasoning="test",
+    )
+    rec = next(
+        r
+        for r in generate_recommendations([], classification=classification)
+        if r.name == "candidate_count"
+    )
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        _output_json(AutoConfigResult(recommendations=(rec,)))
+
+    data = json.loads(buf.getvalue())
+    assert set(data["recommendations"][0]) == {
+        "name",
+        "range_code",
+        "category",
+        "impact",
+        "reasoning",
+    }

--- a/tests/unit/effectuation/test_self_consistency.py
+++ b/tests/unit/effectuation/test_self_consistency.py
@@ -1,0 +1,108 @@
+"""Tests for the self_consistency cardinality strategy."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from traigent.config.context import ConfigurationContext
+from traigent.effectuation import get_strategy
+
+
+def _compile_effect(*, aggregator=None):
+    knob = {
+        "name": "candidate_count",
+        "kind": "cardinality",
+        "value_set": (1, 3),
+    }
+    if aggregator is not None:
+        knob["aggregator"] = aggregator
+    return get_strategy("self_consistency").compile(knob)
+
+
+def test_n3_majority_vote_returns_modal_output() -> None:
+    effect = _compile_effect()
+    responses = iter(["private answer", "other answer", " private answer "])
+    calls: list[int] = []
+
+    def target() -> str:
+        calls.append(1)
+        return next(responses)
+
+    wrapped = effect.wrap_callable(target, plan={})
+
+    with ConfigurationContext({"candidate_count": 3}):
+        assert wrapped() == "private answer"
+
+    assert len(calls) == 3
+    events = effect.emit_events()
+    assert events == [
+        {
+            "strategy": "self_consistency",
+            "knob": "candidate_count",
+            "n": 3,
+            "calls": 3,
+            "unique_outputs": 2,
+            "aggregator": "majority_vote",
+            "passthrough": False,
+        }
+    ]
+    assert "private answer" not in repr(events)
+    assert "other answer" not in repr(events)
+
+
+def test_n1_is_single_call_passthrough_without_aggregator() -> None:
+    def fail_if_called(outputs: Sequence[Any]) -> Any:
+        raise AssertionError("aggregator should not run for N<=1")
+
+    effect = _compile_effect(aggregator=fail_if_called)
+    calls: list[int] = []
+
+    def target() -> str:
+        calls.append(1)
+        return "single"
+
+    wrapped = effect.wrap_callable(target, plan={})
+
+    with ConfigurationContext({"candidate_count": 1}):
+        assert wrapped() == "single"
+
+    assert len(calls) == 1
+    assert effect.emit_events()[0]["passthrough"] is True
+    assert effect.emit_events()[0]["calls"] == 1
+
+
+def test_aggregator_is_pluggable() -> None:
+    def choose_last(outputs: Sequence[Any]) -> Any:
+        return outputs[-1]
+
+    effect = _compile_effect(aggregator=choose_last)
+    responses = iter(["first", "second"])
+
+    def target() -> str:
+        return next(responses)
+
+    wrapped = effect.wrap_callable(target, plan={})
+
+    with ConfigurationContext({"candidate_count": 2}):
+        assert wrapped() == "second"
+
+    assert effect.emit_events()[0]["aggregator"] == "choose_last"
+
+
+def test_wrap_callable_guards_against_double_execution() -> None:
+    effect = _compile_effect()
+    calls: list[int] = []
+
+    def target() -> str:
+        calls.append(1)
+        return "same"
+
+    wrapped_once = effect.wrap_callable(target, plan={})
+    wrapped_twice = effect.wrap_callable(wrapped_once, plan={})
+
+    assert wrapped_twice is wrapped_once
+    with ConfigurationContext({"candidate_count": 2}):
+        assert wrapped_twice() == "same"
+
+    assert len(calls) == 2

--- a/traigent/config_generator/catalog/tvar_catalog.v1.json
+++ b/traigent/config_generator/catalog/tvar_catalog.v1.json
@@ -294,7 +294,8 @@
       "high": 3
     },
     "kind": "cardinality",
-    "effectuation_status": "manual_guidance",
+    "effectuation_status": "executable",
+    "effectuation_strategy": "self_consistency",
     "category": "generation",
     "reasoning": "Spider significance data indicates candidate count matters, but this signal is observational rather than causal.",
     "impact_estimate": "low",
@@ -317,7 +318,7 @@
         ]
       }
     ],
-    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, read cfg['candidate_count'] and generate that many candidate SQL or program outputs before your selection or execution step; 1 preserves single-sample behavior. Add eval coverage for 1..3. NOTE: apply_config() only inserts the decorator + imports; multi-candidate generation remains your code.",
+    "apply_guidance": "Executable when effectuation is explicitly enabled: the self_consistency strategy reads cfg['candidate_count'] and runs the wrapped callable that many times before majority-vote aggregation; 1 preserves single-sample behavior. Add eval coverage for 1..3. NOTE: default optimize behavior is unchanged unless effectuation is enabled.",
     "status": "active",
     "version": "1.0.0"
   },

--- a/traigent/effectuation/__init__.py
+++ b/traigent/effectuation/__init__.py
@@ -1,0 +1,201 @@
+"""Opt-in executable effectuation for declared tuned variables."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from functools import lru_cache
+from typing import Any
+
+from traigent.effectuation.contracts import (
+    STRATEGY_REGISTRY,
+    CompiledEffect,
+    KnobKind,
+    KnobStrategy,
+    get_strategy,
+    knob_field,
+    knob_kind,
+    knob_name,
+    register_strategy,
+)
+from traigent.effectuation.strategies.framework_param import FrameworkParamStrategy
+from traigent.effectuation.strategies.self_consistency import (
+    SELF_CONSISTENCY_NAMES,
+    SelfConsistencyStrategy,
+)
+
+register_strategy(FrameworkParamStrategy())
+register_strategy(SelfConsistencyStrategy())
+
+
+def apply_effectuation(
+    fn: Callable[..., Any],
+    config: Any,
+    *,
+    enabled: bool = False,
+) -> Callable[..., Any]:
+    """Compose registered executable strategies for declared knobs.
+
+    Effectuation is opt-in. With the default ``enabled=False``, the original
+    callable is returned unchanged.
+    """
+
+    if not enabled:
+        return fn
+
+    wrapped = fn
+    for raw_knob in _iter_declared_knobs(config):
+        strategy_id = _strategy_id_for_knob(raw_knob)
+        if strategy_id is None:
+            continue
+        knob = _with_inferred_kind(raw_knob, strategy_id)
+        strategy = get_strategy(strategy_id)
+        strategy.validate(knob, runtime_ctx=config)
+        effect = strategy.compile(knob)
+        wrapped = effect.wrap_callable(wrapped, plan=config)
+    return wrapped
+
+
+def _iter_declared_knobs(config: Any) -> list[Any]:
+    if config is None:
+        return []
+
+    if isinstance(config, Mapping):
+        if _looks_like_single_knob(config):
+            return [dict(config)]
+
+        section_knobs: list[Any] = []
+        for section_key in (
+            "knobs",
+            "tvars",
+            "recommendations",
+            "configuration_space",
+        ):
+            if section_key in config and config[section_key] is not None:
+                section_knobs.extend(_iter_declared_knobs(config[section_key]))
+        if section_knobs:
+            return section_knobs
+
+        return [
+            knob
+            for name, value in config.items()
+            if (knob := _knob_from_flat_entry(name, value)) is not None
+        ]
+
+    if isinstance(config, Sequence) and not isinstance(config, (str, bytes)):
+        knobs: list[Any] = []
+        for item in config:
+            knobs.extend(_iter_declared_knobs(item))
+        return knobs
+
+    object_knobs: list[Any] = []
+    for attr_name in ("knobs", "tvars", "recommendations", "configuration_space"):
+        if hasattr(config, attr_name):
+            object_knobs.extend(_iter_declared_knobs(getattr(config, attr_name)))
+    if object_knobs:
+        return object_knobs
+
+    if hasattr(config, "name"):
+        return [config]
+
+    return []
+
+
+def _looks_like_single_knob(value: Mapping[str, Any]) -> bool:
+    return any(
+        key in value
+        for key in (
+            "name",
+            "kind",
+            "effectuation_strategy",
+            "strategy_id",
+            "range_type",
+            "range_kwargs",
+        )
+    )
+
+
+def _knob_from_flat_entry(name: Any, value: Any) -> dict[str, Any] | None:
+    if not isinstance(name, str) or name.startswith("_"):
+        return None
+
+    strategy_id = _strategy_id_for_name(name)
+    if strategy_id is None:
+        return None
+
+    kind = (
+        KnobKind.CARDINALITY.value
+        if strategy_id == "self_consistency"
+        else KnobKind.VALUE.value
+    )
+    return {
+        "name": name,
+        "kind": kind,
+        "value_set": value,
+        "effectuation_strategy": strategy_id,
+    }
+
+
+def _strategy_id_for_knob(knob: Any) -> str | None:
+    explicit_strategy = knob_field(knob, "effectuation_strategy") or knob_field(
+        knob, "strategy_id"
+    )
+    if explicit_strategy:
+        return str(explicit_strategy)
+
+    try:
+        name = knob_name(knob)
+    except ValueError:
+        return None
+
+    return _strategy_id_for_name(name, knob)
+
+
+def _strategy_id_for_name(name: str, knob: Any | None = None) -> str | None:
+    if name in SELF_CONSISTENCY_NAMES:
+        return "self_consistency"
+
+    try:
+        kind = knob_kind(knob, default=None) if knob is not None else None
+    except ValueError:
+        return None
+
+    if name in _framework_parameter_names():
+        return "framework_param"
+    if kind == KnobKind.VALUE.value and knob_field(knob, "effectuation_strategy"):
+        return "framework_param"
+    return None
+
+
+def _with_inferred_kind(knob: Any, strategy_id: str) -> Any:
+    if not isinstance(knob, Mapping) or "kind" in knob:
+        return knob
+
+    inferred_kind = (
+        KnobKind.CARDINALITY.value
+        if strategy_id == "self_consistency"
+        else KnobKind.VALUE.value
+    )
+    updated = dict(knob)
+    updated["kind"] = inferred_kind
+    return updated
+
+
+@lru_cache(maxsize=1)
+def _framework_parameter_names() -> frozenset[str]:
+    from traigent.integrations.mappings import PARAMETER_MAPPINGS
+
+    names: set[str] = set()
+    for mapping in PARAMETER_MAPPINGS.values():
+        names.update(mapping)
+    return frozenset(names)
+
+
+__all__ = [
+    "CompiledEffect",
+    "KnobKind",
+    "KnobStrategy",
+    "STRATEGY_REGISTRY",
+    "apply_effectuation",
+    "get_strategy",
+    "register_strategy",
+]

--- a/traigent/effectuation/contracts.py
+++ b/traigent/effectuation/contracts.py
@@ -1,0 +1,207 @@
+"""Contracts and registry for executable tuned-variable effectuation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
+
+
+class KnobKind(StrEnum):
+    """Supported tuned-variable effectuation kinds."""
+
+    VALUE = "value"
+    CARDINALITY = "cardinality"
+    TOPOLOGY = "topology"
+    POLICY = "policy"
+
+
+VALID_KNOB_KINDS = frozenset(kind.value for kind in KnobKind)
+
+
+@runtime_checkable
+class CompiledEffect(Protocol):
+    """Executable projection for one declared knob."""
+
+    def project_for_optimizer(self) -> dict[str, Any]:
+        """Return the flattened value set handed to the optimizer."""
+        ...
+
+    def wrap_callable(self, fn: Callable[..., Any], plan: Any) -> Callable[..., Any]:
+        """Return a callable with this effect applied, or ``fn`` unchanged."""
+        ...
+
+    def emit_events(self) -> list[dict[str, Any]]:
+        """Return aggregate, content-free effectuation events."""
+        ...
+
+
+@runtime_checkable
+class KnobStrategy(Protocol):
+    """Strategy that validates and compiles a declared knob."""
+
+    strategy_id: str
+    supported_kinds: set[str]
+
+    def validate(self, knob: Any, runtime_ctx: Any) -> None:
+        """Validate that ``knob`` can be compiled by this strategy."""
+        ...
+
+    def compile(self, knob: Any) -> CompiledEffect:
+        """Compile ``knob`` into an executable effect."""
+        ...
+
+
+STRATEGY_REGISTRY: dict[str, KnobStrategy] = {}
+
+
+def register_strategy(strategy: KnobStrategy) -> KnobStrategy:
+    """Register a knob strategy by its stable strategy id."""
+
+    strategy_id = getattr(strategy, "strategy_id", "")
+    if not isinstance(strategy_id, str) or not strategy_id.strip():
+        raise ValueError("Knob strategy must define a non-empty strategy_id")
+
+    supported_kinds = set(getattr(strategy, "supported_kinds", set()))
+    invalid_kinds = supported_kinds - VALID_KNOB_KINDS
+    if invalid_kinds:
+        raise ValueError(
+            f"Knob strategy {strategy_id!r} declares unsupported kinds: "
+            f"{sorted(invalid_kinds)}"
+        )
+
+    STRATEGY_REGISTRY[strategy_id] = strategy
+    return strategy
+
+
+def get_strategy(strategy_id: str) -> KnobStrategy:
+    """Resolve a registered knob strategy by id."""
+
+    try:
+        return STRATEGY_REGISTRY[strategy_id]
+    except KeyError as exc:
+        raise KeyError(f"No knob strategy registered for {strategy_id!r}") from exc
+
+
+def knob_field(knob: Any, field_name: str, default: Any = None) -> Any:
+    """Read a field from a dict-like or object-like knob declaration."""
+
+    if isinstance(knob, Mapping):
+        return knob.get(field_name, default)
+    return getattr(knob, field_name, default)
+
+
+def knob_name(knob: Any) -> str:
+    """Return a knob name or raise a clear validation error."""
+
+    name = knob_field(knob, "name")
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("Knob declaration must include a non-empty name")
+    return name
+
+
+def knob_kind(knob: Any, default: str | None = None) -> str | None:
+    """Return a normalized knob kind when present."""
+
+    kind = knob_field(knob, "kind", default)
+    if kind is None:
+        return None
+    kind_value = str(kind)
+    if kind_value not in VALID_KNOB_KINDS:
+        raise ValueError(f"Unsupported knob kind: {kind_value!r}")
+    return kind_value
+
+
+def project_knob_for_optimizer(knob: Any) -> dict[str, Any]:
+    """Project a knob declaration to today's flattened optimizer value set."""
+
+    name = knob_name(knob)
+
+    if isinstance(knob, Mapping):
+        for value_key in ("value_set", "config_value", "search_space", "range"):
+            if value_key in knob:
+                return {name: _normalize_config_value(knob[value_key])}
+        if "values" in knob:
+            return {name: list(knob["values"])}
+        if "range_type" in knob and "range_kwargs" in knob:
+            return {
+                name: _project_catalog_range(
+                    str(knob["range_type"]),
+                    knob.get("range_kwargs", {}),
+                )
+            }
+        if "value" in knob:
+            return {name: knob["value"]}
+
+    if hasattr(knob, "to_config_value"):
+        return {name: knob.to_config_value()}
+
+    raise ValueError(f"Knob {name!r} does not include an optimizer value set")
+
+
+def _normalize_config_value(value: Any) -> Any:
+    try:
+        from traigent.api.parameter_ranges import normalize_config_value
+
+        return normalize_config_value(value)
+    except Exception:
+        return value
+
+
+def _project_catalog_range(range_type: str, range_kwargs: Any) -> Any:
+    if not isinstance(range_kwargs, Mapping):
+        raise ValueError("Catalog range_kwargs must be a mapping")
+
+    kwargs = dict(range_kwargs)
+    if range_type == "Choices":
+        values = kwargs.get("values")
+        if not isinstance(values, list):
+            raise ValueError("Choices catalog range must include a values list")
+        return list(values)
+
+    if range_type == "Range":
+        return _project_numeric_range(kwargs, type_name="float")
+    if range_type == "IntRange":
+        return _project_numeric_range(kwargs, type_name="int")
+    if range_type == "LogRange":
+        projected = _project_numeric_range(kwargs, type_name="float")
+        if isinstance(projected, tuple):
+            return {
+                "type": "float",
+                "low": projected[0],
+                "high": projected[1],
+                "log": True,
+            }
+        projected["log"] = True
+        return projected
+
+    raise ValueError(f"Unsupported catalog range_type: {range_type!r}")
+
+
+def _project_numeric_range(kwargs: dict[str, Any], *, type_name: str) -> Any:
+    if "low" not in kwargs or "high" not in kwargs:
+        raise ValueError("Numeric catalog range must include low and high")
+
+    if kwargs.get("step") is None and not kwargs.get("log"):
+        return (kwargs["low"], kwargs["high"])
+
+    projected = {"type": type_name, "low": kwargs["low"], "high": kwargs["high"]}
+    if kwargs.get("step") is not None:
+        projected["step"] = kwargs["step"]
+    if kwargs.get("log"):
+        projected["log"] = True
+    return projected
+
+
+__all__ = [
+    "CompiledEffect",
+    "KnobKind",
+    "KnobStrategy",
+    "STRATEGY_REGISTRY",
+    "get_strategy",
+    "knob_field",
+    "knob_kind",
+    "knob_name",
+    "project_knob_for_optimizer",
+    "register_strategy",
+]

--- a/traigent/effectuation/strategies/__init__.py
+++ b/traigent/effectuation/strategies/__init__.py
@@ -1,0 +1,21 @@
+"""Built-in effectuation strategies."""
+
+from traigent.effectuation.strategies.framework_param import (
+    FrameworkParamEffect,
+    FrameworkParamStrategy,
+)
+from traigent.effectuation.strategies.self_consistency import (
+    SELF_CONSISTENCY_NAMES,
+    SelfConsistencyEffect,
+    SelfConsistencyStrategy,
+    majority_vote,
+)
+
+__all__ = [
+    "FrameworkParamEffect",
+    "FrameworkParamStrategy",
+    "SELF_CONSISTENCY_NAMES",
+    "SelfConsistencyEffect",
+    "SelfConsistencyStrategy",
+    "majority_vote",
+]

--- a/traigent/effectuation/strategies/framework_param.py
+++ b/traigent/effectuation/strategies/framework_param.py
@@ -1,0 +1,56 @@
+"""Framework-parameter effectuation strategy.
+
+Value knobs are already applied by Traigent's integration override path. This
+strategy formalizes that executable path without re-applying or clobbering
+framework kwargs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from traigent.effectuation.contracts import (
+    KnobKind,
+    knob_kind,
+    project_knob_for_optimizer,
+)
+
+
+@dataclass(frozen=True)
+class FrameworkParamEffect:
+    """Compiled value-knob effect that leaves runtime execution unchanged."""
+
+    knob: Any
+
+    def project_for_optimizer(self) -> dict[str, Any]:
+        return project_knob_for_optimizer(self.knob)
+
+    def wrap_callable(self, fn: Callable[..., Any], plan: Any) -> Callable[..., Any]:
+        return fn
+
+    def emit_events(self) -> list[dict[str, Any]]:
+        return []
+
+
+class FrameworkParamStrategy:
+    """Strategy for already-supported framework value parameters."""
+
+    strategy_id = "framework_param"
+    supported_kinds = {KnobKind.VALUE.value}
+
+    def validate(self, knob: Any, runtime_ctx: Any) -> None:
+        kind = knob_kind(knob, default=KnobKind.VALUE.value)
+        if kind != KnobKind.VALUE.value:
+            raise ValueError(
+                f"{self.strategy_id} only supports value knobs, got {kind!r}"
+            )
+        project_knob_for_optimizer(knob)
+
+    def compile(self, knob: Any) -> FrameworkParamEffect:
+        self.validate(knob, runtime_ctx=None)
+        return FrameworkParamEffect(knob=knob)
+
+
+__all__ = ["FrameworkParamEffect", "FrameworkParamStrategy"]

--- a/traigent/effectuation/strategies/self_consistency.py
+++ b/traigent/effectuation/strategies/self_consistency.py
@@ -1,0 +1,208 @@
+"""Self-consistency effectuation strategy."""
+
+from __future__ import annotations
+
+import inspect
+from collections import Counter
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Any
+
+from traigent.config.context import get_config
+from traigent.effectuation.contracts import (
+    KnobKind,
+    knob_field,
+    knob_kind,
+    knob_name,
+    project_knob_for_optimizer,
+)
+
+SELF_CONSISTENCY_NAMES = frozenset({"candidate_count", "self_consistency_k"})
+_WRAPPED_MARKER = "__traigent_effectuation_self_consistency_wrapped__"
+
+
+def majority_vote(outputs: Sequence[Any]) -> Any:
+    """Return the modal output using normalized string equality."""
+
+    if not outputs:
+        return None
+
+    normalized = [_normalize_output(output) for output in outputs]
+    counts = Counter(normalized)
+    first_index = {value: normalized.index(value) for value in counts}
+    selected = max(counts, key=lambda value: (counts[value], -first_index[value]))
+    return outputs[first_index[selected]]
+
+
+@dataclass
+class SelfConsistencyEffect:
+    """Compiled effect that executes the wrapped callable N times."""
+
+    knob: Any
+    aggregator: Callable[[Sequence[Any]], Any] = majority_vote
+    _events: list[dict[str, Any]] = field(default_factory=list, init=False)
+
+    @property
+    def knob_name(self) -> str:
+        return knob_name(self.knob)
+
+    def project_for_optimizer(self) -> dict[str, Any]:
+        return project_knob_for_optimizer(self.knob)
+
+    def wrap_callable(self, fn: Callable[..., Any], plan: Any) -> Callable[..., Any]:
+        if getattr(fn, _WRAPPED_MARKER, False):
+            return fn
+
+        if inspect.iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                n = self._runtime_n()
+                if n <= 1:
+                    output = await fn(*args, **kwargs)
+                    self._record_event(n=n, outputs=[output], passthrough=True)
+                    return output
+
+                outputs = []
+                for _ in range(n):
+                    outputs.append(await fn(*args, **kwargs))
+                result = self.aggregator(outputs)
+                self._record_event(n=n, outputs=outputs, passthrough=False)
+                return result
+
+            setattr(async_wrapped, _WRAPPED_MARKER, True)
+            return async_wrapped
+
+        @wraps(fn)
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            n = self._runtime_n()
+            if n <= 1:
+                output = fn(*args, **kwargs)
+                self._record_event(n=n, outputs=[output], passthrough=True)
+                return output
+
+            outputs = [fn(*args, **kwargs) for _ in range(n)]
+            result = self.aggregator(outputs)
+            self._record_event(n=n, outputs=outputs, passthrough=False)
+            return result
+
+        setattr(wrapped, _WRAPPED_MARKER, True)
+        return wrapped
+
+    def emit_events(self) -> list[dict[str, Any]]:
+        return [dict(event) for event in self._events]
+
+    def _runtime_n(self) -> int:
+        cfg = get_config()
+        raw_value = _config_get(cfg, self.knob_name)
+        if raw_value is None:
+            raw_value = _config_get(cfg, _alternate_name(self.knob_name))
+        if raw_value is None:
+            return 1
+        return _coerce_count(raw_value)
+
+    def _record_event(
+        self,
+        *,
+        n: int,
+        outputs: Sequence[Any],
+        passthrough: bool,
+    ) -> None:
+        self._events = [
+            {
+                "strategy": "self_consistency",
+                "knob": self.knob_name,
+                "n": n,
+                "calls": len(outputs),
+                "unique_outputs": len(
+                    {_normalize_output(output) for output in outputs}
+                ),
+                "aggregator": _aggregator_label(self.aggregator),
+                "passthrough": passthrough,
+            }
+        ]
+
+
+class SelfConsistencyStrategy:
+    """Strategy for candidate-count/self-consistency cardinality knobs."""
+
+    strategy_id = "self_consistency"
+    supported_kinds = {KnobKind.CARDINALITY.value}
+
+    def validate(self, knob: Any, runtime_ctx: Any) -> None:
+        name = knob_name(knob)
+        if name not in SELF_CONSISTENCY_NAMES:
+            raise ValueError(
+                f"{self.strategy_id} only supports {sorted(SELF_CONSISTENCY_NAMES)}, "
+                f"got {name!r}"
+            )
+
+        kind = knob_kind(knob, default=KnobKind.CARDINALITY.value)
+        if kind != KnobKind.CARDINALITY.value:
+            raise ValueError(
+                f"{self.strategy_id} only supports cardinality knobs, got {kind!r}"
+            )
+
+        aggregator = knob_field(knob, "aggregator")
+        if aggregator is not None and not callable(aggregator):
+            raise ValueError("self_consistency aggregator must be callable")
+
+        project_knob_for_optimizer(knob)
+
+    def compile(self, knob: Any) -> SelfConsistencyEffect:
+        self.validate(knob, runtime_ctx=None)
+        aggregator = knob_field(knob, "aggregator", majority_vote)
+        return SelfConsistencyEffect(knob=knob, aggregator=aggregator)
+
+
+def _normalize_output(output: Any) -> str:
+    return str(output).strip().casefold()
+
+
+def _config_get(config: Any, key: str | None) -> Any:
+    if key is None:
+        return None
+    getter = getattr(config, "get", None)
+    if callable(getter):
+        return getter(key)
+    try:
+        return config[key]
+    except Exception:
+        return None
+
+
+def _alternate_name(name: str) -> str | None:
+    if name == "candidate_count":
+        return "self_consistency_k"
+    if name == "self_consistency_k":
+        return "candidate_count"
+    return None
+
+
+def _coerce_count(raw_value: Any) -> int:
+    if isinstance(raw_value, bool):
+        raise ValueError("self_consistency count must be an integer, not bool")
+    if isinstance(raw_value, int):
+        return raw_value
+    if isinstance(raw_value, float) and raw_value.is_integer():
+        return int(raw_value)
+    if isinstance(raw_value, str):
+        stripped = raw_value.strip()
+        if stripped.lstrip("-").isdigit():
+            return int(stripped)
+    raise ValueError(f"self_consistency count must be an integer, got {raw_value!r}")
+
+
+def _aggregator_label(aggregator: Callable[[Sequence[Any]], Any]) -> str:
+    if aggregator is majority_vote:
+        return "majority_vote"
+    return getattr(aggregator, "__name__", "custom")
+
+
+__all__ = [
+    "SELF_CONSISTENCY_NAMES",
+    "SelfConsistencyEffect",
+    "SelfConsistencyStrategy",
+    "majority_vote",
+]


### PR DESCRIPTION
## Executable effectuation: KnobStrategy contract + value/self-consistency strategies (P4, opt-in)

P4 of the Tuned-Variable Knowledge Layer. Closes the "declaration ≠ effectuation" gap the senior-SE
review flagged: declaring a knob can now actually RUN it (Strategy pattern). **Opt-in + additive** —
default optimize behavior is byte-for-byte unchanged.

- `effectuation/contracts.py`: `KnobStrategy`/`CompiledEffect` protocols + `STRATEGY_REGISTRY`.
- `strategies/framework_param.py`: formalizes the EXISTING integration auto-apply of value knobs
  (no-op wrapper — avoids double-application through the integration override path).
- `strategies/self_consistency.py`: `candidate_count`/`self_consistency_k` — runs the callable N times +
  pluggable aggregator (default `majority_vote`); N≤1 passthrough; guards double-wrap; `emit_events`
  are aggregate + **content-free**.
- `effectuation/__init__.py`: `apply_effectuation(fn, config, *, enabled=False)` — **default no-op**
  (returns the same callable; nothing changes unless effectuation is explicitly enabled).
- Catalog: **only** `candidate_count` flipped to `effectuation_status=executable` (strategy
  `self_consistency`). The 7 genuinely-manual structural knobs stay `manual_guidance` — no over-claim.

Verified: 302 config_generator+effectuation tests pass; default no-op confirmed; majority-vote correct;
catalog validates; `generate-config --json` keys unchanged. Stacked on #1078.

### PR checklist
1. Worst-case prod path — default `enabled=False` no-op; opt-in only; no double-apply. No policy surface.
2. Production-branch test — default-no-op + self-consistency + no-double-wrap + content-free-events tests.
3. Contract regen — none (uses existing catalog `effectuation_status`/`effectuation_strategy` fields).
4. Public surface — new `traigent.effectuation` package (additive); CLI shape unchanged.
5. Threads — none yet. 6. Gates — none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
