### PR TITLE
security(config_generator): scrub internal artifact paths + run ids from public EvidenceRef

### DIFF
--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -175,19 +175,16 @@ class TestGenerateRecommendations:
 
         schema_context = recs_by_name["schema_context"]
         assert len(schema_context.evidence_refs) == 2
-        assert schema_context.evidence_refs[0].artifact_path == (
-            "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/"
-            "isolation/schema_context.json"
-        )
+        # Public-safe provenance only: no internal artifact_path / run_id.
+        assert not hasattr(schema_context.evidence_refs[0], "artifact_path")
+        assert not hasattr(schema_context.evidence_refs[0], "run_id")
         assert schema_context.evidence_refs[0].delta == 0.40
         assert schema_context.evidence_refs[1].candidate == "full_ddl_fk"
         assert schema_context.impact_estimate == "high"
 
         retrieval_k = recs_by_name["retrieval_k"]
-        assert retrieval_k.evidence_refs[0].artifact_path == (
-            "TraigentDemo/examples/use-cases/hotpotqa-rag-optimizer/artifacts/"
-            "isolation/retrieval_k.json"
-        )
+        assert not hasattr(retrieval_k.evidence_refs[0], "artifact_path")
+        assert not hasattr(retrieval_k.evidence_refs[0], "run_id")
         assert retrieval_k.evidence_refs[0].metric == "answer_em"
         assert retrieval_k.evidence_refs[0].baseline == 1
         assert retrieval_k.evidence_refs[0].candidate == 5

--- a/tests/unit/config_generator/test_types.py
+++ b/tests/unit/config_generator/test_types.py
@@ -116,8 +116,6 @@ class TestStructuralConstraintSpec:
 class TestEvidenceRef:
     def test_creation_defaults(self) -> None:
         ref = EvidenceRef(
-            artifact_path="artifacts/isolation/schema_context.json",
-            run_id="run-1",
             scope="isolation",
             metric="execution_accuracy",
             n=10,
@@ -130,8 +128,6 @@ class TestEvidenceRef:
 
     def test_frozen(self) -> None:
         ref = EvidenceRef(
-            artifact_path="artifacts/isolation/schema_context.json",
-            run_id="run-1",
             scope="isolation",
             metric="execution_accuracy",
             n=10,
@@ -165,8 +161,6 @@ class TestTVarRecommendation:
 
     def test_with_evidence_and_guidance(self) -> None:
         ref = EvidenceRef(
-            artifact_path="artifacts/isolation/schema_context.json",
-            run_id="run-1",
             scope="isolation",
             metric="execution_accuracy",
             n=10,

--- a/traigent/config_generator/subsystems/tvar_recommendations.py
+++ b/traigent/config_generator/subsystems/tvar_recommendations.py
@@ -59,18 +59,6 @@ def generate_recommendations(
 # ---------------------------------------------------------------------------
 
 _DEMO_MODEL = "bedrock/us.anthropic.claude-haiku-4-5"
-_BIRD_ISOLATION = (
-    "TraigentDemo/examples/use-cases/bird-sql-optimizer/artifacts/isolation"
-)
-_TEXT2SQL_ISOLATION = (
-    "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/isolation"
-)
-_TEXT2SQL_SIGNIFICANCE = (
-    "TraigentDemo/examples/use-cases/text2sql-sota-optimizer/artifacts/significance"
-)
-_HOTPOTQA_ISOLATION = (
-    "TraigentDemo/examples/use-cases/hotpotqa-rag-optimizer/artifacts/isolation"
-)
 _SINGLE_SLICE_LIMITATIONS = ("single_slice", "not_sota")
 _LOW_JOINT_LIMITATIONS = ("low_or_zero_in_isolation", "gains_are_joint")
 _OBSERVATIONAL_LIMITATIONS = ("observational_not_causal",)
@@ -97,8 +85,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "medium",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_HOTPOTQA_ISOLATION}/retrieval_k.json",
-                    run_id="hotpotqa-rag-300-naive",
                     scope="isolation",
                     metric="answer_em",
                     n=10,
@@ -165,8 +151,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "high",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/schema_context.json",
-                    run_id="bird-minidev-300-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -177,8 +161,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
                     limitations=_SINGLE_SLICE_LIMITATIONS,
                 ),
                 EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/schema_context.json",
-                    run_id="text2sql-spider-200-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -207,8 +189,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "medium",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/evidence_usage.json",
-                    run_id="bird-minidev-300-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -235,8 +215,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "medium",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_SIGNIFICANCE}/importance.json",
-                    run_id="text2sql-spider-200-naive",
                     scope="significance",
                     metric="importance",
                     n=200,
@@ -265,8 +243,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "low",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/generation_path.json",
-                    run_id="bird-minidev-300-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -277,8 +253,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
                     limitations=_LOW_JOINT_LIMITATIONS,
                 ),
                 EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/generation_path.json",
-                    run_id="text2sql-spider-200-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -307,8 +281,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "low",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/fewshot_k.json",
-                    run_id="bird-minidev-300-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -319,8 +291,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
                     limitations=_LOW_JOINT_LIMITATIONS,
                 ),
                 EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/fewshot_k.json",
-                    run_id="text2sql-spider-200-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -347,8 +317,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "low",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_SIGNIFICANCE}/importance.json",
-                    run_id="text2sql-spider-200-naive",
                     scope="significance",
                     metric="importance",
                     n=200,
@@ -375,8 +343,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
             "impact": "low",
             "evidence_refs": (
                 EvidenceRef(
-                    artifact_path=f"{_BIRD_ISOLATION}/repair_policy.json",
-                    run_id="bird-minidev-300-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,
@@ -387,8 +353,6 @@ _RECOMMENDATIONS: dict[str, list[dict[str, Any]]] = {
                     limitations=_LOW_JOINT_LIMITATIONS,
                 ),
                 EvidenceRef(
-                    artifact_path=f"{_TEXT2SQL_ISOLATION}/repair_policy.json",
-                    run_id="text2sql-spider-200-naive",
                     scope="isolation",
                     metric="execution_accuracy",
                     n=10,

--- a/traigent/config_generator/types.py
+++ b/traigent/config_generator/types.py
@@ -75,8 +75,6 @@ class StructuralConstraintSpec:
 class EvidenceRef:
     """Reference to measured evidence supporting a recommendation."""
 
-    artifact_path: str
-    run_id: str
     scope: str
     metric: str
     n: int


### PR DESCRIPTION
## Summary
The squash-merge of #1075 landed the **pre-scrub** `EvidenceRef` on public `develop`, re-exposing internal IP that an earlier scrub (`ee9d8acb`) had removed on the feature branch but which never made it into the squashed commit.

Live on `develop` before this PR (`Traigent/Traigent` is a **public** repo):
- `EvidenceRef.artifact_path` / `run_id` fields (`types.py`)
- Private **TraigentDemo** path constants (`_BIRD_ISOLATION`, `_TEXT2SQL_ISOLATION`, `_TEXT2SQL_SIGNIFICANCE`, `_HOTPOTQA_ISOLATION`) + ~12 `artifact_path=`/`run_id=` references with internal run ids (e.g. `bird-minidev-300-naive`) in `tvar_recommendations.py`

Scope confirmed: leak is **only** on `develop` (via `deed01d3`/#1075); `main` is clean, no tags carry it.

## Change
- Remove `artifact_path` / `run_id` from `EvidenceRef`; public evidence now carries only public-safe provenance (`scope, metric, n, model, baseline, candidate, delta, limitations`).
- Drop the private path constants and their kwargs from the recommendation catalog.
- Tests assert the internal fields are absent (`not hasattr(... "artifact_path"/"run_id")`).

## Verification
- `pytest tests/unit/config_generator -q -n0` → **279 passed**
- `git grep` for `TraigentDemo` / internal run ids across tracked `.py` → **0 matches**
- pre-commit (isort/black/ruff/detect-secrets/bandit/mypy/public-test-assertion-contracts) → green

## PR checklist
1. **Worst-case prod path** — N/A behavior; this removes information disclosure (private repo structure) from public source. Fails safe (less data).
2. **Production-branch test** — `tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py` + `test_types.py` assert the internal fields are absent.
3. **Contract regeneration** — none; `EvidenceRef` is an internal SDK dataclass, not a wire contract.
4. **Public surface delta** — `EvidenceRef` loses two fields (`artifact_path`, `run_id`); no documented/public API removed.
5. **Review threads** — n/a (new PR).
6. **Quality gates** — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)