### PR TITLE
feat(knobs): the one-Knob model — bindings, certificates, signals, resolution types (RFC 0001)

### DIFF
--- a/tests/unit/knobs/test_knobs_types.py
+++ b/tests/unit/knobs/test_knobs_types.py
@@ -445,3 +445,16 @@ def test_certificate_target_is_the_rfc_object():
     assert cert.target == _target()
     other_target_ctx = _ctx(target=TargetProperty(name="x", mode="chance_constraint"))
     assert not cert.valid_for("theta", "float", 0.5, other_target_ctx)
+
+
+def test_counts_are_natural_numbers():
+    """Round-2 finding: ℕ means strict non-negative INT — floats and bools
+    are rejected as counts."""
+    from traigent.knobs import EvidenceRef
+
+    for bad in (1.5, True, False, -1):
+        with pytest.raises(ValueError):
+            _ctx(evidence_n=bad)
+        with pytest.raises(ValueError):
+            EvidenceRef(n=bad, pool_hash="p")
+    EvidenceRef(n=0, pool_hash="p")  # zero is a natural number here

--- a/tests/unit/knobs/test_knobs_types.py
+++ b/tests/unit/knobs/test_knobs_types.py
@@ -178,7 +178,7 @@ def _ctx(**overrides) -> FreshnessContext:
         evidence_n=20,
         calibration_split="cal",
         eval_split="eval",
-        target_hash=_target().property_hash(),
+        target=_target(),
         extensions=(),
     )
     base.update(overrides)
@@ -197,7 +197,7 @@ CORE_FLIPS = [
     ("evidence_n", 21),
     ("calibration_split", "cal2"),
     ("eval_split", "eval2"),
-    ("target_hash", canonical_hash("other-target")),
+    ("target", TargetProperty(name="other", mode="chance_constraint")),
 ]
 
 
@@ -239,7 +239,7 @@ def test_audit_copies_must_agree_with_live_context():
     ctx = _ctx()
     cert = issue_certificate("theta", "float", 0.5, ctx)
     for field_name, bad in [
-        ("target_hash", canonical_hash("forged")),
+        ("target", TargetProperty(name="forged", mode="chance_constraint")),
         ("evidence", dataclasses.replace(cert.evidence, n=999)),
         ("evidence", dataclasses.replace(cert.evidence, pool_hash="forged")),
     ]:
@@ -326,11 +326,11 @@ def test_certificate_closed_shape():
         "subject_cvar",
         "subject_type",
         "subject_value_hash",
-        "target_hash",
+        "target",
         "issued_hash",
         "decision",
         "evidence",
-    }  # no payload / metadata field
+    }  # no payload / metadata field; target is the closed TargetProperty
 
 
 # ---------------------------------------------------------------------------
@@ -395,3 +395,53 @@ def test_package_is_import_light():
                 if name.startswith("traigent.effectuation"):
                     # only the guarded kinds import may reference it
                     assert module_path.name == "kinds.py"
+
+
+def test_jcs_number_rule():
+    """RFC 8785: integral floats hash as the integer (1.0 == 1), while bool
+    stays DISTINCT from int (checked before int)."""
+    assert canonical_hash(1.0) == canonical_hash(1)
+    assert canonical_hash({"n": 20.0}) == canonical_hash({"n": 20})
+    assert canonical_hash(True) != canonical_hash(1)
+    assert canonical_hash(0.5) != canonical_hash(0)
+
+
+def test_bytes_like_rejected():
+    for value in (b"x", bytearray(b"x"), memoryview(b"x")):
+        with pytest.raises(CanonicalizationError):
+            canonical_hash(value)
+
+
+def test_ident_and_count_validation():
+    with pytest.raises(ValueError):
+        Knob(name="", binding=Fixed(value=1))
+    with pytest.raises(ValueError):
+        Knob(name="a..b", binding=Fixed(value=1))
+    with pytest.raises(ValueError):
+        Ref(knob="")
+    with pytest.raises(ValueError):
+        _ctx(evidence_n=-1)
+    from traigent.knobs import EvidenceRef
+
+    with pytest.raises(ValueError):
+        EvidenceRef(n=-1, pool_hash="p")
+
+
+def test_calibrated_self_ref_rejected():
+    with pytest.raises(ValueError, match="cannot depend on itself"):
+        Knob(
+            name="theta",
+            binding=Calibrated(
+                signal=_signal(), target=_target(), depends_on=(Ref(knob="theta"),)
+            ),
+        )
+
+
+def test_certificate_target_is_the_rfc_object():
+    """RFC §3.5 fidelity: the certificate carries the TargetProperty itself
+    (closed shape), and validity compares OBJECTS, not hashes."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    assert cert.target == _target()
+    other_target_ctx = _ctx(target=TargetProperty(name="x", mode="chance_constraint"))
+    assert not cert.valid_for("theta", "float", 0.5, other_target_ctx)

--- a/tests/unit/knobs/test_knobs_types.py
+++ b/tests/unit/knobs/test_knobs_types.py
@@ -1,0 +1,397 @@
+"""traigent.knobs type tests (SDK packet 6-B, RFC 0001).
+
+Acceptance criteria from the program plan:
+- ParameterRange -> Knob[Tuned] -> ParameterRange identity for all four
+  range types, with the default carried as a CANDIDATE (never Fixed);
+- certificates become stale when ANY freshness-core input changes
+  (parametrized per-key flips) and cannot be forged across subjects,
+  values, or contexts;
+- KnobKind stays value-identical with the effectuation taxonomy;
+- the persisted-signal shapes are CLOSED (P8).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from traigent.api.parameter_ranges import Choices, IntRange, LogRange, Range
+from traigent.knobs import (
+    CTX_EXT_KEYS,
+    Calibrated,
+    CanonicalizationError,
+    Certificate,
+    CertificateDecision,
+    Fixed,
+    FreshnessContext,
+    Knob,
+    KnobKind,
+    Ref,
+    ResolutionNode,
+    ResolutionRejection,
+    SignalObservation,
+    SignalSpec,
+    TargetProperty,
+    Tuned,
+    canonical_hash,
+    conformal_evidence_floor,
+    issue_certificate,
+    knob_to_parameter_range,
+    parameter_range_to_knob,
+)
+
+# ---------------------------------------------------------------------------
+# Kinds parity (effectuation reconciliation)
+# ---------------------------------------------------------------------------
+
+
+def test_knob_kind_parity_with_effectuation_taxonomy():
+    """Pins member names AND serialized values to the effectuation enum
+    (traigent/effectuation/contracts.py on its feature branch). If either
+    side renames, this test trips."""
+    assert {k.name for k in KnobKind} == {"VALUE", "CARDINALITY", "TOPOLOGY", "POLICY"}
+    assert {k.value for k in KnobKind} == {"value", "cardinality", "topology", "policy"}
+
+
+# ---------------------------------------------------------------------------
+# Bindings
+# ---------------------------------------------------------------------------
+
+
+def _signal() -> SignalSpec:
+    return SignalSpec(
+        name="vote_margin",
+        version="1",
+        score_function="exact_match",
+        score_function_version="1",
+        comparator="key_eq",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="margin_floor", mode="require_calibration")
+
+
+def test_binding_discrimination_is_isinstance_based():
+    tuned = Knob(name="k", binding=Tuned(range=IntRange(0, 8)))
+    fixed = Knob(name="f", binding=Fixed(value=3))
+    calibrated = Knob(
+        name="theta",
+        binding=Calibrated(signal=_signal(), target=_target()),
+    )
+    assert tuned.is_tuned() and not tuned.is_fixed() and not tuned.is_calibrated()
+    assert fixed.is_fixed() and not fixed.is_tuned()
+    assert calibrated.is_calibrated() and not calibrated.is_tuned()
+    # P2: only Tuned is optimizer-visible
+    assert tuned.optimizer_visible
+    assert not fixed.optimizer_visible
+    assert not calibrated.optimizer_visible
+
+
+def test_knob_rejects_non_binding():
+    with pytest.raises(TypeError):
+        Knob(name="bad", binding="not-a-binding")  # type: ignore[arg-type]
+
+
+def test_bindings_are_frozen():
+    knob = Knob(name="k", binding=Fixed(value=1))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        knob.name = "other"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        knob.binding.value = 2  # type: ignore[misc]
+
+
+def test_target_property_mode_registry():
+    with pytest.raises(ValueError):
+        TargetProperty(name="x", mode="vibes")
+
+
+# ---------------------------------------------------------------------------
+# Adapters — identity round-trip, default stays a candidate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parameter_range",
+    [
+        Range(low=0.0, high=1.0, step=0.1, default=0.5),
+        IntRange(low=0, high=8, default=2),
+        LogRange(low=1e-5, high=1e-1),
+        Choices(values=["a", "b", "c"], default="b"),
+    ],
+    ids=["Range", "IntRange", "LogRange", "Choices"],
+)
+def test_parameter_range_round_trip_identity(parameter_range):
+    knob = parameter_range_to_knob("p", parameter_range)
+    assert knob.is_tuned()
+    # identity: the SAME object comes back — no copy, no coercion
+    assert knob_to_parameter_range(knob) is parameter_range
+    # the default is carried as a Tuned CANDIDATE, never a Fixed binding
+    assert knob.binding.default == parameter_range.get_default()
+    assert not knob.is_fixed()
+
+
+def test_fixed_and_calibrated_are_not_projectable():
+    assert knob_to_parameter_range(Knob(name="f", binding=Fixed(value=1))) is None
+    assert (
+        knob_to_parameter_range(
+            Knob(name="c", binding=Calibrated(signal=_signal(), target=_target()))
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical hashing
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_hash_rules():
+    assert canonical_hash({"a": 1, "b": 2}) == canonical_hash({"b": 2, "a": 1})
+    assert canonical_hash({"x": -0.0}) == canonical_hash({"x": 0.0})
+    assert canonical_hash("café") == canonical_hash("café")  # NFC
+    with pytest.raises(CanonicalizationError):
+        canonical_hash(float("nan"))
+    with pytest.raises(CanonicalizationError):
+        canonical_hash(float("inf"))
+    with pytest.raises(CanonicalizationError):
+        canonical_hash(object())
+
+
+# ---------------------------------------------------------------------------
+# Certificates — freshness, subject binding, fail-closed validity
+# ---------------------------------------------------------------------------
+
+
+def _ctx(**overrides) -> FreshnessContext:
+    base = dict(
+        cvar_name="theta",
+        tuned_parent_values=(("model", "m1"), ("retriever.k", 4)),
+        calibration_source_id="pool_a",
+        signal_spec_hash=_signal().spec_hash(),
+        calibrator_id="budget_threshold",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({"budgets": [0.1, 0.2]}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target_hash=_target().property_hash(),
+        extensions=(),
+    )
+    base.update(overrides)
+    return FreshnessContext(**base)
+
+
+CORE_FLIPS = [
+    ("cvar_name", "theta2"),
+    ("tuned_parent_values", (("model", "m2"), ("retriever.k", 4))),
+    ("calibration_source_id", "pool_b"),
+    ("signal_spec_hash", canonical_hash("other-signal")),
+    ("calibrator_id", "other_calibrator"),
+    ("calibrator_version", "2"),
+    ("calibrator_params_hash", canonical_hash({"budgets": [0.3]})),
+    ("dataset_hash", "ds_v2"),
+    ("evidence_n", 21),
+    ("calibration_split", "cal2"),
+    ("eval_split", "eval2"),
+    ("target_hash", canonical_hash("other-target")),
+]
+
+
+def test_certificate_valid_for_same_context():
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    assert cert.valid_for("theta", "float", 0.5, ctx)
+
+
+@pytest.mark.parametrize("field_name,new_value", CORE_FLIPS)
+def test_every_core_key_flip_is_staleness_inducing(field_name, new_value):
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    flipped = dataclasses.replace(ctx, **{field_name: new_value})
+    if field_name == "cvar_name":
+        assert not cert.valid_for("theta2", "float", 0.5, flipped)
+    assert not cert.valid_for("theta", "float", 0.5, flipped), field_name
+
+
+def test_subject_binding_name_type_value():
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    assert not cert.valid_for("theta", "int", 0.5, ctx)  # type
+    assert not cert.valid_for("theta", "float", 0.6, ctx)  # value
+
+
+def test_forged_subject_cross_context_rejected():
+    """A certificate issued against CVAR B's context with a forged subject
+    naming A must not validate A (RFC v4 first conjunct)."""
+    ctx_b = _ctx(cvar_name="theta_b")
+    forged = dataclasses.replace(
+        issue_certificate("theta_b", "float", 0.5, ctx_b), subject_cvar="theta_a"
+    )
+    assert not forged.valid_for("theta_a", "float", 0.5, ctx_b)
+    assert not forged.valid_for("theta_a", "float", 0.5, _ctx(cvar_name="theta_a"))
+
+
+def test_audit_copies_must_agree_with_live_context():
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    for field_name, bad in [
+        ("target_hash", canonical_hash("forged")),
+        ("evidence", dataclasses.replace(cert.evidence, n=999)),
+        ("evidence", dataclasses.replace(cert.evidence, pool_hash="forged")),
+    ]:
+        tampered = dataclasses.replace(cert, **{field_name: bad})
+        assert not tampered.valid_for("theta", "float", 0.5, ctx)
+
+
+def test_non_certified_decisions_never_valid():
+    ctx = _ctx()
+    for decision in (
+        CertificateDecision.NO_DECISION,
+        CertificateDecision.BEST_EFFORT_UNCERTIFIED,
+    ):
+        cert = issue_certificate("theta", "float", 0.5, ctx, decision=decision)
+        assert not cert.valid_for("theta", "float", 0.5, ctx)
+
+
+def test_issue_certificate_subject_must_match_context():
+    with pytest.raises(ValueError):
+        issue_certificate("theta_a", "float", 0.5, _ctx(cvar_name="theta_b"))
+
+
+def test_parent_specificity_cannot_be_disabled_by_extensions():
+    import itertools
+
+    for r in range(len(CTX_EXT_KEYS) + 1):
+        for subset in itertools.combinations(sorted(CTX_EXT_KEYS), r):
+            ext = tuple((k, "v") for k in subset)
+            a = _ctx(extensions=ext)
+            b = _ctx(
+                tuned_parent_values=(("model", "m2"), ("retriever.k", 4)),
+                extensions=ext,
+            )
+            assert a.freshness_hash() != b.freshness_hash(), subset
+
+
+def test_extensions_are_a_canonical_map():
+    a = _ctx(extensions=(("model_versions", "mv1"), ("stage_versions", "sv1")))
+    b = _ctx(extensions=(("stage_versions", "sv1"), ("model_versions", "mv1")))
+    assert a.freshness_hash() == b.freshness_hash()
+    with pytest.raises(ValueError, match="duplicate_calibration_context_key"):
+        _ctx(
+            extensions=(("model_versions", "a"), ("model_versions", "b"))
+        ).freshness_hash()
+    with pytest.raises(ValueError, match="invalid_calibration_context"):
+        _ctx(extensions=(("tuned_parent_values", "x"),)).freshness_hash()
+
+
+def test_parents_are_canonical_too():
+    a = _ctx(tuned_parent_values=(("a", 1), ("b", 2)))
+    b = _ctx(tuned_parent_values=(("b", 2), ("a", 1)))
+    assert a.freshness_hash() == b.freshness_hash()
+    with pytest.raises(ValueError, match="duplicate tuned parent"):
+        _ctx(tuned_parent_values=(("a", 1), ("a", 2))).freshness_hash()
+
+
+def test_conformal_evidence_floor():
+    assert conformal_evidence_floor(0.1) == 9
+    assert conformal_evidence_floor(0.01) == 99
+    with pytest.raises(ValueError):
+        conformal_evidence_floor(0.0)
+    with pytest.raises(ValueError):
+        conformal_evidence_floor(1.5)
+
+
+# ---------------------------------------------------------------------------
+# Signals — closed shape (P8)
+# ---------------------------------------------------------------------------
+
+
+def test_signal_observation_closed_shape():
+    obs = SignalObservation(signal="vote_margin", value=0.7, n=10, split="cal")
+    field_names = {f.name for f in dataclasses.fields(obs)}
+    assert field_names == {"signal", "value", "n", "split"}  # NO metadata map
+    with pytest.raises(ValueError):
+        SignalObservation(signal="s", value=float("nan"), n=1, split="cal")
+    with pytest.raises(ValueError):
+        SignalObservation(signal="s", value=0.5, n=-1, split="cal")
+
+
+def test_certificate_closed_shape():
+    field_names = {f.name for f in dataclasses.fields(Certificate)}
+    assert field_names == {
+        "subject_cvar",
+        "subject_type",
+        "subject_value_hash",
+        "target_hash",
+        "issued_hash",
+        "decision",
+        "evidence",
+    }  # no payload / metadata field
+
+
+# ---------------------------------------------------------------------------
+# Resolution vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_vocabulary_matches_rfc():
+    assert {r.value for r in ResolutionRejection} == {
+        "cycle",
+        "missing_ref",
+        "duplicate_provider",
+        "phase_mismatch",
+        "infeasible_value",
+        "stale_certificate",
+        "evidence_leakage",
+        "insufficient_evidence",
+        "no_decision",
+    }
+    with pytest.raises(ValueError):
+        ResolutionNode(knob="x", binding_kind="searched")
+    with pytest.raises(ValueError):
+        ResolutionNode(knob="x", binding_kind="tuned", phase="later")
+
+
+def test_calibrated_refs_and_fallback_shape():
+    calibrated = Calibrated(
+        signal=_signal(),
+        target=_target(),
+        depends_on=(Ref(knob="model"), Ref(knob="retriever.k")),
+        fallback=Fixed(value=0.5),
+        require_calibration=True,
+        target_epsilon=0.1,
+    )
+    assert calibrated.depends_on[0].knob == "model"
+    assert calibrated.fallback.value == 0.5
+
+
+def test_package_is_import_light():
+    """traigent.knobs modules must not import the orchestrator or cloud
+    client themselves. (Importing ANY traigent.* module triggers the
+    top-level package __init__, so a sys.modules check would measure the
+    package, not this code — a static source check states the actual design
+    property.)"""
+    import ast as ast_mod
+    import pathlib
+
+    import traigent.knobs
+
+    package_dir = pathlib.Path(traigent.knobs.__file__).parent
+    for module_path in package_dir.glob("*.py"):
+        tree = ast_mod.parse(module_path.read_text(encoding="utf-8"))
+        for node in ast_mod.walk(tree):
+            names: list[str] = []
+            if isinstance(node, ast_mod.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast_mod.ImportFrom) and node.module:
+                names = [node.module]
+            for name in names:
+                assert not name.startswith("traigent.core"), module_path.name
+                assert not name.startswith("traigent.cloud"), module_path.name
+                if name.startswith("traigent.effectuation"):
+                    # only the guarded kinds import may reference it
+                    assert module_path.name == "kinds.py"

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -1,0 +1,66 @@
+"""traigent.knobs — the one-Knob model (RFC 0001: knob bindings).
+
+Pure types in this packet: bindings (Tuned | Fixed | Calibrated), signal
+specs and content-free observations, certificates with hash-covered
+freshness contexts, resolution vocabulary, and ParameterRange adapters.
+No runtime behavior changes anywhere else; nothing here is wired into the
+orchestrator yet (that is the knobs-resolver packet) and nothing crosses a
+wire boundary (see the program's contract-decision record).
+
+Import-light by design: importing this package must not pull in
+``traigent.core`` or the cloud client.
+
+DESIGN NOTE for the deferred CVAR optimizer: when many candidate
+configurations share one calibration pool, certification must use
+fixed-sequence testing in a pre-committed (e.g. cost) order — never
+Bonferroni over an unordered grid, and never silent pool reuse
+(multiplicity accounting belongs INSIDE the certificate; see Pareto
+Testing, arXiv:2210.07913).
+"""
+
+from __future__ import annotations
+
+from .adapters import knob_to_parameter_range, parameter_range_to_knob
+from .bindings import Binding, Calibrated, Fixed, Knob, Ref, Tuned
+from .canonical import CTX_SCHEMA_VERSION, CanonicalizationError, canonical_hash
+from .certificates import (
+    CTX_EXT_KEYS,
+    Certificate,
+    CertificateDecision,
+    EvidenceRef,
+    FreshnessContext,
+    TargetProperty,
+    conformal_evidence_floor,
+    issue_certificate,
+)
+from .kinds import KnobKind
+from .resolution import ResolutionError, ResolutionNode, ResolutionRejection
+from .signals import SignalObservation, SignalSpec
+
+__all__ = [
+    "CTX_EXT_KEYS",
+    "CTX_SCHEMA_VERSION",
+    "Binding",
+    "Calibrated",
+    "CanonicalizationError",
+    "Certificate",
+    "CertificateDecision",
+    "EvidenceRef",
+    "Fixed",
+    "FreshnessContext",
+    "Knob",
+    "KnobKind",
+    "Ref",
+    "ResolutionError",
+    "ResolutionNode",
+    "ResolutionRejection",
+    "SignalObservation",
+    "SignalSpec",
+    "TargetProperty",
+    "Tuned",
+    "canonical_hash",
+    "conformal_evidence_floor",
+    "issue_certificate",
+    "knob_to_parameter_range",
+    "parameter_range_to_knob",
+]

--- a/traigent/knobs/adapters.py
+++ b/traigent/knobs/adapters.py
@@ -1,0 +1,44 @@
+"""Adapters between ParameterRange (the existing surface) and Knob[Tuned].
+
+``ParameterRange`` stays unchanged (RFC 0001 decision): ``Range.default``
+remains a default CANDIDATE value, and the adapters preserve that — a Tuned
+default is never coerced into a Fixed binding.
+"""
+
+from __future__ import annotations
+
+from traigent.api.parameter_ranges import ParameterRange
+
+from .bindings import Knob, Tuned
+from .kinds import KnobKind
+
+__all__ = ["knob_to_parameter_range", "parameter_range_to_knob"]
+
+
+def parameter_range_to_knob(
+    name: str,
+    parameter_range: ParameterRange,
+    *,
+    kind: KnobKind = KnobKind.VALUE,
+    description: str | None = None,
+) -> Knob:
+    """Wrap an existing ParameterRange as a Tuned knob (identity-preserving)."""
+    return Knob(
+        name=name,
+        binding=Tuned(range=parameter_range, default=parameter_range.get_default()),
+        kind=kind,
+        description=description,
+    )
+
+
+def knob_to_parameter_range(knob: Knob) -> ParameterRange | None:
+    """Project a knob onto the optimizer-visible surface.
+
+    Returns the underlying ParameterRange for Tuned knobs and ``None`` for
+    Fixed/Calibrated knobs — they are optimizer-invisible (P2), which is
+    exactly what makes ``ConfigSpace.tvars`` the Tuned-only projection.
+    """
+    binding = knob.binding
+    if isinstance(binding, Tuned):
+        return binding.range
+    return None

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -1,0 +1,110 @@
+"""The one-Knob model: typed bindings Tuned | Fixed | Calibrated (RFC 0001).
+
+Every configuration variable is a knob with exactly one binding:
+
+- ``Tuned`` — optimizer-visible, searched over a :class:`ParameterRange`.
+  Its ``default`` mirrors ``ParameterRange.default``: a default CANDIDATE
+  value inside the searched domain, never a Fixed binding.
+- ``Fixed`` — a runtime-supplied constant; never searched.
+- ``Calibrated`` — a CVAR: produced by a calibrator from calibration
+  evidence, optimizer-invisible, certificate-backed.
+
+The binding union is discriminated by ``isinstance`` over the three frozen
+classes — deliberately NO string discriminator, so no second kind taxonomy
+competes with :class:`~traigent.knobs.kinds.KnobKind` (which classifies what
+a knob effectuates, not how it binds).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+from traigent.api.parameter_ranges import ParameterRange
+
+from .certificates import Certificate, TargetProperty
+from .kinds import KnobKind
+from .signals import SignalSpec
+
+__all__ = ["Binding", "Calibrated", "Fixed", "Knob", "Ref", "Tuned"]
+
+TValue = TypeVar("TValue")
+
+
+@dataclass(frozen=True, slots=True)
+class Tuned(Generic[TValue]):
+    """Optimizer-visible binding over a searched domain."""
+
+    range: ParameterRange
+    default: TValue | None = None  # default CANDIDATE, never Fixed
+
+
+@dataclass(frozen=True, slots=True)
+class Fixed(Generic[TValue]):
+    """Runtime-supplied constant binding; never searched."""
+
+    value: TValue
+
+
+@dataclass(frozen=True, slots=True)
+class Ref:
+    """A namespace reference to another knob (a CVAR's tuned parent).
+
+    Per RFC 0001 §3.3, v1 refs MUST name Tuned knobs (CVAR→CVAR parents are
+    deferred). Dependencies are a freshness relation, not a constraint.
+    """
+
+    knob: str
+    field: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Calibrated(Generic[TValue]):
+    """A CVAR binding: value produced by a calibrator, certificate-backed.
+
+    ``fallback`` may only be consumed OUTSIDE strict evidence modes, and its
+    use is always observable in resolution output — never silent.
+    """
+
+    signal: SignalSpec
+    target: TargetProperty
+    depends_on: tuple[Ref, ...] = field(default=())
+    fallback: Fixed[TValue] | None = None
+    certificate: Certificate | None = None
+    require_calibration: bool = False
+    target_epsilon: float | None = None  # chance-style level for the R8 floor
+
+
+#: The binding union — isinstance-discriminated.
+Binding = Tuned[TValue] | Fixed[TValue] | Calibrated[TValue]
+
+
+@dataclass(frozen=True, slots=True)
+class Knob(Generic[TValue]):
+    """A named configuration variable with exactly one typed binding."""
+
+    name: str
+    binding: Tuned[TValue] | Fixed[TValue] | Calibrated[TValue]
+    kind: KnobKind = KnobKind.VALUE
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding, (Tuned, Fixed, Calibrated)):
+            raise TypeError(
+                f"Knob binding must be Tuned, Fixed, or Calibrated; "
+                f"got {type(self.binding).__name__}"
+            )
+
+    def is_tuned(self) -> bool:
+        return isinstance(self.binding, Tuned)
+
+    def is_fixed(self) -> bool:
+        return isinstance(self.binding, Fixed)
+
+    def is_calibrated(self) -> bool:
+        return isinstance(self.binding, Calibrated)
+
+    @property
+    def optimizer_visible(self) -> bool:
+        """P2: only Tuned knobs enter the optimizer's search space."""
+        return self.is_tuned()

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -46,6 +46,11 @@ class Fixed(Generic[TValue]):
     value: TValue
 
 
+_IDENT_RE = __import__("re").compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$"
+)
+
+
 @dataclass(frozen=True, slots=True)
 class Ref:
     """A namespace reference to another knob (a CVAR's tuned parent).
@@ -56,6 +61,10 @@ class Ref:
 
     knob: str
     field: str | None = None
+
+    def __post_init__(self) -> None:
+        if not _IDENT_RE.match(self.knob):
+            raise ValueError(f"Ref.knob is not a valid identifier: {self.knob!r}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,11 +98,17 @@ class Knob(Generic[TValue]):
     description: str | None = None
 
     def __post_init__(self) -> None:
+        if not _IDENT_RE.match(self.name):
+            raise ValueError(f"Knob.name is not a valid identifier: {self.name!r}")
         if not isinstance(self.binding, (Tuned, Fixed, Calibrated)):
             raise TypeError(
                 f"Knob binding must be Tuned, Fixed, or Calibrated; "
                 f"got {type(self.binding).__name__}"
             )
+        if isinstance(self.binding, Calibrated):
+            for ref in self.binding.depends_on:
+                if ref.knob == self.name:
+                    raise ValueError(f"Knob {self.name!r} cannot depend on itself")
 
     def is_tuned(self) -> bool:
         return isinstance(self.binding, Tuned)

--- a/traigent/knobs/canonical.py
+++ b/traigent/knobs/canonical.py
@@ -1,0 +1,74 @@
+"""Canonical hashing for certificate freshness contexts (RFC 0001 §3.5).
+
+``canonical_hash`` implements the TVL canonicalization profile: sorted-key
+compact JSON over NFC-normalized strings with the RFC's value restrictions
+(finite numbers only, ``-0.0`` folded to ``0.0``, duplicate keys rejected at
+parse time by the loaders). The profile is versioned via
+``CTX_SCHEMA_VERSION``, which is itself part of every hashed context, so any
+future change to this module is automatically staleness-inducing for
+previously issued certificates.
+
+Two conformant implementations hashing the same context MUST produce the
+same digest — the cross-implementation known-answer fixtures live in the tvl
+repo's conformance suite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+__all__ = ["CTX_SCHEMA_VERSION", "CanonicalizationError", "canonical_hash"]
+
+#: Version of the freshness-context schema AND this canonicalization profile.
+CTX_SCHEMA_VERSION = 1
+
+
+class CanonicalizationError(ValueError):
+    """Raised when a value cannot be canonically hashed (non-finite numbers,
+    duplicate keys, unsupported types)."""
+
+
+def _normalize(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CanonicalizationError("non-finite numbers are rejected, never hashed")
+        if value == 0.0:
+            return 0.0  # fold -0.0
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CanonicalizationError("mapping keys must be strings")
+            norm_key = unicodedata.normalize("NFC", key)
+            if norm_key in normalized:
+                raise CanonicalizationError(f"duplicate key after NFC: {norm_key!r}")
+            normalized[norm_key] = _normalize(item)
+        return normalized
+    if isinstance(value, Sequence):
+        return [_normalize(item) for item in value]
+    raise CanonicalizationError(
+        f"unsupported type for canonical hashing: {type(value).__name__}"
+    )
+
+
+def canonical_hash(value: Any) -> str:
+    """SHA-256 over the canonical serialization of ``value``."""
+    payload = json.dumps(
+        _normalize(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/traigent/knobs/canonical.py
+++ b/traigent/knobs/canonical.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import unicodedata
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any
 
 __all__ = ["CTX_SCHEMA_VERSION", "CanonicalizationError", "canonical_hash"]
@@ -42,8 +42,10 @@ def _normalize(value: Any) -> Any:
     if isinstance(value, float):
         if value != value or value in (float("inf"), float("-inf")):
             raise CanonicalizationError("non-finite numbers are rejected, never hashed")
-        if value == 0.0:
-            return 0.0  # fold -0.0
+        if value.is_integer():
+            # JCS/RFC 8785 number rule: integral floats serialize as the
+            # integer (1.0 -> "1"); this also folds -0.0 -> 0.
+            return int(value)
         return value
     if isinstance(value, Mapping):
         normalized: dict[str, Any] = {}
@@ -55,7 +57,9 @@ def _normalize(value: Any) -> Any:
                 raise CanonicalizationError(f"duplicate key after NFC: {norm_key!r}")
             normalized[norm_key] = _normalize(item)
         return normalized
-    if isinstance(value, Sequence):
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raise CanonicalizationError("bytes-like values are outside the JSON profile")
+    if isinstance(value, (list, tuple)):
         return [_normalize(item) for item in value]
     raise CanonicalizationError(
         f"unsupported type for canonical hashing: {type(value).__name__}"

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -116,8 +116,12 @@ class FreshnessContext:
     evidence_n: int
     calibration_split: str
     eval_split: str
-    target_hash: str
+    target: TargetProperty
     extensions: tuple[tuple[str, Any], ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        if self.evidence_n < 0:
+            raise ValueError("evidence_n must be non-negative")
 
     def freshness_hash(self) -> str:
         """Canonical hash over the core + selected extensions.
@@ -155,7 +159,12 @@ class FreshnessContext:
                     "evidence_n": self.evidence_n,
                     "calibration_split": self.calibration_split,
                     "eval_split": self.eval_split,
-                    "target_hash": self.target_hash,
+                    "target": {
+                        "name": self.target.name,
+                        "mode": self.target.mode,
+                        "threshold": self.target.threshold,
+                        "confidence": self.target.confidence,
+                    },
                 },
                 "ext": sorted(
                     ([key, value] for key, value in self.extensions),
@@ -172,6 +181,10 @@ class EvidenceRef:
     n: int
     pool_hash: str
 
+    def __post_init__(self) -> None:
+        if self.n < 0:
+            raise ValueError("EvidenceRef.n must be non-negative")
+
 
 @dataclass(frozen=True, slots=True)
 class Certificate:
@@ -186,7 +199,7 @@ class Certificate:
     subject_cvar: str
     subject_type: str
     subject_value_hash: str
-    target_hash: str
+    target: TargetProperty
     issued_hash: str
     decision: CertificateDecision
     evidence: EvidenceRef
@@ -204,7 +217,7 @@ class Certificate:
             and self.subject_cvar == cvar_name
             and self.subject_type == cvar_type
             and self.subject_value_hash == canonical_hash(value)
-            and self.target_hash == ctx_now.target_hash
+            and self.target == ctx_now.target
             and self.evidence.n == ctx_now.evidence_n
             and self.evidence.pool_hash == ctx_now.dataset_hash
             and self.issued_hash == ctx_now.freshness_hash()
@@ -229,7 +242,7 @@ def issue_certificate(
         subject_cvar=cvar_name,
         subject_type=cvar_type,
         subject_value_hash=canonical_hash(value),
-        target_hash=ctx.target_hash,
+        target=ctx.target,
         issued_hash=ctx.freshness_hash(),
         decision=decision,
         evidence=EvidenceRef(n=ctx.evidence_n, pool_hash=ctx.dataset_hash),

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from .canonical import CTX_SCHEMA_VERSION, canonical_hash
@@ -42,7 +42,7 @@ CTX_EXT_KEYS = frozenset(
 )
 
 
-class CertificateDecision(str, Enum):
+class CertificateDecision(StrEnum):
     """Shared decision vocabulary (TraigentSchema guarantee certificates)."""
 
     CERTIFIED = "CERTIFIED_SELECTION"

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -1,0 +1,236 @@
+"""Target properties, freshness contexts, and certificates (RFC 0001 §3.5).
+
+A certificate binds a SPECIFIC calibrated value of a SPECIFIC CVAR to the
+exact context it was fit under. Validity is fail-closed: every field
+participates, the audit copies must agree with the live context, and the
+live context must itself name the queried CVAR (the forged-subject guard).
+
+The certificate is a CLOSED shape (Property P8): identifiers, types, hashes,
+counts, and an enum — no open payload field exists to leak content.
+
+The ``decision`` vocabulary is shared with TraigentSchema's per-config
+guarantee certificates (``guarantee_certificate_schema.json``): one
+certificate ontology, two scopes — per-config selection there, per-CVAR
+value here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from .canonical import CTX_SCHEMA_VERSION, canonical_hash
+
+__all__ = [
+    "CTX_EXT_KEYS",
+    "Certificate",
+    "CertificateDecision",
+    "EvidenceRef",
+    "FreshnessContext",
+    "TargetProperty",
+    "conformal_evidence_floor",
+    "issue_certificate",
+]
+
+#: Optional freshness-context EXTENSION keys. The mandatory core (see
+#: ``FreshnessContext``) is implicit and immutable — module configuration
+#: can only ADD coverage, never remove parent-specificity.
+CTX_EXT_KEYS = frozenset(
+    {"stage_versions", "model_versions", "budget_assumptions", "cost_assumptions"}
+)
+
+
+class CertificateDecision(str, Enum):
+    """Shared decision vocabulary (TraigentSchema guarantee certificates)."""
+
+    CERTIFIED = "CERTIFIED_SELECTION"
+    NO_DECISION = "NO_DECISION"
+    BEST_EFFORT_UNCERTIFIED = "BEST_EFFORT_UNCERTIFIED"
+
+
+@dataclass(frozen=True, slots=True)
+class TargetProperty:
+    """The property a calibrated value is certified against."""
+
+    name: str
+    mode: str  # require_calibration | chance_constraint | guaranteed_selection | certificate_backed
+    threshold: float | None = None
+    confidence: float | None = None
+
+    _MODES = (
+        "require_calibration",
+        "chance_constraint",
+        "guaranteed_selection",
+        "certificate_backed",
+    )
+
+    def __post_init__(self) -> None:
+        if self.mode not in self._MODES:
+            raise ValueError(f"unknown TargetProperty mode: {self.mode!r}")
+
+    def property_hash(self) -> str:
+        return canonical_hash(
+            {
+                "name": self.name,
+                "mode": self.mode,
+                "threshold": self.threshold,
+                "confidence": self.confidence,
+            }
+        )
+
+
+def conformal_evidence_floor(epsilon: float) -> int:
+    """The split-conformal minimum calibration size ``ceil(1/epsilon) - 1``.
+
+    Below this floor even a perfect calibrator cannot certify a chance-style
+    target at level ``epsilon`` — the resolver's R8 rejection uses it as a
+    closed-form ``insufficient_evidence`` precondition.
+    """
+    if not (0.0 < epsilon < 1.0):
+        raise ValueError("epsilon must be in (0, 1)")
+    return math.ceil(1.0 / epsilon) - 1
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessContext:
+    """The hash-covered calibration context (RFC 0001 §3.5).
+
+    The MANDATORY core is every constructor field below except
+    ``extensions`` — it always participates in the hash, so certificates are
+    parent-specific (``tuned_parent_values`` is core), evidence-specific
+    (dataset hash + count), and calibrator-specific (id, version, params) by
+    construction. ``extensions`` selects OPTIONAL extra keys from
+    ``CTX_EXT_KEYS`` only.
+    """
+
+    cvar_name: str
+    tuned_parent_values: tuple[tuple[str, Any], ...]
+    calibration_source_id: str
+    signal_spec_hash: str
+    calibrator_id: str
+    calibrator_version: str
+    calibrator_params_hash: str
+    dataset_hash: str
+    evidence_n: int
+    calibration_split: str
+    eval_split: str
+    target_hash: str
+    extensions: tuple[tuple[str, Any], ...] = field(default=())
+
+    def freshness_hash(self) -> str:
+        """Canonical hash over the core + selected extensions.
+
+        Extensions are a MAP: sorted by key before hashing (order-insensitive)
+        with duplicate keys rejected. Parent values are likewise sorted by
+        name with duplicates rejected — the definition enforces the RFC's
+        "sorted by name", never trusting the caller.
+        """
+        parent_names = [name for name, _ in self.tuned_parent_values]
+        if len(parent_names) != len(set(parent_names)):
+            raise ValueError("duplicate tuned parent name")
+        ext_keys = [key for key, _ in self.extensions]
+        for key in ext_keys:
+            if key not in CTX_EXT_KEYS:
+                raise ValueError(f"invalid_calibration_context: {key!r}")
+        if len(ext_keys) != len(set(ext_keys)):
+            raise ValueError("duplicate_calibration_context_key")
+
+        return canonical_hash(
+            {
+                "core": {
+                    "ctx_schema_version": CTX_SCHEMA_VERSION,
+                    "cvar_name": self.cvar_name,
+                    "tuned_parent_values": sorted(
+                        ([name, value] for name, value in self.tuned_parent_values),
+                        key=lambda pair: pair[0],
+                    ),
+                    "calibration_source_id": self.calibration_source_id,
+                    "signal_spec_hash": self.signal_spec_hash,
+                    "calibrator_id": self.calibrator_id,
+                    "calibrator_version": self.calibrator_version,
+                    "calibrator_params_hash": self.calibrator_params_hash,
+                    "dataset_hash": self.dataset_hash,
+                    "evidence_n": self.evidence_n,
+                    "calibration_split": self.calibration_split,
+                    "eval_split": self.eval_split,
+                    "target_hash": self.target_hash,
+                },
+                "ext": sorted(
+                    ([key, value] for key, value in self.extensions),
+                    key=lambda pair: pair[0],
+                ),
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRef:
+    """Audit copy of the evidence behind a certificate (closed shape)."""
+
+    n: int
+    pool_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class Certificate:
+    """Validity object for one calibrated value of one CVAR.
+
+    ``payload``-style open fields are deliberately ABSENT (P8). The audit
+    copies (``target_hash``, ``evidence``) duplicate context fields for
+    inspection; ``valid_for`` cross-checks them against the live context so
+    a certificate cannot DISPLAY one context while HASHING another.
+    """
+
+    subject_cvar: str
+    subject_type: str
+    subject_value_hash: str
+    target_hash: str
+    issued_hash: str
+    decision: CertificateDecision
+    evidence: EvidenceRef
+
+    def valid_for(
+        self,
+        cvar_name: str,
+        cvar_type: str,
+        value: Any,
+        ctx_now: FreshnessContext,
+    ) -> bool:
+        """RFC 0001 §3.5 validity — all nine conjuncts, fail-closed."""
+        return (
+            ctx_now.cvar_name == cvar_name
+            and self.subject_cvar == cvar_name
+            and self.subject_type == cvar_type
+            and self.subject_value_hash == canonical_hash(value)
+            and self.target_hash == ctx_now.target_hash
+            and self.evidence.n == ctx_now.evidence_n
+            and self.evidence.pool_hash == ctx_now.dataset_hash
+            and self.issued_hash == ctx_now.freshness_hash()
+            and self.decision is CertificateDecision.CERTIFIED
+        )
+
+
+def issue_certificate(
+    cvar_name: str,
+    cvar_type: str,
+    value: Any,
+    ctx: FreshnessContext,
+    *,
+    decision: CertificateDecision = CertificateDecision.CERTIFIED,
+) -> Certificate:
+    """Issue a certificate binding ``value`` of ``cvar_name`` to ``ctx``."""
+    if ctx.cvar_name != cvar_name:
+        raise ValueError(
+            f"context names {ctx.cvar_name!r}, cannot issue for {cvar_name!r}"
+        )
+    return Certificate(
+        subject_cvar=cvar_name,
+        subject_type=cvar_type,
+        subject_value_hash=canonical_hash(value),
+        target_hash=ctx.target_hash,
+        issued_hash=ctx.freshness_hash(),
+        decision=decision,
+        evidence=EvidenceRef(n=ctx.evidence_n, pool_hash=ctx.dataset_hash),
+    )

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -120,6 +120,8 @@ class FreshnessContext:
     extensions: tuple[tuple[str, Any], ...] = field(default=())
 
     def __post_init__(self) -> None:
+        if not isinstance(self.evidence_n, int) or isinstance(self.evidence_n, bool):
+            raise ValueError("evidence_n must be a natural number (int)")
         if self.evidence_n < 0:
             raise ValueError("evidence_n must be non-negative")
 
@@ -182,6 +184,8 @@ class EvidenceRef:
     pool_hash: str
 
     def __post_init__(self) -> None:
+        if not isinstance(self.n, int) or isinstance(self.n, bool):
+            raise ValueError("EvidenceRef.n must be a natural number (int)")
         if self.n < 0:
             raise ValueError("EvidenceRef.n must be non-negative")
 
@@ -191,7 +195,7 @@ class Certificate:
     """Validity object for one calibrated value of one CVAR.
 
     ``payload``-style open fields are deliberately ABSENT (P8). The audit
-    copies (``target_hash``, ``evidence``) duplicate context fields for
+    copies (``target``, ``evidence``) duplicate context fields for
     inspection; ``valid_for`` cross-checks them against the live context so
     a certificate cannot DISPLAY one context while HASHING another.
     """

--- a/traigent/knobs/kinds.py
+++ b/traigent/knobs/kinds.py
@@ -1,0 +1,29 @@
+"""Knob-kind taxonomy — reconciled with the effectuation module.
+
+The canonical ``KnobKind`` lives in ``traigent.effectuation`` (the
+tvar-executable-effectuation branch). Until that branch merges, this module
+provides a values-identical fallback behind an import guard so the two
+surfaces can never drift apart silently: ``tests/unit/knobs/test_kinds.py``
+pins the member names and values, and once the effectuation module is
+importable the guard resolves to it as the single source of truth.
+"""
+
+from __future__ import annotations
+
+__all__ = ["KnobKind"]
+
+try:  # pragma: no cover - exercised only once effectuation merges
+    from traigent.effectuation import KnobKind  # type: ignore[no-redef]
+except Exception:  # pragma: no cover - fallback is the tested path today
+    from enum import Enum
+
+    class KnobKind(str, Enum):  # type: ignore[no-redef]
+        """What aspect of the agent a knob effectuates.
+
+        Values mirror ``traigent.effectuation.contracts.KnobKind`` exactly.
+        """
+
+        VALUE = "value"
+        CARDINALITY = "cardinality"
+        TOPOLOGY = "topology"
+        POLICY = "policy"

--- a/traigent/knobs/kinds.py
+++ b/traigent/knobs/kinds.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 __all__ = ["KnobKind"]
 
 try:  # pragma: no cover - exercised only once effectuation merges
-    from traigent.effectuation import KnobKind  # type: ignore[no-redef]
-except Exception:  # pragma: no cover - fallback is the tested path today
+    from traigent.effectuation.contracts import KnobKind  # type: ignore[no-redef]
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - tested path today
     from enum import Enum
 
     class KnobKind(str, Enum):  # type: ignore[no-redef]

--- a/traigent/knobs/kinds.py
+++ b/traigent/knobs/kinds.py
@@ -15,9 +15,9 @@ __all__ = ["KnobKind"]
 try:  # pragma: no cover - exercised only once effectuation merges
     from traigent.effectuation.contracts import KnobKind  # type: ignore[no-redef]
 except (ImportError, ModuleNotFoundError):  # pragma: no cover - tested path today
-    from enum import Enum
+    from enum import StrEnum
 
-    class KnobKind(str, Enum):  # type: ignore[no-redef]
+    class KnobKind(StrEnum):  # type: ignore[no-redef]
         """What aspect of the agent a knob effectuates.
 
         Values mirror ``traigent.effectuation.contracts.KnobKind`` exactly.

--- a/traigent/knobs/resolution.py
+++ b/traigent/knobs/resolution.py
@@ -9,12 +9,12 @@ and shared with the tvl repo's model-checking suite.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 
 __all__ = ["ResolutionError", "ResolutionNode", "ResolutionRejection"]
 
 
-class ResolutionRejection(str, Enum):
+class ResolutionRejection(StrEnum):
     """RFC 0001 §3.4 rejection conditions (R1–R8) + the no-decision verdict."""
 
     CYCLE = "cycle"  # R1 — unreachable in v1 (CVAR→TVAR only); kept for the deferred extension

--- a/traigent/knobs/resolution.py
+++ b/traigent/knobs/resolution.py
@@ -1,0 +1,64 @@
+"""Resolution types: nodes, errors, and the Resolver contract (RFC 0001 §3.4).
+
+This module ships the TYPES in packet 6-B; the deterministic topological
+resolver LOGIC and its orchestrator injection land in packet 6-C2
+(``feature/knobs-resolver``). The rejection vocabulary R1–R8 is normative
+and shared with the tvl repo's model-checking suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ["ResolutionError", "ResolutionNode", "ResolutionRejection"]
+
+
+class ResolutionRejection(str, Enum):
+    """RFC 0001 §3.4 rejection conditions (R1–R8) + the no-decision verdict."""
+
+    CYCLE = "cycle"  # R1 — unreachable in v1 (CVAR→TVAR only); kept for the deferred extension
+    MISSING_REF = "missing_ref"  # R2
+    DUPLICATE_PROVIDER = "duplicate_provider"  # R3
+    PHASE_MISMATCH = "phase_mismatch"  # R4
+    INFEASIBLE_VALUE = "infeasible_value"  # R5
+    STALE_CERTIFICATE = "stale_certificate"  # R6
+    EVIDENCE_LEAKAGE = "evidence_leakage"  # R7
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"  # R8
+    NO_DECISION = "no_decision"  # calibrator ⊥ with no R_i holding
+
+
+class ResolutionError(Exception):
+    """Typed, fail-closed resolution failure.
+
+    Carries the full set of rejections so callers can report every reason,
+    not just the first — mirrors the model checker's collect-all semantics.
+    """
+
+    def __init__(
+        self, rejections: tuple[ResolutionRejection, ...], detail: str = ""
+    ) -> None:
+        self.rejections = rejections
+        codes = ", ".join(r.value for r in rejections)
+        super().__init__(
+            f"resolution rejected [{codes}]" + (f": {detail}" if detail else "")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionNode:
+    """One node of the resolution DAG (built by the 6-C2 resolver)."""
+
+    knob: str
+    binding_kind: str  # "tuned" | "fixed" | "calibrated"
+    depends_on: tuple[str, ...] = ()
+    phase: str = "post_suggest"  # pre_suggest | post_suggest | pre_eval
+
+    _BINDING_KINDS = ("tuned", "fixed", "calibrated")
+    _PHASES = ("pre_suggest", "post_suggest", "pre_eval")
+
+    def __post_init__(self) -> None:
+        if self.binding_kind not in self._BINDING_KINDS:
+            raise ValueError(f"unknown binding_kind: {self.binding_kind!r}")
+        if self.phase not in self._PHASES:
+            raise ValueError(f"unknown phase: {self.phase!r}")

--- a/traigent/knobs/signals.py
+++ b/traigent/knobs/signals.py
@@ -1,0 +1,71 @@
+"""Signal specifications and content-free observations (RFC 0001 §3.5).
+
+``SignalObservation`` is a CLOSED shape by design (Property P8): every field
+is an identifier, finite number, count, or split label — there is no
+metadata map and no content-typed field to leak. Anything richer belongs
+outside the persisted-signal surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .canonical import canonical_hash
+
+__all__ = ["SignalObservation", "SignalSpec"]
+
+
+@dataclass(frozen=True, slots=True)
+class SignalSpec:
+    """Versioned identification of a measurement procedure.
+
+    The spec hash participates in certificate freshness (``ctx_core``): any
+    change to the signal, its score function, or its comparator — including
+    version bumps — makes previously issued certificates stale by
+    construction.
+    """
+
+    name: str
+    version: str
+    score_function: str
+    score_function_version: str
+    comparator: str
+    comparator_version: str
+
+    def spec_hash(self) -> str:
+        """Stable canonical hash over every identifying field."""
+        return canonical_hash(
+            {
+                "name": self.name,
+                "version": self.version,
+                "score_function": self.score_function,
+                "score_function_version": self.score_function_version,
+                "comparator": self.comparator,
+                "comparator_version": self.comparator_version,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignalObservation:
+    """One content-free observation of a signal (closed shape — P8).
+
+    Args:
+        signal: Signal spec name this observation belongs to.
+        value: The observed signal value (finite float).
+        n: Sample count behind the observation.
+        split: Which data split produced it (e.g. ``"calibration"``,
+            ``"eval"``) — the resolver's evidence-leakage rejection (R7)
+            depends on faithful split tagging.
+    """
+
+    signal: str
+    value: float
+    n: int
+    split: str
+
+    def __post_init__(self) -> None:
+        if self.value != self.value or self.value in (float("inf"), float("-inf")):
+            raise ValueError("SignalObservation.value must be finite")
+        if self.n < 0:
+            raise ValueError("SignalObservation.n must be non-negative")


### PR DESCRIPTION
## Summary
SDK packet 6-B of the TVL-first program (FR-SDK-KNOBS-CVARS-V1, ChangeSession `cs_607ce2f4f8833804`; RFC 0001 owner-accepted — see tvl#2). Pure `traigent.knobs` types, zero runtime behavior changes, no wire shapes (program contract-decision record).

- Bindings: `Tuned | Fixed | Calibrated` (isinstance-discriminated), `Knob`, `Ref`; `Tuned.default` stays a CANDIDATE, never Fixed
- Certificates: mandatory `subject{cvar, type, value_hash}`, immutable freshness core (parents/source/calibrator/dataset/evidence/splits/target), extensions-as-map, all-nine-conjunct `valid_for` incl. the forged-subject guard; decision vocabulary shared with `guarantee_certificate_schema.json`
- Canonicalization: versioned profile (JCS-style numbers, NFC, finite-only, dup-key rejection)
- `KnobKind` via import-guard → resolves to the merged effectuation enum (parity-pinned)
- `SignalSpec`/`SignalObservation` + R1–R8 resolution vocabulary (closed shapes, P8)

## Review
codex gpt-5.5 xhigh, 3 rounds → **ACCEPT** (fixed: RFC target object not hash; JCS integral floats; ℕ strict-int counts). 44 tests.

## Merge order
First of the knobs stack: this → #configspace-knobs → #knobs-resolver. `sdk.knobs` spine module registration follows this merge (merge-gated, recorded in the feature trail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)