### PR TITLE
feat(api): ConfigSpace.knobs — canonical binding-aware surface, tvars as Tuned-only projection

### DIFF
--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -1074,3 +1074,92 @@ class TestTVLSpecWithStandaloneConstraint:
         assert constraint["id"] == "c1"
         assert constraint["description"] == "Min temp"
         assert constraint["error_message"] == "Min temp"
+
+
+class TestKnobsSurface:
+    """ConfigSpace.knobs — the canonical binding-aware surface (6-C1)."""
+
+    def _knob_set(self):
+        from traigent.knobs import (
+            Calibrated,
+            Fixed,
+            Knob,
+            SignalSpec,
+            TargetProperty,
+            Tuned,
+        )
+
+        signal = SignalSpec(
+            name="vote_margin",
+            version="1",
+            score_function="exact_match",
+            score_function_version="1",
+            comparator="key_eq",
+            comparator_version="1",
+        )
+        target = TargetProperty(name="floor", mode="require_calibration")
+        return {
+            "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"]))),
+            "k": Knob(name="k", binding=Fixed(value=4)),
+            "theta": Knob(
+                name="theta", binding=Calibrated(signal=signal, target=target)
+            ),
+        }
+
+    def test_knobs_derive_tuned_only_tvars(self):
+        """P2: tvars is EXACTLY the Tuned projection."""
+        space = ConfigSpace(knobs=self._knob_set())
+        assert set(space.tvars) == {"model"}
+        assert isinstance(space.tvars["model"], Choices)
+        assert set(space.knobs) == {"model", "k", "theta"}
+
+    def test_legacy_tvars_synthesize_all_tuned_knobs(self):
+        space = ConfigSpace(tvars={"temp": Range(0.0, 1.0)})
+        assert set(space.knobs) == {"temp"}
+        assert space.knobs["temp"].is_tuned()
+        # object identity through the adapter
+        assert space.knobs["temp"].binding.range is space.tvars["temp"]
+
+    def test_mismatched_tvars_and_knobs_rejected(self):
+        with pytest.raises(ValueError, match="Tuned-only projection"):
+            ConfigSpace(tvars={"other": Range(0.0, 1.0)}, knobs=self._knob_set())
+
+    def test_knob_name_key_mismatch_rejected(self):
+        from traigent.knobs import Fixed, Knob
+
+        with pytest.raises(ValueError, match="!= knob.name"):
+            ConfigSpace(knobs={"a": Knob(name="b", binding=Fixed(value=1))})
+
+    def test_non_knob_value_rejected(self):
+        with pytest.raises(TypeError, match="is not a Knob"):
+            ConfigSpace(knobs={"a": Range(0.0, 1.0)})  # type: ignore[dict-item]
+
+    def test_pickle_round_trip_carries_knobs(self):
+        import pickle
+
+        space = ConfigSpace(knobs=self._knob_set())
+        rebuilt = pickle.loads(pickle.dumps(space))
+        assert set(rebuilt.knobs) == {"model", "k", "theta"}
+        assert rebuilt.knobs["theta"].is_calibrated()
+        assert set(rebuilt.tvars) == {"model"}
+
+    def test_legacy_pickle_without_knobs_state(self):
+        """Pickles created before the knobs surface restore with synthesized
+        all-Tuned knobs."""
+        space = ConfigSpace(tvars={"temp": Range(0.0, 1.0)})
+        state = space.__getstate__()
+        del state["knobs"]
+        fresh = ConfigSpace.__new__(ConfigSpace)
+        fresh.__setstate__(state)
+        assert set(fresh.knobs) == {"temp"}
+        assert fresh.knobs["temp"].is_tuned()
+
+    def test_optimizer_dict_surface_unchanged(self):
+        """Dict-based optimizers consume tvars exactly as before — Fixed and
+        Calibrated knobs never appear."""
+        space = ConfigSpace(knobs=self._knob_set())
+        config_space_dict = {
+            name: parameter_range.to_config_value()
+            for name, parameter_range in space.tvars.items()
+        }
+        assert set(config_space_dict) == {"model"}

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -53,6 +53,7 @@ from traigent.api.validation_protocol import (
 )
 
 if TYPE_CHECKING:
+    from traigent.knobs import Knob
     from traigent.tvl.models import StructuralConstraint, TVarDecl
 
 
@@ -102,9 +103,12 @@ class ConfigSpace:
     the TVL ecosystem.
 
     Attributes:
-        tvars: Read-only mapping of parameter names to ParameterRange definitions
+        tvars: Read-only Tuned-only projection — parameter names to
+            ParameterRange definitions; exactly what dict-based optimizers see
         constraints: Immutable tuple of structural constraints on the space
         description: Optional description of the configuration space
+        knobs: Read-only canonical binding-aware surface (RFC 0001). Always
+            populated: derived from ``tvars`` as all-Tuned when not supplied
 
     Example:
         >>> from traigent import Range, Choices, implies
@@ -119,13 +123,58 @@ class ConfigSpace:
         ... )
     """
 
-    tvars: Mapping[str, ParameterRange]
+    tvars: Mapping[str, ParameterRange] = field(default_factory=dict)
     constraints: tuple[Constraint, ...] = field(default_factory=tuple)
     description: str | None = None
+    knobs: Mapping[str, Knob] | None = None
 
     def __post_init__(self) -> None:
-        """Validate the configuration space after initialization."""
-        object.__setattr__(self, "tvars", MappingProxyType(dict(self.tvars)))
+        """Validate the configuration space after initialization.
+
+        Knob/tvar coherence (RFC 0001, the one-Knob model):
+        - constructed with ``knobs`` -> ``tvars`` is DERIVED as the
+          Tuned-only projection (Fixed/Calibrated knobs are
+          optimizer-invisible, P2); passing both with a mismatch is an error;
+        - constructed with ``tvars`` only (every existing call site) ->
+          ``knobs`` is synthesized as all-Tuned via the adapter, so the two
+          surfaces can never drift apart.
+        """
+        from traigent.knobs import Knob as _Knob
+        from traigent.knobs import knob_to_parameter_range, parameter_range_to_knob
+
+        if self.knobs is not None:
+            knobs = dict(self.knobs)
+            for knob_name, knob in knobs.items():
+                if not isinstance(knob, _Knob):
+                    raise TypeError(f"knobs[{knob_name!r}] is not a Knob")
+                if knob.name != knob_name:
+                    raise ValueError(
+                        f"knob mapping key {knob_name!r} != knob.name {knob.name!r}"
+                    )
+            projected = {
+                name: knob_to_parameter_range(knob)
+                for name, knob in knobs.items()
+                if knob.is_tuned()
+            }
+            if self.tvars and dict(self.tvars) != projected:
+                raise ValueError(
+                    "tvars must be the Tuned-only projection of knobs; "
+                    "pass only knobs and let tvars be derived"
+                )
+            object.__setattr__(self, "tvars", MappingProxyType(projected))
+            object.__setattr__(self, "knobs", MappingProxyType(knobs))
+        else:
+            object.__setattr__(self, "tvars", MappingProxyType(dict(self.tvars)))
+            object.__setattr__(
+                self,
+                "knobs",
+                MappingProxyType(
+                    {
+                        name: parameter_range_to_knob(name, parameter_range)
+                        for name, parameter_range in self.tvars.items()
+                    }
+                ),
+            )
         object.__setattr__(self, "constraints", tuple(self.constraints))
 
         # Ensure all tvars have unique names
@@ -146,15 +195,25 @@ class ConfigSpace:
             "tvars": dict(self.tvars),
             "constraints": tuple(self.constraints),
             "description": self.description,
+            "knobs": dict(self.knobs) if self.knobs is not None else None,
         }
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
         """Restore immutable state after unpickling."""
+        from traigent.knobs import parameter_range_to_knob
+
         object.__setattr__(self, "tvars", MappingProxyType(dict(state["tvars"])))
         object.__setattr__(
             self, "constraints", tuple(cast(Sequence[Constraint], state["constraints"]))
         )
         object.__setattr__(self, "description", state.get("description"))
+        knobs = state.get("knobs")
+        if knobs is None:  # pickles from before the knobs surface
+            knobs = {
+                name: parameter_range_to_knob(name, parameter_range)
+                for name, parameter_range in state["tvars"].items()
+            }
+        object.__setattr__(self, "knobs", MappingProxyType(dict(knobs)))
 
     @classmethod
     def from_decorator_args(


### PR DESCRIPTION
## Summary
SDK packet 6-C1 (stacked on #1097). `ConfigSpace.knobs` is the canonical binding-aware surface; `tvars` becomes the DERIVED Tuned-only projection (P2: Fixed/Calibrated optimizer-invisible) — or is synthesized all-Tuned from legacy `tvars` constructions so the surfaces can never drift. Pickle round-trip incl. legacy pre-knobs pickles; dict-based optimizer surface byte-identical.

## Review
Covered by the 6-C2 review scope (converged, 3 rounds). 8 tests; 531 passed across suites.

**Stacked on** `feature/knobs-types` — retarget to develop after #1097 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)