### PR TITLE
feat(knobs): deterministic fail-closed resolver + in-trial injection (RFC 0001 §3.4)

### DIFF
--- a/tests/unit/api/test_config_space.py
+++ b/tests/unit/api/test_config_space.py
@@ -1074,3 +1074,92 @@ class TestTVLSpecWithStandaloneConstraint:
         assert constraint["id"] == "c1"
         assert constraint["description"] == "Min temp"
         assert constraint["error_message"] == "Min temp"
+
+
+class TestKnobsSurface:
+    """ConfigSpace.knobs — the canonical binding-aware surface (6-C1)."""
+
+    def _knob_set(self):
+        from traigent.knobs import (
+            Calibrated,
+            Fixed,
+            Knob,
+            SignalSpec,
+            TargetProperty,
+            Tuned,
+        )
+
+        signal = SignalSpec(
+            name="vote_margin",
+            version="1",
+            score_function="exact_match",
+            score_function_version="1",
+            comparator="key_eq",
+            comparator_version="1",
+        )
+        target = TargetProperty(name="floor", mode="require_calibration")
+        return {
+            "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"]))),
+            "k": Knob(name="k", binding=Fixed(value=4)),
+            "theta": Knob(
+                name="theta", binding=Calibrated(signal=signal, target=target)
+            ),
+        }
+
+    def test_knobs_derive_tuned_only_tvars(self):
+        """P2: tvars is EXACTLY the Tuned projection."""
+        space = ConfigSpace(knobs=self._knob_set())
+        assert set(space.tvars) == {"model"}
+        assert isinstance(space.tvars["model"], Choices)
+        assert set(space.knobs) == {"model", "k", "theta"}
+
+    def test_legacy_tvars_synthesize_all_tuned_knobs(self):
+        space = ConfigSpace(tvars={"temp": Range(0.0, 1.0)})
+        assert set(space.knobs) == {"temp"}
+        assert space.knobs["temp"].is_tuned()
+        # object identity through the adapter
+        assert space.knobs["temp"].binding.range is space.tvars["temp"]
+
+    def test_mismatched_tvars_and_knobs_rejected(self):
+        with pytest.raises(ValueError, match="Tuned-only projection"):
+            ConfigSpace(tvars={"other": Range(0.0, 1.0)}, knobs=self._knob_set())
+
+    def test_knob_name_key_mismatch_rejected(self):
+        from traigent.knobs import Fixed, Knob
+
+        with pytest.raises(ValueError, match="!= knob.name"):
+            ConfigSpace(knobs={"a": Knob(name="b", binding=Fixed(value=1))})
+
+    def test_non_knob_value_rejected(self):
+        with pytest.raises(TypeError, match="is not a Knob"):
+            ConfigSpace(knobs={"a": Range(0.0, 1.0)})  # type: ignore[dict-item]
+
+    def test_pickle_round_trip_carries_knobs(self):
+        import pickle
+
+        space = ConfigSpace(knobs=self._knob_set())
+        rebuilt = pickle.loads(pickle.dumps(space))
+        assert set(rebuilt.knobs) == {"model", "k", "theta"}
+        assert rebuilt.knobs["theta"].is_calibrated()
+        assert set(rebuilt.tvars) == {"model"}
+
+    def test_legacy_pickle_without_knobs_state(self):
+        """Pickles created before the knobs surface restore with synthesized
+        all-Tuned knobs."""
+        space = ConfigSpace(tvars={"temp": Range(0.0, 1.0)})
+        state = space.__getstate__()
+        del state["knobs"]
+        fresh = ConfigSpace.__new__(ConfigSpace)
+        fresh.__setstate__(state)
+        assert set(fresh.knobs) == {"temp"}
+        assert fresh.knobs["temp"].is_tuned()
+
+    def test_optimizer_dict_surface_unchanged(self):
+        """Dict-based optimizers consume tvars exactly as before — Fixed and
+        Calibrated knobs never appear."""
+        space = ConfigSpace(knobs=self._knob_set())
+        config_space_dict = {
+            name: parameter_range.to_config_value()
+            for name, parameter_range in space.tvars.items()
+        }
+        assert set(config_space_dict) == {"model"}

--- a/tests/unit/core/test_trial_lifecycle.py
+++ b/tests/unit/core/test_trial_lifecycle.py
@@ -65,6 +65,7 @@ class MockOrchestrator:
     def __init__(self):
         self.optimizer = MockOptimizer()
         self.evaluator = MockEvaluator()
+        self.knob_resolver = None
         self._optimization_id = "test-optimization-123"
         self._sample_budget_manager = None
         self._consumed_examples = 0
@@ -82,6 +83,14 @@ class MockOrchestrator:
         self._default_config_used = False
         self.objective_schema = None  # For band-based pruning support
 
+
+    def _apply_knob_resolution(self, config):
+        """Mirror of OptimizationOrchestrator._apply_knob_resolution (RFC 0001):
+        passthrough when no resolver is configured."""
+        if self.knob_resolver is None:
+            return config
+        resolved = self.knob_resolver.resolve(config)
+        return dict(resolved.config)
     def _consume_default_config(self):
         return None
 

--- a/tests/unit/knobs/test_knobs_types.py
+++ b/tests/unit/knobs/test_knobs_types.py
@@ -445,3 +445,16 @@ def test_certificate_target_is_the_rfc_object():
     assert cert.target == _target()
     other_target_ctx = _ctx(target=TargetProperty(name="x", mode="chance_constraint"))
     assert not cert.valid_for("theta", "float", 0.5, other_target_ctx)
+
+
+def test_counts_are_natural_numbers():
+    """Round-2 finding: ℕ means strict non-negative INT — floats and bools
+    are rejected as counts."""
+    from traigent.knobs import EvidenceRef
+
+    for bad in (1.5, True, False, -1):
+        with pytest.raises(ValueError):
+            _ctx(evidence_n=bad)
+        with pytest.raises(ValueError):
+            EvidenceRef(n=bad, pool_hash="p")
+    EvidenceRef(n=0, pool_hash="p")  # zero is a natural number here

--- a/tests/unit/knobs/test_knobs_types.py
+++ b/tests/unit/knobs/test_knobs_types.py
@@ -178,7 +178,7 @@ def _ctx(**overrides) -> FreshnessContext:
         evidence_n=20,
         calibration_split="cal",
         eval_split="eval",
-        target_hash=_target().property_hash(),
+        target=_target(),
         extensions=(),
     )
     base.update(overrides)
@@ -197,7 +197,7 @@ CORE_FLIPS = [
     ("evidence_n", 21),
     ("calibration_split", "cal2"),
     ("eval_split", "eval2"),
-    ("target_hash", canonical_hash("other-target")),
+    ("target", TargetProperty(name="other", mode="chance_constraint")),
 ]
 
 
@@ -239,7 +239,7 @@ def test_audit_copies_must_agree_with_live_context():
     ctx = _ctx()
     cert = issue_certificate("theta", "float", 0.5, ctx)
     for field_name, bad in [
-        ("target_hash", canonical_hash("forged")),
+        ("target", TargetProperty(name="forged", mode="chance_constraint")),
         ("evidence", dataclasses.replace(cert.evidence, n=999)),
         ("evidence", dataclasses.replace(cert.evidence, pool_hash="forged")),
     ]:
@@ -326,11 +326,11 @@ def test_certificate_closed_shape():
         "subject_cvar",
         "subject_type",
         "subject_value_hash",
-        "target_hash",
+        "target",
         "issued_hash",
         "decision",
         "evidence",
-    }  # no payload / metadata field
+    }  # no payload / metadata field; target is the closed TargetProperty
 
 
 # ---------------------------------------------------------------------------
@@ -395,3 +395,53 @@ def test_package_is_import_light():
                 if name.startswith("traigent.effectuation"):
                     # only the guarded kinds import may reference it
                     assert module_path.name == "kinds.py"
+
+
+def test_jcs_number_rule():
+    """RFC 8785: integral floats hash as the integer (1.0 == 1), while bool
+    stays DISTINCT from int (checked before int)."""
+    assert canonical_hash(1.0) == canonical_hash(1)
+    assert canonical_hash({"n": 20.0}) == canonical_hash({"n": 20})
+    assert canonical_hash(True) != canonical_hash(1)
+    assert canonical_hash(0.5) != canonical_hash(0)
+
+
+def test_bytes_like_rejected():
+    for value in (b"x", bytearray(b"x"), memoryview(b"x")):
+        with pytest.raises(CanonicalizationError):
+            canonical_hash(value)
+
+
+def test_ident_and_count_validation():
+    with pytest.raises(ValueError):
+        Knob(name="", binding=Fixed(value=1))
+    with pytest.raises(ValueError):
+        Knob(name="a..b", binding=Fixed(value=1))
+    with pytest.raises(ValueError):
+        Ref(knob="")
+    with pytest.raises(ValueError):
+        _ctx(evidence_n=-1)
+    from traigent.knobs import EvidenceRef
+
+    with pytest.raises(ValueError):
+        EvidenceRef(n=-1, pool_hash="p")
+
+
+def test_calibrated_self_ref_rejected():
+    with pytest.raises(ValueError, match="cannot depend on itself"):
+        Knob(
+            name="theta",
+            binding=Calibrated(
+                signal=_signal(), target=_target(), depends_on=(Ref(knob="theta"),)
+            ),
+        )
+
+
+def test_certificate_target_is_the_rfc_object():
+    """RFC §3.5 fidelity: the certificate carries the TargetProperty itself
+    (closed shape), and validity compares OBJECTS, not hashes."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    assert cert.target == _target()
+    other_target_ctx = _ctx(target=TargetProperty(name="x", mode="chance_constraint"))
+    assert not cert.valid_for("theta", "float", 0.5, other_target_ctx)

--- a/tests/unit/knobs/test_knobs_types.py
+++ b/tests/unit/knobs/test_knobs_types.py
@@ -1,0 +1,397 @@
+"""traigent.knobs type tests (SDK packet 6-B, RFC 0001).
+
+Acceptance criteria from the program plan:
+- ParameterRange -> Knob[Tuned] -> ParameterRange identity for all four
+  range types, with the default carried as a CANDIDATE (never Fixed);
+- certificates become stale when ANY freshness-core input changes
+  (parametrized per-key flips) and cannot be forged across subjects,
+  values, or contexts;
+- KnobKind stays value-identical with the effectuation taxonomy;
+- the persisted-signal shapes are CLOSED (P8).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from traigent.api.parameter_ranges import Choices, IntRange, LogRange, Range
+from traigent.knobs import (
+    CTX_EXT_KEYS,
+    Calibrated,
+    CanonicalizationError,
+    Certificate,
+    CertificateDecision,
+    Fixed,
+    FreshnessContext,
+    Knob,
+    KnobKind,
+    Ref,
+    ResolutionNode,
+    ResolutionRejection,
+    SignalObservation,
+    SignalSpec,
+    TargetProperty,
+    Tuned,
+    canonical_hash,
+    conformal_evidence_floor,
+    issue_certificate,
+    knob_to_parameter_range,
+    parameter_range_to_knob,
+)
+
+# ---------------------------------------------------------------------------
+# Kinds parity (effectuation reconciliation)
+# ---------------------------------------------------------------------------
+
+
+def test_knob_kind_parity_with_effectuation_taxonomy():
+    """Pins member names AND serialized values to the effectuation enum
+    (traigent/effectuation/contracts.py on its feature branch). If either
+    side renames, this test trips."""
+    assert {k.name for k in KnobKind} == {"VALUE", "CARDINALITY", "TOPOLOGY", "POLICY"}
+    assert {k.value for k in KnobKind} == {"value", "cardinality", "topology", "policy"}
+
+
+# ---------------------------------------------------------------------------
+# Bindings
+# ---------------------------------------------------------------------------
+
+
+def _signal() -> SignalSpec:
+    return SignalSpec(
+        name="vote_margin",
+        version="1",
+        score_function="exact_match",
+        score_function_version="1",
+        comparator="key_eq",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="margin_floor", mode="require_calibration")
+
+
+def test_binding_discrimination_is_isinstance_based():
+    tuned = Knob(name="k", binding=Tuned(range=IntRange(0, 8)))
+    fixed = Knob(name="f", binding=Fixed(value=3))
+    calibrated = Knob(
+        name="theta",
+        binding=Calibrated(signal=_signal(), target=_target()),
+    )
+    assert tuned.is_tuned() and not tuned.is_fixed() and not tuned.is_calibrated()
+    assert fixed.is_fixed() and not fixed.is_tuned()
+    assert calibrated.is_calibrated() and not calibrated.is_tuned()
+    # P2: only Tuned is optimizer-visible
+    assert tuned.optimizer_visible
+    assert not fixed.optimizer_visible
+    assert not calibrated.optimizer_visible
+
+
+def test_knob_rejects_non_binding():
+    with pytest.raises(TypeError):
+        Knob(name="bad", binding="not-a-binding")  # type: ignore[arg-type]
+
+
+def test_bindings_are_frozen():
+    knob = Knob(name="k", binding=Fixed(value=1))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        knob.name = "other"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        knob.binding.value = 2  # type: ignore[misc]
+
+
+def test_target_property_mode_registry():
+    with pytest.raises(ValueError):
+        TargetProperty(name="x", mode="vibes")
+
+
+# ---------------------------------------------------------------------------
+# Adapters — identity round-trip, default stays a candidate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parameter_range",
+    [
+        Range(low=0.0, high=1.0, step=0.1, default=0.5),
+        IntRange(low=0, high=8, default=2),
+        LogRange(low=1e-5, high=1e-1),
+        Choices(values=["a", "b", "c"], default="b"),
+    ],
+    ids=["Range", "IntRange", "LogRange", "Choices"],
+)
+def test_parameter_range_round_trip_identity(parameter_range):
+    knob = parameter_range_to_knob("p", parameter_range)
+    assert knob.is_tuned()
+    # identity: the SAME object comes back — no copy, no coercion
+    assert knob_to_parameter_range(knob) is parameter_range
+    # the default is carried as a Tuned CANDIDATE, never a Fixed binding
+    assert knob.binding.default == parameter_range.get_default()
+    assert not knob.is_fixed()
+
+
+def test_fixed_and_calibrated_are_not_projectable():
+    assert knob_to_parameter_range(Knob(name="f", binding=Fixed(value=1))) is None
+    assert (
+        knob_to_parameter_range(
+            Knob(name="c", binding=Calibrated(signal=_signal(), target=_target()))
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical hashing
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_hash_rules():
+    assert canonical_hash({"a": 1, "b": 2}) == canonical_hash({"b": 2, "a": 1})
+    assert canonical_hash({"x": -0.0}) == canonical_hash({"x": 0.0})
+    assert canonical_hash("café") == canonical_hash("café")  # NFC
+    with pytest.raises(CanonicalizationError):
+        canonical_hash(float("nan"))
+    with pytest.raises(CanonicalizationError):
+        canonical_hash(float("inf"))
+    with pytest.raises(CanonicalizationError):
+        canonical_hash(object())
+
+
+# ---------------------------------------------------------------------------
+# Certificates — freshness, subject binding, fail-closed validity
+# ---------------------------------------------------------------------------
+
+
+def _ctx(**overrides) -> FreshnessContext:
+    base = dict(
+        cvar_name="theta",
+        tuned_parent_values=(("model", "m1"), ("retriever.k", 4)),
+        calibration_source_id="pool_a",
+        signal_spec_hash=_signal().spec_hash(),
+        calibrator_id="budget_threshold",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({"budgets": [0.1, 0.2]}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target_hash=_target().property_hash(),
+        extensions=(),
+    )
+    base.update(overrides)
+    return FreshnessContext(**base)
+
+
+CORE_FLIPS = [
+    ("cvar_name", "theta2"),
+    ("tuned_parent_values", (("model", "m2"), ("retriever.k", 4))),
+    ("calibration_source_id", "pool_b"),
+    ("signal_spec_hash", canonical_hash("other-signal")),
+    ("calibrator_id", "other_calibrator"),
+    ("calibrator_version", "2"),
+    ("calibrator_params_hash", canonical_hash({"budgets": [0.3]})),
+    ("dataset_hash", "ds_v2"),
+    ("evidence_n", 21),
+    ("calibration_split", "cal2"),
+    ("eval_split", "eval2"),
+    ("target_hash", canonical_hash("other-target")),
+]
+
+
+def test_certificate_valid_for_same_context():
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    assert cert.valid_for("theta", "float", 0.5, ctx)
+
+
+@pytest.mark.parametrize("field_name,new_value", CORE_FLIPS)
+def test_every_core_key_flip_is_staleness_inducing(field_name, new_value):
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    flipped = dataclasses.replace(ctx, **{field_name: new_value})
+    if field_name == "cvar_name":
+        assert not cert.valid_for("theta2", "float", 0.5, flipped)
+    assert not cert.valid_for("theta", "float", 0.5, flipped), field_name
+
+
+def test_subject_binding_name_type_value():
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    assert not cert.valid_for("theta", "int", 0.5, ctx)  # type
+    assert not cert.valid_for("theta", "float", 0.6, ctx)  # value
+
+
+def test_forged_subject_cross_context_rejected():
+    """A certificate issued against CVAR B's context with a forged subject
+    naming A must not validate A (RFC v4 first conjunct)."""
+    ctx_b = _ctx(cvar_name="theta_b")
+    forged = dataclasses.replace(
+        issue_certificate("theta_b", "float", 0.5, ctx_b), subject_cvar="theta_a"
+    )
+    assert not forged.valid_for("theta_a", "float", 0.5, ctx_b)
+    assert not forged.valid_for("theta_a", "float", 0.5, _ctx(cvar_name="theta_a"))
+
+
+def test_audit_copies_must_agree_with_live_context():
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    for field_name, bad in [
+        ("target_hash", canonical_hash("forged")),
+        ("evidence", dataclasses.replace(cert.evidence, n=999)),
+        ("evidence", dataclasses.replace(cert.evidence, pool_hash="forged")),
+    ]:
+        tampered = dataclasses.replace(cert, **{field_name: bad})
+        assert not tampered.valid_for("theta", "float", 0.5, ctx)
+
+
+def test_non_certified_decisions_never_valid():
+    ctx = _ctx()
+    for decision in (
+        CertificateDecision.NO_DECISION,
+        CertificateDecision.BEST_EFFORT_UNCERTIFIED,
+    ):
+        cert = issue_certificate("theta", "float", 0.5, ctx, decision=decision)
+        assert not cert.valid_for("theta", "float", 0.5, ctx)
+
+
+def test_issue_certificate_subject_must_match_context():
+    with pytest.raises(ValueError):
+        issue_certificate("theta_a", "float", 0.5, _ctx(cvar_name="theta_b"))
+
+
+def test_parent_specificity_cannot_be_disabled_by_extensions():
+    import itertools
+
+    for r in range(len(CTX_EXT_KEYS) + 1):
+        for subset in itertools.combinations(sorted(CTX_EXT_KEYS), r):
+            ext = tuple((k, "v") for k in subset)
+            a = _ctx(extensions=ext)
+            b = _ctx(
+                tuned_parent_values=(("model", "m2"), ("retriever.k", 4)),
+                extensions=ext,
+            )
+            assert a.freshness_hash() != b.freshness_hash(), subset
+
+
+def test_extensions_are_a_canonical_map():
+    a = _ctx(extensions=(("model_versions", "mv1"), ("stage_versions", "sv1")))
+    b = _ctx(extensions=(("stage_versions", "sv1"), ("model_versions", "mv1")))
+    assert a.freshness_hash() == b.freshness_hash()
+    with pytest.raises(ValueError, match="duplicate_calibration_context_key"):
+        _ctx(
+            extensions=(("model_versions", "a"), ("model_versions", "b"))
+        ).freshness_hash()
+    with pytest.raises(ValueError, match="invalid_calibration_context"):
+        _ctx(extensions=(("tuned_parent_values", "x"),)).freshness_hash()
+
+
+def test_parents_are_canonical_too():
+    a = _ctx(tuned_parent_values=(("a", 1), ("b", 2)))
+    b = _ctx(tuned_parent_values=(("b", 2), ("a", 1)))
+    assert a.freshness_hash() == b.freshness_hash()
+    with pytest.raises(ValueError, match="duplicate tuned parent"):
+        _ctx(tuned_parent_values=(("a", 1), ("a", 2))).freshness_hash()
+
+
+def test_conformal_evidence_floor():
+    assert conformal_evidence_floor(0.1) == 9
+    assert conformal_evidence_floor(0.01) == 99
+    with pytest.raises(ValueError):
+        conformal_evidence_floor(0.0)
+    with pytest.raises(ValueError):
+        conformal_evidence_floor(1.5)
+
+
+# ---------------------------------------------------------------------------
+# Signals — closed shape (P8)
+# ---------------------------------------------------------------------------
+
+
+def test_signal_observation_closed_shape():
+    obs = SignalObservation(signal="vote_margin", value=0.7, n=10, split="cal")
+    field_names = {f.name for f in dataclasses.fields(obs)}
+    assert field_names == {"signal", "value", "n", "split"}  # NO metadata map
+    with pytest.raises(ValueError):
+        SignalObservation(signal="s", value=float("nan"), n=1, split="cal")
+    with pytest.raises(ValueError):
+        SignalObservation(signal="s", value=0.5, n=-1, split="cal")
+
+
+def test_certificate_closed_shape():
+    field_names = {f.name for f in dataclasses.fields(Certificate)}
+    assert field_names == {
+        "subject_cvar",
+        "subject_type",
+        "subject_value_hash",
+        "target_hash",
+        "issued_hash",
+        "decision",
+        "evidence",
+    }  # no payload / metadata field
+
+
+# ---------------------------------------------------------------------------
+# Resolution vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_vocabulary_matches_rfc():
+    assert {r.value for r in ResolutionRejection} == {
+        "cycle",
+        "missing_ref",
+        "duplicate_provider",
+        "phase_mismatch",
+        "infeasible_value",
+        "stale_certificate",
+        "evidence_leakage",
+        "insufficient_evidence",
+        "no_decision",
+    }
+    with pytest.raises(ValueError):
+        ResolutionNode(knob="x", binding_kind="searched")
+    with pytest.raises(ValueError):
+        ResolutionNode(knob="x", binding_kind="tuned", phase="later")
+
+
+def test_calibrated_refs_and_fallback_shape():
+    calibrated = Calibrated(
+        signal=_signal(),
+        target=_target(),
+        depends_on=(Ref(knob="model"), Ref(knob="retriever.k")),
+        fallback=Fixed(value=0.5),
+        require_calibration=True,
+        target_epsilon=0.1,
+    )
+    assert calibrated.depends_on[0].knob == "model"
+    assert calibrated.fallback.value == 0.5
+
+
+def test_package_is_import_light():
+    """traigent.knobs modules must not import the orchestrator or cloud
+    client themselves. (Importing ANY traigent.* module triggers the
+    top-level package __init__, so a sys.modules check would measure the
+    package, not this code — a static source check states the actual design
+    property.)"""
+    import ast as ast_mod
+    import pathlib
+
+    import traigent.knobs
+
+    package_dir = pathlib.Path(traigent.knobs.__file__).parent
+    for module_path in package_dir.glob("*.py"):
+        tree = ast_mod.parse(module_path.read_text(encoding="utf-8"))
+        for node in ast_mod.walk(tree):
+            names: list[str] = []
+            if isinstance(node, ast_mod.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast_mod.ImportFrom) and node.module:
+                names = [node.module]
+            for name in names:
+                assert not name.startswith("traigent.core"), module_path.name
+                assert not name.startswith("traigent.cloud"), module_path.name
+                if name.startswith("traigent.effectuation"):
+                    # only the guarded kinds import may reference it
+                    assert module_path.name == "kinds.py"

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -283,14 +283,16 @@ class TestRejections:
 
 
 class TestFallbacks:
-    def test_non_governed_no_decision_uses_fallback_recorded(self):
+    def test_bottom_never_falls_back_even_non_governed(self):
+        """Review fix (B1): Accept requires calibrator != ⊥ with NO fallback
+        carve-out — abstention is no_decision regardless of governance."""
         space = _space(governed=False, fallback=Fixed(value=0.42))
         resolver = KnobResolver(
             space, calibrated_inputs={"theta": CalibratedInput(value=None)}
         )
-        result = resolver.resolve({"model": "a"})
-        assert result.config["theta"] == 0.42
-        assert result.used_fallbacks == ("theta",)  # observable, never silent
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.NO_DECISION in excinfo.value.rejections
 
     def test_governed_no_decision_never_falls_back(self):
         space = _space(governed=True, fallback=Fixed(value=0.42))
@@ -299,6 +301,23 @@ class TestFallbacks:
         )
         with pytest.raises(ResolutionError):
             resolver.resolve({"model": "a"})
+
+    def test_stale_certificate_fallback_for_non_governed_recorded(self):
+        """The §3.5 carve-out: a NON-governed CVAR whose optional certificate
+        went stale MAY use its declared fallback — always recorded."""
+        space = _space(governed=False, fallback=Fixed(value=0.42))
+        ctx_a = _ctx(parents=(("model", "a"),))
+        cert = issue_certificate("theta", "float", 0.5, ctx_a)
+        ctx_b = dataclasses.replace(ctx_a, tuned_parent_values=(("model", "b"),))
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx_b)
+            },
+        )
+        result = resolver.resolve({"model": "b"})
+        assert result.config["theta"] == 0.42
+        assert result.used_fallbacks == ("theta",)  # observable, never silent
 
 
 class TestDeterminism:
@@ -351,3 +370,74 @@ class TestOrchestratorInjection:
         orchestrator.knob_resolver = KnobResolver(_space())  # unproduced CVAR
         with pytest.raises(ResolutionError):
             orchestrator._apply_knob_resolution({"model": "a"})
+
+
+class TestReviewRoundTwoCoverage:
+    def test_r8_epsilon_without_context_fails_closed(self):
+        """Review fix (B2): a declared epsilon with NO context is
+        unverifiable evidence — R8, not silent acceptance."""
+        space = _space(governed=False, epsilon=0.1)
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=0.5)}
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.INSUFFICIENT_EVIDENCE in excinfo.value.rejections
+
+    def test_r1_cycle_via_deferred_cvar_parents(self):
+        """R1 machinery (forward-compat): two CVARs referencing each other
+        produce CYCLE alongside the v1 MISSING_REF kind errors."""
+        space = ConfigSpace(
+            knobs={
+                "c1": Knob(
+                    name="c1",
+                    binding=Calibrated(
+                        signal=_signal(), target=_target(),
+                        depends_on=(Ref(knob="c2"),),
+                    ),
+                ),
+                "c2": Knob(
+                    name="c2",
+                    binding=Calibrated(
+                        signal=_signal(), target=_target(),
+                        depends_on=(Ref(knob="c1"),),
+                    ),
+                ),
+            }
+        )
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "c1": CalibratedInput(value=0.1),
+                "c2": CalibratedInput(value=0.2),
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({})
+        assert ResolutionRejection.CYCLE in excinfo.value.rejections
+        assert ResolutionRejection.MISSING_REF in excinfo.value.rejections
+
+    def test_internal_resolver_errors_surface_typed_not_swallowed(self):
+        """Review fix (B5): internal ValueErrors wrap into ResolutionError so
+        the suggest-site except tuples can never silently break."""
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        class ExplodingResolver:
+            def resolve(self, suggestion):
+                raise ValueError("internal canonicalization failure")
+
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = ExplodingResolver()
+        with pytest.raises(ResolutionError) as excinfo:
+            orchestrator._apply_knob_resolution({"model": "a"})
+        assert ResolutionRejection.INFEASIBLE_VALUE in excinfo.value.rejections
+
+    def test_baseline_config_paths_resolve_too(self):
+        """Review fix (B3): the default/baseline config goes through the same
+        chokepoint — Fixed and CVAR values are injected."""
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = _happy_resolver()
+        baseline = orchestrator._apply_knob_resolution({"model": "a"})
+        assert baseline == {"model": "a", "k": 4, "theta": 0.5}

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -1,0 +1,353 @@
+"""KnobResolver tests (SDK packet 6-C2, RFC 0001 §3.4).
+
+Program acceptance criteria covered here:
+- every rejection R1-R8 (+ no_decision) is reachable with a typed error;
+- the Accept path produces suggestion ∪ fixed ∪ calibrated (config ⊇ N_C);
+- CVARs are optimizer-invisible (tvars projection) AND resolved in-trial
+  (the orchestrator injection test);
+- a None resolver is an exact passthrough (legacy byte-identical).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from traigent.api.config_space import ConfigSpace
+from traigent.api.parameter_ranges import Choices, IntRange
+from traigent.knobs import (
+    Calibrated,
+    CalibratedInput,
+    Fixed,
+    FreshnessContext,
+    Knob,
+    KnobResolver,
+    Ref,
+    ResolutionError,
+    ResolutionRejection,
+    SignalObservation,
+    SignalSpec,
+    TargetProperty,
+    Tuned,
+    canonical_hash,
+    issue_certificate,
+)
+
+
+def _signal() -> SignalSpec:
+    return SignalSpec(
+        name="vote_margin",
+        version="1",
+        score_function="exact_match",
+        score_function_version="1",
+        comparator="key_eq",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="margin_floor", mode="require_calibration")
+
+
+def _ctx(parents=(("model", "a"),), **overrides) -> FreshnessContext:
+    base = dict(
+        cvar_name="theta",
+        tuned_parent_values=tuple(parents),
+        calibration_source_id="pool_a",
+        signal_spec_hash=_signal().spec_hash(),
+        calibrator_id="budget_threshold",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target=_target(),
+    )
+    base.update(overrides)
+    return FreshnessContext(**base)
+
+
+def _space(*, governed: bool = True, fallback=None, epsilon=None) -> ConfigSpace:
+    return ConfigSpace(
+        knobs={
+            "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"]))),
+            "k": Knob(name="k", binding=Fixed(value=4)),
+            "theta": Knob(
+                name="theta",
+                binding=Calibrated(
+                    signal=_signal(),
+                    target=_target(),
+                    depends_on=(Ref(knob="model"),),
+                    require_calibration=governed,
+                    fallback=fallback,
+                    target_epsilon=epsilon,
+                ),
+            ),
+        }
+    )
+
+
+def _happy_resolver(space=None) -> KnobResolver:
+    space = space or _space()
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    return KnobResolver(
+        space,
+        calibrated_inputs={
+            "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx)
+        },
+    )
+
+
+class TestAcceptPath:
+    def test_happy_path_resolves_full_config(self):
+        result = _happy_resolver().resolve({"model": "a"})
+        assert dict(result.config) == {"model": "a", "k": 4, "theta": 0.5}
+        assert result.used_fallbacks == ()
+
+    def test_accepted_config_contains_every_cvar_and_fixed(self):
+        result = _happy_resolver().resolve({"model": "a"})
+        assert {"theta", "k"} <= set(result.config)
+
+    def test_runtime_fixed_merges_without_collision(self):
+        space = _space()
+        ctx = _ctx()
+        cert = issue_certificate("theta", "float", 0.5, ctx)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx)
+            },
+            runtime_fixed={"deployment_region": "eu"},
+        )
+        result = resolver.resolve({"model": "a"})
+        assert result.config["deployment_region"] == "eu"
+
+
+class TestRejections:
+    def test_r3_runtime_fixed_collides_with_knob(self):
+        space = _space()
+        ctx = _ctx()
+        cert = issue_certificate("theta", "float", 0.5, ctx)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx)
+            },
+            runtime_fixed={"model": "b"},
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.DUPLICATE_PROVIDER in excinfo.value.rejections
+
+    def test_r3_suggestion_with_non_tuned_name(self):
+        with pytest.raises(ResolutionError) as excinfo:
+            _happy_resolver().resolve({"model": "a", "theta": 0.9})
+        assert ResolutionRejection.DUPLICATE_PROVIDER in excinfo.value.rejections
+
+    def test_r4_missing_tuned_value(self):
+        with pytest.raises(ResolutionError) as excinfo:
+            _happy_resolver().resolve({})
+        assert ResolutionRejection.PHASE_MISMATCH in excinfo.value.rejections
+
+    def test_r4_unproduced_cvar_even_when_unconsumed(self):
+        resolver = KnobResolver(_space())  # no calibrated inputs at all
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.PHASE_MISMATCH in excinfo.value.rejections
+
+    def test_r2_ref_to_unknown_or_cvar_parent(self):
+        space = ConfigSpace(
+            knobs={
+                "model": Knob(name="model", binding=Tuned(range=Choices(["a"]))),
+                "theta": Knob(
+                    name="theta",
+                    binding=Calibrated(
+                        signal=_signal(),
+                        target=_target(),
+                        depends_on=(Ref(knob="ghost"),),
+                    ),
+                ),
+            }
+        )
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=0.5)}
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.MISSING_REF in excinfo.value.rejections
+
+    def test_r5_type_mismatch(self):
+        space = _space(governed=False)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={"theta": CalibratedInput(value="not-a-number")},
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.INFEASIBLE_VALUE in excinfo.value.rejections
+
+    def test_r6_stale_certificate_on_parent_change(self):
+        """The optimizer suggested model='b' but the certificate was issued
+        for model='a' — parent-specific staleness by construction."""
+        space = _space()
+        ctx_a = _ctx(parents=(("model", "a"),))
+        cert = issue_certificate("theta", "float", 0.5, ctx_a)
+        ctx_b = dataclasses.replace(ctx_a, tuned_parent_values=(("model", "b"),))
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx_b)
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "b"})
+        assert ResolutionRejection.STALE_CERTIFICATE in excinfo.value.rejections
+
+    def test_r6_governed_without_certificate(self):
+        resolver = KnobResolver(
+            _space(), calibrated_inputs={"theta": CalibratedInput(value=0.5)}
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.STALE_CERTIFICATE in excinfo.value.rejections
+
+    def test_r7_observation_from_eval_split(self):
+        space = _space(governed=False)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(
+                    value=0.5,
+                    observations=(
+                        SignalObservation(
+                            signal="vote_margin", value=0.7, n=5, split="eval"
+                        ),
+                    ),
+                )
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.EVIDENCE_LEAKAGE in excinfo.value.rejections
+
+    def test_r7_true_item_intersection(self):
+        space = _space(governed=False)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(
+                    value=0.5, evidence_item_ids=frozenset({"e1", "c2"})
+                )
+            },
+            eval_item_ids=frozenset({"e1", "e9"}),
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.EVIDENCE_LEAKAGE in excinfo.value.rejections
+
+    def test_r8_conformal_floor(self):
+        space = _space(governed=False, epsilon=0.1)  # floor = 9
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, context=_ctx(evidence_n=3))
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.INSUFFICIENT_EVIDENCE in excinfo.value.rejections
+
+    def test_no_decision_strict_rejects(self):
+        resolver = KnobResolver(
+            _space(governed=True),
+            calibrated_inputs={"theta": CalibratedInput(value=None)},
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.NO_DECISION in excinfo.value.rejections
+
+    def test_rejections_are_collected_not_short_circuited(self):
+        resolver = KnobResolver(
+            _space(),  # governed CVAR without inputs -> R4
+            runtime_fixed={"model": "b"},  # -> R3
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({})  # missing tuned -> R4
+        assert {
+            ResolutionRejection.DUPLICATE_PROVIDER,
+            ResolutionRejection.PHASE_MISMATCH,
+        } <= set(excinfo.value.rejections)
+
+
+class TestFallbacks:
+    def test_non_governed_no_decision_uses_fallback_recorded(self):
+        space = _space(governed=False, fallback=Fixed(value=0.42))
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=None)}
+        )
+        result = resolver.resolve({"model": "a"})
+        assert result.config["theta"] == 0.42
+        assert result.used_fallbacks == ("theta",)  # observable, never silent
+
+    def test_governed_no_decision_never_falls_back(self):
+        space = _space(governed=True, fallback=Fixed(value=0.42))
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=None)}
+        )
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"model": "a"})
+
+
+class TestDeterminism:
+    def test_same_inputs_same_resolution(self):
+        resolver = _happy_resolver()
+        first = resolver.resolve({"model": "a"})
+        second = resolver.resolve({"model": "a"})
+        assert dict(first.config) == dict(second.config)
+
+
+class TestOrchestratorInjection:
+    """The program acceptance criterion: CVARs are optimizer-invisible AND
+    resolved in-trial — proven at the orchestrator chokepoint."""
+
+    def _orchestrator_stub(self):
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = None
+        return orchestrator
+
+    def test_none_resolver_is_exact_passthrough(self):
+        orchestrator = self._orchestrator_stub()
+        config = {"model": "a", "k": 3}
+        assert orchestrator._apply_knob_resolution(config) is config
+
+    def test_resolver_injects_fixed_and_cvar_values(self):
+        orchestrator = self._orchestrator_stub()
+        orchestrator.knob_resolver = _happy_resolver()
+        resolved = orchestrator._apply_knob_resolution({"model": "a"})
+        assert resolved == {"model": "a", "k": 4, "theta": 0.5}
+
+    def test_optimizer_never_sees_cvars_but_evaluator_does(self):
+        """tvars projection (what dict-based optimizers consume) excludes the
+        CVAR; the resolved trial config includes it."""
+        space = _space()
+        optimizer_view = {
+            name: parameter_range.to_config_value()
+            for name, parameter_range in space.tvars.items()
+        }
+        assert set(optimizer_view) == {"model"}  # P2
+
+        orchestrator = self._orchestrator_stub()
+        orchestrator.knob_resolver = _happy_resolver(space)
+        trial_config = orchestrator._apply_knob_resolution({"model": "a"})
+        assert trial_config["theta"] == 0.5  # resolved in-trial
+
+    def test_resolution_failure_is_fail_closed_at_the_chokepoint(self):
+        orchestrator = self._orchestrator_stub()
+        orchestrator.knob_resolver = KnobResolver(_space())  # unproduced CVAR
+        with pytest.raises(ResolutionError):
+            orchestrator._apply_knob_resolution({"model": "a"})

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -441,3 +441,21 @@ class TestReviewRoundTwoCoverage:
         orchestrator.knob_resolver = _happy_resolver()
         baseline = orchestrator._apply_knob_resolution({"model": "a"})
         assert baseline == {"model": "a", "k": 4, "theta": 0.5}
+
+
+def test_unverifiable_optional_certificate_is_ignored_not_fallbacked():
+    """Round-2 new finding: with NO context, staleness is not established —
+    a non-governed CVAR's optional certificate is ignored and the calibrated
+    value stands (no fallback consumption)."""
+    space = _space(governed=False, fallback=Fixed(value=0.42))
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    resolver = KnobResolver(
+        space,
+        calibrated_inputs={
+            "theta": CalibratedInput(value=0.5, certificate=cert, context=None)
+        },
+    )
+    result = resolver.resolve({"model": "a"})
+    assert result.config["theta"] == 0.5
+    assert result.used_fallbacks == ()

--- a/traigent/api/config_space.py
+++ b/traigent/api/config_space.py
@@ -53,6 +53,7 @@ from traigent.api.validation_protocol import (
 )
 
 if TYPE_CHECKING:
+    from traigent.knobs import Knob
     from traigent.tvl.models import StructuralConstraint, TVarDecl
 
 
@@ -102,9 +103,12 @@ class ConfigSpace:
     the TVL ecosystem.
 
     Attributes:
-        tvars: Read-only mapping of parameter names to ParameterRange definitions
+        tvars: Read-only Tuned-only projection — parameter names to
+            ParameterRange definitions; exactly what dict-based optimizers see
         constraints: Immutable tuple of structural constraints on the space
         description: Optional description of the configuration space
+        knobs: Read-only canonical binding-aware surface (RFC 0001). Always
+            populated: derived from ``tvars`` as all-Tuned when not supplied
 
     Example:
         >>> from traigent import Range, Choices, implies
@@ -119,13 +123,58 @@ class ConfigSpace:
         ... )
     """
 
-    tvars: Mapping[str, ParameterRange]
+    tvars: Mapping[str, ParameterRange] = field(default_factory=dict)
     constraints: tuple[Constraint, ...] = field(default_factory=tuple)
     description: str | None = None
+    knobs: Mapping[str, Knob] | None = None
 
     def __post_init__(self) -> None:
-        """Validate the configuration space after initialization."""
-        object.__setattr__(self, "tvars", MappingProxyType(dict(self.tvars)))
+        """Validate the configuration space after initialization.
+
+        Knob/tvar coherence (RFC 0001, the one-Knob model):
+        - constructed with ``knobs`` -> ``tvars`` is DERIVED as the
+          Tuned-only projection (Fixed/Calibrated knobs are
+          optimizer-invisible, P2); passing both with a mismatch is an error;
+        - constructed with ``tvars`` only (every existing call site) ->
+          ``knobs`` is synthesized as all-Tuned via the adapter, so the two
+          surfaces can never drift apart.
+        """
+        from traigent.knobs import Knob as _Knob
+        from traigent.knobs import knob_to_parameter_range, parameter_range_to_knob
+
+        if self.knobs is not None:
+            knobs = dict(self.knobs)
+            for knob_name, knob in knobs.items():
+                if not isinstance(knob, _Knob):
+                    raise TypeError(f"knobs[{knob_name!r}] is not a Knob")
+                if knob.name != knob_name:
+                    raise ValueError(
+                        f"knob mapping key {knob_name!r} != knob.name {knob.name!r}"
+                    )
+            projected = {
+                name: knob_to_parameter_range(knob)
+                for name, knob in knobs.items()
+                if knob.is_tuned()
+            }
+            if self.tvars and dict(self.tvars) != projected:
+                raise ValueError(
+                    "tvars must be the Tuned-only projection of knobs; "
+                    "pass only knobs and let tvars be derived"
+                )
+            object.__setattr__(self, "tvars", MappingProxyType(projected))
+            object.__setattr__(self, "knobs", MappingProxyType(knobs))
+        else:
+            object.__setattr__(self, "tvars", MappingProxyType(dict(self.tvars)))
+            object.__setattr__(
+                self,
+                "knobs",
+                MappingProxyType(
+                    {
+                        name: parameter_range_to_knob(name, parameter_range)
+                        for name, parameter_range in self.tvars.items()
+                    }
+                ),
+            )
         object.__setattr__(self, "constraints", tuple(self.constraints))
 
         # Ensure all tvars have unique names
@@ -146,15 +195,25 @@ class ConfigSpace:
             "tvars": dict(self.tvars),
             "constraints": tuple(self.constraints),
             "description": self.description,
+            "knobs": dict(self.knobs) if self.knobs is not None else None,
         }
 
     def __setstate__(self, state: Mapping[str, Any]) -> None:
         """Restore immutable state after unpickling."""
+        from traigent.knobs import parameter_range_to_knob
+
         object.__setattr__(self, "tvars", MappingProxyType(dict(state["tvars"])))
         object.__setattr__(
             self, "constraints", tuple(cast(Sequence[Constraint], state["constraints"]))
         )
         object.__setattr__(self, "description", state.get("description"))
+        knobs = state.get("knobs")
+        if knobs is None:  # pickles from before the knobs surface
+            knobs = {
+                name: parameter_range_to_knob(name, parameter_range)
+                for name, parameter_range in state["tvars"].items()
+            }
+        object.__setattr__(self, "knobs", MappingProxyType(dict(knobs)))
 
     @classmethod
     def from_decorator_args(

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1235,7 +1235,9 @@ class OptimizationOrchestrator:
 
         baseline_config = self._consume_default_config()
         if baseline_config is not None:
-            configs.append(baseline_config)
+            # baseline trials get the same Fixed/CVAR injection as suggested
+            # ones — no bypass of R3/R6/R8 (RFC 0001)
+            configs.append(self._apply_knob_resolution(baseline_config))
             remaining -= 1
             if remaining <= 0:
                 return configs, False
@@ -1245,7 +1247,10 @@ class OptimizationOrchestrator:
         if self.traigent_config.execution_mode_enum is ExecutionMode.HYBRID:
             async_configs = await self._try_hybrid_batch_generation(dataset, remaining)
             if async_configs:
-                configs.extend(async_configs)
+                configs.extend(
+                    self._apply_knob_resolution(async_config)
+                    for async_config in async_configs
+                )
                 used_async_batch = True
 
         # Fall back to sequential generation
@@ -1265,7 +1270,20 @@ class OptimizationOrchestrator:
         """
         if self.knob_resolver is None:
             return config
-        resolved = self.knob_resolver.resolve(config)
+        from traigent.knobs import ResolutionError, ResolutionRejection
+
+        try:
+            resolved = self.knob_resolver.resolve(config)
+        except ResolutionError:
+            raise
+        except Exception as exc:
+            # Internal resolver failures (ValueError, canonicalization, ...)
+            # MUST surface as the typed fail-closed error — the suggest-site
+            # except tuples catch ValueError and would silently break.
+            raise ResolutionError(
+                (ResolutionRejection.INFEASIBLE_VALUE,),
+                f"resolver internal failure: {exc}",
+            ) from exc
         if resolved.used_fallbacks:
             logger.warning(
                 "Knob resolution used declared fallbacks for: %s",

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -638,6 +638,10 @@ class OptimizationOrchestrator:
 
     def _initialize_runtime_state(self) -> None:
         self._trials: list[TrialResult] = []
+        # RFC 0001 (knob bindings): optional resolver injecting Fixed/CVAR
+        # values post-suggest, pre-validation. None => byte-identical legacy
+        # behavior. Set via `orchestrator.knob_resolver = KnobResolver(...)`.
+        self.knob_resolver: Any | None = None
         self._start_time: float | None = None
         self._status = OptimizationStatus.PENDING
         self._optimization_id = str(uuid.uuid4())
@@ -1201,6 +1205,7 @@ class OptimizationOrchestrator:
         for _ in range(count):
             try:
                 config = self.optimizer.suggest_next_trial(self._trials)
+                config = self._apply_knob_resolution(config)
             except OptimizationError:
                 break
             except (ValueError, TypeError, KeyError, AttributeError) as e:
@@ -1248,6 +1253,25 @@ class OptimizationOrchestrator:
             configs.extend(self._generate_sequential_configs(remaining))
 
         return configs, used_async_batch
+
+    def _apply_knob_resolution(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Resolve knob bindings for one suggestion (RFC 0001 §3.4).
+
+        With no resolver configured this is an exact passthrough (legacy
+        behavior byte-identical). With a resolver, Fixed and Calibrated
+        values are injected fail-closed: any rejection (stale certificate,
+        evidence leakage, missing producer, ...) raises ResolutionError —
+        there is no silent fallback. Recorded fallback use is logged.
+        """
+        if self.knob_resolver is None:
+            return config
+        resolved = self.knob_resolver.resolve(config)
+        if resolved.used_fallbacks:
+            logger.warning(
+                "Knob resolution used declared fallbacks for: %s",
+                ", ".join(resolved.used_fallbacks),
+            )
+        return dict(resolved.config)
 
     def _build_trial_descriptors(
         self,

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -119,6 +119,7 @@ class TrialLifecycle:
         if config is None:
             try:
                 config = orchestrator.optimizer.suggest_next_trial(orchestrator._trials)
+                config = orchestrator._apply_knob_resolution(config)
             except OptimizationError:
                 raise
             except (ValueError, TypeError, KeyError, AttributeError) as e:

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -116,6 +116,9 @@ class TrialLifecycle:
             return trial_count, "break"
 
         config = orchestrator._consume_default_config()
+        if config is not None:
+            # baseline trials get the same Fixed/CVAR injection (RFC 0001)
+            config = orchestrator._apply_knob_resolution(config)
         if config is None:
             try:
                 config = orchestrator.optimizer.suggest_next_trial(orchestrator._trials)

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -1,0 +1,66 @@
+"""traigent.knobs — the one-Knob model (RFC 0001: knob bindings).
+
+Pure types in this packet: bindings (Tuned | Fixed | Calibrated), signal
+specs and content-free observations, certificates with hash-covered
+freshness contexts, resolution vocabulary, and ParameterRange adapters.
+No runtime behavior changes anywhere else; nothing here is wired into the
+orchestrator yet (that is the knobs-resolver packet) and nothing crosses a
+wire boundary (see the program's contract-decision record).
+
+Import-light by design: importing this package must not pull in
+``traigent.core`` or the cloud client.
+
+DESIGN NOTE for the deferred CVAR optimizer: when many candidate
+configurations share one calibration pool, certification must use
+fixed-sequence testing in a pre-committed (e.g. cost) order — never
+Bonferroni over an unordered grid, and never silent pool reuse
+(multiplicity accounting belongs INSIDE the certificate; see Pareto
+Testing, arXiv:2210.07913).
+"""
+
+from __future__ import annotations
+
+from .adapters import knob_to_parameter_range, parameter_range_to_knob
+from .bindings import Binding, Calibrated, Fixed, Knob, Ref, Tuned
+from .canonical import CTX_SCHEMA_VERSION, CanonicalizationError, canonical_hash
+from .certificates import (
+    CTX_EXT_KEYS,
+    Certificate,
+    CertificateDecision,
+    EvidenceRef,
+    FreshnessContext,
+    TargetProperty,
+    conformal_evidence_floor,
+    issue_certificate,
+)
+from .kinds import KnobKind
+from .resolution import ResolutionError, ResolutionNode, ResolutionRejection
+from .signals import SignalObservation, SignalSpec
+
+__all__ = [
+    "CTX_EXT_KEYS",
+    "CTX_SCHEMA_VERSION",
+    "Binding",
+    "Calibrated",
+    "CanonicalizationError",
+    "Certificate",
+    "CertificateDecision",
+    "EvidenceRef",
+    "Fixed",
+    "FreshnessContext",
+    "Knob",
+    "KnobKind",
+    "Ref",
+    "ResolutionError",
+    "ResolutionNode",
+    "ResolutionRejection",
+    "SignalObservation",
+    "SignalSpec",
+    "TargetProperty",
+    "Tuned",
+    "canonical_hash",
+    "conformal_evidence_floor",
+    "issue_certificate",
+    "knob_to_parameter_range",
+    "parameter_range_to_knob",
+]

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -35,6 +35,7 @@ from .certificates import (
 )
 from .kinds import KnobKind
 from .resolution import ResolutionError, ResolutionNode, ResolutionRejection
+from .resolver import CalibratedInput, KnobResolver, ResolvedConfiguration
 from .signals import SignalObservation, SignalSpec
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     "CTX_SCHEMA_VERSION",
     "Binding",
     "Calibrated",
+    "CalibratedInput",
     "CanonicalizationError",
     "Certificate",
     "CertificateDecision",
@@ -50,10 +52,12 @@ __all__ = [
     "FreshnessContext",
     "Knob",
     "KnobKind",
+    "KnobResolver",
     "Ref",
     "ResolutionError",
     "ResolutionNode",
     "ResolutionRejection",
+    "ResolvedConfiguration",
     "SignalObservation",
     "SignalSpec",
     "TargetProperty",

--- a/traigent/knobs/adapters.py
+++ b/traigent/knobs/adapters.py
@@ -1,0 +1,44 @@
+"""Adapters between ParameterRange (the existing surface) and Knob[Tuned].
+
+``ParameterRange`` stays unchanged (RFC 0001 decision): ``Range.default``
+remains a default CANDIDATE value, and the adapters preserve that — a Tuned
+default is never coerced into a Fixed binding.
+"""
+
+from __future__ import annotations
+
+from traigent.api.parameter_ranges import ParameterRange
+
+from .bindings import Knob, Tuned
+from .kinds import KnobKind
+
+__all__ = ["knob_to_parameter_range", "parameter_range_to_knob"]
+
+
+def parameter_range_to_knob(
+    name: str,
+    parameter_range: ParameterRange,
+    *,
+    kind: KnobKind = KnobKind.VALUE,
+    description: str | None = None,
+) -> Knob:
+    """Wrap an existing ParameterRange as a Tuned knob (identity-preserving)."""
+    return Knob(
+        name=name,
+        binding=Tuned(range=parameter_range, default=parameter_range.get_default()),
+        kind=kind,
+        description=description,
+    )
+
+
+def knob_to_parameter_range(knob: Knob) -> ParameterRange | None:
+    """Project a knob onto the optimizer-visible surface.
+
+    Returns the underlying ParameterRange for Tuned knobs and ``None`` for
+    Fixed/Calibrated knobs — they are optimizer-invisible (P2), which is
+    exactly what makes ``ConfigSpace.tvars`` the Tuned-only projection.
+    """
+    binding = knob.binding
+    if isinstance(binding, Tuned):
+        return binding.range
+    return None

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -1,0 +1,110 @@
+"""The one-Knob model: typed bindings Tuned | Fixed | Calibrated (RFC 0001).
+
+Every configuration variable is a knob with exactly one binding:
+
+- ``Tuned`` — optimizer-visible, searched over a :class:`ParameterRange`.
+  Its ``default`` mirrors ``ParameterRange.default``: a default CANDIDATE
+  value inside the searched domain, never a Fixed binding.
+- ``Fixed`` — a runtime-supplied constant; never searched.
+- ``Calibrated`` — a CVAR: produced by a calibrator from calibration
+  evidence, optimizer-invisible, certificate-backed.
+
+The binding union is discriminated by ``isinstance`` over the three frozen
+classes — deliberately NO string discriminator, so no second kind taxonomy
+competes with :class:`~traigent.knobs.kinds.KnobKind` (which classifies what
+a knob effectuates, not how it binds).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+from traigent.api.parameter_ranges import ParameterRange
+
+from .certificates import Certificate, TargetProperty
+from .kinds import KnobKind
+from .signals import SignalSpec
+
+__all__ = ["Binding", "Calibrated", "Fixed", "Knob", "Ref", "Tuned"]
+
+TValue = TypeVar("TValue")
+
+
+@dataclass(frozen=True, slots=True)
+class Tuned(Generic[TValue]):
+    """Optimizer-visible binding over a searched domain."""
+
+    range: ParameterRange
+    default: TValue | None = None  # default CANDIDATE, never Fixed
+
+
+@dataclass(frozen=True, slots=True)
+class Fixed(Generic[TValue]):
+    """Runtime-supplied constant binding; never searched."""
+
+    value: TValue
+
+
+@dataclass(frozen=True, slots=True)
+class Ref:
+    """A namespace reference to another knob (a CVAR's tuned parent).
+
+    Per RFC 0001 §3.3, v1 refs MUST name Tuned knobs (CVAR→CVAR parents are
+    deferred). Dependencies are a freshness relation, not a constraint.
+    """
+
+    knob: str
+    field: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Calibrated(Generic[TValue]):
+    """A CVAR binding: value produced by a calibrator, certificate-backed.
+
+    ``fallback`` may only be consumed OUTSIDE strict evidence modes, and its
+    use is always observable in resolution output — never silent.
+    """
+
+    signal: SignalSpec
+    target: TargetProperty
+    depends_on: tuple[Ref, ...] = field(default=())
+    fallback: Fixed[TValue] | None = None
+    certificate: Certificate | None = None
+    require_calibration: bool = False
+    target_epsilon: float | None = None  # chance-style level for the R8 floor
+
+
+#: The binding union — isinstance-discriminated.
+Binding = Tuned[TValue] | Fixed[TValue] | Calibrated[TValue]
+
+
+@dataclass(frozen=True, slots=True)
+class Knob(Generic[TValue]):
+    """A named configuration variable with exactly one typed binding."""
+
+    name: str
+    binding: Tuned[TValue] | Fixed[TValue] | Calibrated[TValue]
+    kind: KnobKind = KnobKind.VALUE
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding, (Tuned, Fixed, Calibrated)):
+            raise TypeError(
+                f"Knob binding must be Tuned, Fixed, or Calibrated; "
+                f"got {type(self.binding).__name__}"
+            )
+
+    def is_tuned(self) -> bool:
+        return isinstance(self.binding, Tuned)
+
+    def is_fixed(self) -> bool:
+        return isinstance(self.binding, Fixed)
+
+    def is_calibrated(self) -> bool:
+        return isinstance(self.binding, Calibrated)
+
+    @property
+    def optimizer_visible(self) -> bool:
+        """P2: only Tuned knobs enter the optimizer's search space."""
+        return self.is_tuned()

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -46,6 +46,11 @@ class Fixed(Generic[TValue]):
     value: TValue
 
 
+_IDENT_RE = __import__("re").compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$"
+)
+
+
 @dataclass(frozen=True, slots=True)
 class Ref:
     """A namespace reference to another knob (a CVAR's tuned parent).
@@ -56,6 +61,10 @@ class Ref:
 
     knob: str
     field: str | None = None
+
+    def __post_init__(self) -> None:
+        if not _IDENT_RE.match(self.knob):
+            raise ValueError(f"Ref.knob is not a valid identifier: {self.knob!r}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,11 +98,17 @@ class Knob(Generic[TValue]):
     description: str | None = None
 
     def __post_init__(self) -> None:
+        if not _IDENT_RE.match(self.name):
+            raise ValueError(f"Knob.name is not a valid identifier: {self.name!r}")
         if not isinstance(self.binding, (Tuned, Fixed, Calibrated)):
             raise TypeError(
                 f"Knob binding must be Tuned, Fixed, or Calibrated; "
                 f"got {type(self.binding).__name__}"
             )
+        if isinstance(self.binding, Calibrated):
+            for ref in self.binding.depends_on:
+                if ref.knob == self.name:
+                    raise ValueError(f"Knob {self.name!r} cannot depend on itself")
 
     def is_tuned(self) -> bool:
         return isinstance(self.binding, Tuned)

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -77,6 +77,7 @@ class Calibrated(Generic[TValue]):
 
     signal: SignalSpec
     target: TargetProperty
+    value_type: str = "float"  # declared CVAR type (R5/R6 conformance)
     depends_on: tuple[Ref, ...] = field(default=())
     fallback: Fixed[TValue] | None = None
     certificate: Certificate | None = None

--- a/traigent/knobs/canonical.py
+++ b/traigent/knobs/canonical.py
@@ -1,0 +1,74 @@
+"""Canonical hashing for certificate freshness contexts (RFC 0001 §3.5).
+
+``canonical_hash`` implements the TVL canonicalization profile: sorted-key
+compact JSON over NFC-normalized strings with the RFC's value restrictions
+(finite numbers only, ``-0.0`` folded to ``0.0``, duplicate keys rejected at
+parse time by the loaders). The profile is versioned via
+``CTX_SCHEMA_VERSION``, which is itself part of every hashed context, so any
+future change to this module is automatically staleness-inducing for
+previously issued certificates.
+
+Two conformant implementations hashing the same context MUST produce the
+same digest — the cross-implementation known-answer fixtures live in the tvl
+repo's conformance suite.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+__all__ = ["CTX_SCHEMA_VERSION", "CanonicalizationError", "canonical_hash"]
+
+#: Version of the freshness-context schema AND this canonicalization profile.
+CTX_SCHEMA_VERSION = 1
+
+
+class CanonicalizationError(ValueError):
+    """Raised when a value cannot be canonically hashed (non-finite numbers,
+    duplicate keys, unsupported types)."""
+
+
+def _normalize(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return unicodedata.normalize("NFC", value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CanonicalizationError("non-finite numbers are rejected, never hashed")
+        if value == 0.0:
+            return 0.0  # fold -0.0
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise CanonicalizationError("mapping keys must be strings")
+            norm_key = unicodedata.normalize("NFC", key)
+            if norm_key in normalized:
+                raise CanonicalizationError(f"duplicate key after NFC: {norm_key!r}")
+            normalized[norm_key] = _normalize(item)
+        return normalized
+    if isinstance(value, Sequence):
+        return [_normalize(item) for item in value]
+    raise CanonicalizationError(
+        f"unsupported type for canonical hashing: {type(value).__name__}"
+    )
+
+
+def canonical_hash(value: Any) -> str:
+    """SHA-256 over the canonical serialization of ``value``."""
+    payload = json.dumps(
+        _normalize(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/traigent/knobs/canonical.py
+++ b/traigent/knobs/canonical.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import hashlib
 import json
 import unicodedata
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any
 
 __all__ = ["CTX_SCHEMA_VERSION", "CanonicalizationError", "canonical_hash"]
@@ -42,8 +42,10 @@ def _normalize(value: Any) -> Any:
     if isinstance(value, float):
         if value != value or value in (float("inf"), float("-inf")):
             raise CanonicalizationError("non-finite numbers are rejected, never hashed")
-        if value == 0.0:
-            return 0.0  # fold -0.0
+        if value.is_integer():
+            # JCS/RFC 8785 number rule: integral floats serialize as the
+            # integer (1.0 -> "1"); this also folds -0.0 -> 0.
+            return int(value)
         return value
     if isinstance(value, Mapping):
         normalized: dict[str, Any] = {}
@@ -55,7 +57,9 @@ def _normalize(value: Any) -> Any:
                 raise CanonicalizationError(f"duplicate key after NFC: {norm_key!r}")
             normalized[norm_key] = _normalize(item)
         return normalized
-    if isinstance(value, Sequence):
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        raise CanonicalizationError("bytes-like values are outside the JSON profile")
+    if isinstance(value, (list, tuple)):
         return [_normalize(item) for item in value]
     raise CanonicalizationError(
         f"unsupported type for canonical hashing: {type(value).__name__}"

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -116,8 +116,12 @@ class FreshnessContext:
     evidence_n: int
     calibration_split: str
     eval_split: str
-    target_hash: str
+    target: TargetProperty
     extensions: tuple[tuple[str, Any], ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        if self.evidence_n < 0:
+            raise ValueError("evidence_n must be non-negative")
 
     def freshness_hash(self) -> str:
         """Canonical hash over the core + selected extensions.
@@ -155,7 +159,12 @@ class FreshnessContext:
                     "evidence_n": self.evidence_n,
                     "calibration_split": self.calibration_split,
                     "eval_split": self.eval_split,
-                    "target_hash": self.target_hash,
+                    "target": {
+                        "name": self.target.name,
+                        "mode": self.target.mode,
+                        "threshold": self.target.threshold,
+                        "confidence": self.target.confidence,
+                    },
                 },
                 "ext": sorted(
                     ([key, value] for key, value in self.extensions),
@@ -172,6 +181,10 @@ class EvidenceRef:
     n: int
     pool_hash: str
 
+    def __post_init__(self) -> None:
+        if self.n < 0:
+            raise ValueError("EvidenceRef.n must be non-negative")
+
 
 @dataclass(frozen=True, slots=True)
 class Certificate:
@@ -186,7 +199,7 @@ class Certificate:
     subject_cvar: str
     subject_type: str
     subject_value_hash: str
-    target_hash: str
+    target: TargetProperty
     issued_hash: str
     decision: CertificateDecision
     evidence: EvidenceRef
@@ -204,7 +217,7 @@ class Certificate:
             and self.subject_cvar == cvar_name
             and self.subject_type == cvar_type
             and self.subject_value_hash == canonical_hash(value)
-            and self.target_hash == ctx_now.target_hash
+            and self.target == ctx_now.target
             and self.evidence.n == ctx_now.evidence_n
             and self.evidence.pool_hash == ctx_now.dataset_hash
             and self.issued_hash == ctx_now.freshness_hash()
@@ -229,7 +242,7 @@ def issue_certificate(
         subject_cvar=cvar_name,
         subject_type=cvar_type,
         subject_value_hash=canonical_hash(value),
-        target_hash=ctx.target_hash,
+        target=ctx.target,
         issued_hash=ctx.freshness_hash(),
         decision=decision,
         evidence=EvidenceRef(n=ctx.evidence_n, pool_hash=ctx.dataset_hash),

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from .canonical import CTX_SCHEMA_VERSION, canonical_hash
@@ -42,7 +42,7 @@ CTX_EXT_KEYS = frozenset(
 )
 
 
-class CertificateDecision(str, Enum):
+class CertificateDecision(StrEnum):
     """Shared decision vocabulary (TraigentSchema guarantee certificates)."""
 
     CERTIFIED = "CERTIFIED_SELECTION"

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -1,0 +1,236 @@
+"""Target properties, freshness contexts, and certificates (RFC 0001 §3.5).
+
+A certificate binds a SPECIFIC calibrated value of a SPECIFIC CVAR to the
+exact context it was fit under. Validity is fail-closed: every field
+participates, the audit copies must agree with the live context, and the
+live context must itself name the queried CVAR (the forged-subject guard).
+
+The certificate is a CLOSED shape (Property P8): identifiers, types, hashes,
+counts, and an enum — no open payload field exists to leak content.
+
+The ``decision`` vocabulary is shared with TraigentSchema's per-config
+guarantee certificates (``guarantee_certificate_schema.json``): one
+certificate ontology, two scopes — per-config selection there, per-CVAR
+value here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from .canonical import CTX_SCHEMA_VERSION, canonical_hash
+
+__all__ = [
+    "CTX_EXT_KEYS",
+    "Certificate",
+    "CertificateDecision",
+    "EvidenceRef",
+    "FreshnessContext",
+    "TargetProperty",
+    "conformal_evidence_floor",
+    "issue_certificate",
+]
+
+#: Optional freshness-context EXTENSION keys. The mandatory core (see
+#: ``FreshnessContext``) is implicit and immutable — module configuration
+#: can only ADD coverage, never remove parent-specificity.
+CTX_EXT_KEYS = frozenset(
+    {"stage_versions", "model_versions", "budget_assumptions", "cost_assumptions"}
+)
+
+
+class CertificateDecision(str, Enum):
+    """Shared decision vocabulary (TraigentSchema guarantee certificates)."""
+
+    CERTIFIED = "CERTIFIED_SELECTION"
+    NO_DECISION = "NO_DECISION"
+    BEST_EFFORT_UNCERTIFIED = "BEST_EFFORT_UNCERTIFIED"
+
+
+@dataclass(frozen=True, slots=True)
+class TargetProperty:
+    """The property a calibrated value is certified against."""
+
+    name: str
+    mode: str  # require_calibration | chance_constraint | guaranteed_selection | certificate_backed
+    threshold: float | None = None
+    confidence: float | None = None
+
+    _MODES = (
+        "require_calibration",
+        "chance_constraint",
+        "guaranteed_selection",
+        "certificate_backed",
+    )
+
+    def __post_init__(self) -> None:
+        if self.mode not in self._MODES:
+            raise ValueError(f"unknown TargetProperty mode: {self.mode!r}")
+
+    def property_hash(self) -> str:
+        return canonical_hash(
+            {
+                "name": self.name,
+                "mode": self.mode,
+                "threshold": self.threshold,
+                "confidence": self.confidence,
+            }
+        )
+
+
+def conformal_evidence_floor(epsilon: float) -> int:
+    """The split-conformal minimum calibration size ``ceil(1/epsilon) - 1``.
+
+    Below this floor even a perfect calibrator cannot certify a chance-style
+    target at level ``epsilon`` — the resolver's R8 rejection uses it as a
+    closed-form ``insufficient_evidence`` precondition.
+    """
+    if not (0.0 < epsilon < 1.0):
+        raise ValueError("epsilon must be in (0, 1)")
+    return math.ceil(1.0 / epsilon) - 1
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessContext:
+    """The hash-covered calibration context (RFC 0001 §3.5).
+
+    The MANDATORY core is every constructor field below except
+    ``extensions`` — it always participates in the hash, so certificates are
+    parent-specific (``tuned_parent_values`` is core), evidence-specific
+    (dataset hash + count), and calibrator-specific (id, version, params) by
+    construction. ``extensions`` selects OPTIONAL extra keys from
+    ``CTX_EXT_KEYS`` only.
+    """
+
+    cvar_name: str
+    tuned_parent_values: tuple[tuple[str, Any], ...]
+    calibration_source_id: str
+    signal_spec_hash: str
+    calibrator_id: str
+    calibrator_version: str
+    calibrator_params_hash: str
+    dataset_hash: str
+    evidence_n: int
+    calibration_split: str
+    eval_split: str
+    target_hash: str
+    extensions: tuple[tuple[str, Any], ...] = field(default=())
+
+    def freshness_hash(self) -> str:
+        """Canonical hash over the core + selected extensions.
+
+        Extensions are a MAP: sorted by key before hashing (order-insensitive)
+        with duplicate keys rejected. Parent values are likewise sorted by
+        name with duplicates rejected — the definition enforces the RFC's
+        "sorted by name", never trusting the caller.
+        """
+        parent_names = [name for name, _ in self.tuned_parent_values]
+        if len(parent_names) != len(set(parent_names)):
+            raise ValueError("duplicate tuned parent name")
+        ext_keys = [key for key, _ in self.extensions]
+        for key in ext_keys:
+            if key not in CTX_EXT_KEYS:
+                raise ValueError(f"invalid_calibration_context: {key!r}")
+        if len(ext_keys) != len(set(ext_keys)):
+            raise ValueError("duplicate_calibration_context_key")
+
+        return canonical_hash(
+            {
+                "core": {
+                    "ctx_schema_version": CTX_SCHEMA_VERSION,
+                    "cvar_name": self.cvar_name,
+                    "tuned_parent_values": sorted(
+                        ([name, value] for name, value in self.tuned_parent_values),
+                        key=lambda pair: pair[0],
+                    ),
+                    "calibration_source_id": self.calibration_source_id,
+                    "signal_spec_hash": self.signal_spec_hash,
+                    "calibrator_id": self.calibrator_id,
+                    "calibrator_version": self.calibrator_version,
+                    "calibrator_params_hash": self.calibrator_params_hash,
+                    "dataset_hash": self.dataset_hash,
+                    "evidence_n": self.evidence_n,
+                    "calibration_split": self.calibration_split,
+                    "eval_split": self.eval_split,
+                    "target_hash": self.target_hash,
+                },
+                "ext": sorted(
+                    ([key, value] for key, value in self.extensions),
+                    key=lambda pair: pair[0],
+                ),
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRef:
+    """Audit copy of the evidence behind a certificate (closed shape)."""
+
+    n: int
+    pool_hash: str
+
+
+@dataclass(frozen=True, slots=True)
+class Certificate:
+    """Validity object for one calibrated value of one CVAR.
+
+    ``payload``-style open fields are deliberately ABSENT (P8). The audit
+    copies (``target_hash``, ``evidence``) duplicate context fields for
+    inspection; ``valid_for`` cross-checks them against the live context so
+    a certificate cannot DISPLAY one context while HASHING another.
+    """
+
+    subject_cvar: str
+    subject_type: str
+    subject_value_hash: str
+    target_hash: str
+    issued_hash: str
+    decision: CertificateDecision
+    evidence: EvidenceRef
+
+    def valid_for(
+        self,
+        cvar_name: str,
+        cvar_type: str,
+        value: Any,
+        ctx_now: FreshnessContext,
+    ) -> bool:
+        """RFC 0001 §3.5 validity — all nine conjuncts, fail-closed."""
+        return (
+            ctx_now.cvar_name == cvar_name
+            and self.subject_cvar == cvar_name
+            and self.subject_type == cvar_type
+            and self.subject_value_hash == canonical_hash(value)
+            and self.target_hash == ctx_now.target_hash
+            and self.evidence.n == ctx_now.evidence_n
+            and self.evidence.pool_hash == ctx_now.dataset_hash
+            and self.issued_hash == ctx_now.freshness_hash()
+            and self.decision is CertificateDecision.CERTIFIED
+        )
+
+
+def issue_certificate(
+    cvar_name: str,
+    cvar_type: str,
+    value: Any,
+    ctx: FreshnessContext,
+    *,
+    decision: CertificateDecision = CertificateDecision.CERTIFIED,
+) -> Certificate:
+    """Issue a certificate binding ``value`` of ``cvar_name`` to ``ctx``."""
+    if ctx.cvar_name != cvar_name:
+        raise ValueError(
+            f"context names {ctx.cvar_name!r}, cannot issue for {cvar_name!r}"
+        )
+    return Certificate(
+        subject_cvar=cvar_name,
+        subject_type=cvar_type,
+        subject_value_hash=canonical_hash(value),
+        target_hash=ctx.target_hash,
+        issued_hash=ctx.freshness_hash(),
+        decision=decision,
+        evidence=EvidenceRef(n=ctx.evidence_n, pool_hash=ctx.dataset_hash),
+    )

--- a/traigent/knobs/certificates.py
+++ b/traigent/knobs/certificates.py
@@ -120,6 +120,8 @@ class FreshnessContext:
     extensions: tuple[tuple[str, Any], ...] = field(default=())
 
     def __post_init__(self) -> None:
+        if not isinstance(self.evidence_n, int) or isinstance(self.evidence_n, bool):
+            raise ValueError("evidence_n must be a natural number (int)")
         if self.evidence_n < 0:
             raise ValueError("evidence_n must be non-negative")
 
@@ -182,6 +184,8 @@ class EvidenceRef:
     pool_hash: str
 
     def __post_init__(self) -> None:
+        if not isinstance(self.n, int) or isinstance(self.n, bool):
+            raise ValueError("EvidenceRef.n must be a natural number (int)")
         if self.n < 0:
             raise ValueError("EvidenceRef.n must be non-negative")
 
@@ -191,7 +195,7 @@ class Certificate:
     """Validity object for one calibrated value of one CVAR.
 
     ``payload``-style open fields are deliberately ABSENT (P8). The audit
-    copies (``target_hash``, ``evidence``) duplicate context fields for
+    copies (``target``, ``evidence``) duplicate context fields for
     inspection; ``valid_for`` cross-checks them against the live context so
     a certificate cannot DISPLAY one context while HASHING another.
     """

--- a/traigent/knobs/kinds.py
+++ b/traigent/knobs/kinds.py
@@ -1,0 +1,29 @@
+"""Knob-kind taxonomy — reconciled with the effectuation module.
+
+The canonical ``KnobKind`` lives in ``traigent.effectuation`` (the
+tvar-executable-effectuation branch). Until that branch merges, this module
+provides a values-identical fallback behind an import guard so the two
+surfaces can never drift apart silently: ``tests/unit/knobs/test_kinds.py``
+pins the member names and values, and once the effectuation module is
+importable the guard resolves to it as the single source of truth.
+"""
+
+from __future__ import annotations
+
+__all__ = ["KnobKind"]
+
+try:  # pragma: no cover - exercised only once effectuation merges
+    from traigent.effectuation import KnobKind  # type: ignore[no-redef]
+except Exception:  # pragma: no cover - fallback is the tested path today
+    from enum import Enum
+
+    class KnobKind(str, Enum):  # type: ignore[no-redef]
+        """What aspect of the agent a knob effectuates.
+
+        Values mirror ``traigent.effectuation.contracts.KnobKind`` exactly.
+        """
+
+        VALUE = "value"
+        CARDINALITY = "cardinality"
+        TOPOLOGY = "topology"
+        POLICY = "policy"

--- a/traigent/knobs/kinds.py
+++ b/traigent/knobs/kinds.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 __all__ = ["KnobKind"]
 
 try:  # pragma: no cover - exercised only once effectuation merges
-    from traigent.effectuation import KnobKind  # type: ignore[no-redef]
-except Exception:  # pragma: no cover - fallback is the tested path today
+    from traigent.effectuation.contracts import KnobKind  # type: ignore[no-redef]
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - tested path today
     from enum import Enum
 
     class KnobKind(str, Enum):  # type: ignore[no-redef]

--- a/traigent/knobs/kinds.py
+++ b/traigent/knobs/kinds.py
@@ -15,9 +15,9 @@ __all__ = ["KnobKind"]
 try:  # pragma: no cover - exercised only once effectuation merges
     from traigent.effectuation.contracts import KnobKind  # type: ignore[no-redef]
 except (ImportError, ModuleNotFoundError):  # pragma: no cover - tested path today
-    from enum import Enum
+    from enum import StrEnum
 
-    class KnobKind(str, Enum):  # type: ignore[no-redef]
+    class KnobKind(StrEnum):  # type: ignore[no-redef]
         """What aspect of the agent a knob effectuates.
 
         Values mirror ``traigent.effectuation.contracts.KnobKind`` exactly.

--- a/traigent/knobs/resolution.py
+++ b/traigent/knobs/resolution.py
@@ -9,12 +9,12 @@ and shared with the tvl repo's model-checking suite.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 
 __all__ = ["ResolutionError", "ResolutionNode", "ResolutionRejection"]
 
 
-class ResolutionRejection(str, Enum):
+class ResolutionRejection(StrEnum):
     """RFC 0001 §3.4 rejection conditions (R1–R8) + the no-decision verdict."""
 
     CYCLE = "cycle"  # R1 — unreachable in v1 (CVAR→TVAR only); kept for the deferred extension

--- a/traigent/knobs/resolution.py
+++ b/traigent/knobs/resolution.py
@@ -1,0 +1,64 @@
+"""Resolution types: nodes, errors, and the Resolver contract (RFC 0001 §3.4).
+
+This module ships the TYPES in packet 6-B; the deterministic topological
+resolver LOGIC and its orchestrator injection land in packet 6-C2
+(``feature/knobs-resolver``). The rejection vocabulary R1–R8 is normative
+and shared with the tvl repo's model-checking suite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = ["ResolutionError", "ResolutionNode", "ResolutionRejection"]
+
+
+class ResolutionRejection(str, Enum):
+    """RFC 0001 §3.4 rejection conditions (R1–R8) + the no-decision verdict."""
+
+    CYCLE = "cycle"  # R1 — unreachable in v1 (CVAR→TVAR only); kept for the deferred extension
+    MISSING_REF = "missing_ref"  # R2
+    DUPLICATE_PROVIDER = "duplicate_provider"  # R3
+    PHASE_MISMATCH = "phase_mismatch"  # R4
+    INFEASIBLE_VALUE = "infeasible_value"  # R5
+    STALE_CERTIFICATE = "stale_certificate"  # R6
+    EVIDENCE_LEAKAGE = "evidence_leakage"  # R7
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"  # R8
+    NO_DECISION = "no_decision"  # calibrator ⊥ with no R_i holding
+
+
+class ResolutionError(Exception):
+    """Typed, fail-closed resolution failure.
+
+    Carries the full set of rejections so callers can report every reason,
+    not just the first — mirrors the model checker's collect-all semantics.
+    """
+
+    def __init__(
+        self, rejections: tuple[ResolutionRejection, ...], detail: str = ""
+    ) -> None:
+        self.rejections = rejections
+        codes = ", ".join(r.value for r in rejections)
+        super().__init__(
+            f"resolution rejected [{codes}]" + (f": {detail}" if detail else "")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionNode:
+    """One node of the resolution DAG (built by the 6-C2 resolver)."""
+
+    knob: str
+    binding_kind: str  # "tuned" | "fixed" | "calibrated"
+    depends_on: tuple[str, ...] = ()
+    phase: str = "post_suggest"  # pre_suggest | post_suggest | pre_eval
+
+    _BINDING_KINDS = ("tuned", "fixed", "calibrated")
+    _PHASES = ("pre_suggest", "post_suggest", "pre_eval")
+
+    def __post_init__(self) -> None:
+        if self.binding_kind not in self._BINDING_KINDS:
+            raise ValueError(f"unknown binding_kind: {self.binding_kind!r}")
+        if self.phase not in self._PHASES:
+            raise ValueError(f"unknown phase: {self.phase!r}")

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -206,10 +206,12 @@ class KnobResolver:
         used_fallbacks: list[str],
         reject: Any,
     ) -> None:
+        # Governance is DECLARED (on the binding/target), never inferred
+        # from runtime-presented evidence — presenting a certificate is
+        # evidence, not an opt-in to strictness.
         governed = (
             binding.require_calibration
             or binding.certificate is not None
-            or provided.certificate is not None
             or binding.target.mode in ("certificate_backed", "guaranteed_selection")
         )
 
@@ -235,26 +237,31 @@ class KnobResolver:
                 f"CVAR {name!r} calibration pool intersects the eval split items",
             )
 
-        # R8 insufficient evidence — closed-form conformal floor
-        if binding.target_epsilon is not None and provided.context is not None:
+        # R8 insufficient evidence — closed-form conformal floor. A declared
+        # epsilon with NO context means the floor is unverifiable: fail
+        # closed (unverifiable evidence IS insufficient evidence).
+        if binding.target_epsilon is not None:
             floor = conformal_evidence_floor(binding.target_epsilon)
-            if provided.context.evidence_n < floor:
+            if provided.context is None:
+                reject(
+                    ResolutionRejection.INSUFFICIENT_EVIDENCE,
+                    f"CVAR {name!r} declares epsilon={binding.target_epsilon} "
+                    "but no freshness context carries the evidence count",
+                )
+            elif provided.context.evidence_n < floor:
                 reject(
                     ResolutionRejection.INSUFFICIENT_EVIDENCE,
                     f"CVAR {name!r} has n={provided.context.evidence_n} < "
                     f"conformal floor {floor} for epsilon={binding.target_epsilon}",
                 )
 
-        # calibrator ⊥
+        # calibrator ⊥ — the Accept biconditional requires 𝒦 ≠ ⊥ with NO
+        # fallback carve-out (RFC §3.4); §3.5's non-strict fallback applies
+        # to STALE CERTIFICATES only, never to abstention.
         if provided.value is None:
-            if not governed and binding.fallback is not None:
-                values[name] = binding.fallback.value
-                used_fallbacks.append(name)
-                return
             reject(
                 ResolutionRejection.NO_DECISION,
-                f"calibrator for CVAR {name!r} abstained and no admissible "
-                "fallback exists",
+                f"calibrator for CVAR {name!r} abstained (⊥)",
             )
             return
 
@@ -284,6 +291,15 @@ class KnobResolver:
                     f"certificate for CVAR {name!r} is stale or invalid for the "
                     "current context",
                 )
+                return
+        elif binding.fallback is not None and provided.certificate is not None:
+            # non-governed CVAR whose OPTIONAL certificate turned stale: the
+            # §3.5 carve-out — declared fallback MAY be used, always recorded
+            if provided.context is None or not provided.certificate.valid_for(
+                name, binding.value_type, provided.value, provided.context
+            ):
+                values[name] = binding.fallback.value
+                used_fallbacks.append(name)
                 return
 
         values[name] = provided.value

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -292,15 +292,22 @@ class KnobResolver:
                     "current context",
                 )
                 return
-        elif binding.fallback is not None and provided.certificate is not None:
-            # non-governed CVAR whose OPTIONAL certificate turned stale: the
-            # §3.5 carve-out — declared fallback MAY be used, always recorded
-            if provided.context is None or not provided.certificate.valid_for(
+        elif (
+            binding.fallback is not None
+            and provided.certificate is not None
+            and provided.context is not None
+            and not provided.certificate.valid_for(
                 name, binding.value_type, provided.value, provided.context
-            ):
-                values[name] = binding.fallback.value
-                used_fallbacks.append(name)
-                return
+            )
+        ):
+            # non-governed CVAR whose optional certificate is PROVEN stale
+            # against a live context: the §3.5 carve-out — declared fallback
+            # MAY be used, always recorded. With NO context, staleness is
+            # not established: the unverifiable certificate is ignored and
+            # the calibrated value stands (non-governed acceptance).
+            values[name] = binding.fallback.value
+            used_fallbacks.append(name)
+            return
 
         values[name] = provided.value
 

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -1,0 +1,322 @@
+"""The deterministic knob resolver (RFC 0001 §3.4) — SDK packet 6-C2.
+
+Resolution turns an optimizer suggestion (Tuned values only, P2) into the
+full executed configuration:
+
+    config = suggestion ∪ fixed-binding values ∪ runtime fixed ∪ calibrated values
+
+Acceptance is EXACTLY the complement of the rejection conditions plus
+calibrator success (the Accept biconditional — P3/P4):
+
+    Accept ⟺ ¬(R1 ∨ … ∨ R8) ∧ every calibrated value present
+
+The resolver CHECKS certificate freshness; it never fits. In-loop
+re-calibration and the CVAR optimizer are explicitly deferred (RFC §2).
+Rejections are collected exhaustively (no short-circuit) and raised as one
+typed, fail-closed :class:`ResolutionError`. Fallbacks are consumed only for
+non-governed CVARs and are always recorded in the result — never silent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from .bindings import Calibrated, Fixed, Tuned
+from .certificates import Certificate, FreshnessContext, conformal_evidence_floor
+from .resolution import ResolutionError, ResolutionRejection
+from .signals import SignalObservation
+
+if TYPE_CHECKING:
+    from traigent.api.config_space import ConfigSpace
+
+__all__ = ["CalibratedInput", "KnobResolver", "ResolvedConfiguration"]
+
+
+@dataclass(frozen=True, slots=True)
+class CalibratedInput:
+    """The runtime inputs for one CVAR: its calibrated value + validity data.
+
+    ``value is None`` means the calibrator abstained (⊥ / no_decision).
+    """
+
+    value: Any | None
+    certificate: Certificate | None = None
+    context: FreshnessContext | None = None
+    observations: tuple[SignalObservation, ...] = field(default=())
+    evidence_item_ids: frozenset[str] = frozenset()  # calibration pool item ids
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedConfiguration:
+    """A successful resolution: the executed config + observability."""
+
+    config: Mapping[str, Any]
+    used_fallbacks: tuple[str, ...] = ()
+
+
+def _type_conforms(value: Any, value_type: str) -> bool:
+    """R5 type conformance (the model checker's transcription, productized)."""
+    if value_type == "bool":
+        return isinstance(value, bool)
+    if value_type == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if value_type == "float":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, str)  # enum[str] / str-like
+
+
+class KnobResolver:
+    """Deterministic, topological, fail-closed resolution over a ConfigSpace.
+
+    Args:
+        space: The configuration space whose ``knobs`` drive resolution.
+        calibrated_inputs: Per-CVAR runtime inputs (value, certificate,
+            context, observations). EVERY Calibrated knob needs an entry —
+            a declared CVAR that cannot be produced is R4 (phase mismatch),
+            consumed or not.
+        runtime_fixed: The runtime-supplied fixed assignment ``f`` (N_F).
+            Its domain must not intersect declared knob names (R3).
+        eval_split: The evaluation split label; calibration evidence tagged
+            with it (or item-overlapping it) is R7 evidence leakage.
+        eval_item_ids: Optional eval-split item ids for the true-intersection
+            form of R7 when callers track item identity.
+    """
+
+    def __init__(
+        self,
+        space: ConfigSpace,
+        *,
+        calibrated_inputs: Mapping[str, CalibratedInput] | None = None,
+        runtime_fixed: Mapping[str, Any] | None = None,
+        eval_split: str = "eval",
+        eval_item_ids: frozenset[str] = frozenset(),
+    ) -> None:
+        self._space = space
+        self._calibrated_inputs = dict(calibrated_inputs or {})
+        self._runtime_fixed = dict(runtime_fixed or {})
+        self._eval_split = eval_split
+        self._eval_item_ids = eval_item_ids
+
+    # ------------------------------------------------------------------
+    def resolve(self, suggestion: Mapping[str, Any]) -> ResolvedConfiguration:
+        """Resolve one optimizer suggestion into the executed configuration.
+
+        Raises:
+            ResolutionError: carrying EVERY applicable rejection.
+        """
+        rejections: list[ResolutionRejection] = []
+        details: list[str] = []
+        knobs = dict(self._space.knobs or {})
+
+        tuned_names = {n for n, k in knobs.items() if isinstance(k.binding, Tuned)}
+        fixed_knobs = {
+            n: k.binding for n, k in knobs.items() if isinstance(k.binding, Fixed)
+        }
+        calibrated_knobs = {
+            n: k.binding for n, k in knobs.items() if isinstance(k.binding, Calibrated)
+        }
+
+        def reject(code: ResolutionRejection, detail: str) -> None:
+            rejections.append(code)
+            details.append(f"{code.value}: {detail}")
+
+        # --- R3 duplicate providers -----------------------------------
+        fixed_collisions = set(self._runtime_fixed) & set(knobs)
+        for name in sorted(fixed_collisions):
+            reject(
+                ResolutionRejection.DUPLICATE_PROVIDER,
+                f"runtime fixed assignment collides with declared knob {name!r}",
+            )
+        for name in sorted(set(self._calibrated_inputs) - set(calibrated_knobs)):
+            reject(
+                ResolutionRejection.DUPLICATE_PROVIDER,
+                f"calibrated input provided for non-calibrated knob {name!r}",
+            )
+        for name in sorted(set(suggestion) - tuned_names):
+            reject(
+                ResolutionRejection.DUPLICATE_PROVIDER,
+                f"suggestion provides non-tuned name {name!r} (dom(t) must be N_T)",
+            )
+
+        # --- R4 phase: every tuned value present, every CVAR producible -
+        for name in sorted(tuned_names - set(suggestion)):
+            reject(
+                ResolutionRejection.PHASE_MISMATCH,
+                f"suggestion is missing tuned knob {name!r}",
+            )
+        for name in sorted(set(calibrated_knobs) - set(self._calibrated_inputs)):
+            reject(
+                ResolutionRejection.PHASE_MISMATCH,
+                f"declared CVAR {name!r} has no calibrated input (cannot be "
+                "produced before use; resolution includes every n in N_C)",
+            )
+
+        # --- R2 refs + R1 cycles --------------------------------------
+        for name in sorted(calibrated_knobs):
+            for ref in calibrated_knobs[name].depends_on:
+                if ref.knob in calibrated_knobs:
+                    # v1: CVAR->CVAR parents are deferred; also feeds R1 below
+                    reject(
+                        ResolutionRejection.MISSING_REF,
+                        f"CVAR {name!r} depends on CVAR {ref.knob!r} "
+                        "(v1 parents must be Tuned)",
+                    )
+                elif ref.knob not in tuned_names:
+                    reject(
+                        ResolutionRejection.MISSING_REF,
+                        f"CVAR {name!r} depends_on {ref.knob!r} which does not "
+                        "resolve to a Tuned knob",
+                    )
+        self._detect_cycles(calibrated_knobs, reject)
+
+        # --- per-CVAR resolution in deterministic (sorted) topo order --
+        values: dict[str, Any] = {}
+        used_fallbacks: list[str] = []
+        for name in sorted(set(calibrated_knobs) & set(self._calibrated_inputs)):
+            binding = calibrated_knobs[name]
+            self._resolve_calibrated(
+                name,
+                binding,
+                self._calibrated_inputs[name],
+                values,
+                used_fallbacks,
+                reject,
+            )
+
+        if rejections:
+            raise ResolutionError(tuple(dict.fromkeys(rejections)), "; ".join(details))
+
+        config: dict[str, Any] = dict(suggestion)
+        config.update({name: binding.value for name, binding in fixed_knobs.items()})
+        config.update(self._runtime_fixed)
+        config.update(values)
+        return ResolvedConfiguration(
+            config=config, used_fallbacks=tuple(used_fallbacks)
+        )
+
+    # ------------------------------------------------------------------
+    def _resolve_calibrated(
+        self,
+        name: str,
+        binding: Calibrated,
+        provided: CalibratedInput,
+        values: dict[str, Any],
+        used_fallbacks: list[str],
+        reject: Any,
+    ) -> None:
+        governed = (
+            binding.require_calibration
+            or binding.certificate is not None
+            or provided.certificate is not None
+            or binding.target.mode in ("certificate_backed", "guaranteed_selection")
+        )
+
+        # R7 evidence leakage — split tag or true item intersection
+        for observation in provided.observations:
+            if observation.split == self._eval_split:
+                reject(
+                    ResolutionRejection.EVIDENCE_LEAKAGE,
+                    f"CVAR {name!r} consumed an observation from the eval split",
+                )
+                break
+        if provided.context is not None and (
+            provided.context.calibration_split == self._eval_split
+        ):
+            reject(
+                ResolutionRejection.EVIDENCE_LEAKAGE,
+                f"CVAR {name!r} calibration split equals the eval split",
+            )
+        if self._eval_item_ids and (provided.evidence_item_ids & self._eval_item_ids):
+            # the TRUE intersection form: 𝓔_cal ∩ 𝓔_eval ≠ ∅ over item ids
+            reject(
+                ResolutionRejection.EVIDENCE_LEAKAGE,
+                f"CVAR {name!r} calibration pool intersects the eval split items",
+            )
+
+        # R8 insufficient evidence — closed-form conformal floor
+        if binding.target_epsilon is not None and provided.context is not None:
+            floor = conformal_evidence_floor(binding.target_epsilon)
+            if provided.context.evidence_n < floor:
+                reject(
+                    ResolutionRejection.INSUFFICIENT_EVIDENCE,
+                    f"CVAR {name!r} has n={provided.context.evidence_n} < "
+                    f"conformal floor {floor} for epsilon={binding.target_epsilon}",
+                )
+
+        # calibrator ⊥
+        if provided.value is None:
+            if not governed and binding.fallback is not None:
+                values[name] = binding.fallback.value
+                used_fallbacks.append(name)
+                return
+            reject(
+                ResolutionRejection.NO_DECISION,
+                f"calibrator for CVAR {name!r} abstained and no admissible "
+                "fallback exists",
+            )
+            return
+
+        # R5 type + validity
+        if not _type_conforms(provided.value, binding.value_type):
+            reject(
+                ResolutionRejection.INFEASIBLE_VALUE,
+                f"CVAR {name!r} value {provided.value!r} does not conform to "
+                f"declared type {binding.value_type!r}",
+            )
+            return
+
+        # R6 certificate validity for governed CVARs
+        if governed:
+            certificate = provided.certificate or binding.certificate
+            if certificate is None or provided.context is None:
+                reject(
+                    ResolutionRejection.STALE_CERTIFICATE,
+                    f"governed CVAR {name!r} lacks a certificate/context",
+                )
+                return
+            if not certificate.valid_for(
+                name, binding.value_type, provided.value, provided.context
+            ):
+                reject(
+                    ResolutionRejection.STALE_CERTIFICATE,
+                    f"certificate for CVAR {name!r} is stale or invalid for the "
+                    "current context",
+                )
+                return
+
+        values[name] = provided.value
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _detect_cycles(calibrated_knobs: Mapping[str, Calibrated], reject: Any) -> None:
+        """R1 — unreachable in v1 (CVAR->TVAR only) but kept normative for
+        the deferred CVAR->CVAR extension."""
+        adjacency = {
+            name: {
+                ref.knob for ref in binding.depends_on if ref.knob in calibrated_knobs
+            }
+            for name, binding in calibrated_knobs.items()
+        }
+        state: dict[str, int] = {}
+
+        def visit(node: str) -> bool:
+            if state.get(node) == 1:
+                return True
+            if state.get(node) == 2:
+                return False
+            state[node] = 1
+            for neighbour in adjacency.get(node, ()):
+                if visit(neighbour):
+                    return True
+            state[node] = 2
+            return False
+
+        for name in sorted(adjacency):
+            if visit(name):
+                reject(
+                    ResolutionRejection.CYCLE,
+                    f"dependency cycle involving CVAR {name!r}",
+                )
+                return

--- a/traigent/knobs/signals.py
+++ b/traigent/knobs/signals.py
@@ -1,0 +1,71 @@
+"""Signal specifications and content-free observations (RFC 0001 §3.5).
+
+``SignalObservation`` is a CLOSED shape by design (Property P8): every field
+is an identifier, finite number, count, or split label — there is no
+metadata map and no content-typed field to leak. Anything richer belongs
+outside the persisted-signal surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .canonical import canonical_hash
+
+__all__ = ["SignalObservation", "SignalSpec"]
+
+
+@dataclass(frozen=True, slots=True)
+class SignalSpec:
+    """Versioned identification of a measurement procedure.
+
+    The spec hash participates in certificate freshness (``ctx_core``): any
+    change to the signal, its score function, or its comparator — including
+    version bumps — makes previously issued certificates stale by
+    construction.
+    """
+
+    name: str
+    version: str
+    score_function: str
+    score_function_version: str
+    comparator: str
+    comparator_version: str
+
+    def spec_hash(self) -> str:
+        """Stable canonical hash over every identifying field."""
+        return canonical_hash(
+            {
+                "name": self.name,
+                "version": self.version,
+                "score_function": self.score_function,
+                "score_function_version": self.score_function_version,
+                "comparator": self.comparator,
+                "comparator_version": self.comparator_version,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SignalObservation:
+    """One content-free observation of a signal (closed shape — P8).
+
+    Args:
+        signal: Signal spec name this observation belongs to.
+        value: The observed signal value (finite float).
+        n: Sample count behind the observation.
+        split: Which data split produced it (e.g. ``"calibration"``,
+            ``"eval"``) — the resolver's evidence-leakage rejection (R7)
+            depends on faithful split tagging.
+    """
+
+    signal: str
+    value: float
+    n: int
+    split: str
+
+    def __post_init__(self) -> None:
+        if self.value != self.value or self.value in (float("inf"), float("-inf")):
+            raise ValueError("SignalObservation.value must be finite")
+        if self.n < 0:
+            raise ValueError("SignalObservation.n must be non-negative")


### PR DESCRIPTION
## Summary
SDK packet 6-C2 (stacked on the C1 PR). `KnobResolver` implements the Accept biconditional with collect-all typed rejections (R1–R8 + no_decision); `_apply_knob_resolution` chokepoint wired at ALL FOUR config paths (sequential, batch, baseline, hybrid async — the review found the two bypass paths); internal errors wrap into `ResolutionError` so suggest-site except-tuples can never swallow; ⊥ NEVER falls back (Accept fidelity), stale-cert fallback only on PROVEN staleness for declared-non-governed CVARs, always recorded. `None`-resolver = byte-identical legacy.

## Review
codex gpt-5.5 xhigh, 3 rounds → **ACCEPT** (5 blockers fixed incl. both bypass paths + the proven-staleness narrowing). 73 knobs tests; core suite 1932 passed.

**Stacked on** `feature/configspace-knobs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)