### PR TITLE
feat(knobs): CascadePolicy — staged escalate-or-stop execution (RFC 0001 §3.8)

### DIFF
--- a/tests/unit/knobs/test_cascade.py
+++ b/tests/unit/knobs/test_cascade.py
@@ -26,7 +26,7 @@ def _stage(name: str, outputs, key_fn=lambda x: x, samples=None):
         name=name,
         run=lambda _item: list(outputs),
         key_fn=key_fn,
-        samples=samples or max(len(outputs), 1),
+        samples=samples if samples is not None else max(len(outputs), 1),
     )
 
 
@@ -191,8 +191,59 @@ class TestBinaryRouterEquivalence:
         step = policy.decide("item")
         assert (step.stage_index == 1) == expected_escalated, (cheap, theta)
         assert step.output == expected_output
-        assert (step.vote.margin if step.stage_index == 0 else expected_margin) == (
-            expected_margin
-        )
+        # NON-VACUOUS: the cheap stage's margin is exposed via stage_votes
+        # for escalated AND non-escalated decisions alike
+        assert step.stage_votes[0].margin == expected_margin, (cheap, theta)
         if step.stage_index == 0:
             assert step.representative == expected_repr
+
+
+class TestReviewFixes:
+    def test_nan_threshold_fails_closed(self):
+        """B1: margin < NaN is always False — a NaN threshold would silently
+        never escalate (fail-open). It must raise instead."""
+        policy = _binary(["A", "B"], "S", {"theta": float("nan")})
+        with pytest.raises(ValueError, match="non-finite"):
+            policy.decide("item")
+        policy = _binary(["A", "B"], "S", {"theta": float("inf")})
+        with pytest.raises(ValueError, match="non-finite"):
+            policy.decide("item")
+
+    def test_declared_cardinality_enforced(self):
+        """NB3: samples is the declared cardinality knob value — a runtime
+        mismatch is an effectuation defect, not a silent re-normalization."""
+        policy = CascadePolicy(
+            stages=(
+                _stage("cheap", ["A", "A"], samples=5),  # declares 5, runs 2
+                _stage("strong", ["S"]),
+            ),
+            gates=(Gate(threshold_ref=lambda: 0.5),),
+        )
+        with pytest.raises(ValueError, match="declared samples=5"):
+            policy.decide("item")
+
+    def test_vote_over_rejects_invalid_denominator(self):
+        """NB4: a denominator smaller than the sample count would produce
+        margins above 1."""
+        with pytest.raises(ValueError, match="denominator"):
+            vote_over(["a", "a", "b"], 2)
+        with pytest.raises(ValueError, match="denominator"):
+            vote_over(["a"], 0)
+
+    def test_stage_votes_expose_every_evaluated_stage(self):
+        holder = {"theta": 0.9}
+        policy = CascadePolicy(
+            stages=(
+                _stage("s1", ["a", "b", "c"]),
+                _stage("s2", ["x", "x", "y"]),
+                _stage("s3", ["final"]),
+            ),
+            gates=(
+                Gate(threshold_ref=lambda: holder["theta"]),
+                Gate(threshold_ref=lambda: holder["theta"]),
+            ),
+        )
+        step = policy.decide("item")
+        assert len(step.stage_votes) == 3
+        assert step.stage_votes[0].margin == pytest.approx(1 / 3)
+        assert step.stage_votes[1].margin == pytest.approx(2 / 3)

--- a/tests/unit/knobs/test_cascade.py
+++ b/tests/unit/knobs/test_cascade.py
@@ -1,0 +1,198 @@
+"""CascadePolicy tests (SDK packet 6-D, RFC 0001 §3.8).
+
+Includes the binary-router EQUIVALENCE BATTERY: a reference transcription of
+the unmerged Router's decide() semantics (margin vote over key_fn, escalate
+when margin < θ, terminal output vs stage-0 representative) is compared
+against the m=2 cascade across vote shapes — so when the Router branch
+merges, its adapter over CascadePolicy is a mechanical, pre-verified diff.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.knobs.cascade import (
+    CascadePolicy,
+    Gate,
+    GateKind,
+    StageSpec,
+    VoteStats,
+    vote_over,
+)
+
+
+def _stage(name: str, outputs, key_fn=lambda x: x, samples=None):
+    return StageSpec(
+        name=name,
+        run=lambda _item: list(outputs),
+        key_fn=key_fn,
+        samples=samples or max(len(outputs), 1),
+    )
+
+
+def _binary(cheap_outputs, strong_output, threshold_holder):
+    return CascadePolicy(
+        stages=(
+            _stage("cheap", cheap_outputs),
+            _stage("strong", [strong_output]),
+        ),
+        gates=(Gate(threshold_ref=lambda: threshold_holder["theta"]),),
+    )
+
+
+class TestArityAndTotality:
+    def test_m1_degenerate_no_gates(self):
+        policy = CascadePolicy(stages=(_stage("only", ["A"]),))
+        step = policy.decide("item")
+        assert step.stage_index == 0
+        assert step.output == "A"
+        assert step.escalations == 0
+
+    def test_arity_invariant_enforced(self):
+        with pytest.raises(ValueError, match="arity"):
+            CascadePolicy(stages=(_stage("a", ["x"]), _stage("b", ["y"])))
+        with pytest.raises(ValueError, match="at least one stage"):
+            CascadePolicy(stages=())
+
+    def test_three_stage_cascade_walks_gates_in_order(self):
+        holder = {"theta": 0.9}
+        policy = CascadePolicy(
+            stages=(
+                _stage("s1", ["a", "b", "c"]),  # margin 1/3 < 0.9 -> escalate
+                _stage("s2", ["x", "x", "y"]),  # margin 2/3 < 0.9 -> escalate
+                _stage("s3", ["final"]),
+            ),
+            gates=(
+                Gate(threshold_ref=lambda: holder["theta"]),
+                Gate(threshold_ref=lambda: holder["theta"]),
+            ),
+        )
+        step = policy.decide("item")
+        assert step.stage_index == 2
+        assert step.output == "final"
+        assert step.escalations == 2
+
+    def test_unset_threshold_raises(self):
+        policy = _binary(["A", "A"], "S", {"theta": None})
+        with pytest.raises(ValueError, match="calibrate the CVAR"):
+            policy.decide("item")
+
+    def test_stage_exception_propagates_never_degrades(self):
+        def explode(_item):
+            raise RuntimeError("provider 404")
+
+        policy = CascadePolicy(
+            stages=(
+                StageSpec(name="cheap", run=explode, key_fn=lambda x: x),
+                _stage("strong", ["S"]),
+            ),
+            gates=(Gate(threshold_ref=lambda: 0.5),),
+        )
+        with pytest.raises(RuntimeError, match="provider 404"):
+            policy.decide("item")
+
+    def test_voting_stage_requires_comparator(self):
+        policy = CascadePolicy(
+            stages=(
+                StageSpec(name="cheap", run=lambda _i: ["a"], key_fn=None),
+                _stage("strong", ["S"]),
+            ),
+            gates=(Gate(threshold_ref=lambda: 0.5),),
+        )
+        with pytest.raises(ValueError, match="key_fn"):
+            policy.decide("item")
+
+
+class TestGateSemantics:
+    def test_empty_vote_escalates_for_positive_theta(self):
+        policy = _binary([None, None], "S", {"theta": 0.6})
+        step = policy.decide("item")
+        assert step.stage_index == 1  # margin 0 < 0.6
+
+    def test_theta_zero_never_escalates(self):
+        policy = _binary([None, None], "S", {"theta": 0.0})
+        step = policy.decide("item")
+        assert step.stage_index == 0  # strict inequality: 0 < 0 is False
+
+    def test_live_threshold_read(self):
+        """Re-calibration is observed at decide time, never snapshotted."""
+        holder = {"theta": 0.9}
+        policy = _binary(["A", "A", "B"], "S", holder)  # margin 2/3
+        assert policy.decide("item").stage_index == 1  # 2/3 < 0.9 -> escalate
+        holder["theta"] = 0.5  # the CVAR was re-fit
+        assert policy.decide("item").stage_index == 0  # 2/3 >= 0.5 -> stop
+
+    def test_tie_does_not_change_selection(self):
+        holder = {"theta": 0.4}
+        tied = _binary(["A", "A", "B", "B"], "S", holder)  # margin 1/2, tie
+        untied = _binary(["A", "A", "B", "C"], "S", holder)  # margin 1/2
+        assert tied.decide("i").stage_index == untied.decide("i").stage_index
+
+    def test_gate_kind_registry(self):
+        assert Gate().kind is GateKind.MARGIN_BELOW
+
+
+class TestVoteOver:
+    def test_abstentions_lower_valid_rate_not_margin_base(self):
+        vote = vote_over(["a", "a", None, None], 4)
+        assert vote.margin == 0.5
+        assert vote.valid_rate == 0.5
+        assert vote.top_key == "a"
+
+    def test_tie_representative_deterministic(self):
+        vote = vote_over(["b", "a"], 2)
+        assert vote.tie is True
+        assert vote.top_key == "a"  # lexicographic over serialized keys
+
+
+class TestBinaryRouterEquivalence:
+    """The equivalence battery: the m=2 cascade against a reference
+    transcription of the unmerged Router.decide() semantics."""
+
+    @staticmethod
+    def _reference_router_decide(cheap_samples, strong_output, key_fn, threshold):
+        """Transcription of routing/router.py decide() (unmerged branch):
+        vote over key_fn, escalate iff margin < threshold, output = strong on
+        escalation else the representative."""
+        keys = [key_fn(sample) for sample in cheap_samples]
+        vote = vote_over(keys, len(cheap_samples))
+        representative = next(
+            (
+                sample
+                for sample, key in zip(cheap_samples, keys, strict=False)
+                if key == vote.top_key
+            ),
+            cheap_samples[0] if cheap_samples else None,
+        )
+        escalated = vote.margin < threshold
+        output = strong_output if escalated else representative
+        return escalated, output, representative, vote.margin
+
+    BATTERY = [
+        # (cheap samples, threshold) — unanimous, majority, tie, all-distinct,
+        # abstain-heavy, empty
+        (["A", "A", "A"], 0.6),
+        (["A", "A", "B"], 0.6),
+        (["A", "B"], 0.6),
+        (["A", "B", "C"], 0.6),
+        (["A", None, None], 0.5),
+        ([None, None], 0.5),
+        (["A", "A", "B"], 0.0),
+        (["A", "B", "C"], 1.0),
+    ]
+
+    @pytest.mark.parametrize("cheap,theta", BATTERY)
+    def test_equivalence(self, cheap, theta):
+        key_fn = lambda x: x  # noqa: E731
+        expected_escalated, expected_output, expected_repr, expected_margin = (
+            self._reference_router_decide(cheap, "STRONG", key_fn, theta)
+        )
+        policy = _binary(cheap, "STRONG", {"theta": theta})
+        step = policy.decide("item")
+        assert (step.stage_index == 1) == expected_escalated, (cheap, theta)
+        assert step.output == expected_output
+        assert (step.vote.margin if step.stage_index == 0 else expected_margin) == (
+            expected_margin
+        )
+        if step.stage_index == 0:
+            assert step.representative == expected_repr

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -23,6 +23,15 @@ from __future__ import annotations
 from .adapters import knob_to_parameter_range, parameter_range_to_knob
 from .bindings import Binding, Calibrated, Fixed, Knob, Ref, Tuned
 from .canonical import CTX_SCHEMA_VERSION, CanonicalizationError, canonical_hash
+from .cascade import (
+    CascadePolicy,
+    CascadeStep,
+    Gate,
+    GateKind,
+    StageSpec,
+    VoteStats,
+    vote_over,
+)
 from .certificates import (
     CTX_EXT_KEYS,
     Certificate,
@@ -43,11 +52,15 @@ __all__ = [
     "Binding",
     "Calibrated",
     "CanonicalizationError",
+    "CascadePolicy",
+    "CascadeStep",
     "Certificate",
     "CertificateDecision",
     "EvidenceRef",
     "Fixed",
     "FreshnessContext",
+    "Gate",
+    "GateKind",
     "Knob",
     "KnobKind",
     "Ref",
@@ -56,11 +69,14 @@ __all__ = [
     "ResolutionRejection",
     "SignalObservation",
     "SignalSpec",
+    "StageSpec",
     "TargetProperty",
     "Tuned",
+    "VoteStats",
     "canonical_hash",
     "conformal_evidence_floor",
     "issue_certificate",
     "knob_to_parameter_range",
     "parameter_range_to_knob",
+    "vote_over",
 ]

--- a/traigent/knobs/cascade.py
+++ b/traigent/knobs/cascade.py
@@ -71,6 +71,11 @@ def vote_over(keys: Sequence[VoteKey], n: int) -> VoteStats:
     θ > 0). Tie-breaking for the representative key is deterministic
     (lexicographic over serialized keys) and never affects the margin.
     """
+    if n < len(keys) or (keys and n < 1):
+        raise ValueError(
+            f"vote_over denominator n={n} is smaller than the number of "
+            f"samples ({len(keys)}); margins would exceed 1"
+        )
     counts: Counter[VoteKey] = Counter(key for key in keys if key is not None)
     if not counts:
         return VoteStats(
@@ -106,6 +111,14 @@ class Gate:
             raise ValueError(
                 "Gate threshold is unset; calibrate the CVAR before routing."
             )
+        if threshold != threshold or threshold in (float("inf"), float("-inf")):
+            # NaN comparisons are always False — a NaN threshold would
+            # silently NEVER escalate (fail-open). Non-finite thresholds are
+            # a calibration defect: fail closed.
+            raise ValueError(
+                f"Gate threshold is non-finite ({threshold!r}); "
+                "re-calibrate the CVAR."
+            )
         return vote.margin < threshold
 
 
@@ -130,7 +143,12 @@ class StageSpec:
 
 @dataclass(frozen=True)
 class CascadeStep:
-    """The outcome of one cascade evaluation."""
+    """The outcome of one cascade evaluation.
+
+    ``stage_votes`` carries the vote statistics of EVERY evaluated stage (in
+    order), so escalated decisions remain fully observable — the terminal
+    stage's vote is also exposed as ``vote`` for convenience.
+    """
 
     stage_index: int
     stage_name: str
@@ -138,6 +156,7 @@ class CascadeStep:
     representative: Any
     vote: VoteStats | None
     escalations: int
+    stage_votes: tuple[VoteStats | None, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -168,8 +187,16 @@ class CascadePolicy:
         stage is a deterministic function of (votes, thresholds).
         """
         escalations = 0
+        stage_votes: list[VoteStats | None] = []
         for index, stage in enumerate(self.stages):
             samples = list(stage.run(item))
+            if len(samples) != stage.samples:
+                # samples is the stage's declared CARDINALITY knob value — a
+                # mismatch means the effectuation did not happen as declared.
+                raise ValueError(
+                    f"stage {stage.name!r} declared samples={stage.samples} "
+                    f"but produced {len(samples)}"
+                )
             is_last = index == len(self.stages) - 1
             if stage.key_fn is None:
                 vote = None
@@ -185,6 +212,7 @@ class CascadePolicy:
                     ),
                     samples[0] if samples else None,
                 )
+            stage_votes.append(vote)
             if is_last:
                 return CascadeStep(
                     stage_index=index,
@@ -193,6 +221,7 @@ class CascadePolicy:
                     representative=representative,
                     vote=vote,
                     escalations=escalations,
+                    stage_votes=tuple(stage_votes),
                 )
             gate = self.gates[index]
             if vote is None:
@@ -210,5 +239,6 @@ class CascadePolicy:
                 representative=representative,
                 vote=vote,
                 escalations=escalations,
+                stage_votes=tuple(stage_votes),
             )
         raise AssertionError("unreachable: the last stage always returns")

--- a/traigent/knobs/cascade.py
+++ b/traigent/knobs/cascade.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Callable, Hashable, Sequence
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 __all__ = [
@@ -47,7 +47,7 @@ __all__ = [
 VoteKey = Hashable | None
 
 
-class GateKind(str, Enum):
+class GateKind(StrEnum):
     """v1 gate registry (RFC 0001 §3.8)."""
 
     MARGIN_BELOW = "margin_below"

--- a/traigent/knobs/cascade.py
+++ b/traigent/knobs/cascade.py
@@ -1,0 +1,214 @@
+"""Cascade policies — staged escalate-or-stop execution (RFC 0001 §3.8).
+
+A cascade of arity ``m`` is ``(stages, gates)`` with ``|gates| = m - 1``.
+For an input, stage ``j`` is selected where::
+
+    j = min{ i : i = m ∨ gate_i(vote_i) = stop }
+
+The v1 gate predicate is ``escalate ⟺ margin < θ`` where each θ is a
+**calibrated variable** (a CVAR — certificate-backed, never searched). Gate
+thresholds are read LIVE via ``threshold_ref`` so a re-calibration (e.g.
+``Router.fit``-style assignment) is observed at decide time, never
+snapshotted at construction.
+
+Totality (RFC §3.8): an empty/abstain-only vote has ``margin = 0`` and
+escalates for any θ > 0 (θ = 0 means "never escalate" by the strict
+inequality); ties affect representative choice only, never the margin or
+the selected stage; a stage or gate exception PROPAGATES — the cascade
+never silently degrades to some stage's output.
+
+NOTE (consolidation obligation, FR-SDK-KNOBS-CVARS-V1 trail): the binary
+``Router`` (fit/decide/route) lives on an unmerged branch — when it lands,
+``Router`` becomes a thin adapter over ``CascadePolicy`` with
+``threshold_ref=lambda: self.threshold``; its public surface and test suite
+must pass unchanged. The equivalence battery in
+``tests/unit/knobs/test_cascade.py`` transcribes the router's voting
+semantics so that adapter is a documented, mechanical diff.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Hashable, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+__all__ = [
+    "CascadePolicy",
+    "CascadeStep",
+    "Gate",
+    "GateKind",
+    "StageSpec",
+    "VoteStats",
+    "vote_over",
+]
+
+VoteKey = Hashable | None
+
+
+class GateKind(str, Enum):
+    """v1 gate registry (RFC 0001 §3.8)."""
+
+    MARGIN_BELOW = "margin_below"
+
+
+@dataclass(frozen=True)
+class VoteStats:
+    """Deterministic, content-free vote summary over equivalence keys."""
+
+    top_key: VoteKey
+    margin: float
+    valid_rate: float
+    n_distinct: int
+    tie: bool
+
+
+def vote_over(keys: Sequence[VoteKey], n: int) -> VoteStats:
+    """Majority vote over hashable keys; ``None`` is an abstention.
+
+    The empty/abstain-only vote yields ``margin = 0`` (it escalates for any
+    θ > 0). Tie-breaking for the representative key is deterministic
+    (lexicographic over serialized keys) and never affects the margin.
+    """
+    counts: Counter[VoteKey] = Counter(key for key in keys if key is not None)
+    if not counts:
+        return VoteStats(
+            top_key=None, margin=0.0, valid_rate=0.0, n_distinct=0, tie=False
+        )
+    top_count = max(counts.values())
+    tied = sorted((key for key, count in counts.items() if count == top_count), key=str)
+    denominator = n or 1
+    return VoteStats(
+        top_key=tied[0],
+        margin=top_count / denominator,
+        valid_rate=sum(counts.values()) / denominator,
+        n_distinct=len(counts),
+        tie=len(tied) > 1,
+    )
+
+
+@dataclass(frozen=True)
+class Gate:
+    """A cascade gate: escalate when the stage's vote margin is below θ.
+
+    ``threshold_ref`` is a LIVE read — re-calibration of the underlying CVAR
+    is observed at decide time. An unset threshold (``None``) is a hard
+    error, mirroring the router's "calibrate before routing" contract.
+    """
+
+    kind: GateKind = GateKind.MARGIN_BELOW
+    threshold_ref: Callable[[], float | None] = lambda: None
+
+    def should_escalate(self, vote: VoteStats) -> bool:
+        threshold = self.threshold_ref()
+        if threshold is None:
+            raise ValueError(
+                "Gate threshold is unset; calibrate the CVAR before routing."
+            )
+        return vote.margin < threshold
+
+
+@dataclass(frozen=True)
+class StageSpec:
+    """One cascade stage: a runtime execution unit.
+
+    ``samples`` is the per-stage CARDINALITY knob (the router's ``k``);
+    ``run`` returns the stage's samples for an item; ``key_fn`` maps outputs
+    to equivalence keys (the comparator — required for voting stages).
+    """
+
+    name: str
+    run: Callable[[Any], Sequence[Any]]
+    key_fn: Callable[[Any], VoteKey] | None = None
+    samples: int = 1
+
+    def __post_init__(self) -> None:
+        if self.samples < 1:
+            raise ValueError("StageSpec.samples must be >= 1")
+
+
+@dataclass(frozen=True)
+class CascadeStep:
+    """The outcome of one cascade evaluation."""
+
+    stage_index: int
+    stage_name: str
+    output: Any
+    representative: Any
+    vote: VoteStats | None
+    escalations: int
+
+
+@dataclass(frozen=True)
+class CascadePolicy:
+    """Staged escalate-or-stop execution policy (arity = ``len(stages)``)."""
+
+    stages: tuple[StageSpec, ...]
+    gates: tuple[Gate, ...] = field(default=())
+
+    def __post_init__(self) -> None:
+        if len(self.stages) < 1:
+            raise ValueError("CascadePolicy requires at least one stage")
+        if len(self.gates) != len(self.stages) - 1:
+            raise ValueError(
+                f"CascadePolicy arity violation: {len(self.gates)} gate(s) for "
+                f"{len(self.stages)} stage(s); |gates| must equal |stages| - 1"
+            )
+
+    @property
+    def arity(self) -> int:
+        return len(self.stages)
+
+    def decide(self, item: Any) -> CascadeStep:
+        """Evaluate the cascade for one item (RFC §3.8 semantics).
+
+        Stage/gate exceptions PROPAGATE — never a silent degradation to a
+        stage's output. Given the per-stage sample multisets, the selected
+        stage is a deterministic function of (votes, thresholds).
+        """
+        escalations = 0
+        for index, stage in enumerate(self.stages):
+            samples = list(stage.run(item))
+            is_last = index == len(self.stages) - 1
+            if stage.key_fn is None:
+                vote = None
+                representative = samples[0] if samples else None
+            else:
+                keys = [stage.key_fn(sample) for sample in samples]
+                vote = vote_over(keys, len(samples))
+                representative = next(
+                    (
+                        sample
+                        for sample, key in zip(samples, keys, strict=False)
+                        if key == vote.top_key
+                    ),
+                    samples[0] if samples else None,
+                )
+            if is_last:
+                return CascadeStep(
+                    stage_index=index,
+                    stage_name=stage.name,
+                    output=representative,
+                    representative=representative,
+                    vote=vote,
+                    escalations=escalations,
+                )
+            gate = self.gates[index]
+            if vote is None:
+                raise ValueError(
+                    f"stage {stage.name!r} feeds a gate but has no key_fn "
+                    "comparator; voting stages require one"
+                )
+            if gate.should_escalate(vote):
+                escalations += 1
+                continue
+            return CascadeStep(
+                stage_index=index,
+                stage_name=stage.name,
+                output=representative,
+                representative=representative,
+                vote=vote,
+                escalations=escalations,
+            )
+        raise AssertionError("unreachable: the last stage always returns")


### PR DESCRIPTION
## Summary
SDK packet 6-D (stacked on #1097). Cascade runtime with the full §3.8 totality semantics: arity invariant, m=1 degenerate case, live `threshold_ref` reads (CVAR re-calibration observed at decide time), NaN thresholds FAIL CLOSED, declared-cardinality enforcement, per-stage `stage_votes` observability, exception propagation (never silent degradation).

**Recorded adjustment**: `traigent/routing/router.py` is not on develop (unmerged self-consistency branch) — the Router-as-sugar adapter is a consolidation obligation; the equivalence battery here transcribes the router semantics so that adapter is a mechanical, pre-verified diff.

## Review
codex gpt-5.5 xhigh, 2 rounds → **ACCEPT**. 69 knobs tests.

**Stacked on** `feature/knobs-types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)