### PR TITLE
feat(tvl): TVL 1.1 loader — cvars/policies sections + require_calibration

### DIFF
--- a/tests/unit/tvl/test_tvl11_loader.py
+++ b/tests/unit/tvl/test_tvl11_loader.py
@@ -1,0 +1,169 @@
+"""TVL 1.1 loader support (RFC 0001): cvars, policies, require_calibration.
+
+The SDK loader accepts the new sections, exposes them as RAW declarations on
+the artifact (typed knob bindings are the traigent.knobs surface's job), and
+keeps CVARs OUT of the configuration space (P2/P5: governed, not searched).
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from traigent.tvl.models import PromotionPolicy, RequireCalibration
+from traigent.tvl.spec_loader import TVLValidationError, load_tvl_spec
+
+SPEC_11 = textwrap.dedent(
+    """
+    tvl:
+      module: corp.test.tvl11
+
+    environment:
+      snapshot_id: "2026-06-05T00:00:00Z"
+
+    evaluation_set:
+      dataset: s3://datasets/test/dev.parquet
+
+    tvars:
+      - name: model
+        type: enum[str]
+        domain: ["gpt-4o-mini", "gpt-4o"]
+      - name: retriever.k
+        type: int
+        domain:
+          range: [0, 20]
+
+    cvars:
+      - name: router.margin_threshold
+        type: float
+        domain:
+          range: [0.0, 1.0]
+        calibration:
+          source: margin_eval_pool
+          signal: vote_margin_v1
+          depends_on: [model, retriever.k]
+        governance:
+          require_calibration: true
+
+    policies:
+      - name: cheap_strong_cascade
+        kind: policy
+        strategy: cascade
+        stages: [cheap, strong]
+        gates:
+          - kind: margin_below
+            threshold: router.margin_threshold
+
+    constraints:
+      structural: []
+
+    objectives:
+      - name: quality
+        direction: maximize
+
+    promotion_policy:
+      dominance: epsilon_pareto
+      alpha: 0.05
+      min_effect:
+        quality: 0.02
+      require_calibration:
+        enabled: true
+        hash_covered_context: [model_versions]
+    """
+)
+
+
+def _write(tmp_path, content: str):
+    spec_path = tmp_path / "spec.tvl.yml"
+    spec_path.write_text(content, encoding="utf-8")
+    return spec_path
+
+
+def test_tvl11_spec_loads(tmp_path):
+    artifact = load_tvl_spec(spec_path=_write(tmp_path, SPEC_11))
+    assert artifact.cvars is not None and len(artifact.cvars) == 1
+    assert artifact.cvars[0]["name"] == "router.margin_threshold"
+    assert artifact.policies is not None
+    assert artifact.policies[0]["strategy"] == "cascade"
+
+
+def test_cvars_never_enter_configuration_space(tmp_path):
+    """P2/P5: governed, not searched."""
+    artifact = load_tvl_spec(spec_path=_write(tmp_path, SPEC_11))
+    assert set(artifact.configuration_space) == {"model", "retriever.k"}
+    assert "router.margin_threshold" not in artifact.configuration_space
+
+
+def test_require_calibration_parsed(tmp_path):
+    artifact = load_tvl_spec(spec_path=_write(tmp_path, SPEC_11))
+    policy = artifact.promotion_policy
+    assert isinstance(policy, PromotionPolicy)
+    assert isinstance(policy.require_calibration, RequireCalibration)
+    assert policy.require_calibration.enabled is True
+    assert policy.require_calibration.hash_covered_context == ["model_versions"]
+
+
+def test_require_calibration_rejects_core_keys(tmp_path):
+    bad = SPEC_11.replace(
+        "hash_covered_context: [model_versions]",
+        "hash_covered_context: [tuned_parent_values]",
+    )
+    with pytest.raises(TVLValidationError, match="not extension keys|Invalid promotion_policy"):
+        load_tvl_spec(spec_path=_write(tmp_path, bad))
+
+
+def test_cvar_shadowing_tvar_rejected(tmp_path):
+    bad = SPEC_11.replace("name: router.margin_threshold", "name: model")
+    with pytest.raises(TVLValidationError, match="shadows a TVAR"):
+        load_tvl_spec(spec_path=_write(tmp_path, bad))
+
+
+def test_cvar_missing_source_rejected(tmp_path):
+    bad = SPEC_11.replace("source: margin_eval_pool", "signal_only: x")
+    with pytest.raises(TVLValidationError, match="calibration.source"):
+        load_tvl_spec(spec_path=_write(tmp_path, bad))
+
+
+def test_policy_kind_literal_enforced(tmp_path):
+    bad = SPEC_11.replace("kind: policy", "kind: router")
+    with pytest.raises(TVLValidationError, match="literal 'policy'"):
+        load_tvl_spec(spec_path=_write(tmp_path, bad))
+
+
+def test_legacy_spec_without_11_sections_unchanged(tmp_path):
+    """P1: a 1.0 spec loads exactly as before — cvars/policies stay None."""
+    legacy_spec = textwrap.dedent(
+        """
+        tvl:
+          module: corp.test.legacy
+
+        environment:
+          snapshot_id: "2026-06-05T00:00:00Z"
+
+        evaluation_set:
+          dataset: s3://datasets/test/dev.parquet
+
+        tvars:
+          - name: model
+            type: enum[str]
+            domain: ["a", "b"]
+
+        constraints:
+          structural: []
+
+        objectives:
+          - name: quality
+            direction: maximize
+
+        promotion_policy:
+          dominance: epsilon_pareto
+          alpha: 0.05
+          min_effect:
+            quality: 0.02
+        """
+    )
+    artifact = load_tvl_spec(spec_path=_write(tmp_path, legacy_spec))
+    assert artifact.cvars is None
+    assert artifact.policies is None
+    assert artifact.promotion_policy.require_calibration is None

--- a/traigent/tvl/models.py
+++ b/traigent/tvl/models.py
@@ -214,6 +214,44 @@ class BandTarget:
         )
 
 
+CTX_EXT_KEYS = frozenset(
+    {"stage_versions", "model_versions", "budget_assumptions", "cost_assumptions"}
+)
+
+
+@dataclass(slots=True)
+class RequireCalibration:
+    """TVL 1.1 strict evidence mode (RFC 0001 §3.5).
+
+    The mandatory freshness-context core is implicit and immutable;
+    ``hash_covered_context`` selects EXTENSION keys only — naming a core key
+    here is an error by construction.
+    """
+
+    enabled: bool = False
+    hash_covered_context: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        invalid = [k for k in self.hash_covered_context if k not in CTX_EXT_KEYS]
+        if invalid:
+            raise ValueError(
+                f"hash_covered_context keys {invalid!r} are not extension keys; "
+                "the mandatory core is not module-configurable"
+            )
+        if len(self.hash_covered_context) != len(set(self.hash_covered_context)):
+            raise ValueError("hash_covered_context keys must be unique")
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RequireCalibration:
+        enabled = data.get("enabled")
+        if not isinstance(enabled, bool):
+            raise ValueError("require_calibration.enabled must be a boolean")
+        context = data.get("hash_covered_context", [])
+        if not isinstance(context, list):
+            raise ValueError("hash_covered_context must be a list")
+        return cls(enabled=enabled, hash_covered_context=list(context))
+
+
 @dataclass(slots=True)
 class ChanceConstraint:
     """Chance constraint for promotion policy.
@@ -267,6 +305,7 @@ class PromotionPolicy:
     adjust: AdjustMethod = "none"
     chance_constraints: list[ChanceConstraint] = field(default_factory=list)
     tie_breakers: dict[str, TieBreaker] = field(default_factory=dict)
+    require_calibration: RequireCalibration | None = None  # TVL 1.1 strict mode
 
     def __post_init__(self) -> None:
         """Validate promotion policy."""
@@ -297,6 +336,12 @@ class PromotionPolicy:
         chance_constraints = [
             ChanceConstraint.from_dict(cc) for cc in data.get("chance_constraints", [])
         ]
+        require_calibration = None
+        if "require_calibration" in data:
+            raw = data["require_calibration"]
+            if not isinstance(raw, dict):
+                raise ValueError("require_calibration must be a mapping")
+            require_calibration = RequireCalibration.from_dict(raw)
 
         return cls(
             dominance=data.get("dominance", "epsilon_pareto"),
@@ -305,6 +350,7 @@ class PromotionPolicy:
             adjust=data.get("adjust", "none"),
             chance_constraints=chance_constraints,
             tie_breakers=data.get("tie_breakers", {}),
+            require_calibration=require_calibration,
         )
 
 

--- a/traigent/tvl/spec_loader.py
+++ b/traigent/tvl/spec_loader.py
@@ -104,6 +104,10 @@ class TVLSpecArtifact:
     # TVL 0.9 additions
     tvl_header: TVLHeader | None = None
     environment_snapshot: EnvironmentSnapshot | None = None
+    # TVL 1.1 additions (RFC 0001) — raw declarations; typed knob bindings
+    # are constructed by the traigent.knobs surface, not the loader
+    cvars: list[dict[str, Any]] | None = None
+    policies: list[dict[str, Any]] | None = None
     evaluation_set: EvaluationSet | None = None
     tvl_version: str | None = None
     convergence: ConvergenceCriteria | None = None
@@ -223,6 +227,8 @@ _KNOWN_TVL_SECTIONS = frozenset(
         "promotion_policy",
         "extends",  # Spec-level inheritance
         "safety_constraints",  # Safety constraint definitions
+        "cvars",  # TVL 1.1 (RFC 0001): calibrated variables — governed, NOT searched
+        "policies",  # TVL 1.1 (RFC 0001): operational policy declarations
         "datasets",  # Dataset references for evaluation
         "evaluators",  # Evaluator definitions
         # Legacy sections (deprecated but still valid)
@@ -252,6 +258,8 @@ _SECTION_TYPES: dict[str, type | tuple[type, ...]] = {
     "evaluators": dict,  # Evaluator definitions
     "configuration_space": dict,
     "optimization": dict,
+    "cvars": list,
+    "policies": list,
 }
 
 
@@ -722,6 +730,11 @@ def load_tvl_spec(
     # Parse promotion policy (TVL 0.9)
     promotion_policy = _parse_promotion_policy(resolved.get("promotion_policy"))
 
+    # Parse TVL 1.1 sections (RFC 0001) — cvars are governed but NOT
+    # searched: they never enter configuration_space (P2/P5)
+    cvars_decls = _parse_cvar_decls(resolved.get("cvars"), config_space)
+    policy_decls = _parse_policy_decls(resolved.get("policies"))
+
     metadata = _build_metadata(
         resolved,
         path,
@@ -745,6 +758,8 @@ def load_tvl_spec(
         derived_constraints=derived_constraints,
         tvl_header=tvl_header,
         environment_snapshot=environment_snapshot,
+        cvars=cvars_decls,
+        policies=policy_decls,
         evaluation_set=evaluation_set,
         tvl_version=tvl_version,
         convergence=convergence,
@@ -1057,6 +1072,66 @@ def _parse_promotion_policy(policy_data: Any) -> PromotionPolicy | None:
         return PromotionPolicy.from_dict(policy_data)
     except (ValueError, KeyError) as exc:
         raise TVLValidationError(f"Invalid promotion_policy: {exc}") from exc
+
+
+def _parse_cvar_decls(
+    cvars_data: Any, configuration_space: dict[str, Any]
+) -> list[dict[str, Any]] | None:
+    """Parse TVL 1.1 ``cvars`` declarations (RFC 0001 §3.3).
+
+    Returns the RAW declaration dicts (typed knob bindings are built by the
+    ``traigent.knobs`` surface). Enforces: list-of-dicts shape, unique names,
+    and the shared-namespace rule — a CVAR shadowing a TVAR is an error.
+    CVARs are NEVER added to the configuration space (optimizer-invisible).
+    """
+    if cvars_data is None:
+        return None
+    if not isinstance(cvars_data, list):
+        raise TVLValidationError("cvars must be a list of declarations")
+    seen: set[str] = set()
+    for index, decl in enumerate(cvars_data):
+        if not isinstance(decl, dict) or not isinstance(decl.get("name"), str):
+            raise TVLValidationError(
+                f"cvars[{index}] must be a mapping with a string name"
+            )
+        name = decl["name"]
+        if name in seen:
+            raise TVLValidationError(f"CVAR {name!r} is declared multiple times")
+        seen.add(name)
+        if name in configuration_space:
+            raise TVLValidationError(
+                f"CVAR {name!r} shadows a TVAR — tvars, cvars, and policies "
+                "share one namespace (RFC 0001 §3.7)"
+            )
+        calibration = decl.get("calibration")
+        if not isinstance(calibration, dict) or not isinstance(
+            calibration.get("source"), str
+        ):
+            raise TVLValidationError(f"CVAR {name!r} requires calibration.source")
+    return [dict(decl) for decl in cvars_data]
+
+
+def _parse_policy_decls(policies_data: Any) -> list[dict[str, Any]] | None:
+    """Parse TVL 1.1 ``policies`` declarations (RFC 0001 §3.8) — raw dicts."""
+    if policies_data is None:
+        return None
+    if not isinstance(policies_data, list):
+        raise TVLValidationError("policies must be a list of declarations")
+    seen: set[str] = set()
+    for index, decl in enumerate(policies_data):
+        if not isinstance(decl, dict) or not isinstance(decl.get("name"), str):
+            raise TVLValidationError(
+                f"policies[{index}] must be a mapping with a string name"
+            )
+        name = decl["name"]
+        if name in seen:
+            raise TVLValidationError(f"policy {name!r} is declared multiple times")
+        seen.add(name)
+        if decl.get("kind") != "policy":
+            raise TVLValidationError(
+                f"policy {name!r} kind must be the literal 'policy'"
+            )
+    return [dict(decl) for decl in policies_data]
 
 
 def _parse_tvl_header(header_data: Any) -> TVLHeader | None:


### PR DESCRIPTION
## Summary
SDK loader side of the TVL-growth packet (FR-TVL-CVARS-POLICIES-V1; pairs with tvl#4). `cvars`/`policies` admitted as known sections, exposed as RAW declarations on `TVLSpecArtifact` (typed bindings are `traigent.knobs`' job); CVARs NEVER enter `configuration_space` (P2/P5); shared-namespace shadowing rejected; `RequireCalibration` model with extension-keys-only validation (the freshness core is not module-configurable) wired into `PromotionPolicy.from_dict`. P1: 1.0 specs load unchanged.

## Review
Covered by the 6-C3 review scope (converged, 4 rounds). 8 tests; tests/unit/tvl 417 passed.

Base of `feature/fail-closed-promotion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)