### PR TITLE
feat(core): strict-evidence promotion fails closed — all four leak sites (FR-SDK-FAIL-CLOSED-PROMOTION-V1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,21 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`langgraph-checkpoint` 3.x → 4.x:** the 4.0 release drops default deserialization of payloads serialized with the legacy `"json"` serde mode. Users running `langgraph` with a persistent checkpoint saver (SQLite, Postgres, Redis, etc.) whose stored state contains JSON-format blobs will see deserialization failures unless they configure `serde` with an explicit `allowed_json_modules` list. Traigent does not bind `langgraph-checkpoint` directly — it arrives transitively through the `langgraph` dependency — so this only affects projects that also use `langgraph` checkpointers in their own code. See [CVE-2026-27794](https://github.com/langchain-ai/langgraph/security/advisories) for the underlying RCE that motivated removing the default.
 
 ### Changed
-- **Dual-licensed** under `AGPL-3.0-only OR LicenseRef-Traigent-Commercial`: declared the SPDX
+- **Strict evidence modes now fail closed in promotion** (#1103,
+  FR-SDK-FAIL-CLOSED-PROMOTION-V1). When a TVL promotion policy declares a strict
+  evidence mode — `require_calibration.enabled: true` or `chance_constraints` —
+  the verdicts *no decision*, *insufficient samples*, and *gate exception* now
+  WITHHOLD promotion instead of silently falling back to the permissive simple
+  comparison, and the terminal selector returns either the gate-certified
+  incumbent verbatim or an explicit no-winner result
+  (`reason_code="no_certified_selection"`, empty `best_config`,
+  `best_score=None`) instead of re-deriving a winner by raw score.
+  **Behavior change for existing specs that already declare
+  `chance_constraints`:** runs whose evidence never certifies a winner now
+  return the explicit no-winner result (and `export_best_config()` /
+  `publish_best_config()` raise instead of exporting an uncertified config).
+  Runs with certified winners, and all specs without strict declarations, are
+  unchanged. First-trial incumbency counts as initialization, not certification.
   license expression in package metadata (PEP 639 via `setuptools>=77`), added `license-files`,
   per-module SPDX headers, and `COMMERCIAL-LICENSE.md`; aligned `NOTICE`, `README`, and
   `DISCLAIMER`. Commercial terms remain available under separate agreement; see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,14 +47,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   WITHHOLD promotion instead of silently falling back to the permissive simple
   comparison, and the terminal selector returns either the gate-certified
   incumbent verbatim or an explicit no-winner result
-  (`reason_code="no_certified_selection"`, empty `best_config`,
+  (`reason_code="NO_CERTIFIED_SELECTION"`, empty `best_config`,
   `best_score=None`) instead of re-deriving a winner by raw score.
   **Behavior change for existing specs that already declare
   `chance_constraints`:** runs whose evidence never certifies a winner now
-  return the explicit no-winner result (and `export_best_config()` /
-  `publish_best_config()` raise instead of exporting an uncertified config).
-  Runs with certified winners, and all specs without strict declarations, are
-  unchanged. First-trial incumbency counts as initialization, not certification.
+  return the explicit no-winner result; no best config is applied or
+  snapshotted, so `export_best_config()` raises `ConfigurationError` instead
+  of exporting an uncertified config. Runs with certified winners, and all
+  specs without strict declarations, are unchanged. First-trial incumbency
+  counts as initialization, not certification.
+- **Dual-licensed** under `AGPL-3.0-only OR LicenseRef-Traigent-Commercial`: declared the SPDX
   license expression in package metadata (PEP 639 via `setuptools>=77`), added `license-files`,
   per-module SPDX headers, and `COMMERCIAL-LICENSE.md`; aligned `NOTICE`, `README`, and
   `DISCLAIMER`. Commercial terms remain available under separate agreement; see

--- a/tests/unit/core/test_fail_closed_promotion.py
+++ b/tests/unit/core/test_fail_closed_promotion.py
@@ -1,0 +1,199 @@
+"""Fail-closed strict-evidence promotion (FR-SDK-FAIL-CLOSED-PROMOTION-V1).
+
+The four verified leak sites, closed strictly behind _is_strict_evidence_mode:
+1. gate no_decision           -> never _simple_is_better (spy-verified)
+2. insufficient samples       -> never _simple_is_better
+3. gate exception             -> never _simple_is_better (Rule 1: deny)
+4. terminal selector          -> NO_CERTIFIED_SELECTION, never re-derived
+Non-strict behavior is pinned byte-identical (the legacy lane).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from traigent.api.types import TrialResult, TrialStatus
+from traigent.core.orchestrator import OptimizationOrchestrator
+from traigent.core.result_selection import (
+    NO_CERTIFIED_SELECTION,
+    select_best_configuration,
+)
+from traigent.tvl.models import ChanceConstraint, PromotionPolicy, RequireCalibration
+
+
+def _trial(score: float = 0.9, config=None) -> TrialResult:
+    return TrialResult(
+        trial_id="t1",
+        config=config or {"model": "a"},
+        metrics={"accuracy": score},
+        status=TrialStatus.COMPLETED,
+        duration=0.1,
+        timestamp=0.0,
+        metadata={"successful_examples": 1},
+    )
+
+
+def _orchestrator(policy: PromotionPolicy | None) -> OptimizationOrchestrator:
+    orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+    orchestrator._strict_withheld_promotions = []
+    orchestrator._promotion_gate = (
+        None if policy is None else SimpleNamespace(policy=policy)
+    )
+    orchestrator._best_trial_cached = _trial(0.5)
+    orchestrator.optimizer = SimpleNamespace(objectives=["accuracy"])
+    orchestrator._config_metrics_history = {}
+    orchestrator._incumbent_config_hash = "incumbent"
+    return orchestrator
+
+
+STRICT_POLICIES = {
+    "require_calibration": PromotionPolicy(
+        require_calibration=RequireCalibration(enabled=True)
+    ),
+    "chance_constraints": PromotionPolicy(
+        chance_constraints=[
+            ChanceConstraint(name="accuracy", threshold=0.8, confidence=0.95)
+        ]
+    ),
+}
+
+NON_STRICT_POLICY = PromotionPolicy()
+
+
+class TestStrictModeDetection:
+    @pytest.mark.parametrize("name,policy", sorted(STRICT_POLICIES.items()))
+    def test_each_declared_trigger_is_strict(self, name, policy):
+        assert _orchestrator(policy)._is_strict_evidence_mode(), name
+
+    def test_plain_policy_is_not_strict(self):
+        assert not _orchestrator(NON_STRICT_POLICY)._is_strict_evidence_mode()
+
+    def test_no_gate_is_not_strict(self):
+        assert not _orchestrator(None)._is_strict_evidence_mode()
+
+    def test_disabled_require_calibration_is_not_strict(self):
+        policy = PromotionPolicy(
+            require_calibration=RequireCalibration(enabled=False)
+        )
+        assert not _orchestrator(policy)._is_strict_evidence_mode()
+
+
+@pytest.mark.parametrize("name,policy", sorted(STRICT_POLICIES.items()))
+class TestStrictFailClosed:
+    def test_no_decision_withholds_without_simple_fallback(self, name, policy):
+        orchestrator = _orchestrator(policy)
+        orchestrator._simple_is_better = MagicMock(name="simple")  # spy
+        decision = SimpleNamespace(decision="no_decision", reason="too few samples")
+        assert orchestrator._handle_promotion_decision(decision, _trial()) is False
+        orchestrator._simple_is_better.assert_not_called()
+        assert orchestrator._strict_withheld_promotions
+
+    def test_insufficient_samples_withholds(self, name, policy):
+        orchestrator = _orchestrator(policy)
+        orchestrator._simple_is_better = MagicMock(name="simple")
+        orchestrator._has_sufficient_samples = MagicMock(return_value=False)
+        orchestrator._config_metrics_history = {
+            "candidate": {"accuracy": [0.9]},
+            "incumbent": {"accuracy": [0.5]},
+        }
+        assert orchestrator._evaluate_promotion("candidate", _trial()) is False
+        orchestrator._simple_is_better.assert_not_called()
+
+    def test_gate_exception_fails_closed(self, name, policy):
+        orchestrator = _orchestrator(policy)
+        orchestrator._simple_is_better = MagicMock(name="simple")
+        orchestrator._has_sufficient_samples = MagicMock(return_value=True)
+        orchestrator._config_metrics_history = {
+            "candidate": {"accuracy": [0.9, 0.91]},
+            "incumbent": {"accuracy": [0.5, 0.52]},
+        }
+        orchestrator._promotion_gate.evaluate = MagicMock(
+            side_effect=RuntimeError("gate blew up")
+        )
+        orchestrator._promotion_gate.policy = policy
+        assert orchestrator._evaluate_promotion("candidate", _trial()) is False
+        orchestrator._simple_is_better.assert_not_called()
+        assert any(
+            "gate exception" in reason
+            for reason in orchestrator._strict_withheld_promotions
+        )
+
+    def test_promote_and_reject_still_flow_through(self, name, policy):
+        orchestrator = _orchestrator(policy)
+        promote = SimpleNamespace(decision="promote", reason="dominates")
+        reject = SimpleNamespace(decision="reject", reason="dominated")
+        assert orchestrator._handle_promotion_decision(promote, _trial()) is True
+        assert orchestrator._handle_promotion_decision(reject, _trial()) is False
+
+
+class TestNonStrictLaneUnchanged:
+    """The legacy lane must stay byte-identical (no behavior change for
+    modules without strict declarations)."""
+
+    def test_no_decision_falls_back_to_simple(self):
+        orchestrator = _orchestrator(NON_STRICT_POLICY)
+        orchestrator._simple_is_better = MagicMock(return_value=True)
+        decision = SimpleNamespace(decision="no_decision", reason="few samples")
+        assert orchestrator._handle_promotion_decision(decision, _trial()) is True
+        orchestrator._simple_is_better.assert_called_once()
+
+    def test_gate_exception_falls_back_to_simple(self):
+        orchestrator = _orchestrator(NON_STRICT_POLICY)
+        orchestrator._simple_is_better = MagicMock(return_value=True)
+        orchestrator._has_sufficient_samples = MagicMock(return_value=True)
+        orchestrator._config_metrics_history = {
+            "candidate": {"accuracy": [0.9]},
+            "incumbent": {"accuracy": [0.5]},
+        }
+        orchestrator._promotion_gate.evaluate = MagicMock(
+            side_effect=RuntimeError("gate blew up")
+        )
+        assert orchestrator._evaluate_promotion("candidate", _trial()) is True
+        orchestrator._simple_is_better.assert_called_once()
+
+
+class TestTerminalSelector:
+    """Leak 4: select_best_configuration is gate-independent by default —
+    require_certified makes it honor the certified incumbent or return the
+    explicit no-winner shape."""
+
+    def test_no_certified_winner_returns_explicit_empty(self):
+        result = select_best_configuration(
+            trials=[_trial(0.99)],  # high score MUST NOT win
+            primary_objective="accuracy",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            require_certified=True,
+            certified_config=None,
+        )
+        assert result.best_config == {}
+        assert result.best_score is None
+        assert result.reason_code == NO_CERTIFIED_SELECTION
+
+    def test_certified_incumbent_returned_verbatim(self):
+        result = select_best_configuration(
+            trials=[_trial(0.99, config={"model": "hot"})],
+            primary_objective="accuracy",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            require_certified=True,
+            certified_config={"model": "certified"},
+            certified_score=0.7,
+        )
+        # the certified incumbent wins even though a higher-scoring trial exists
+        assert result.best_config == {"model": "certified"}
+        assert result.best_score == 0.7
+        assert result.reason_code is None
+
+    def test_default_mode_unchanged(self):
+        result = select_best_configuration(
+            trials=[_trial(0.99, config={"model": "hot"})],
+            primary_objective="accuracy",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            comparability_mode="legacy",
+        )
+        assert result.best_config.get("model") == "hot"

--- a/tests/unit/core/test_fail_closed_promotion.py
+++ b/tests/unit/core/test_fail_closed_promotion.py
@@ -317,6 +317,33 @@ class TestResultWinnerClaimGuards:
         scores = result.calculate_weighted_scores(
             objective_weights={"accuracy": 1.0}
         )
-        assert scores["best_weighted_config"] == {}
+        # the winner-claim KEY is omitted entirely on a no-winner result
+        assert "best_weighted_config" not in scores
         # descriptive per-trial statistics are still computed
         assert scores["weighted_scores"]
+
+    def test_valid_empty_config_winner_not_regressed(self):
+        """Round-2 blocker: a VALID winner whose config happens to be empty
+        (score present) keeps its winner surfaces — only the
+        NO_CERTIFIED_SELECTION shape (empty config AND None score) is a
+        no-winner."""
+        from traigent.api.types import OptimizationResult
+
+        result = OptimizationResult(
+            best_config={},
+            best_score=0.99,  # a real winner, degenerate empty config
+            trials=[_trial(0.99, config={})],
+            total_cost=0.0,
+            duration=1.0,
+            objectives=["accuracy"],
+            optimization_id="opt-test",
+            convergence_info={},
+            status="completed",
+            algorithm="test",
+            timestamp=0.0,
+        )
+        assert result.best_metrics  # winner metrics preserved
+        scores = result.calculate_weighted_scores(
+            objective_weights={"accuracy": 1.0}
+        )
+        assert "best_weighted_config" in scores

--- a/tests/unit/core/test_fail_closed_promotion.py
+++ b/tests/unit/core/test_fail_closed_promotion.py
@@ -347,3 +347,25 @@ class TestResultWinnerClaimGuards:
             objective_weights={"accuracy": 1.0}
         )
         assert "best_weighted_config" in scores
+
+
+    def test_weighted_scores_early_branch_also_omits_winner_key(self):
+        """Round-3 residual: the no-successful-trials early return must obey
+        the same omit-on-no-winner rule."""
+        from traigent.api.types import OptimizationResult
+
+        result = OptimizationResult(
+            best_config={},
+            best_score=None,
+            trials=[],  # no trials -> the early-return branch
+            total_cost=0.0,
+            duration=1.0,
+            objectives=["accuracy"],
+            optimization_id="opt-test",
+            convergence_info={},
+            status="completed",
+            algorithm="test",
+            timestamp=0.0,
+        )
+        scores = result.calculate_weighted_scores(objective_weights={"accuracy": 1.0})
+        assert "best_weighted_config" not in scores

--- a/tests/unit/core/test_fail_closed_promotion.py
+++ b/tests/unit/core/test_fail_closed_promotion.py
@@ -197,3 +197,126 @@ class TestTerminalSelector:
             comparability_mode="legacy",
         )
         assert result.best_config.get("model") == "hot"
+
+
+class TestCertifiedPromotionChain:
+    """Review round-1 fixes: first-incumbent overclaim (B1), dict-policy
+    fail-open (B2), per-run state reset (NB4), and the winner-claim guards
+    on result surfaces (B3, scoped)."""
+
+    def _orchestrator_with_real_chain(self, policy):
+        orchestrator = _orchestrator(policy)
+        orchestrator._best_trial_cached = None
+        orchestrator._incumbent_config_hash = None
+        orchestrator._certified_promotions = 0
+        orchestrator._track_trial_metrics = lambda t: "hash-" + str(
+            t.config.get("model")
+        )
+        return orchestrator
+
+    def test_strict_zero_promotions_yields_no_certified_winner(self):
+        """B1: the FIRST trial seeds the incumbent as initialization, not
+        certification — a strict run with zero gate promotions must produce
+        certified_promotions == 0, driving NO_CERTIFIED_SELECTION."""
+        policy = STRICT_POLICIES["require_calibration"]
+        orchestrator = self._orchestrator_with_real_chain(policy)
+        orchestrator._update_best_trial_cache(_trial(0.9, config={"model": "a"}))
+        assert orchestrator._best_trial_cached is not None  # seeded
+        assert orchestrator._certified_promotions == 0  # NOT certified
+        # second trial: gate says no_decision -> withheld, still zero
+        orchestrator._has_sufficient_samples = MagicMock(return_value=True)
+        orchestrator._config_metrics_history = {
+            "hash-b": {"accuracy": [0.95]},
+            "hash-a": {"accuracy": [0.9]},
+        }
+        orchestrator._incumbent_config_hash = "hash-a"
+        orchestrator._promotion_gate.evaluate = MagicMock(
+            return_value=SimpleNamespace(decision="no_decision", reason="thin")
+        )
+        orchestrator._update_best_trial_cache(_trial(0.95, config={"model": "b"}))
+        assert orchestrator._certified_promotions == 0
+        assert orchestrator._best_trial_cached.config == {"model": "a"}
+
+    def test_strict_gate_promote_counts_as_certified(self):
+        policy = STRICT_POLICIES["require_calibration"]
+        orchestrator = self._orchestrator_with_real_chain(policy)
+        orchestrator._update_best_trial_cache(_trial(0.5, config={"model": "a"}))
+        orchestrator._has_sufficient_samples = MagicMock(return_value=True)
+        orchestrator._config_metrics_history = {
+            "hash-b": {"accuracy": [0.95]},
+            "hash-a": {"accuracy": [0.5]},
+        }
+        orchestrator._incumbent_config_hash = "hash-a"
+        orchestrator._promotion_gate.evaluate = MagicMock(
+            return_value=SimpleNamespace(decision="promote", reason="dominates")
+        )
+        orchestrator._update_best_trial_cache(_trial(0.95, config={"model": "b"}))
+        assert orchestrator._certified_promotions == 1
+        assert orchestrator._best_trial_cached.config == {"model": "b"}
+
+    def test_dict_policy_with_strict_keys_reads_strict(self):
+        """B2: a raw dict policy (discovered specs) must not silently read
+        as non-strict."""
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator._promotion_gate = SimpleNamespace(
+            policy={
+                "dominance": "epsilon_pareto",
+                "require_calibration": {"enabled": True},
+            }
+        )
+        assert orchestrator._is_strict_evidence_mode() is True
+
+    def test_unparseable_dict_policy_with_strict_keys_fails_closed(self):
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator._promotion_gate = SimpleNamespace(
+            policy={
+                "require_calibration": {"enabled": "not-a-bool"},  # from_dict raises
+            }
+        )
+        assert orchestrator._is_strict_evidence_mode() is True
+
+    def test_plain_dict_policy_without_strict_keys_is_not_strict(self):
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator._promotion_gate = SimpleNamespace(
+            policy={"dominance": "epsilon_pareto", "alpha": 0.05}
+        )
+        assert orchestrator._is_strict_evidence_mode() is False
+
+
+class TestResultWinnerClaimGuards:
+    """B3 (scoped): a no-winner result makes no winner claims on its other
+    surfaces. Optimizer-internal best tracking and in-flight progress
+    callbacks are search guidance / observability, NOT promoted-winner
+    claims — recorded as a disposition in the feature trail."""
+
+    def _result(self, best_config):
+        from traigent.api.types import OptimizationResult
+
+        return OptimizationResult(
+            best_config=best_config,
+            best_score=None if not best_config else 0.9,
+            trials=[_trial(0.99, config={"model": "hot"})],
+            total_cost=0.0,
+            duration=1.0,
+            objectives=["accuracy"],
+            optimization_id="opt-test",
+            convergence_info={},
+            status="completed",
+            algorithm="test",
+            timestamp=0.0,
+        )
+
+    def test_best_metrics_empty_when_no_winner(self):
+        assert self._result({}).best_metrics == {}
+
+    def test_best_metrics_present_with_winner(self):
+        assert self._result({"model": "hot"}).best_metrics
+
+    def test_weighted_scores_omit_winner_claim_when_no_winner(self):
+        result = self._result({})
+        scores = result.calculate_weighted_scores(
+            objective_weights={"accuracy": 1.0}
+        )
+        assert scores["best_weighted_config"] == {}
+        # descriptive per-trial statistics are still computed
+        assert scores["weighted_scores"]

--- a/tests/unit/core/test_fail_closed_promotion.py
+++ b/tests/unit/core/test_fail_closed_promotion.py
@@ -369,3 +369,114 @@ class TestResultWinnerClaimGuards:
         )
         scores = result.calculate_weighted_scores(objective_weights={"accuracy": 1.0})
         assert "best_weighted_config" not in scores
+
+
+class TestBestConfigRuntimeInterplay:
+    """FR-SDK-BEST-CONFIG-RUNTIME-V1 interplay: a strict run with no certified
+    winner produces NO snapshot/export/publish — the runtime keeps defaults.
+
+    Exercises the REAL finalize path (_run_and_finalize_optimization's
+    ``if result.best_config`` guard) and the REAL ConfigStateManager export
+    guard, not re-implementations of them.
+    """
+
+    @staticmethod
+    def _no_certified_result():
+        from traigent.api.types import OptimizationResult
+
+        return OptimizationResult(
+            best_config={},  # NO_CERTIFIED_SELECTION shape
+            best_score=None,
+            trials=[],
+            total_cost=0.0,
+            duration=1.0,
+            objectives=["accuracy"],
+            optimization_id="opt-no-certified",
+            convergence_info={},
+            status="completed",
+            algorithm="test",
+            timestamp=0.0,
+            metadata={"reason_code": NO_CERTIFIED_SELECTION},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_certified_winner_yields_no_snapshot_or_export(self, tmp_path):
+        from unittest.mock import AsyncMock
+
+        from traigent.core.optimized_function import OptimizedFunction
+        from traigent.evaluators.base import Dataset, EvaluationExample
+        from traigent.utils.exceptions import ConfigurationError
+
+        def answer(text: str) -> str:
+            return text
+
+        fn = OptimizedFunction(
+            func=answer,
+            config_space={"model": ["a", "b"]},
+            default_config={"model": "a"},
+        )
+        fn.traigent_config = SimpleNamespace(is_edge_analytics_mode=lambda: False)
+        orchestrator = MagicMock()
+        orchestrator.optimize = AsyncMock(return_value=self._no_certified_result())
+        dataset = Dataset([EvaluationExample({"text": "x"}, "x")], name="d")
+
+        result = await fn._run_and_finalize_optimization(
+            orchestrator,
+            dataset,
+            {"model": ["a", "b"]},
+            save_to=None,
+        )
+
+        # the no-winner result flowed through the real finalize path
+        assert result.best_config == {}
+        # no winner was applied: snapshot stays DEFAULT, best config is None
+        assert fn.get_best_config() is None
+        assert fn.current_config == {"model": "a"}
+        assert fn.best_config_snapshot.source == "default"
+        # and the export/publish surface fails closed (config_state_manager guard)
+        with pytest.raises(ConfigurationError, match="No best configuration"):
+            fn.export_best_config(tmp_path / "best-configs")
+
+    @pytest.mark.asyncio
+    async def test_certified_winner_still_exports(self, tmp_path):
+        """Control: a result WITH a winner applies and exports — the guard
+        only bites the no-winner shape."""
+        from unittest.mock import AsyncMock
+
+        from traigent.api.types import OptimizationResult
+        from traigent.core.optimized_function import OptimizedFunction
+        from traigent.evaluators.base import Dataset, EvaluationExample
+
+        def answer(text: str) -> str:
+            return text
+
+        winner = OptimizationResult(
+            best_config={"model": "b"},
+            best_score=0.9,
+            trials=[],
+            total_cost=0.0,
+            duration=1.0,
+            objectives=["accuracy"],
+            optimization_id="opt-certified",
+            convergence_info={},
+            status="completed",
+            algorithm="test",
+            timestamp=0.0,
+        )
+        fn = OptimizedFunction(
+            func=answer,
+            config_space={"model": ["a", "b"]},
+            default_config={"model": "a"},
+        )
+        fn.traigent_config = SimpleNamespace(is_edge_analytics_mode=lambda: False)
+        orchestrator = MagicMock()
+        orchestrator.optimize = AsyncMock(return_value=winner)
+        dataset = Dataset([EvaluationExample({"text": "x"}, "x")], name="d")
+
+        await fn._run_and_finalize_optimization(
+            orchestrator, dataset, {"model": ["a", "b"]}, save_to=None
+        )
+
+        assert fn.get_best_config() == {"model": "b"}
+        exported = fn.export_best_config(tmp_path / "best-configs")
+        assert exported.exists()

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -1290,7 +1290,11 @@ class OptimizationResult:
         """
         if not self.successful_trials:
             return {
-                "best_weighted_config": self.best_config,
+                **(
+                    {"best_weighted_config": self.best_config}
+                    if (self.best_config or self.best_score is not None)
+                    else {}
+                ),
                 "best_weighted_score": 0.0,
                 "weighted_scores": [],
                 "normalization_ranges": {},

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -610,11 +610,12 @@ class OptimizationResult:
     def best_metrics(self) -> dict[str, float]:
         """Get best metrics from the best trial.
 
-        A result with no winner (empty ``best_config`` — e.g. a strict
-        evidence run that returned NO_CERTIFIED_SELECTION) makes no
-        winner-metric claims either.
+        A result with NO WINNER — empty ``best_config`` AND ``best_score``
+        of ``None``, the NO_CERTIFIED_SELECTION shape from strict evidence
+        runs — makes no winner-metric claims. A valid winner whose config
+        happens to be empty still carries a score and keeps its metrics.
         """
-        if not self.best_config:
+        if not self.best_config and self.best_score is None:
             return {}
         if not self.trials:
             return {}
@@ -1317,7 +1318,11 @@ class OptimizationResult:
         )
 
         return {
-            "best_weighted_config": (best_weighted_config if self.best_config else {}),
+            **(
+                {"best_weighted_config": best_weighted_config}
+                if (self.best_config or self.best_score is not None)
+                else {}
+            ),
             "best_weighted_score": best_weighted_score,
             "weighted_scores": weighted_scores,
             "normalization_ranges": ranges,

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -608,7 +608,14 @@ class OptimizationResult:
 
     @property
     def best_metrics(self) -> dict[str, float]:
-        """Get best metrics from the best trial."""
+        """Get best metrics from the best trial.
+
+        A result with no winner (empty ``best_config`` — e.g. a strict
+        evidence run that returned NO_CERTIFIED_SELECTION) makes no
+        winner-metric claims either.
+        """
+        if not self.best_config:
+            return {}
         if not self.trials:
             return {}
         if not self.objectives:
@@ -1261,6 +1268,11 @@ class OptimizationResult:
         This method allows proper multi-objective scoring after the optimization has
         completed, using the full range of observed values for normalization.
 
+        Winner-claim note (FR-SDK-FAIL-CLOSED-PROMOTION-V1): the per-trial
+        weighted scores are DESCRIPTIVE statistics and always computed; the
+        ``best_weighted_config`` key is a winner claim and is omitted when the
+        result carries no certified winner (empty ``best_config``).
+
         Args:
             objective_weights: Dictionary of objective weights (defaults to equal weights)
             minimize_objectives: List of objectives to minimize (e.g., ["cost", "latency"])
@@ -1305,7 +1317,7 @@ class OptimizationResult:
         )
 
         return {
-            "best_weighted_config": best_weighted_config,
+            "best_weighted_config": (best_weighted_config if self.best_config else {}),
             "best_weighted_score": best_weighted_score,
             "weighted_scores": weighted_scores,
             "normalization_ranges": ranges,

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1072,6 +1072,14 @@ class OptimizedFunction:
 
         from traigent.tvl.promotion_gate import PromotionGate
 
+        # Normalize discovered dict payloads into the typed PromotionPolicy —
+        # a raw dict would read as NON-strict in _is_strict_evidence_mode and
+        # then fail OPEN on gate exceptions (FR-SDK-FAIL-CLOSED-PROMOTION-V1).
+        if isinstance(promotion_policy, dict):
+            from traigent.tvl.models import PromotionPolicy
+
+            promotion_policy = PromotionPolicy.from_dict(promotion_policy)
+
         state["promotion_gate"] = getattr(self, "promotion_gate", None)
         self.promotion_gate = PromotionGate.from_policy(
             promotion_policy=promotion_policy,

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -796,15 +796,16 @@ class OptimizationOrchestrator:
         if isinstance(policy, dict):
             # Defensive normalization: a raw dict policy must not silently
             # read as non-strict (it would then fail OPEN on gate errors).
+            raw_policy = policy
             try:
                 from traigent.tvl.models import PromotionPolicy
 
-                policy = PromotionPolicy.from_dict(policy)
+                policy = PromotionPolicy.from_dict(raw_policy)
             except Exception:
                 # Unparseable policy declaring strict keys ⇒ fail CLOSED.
                 return bool(
-                    policy.get("require_calibration")
-                    or policy.get("chance_constraints")
+                    raw_policy.get("require_calibration")
+                    or raw_policy.get("chance_constraints")
                 )
         require_calibration = getattr(policy, "require_calibration", None)
         if require_calibration is not None and getattr(

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -638,6 +638,7 @@ class OptimizationOrchestrator:
 
     def _initialize_runtime_state(self) -> None:
         self._trials: list[TrialResult] = []
+        self._strict_withheld_promotions: list[str] = []
         self._start_time: float | None = None
         self._status = OptimizationStatus.PENDING
         self._optimization_id = str(uuid.uuid4())
@@ -776,6 +777,38 @@ class OptimizationOrchestrator:
             for obj in objectives
         )
 
+    def _is_strict_evidence_mode(self) -> bool:
+        """RFC 0001 §3.6 strict(M): the declared strict evidence modes.
+
+        Detected from the promotion policy today: require_calibration enabled
+        or chance constraints present. The per-CVAR disjuncts (consumed
+        governed CVARs / certificate-backed targets via the knob resolver)
+        join this predicate when the knobs branches consolidate — tracked in
+        FR-SDK-FAIL-CLOSED-PROMOTION-V1's artifact trail.
+        """
+        gate = self._promotion_gate
+        if gate is None:
+            return False
+        policy = getattr(gate, "policy", None)
+        if policy is None:
+            return False
+        require_calibration = getattr(policy, "require_calibration", None)
+        if require_calibration is not None and getattr(
+            require_calibration, "enabled", False
+        ):
+            return True
+        return bool(getattr(policy, "chance_constraints", None))
+
+    def _withhold_promotion(self, reason: str) -> bool:
+        """Fail closed: record + log a strict-mode withheld promotion."""
+        self._strict_withheld_promotions.append(reason)
+        logger.warning(
+            "Strict evidence mode: promotion withheld (%s); "
+            "no winner-by-objective fallback",
+            reason,
+        )
+        return False
+
     def _handle_promotion_decision(
         self,
         decision: Any,
@@ -794,7 +827,11 @@ class OptimizationOrchestrator:
                 decision.reason,
             )
             return False
-        # "no_decision" - fall back to simple comparison
+        # "no_decision": strict evidence modes fail CLOSED — insufficient
+        # evidence never promotes and never falls back to simple comparison
+        # (RFC 0001 P7). Non-strict keeps the legacy simple comparison.
+        if self._is_strict_evidence_mode():
+            return self._withhold_promotion(f"gate no_decision: {decision.reason}")
         logger.debug(
             "PromotionGate: no decision, using simple comparison (reason: %s)",
             decision.reason,
@@ -831,6 +868,10 @@ class OptimizationOrchestrator:
         if not has_data or not self._has_sufficient_samples(
             candidate_metrics, incumbent_metrics
         ):
+            if self._is_strict_evidence_mode():
+                return self._withhold_promotion(
+                    "insufficient samples for statistical comparison"
+                )
             return self._simple_is_better(candidate_trial)
 
         # Use PromotionGate for statistical evaluation
@@ -843,6 +884,16 @@ class OptimizationOrchestrator:
             )
             return self._handle_promotion_decision(decision, candidate_trial)
         except Exception as e:
+            if self._is_strict_evidence_mode():
+                # Gate exception fails CLOSED in strict modes (Rule 1: a
+                # failing policy surface denies; it never silently degrades
+                # to the permissive simple comparison).
+                logger.error(
+                    "PromotionGate evaluation failed in strict evidence "
+                    "mode; promotion withheld: %s",
+                    e,
+                )
+                return self._withhold_promotion(f"gate exception: {e}")
             logger.warning(
                 "PromotionGate evaluation failed, using simple comparison: %s", e
             )
@@ -2578,6 +2629,27 @@ class OptimizationOrchestrator:
         Returns:
             OptimizationResult with all trial data
         """
+        strict_mode = self._is_strict_evidence_mode()
+        certified_config: dict[str, Any] | None = None
+        certified_score: float | None = None
+        if strict_mode and self._best_trial_cached is not None:
+            # The gate-mediated incumbent chain IS the certified winner; the
+            # selector must never re-derive by raw score in strict modes.
+            config_space_keys = set(getattr(self.optimizer, "config_space", {}).keys())
+            incumbent = self._best_trial_cached
+            certified_config = {
+                key: value
+                for key, value in (incumbent.config or {}).items()
+                if not config_space_keys or key in config_space_keys
+            }
+            primary = (
+                self.optimizer.objectives[0] if self.optimizer.objectives else None
+            )
+            certified_score = (
+                incumbent.get_metric(primary)
+                if primary and hasattr(incumbent, "get_metric")
+                else None
+            )
         selection = select_best_configuration(
             trials=self._trials,
             primary_objective=self.optimizer.objectives[0],
@@ -2586,6 +2658,9 @@ class OptimizationOrchestrator:
             tie_breakers=self._tie_breakers or None,
             band_target=self._band_target,
             comparability_mode=self.traigent_config.get_comparability_mode(),
+            require_certified=strict_mode,
+            certified_config=certified_config,
+            certified_score=certified_score,
         )
         best_config = selection.best_config
         best_score = selection.best_score

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -639,6 +639,7 @@ class OptimizationOrchestrator:
     def _initialize_runtime_state(self) -> None:
         self._trials: list[TrialResult] = []
         self._strict_withheld_promotions: list[str] = []
+        self._certified_promotions = 0
         self._start_time: float | None = None
         self._status = OptimizationStatus.PENDING
         self._optimization_id = str(uuid.uuid4())
@@ -792,6 +793,19 @@ class OptimizationOrchestrator:
         policy = getattr(gate, "policy", None)
         if policy is None:
             return False
+        if isinstance(policy, dict):
+            # Defensive normalization: a raw dict policy must not silently
+            # read as non-strict (it would then fail OPEN on gate errors).
+            try:
+                from traigent.tvl.models import PromotionPolicy
+
+                policy = PromotionPolicy.from_dict(policy)
+            except Exception:
+                # Unparseable policy declaring strict keys ⇒ fail CLOSED.
+                return bool(
+                    policy.get("require_calibration")
+                    or policy.get("chance_constraints")
+                )
         require_calibration = getattr(policy, "require_calibration", None)
         if require_calibration is not None and getattr(
             require_calibration, "enabled", False
@@ -945,6 +959,11 @@ class OptimizationOrchestrator:
 
         # Evaluate if this trial should become the new best
         if self._evaluate_promotion(config_hash, trial_result):
+            if self._is_strict_evidence_mode():
+                # In strict mode a True here can only come from the gate's
+                # explicit "promote" (all other lanes withhold) — count it:
+                # only gate-certified promotions justify a certified winner.
+                self._certified_promotions += 1
             self._best_trial_cached = trial_result
             self._incumbent_config_hash = config_hash
 
@@ -1769,6 +1788,8 @@ class OptimizationOrchestrator:
         self._successful_trials = 0
         self._failed_trials = 0
         self._best_trial_cached = None
+        self._strict_withheld_promotions = []
+        self._certified_promotions = 0
 
         # Reset stop conditions for fresh optimization run
         self._stop_condition_manager.reset()
@@ -2632,9 +2653,17 @@ class OptimizationOrchestrator:
         strict_mode = self._is_strict_evidence_mode()
         certified_config: dict[str, Any] | None = None
         certified_score: float | None = None
-        if strict_mode and self._best_trial_cached is not None:
-            # The gate-mediated incumbent chain IS the certified winner; the
-            # selector must never re-derive by raw score in strict modes.
+        if (
+            strict_mode
+            and self._best_trial_cached is not None
+            and self._certified_promotions > 0
+        ):
+            # Only an incumbent that won at least one explicit gate
+            # promotion is a certified winner. The FIRST trial seeds the
+            # incumbent as comparison initialization, NOT as certification —
+            # a strict run with zero gate promotions returns
+            # NO_CERTIFIED_SELECTION (review finding: first-incumbent
+            # overclaim).
             config_space_keys = set(getattr(self.optimizer, "config_space", {}).keys())
             incumbent = self._best_trial_cached
             certified_config = {

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -21,6 +21,7 @@ __all__ = [
 TieBreaker = Literal["min_abs_deviation", "custom"]
 ComparabilityMode = Literal["legacy", "warn", "strict"]
 NO_RANKING_ELIGIBLE_TRIALS = "NO_RANKING_ELIGIBLE_TRIALS"
+NO_CERTIFIED_SELECTION = "NO_CERTIFIED_SELECTION"
 
 
 @dataclass(slots=True)
@@ -564,8 +565,18 @@ def select_best_configuration(
     tie_breakers: dict[str, TieBreaker] | None = None,
     band_target: float | None = None,
     comparability_mode: ComparabilityMode = "warn",
+    require_certified: bool = False,
+    certified_config: dict[str, Any] | None = None,
+    certified_score: float | None = None,
 ) -> SelectionResult:
     """Return the configuration that best satisfies the primary objective.
+
+    Strict evidence modes (RFC 0001 / FR-SDK-FAIL-CLOSED-PROMOTION-V1):
+    with ``require_certified=True`` the selector NEVER re-derives a winner by
+    raw score. It returns the gate-certified incumbent verbatim, or — when no
+    certified winner exists — an explicit empty result with
+    ``reason_code=NO_CERTIFIED_SELECTION``. Silent fallback to
+    highest-score-wins is exactly the fail-open behavior this closes.
 
     Args:
         trials: Iterable of completed trial results.
@@ -579,6 +590,28 @@ def select_best_configuration(
     Returns:
         SelectionResult with best configuration and score.
     """
+    if require_certified:
+        if certified_config is None:
+            return SelectionResult(
+                best_config={},
+                best_score=None,
+                session_summary={
+                    "reason": (
+                        "strict evidence mode: no certified winner exists; "
+                        "refusing winner-by-objective fallback"
+                    ),
+                    "reason_code": NO_CERTIFIED_SELECTION,
+                },
+                reason_code=NO_CERTIFIED_SELECTION,
+            )
+        return SelectionResult(
+            best_config=dict(certified_config),
+            best_score=certified_score,
+            session_summary={
+                "reason": "strict evidence mode: gate-certified incumbent",
+            },
+        )
+
     trial_list = list(trials)
     successful_trials = [t for t in trial_list if _trial_produced_outputs(t)]
     non_successful_count = len(trial_list) - len(successful_trials)


### PR DESCRIPTION
## Summary
SDK packet 6-C3 (stacked on the loader PR). Owner-approved IMMEDIATE enforcement: under declared strict evidence modes (require_calibration, chance constraints), the verdicts no_decision / insufficient samples / gate exception each WITHHOLD promotion (recorded reasons, spy-verified no `_simple_is_better`), and the terminal selector returns the gate-certified incumbent VERBATIM or the explicit `NO_CERTIFIED_SELECTION` empty result — never a re-derived raw-score winner. First-trial incumbency is initialization, not certification (`_certified_promotions` counting). Dict policies normalize (unparseable-with-strict-keys fails CLOSED). No-winner results make no winner claims on `best_metrics`/`best_weighted_config` (valid degenerate winners keep theirs). Non-strict lane pinned byte-identical.

## PR checklist (policy surface)
- **Worst-case prod path**: a strict run silently promoting on absent evidence — now denied (Rule 1).
- **Production-branch deny tests**: `tests/unit/core/test_fail_closed_promotion.py` (28 tests, spy-verified, all four sites + the real promotion chain).
- **Contracts**: no wire shapes (contract-decision record); `select_best_configuration` keyword-only additive.
- **Behavior change**: existing chance-constraint specs — release-notes entry required at merge (owner-approved immediate enforcement).

## Review
codex gpt-5.5 xhigh, 4 rounds → **ACCEPT** (fixed: first-incumbent overclaim, dict-policy fail-open, winner-claim guards + the valid-empty-config-winner regression + the early-branch residual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)