### PR TITLE
fix(observability): offline mode blocks backend egress, not custom senders

### DIFF
--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -187,6 +187,73 @@ def test_observability_client_offline_mode_does_not_attempt_ingest(monkeypatch, 
     assert caplog.text.count("Observability transport in offline mode") == 1
 
 
+def test_observability_client_offline_mode_memory_sender_has_no_backend_egress(
+    monkeypatch,
+):
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
+    sentinel = "offline-memory-canary-local-only"
+    sent_batches: list[list[dict]] = []
+    backend_attempts: list[tuple[str, str]] = []
+
+    def fake_urlopen(http_request, *args, **kwargs):
+        body = getattr(http_request, "data", b"")
+        body_text = body.decode("utf-8") if isinstance(body, bytes) else str(body)
+        backend_attempts.append(("urlopen", body_text))
+        raise AssertionError("network attempted")
+
+    def memory_sender(traces):
+        sent_batches.append(traces)
+
+    def request_sender(method: str, path: str, payload: dict | None):
+        backend_attempts.append(("request_sender", json.dumps([method, path, payload])))
+        raise AssertionError("request sender should not be called in offline mode")
+
+    monkeypatch.setattr(
+        "traigent.observability.client.request.urlopen",
+        fake_urlopen,
+    )
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=100,
+            max_buffer_age=999.0,
+            max_queue_size=10,
+            enable_atexit_flush=False,
+        ),
+        sender=memory_sender,
+        request_sender=request_sender,
+    )
+
+    trace_id = client.start_trace(
+        "offline-memory-canary",
+        trace_id="trace_offline_memory_canary",
+        metadata={"sentinel": sentinel},
+        input_data={"sentinel": sentinel},
+    )
+    client.record_observation(
+        trace_id,
+        name="offline-memory-observation",
+        input_data={"sentinel": sentinel},
+    )
+    client.end_trace(trace_id, output_data={"sentinel": sentinel})
+
+    result = client.flush()
+    with pytest.raises(ClientError, match="TRAIGENT_OFFLINE_MODE=true"):
+        client.list_sessions()
+    close_result = client.close()
+
+    memory_payload = json.dumps(sent_batches)
+    egress_payload = json.dumps(backend_attempts)
+    assert client.config.offline_mode is True
+    assert result.success is True
+    assert result.items_sent >= 1
+    assert close_result.success is True
+    assert sentinel in memory_payload
+    assert backend_attempts == []
+    assert sentinel not in egress_payload
+
+
 def test_observability_client_offline_mode_blocks_request_api():
     request_calls: list[tuple[str, str, dict | None]] = []
 

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -532,7 +532,7 @@ class ObservabilityClient:
 
     def flush(self, timeout: float | None = None) -> FlushResult:
         timeout = timeout or self.config.flush_timeout
-        if self.config.offline_mode:
+        if self.config.offline_mode and not self._has_custom_trace_sender:
             self._log_offline_mode_once()
             return self._offline_flush_result()
         with self._lock:
@@ -571,7 +571,7 @@ class ObservabilityClient:
                 warnings=[],
             )
 
-        if self.config.offline_mode:
+        if self.config.offline_mode and not self._has_custom_trace_sender:
             self._log_offline_mode_once()
             self._closed = True
             return self._offline_flush_result()
@@ -754,6 +754,10 @@ class ObservabilityClient:
 
         return self._post_batch_sync(traces)
 
+    @property
+    def _has_custom_trace_sender(self) -> bool:
+        return self._sender_override is not None
+
     def _post_batch_sync(self, traces: list[dict[str, Any]]) -> dict[str, Any] | None:
         if self.config.offline_mode:
             self._log_offline_mode_once()
@@ -896,7 +900,7 @@ class ObservabilityClient:
         return data
 
     def _queue_trace_snapshot(self, trace_id: str) -> None:
-        if self.config.offline_mode:
+        if self.config.offline_mode and not self._has_custom_trace_sender:
             return
         with self._lock:
             state = self._trace_states.get(trace_id)


### PR DESCRIPTION
Closes #1084 (found + filed during the 2026-06-04 posture pass; serially reproduced).

## Root cause
`traigent/observability/client.py` returned the offline no-op from `flush()`/`close()`/`_queue_trace_snapshot()` whenever `TRAIGENT_OFFLINE_MODE` was set — even with a custom in-memory sender supplied — so local trace collection silently delivered nothing (demo: 0 vs 17 traces).

## Fix
Offline mode now governs **backend egress only**: with a custom `sender=`, the client queues/flushes/closes through it; without one, the offline no-op stands. Client-side seam so every memory-sender user benefits (not just the demo).

## Privacy canary (policy surface)
The #83 air-gap kill-switch contract is proven, not assumed: under offline mode + memory sender, a sentinel reaches **only** the memory sender — `urlopen` never called, request sender never invoked, request APIs still blocked.

## Verification (serial)
`tests/unit/observability` **37 passed**, incl. the previously-failing demo test and the new canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)