### PR TITLE
fix(tracing): consolidate trace-enable env vars on TRAIGENT_TRACE_ENABLED

### DIFF
--- a/docs/api-reference/telemetry.md
+++ b/docs/api-reference/telemetry.md
@@ -65,6 +65,21 @@ Traigent will:
 
 Privacy mode does not disable telemetry; use `TRAIGENT_DISABLE_TELEMETRY=true` for a full opt-out.
 
+### OpenTelemetry Tracing
+
+OpenTelemetry tracing is opt-in and uses a separate flag from telemetry
+opt-out:
+
+```bash
+export TRAIGENT_TRACE_ENABLED=true
+```
+
+`TRAIGENT_TRACE_ENABLED` is the canonical tracing flag and defaults to
+`false`. It controls SDK span emission and workflow trace tracker creation.
+The older plural spelling `TRAIGENT_TRACES_ENABLED` remains as a deprecated
+alias when the canonical flag is unset; if both are set,
+`TRAIGENT_TRACE_ENABLED` takes precedence.
+
 ## How Telemetry is Used
 
 Telemetry data is used for:

--- a/plugins/traigent-tracing/README.md
+++ b/plugins/traigent-tracing/README.md
@@ -22,7 +22,7 @@ pip install traigent-tracing[jaeger]
 
 ## Usage
 
-Once installed, tracing is automatically enabled. Configure via environment variables:
+Tracing is opt-in. Configure it via environment variables:
 
 ```bash
 # Enable tracing
@@ -34,6 +34,11 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # Set service name
 export OTEL_SERVICE_NAME=my-optimization-service
 ```
+
+`TRAIGENT_TRACE_ENABLED` is the canonical tracing flag and defaults to
+`false`. The older plural spelling `TRAIGENT_TRACES_ENABLED` is still honored
+as a deprecated alias when the canonical flag is unset; if both are set,
+`TRAIGENT_TRACE_ENABLED` takes precedence.
 
 Or configure programmatically:
 

--- a/plugins/traigent-tracing/traigent_tracing/tracing.py
+++ b/plugins/traigent-tracing/traigent_tracing/tracing.py
@@ -23,12 +23,10 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+from traigent.core.trace_env import is_trace_enabled
+
 # Check if tracing is enabled and OpenTelemetry is available
-TRACING_ENABLED = os.environ.get("TRAIGENT_TRACE_ENABLED", "false").lower() in (
-    "true",
-    "1",
-    "yes",
-)
+TRACING_ENABLED = is_trace_enabled()
 
 try:
     from opentelemetry import context as otel_context
@@ -658,9 +656,7 @@ def _serialize_output(output: Any, max_length: int) -> str:
     """
     scrubbed = _scrub_for_export(output)
     try:
-        output_str = (
-            json.dumps(scrubbed) if not isinstance(scrubbed, str) else scrubbed
-        )
+        output_str = json.dumps(scrubbed) if not isinstance(scrubbed, str) else scrubbed
     except (TypeError, ValueError):
         output_str = _scrub_pii_text(str(scrubbed))
     if len(output_str) > max_length:

--- a/tests/unit/core/test_optimization_pipeline.py
+++ b/tests/unit/core/test_optimization_pipeline.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
-from traigent.core.optimization_pipeline import collect_orchestrator_kwargs
+from traigent.core.optimization_pipeline import (
+    collect_orchestrator_kwargs,
+    create_workflow_traces_tracker,
+)
 
 # ---------------------------------------------------------------------------
 # collect_orchestrator_kwargs: invocations_per_example
@@ -77,3 +81,82 @@ class TestCollectOrchestratorKwargsInvocations:
             promotion_gate=None,
         )
         assert result["invocations_per_example"] == 1
+
+
+@pytest.fixture
+def workflow_trace_backend_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRAIGENT_BACKEND_URL", "https://backend.example")
+    monkeypatch.setenv("TRAIGENT_API_KEY", "api-key")
+    monkeypatch.delenv("TRAIGENT_TRACE_ENABLED", raising=False)
+    monkeypatch.delenv("TRAIGENT_TRACES_ENABLED", raising=False)
+
+
+def _patch_workflow_traces_tracker(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, Any]:
+    tracker = object()
+    tracker_factory = MagicMock(return_value=tracker)
+    monkeypatch.setattr(
+        "traigent.integrations.observability.workflow_traces.WorkflowTracesTracker",
+        tracker_factory,
+    )
+    return tracker, tracker_factory
+
+
+class TestCreateWorkflowTracesTrackerTraceEnv:
+    """Workflow trace tracker follows the same trace enablement env contract."""
+
+    def test_canonical_only_enabled_creates_tracker(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workflow_trace_backend_env: None,
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_TRACE_ENABLED", "true")
+        tracker, tracker_factory = _patch_workflow_traces_tracker(monkeypatch)
+
+        result = create_workflow_traces_tracker(None)  # type: ignore[arg-type]
+
+        assert result is tracker
+        tracker_factory.assert_called_once_with(
+            backend_url="https://backend.example",
+            auth_token="api-key",
+        )
+
+    def test_alias_only_enabled_warns_and_creates_tracker(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workflow_trace_backend_env: None,
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_TRACES_ENABLED", "true")
+        tracker, tracker_factory = _patch_workflow_traces_tracker(monkeypatch)
+
+        with pytest.warns(DeprecationWarning, match="TRAIGENT_TRACES_ENABLED"):
+            result = create_workflow_traces_tracker(None)  # type: ignore[arg-type]
+
+        assert result is tracker
+        tracker_factory.assert_called_once()
+
+    def test_both_set_canonical_takes_precedence(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workflow_trace_backend_env: None,
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_TRACE_ENABLED", "false")
+        monkeypatch.setenv("TRAIGENT_TRACES_ENABLED", "true")
+        _, tracker_factory = _patch_workflow_traces_tracker(monkeypatch)
+
+        with pytest.warns(DeprecationWarning, match="ignored"):
+            result = create_workflow_traces_tracker(None)  # type: ignore[arg-type]
+
+        assert result is None
+        tracker_factory.assert_not_called()
+
+    def test_neither_set_defaults_off(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workflow_trace_backend_env: None,
+    ) -> None:
+        _, tracker_factory = _patch_workflow_traces_tracker(monkeypatch)
+
+        result = create_workflow_traces_tracker(None)  # type: ignore[arg-type]
+
+        assert result is None
+        tracker_factory.assert_not_called()

--- a/tests/unit/core/test_trace_env.py
+++ b/tests/unit/core/test_trace_env.py
@@ -1,0 +1,38 @@
+"""Regression tests for trace enablement environment handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.core.trace_env import (
+    LEGACY_TRACES_ENABLED_ENV,
+    TRACE_ENABLED_ENV,
+    is_trace_enabled,
+)
+
+
+def test_trace_enabled_canonical_only_is_honored() -> None:
+    assert is_trace_enabled({TRACE_ENABLED_ENV: "true"}) is True
+
+
+def test_trace_enabled_alias_only_warns_and_is_honored() -> None:
+    with pytest.warns(DeprecationWarning, match=LEGACY_TRACES_ENABLED_ENV):
+        enabled = is_trace_enabled({LEGACY_TRACES_ENABLED_ENV: "true"})
+
+    assert enabled is True
+
+
+def test_trace_enabled_both_set_canonical_takes_precedence() -> None:
+    with pytest.warns(DeprecationWarning, match="ignored"):
+        enabled = is_trace_enabled(
+            {
+                TRACE_ENABLED_ENV: "false",
+                LEGACY_TRACES_ENABLED_ENV: "true",
+            }
+        )
+
+    assert enabled is False
+
+
+def test_trace_enabled_neither_set_defaults_off() -> None:
+    assert is_trace_enabled({}) is False

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -22,6 +22,7 @@ from traigent.config.parallel import (
 )
 from traigent.config.types import ExecutionMode, TraigentConfig, resolve_execution_mode
 from traigent.core.evaluator_wrapper import CustomEvaluatorWrapper
+from traigent.core.trace_env import is_trace_enabled
 from traigent.evaluators.base import BaseEvaluator, Dataset
 from traigent.evaluators.local import LocalEvaluator
 from traigent.utils.logging import get_logger
@@ -550,7 +551,7 @@ def create_workflow_traces_tracker(
     if not backend_url or not api_key:
         return None
 
-    if os.environ.get("TRAIGENT_TRACES_ENABLED", "").lower() == "false":
+    if not is_trace_enabled():
         return None
 
     try:

--- a/traigent/core/trace_env.py
+++ b/traigent/core/trace_env.py
@@ -1,0 +1,64 @@
+"""Shared environment handling for Traigent trace enablement."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from collections.abc import Mapping
+
+TRACE_ENABLED_ENV = "TRAIGENT_TRACE_ENABLED"
+LEGACY_TRACES_ENABLED_ENV = "TRAIGENT_TRACES_ENABLED"
+
+_TRUTHY_TRACE_VALUES = frozenset(("true", "1", "yes"))
+_FALSY_TRACE_VALUES = frozenset(("false", "0", "no"))
+
+
+def _parse_trace_enabled(value: str, *, default: bool) -> bool:
+    normalized = value.strip().lower()
+    if normalized in _TRUTHY_TRACE_VALUES:
+        return True
+    if normalized in _FALSY_TRACE_VALUES:
+        return False
+    return default
+
+
+def is_trace_enabled(
+    environ: Mapping[str, str] | None = None,
+    *,
+    default: bool = False,
+) -> bool:
+    """Return whether Traigent tracing is enabled by environment.
+
+    ``TRAIGENT_TRACE_ENABLED`` is canonical and always takes precedence.
+    ``TRAIGENT_TRACES_ENABLED`` is a deprecated alias that is honored only
+    when the canonical variable is unset.
+    """
+    env = os.environ if environ is None else environ
+    canonical_value = env.get(TRACE_ENABLED_ENV)
+    legacy_value = env.get(LEGACY_TRACES_ENABLED_ENV)
+
+    if legacy_value is not None:
+        if canonical_value is None:
+            message = (
+                f"{LEGACY_TRACES_ENABLED_ENV} is deprecated; use "
+                f"{TRACE_ENABLED_ENV} instead."
+            )
+        else:
+            message = (
+                f"{LEGACY_TRACES_ENABLED_ENV} is deprecated and ignored because "
+                f"{TRACE_ENABLED_ENV} is set."
+            )
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+
+    if canonical_value is not None:
+        return _parse_trace_enabled(canonical_value, default=default)
+    if legacy_value is not None:
+        return _parse_trace_enabled(legacy_value, default=default)
+    return default
+
+
+__all__ = [
+    "LEGACY_TRACES_ENABLED_ENV",
+    "TRACE_ENABLED_ENV",
+    "is_trace_enabled",
+]

--- a/traigent/core/tracing.py
+++ b/traigent/core/tracing.py
@@ -52,12 +52,10 @@ except ImportError:
     from contextlib import contextmanager
     from typing import TYPE_CHECKING, Any
 
+    from traigent.core.trace_env import is_trace_enabled
+
     # Check if tracing is enabled and OpenTelemetry is available
-    TRACING_ENABLED = os.environ.get("TRAIGENT_TRACE_ENABLED", "false").lower() in (
-        "true",
-        "1",
-        "yes",
-    )
+    TRACING_ENABLED = is_trace_enabled()
 
     try:
         from opentelemetry import context as otel_context


### PR DESCRIPTION
Closes #1091.

One canonical var, one default, one explicit precedence rule — via a shared `trace_env` helper used by core tracing, the optimization-pipeline tracker, and the tracing plugin:
- `TRAIGENT_TRACE_ENABLED` — canonical, always takes precedence
- `TRAIGENT_TRACES_ENABLED` — deprecated alias, honored **only when canonical is unset**, emits a deprecation warning
- Docs updated (telemetry API reference + plugin README)

**Verification (serial)**: 75 passed across trace-env/pipeline/tracing/plugin suites — canonical-only, alias-only (warns+honored), both-set precedence, neither-set default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)