### PR TITLE
consolidation gate: per-CVAR strict disjuncts + public optimize() e2e (merge AFTER #1097–#1103)

### DIFF
--- a/tests/integration/test_knobs_strict_e2e.py
+++ b/tests/integration/test_knobs_strict_e2e.py
@@ -1,0 +1,240 @@
+"""End-to-end smoke: knobs resolution + fail-closed promotion through the
+PUBLIC optimize() API (the consolidation release gate).
+
+Plan obligation (TVL-first program, Verification): a spec with 1 TVAR + 1 CVAR
+under require_calibration runs end-to-end — the CVAR resolves in-trial (the
+evaluated function sees it; the optimizer never does), a stale certificate
+fails closed with the typed error and no winner output, and a certified
+promotion path produces a real winner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import traigent
+from traigent.api.config_space import ConfigSpace
+from traigent.api.parameter_ranges import Choices
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.knobs import (
+    Calibrated,
+    CalibratedInput,
+    FreshnessContext,
+    Knob,
+    KnobResolver,
+    ResolutionError,
+    ResolutionRejection,
+    SignalSpec,
+    TargetProperty,
+    Tuned,
+    canonical_hash,
+    issue_certificate,
+)
+from traigent.optimizers.random import RandomSearchOptimizer
+from traigent.optimizers.registry import register_optimizer
+from traigent.tvl.models import PromotionPolicy, RequireCalibration
+from traigent.tvl.promotion_gate import ObjectiveSpec, PromotionGate
+
+
+def _signal() -> SignalSpec:
+    return SignalSpec(
+        name="vote_margin",
+        version="1",
+        score_function="exact_match",
+        score_function_version="1",
+        comparator="key_eq",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="margin_floor", mode="require_calibration")
+
+
+def _ctx(parents: tuple = ()) -> FreshnessContext:
+    return FreshnessContext(
+        cvar_name="threshold",
+        tuned_parent_values=parents,
+        calibration_source_id="pool_a",
+        signal_spec_hash=_signal().spec_hash(),
+        calibrator_id="budget_threshold",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target=_target(),
+    )
+
+
+def _space(depends_on: tuple = ()) -> ConfigSpace:
+    return ConfigSpace(
+        knobs={
+            "variant": Knob(
+                name="variant", binding=Tuned(range=Choices(["cheap", "strong"]))
+            ),
+            "threshold": Knob(
+                name="threshold",
+                binding=Calibrated(
+                    signal=_signal(),
+                    target=_target(),
+                    depends_on=depends_on,
+                    require_calibration=True,
+                ),
+            ),
+        }
+    )
+
+
+def _fresh_resolver(space: ConfigSpace) -> KnobResolver:
+    ctx = _ctx(parents=())
+    cert = issue_certificate("threshold", "float", 0.42, ctx)
+    return KnobResolver(
+        space,
+        calibrated_inputs={
+            "threshold": CalibratedInput(value=0.42, certificate=cert, context=ctx)
+        },
+    )
+
+
+def _dataset(size: int = 3) -> Dataset:
+    return Dataset(
+        [EvaluationExample({"text": f"q{i}"}, "strong:0.42") for i in range(size)],
+        name="strict_e2e",
+    )
+
+
+def _strict_gate() -> PromotionGate:
+    policy = PromotionPolicy(
+        require_calibration=RequireCalibration(enabled=True),
+    )
+    return PromotionGate(policy, [ObjectiveSpec("accuracy", "maximize")])
+
+
+def _make_wrapped(resolver: KnobResolver, gate: PromotionGate):
+    """The public decorator path (context injection — the default lane); the
+    trial function PROVES in-trial CVAR resolution by recording and emitting
+    the resolved values it actually saw."""
+    function_saw: list[dict] = []
+
+    @traigent.optimize(
+        eval_dataset=_dataset(),
+        objectives=["accuracy"],
+        configuration_space={"variant": ["cheap", "strong"]},  # Tuned projection ONLY
+        default_config={"variant": "cheap"},
+    )
+    def answer(text: str) -> str:
+        cfg = traigent.get_config()
+        # context injection hands the raw per-trial dict; TraigentConfig
+        # surfaces the same keys under custom_params
+        params = cfg.custom_params if hasattr(cfg, "custom_params") else dict(cfg)
+        function_saw.append(dict(params))
+        # the evaluator-visible answer encodes the RESOLVED configuration
+        return f"{params.get('variant')}:{params.get('threshold')}"
+
+    # the same attribute seam the TVL-spec path uses internally
+    answer.promotion_gate = gate
+    answer.knob_resolver = resolver
+    return answer, function_saw
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("cost_preflight_approved")
+async def test_cvar_resolves_in_trial_and_strict_run_never_silently_promotes():
+    """Fresh certificate: every trial executes with the injected CVAR; with
+    one sample per config the strict gate cannot certify, so the run ends
+    with the explicit no-winner shape — never a raw-score winner."""
+    space = _space(depends_on=())
+    wrapped, function_saw = _make_wrapped(_fresh_resolver(space), _strict_gate())
+
+    result = await wrapped.optimize(algorithm="grid", max_trials=3)
+
+    # the CVAR resolved IN-TRIAL: the evaluated FUNCTION saw threshold=0.42
+    # on every call (not merely the recorded trial config)
+    assert len(result.trials) == 3  # baseline + both grid configs
+    for trial in result.trials:
+        assert trial.config.get("threshold") == 0.42, trial.config
+    assert function_saw and all(
+        call.get("threshold") == 0.42 for call in function_saw
+    ), function_saw[:3]
+    assert {call.get("variant") for call in function_saw} == {"cheap", "strong"}
+    # the optimizer's search space never contained the CVAR (P2)
+    assert set(wrapped.configuration_space) == {"variant"}
+    # strict + one-sample-per-config evidence => explicit no-winner, applied
+    # nowhere (fail closed end-to-end)
+    assert result.best_config == {}
+    assert result.best_score is None
+    assert wrapped.get_best_config() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("cost_preflight_approved")
+async def test_stale_certificate_blocks_the_run_with_typed_error():
+    """Parent-specific certificate (depends_on=variant, issued for 'cheap'):
+    the first suggestion for the other parent value is R6 stale — the run
+    aborts with the typed fail-closed error and no winner is ever applied."""
+    from traigent.knobs import Ref
+
+    space = _space(depends_on=(Ref(knob="variant"),))
+    ctx = _ctx(parents=(("variant", "cheap"),))
+    cert = issue_certificate("threshold", "float", 0.42, ctx)
+    resolver = KnobResolver(
+        space,
+        calibrated_inputs={
+            "threshold": CalibratedInput(value=0.42, certificate=cert, context=ctx)
+        },
+    )
+    wrapped, _ = _make_wrapped(resolver, _strict_gate())
+
+    with pytest.raises(ResolutionError) as err:
+        await wrapped.optimize(algorithm="grid", max_trials=3)
+
+    assert ResolutionRejection.STALE_CERTIFICATE in err.value.rejections
+    assert wrapped.get_best_config() is None
+
+
+class _TwoPassScheduleOptimizer(RandomSearchOptimizer):
+    """Public optimizer-plugin seam: revisits each config so the strict gate
+    accumulates >= 2 metric samples per config (grid/random dedup discrete
+    spaces by design; reps_per_trial is rejected in this version)."""
+
+    _SCHEDULE = ({"variant": "strong"}, {"variant": "cheap"}, {"variant": "strong"})
+
+    def suggest_next_trial(self, trials):
+        # the consumed baseline default ({"variant": "cheap"}) is trial 0
+        idx = len(trials) - 1
+        if idx >= len(self._SCHEDULE):
+            from traigent.utils.exceptions import OptimizationError
+
+            raise OptimizationError("schedule exhausted")
+        return dict(self._SCHEDULE[idx])
+
+
+register_optimizer("strict-e2e-schedule", _TwoPassScheduleOptimizer)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("cost_preflight_approved")
+async def test_certified_promotion_produces_a_real_winner():
+    """With two evaluations per config the strict gate accumulates real
+    evidence and certifies a promotion — the winner is the gate's certified
+    incumbent, not a raw re-derivation."""
+    space = _space(depends_on=())
+    wrapped, function_saw = _make_wrapped(_fresh_resolver(space), _strict_gate())
+
+    result = await wrapped.optimize(
+        algorithm="strict-e2e-schedule",
+        max_trials=4,
+    )
+
+    samples_per_config: dict[str, int] = {}
+    for trial in result.trials:
+        key = str(trial.config.get("variant"))
+        samples_per_config[key] = samples_per_config.get(key, 0) + 1
+    assert samples_per_config == {"cheap": 2, "strong": 2}
+
+    # a certified winner exists and carries the resolved CVAR
+    assert result.best_config.get("variant") == "strong"
+    assert result.best_score is not None
+    assert wrapped.get_best_config() is not None

--- a/tests/unit/core/test_fail_closed_promotion.py
+++ b/tests/unit/core/test_fail_closed_promotion.py
@@ -38,6 +38,8 @@ def _trial(score: float = 0.9, config=None) -> TrialResult:
 
 def _orchestrator(policy: PromotionPolicy | None) -> OptimizationOrchestrator:
     orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+    orchestrator.knob_resolver = None
+    orchestrator._certified_promotions = 0
     orchestrator._strict_withheld_promotions = []
     orchestrator._promotion_gate = (
         None if policy is None else SimpleNamespace(policy=policy)
@@ -258,6 +260,7 @@ class TestCertifiedPromotionChain:
         """B2: a raw dict policy (discovered specs) must not silently read
         as non-strict."""
         orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = None
         orchestrator._promotion_gate = SimpleNamespace(
             policy={
                 "dominance": "epsilon_pareto",
@@ -268,6 +271,7 @@ class TestCertifiedPromotionChain:
 
     def test_unparseable_dict_policy_with_strict_keys_fails_closed(self):
         orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = None
         orchestrator._promotion_gate = SimpleNamespace(
             policy={
                 "require_calibration": {"enabled": "not-a-bool"},  # from_dict raises
@@ -277,6 +281,7 @@ class TestCertifiedPromotionChain:
 
     def test_plain_dict_policy_without_strict_keys_is_not_strict(self):
         orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = None
         orchestrator._promotion_gate = SimpleNamespace(
             policy={"dominance": "epsilon_pareto", "alpha": 0.05}
         )
@@ -480,3 +485,98 @@ class TestBestConfigRuntimeInterplay:
         assert fn.get_best_config() == {"model": "b"}
         exported = fn.export_best_config(tmp_path / "best-configs")
         assert exported.exists()
+
+
+class _GovernedResolverStub:
+    """Duck-typed resolver declaring a governed CVAR (consolidation seam)."""
+
+    def __init__(self, governed: bool = True):
+        self._governed = governed
+
+    def has_governed_cvars(self) -> bool:
+        return self._governed
+
+    def resolve(self, suggestion):  # pragma: no cover - not exercised here
+        raise AssertionError("resolution is not under test")
+
+
+class _OpaqueResolverStub:
+    """A custom resolver WITHOUT governance introspection."""
+
+    def resolve(self, suggestion):  # pragma: no cover - not exercised here
+        raise AssertionError("resolution is not under test")
+
+
+class TestPerCvarStrictDisjuncts:
+    """RFC 0001 §3.6 consolidation: declared-governed CVARs make the run
+    strict, gate-independently."""
+
+    def test_governed_resolver_is_strict_without_any_gate(self):
+        orchestrator = _orchestrator(None)
+        orchestrator.knob_resolver = _GovernedResolverStub(governed=True)
+        assert orchestrator._is_strict_evidence_mode()
+
+    def test_governed_resolver_is_strict_with_non_strict_policy(self):
+        orchestrator = _orchestrator(NON_STRICT_POLICY)
+        orchestrator.knob_resolver = _GovernedResolverStub(governed=True)
+        assert orchestrator._is_strict_evidence_mode()
+
+    def test_ungoverned_resolver_alone_is_not_strict(self):
+        orchestrator = _orchestrator(NON_STRICT_POLICY)
+        orchestrator.knob_resolver = _GovernedResolverStub(governed=False)
+        assert not orchestrator._is_strict_evidence_mode()
+
+    def test_opaque_custom_resolver_contributes_no_disjunct(self):
+        """Documented degradation: a duck-typed resolver without
+        has_governed_cvars cannot opt the run into strictness — declare via
+        the promotion policy instead."""
+        orchestrator = _orchestrator(NON_STRICT_POLICY)
+        orchestrator.knob_resolver = _OpaqueResolverStub()
+        assert not orchestrator._is_strict_evidence_mode()
+        strict = _orchestrator(STRICT_POLICIES["require_calibration"])
+        strict.knob_resolver = _OpaqueResolverStub()
+        assert strict._is_strict_evidence_mode()
+
+
+class TestNoGateStrictClosure:
+    """The no-gate lane must not promote under strict mode: a raw
+    _simple_is_better win would be counted as a certified promotion by
+    _update_best_trial_cache (fail open). Found during consolidation."""
+
+    def test_no_gate_strict_withholds_and_never_consults_simple(self):
+        orchestrator = _orchestrator(None)
+        orchestrator.knob_resolver = _GovernedResolverStub(governed=True)
+        orchestrator._simple_is_better = MagicMock(return_value=True)
+
+        assert orchestrator._evaluate_promotion("candidate", _trial(0.99)) is False
+        orchestrator._simple_is_better.assert_not_called()
+        assert any(
+            "no promotion gate" in reason
+            for reason in orchestrator._strict_withheld_promotions
+        )
+
+    def test_no_gate_strict_full_cache_flow_certifies_nothing(self):
+        orchestrator = _orchestrator(None)
+        orchestrator.knob_resolver = _GovernedResolverStub(governed=True)
+        orchestrator._best_trial_cached = None
+        orchestrator._incumbent_config_hash = None
+        orchestrator._simple_is_better = MagicMock(return_value=True)
+
+        first = _trial(0.5, config={"model": "a"})
+        second = _trial(0.99, config={"model": "b"})
+        orchestrator._update_best_trial_cache(first)
+        # first trial seeds the incumbent: initialization, not certification
+        assert orchestrator._best_trial_cached is first
+        assert orchestrator._certified_promotions == 0
+
+        orchestrator._update_best_trial_cache(second)
+        # the higher-scoring trial must NOT displace the incumbent rawly
+        assert orchestrator._best_trial_cached is first
+        assert orchestrator._certified_promotions == 0
+        orchestrator._simple_is_better.assert_not_called()
+
+    def test_no_gate_non_strict_keeps_legacy_simple_lane(self):
+        orchestrator = _orchestrator(None)
+        orchestrator._simple_is_better = MagicMock(return_value=True)
+        assert orchestrator._evaluate_promotion("candidate", _trial(0.9)) is True
+        orchestrator._simple_is_better.assert_called_once()

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -459,3 +459,59 @@ def test_unverifiable_optional_certificate_is_ignored_not_fallbacked():
     result = resolver.resolve({"model": "a"})
     assert result.config["theta"] == 0.5
     assert result.used_fallbacks == ()
+
+
+class TestGovernedIntrospection:
+    """RFC 0001 §3.6: has_governed_cvars feeds the orchestrator's
+    strict-evidence-mode detection from DECLARED bindings only."""
+
+    def test_governed_via_per_cvar_require_calibration(self):
+        assert KnobResolver(_space(governed=True)).has_governed_cvars()
+
+    def test_not_governed_when_nothing_declares_governance(self):
+        assert not KnobResolver(_space(governed=False)).has_governed_cvars()
+
+    def test_governed_via_certificate_backed_target(self):
+        space = ConfigSpace(
+            knobs={
+                "model": Knob(name="model", binding=Tuned(range=Choices(["a"]))),
+                "theta": Knob(
+                    name="theta",
+                    binding=Calibrated(
+                        signal=_signal(),
+                        target=TargetProperty(
+                            name="margin_floor", mode="certificate_backed"
+                        ),
+                    ),
+                ),
+            }
+        )
+        assert KnobResolver(space).has_governed_cvars()
+
+    def test_governed_via_declaration_pinned_certificate(self):
+        ctx = _ctx()
+        cert = issue_certificate("theta", "float", 0.5, ctx)
+        space = ConfigSpace(
+            knobs={
+                "model": Knob(name="model", binding=Tuned(range=Choices(["a"]))),
+                "theta": Knob(
+                    name="theta",
+                    binding=Calibrated(
+                        signal=_signal(), target=_target(), certificate=cert
+                    ),
+                ),
+            }
+        )
+        assert KnobResolver(space).has_governed_cvars()
+
+    def test_all_tuned_space_is_not_governed(self):
+        space = ConfigSpace(
+            knobs={"model": Knob(name="model", binding=Tuned(range=Choices(["a"])))}
+        )
+        assert not KnobResolver(space).has_governed_cvars()
+
+    def test_runtime_presented_certificate_does_not_opt_in(self):
+        """Presenting a certificate at resolution time is evidence, not an
+        opt-in to strictness — only DECLARED governance counts."""
+        resolver = _happy_resolver(_space(governed=False))
+        assert not resolver.has_governed_cvars()

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1594,6 +1594,14 @@ class OptimizedFunction:
         )
 
         orchestrator.samples_include_pruned = samples_include_pruned_value
+        # RFC 0001 §3.4: forward the user-attached knob resolver so the
+        # public optimize() path resolves Fixed/CVAR bindings in-trial.
+        # Attribute seam (like promotion_gate): set
+        # ``wrapped.knob_resolver = KnobResolver(...)`` before optimizing;
+        # absent ⇒ byte-identical legacy behavior.
+        knob_resolver = getattr(self, "knob_resolver", None)
+        if knob_resolver is not None:
+            orchestrator.knob_resolver = knob_resolver
         return orchestrator
 
     async def _run_and_finalize_optimization(
@@ -1900,7 +1908,14 @@ class OptimizedFunction:
         except OptimizationError:
             raise
         except Exception as e:
+            from traigent.knobs import ResolutionError
+
             logger.error(f"Optimization failed: {e}")
+            if isinstance(e, ResolutionError):
+                # RFC 0001 §3.4: the typed fail-closed governance rejection
+                # IS the public contract — never dilute it into a generic
+                # OptimizationError.
+                raise
             raise OptimizationError(f"Optimization failed: {e}") from e
         finally:
             self._restore_hybrid_discovery_state(hybrid_discovery_state, evaluator)

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -783,14 +783,25 @@ class OptimizationOrchestrator:
         )
 
     def _is_strict_evidence_mode(self) -> bool:
-        """RFC 0001 §3.6 strict(M): the declared strict evidence modes.
+        """RFC 0001 §3.6 strict(M, c): the declared strict evidence modes.
 
-        Detected from the promotion policy today: require_calibration enabled
-        or chance constraints present. The per-CVAR disjuncts (consumed
-        governed CVARs / certificate-backed targets via the knob resolver)
-        join this predicate when the knobs branches consolidate — tracked in
-        FR-SDK-FAIL-CLOSED-PROMOTION-V1's artifact trail.
+        Disjuncts: promotion_policy.require_calibration ∨ chance_constraints
+        ∨ a declared-governed CVAR in the resolved space (per-CVAR
+        require_calibration, declaration-pinned certificate, or a
+        certificate-backed / guaranteed-selection target). The per-CVAR
+        disjuncts are GATE-INDEPENDENT: declaring a governed CVAR demands
+        certificate-backed promotion evidence even when no promotion policy
+        was configured. Governance is read from the resolver's DECLARED
+        bindings (``has_governed_cvars``) — never inferred from runtime
+        evidence; a duck-typed custom resolver without that method
+        contributes no per-CVAR disjunct (declare strictness via the
+        promotion policy in that case).
         """
+        resolver = getattr(self, "knob_resolver", None)
+        if resolver is not None:
+            has_governed = getattr(resolver, "has_governed_cvars", None)
+            if callable(has_governed) and has_governed():
+                return True
         gate = self._promotion_gate
         if gate is None:
             return False
@@ -872,6 +883,16 @@ class OptimizationOrchestrator:
         """
         # If no promotion gate or no incumbent, use simple logic
         if self._promotion_gate is None:
+            if self._is_strict_evidence_mode():
+                # RFC 0001 §3.6: a declared-governed CVAR demands
+                # certificate-backed promotion evidence; with no promotion
+                # gate there is no certification machinery, so the raw
+                # comparison MUST NOT promote (it would otherwise be counted
+                # as a certified promotion by _update_best_trial_cache and
+                # launder an uncertified winner — fail open).
+                return self._withhold_promotion(
+                    "no promotion gate in strict evidence mode"
+                )
             return self._simple_is_better(candidate_trial)
         if self._incumbent_config_hash is None:
             return True
@@ -966,8 +987,10 @@ class OptimizationOrchestrator:
         if self._evaluate_promotion(config_hash, trial_result):
             if self._is_strict_evidence_mode():
                 # In strict mode a True here can only come from the gate's
-                # explicit "promote" (all other lanes withhold) — count it:
-                # only gate-certified promotions justify a certified winner.
+                # explicit "promote": the no-gate lane, the no-decision /
+                # insufficient-samples / exception lanes all withhold — so
+                # counting it is sound: only gate-certified promotions
+                # justify a certified winner.
                 self._certified_promotions += 1
             self._best_trial_cached = trial_result
             self._incumbent_config_hash = config_hash
@@ -2385,8 +2408,16 @@ class OptimizationOrchestrator:
             self._status = OptimizationStatus.FAILED
             raise
         except Exception as e:
+            from traigent.knobs import ResolutionError
+
             self._status = OptimizationStatus.FAILED
             logger.error(f"Optimization {self._optimization_id} failed: {e}")
+            if isinstance(e, ResolutionError):
+                # RFC 0001 §3.4: the typed fail-closed governance rejection
+                # IS the public contract — callers distinguish a stale
+                # certificate / evidence leak from a generic optimization
+                # failure. Never dilute it into OptimizationError.
+                raise
             raise OptimizationError(f"Optimization failed: {e}") from e
         finally:
             await self._cleanup_backend_client()

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -21,7 +21,7 @@ Testing, arXiv:2210.07913).
 from __future__ import annotations
 
 from .adapters import knob_to_parameter_range, parameter_range_to_knob
-from .bindings import Binding, Calibrated, Fixed, Knob, Ref, Tuned
+from .bindings import Binding, Calibrated, Fixed, Knob, Ref, Tuned, is_governed
 from .canonical import CTX_SCHEMA_VERSION, CanonicalizationError, canonical_hash
 from .cascade import (
     CascadePolicy,
@@ -64,6 +64,7 @@ __all__ = [
     "Gate",
     "GateKind",
     "Knob",
+    "is_governed",
     "KnobKind",
     "KnobResolver",
     "Ref",

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -18,7 +18,7 @@ a knob effectuates, not how it binds).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from traigent.api.parameter_ranges import ParameterRange
 
@@ -26,7 +26,7 @@ from .certificates import Certificate, TargetProperty
 from .kinds import KnobKind
 from .signals import SignalSpec
 
-__all__ = ["Binding", "Calibrated", "Fixed", "Knob", "Ref", "Tuned"]
+__all__ = ["Binding", "Calibrated", "Fixed", "Knob", "Ref", "Tuned", "is_governed"]
 
 TValue = TypeVar("TValue")
 
@@ -83,6 +83,25 @@ class Calibrated(Generic[TValue]):
     certificate: Certificate | None = None
     require_calibration: bool = False
     target_epsilon: float | None = None  # chance-style level for the R8 floor
+
+
+def is_governed(binding: Calibrated[Any]) -> bool:
+    """RFC 0001 §3.6: is this Calibrated binding under DECLARED governance?
+
+    Governance is declared on the binding/target — per-CVAR
+    ``require_calibration``, a declaration-pinned certificate, or a
+    certificate-backed / guaranteed-selection target property. It is never
+    inferred from runtime-presented evidence (presenting a certificate at
+    resolution time is evidence, not an opt-in to strictness).
+
+    Shared by the resolver's per-CVAR resolution rules and the orchestrator's
+    strict-evidence-mode detection so the two can never drift.
+    """
+    return (
+        binding.require_calibration
+        or binding.certificate is not None
+        or binding.target.mode in ("certificate_backed", "guaranteed_selection")
+    )
 
 
 #: The binding union — isinstance-discriminated.

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -19,11 +19,12 @@ non-governed CVARs and are always recorded in the result — never silent.
 
 from __future__ import annotations
 
+import dataclasses
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from .bindings import Calibrated, Fixed, Tuned
+from .bindings import Calibrated, Fixed, Tuned, is_governed
 from .certificates import Certificate, FreshnessContext, conformal_evidence_floor
 from .resolution import ResolutionError, ResolutionRejection
 from .signals import SignalObservation
@@ -98,6 +99,23 @@ class KnobResolver:
         self._runtime_fixed = dict(runtime_fixed or {})
         self._eval_split = eval_split
         self._eval_item_ids = eval_item_ids
+
+    # ------------------------------------------------------------------
+    def has_governed_cvars(self) -> bool:
+        """RFC 0001 §3.6: does the space declare any governed CVAR?
+
+        The strict-mode disjuncts quantify over CVARs *consumed by c*; every
+        accepted configuration contains every declared CVAR (R4 rejects
+        unproducible declarations outright), so declared-governed ⇔
+        consumed-governed for any configuration this resolver accepts. The
+        orchestrator consults this to enter strict evidence mode — custom
+        resolvers that hide declarations should expose the same method.
+        """
+        knobs = dict(self._space.knobs or {})
+        return any(
+            isinstance(k.binding, Calibrated) and is_governed(k.binding)
+            for k in knobs.values()
+        )
 
     # ------------------------------------------------------------------
     def resolve(self, suggestion: Mapping[str, Any]) -> ResolvedConfiguration:
@@ -180,6 +198,7 @@ class KnobResolver:
                 name,
                 binding,
                 self._calibrated_inputs[name],
+                suggestion,
                 values,
                 used_fallbacks,
                 reject,
@@ -202,18 +221,35 @@ class KnobResolver:
         name: str,
         binding: Calibrated,
         provided: CalibratedInput,
+        suggestion: Mapping[str, Any],
         values: dict[str, Any],
         used_fallbacks: list[str],
         reject: Any,
     ) -> None:
         # Governance is DECLARED (on the binding/target), never inferred
-        # from runtime-presented evidence — presenting a certificate is
-        # evidence, not an opt-in to strictness.
-        governed = (
-            binding.require_calibration
-            or binding.certificate is not None
-            or binding.target.mode in ("certificate_backed", "guaranteed_selection")
-        )
+        # from runtime-presented evidence — the shared predicate keeps this
+        # in lockstep with the orchestrator's strict-mode detection.
+        governed = is_governed(binding)
+
+        # ctx_now derivation (RFC 0001 §3.5): certificates are PARENT-SPECIFIC
+        # — tuned_parent_values must reflect the LIVE suggestion, not whatever
+        # the caller's static context said. Without this rebuild a certificate
+        # issued for one parent value would read fresh for every other value
+        # the optimizer explores (found by the consolidation e2e smoke).
+        # Skipped when a declared parent is absent from the suggestion: that
+        # is already an R2/R4 rejection and the run cannot accept.
+        live_context = provided.context
+        if (
+            live_context is not None
+            and binding.depends_on
+            and all(ref.knob in suggestion for ref in binding.depends_on)
+        ):
+            live_context = dataclasses.replace(
+                live_context,
+                tuned_parent_values=tuple(
+                    (ref.knob, suggestion[ref.knob]) for ref in binding.depends_on
+                ),
+            )
 
         # R7 evidence leakage — split tag or true item intersection
         for observation in provided.observations:
@@ -277,14 +313,14 @@ class KnobResolver:
         # R6 certificate validity for governed CVARs
         if governed:
             certificate = provided.certificate or binding.certificate
-            if certificate is None or provided.context is None:
+            if certificate is None or live_context is None:
                 reject(
                     ResolutionRejection.STALE_CERTIFICATE,
                     f"governed CVAR {name!r} lacks a certificate/context",
                 )
                 return
             if not certificate.valid_for(
-                name, binding.value_type, provided.value, provided.context
+                name, binding.value_type, provided.value, live_context
             ):
                 reject(
                     ResolutionRejection.STALE_CERTIFICATE,
@@ -295,9 +331,9 @@ class KnobResolver:
         elif (
             binding.fallback is not None
             and provided.certificate is not None
-            and provided.context is not None
+            and live_context is not None
             and not provided.certificate.valid_for(
-                name, binding.value_type, provided.value, provided.context
+                name, binding.value_type, provided.value, live_context
             )
         ):
             # non-governed CVAR whose optional certificate is PROVEN stale


### PR DESCRIPTION
## This PR is the program's release gate

**Merge ONLY after the train** ([#1097](https://github.com/Traigent/Traigent/pull/1097) → #1098 → #1099, #1102 → #1103, #1100, #1101). Branch = merged-stacks base (all six branches) + the consolidation work the external review demanded as a gate ("the merge gate should be TVL + SDK + JS + spine all green, plus consolidation tests for CVAR strict mode").

## What consolidation surfaced (3 real gaps closed)

1. **No-gate fail-open**: `_evaluate_promotion`'s no-gate lane went straight to `_simple_is_better` — with the new gate-independent per-CVAR strict disjunct, `_update_best_trial_cache` would have counted that raw win as a CERTIFIED promotion. Now withholds under strict mode (spy-verified).
2. **Parent-specific staleness couldn't fire in-trial**: the resolver validated certificates against the caller's STATIC freshness context — `tuned_parent_values` was never rebuilt from the live suggestion, so a certificate issued for one parent value read fresh for every other value the optimizer explored. `ctx_now` is now derived per-suggestion from the declared `depends_on` refs (RFC 0001 §3.5).
3. **Typed-error dilution**: both outer wrappers re-wrapped `ResolutionError` into generic `OptimizationError`; the typed fail-closed rejection now passes through as the public contract.

## Release-gate obligations implemented

- **Per-CVAR strict disjuncts** (RFC 0001 §3.6): `_is_strict_evidence_mode` consults `KnobResolver.has_governed_cvars()` (shared `is_governed` predicate — resolver and orchestrator can never drift). Gate-independent; duck-typed custom resolvers without the method contribute no disjunct (documented; declare via policy).
- **Public e2e smoke** (`tests/integration/test_knobs_strict_e2e.py`): decorator + `wrapped.optimize()`, 1 TVAR + 1 CVAR + require_calibration —
  - fresh cert ⇒ the evaluated FUNCTION records seeing the resolved CVAR on every call; optimizer space stays Tuned-only (P2); strict 1-sample run honestly ends no-winner;
  - stale cert (parent-specific) ⇒ run aborts with typed `ResolutionError(STALE_CERTIFICATE)`, no winner applied;
  - certified ⇒ a schedule optimizer (public plugin seam) accumulates real evidence; the gate certifies the winner.
- **Public wiring**: `OptimizedFunction` forwards the user-attached `knob_resolver` attribute (same seam as `promotion_gate`) — the public path is real, not stub-anchored.

## Tests
13 new unit (governed introspection + strict/no-gate spies) + 3 e2e; knobs/tvl/core **2448 passed**; api suite delta-clean vs the develop baseline (stash-run verified: same pre-existing 4 failures + 2 import errors).

## Out of scope (recorded)
Router adapter (routing branch unmerged; equivalence battery pre-pins it). Pre-existing parameter-injection-mode bug found during the e2e (per-trial configs never reach `injection_mode="parameter"` functions — issue filed separately).

Governance: ChangeSession `cs_607ce2f4f8833804` · FR-SDK-KNOBS-CVARS-V1 / FR-SDK-FAIL-CLOSED-PROMOTION-V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)