### PR TITLE
fix(examples): make every examples/tvl spec pass the strict validator

### DIFF
--- a/examples/tvl/banded_objectives/banded.tvl.yml
+++ b/examples/tvl/banded_objectives/banded.tvl.yml
@@ -1,9 +1,9 @@
 # TVL 0.9 Example: Banded Objectives
 # Demonstrates banded objectives with TOST testing
 
-spec:
-  id: banded-objectives-example
-  version: 0.1.0
+tvl:
+  module: examples.banded_objectives_example
+tvl_version: "0.1.0"
 
 metadata:
   owner: "team@example.com"

--- a/examples/tvl/constraints_units/constraints.tvl.yml
+++ b/examples/tvl/constraints_units/constraints.tvl.yml
@@ -1,18 +1,20 @@
 # TVL 0.9 Example: Constraints and Units
 # Demonstrates structural constraints with units
 
-spec:
-  id: constraints-units-example
-  version: 0.1.0
+tvl:
+  module: examples.constraints_units_example
+tvl_version: "0.1.0"
 
 metadata:
   owner: "team@example.com"
   description: "Example demonstrating constraints and units"
+  # Unit declarations are documentational; validators read tvar/objective
+  # fields, not this registry.
+  units:
+    time: [milliseconds, seconds]
+    currency: [USD]
+    ratio: [dimensionless]
 
-units:
-  time: [milliseconds, seconds]
-  currency: [USD]
-  ratio: [dimensionless]
 
 # TVL 0.9 typed variables
 tvars:

--- a/examples/tvl/environment_overlays/overlays.tvl.yml
+++ b/examples/tvl/environment_overlays/overlays.tvl.yml
@@ -1,9 +1,9 @@
 # TVL Legacy Format Example: Environment Overlays
 # Uses legacy format to test deprecation warnings
 
-spec:
-  id: environment-overlays-example
-  version: 0.0.1
+tvl:
+  module: examples.environment_overlays_example
+tvl_version: "0.0.1"
 
 metadata:
   owner: "team@example.com"
@@ -35,12 +35,13 @@ optimization:
       value: 30
     timeout_seconds: 900
 
-# Legacy constraints format (should emit deprecation warning)
+# Structural constraint (TVL 0.9 form; the pre-0.9 'type: expression'
+# legacy shape is no longer schema-valid)
 constraints:
-  - id: temperature-limit
-    type: expression
-    rule: 'params.temperature <= 0.8'
-    error_message: "Keep temperature reasonable"
+  structural:
+    - id: temperature-limit
+      expr: 'params.temperature <= 0.8'
+      error_message: "Keep temperature reasonable"
 
 environments:
   base:

--- a/examples/tvl/hello_tvl/hello_tvl.tvl.yml
+++ b/examples/tvl/hello_tvl/hello_tvl.tvl.yml
@@ -1,12 +1,17 @@
 # TVL 0.9 Example: Hello TVL
 # A minimal example demonstrating basic TVL structure
 
-spec:
-  id: hello-tvl
-  version: 0.0.1
+tvl:
+  module: examples.hello_tvl
+tvl_version: "0.0.1"
 
 metadata:
   owner: "team@example.com"
+  # Legacy operational promotion hints (pre-0.9 'promotion:' block); the
+  # statistical gate lives in promotion_policy.
+  legacy_promotion:
+    gate: manual_review
+    reviewers: ["reviewer@example.com"]
   description: "Minimal TVL spec demonstrating basic structure"
 
 # TVL 0.9 typed variables
@@ -31,7 +36,3 @@ constraints:
     - expr: 'params.temperature <= 1.0'
       id: max-temperature
       error_message: "Temperature must be at most 1.0"
-
-promotion:
-  gate: manual_review
-  reviewers: ["reviewer@example.com"]

--- a/examples/tvl/hello_tvl/index.html
+++ b/examples/tvl/hello_tvl/index.html
@@ -71,9 +71,9 @@
         <section class="content-section">
             <h2>TVL Spec Structure</h2>
             <div class="code-block">
-                <code>spec:
-  id: hello-tvl
-  version: 0.0.1
+                <code>tvl:
+  module: examples.hello_tvl
+tvl_version: "0.0.1"
 
 metadata:
   owner: "team@example.com"

--- a/examples/tvl/promotion_policy/promotion.tvl.yml
+++ b/examples/tvl/promotion_policy/promotion.tvl.yml
@@ -1,9 +1,9 @@
 # TVL 0.9 Example: Promotion Policy
 # Demonstrates statistical promotion with multiple objectives
 
-spec:
-  id: promotion-policy-example
-  version: 0.1.0
+tvl:
+  module: examples.promotion_policy_example
+tvl_version: "0.1.0"
 
 metadata:
   owner: "team@example.com"

--- a/examples/tvl/tutorials/01_getting_started/chatbot_optimization.tvl.yml
+++ b/examples/tvl/tutorials/01_getting_started/chatbot_optimization.tvl.yml
@@ -9,9 +9,9 @@
 #
 # Run with: traigent optimize --spec chatbot_optimization.tvl.yml
 
-spec:
-  id: chatbot-quickstart
-  version: "1.0"
+tvl:
+  module: examples.chatbot_quickstart
+tvl_version: "1.0"
 
 metadata:
   owner: team@example.com

--- a/examples/tvl/tutorials/02_typed_tvars/advanced_tvars.tvl.yml
+++ b/examples/tvl/tutorials/02_typed_tvars/advanced_tvars.tvl.yml
@@ -9,9 +9,9 @@
 #
 # This is a RAG (Retrieval-Augmented Generation) optimization example.
 
-spec:
-  id: rag-advanced-tvars
-  version: "1.0"
+tvl:
+  module: examples.rag_advanced_tvars
+tvl_version: "1.0"
 
 metadata:
   owner: team@example.com

--- a/examples/tvl/tutorials/03_multi_objective/multi_objective_rag.tvl.yml
+++ b/examples/tvl/tutorials/03_multi_objective/multi_objective_rag.tvl.yml
@@ -10,9 +10,9 @@
 # - Epsilon-Pareto dominance
 # - Constraint handling
 
-spec:
-  id: multi-objective-rag
-  version: "1.0"
+tvl:
+  module: examples.multi_objective_rag
+tvl_version: "1.0"
 
 metadata:
   owner: team@example.com

--- a/examples/tvl/tutorials/04_promotion_policy/safety_critical.tvl.yml
+++ b/examples/tvl/tutorials/04_promotion_policy/safety_critical.tvl.yml
@@ -8,9 +8,9 @@
 # - Benjamini-Hochberg correction: Control false discovery rate
 # - Tie-breakers: Resolve equivalent candidates
 
-spec:
-  id: safety-critical-llm
-  version: "1.0"
+tvl:
+  module: examples.safety_critical_llm
+tvl_version: "1.0"
 
 metadata:
   owner: team@example.com

--- a/examples/tvl/tutorials/05_statistical_testing/banded_objectives.tvl.yml
+++ b/examples/tvl/tutorials/05_statistical_testing/banded_objectives.tvl.yml
@@ -10,9 +10,9 @@
 # TVL 0.9 supports banded objectives with TOST (Two One-Sided Tests)
 # for statistical equivalence testing.
 
-spec:
-  id: banded-objectives-demo
-  version: "1.0"
+tvl:
+  module: examples.banded_objectives_demo
+tvl_version: "1.0"
 
 metadata:
   owner: team@example.com

--- a/examples/tvl/tutorials/05_statistical_testing/banded_tost_complete.tvl.yml
+++ b/examples/tvl/tutorials/05_statistical_testing/banded_tost_complete.tvl.yml
@@ -1,9 +1,9 @@
 # TVL 0.9 Example: Complete Banded TOST
 # Full example of banded objectives with TOST equivalence testing
 
-spec:
-  id: banded-tost-complete
-  version: 0.1.0
+tvl:
+  module: examples.banded_tost_complete
+tvl_version: "0.1.0"
 
 metadata:
   owner: "team@example.com"

--- a/examples/tvl/tutorials/README.md
+++ b/examples/tvl/tutorials/README.md
@@ -85,9 +85,9 @@ python tost_demo.py
 ### TVL 0.9 Spec Structure
 
 ```yaml
-spec:
-  id: my-optimization
-  version: "1.0"
+tvl:
+  module: examples.my_optimization
+tvl_version: "1.0"
 
 metadata:
   owner: team@company.com

--- a/tests/unit/tvl/test_spec_loader.py
+++ b/tests/unit/tvl/test_spec_loader.py
@@ -180,10 +180,34 @@ def test_constraint_expression_allows_math_function_calls() -> None:
     assert evaluator({"value": 16.0}, None) is True
 
 
-def test_legacy_formats_emit_deprecation_warnings() -> None:
+def test_legacy_formats_emit_deprecation_warnings(tmp_path) -> None:
     """Legacy TVL formats emit DeprecationWarnings during spec loading."""
-    # Use the environment_overlays example which is intentionally legacy format
-    legacy_spec = Path("examples/tvl/environment_overlays/overlays.tvl.yml")
+    # Inline legacy fixture: doc examples are kept strict-valid, so the
+    # deprecated constructs live here, owned by the test.
+    legacy_spec = tmp_path / "legacy.tvl.yml"
+    legacy_spec.write_text(
+        """
+configuration_space:
+  model:
+    type: categorical
+    values: ["gpt-4o-mini", "gpt-4o"]
+  temperature:
+    type: continuous
+    range: [0.0, 1.0]
+
+constraints:
+  - id: temperature-limit
+    type: expression
+    rule: 'params.temperature <= 0.8'
+    error_message: "Keep temperature reasonable"
+
+optimization:
+  objectives:
+    - name: accuracy
+      direction: maximize
+""",
+        encoding="utf-8",
+    )
     with pytest.warns(DeprecationWarning) as record:
         load_tvl_spec(spec_path=legacy_spec)
 


### PR DESCRIPTION
Closes #1107.

The `validate-tvl-specs` hook env was broken since inception (fixed in #1101), masking **11 of 14** `examples/tvl/` specs failing `python -m traigent.tvl --strict`:

- legacy `spec: {id, version}` headers → `tvl: {module}` + `tvl_version` (ids underscored, `examples.*` prefix; comments preserved via textual conversion)
- hello_tvl's pre-0.9 `promotion:` block → `metadata.legacy_promotion` (same mapping the JS loader applies)
- constraints_units' `units:` registry → `metadata.units` (documentational)
- environment_overlays' pre-0.9 constraint shape (`type: expression`) → the 0.9 structural form; the file keeps its deliberately-deprecated `configuration_space`/`optimization` sections (loadable, warning-emitting — its stated purpose)
- `test_legacy_formats_emit_deprecation_warnings` now owns an **inline** legacy fixture instead of depending on the doc example

**Proof**: `--strict` over all 14 examples exits 0 (was failing 11); `tests/unit/tvl` 409 passed. (Committed with `SKIP=validate-tvl-specs` — this branch is off develop where the hook env is still broken until #1101 merges; the real check passes in the project venv.)

Found during the TVL-first knobs/CVARs gap-closure pass; external-review recommendation R4 ('fix before publishing examples as canonical').

🤖 Generated with [Claude Code](https://claude.com/claude-code)