### PR TITLE
fix(injection): parameter mode delivers per-trial configs, not the wrap-time default

### DIFF
--- a/tests/integration/test_parameter_injection_per_trial.py
+++ b/tests/integration/test_parameter_injection_per_trial.py
@@ -1,0 +1,92 @@
+"""Regression for #1109: injection_mode="parameter" must deliver PER-TRIAL
+configs, not the wrap-time default.
+
+Before the fix, ParameterBasedProvider captured ``TraigentConfig.from_dict``
+once at wrap time and injected that frozen object on every call — every
+trial of a parameter-mode optimization evaluated the DEFAULT configuration
+while the recorded ``trial.config`` showed the suggested values, silently
+making the results meaningless. The pre-existing integration tests only
+asserted ``len(result.trials) > 0`` and passed regardless.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import traigent
+from traigent.config.types import TraigentConfig
+from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+def _dataset(size: int = 2) -> Dataset:
+    return Dataset(
+        [EvaluationExample({"text": f"q{i}"}, "fast") for i in range(size)],
+        name="param_injection_regression",
+    )
+
+
+def _make_wrapped():
+    function_saw: list[dict] = []
+
+    @traigent.optimize(
+        eval_dataset=_dataset(),
+        objectives=["accuracy"],
+        configuration_space={"variant": ["slow", "fast"]},
+        default_config={"variant": "slow"},
+        injection_mode="parameter",
+    )
+    def answer(text: str, config: TraigentConfig) -> str:
+        function_saw.append(dict(config.custom_params))
+        return str(config.custom_params.get("variant"))
+
+    return answer, function_saw
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("cost_preflight_approved")
+async def test_parameter_mode_delivers_per_trial_configs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # isolate .traigent/ storage per test
+    wrapped, function_saw = _make_wrapped()
+
+    result = await wrapped.optimize(algorithm="grid", max_trials=3)
+
+    # every recorded trial config value must have been SEEN by the function
+    recorded = {trial.config.get("variant") for trial in result.trials}
+    seen = {call.get("variant") for call in function_saw}
+    assert recorded == {"slow", "fast"}
+    assert seen == {"slow", "fast"}, (
+        f"function saw only {seen} — wrap-time default injected (#1109)"
+    )
+
+    # and the metrics must reflect what the function actually evaluated:
+    # variant=fast answers 'fast' (accuracy 1.0), variant=slow answers 'slow'
+    by_variant = {
+        trial.config.get("variant"): trial.metrics.get("accuracy")
+        for trial in result.trials
+    }
+    assert by_variant.get("fast") == 1.0, by_variant
+    assert by_variant.get("slow") == 0.0, by_variant
+
+
+def test_direct_call_outside_optimization_keeps_wrap_time_default(
+    tmp_path, monkeypatch
+):
+    """Preserved behavior: calling the wrapped function directly (no active
+    configuration context) injects the wrap-time default config."""
+    monkeypatch.chdir(tmp_path)  # isolate .traigent/ storage per test
+    wrapped, function_saw = _make_wrapped()
+
+    out = wrapped("hello")
+
+    assert out == "slow"
+    assert function_saw[-1].get("variant") == "slow"
+
+
+def test_explicit_config_kwarg_still_wins(tmp_path, monkeypatch):
+    """Preserved behavior: a caller-supplied config param is never overridden."""
+    monkeypatch.chdir(tmp_path)  # isolate .traigent/ storage per test
+    wrapped, function_saw = _make_wrapped()
+
+    out = wrapped("hello", config=TraigentConfig.from_dict({"variant": "fast"}))
+
+    assert out == "fast"

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -19,7 +19,12 @@ from threading import Lock
 from typing import Any
 
 from traigent.config.ast_transformer import ConfigTransformer, SafeASTCompiler
-from traigent.config.context import ConfigurationContext, get_config, merge_with_context
+from traigent.config.context import (
+    ConfigurationContext,
+    applied_config_context,
+    get_config,
+    merge_with_context,
+)
 from traigent.config.runtime_injector import create_runtime_shim
 from traigent.config.types import TraigentConfig
 from traigent.utils.exceptions import ConfigurationError
@@ -271,12 +276,40 @@ class ParameterBasedProvider(ConfigurationProvider):
         # Create TraigentConfig from dict if needed
         config_obj = TraigentConfig.from_dict(config)
 
+        def _effective_config() -> TraigentConfig:
+            """Prefer an APPLIED configuration over the wrap-time snapshot.
+
+            During optimization the evaluator wraps every trial call in
+            ``ConfigurationContext(<per-trial config>)``; injecting the
+            wrap-time ``config_obj`` here would hand the function the SAME
+            default configuration on every trial — silently making
+            parameter-mode optimization results meaningless (#1109).
+
+            The discriminator is ``applied_config_context``: only a real
+            ``ConfigurationContext`` application sets it (the evaluator's
+            per-trial wrap, or an explicit user ``with ConfigurationContext``)
+            — a bare global ``set_config()`` does not, so direct calls keep
+            the wrap-time default.
+            """
+            try:
+                active = applied_config_context.get()
+            except LookupError:
+                active = None
+            if active is None:
+                return config_obj
+            if isinstance(active, TraigentConfig):
+                return active
+            if isinstance(active, dict):
+                return TraigentConfig.from_dict(active)
+            return config_obj
+
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            effective = _effective_config()
             # Only inject configuration if not already provided
             if param_name not in kwargs:
-                kwargs[param_name] = config_obj
-            with ConfigurationContext(config_obj):
+                kwargs[param_name] = effective
+            with ConfigurationContext(effective):
                 return func(*args, **kwargs)
 
         # For async functions
@@ -284,10 +317,11 @@ class ParameterBasedProvider(ConfigurationProvider):
 
             @wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                effective = _effective_config()
                 # Only inject configuration if not already provided
                 if param_name not in kwargs:
-                    kwargs[param_name] = config_obj
-                with ConfigurationContext(config_obj):
+                    kwargs[param_name] = effective
+                with ConfigurationContext(effective):
                     return await func(*args, **kwargs)
 
             return async_wrapper


### PR DESCRIPTION
Closes #1109 — flagged **release-blocking for any demo/customer path using `injection_mode="parameter"`** by the external program review.

## The bug
`ParameterBasedProvider` captured `TraigentConfig.from_dict(config)` **once at wrap time** and injected that frozen object on every call. Every trial of a parameter-mode optimization evaluated the DEFAULT configuration while `trial.config` recorded the suggested values — results were silently meaningless for this mode. Masked by integration tests that only asserted trial counts.

## The fix
The wrappers prefer the **applied** configuration context — set only by a real `ConfigurationContext` application (the evaluator's per-trial wrap, or an explicit user `with ConfigurationContext`) — over the wrap-time snapshot. A bare global `set_config()` does NOT set the applied var, so:
- per-trial configs reach the function during optimization ✅
- direct calls outside optimization keep the wrap-time default (test-pinned) ✅
- an explicit `config` kwarg still wins (test-pinned) ✅

## Proof
The regression test is red on the unfixed baseline (stash-run verified: the function saw only the default) and green with the fix — per-trial values are function-visible AND per-variant accuracy reflects what actually executed. Set-diff vs baseline across config/core/api/integration suites: **zero new failures**.

Found by the knobs/CVARs consolidation e2e (the function-visibility assertions exposed it); orthogonal to that program — plain tvars affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)