### PR TITLE
feat(knobs): deterministic fail-closed resolver + in-trial injection (RFC 0001 §3.4)

### DIFF
--- a/tests/unit/core/test_trial_lifecycle.py
+++ b/tests/unit/core/test_trial_lifecycle.py
@@ -65,6 +65,7 @@ class MockOrchestrator:
     def __init__(self):
         self.optimizer = MockOptimizer()
         self.evaluator = MockEvaluator()
+        self.knob_resolver = None
         self._optimization_id = "test-optimization-123"
         self._sample_budget_manager = None
         self._consumed_examples = 0
@@ -82,6 +83,14 @@ class MockOrchestrator:
         self._default_config_used = False
         self.objective_schema = None  # For band-based pruning support
 
+
+    def _apply_knob_resolution(self, config):
+        """Mirror of OptimizationOrchestrator._apply_knob_resolution (RFC 0001):
+        passthrough when no resolver is configured."""
+        if self.knob_resolver is None:
+            return config
+        resolved = self.knob_resolver.resolve(config)
+        return dict(resolved.config)
     def _consume_default_config(self):
         return None
 

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -283,14 +283,16 @@ class TestRejections:
 
 
 class TestFallbacks:
-    def test_non_governed_no_decision_uses_fallback_recorded(self):
+    def test_bottom_never_falls_back_even_non_governed(self):
+        """Review fix (B1): Accept requires calibrator != ⊥ with NO fallback
+        carve-out — abstention is no_decision regardless of governance."""
         space = _space(governed=False, fallback=Fixed(value=0.42))
         resolver = KnobResolver(
             space, calibrated_inputs={"theta": CalibratedInput(value=None)}
         )
-        result = resolver.resolve({"model": "a"})
-        assert result.config["theta"] == 0.42
-        assert result.used_fallbacks == ("theta",)  # observable, never silent
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.NO_DECISION in excinfo.value.rejections
 
     def test_governed_no_decision_never_falls_back(self):
         space = _space(governed=True, fallback=Fixed(value=0.42))
@@ -299,6 +301,23 @@ class TestFallbacks:
         )
         with pytest.raises(ResolutionError):
             resolver.resolve({"model": "a"})
+
+    def test_stale_certificate_fallback_for_non_governed_recorded(self):
+        """The §3.5 carve-out: a NON-governed CVAR whose optional certificate
+        went stale MAY use its declared fallback — always recorded."""
+        space = _space(governed=False, fallback=Fixed(value=0.42))
+        ctx_a = _ctx(parents=(("model", "a"),))
+        cert = issue_certificate("theta", "float", 0.5, ctx_a)
+        ctx_b = dataclasses.replace(ctx_a, tuned_parent_values=(("model", "b"),))
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx_b)
+            },
+        )
+        result = resolver.resolve({"model": "b"})
+        assert result.config["theta"] == 0.42
+        assert result.used_fallbacks == ("theta",)  # observable, never silent
 
 
 class TestDeterminism:
@@ -351,3 +370,74 @@ class TestOrchestratorInjection:
         orchestrator.knob_resolver = KnobResolver(_space())  # unproduced CVAR
         with pytest.raises(ResolutionError):
             orchestrator._apply_knob_resolution({"model": "a"})
+
+
+class TestReviewRoundTwoCoverage:
+    def test_r8_epsilon_without_context_fails_closed(self):
+        """Review fix (B2): a declared epsilon with NO context is
+        unverifiable evidence — R8, not silent acceptance."""
+        space = _space(governed=False, epsilon=0.1)
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=0.5)}
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.INSUFFICIENT_EVIDENCE in excinfo.value.rejections
+
+    def test_r1_cycle_via_deferred_cvar_parents(self):
+        """R1 machinery (forward-compat): two CVARs referencing each other
+        produce CYCLE alongside the v1 MISSING_REF kind errors."""
+        space = ConfigSpace(
+            knobs={
+                "c1": Knob(
+                    name="c1",
+                    binding=Calibrated(
+                        signal=_signal(), target=_target(),
+                        depends_on=(Ref(knob="c2"),),
+                    ),
+                ),
+                "c2": Knob(
+                    name="c2",
+                    binding=Calibrated(
+                        signal=_signal(), target=_target(),
+                        depends_on=(Ref(knob="c1"),),
+                    ),
+                ),
+            }
+        )
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "c1": CalibratedInput(value=0.1),
+                "c2": CalibratedInput(value=0.2),
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({})
+        assert ResolutionRejection.CYCLE in excinfo.value.rejections
+        assert ResolutionRejection.MISSING_REF in excinfo.value.rejections
+
+    def test_internal_resolver_errors_surface_typed_not_swallowed(self):
+        """Review fix (B5): internal ValueErrors wrap into ResolutionError so
+        the suggest-site except tuples can never silently break."""
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        class ExplodingResolver:
+            def resolve(self, suggestion):
+                raise ValueError("internal canonicalization failure")
+
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = ExplodingResolver()
+        with pytest.raises(ResolutionError) as excinfo:
+            orchestrator._apply_knob_resolution({"model": "a"})
+        assert ResolutionRejection.INFEASIBLE_VALUE in excinfo.value.rejections
+
+    def test_baseline_config_paths_resolve_too(self):
+        """Review fix (B3): the default/baseline config goes through the same
+        chokepoint — Fixed and CVAR values are injected."""
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = _happy_resolver()
+        baseline = orchestrator._apply_knob_resolution({"model": "a"})
+        assert baseline == {"model": "a", "k": 4, "theta": 0.5}

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -1,0 +1,353 @@
+"""KnobResolver tests (SDK packet 6-C2, RFC 0001 §3.4).
+
+Program acceptance criteria covered here:
+- every rejection R1-R8 (+ no_decision) is reachable with a typed error;
+- the Accept path produces suggestion ∪ fixed ∪ calibrated (config ⊇ N_C);
+- CVARs are optimizer-invisible (tvars projection) AND resolved in-trial
+  (the orchestrator injection test);
+- a None resolver is an exact passthrough (legacy byte-identical).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from traigent.api.config_space import ConfigSpace
+from traigent.api.parameter_ranges import Choices, IntRange
+from traigent.knobs import (
+    Calibrated,
+    CalibratedInput,
+    Fixed,
+    FreshnessContext,
+    Knob,
+    KnobResolver,
+    Ref,
+    ResolutionError,
+    ResolutionRejection,
+    SignalObservation,
+    SignalSpec,
+    TargetProperty,
+    Tuned,
+    canonical_hash,
+    issue_certificate,
+)
+
+
+def _signal() -> SignalSpec:
+    return SignalSpec(
+        name="vote_margin",
+        version="1",
+        score_function="exact_match",
+        score_function_version="1",
+        comparator="key_eq",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="margin_floor", mode="require_calibration")
+
+
+def _ctx(parents=(("model", "a"),), **overrides) -> FreshnessContext:
+    base = dict(
+        cvar_name="theta",
+        tuned_parent_values=tuple(parents),
+        calibration_source_id="pool_a",
+        signal_spec_hash=_signal().spec_hash(),
+        calibrator_id="budget_threshold",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target=_target(),
+    )
+    base.update(overrides)
+    return FreshnessContext(**base)
+
+
+def _space(*, governed: bool = True, fallback=None, epsilon=None) -> ConfigSpace:
+    return ConfigSpace(
+        knobs={
+            "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"]))),
+            "k": Knob(name="k", binding=Fixed(value=4)),
+            "theta": Knob(
+                name="theta",
+                binding=Calibrated(
+                    signal=_signal(),
+                    target=_target(),
+                    depends_on=(Ref(knob="model"),),
+                    require_calibration=governed,
+                    fallback=fallback,
+                    target_epsilon=epsilon,
+                ),
+            ),
+        }
+    )
+
+
+def _happy_resolver(space=None) -> KnobResolver:
+    space = space or _space()
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    return KnobResolver(
+        space,
+        calibrated_inputs={
+            "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx)
+        },
+    )
+
+
+class TestAcceptPath:
+    def test_happy_path_resolves_full_config(self):
+        result = _happy_resolver().resolve({"model": "a"})
+        assert dict(result.config) == {"model": "a", "k": 4, "theta": 0.5}
+        assert result.used_fallbacks == ()
+
+    def test_accepted_config_contains_every_cvar_and_fixed(self):
+        result = _happy_resolver().resolve({"model": "a"})
+        assert {"theta", "k"} <= set(result.config)
+
+    def test_runtime_fixed_merges_without_collision(self):
+        space = _space()
+        ctx = _ctx()
+        cert = issue_certificate("theta", "float", 0.5, ctx)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx)
+            },
+            runtime_fixed={"deployment_region": "eu"},
+        )
+        result = resolver.resolve({"model": "a"})
+        assert result.config["deployment_region"] == "eu"
+
+
+class TestRejections:
+    def test_r3_runtime_fixed_collides_with_knob(self):
+        space = _space()
+        ctx = _ctx()
+        cert = issue_certificate("theta", "float", 0.5, ctx)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx)
+            },
+            runtime_fixed={"model": "b"},
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.DUPLICATE_PROVIDER in excinfo.value.rejections
+
+    def test_r3_suggestion_with_non_tuned_name(self):
+        with pytest.raises(ResolutionError) as excinfo:
+            _happy_resolver().resolve({"model": "a", "theta": 0.9})
+        assert ResolutionRejection.DUPLICATE_PROVIDER in excinfo.value.rejections
+
+    def test_r4_missing_tuned_value(self):
+        with pytest.raises(ResolutionError) as excinfo:
+            _happy_resolver().resolve({})
+        assert ResolutionRejection.PHASE_MISMATCH in excinfo.value.rejections
+
+    def test_r4_unproduced_cvar_even_when_unconsumed(self):
+        resolver = KnobResolver(_space())  # no calibrated inputs at all
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.PHASE_MISMATCH in excinfo.value.rejections
+
+    def test_r2_ref_to_unknown_or_cvar_parent(self):
+        space = ConfigSpace(
+            knobs={
+                "model": Knob(name="model", binding=Tuned(range=Choices(["a"]))),
+                "theta": Knob(
+                    name="theta",
+                    binding=Calibrated(
+                        signal=_signal(),
+                        target=_target(),
+                        depends_on=(Ref(knob="ghost"),),
+                    ),
+                ),
+            }
+        )
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=0.5)}
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.MISSING_REF in excinfo.value.rejections
+
+    def test_r5_type_mismatch(self):
+        space = _space(governed=False)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={"theta": CalibratedInput(value="not-a-number")},
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.INFEASIBLE_VALUE in excinfo.value.rejections
+
+    def test_r6_stale_certificate_on_parent_change(self):
+        """The optimizer suggested model='b' but the certificate was issued
+        for model='a' — parent-specific staleness by construction."""
+        space = _space()
+        ctx_a = _ctx(parents=(("model", "a"),))
+        cert = issue_certificate("theta", "float", 0.5, ctx_a)
+        ctx_b = dataclasses.replace(ctx_a, tuned_parent_values=(("model", "b"),))
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, certificate=cert, context=ctx_b)
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "b"})
+        assert ResolutionRejection.STALE_CERTIFICATE in excinfo.value.rejections
+
+    def test_r6_governed_without_certificate(self):
+        resolver = KnobResolver(
+            _space(), calibrated_inputs={"theta": CalibratedInput(value=0.5)}
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.STALE_CERTIFICATE in excinfo.value.rejections
+
+    def test_r7_observation_from_eval_split(self):
+        space = _space(governed=False)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(
+                    value=0.5,
+                    observations=(
+                        SignalObservation(
+                            signal="vote_margin", value=0.7, n=5, split="eval"
+                        ),
+                    ),
+                )
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.EVIDENCE_LEAKAGE in excinfo.value.rejections
+
+    def test_r7_true_item_intersection(self):
+        space = _space(governed=False)
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(
+                    value=0.5, evidence_item_ids=frozenset({"e1", "c2"})
+                )
+            },
+            eval_item_ids=frozenset({"e1", "e9"}),
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.EVIDENCE_LEAKAGE in excinfo.value.rejections
+
+    def test_r8_conformal_floor(self):
+        space = _space(governed=False, epsilon=0.1)  # floor = 9
+        resolver = KnobResolver(
+            space,
+            calibrated_inputs={
+                "theta": CalibratedInput(value=0.5, context=_ctx(evidence_n=3))
+            },
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.INSUFFICIENT_EVIDENCE in excinfo.value.rejections
+
+    def test_no_decision_strict_rejects(self):
+        resolver = KnobResolver(
+            _space(governed=True),
+            calibrated_inputs={"theta": CalibratedInput(value=None)},
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({"model": "a"})
+        assert ResolutionRejection.NO_DECISION in excinfo.value.rejections
+
+    def test_rejections_are_collected_not_short_circuited(self):
+        resolver = KnobResolver(
+            _space(),  # governed CVAR without inputs -> R4
+            runtime_fixed={"model": "b"},  # -> R3
+        )
+        with pytest.raises(ResolutionError) as excinfo:
+            resolver.resolve({})  # missing tuned -> R4
+        assert {
+            ResolutionRejection.DUPLICATE_PROVIDER,
+            ResolutionRejection.PHASE_MISMATCH,
+        } <= set(excinfo.value.rejections)
+
+
+class TestFallbacks:
+    def test_non_governed_no_decision_uses_fallback_recorded(self):
+        space = _space(governed=False, fallback=Fixed(value=0.42))
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=None)}
+        )
+        result = resolver.resolve({"model": "a"})
+        assert result.config["theta"] == 0.42
+        assert result.used_fallbacks == ("theta",)  # observable, never silent
+
+    def test_governed_no_decision_never_falls_back(self):
+        space = _space(governed=True, fallback=Fixed(value=0.42))
+        resolver = KnobResolver(
+            space, calibrated_inputs={"theta": CalibratedInput(value=None)}
+        )
+        with pytest.raises(ResolutionError):
+            resolver.resolve({"model": "a"})
+
+
+class TestDeterminism:
+    def test_same_inputs_same_resolution(self):
+        resolver = _happy_resolver()
+        first = resolver.resolve({"model": "a"})
+        second = resolver.resolve({"model": "a"})
+        assert dict(first.config) == dict(second.config)
+
+
+class TestOrchestratorInjection:
+    """The program acceptance criterion: CVARs are optimizer-invisible AND
+    resolved in-trial — proven at the orchestrator chokepoint."""
+
+    def _orchestrator_stub(self):
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        orchestrator = OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+        orchestrator.knob_resolver = None
+        return orchestrator
+
+    def test_none_resolver_is_exact_passthrough(self):
+        orchestrator = self._orchestrator_stub()
+        config = {"model": "a", "k": 3}
+        assert orchestrator._apply_knob_resolution(config) is config
+
+    def test_resolver_injects_fixed_and_cvar_values(self):
+        orchestrator = self._orchestrator_stub()
+        orchestrator.knob_resolver = _happy_resolver()
+        resolved = orchestrator._apply_knob_resolution({"model": "a"})
+        assert resolved == {"model": "a", "k": 4, "theta": 0.5}
+
+    def test_optimizer_never_sees_cvars_but_evaluator_does(self):
+        """tvars projection (what dict-based optimizers consume) excludes the
+        CVAR; the resolved trial config includes it."""
+        space = _space()
+        optimizer_view = {
+            name: parameter_range.to_config_value()
+            for name, parameter_range in space.tvars.items()
+        }
+        assert set(optimizer_view) == {"model"}  # P2
+
+        orchestrator = self._orchestrator_stub()
+        orchestrator.knob_resolver = _happy_resolver(space)
+        trial_config = orchestrator._apply_knob_resolution({"model": "a"})
+        assert trial_config["theta"] == 0.5  # resolved in-trial
+
+    def test_resolution_failure_is_fail_closed_at_the_chokepoint(self):
+        orchestrator = self._orchestrator_stub()
+        orchestrator.knob_resolver = KnobResolver(_space())  # unproduced CVAR
+        with pytest.raises(ResolutionError):
+            orchestrator._apply_knob_resolution({"model": "a"})

--- a/tests/unit/knobs/test_resolver.py
+++ b/tests/unit/knobs/test_resolver.py
@@ -441,3 +441,21 @@ class TestReviewRoundTwoCoverage:
         orchestrator.knob_resolver = _happy_resolver()
         baseline = orchestrator._apply_knob_resolution({"model": "a"})
         assert baseline == {"model": "a", "k": 4, "theta": 0.5}
+
+
+def test_unverifiable_optional_certificate_is_ignored_not_fallbacked():
+    """Round-2 new finding: with NO context, staleness is not established —
+    a non-governed CVAR's optional certificate is ignored and the calibrated
+    value stands (no fallback consumption)."""
+    space = _space(governed=False, fallback=Fixed(value=0.42))
+    ctx = _ctx()
+    cert = issue_certificate("theta", "float", 0.5, ctx)
+    resolver = KnobResolver(
+        space,
+        calibrated_inputs={
+            "theta": CalibratedInput(value=0.5, certificate=cert, context=None)
+        },
+    )
+    result = resolver.resolve({"model": "a"})
+    assert result.config["theta"] == 0.5
+    assert result.used_fallbacks == ()

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1235,7 +1235,9 @@ class OptimizationOrchestrator:
 
         baseline_config = self._consume_default_config()
         if baseline_config is not None:
-            configs.append(baseline_config)
+            # baseline trials get the same Fixed/CVAR injection as suggested
+            # ones — no bypass of R3/R6/R8 (RFC 0001)
+            configs.append(self._apply_knob_resolution(baseline_config))
             remaining -= 1
             if remaining <= 0:
                 return configs, False
@@ -1245,7 +1247,10 @@ class OptimizationOrchestrator:
         if self.traigent_config.execution_mode_enum is ExecutionMode.HYBRID:
             async_configs = await self._try_hybrid_batch_generation(dataset, remaining)
             if async_configs:
-                configs.extend(async_configs)
+                configs.extend(
+                    self._apply_knob_resolution(async_config)
+                    for async_config in async_configs
+                )
                 used_async_batch = True
 
         # Fall back to sequential generation
@@ -1265,7 +1270,20 @@ class OptimizationOrchestrator:
         """
         if self.knob_resolver is None:
             return config
-        resolved = self.knob_resolver.resolve(config)
+        from traigent.knobs import ResolutionError, ResolutionRejection
+
+        try:
+            resolved = self.knob_resolver.resolve(config)
+        except ResolutionError:
+            raise
+        except Exception as exc:
+            # Internal resolver failures (ValueError, canonicalization, ...)
+            # MUST surface as the typed fail-closed error — the suggest-site
+            # except tuples catch ValueError and would silently break.
+            raise ResolutionError(
+                (ResolutionRejection.INFEASIBLE_VALUE,),
+                f"resolver internal failure: {exc}",
+            ) from exc
         if resolved.used_fallbacks:
             logger.warning(
                 "Knob resolution used declared fallbacks for: %s",

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -638,6 +638,10 @@ class OptimizationOrchestrator:
 
     def _initialize_runtime_state(self) -> None:
         self._trials: list[TrialResult] = []
+        # RFC 0001 (knob bindings): optional resolver injecting Fixed/CVAR
+        # values post-suggest, pre-validation. None => byte-identical legacy
+        # behavior. Set via `orchestrator.knob_resolver = KnobResolver(...)`.
+        self.knob_resolver: Any | None = None
         self._start_time: float | None = None
         self._status = OptimizationStatus.PENDING
         self._optimization_id = str(uuid.uuid4())
@@ -1201,6 +1205,7 @@ class OptimizationOrchestrator:
         for _ in range(count):
             try:
                 config = self.optimizer.suggest_next_trial(self._trials)
+                config = self._apply_knob_resolution(config)
             except OptimizationError:
                 break
             except (ValueError, TypeError, KeyError, AttributeError) as e:
@@ -1248,6 +1253,25 @@ class OptimizationOrchestrator:
             configs.extend(self._generate_sequential_configs(remaining))
 
         return configs, used_async_batch
+
+    def _apply_knob_resolution(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Resolve knob bindings for one suggestion (RFC 0001 §3.4).
+
+        With no resolver configured this is an exact passthrough (legacy
+        behavior byte-identical). With a resolver, Fixed and Calibrated
+        values are injected fail-closed: any rejection (stale certificate,
+        evidence leakage, missing producer, ...) raises ResolutionError —
+        there is no silent fallback. Recorded fallback use is logged.
+        """
+        if self.knob_resolver is None:
+            return config
+        resolved = self.knob_resolver.resolve(config)
+        if resolved.used_fallbacks:
+            logger.warning(
+                "Knob resolution used declared fallbacks for: %s",
+                ", ".join(resolved.used_fallbacks),
+            )
+        return dict(resolved.config)
 
     def _build_trial_descriptors(
         self,

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -119,6 +119,7 @@ class TrialLifecycle:
         if config is None:
             try:
                 config = orchestrator.optimizer.suggest_next_trial(orchestrator._trials)
+                config = orchestrator._apply_knob_resolution(config)
             except OptimizationError:
                 raise
             except (ValueError, TypeError, KeyError, AttributeError) as e:

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -116,6 +116,9 @@ class TrialLifecycle:
             return trial_count, "break"
 
         config = orchestrator._consume_default_config()
+        if config is not None:
+            # baseline trials get the same Fixed/CVAR injection (RFC 0001)
+            config = orchestrator._apply_knob_resolution(config)
         if config is None:
             try:
                 config = orchestrator.optimizer.suggest_next_trial(orchestrator._trials)

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -35,6 +35,7 @@ from .certificates import (
 )
 from .kinds import KnobKind
 from .resolution import ResolutionError, ResolutionNode, ResolutionRejection
+from .resolver import CalibratedInput, KnobResolver, ResolvedConfiguration
 from .signals import SignalObservation, SignalSpec
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     "CTX_SCHEMA_VERSION",
     "Binding",
     "Calibrated",
+    "CalibratedInput",
     "CanonicalizationError",
     "Certificate",
     "CertificateDecision",
@@ -50,10 +52,12 @@ __all__ = [
     "FreshnessContext",
     "Knob",
     "KnobKind",
+    "KnobResolver",
     "Ref",
     "ResolutionError",
     "ResolutionNode",
     "ResolutionRejection",
+    "ResolvedConfiguration",
     "SignalObservation",
     "SignalSpec",
     "TargetProperty",

--- a/traigent/knobs/bindings.py
+++ b/traigent/knobs/bindings.py
@@ -77,6 +77,7 @@ class Calibrated(Generic[TValue]):
 
     signal: SignalSpec
     target: TargetProperty
+    value_type: str = "float"  # declared CVAR type (R5/R6 conformance)
     depends_on: tuple[Ref, ...] = field(default=())
     fallback: Fixed[TValue] | None = None
     certificate: Certificate | None = None

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -206,10 +206,12 @@ class KnobResolver:
         used_fallbacks: list[str],
         reject: Any,
     ) -> None:
+        # Governance is DECLARED (on the binding/target), never inferred
+        # from runtime-presented evidence — presenting a certificate is
+        # evidence, not an opt-in to strictness.
         governed = (
             binding.require_calibration
             or binding.certificate is not None
-            or provided.certificate is not None
             or binding.target.mode in ("certificate_backed", "guaranteed_selection")
         )
 
@@ -235,26 +237,31 @@ class KnobResolver:
                 f"CVAR {name!r} calibration pool intersects the eval split items",
             )
 
-        # R8 insufficient evidence — closed-form conformal floor
-        if binding.target_epsilon is not None and provided.context is not None:
+        # R8 insufficient evidence — closed-form conformal floor. A declared
+        # epsilon with NO context means the floor is unverifiable: fail
+        # closed (unverifiable evidence IS insufficient evidence).
+        if binding.target_epsilon is not None:
             floor = conformal_evidence_floor(binding.target_epsilon)
-            if provided.context.evidence_n < floor:
+            if provided.context is None:
+                reject(
+                    ResolutionRejection.INSUFFICIENT_EVIDENCE,
+                    f"CVAR {name!r} declares epsilon={binding.target_epsilon} "
+                    "but no freshness context carries the evidence count",
+                )
+            elif provided.context.evidence_n < floor:
                 reject(
                     ResolutionRejection.INSUFFICIENT_EVIDENCE,
                     f"CVAR {name!r} has n={provided.context.evidence_n} < "
                     f"conformal floor {floor} for epsilon={binding.target_epsilon}",
                 )
 
-        # calibrator ⊥
+        # calibrator ⊥ — the Accept biconditional requires 𝒦 ≠ ⊥ with NO
+        # fallback carve-out (RFC §3.4); §3.5's non-strict fallback applies
+        # to STALE CERTIFICATES only, never to abstention.
         if provided.value is None:
-            if not governed and binding.fallback is not None:
-                values[name] = binding.fallback.value
-                used_fallbacks.append(name)
-                return
             reject(
                 ResolutionRejection.NO_DECISION,
-                f"calibrator for CVAR {name!r} abstained and no admissible "
-                "fallback exists",
+                f"calibrator for CVAR {name!r} abstained (⊥)",
             )
             return
 
@@ -284,6 +291,15 @@ class KnobResolver:
                     f"certificate for CVAR {name!r} is stale or invalid for the "
                     "current context",
                 )
+                return
+        elif binding.fallback is not None and provided.certificate is not None:
+            # non-governed CVAR whose OPTIONAL certificate turned stale: the
+            # §3.5 carve-out — declared fallback MAY be used, always recorded
+            if provided.context is None or not provided.certificate.valid_for(
+                name, binding.value_type, provided.value, provided.context
+            ):
+                values[name] = binding.fallback.value
+                used_fallbacks.append(name)
                 return
 
         values[name] = provided.value

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -292,15 +292,22 @@ class KnobResolver:
                     "current context",
                 )
                 return
-        elif binding.fallback is not None and provided.certificate is not None:
-            # non-governed CVAR whose OPTIONAL certificate turned stale: the
-            # §3.5 carve-out — declared fallback MAY be used, always recorded
-            if provided.context is None or not provided.certificate.valid_for(
+        elif (
+            binding.fallback is not None
+            and provided.certificate is not None
+            and provided.context is not None
+            and not provided.certificate.valid_for(
                 name, binding.value_type, provided.value, provided.context
-            ):
-                values[name] = binding.fallback.value
-                used_fallbacks.append(name)
-                return
+            )
+        ):
+            # non-governed CVAR whose optional certificate is PROVEN stale
+            # against a live context: the §3.5 carve-out — declared fallback
+            # MAY be used, always recorded. With NO context, staleness is
+            # not established: the unverifiable certificate is ignored and
+            # the calibrated value stands (non-governed acceptance).
+            values[name] = binding.fallback.value
+            used_fallbacks.append(name)
+            return
 
         values[name] = provided.value
 

--- a/traigent/knobs/resolver.py
+++ b/traigent/knobs/resolver.py
@@ -1,0 +1,322 @@
+"""The deterministic knob resolver (RFC 0001 §3.4) — SDK packet 6-C2.
+
+Resolution turns an optimizer suggestion (Tuned values only, P2) into the
+full executed configuration:
+
+    config = suggestion ∪ fixed-binding values ∪ runtime fixed ∪ calibrated values
+
+Acceptance is EXACTLY the complement of the rejection conditions plus
+calibrator success (the Accept biconditional — P3/P4):
+
+    Accept ⟺ ¬(R1 ∨ … ∨ R8) ∧ every calibrated value present
+
+The resolver CHECKS certificate freshness; it never fits. In-loop
+re-calibration and the CVAR optimizer are explicitly deferred (RFC §2).
+Rejections are collected exhaustively (no short-circuit) and raised as one
+typed, fail-closed :class:`ResolutionError`. Fallbacks are consumed only for
+non-governed CVARs and are always recorded in the result — never silent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from .bindings import Calibrated, Fixed, Tuned
+from .certificates import Certificate, FreshnessContext, conformal_evidence_floor
+from .resolution import ResolutionError, ResolutionRejection
+from .signals import SignalObservation
+
+if TYPE_CHECKING:
+    from traigent.api.config_space import ConfigSpace
+
+__all__ = ["CalibratedInput", "KnobResolver", "ResolvedConfiguration"]
+
+
+@dataclass(frozen=True, slots=True)
+class CalibratedInput:
+    """The runtime inputs for one CVAR: its calibrated value + validity data.
+
+    ``value is None`` means the calibrator abstained (⊥ / no_decision).
+    """
+
+    value: Any | None
+    certificate: Certificate | None = None
+    context: FreshnessContext | None = None
+    observations: tuple[SignalObservation, ...] = field(default=())
+    evidence_item_ids: frozenset[str] = frozenset()  # calibration pool item ids
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedConfiguration:
+    """A successful resolution: the executed config + observability."""
+
+    config: Mapping[str, Any]
+    used_fallbacks: tuple[str, ...] = ()
+
+
+def _type_conforms(value: Any, value_type: str) -> bool:
+    """R5 type conformance (the model checker's transcription, productized)."""
+    if value_type == "bool":
+        return isinstance(value, bool)
+    if value_type == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if value_type == "float":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, str)  # enum[str] / str-like
+
+
+class KnobResolver:
+    """Deterministic, topological, fail-closed resolution over a ConfigSpace.
+
+    Args:
+        space: The configuration space whose ``knobs`` drive resolution.
+        calibrated_inputs: Per-CVAR runtime inputs (value, certificate,
+            context, observations). EVERY Calibrated knob needs an entry —
+            a declared CVAR that cannot be produced is R4 (phase mismatch),
+            consumed or not.
+        runtime_fixed: The runtime-supplied fixed assignment ``f`` (N_F).
+            Its domain must not intersect declared knob names (R3).
+        eval_split: The evaluation split label; calibration evidence tagged
+            with it (or item-overlapping it) is R7 evidence leakage.
+        eval_item_ids: Optional eval-split item ids for the true-intersection
+            form of R7 when callers track item identity.
+    """
+
+    def __init__(
+        self,
+        space: ConfigSpace,
+        *,
+        calibrated_inputs: Mapping[str, CalibratedInput] | None = None,
+        runtime_fixed: Mapping[str, Any] | None = None,
+        eval_split: str = "eval",
+        eval_item_ids: frozenset[str] = frozenset(),
+    ) -> None:
+        self._space = space
+        self._calibrated_inputs = dict(calibrated_inputs or {})
+        self._runtime_fixed = dict(runtime_fixed or {})
+        self._eval_split = eval_split
+        self._eval_item_ids = eval_item_ids
+
+    # ------------------------------------------------------------------
+    def resolve(self, suggestion: Mapping[str, Any]) -> ResolvedConfiguration:
+        """Resolve one optimizer suggestion into the executed configuration.
+
+        Raises:
+            ResolutionError: carrying EVERY applicable rejection.
+        """
+        rejections: list[ResolutionRejection] = []
+        details: list[str] = []
+        knobs = dict(self._space.knobs or {})
+
+        tuned_names = {n for n, k in knobs.items() if isinstance(k.binding, Tuned)}
+        fixed_knobs = {
+            n: k.binding for n, k in knobs.items() if isinstance(k.binding, Fixed)
+        }
+        calibrated_knobs = {
+            n: k.binding for n, k in knobs.items() if isinstance(k.binding, Calibrated)
+        }
+
+        def reject(code: ResolutionRejection, detail: str) -> None:
+            rejections.append(code)
+            details.append(f"{code.value}: {detail}")
+
+        # --- R3 duplicate providers -----------------------------------
+        fixed_collisions = set(self._runtime_fixed) & set(knobs)
+        for name in sorted(fixed_collisions):
+            reject(
+                ResolutionRejection.DUPLICATE_PROVIDER,
+                f"runtime fixed assignment collides with declared knob {name!r}",
+            )
+        for name in sorted(set(self._calibrated_inputs) - set(calibrated_knobs)):
+            reject(
+                ResolutionRejection.DUPLICATE_PROVIDER,
+                f"calibrated input provided for non-calibrated knob {name!r}",
+            )
+        for name in sorted(set(suggestion) - tuned_names):
+            reject(
+                ResolutionRejection.DUPLICATE_PROVIDER,
+                f"suggestion provides non-tuned name {name!r} (dom(t) must be N_T)",
+            )
+
+        # --- R4 phase: every tuned value present, every CVAR producible -
+        for name in sorted(tuned_names - set(suggestion)):
+            reject(
+                ResolutionRejection.PHASE_MISMATCH,
+                f"suggestion is missing tuned knob {name!r}",
+            )
+        for name in sorted(set(calibrated_knobs) - set(self._calibrated_inputs)):
+            reject(
+                ResolutionRejection.PHASE_MISMATCH,
+                f"declared CVAR {name!r} has no calibrated input (cannot be "
+                "produced before use; resolution includes every n in N_C)",
+            )
+
+        # --- R2 refs + R1 cycles --------------------------------------
+        for name in sorted(calibrated_knobs):
+            for ref in calibrated_knobs[name].depends_on:
+                if ref.knob in calibrated_knobs:
+                    # v1: CVAR->CVAR parents are deferred; also feeds R1 below
+                    reject(
+                        ResolutionRejection.MISSING_REF,
+                        f"CVAR {name!r} depends on CVAR {ref.knob!r} "
+                        "(v1 parents must be Tuned)",
+                    )
+                elif ref.knob not in tuned_names:
+                    reject(
+                        ResolutionRejection.MISSING_REF,
+                        f"CVAR {name!r} depends_on {ref.knob!r} which does not "
+                        "resolve to a Tuned knob",
+                    )
+        self._detect_cycles(calibrated_knobs, reject)
+
+        # --- per-CVAR resolution in deterministic (sorted) topo order --
+        values: dict[str, Any] = {}
+        used_fallbacks: list[str] = []
+        for name in sorted(set(calibrated_knobs) & set(self._calibrated_inputs)):
+            binding = calibrated_knobs[name]
+            self._resolve_calibrated(
+                name,
+                binding,
+                self._calibrated_inputs[name],
+                values,
+                used_fallbacks,
+                reject,
+            )
+
+        if rejections:
+            raise ResolutionError(tuple(dict.fromkeys(rejections)), "; ".join(details))
+
+        config: dict[str, Any] = dict(suggestion)
+        config.update({name: binding.value for name, binding in fixed_knobs.items()})
+        config.update(self._runtime_fixed)
+        config.update(values)
+        return ResolvedConfiguration(
+            config=config, used_fallbacks=tuple(used_fallbacks)
+        )
+
+    # ------------------------------------------------------------------
+    def _resolve_calibrated(
+        self,
+        name: str,
+        binding: Calibrated,
+        provided: CalibratedInput,
+        values: dict[str, Any],
+        used_fallbacks: list[str],
+        reject: Any,
+    ) -> None:
+        governed = (
+            binding.require_calibration
+            or binding.certificate is not None
+            or provided.certificate is not None
+            or binding.target.mode in ("certificate_backed", "guaranteed_selection")
+        )
+
+        # R7 evidence leakage — split tag or true item intersection
+        for observation in provided.observations:
+            if observation.split == self._eval_split:
+                reject(
+                    ResolutionRejection.EVIDENCE_LEAKAGE,
+                    f"CVAR {name!r} consumed an observation from the eval split",
+                )
+                break
+        if provided.context is not None and (
+            provided.context.calibration_split == self._eval_split
+        ):
+            reject(
+                ResolutionRejection.EVIDENCE_LEAKAGE,
+                f"CVAR {name!r} calibration split equals the eval split",
+            )
+        if self._eval_item_ids and (provided.evidence_item_ids & self._eval_item_ids):
+            # the TRUE intersection form: 𝓔_cal ∩ 𝓔_eval ≠ ∅ over item ids
+            reject(
+                ResolutionRejection.EVIDENCE_LEAKAGE,
+                f"CVAR {name!r} calibration pool intersects the eval split items",
+            )
+
+        # R8 insufficient evidence — closed-form conformal floor
+        if binding.target_epsilon is not None and provided.context is not None:
+            floor = conformal_evidence_floor(binding.target_epsilon)
+            if provided.context.evidence_n < floor:
+                reject(
+                    ResolutionRejection.INSUFFICIENT_EVIDENCE,
+                    f"CVAR {name!r} has n={provided.context.evidence_n} < "
+                    f"conformal floor {floor} for epsilon={binding.target_epsilon}",
+                )
+
+        # calibrator ⊥
+        if provided.value is None:
+            if not governed and binding.fallback is not None:
+                values[name] = binding.fallback.value
+                used_fallbacks.append(name)
+                return
+            reject(
+                ResolutionRejection.NO_DECISION,
+                f"calibrator for CVAR {name!r} abstained and no admissible "
+                "fallback exists",
+            )
+            return
+
+        # R5 type + validity
+        if not _type_conforms(provided.value, binding.value_type):
+            reject(
+                ResolutionRejection.INFEASIBLE_VALUE,
+                f"CVAR {name!r} value {provided.value!r} does not conform to "
+                f"declared type {binding.value_type!r}",
+            )
+            return
+
+        # R6 certificate validity for governed CVARs
+        if governed:
+            certificate = provided.certificate or binding.certificate
+            if certificate is None or provided.context is None:
+                reject(
+                    ResolutionRejection.STALE_CERTIFICATE,
+                    f"governed CVAR {name!r} lacks a certificate/context",
+                )
+                return
+            if not certificate.valid_for(
+                name, binding.value_type, provided.value, provided.context
+            ):
+                reject(
+                    ResolutionRejection.STALE_CERTIFICATE,
+                    f"certificate for CVAR {name!r} is stale or invalid for the "
+                    "current context",
+                )
+                return
+
+        values[name] = provided.value
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _detect_cycles(calibrated_knobs: Mapping[str, Calibrated], reject: Any) -> None:
+        """R1 — unreachable in v1 (CVAR->TVAR only) but kept normative for
+        the deferred CVAR->CVAR extension."""
+        adjacency = {
+            name: {
+                ref.knob for ref in binding.depends_on if ref.knob in calibrated_knobs
+            }
+            for name, binding in calibrated_knobs.items()
+        }
+        state: dict[str, int] = {}
+
+        def visit(node: str) -> bool:
+            if state.get(node) == 1:
+                return True
+            if state.get(node) == 2:
+                return False
+            state[node] = 1
+            for neighbour in adjacency.get(node, ()):
+                if visit(neighbour):
+                    return True
+            state[node] = 2
+            return False
+
+        for name in sorted(adjacency):
+            if visit(name):
+                reject(
+                    ResolutionRejection.CYCLE,
+                    f"dependency cycle involving CVAR {name!r}",
+                )
+                return


### PR DESCRIPTION
Continuation of **#1099** (auto-closed when its base `feature/configspace-knobs` was deleted on #1112's squash-merge; branch since rebased onto develop). Identical converged content: KnobResolver (collect-all R1–R8), `_apply_knob_resolution` at all four config paths, ⊥ never falls back, proven-staleness-only fallback for non-governed CVARs. Review chain (3 rounds, found the two bypass paths) + CI evidence: see #1099.

🤖 Generated with [Claude Code](https://claude.com/claude-code)