### PR TITLE
feat(cli): traigent onboard — device-code login, guided setup, first-prompt (stacked on #1116)

### DIFF
--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -18,7 +18,8 @@ DEVICE_CODE = "A" * 43
 
 
 class _FakeSecureStore:
-    def __init__(self) -> None:
+    def __init__(self, *, fail_on_set: bool = False) -> None:
+        self.fail_on_set = fail_on_set
         self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
 
     def get(self, name: str, check_env: bool = True) -> str | None:
@@ -33,6 +34,8 @@ class _FakeSecureStore:
         credential_type: CredentialType,
         metadata: dict[str, str] | None = None,
     ) -> None:
+        if self.fail_on_set:
+            raise auth_commands.SecurityError("secure store unavailable")
         self.saved = (name, value, credential_type, metadata)
 
     def delete_secure(self, name: str) -> bool:
@@ -57,7 +60,7 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    def __init__(self, responses: list[_FakeResponse]) -> None:
+    def __init__(self, responses: list[_FakeResponse | BaseException]) -> None:
         self.responses = responses
         self.post_calls: list[dict[str, Any]] = []
 
@@ -71,18 +74,32 @@ class _FakeSession:
         self.post_calls.append({"url": url, **kwargs})
         if not self.responses:
             raise AssertionError(f"Unexpected POST: {url}")
-        return self.responses.pop(0)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
 
 
-def _authorize_payload(interval: int = 1) -> dict[str, Any]:
+def _authorize_payload(interval: int = 1, expires_in: int = 600) -> dict[str, Any]:
     return {
         "device_code": DEVICE_CODE,
         "user_code": "BCDF-2345",
         "verification_uri": "https://portal.example.test/device",
         "verification_uri_complete": "https://portal.example.test/device?user_code=BCDF-2345",
-        "expires_in": 600,
+        "expires_in": expires_in,
         "interval": interval,
     }
+
+
+# Required by TraigentSchema#94 device_token_success_schema.json.
+DEVICE_TOKEN_SUCCESS_REQUIRED_KEYS = [
+    "api_key",
+    "tenant_id",
+    "project_id",
+    "user",
+    "subscription_tier",
+    "quota",
+]
 
 
 def _success_payload() -> dict[str, Any]:
@@ -113,9 +130,11 @@ def _error_payload(error: str, details: dict[str, Any] | None = None) -> dict[st
 def _install_device_test_fakes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    responses: list[_FakeResponse],
+    responses: list[_FakeResponse | BaseException],
+    *,
+    fail_secure_store: bool = False,
 ) -> tuple[_FakeSecureStore, _FakeSession]:
-    store = _FakeSecureStore()
+    store = _FakeSecureStore(fail_on_set=fail_secure_store)
     session = _FakeSession(responses)
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(auth_commands, "TRAIGENT_CONFIG_DIR", tmp_path / ".traigent")
@@ -136,7 +155,27 @@ def _make_cli() -> TraigentAuthCLI:
     return TraigentAuthCLI(backend_url_override="https://backend.example.test")
 
 
-def test_device_flow_happy_path_persists_credentials_and_env_file(
+def test_device_token_success_schema_contract_pins_subscription_tier() -> None:
+    cli = TraigentAuthCLI.__new__(TraigentAuthCLI)
+    cli.backend_url = "https://backend.example.test"
+    token_data = _success_payload()["data"]
+    assert isinstance(token_data, dict)
+    assert list(token_data.keys()) == DEVICE_TOKEN_SUCCESS_REQUIRED_KEYS
+
+    validated = cli._validate_device_token_success(_success_payload())
+
+    assert validated["subscription_tier"] == "trial"
+
+    missing_subscription_tier = _success_payload()
+    missing_data = missing_subscription_tier["data"]
+    assert isinstance(missing_data, dict)
+    missing_data.pop("subscription_tier")
+
+    with pytest.raises(auth_commands.AuthenticationError, match="subscription_tier"):
+        cli._validate_device_token_success(missing_subscription_tier)
+
+
+def test_device_flow_happy_path_persists_credentials_secure_only_by_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -164,6 +203,37 @@ def test_device_flow_happy_path_persists_credentials_and_env_file(
     assert saved["project_id"] == "project_456"
     assert saved["backend_url"] == "https://backend.example.test"
 
+    assert not (tmp_path / ".env").exists()
+
+    assert session.post_calls[0]["url"].endswith("/auth/device/authorize")
+    assert session.post_calls[1]["url"].endswith("/auth/device/token")
+    assert session.post_calls[1]["json"] == {"device_code": DEVICE_CODE}
+    captured = capsys.readouterr()
+    assert API_KEY not in captured.out
+    assert API_KEY not in captured.err
+
+
+def test_device_flow_env_file_consent_writes_with_0600(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _store, _session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+
+    result = asyncio.run(
+        _make_cli().device_login(
+            save_env_file=True,
+            sleep=lambda _seconds: _noop_sleep(),
+        )
+    )
+
+    assert result is True
     env_file = tmp_path / ".env"
     assert env_file.exists()
     assert env_file.stat().st_mode & 0o777 == 0o600
@@ -173,12 +243,63 @@ def test_device_flow_happy_path_persists_credentials_and_env_file(
     assert "TRAIGENT_PROJECT_ID=project_456" in env_text
     assert "TRAIGENT_BACKEND_URL=https://backend.example.test" in env_text
 
-    assert session.post_calls[0]["url"].endswith("/auth/device/authorize")
-    assert session.post_calls[1]["url"].endswith("/auth/device/token")
-    assert session.post_calls[1]["json"] == {"device_code": DEVICE_CODE}
-    captured = capsys.readouterr()
-    assert API_KEY not in captured.out
-    assert API_KEY not in captured.err
+
+def test_device_flow_secure_store_failure_without_explicit_flag_skips_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store, _session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(200, _success_payload()),
+        ],
+        fail_secure_store=True,
+    )
+
+    result = asyncio.run(
+        _make_cli().device_login(
+            save_env_file=True,
+            sleep=lambda _seconds: _noop_sleep(),
+        )
+    )
+
+    assert result is False
+    assert store.saved is None
+    assert not (tmp_path / ".env").exists()
+
+
+def test_env_file_rewrite_replaces_export_prefixed_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "export TRAIGENT_API_KEY=sk_stale",  # pragma: allowlist secret
+                "TRAIGENT_API_KEY=sk_duplicate",  # pragma: allowlist secret
+                "OTHER=value",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _make_cli()._save_api_key_to_env_file(
+        API_KEY,
+        tenant_id="tenant_123",
+        project_id="project_456",
+        backend_url="https://backend.example.test",
+    )
+
+    env_text = env_file.read_text(encoding="utf-8")
+    assert "sk_stale" not in env_text
+    assert "sk_duplicate" not in env_text
+    assert env_text.count("TRAIGENT_API_KEY=") == 1
+    assert f"export TRAIGENT_API_KEY={API_KEY}" in env_text
 
 
 def test_device_flow_pending_then_slow_down_honors_authoritative_interval(
@@ -204,6 +325,73 @@ def test_device_flow_pending_then_slow_down_honors_authoritative_interval(
 
     assert result is True
     assert sleeps == [1, 7]
+
+
+def test_device_poll_caps_sleep_and_timeout_to_expiry_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload(interval=10, expires_in=3)),
+            _FakeResponse(400, _error_payload("authorization_pending")),
+        ],
+    )
+    now = 0.0
+    sleeps: list[float] = []
+
+    def fake_clock() -> float:
+        return now
+
+    async def fake_sleep(seconds: float) -> None:
+        nonlocal now
+        sleeps.append(seconds)
+        now += seconds
+
+    result = asyncio.run(
+        _make_cli().device_login(sleep=fake_sleep, clock=fake_clock)
+    )
+
+    assert result is False
+    assert sleeps == [3]
+    token_call = session.post_calls[1]
+    assert token_call["url"].endswith("/auth/device/token")
+    assert token_call["timeout"].total == 3
+
+
+def test_device_poll_transport_error_retry_bound(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload(interval=1)),
+            OSError("network one"),
+            OSError("network two"),
+            OSError("network three"),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    result = asyncio.run(_make_cli().device_login(sleep=fake_sleep))
+
+    assert result is False
+    assert store.saved is None
+    assert sleeps == [1, 1]
+    token_calls = [
+        call for call in session.post_calls if call["url"].endswith("/auth/device/token")
+    ]
+    assert len(token_calls) == 3
+    assert "failed after 3 consecutive transport errors" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -1,0 +1,265 @@
+"""Tests for Traigent device-code authentication."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from traigent.cli import auth_commands
+from traigent.cli.auth_commands import SECURE_CLI_CREDENTIAL_NAME, TraigentAuthCLI
+from traigent.security.credentials import CredentialType
+
+API_KEY = "sk_" + "a" * 43  # pragma: allowlist secret
+DEVICE_CODE = "A" * 43
+
+
+class _FakeSecureStore:
+    def __init__(self) -> None:
+        self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
+
+    def get(self, name: str, check_env: bool = True) -> str | None:
+        assert name == SECURE_CLI_CREDENTIAL_NAME
+        assert check_env is False
+        return None
+
+    def set(
+        self,
+        name: str,
+        value: str,
+        credential_type: CredentialType,
+        metadata: dict[str, str] | None = None,
+    ) -> None:
+        self.saved = (name, value, credential_type, metadata)
+
+    def delete_secure(self, name: str) -> bool:
+        assert name == SECURE_CLI_CREDENTIAL_NAME
+        return True
+
+
+class _FakeResponse:
+    def __init__(self, status: int, payload: dict[str, Any]) -> None:
+        self.status = status
+        self.payload = payload
+        self.headers: dict[str, str] = {}
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def text(self) -> str:
+        return json.dumps(self.payload)
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self.responses = responses
+        self.post_calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.post_calls.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError(f"Unexpected POST: {url}")
+        return self.responses.pop(0)
+
+
+def _authorize_payload(interval: int = 1) -> dict[str, Any]:
+    return {
+        "device_code": DEVICE_CODE,
+        "user_code": "BCDF-2345",
+        "verification_uri": "https://portal.example.test/device",
+        "verification_uri_complete": "https://portal.example.test/device?user_code=BCDF-2345",
+        "expires_in": 600,
+        "interval": interval,
+    }
+
+
+def _success_payload() -> dict[str, Any]:
+    return {
+        "success": True,
+        "data": {
+            "api_key": API_KEY,
+            "tenant_id": "tenant_123",
+            "project_id": "project_456",
+            "user": {"id": "user_1", "email": "dev@example.test"},
+            "subscription_tier": "trial",
+            "quota": {"trial_limit": 25, "api_call_limit": 1000},
+        },
+    }
+
+
+def _error_payload(error: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "success": False,
+        "error": error,
+        "error_code": error,
+    }
+    if details is not None:
+        payload["details"] = details
+    return payload
+
+
+def _install_device_test_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    responses: list[_FakeResponse],
+) -> tuple[_FakeSecureStore, _FakeSession]:
+    store = _FakeSecureStore()
+    session = _FakeSession(responses)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(auth_commands, "TRAIGENT_CONFIG_DIR", tmp_path / ".traigent")
+    monkeypatch.setattr(
+        auth_commands, "CREDENTIALS_FILE", tmp_path / ".traigent" / "credentials.json"
+    )
+    monkeypatch.setattr(auth_commands, "get_secure_credential_store", lambda: store)
+    assert auth_commands.aiohttp is not None
+    monkeypatch.setattr(
+        auth_commands.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: session,
+    )
+    return store, session
+
+
+def _make_cli() -> TraigentAuthCLI:
+    return TraigentAuthCLI(backend_url_override="https://backend.example.test")
+
+
+def test_device_flow_happy_path_persists_credentials_and_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+
+    result = asyncio.run(_make_cli().device_login(sleep=lambda _seconds: _noop_sleep()))
+
+    assert result is True
+    assert store.saved is not None
+    name, serialized, credential_type, metadata = store.saved
+    assert name == SECURE_CLI_CREDENTIAL_NAME
+    assert credential_type is CredentialType.TOKEN
+    assert metadata == {"source": "traigent-cli"}
+    saved = json.loads(serialized)
+    assert saved["api_key"] == API_KEY
+    assert saved["tenant_id"] == "tenant_123"
+    assert saved["project_id"] == "project_456"
+    assert saved["backend_url"] == "https://backend.example.test"
+
+    env_file = tmp_path / ".env"
+    assert env_file.exists()
+    assert env_file.stat().st_mode & 0o777 == 0o600
+    env_text = env_file.read_text(encoding="utf-8")
+    assert f"TRAIGENT_API_KEY={API_KEY}" in env_text
+    assert "TRAIGENT_TENANT_ID=tenant_123" in env_text
+    assert "TRAIGENT_PROJECT_ID=project_456" in env_text
+    assert "TRAIGENT_BACKEND_URL=https://backend.example.test" in env_text
+
+    assert session.post_calls[0]["url"].endswith("/auth/device/authorize")
+    assert session.post_calls[1]["url"].endswith("/auth/device/token")
+    assert session.post_calls[1]["json"] == {"device_code": DEVICE_CODE}
+    captured = capsys.readouterr()
+    assert API_KEY not in captured.out
+    assert API_KEY not in captured.err
+
+
+def test_device_flow_pending_then_slow_down_honors_authoritative_interval(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _store, _session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload(interval=1)),
+            _FakeResponse(400, _error_payload("authorization_pending")),
+            _FakeResponse(400, _error_payload("slow_down", {"interval": 7})),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    result = asyncio.run(_make_cli().device_login(sleep=fake_sleep))
+
+    assert result is True
+    assert sleeps == [1, 7]
+
+
+@pytest.mark.parametrize(
+    ("error_name", "message"),
+    [
+        ("access_denied", "denied"),
+        ("expired_token", "expired"),
+    ],
+)
+def test_device_flow_terminal_errors_exit_clearly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    error_name: str,
+    message: str,
+) -> None:
+    store, _session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(400, _error_payload(error_name)),
+        ],
+    )
+
+    result = asyncio.run(_make_cli().device_login(sleep=lambda _seconds: _noop_sleep()))
+
+    assert result is False
+    assert store.saved is None
+    assert message in capsys.readouterr().out
+
+
+def test_device_flow_malformed_success_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store, _session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(
+                200,
+                {
+                    "success": True,
+                    "data": {"api_key": API_KEY, "tenant_id": "tenant_123"},
+                },
+            ),
+        ],
+    )
+
+    result = asyncio.run(_make_cli().device_login(sleep=lambda _seconds: _noop_sleep()))
+
+    assert result is False
+    assert store.saved is None
+
+
+async def _noop_sleep() -> None:
+    return None

--- a/tests/unit/cli/test_onboard_commands.py
+++ b/tests/unit/cli/test_onboard_commands.py
@@ -20,6 +20,32 @@ from traigent.cli.onboard_commands import (
 )
 
 
+class _RecordingSecureStore:
+    def __init__(self) -> None:
+        self.saved: list[tuple[object, ...]] = []
+
+    def get(self, name: str, check_env: bool = True) -> str | None:
+        return None
+
+    def set(self, *args: object, **_kwargs: object) -> None:
+        self.saved.append(args)
+
+
+class _RecordingSession:
+    def __init__(self) -> None:
+        self.post_calls: list[dict[str, object]] = []
+
+    async def __aenter__(self) -> _RecordingSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def post(self, url: str, **kwargs: object) -> object:
+        self.post_calls.append({"url": url, **kwargs})
+        raise AssertionError(f"Unexpected POST: {url}")
+
+
 def _extract_plan(output: str) -> dict[str, object]:
     start = output.index(PLAN_JSON_BEGIN) + len(PLAN_JSON_BEGIN)
     end = output.index(PLAN_JSON_END)
@@ -29,10 +55,6 @@ def _extract_plan(output: str) -> dict[str, object]:
 def test_onboard_non_tty_emits_human_and_json_plan(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fake_auth_status(_auth_cli) -> str:
-        return "not_authenticated"
-
-    monkeypatch.setattr(onboard_commands, "_auth_status", fake_auth_status)
     monkeypatch.setattr(
         onboard_commands, "_detect_coding_agents", lambda _cwd: ["codex"]
     )
@@ -48,7 +70,7 @@ def test_onboard_non_tty_emits_human_and_json_plan(
         Path("pyproject.toml").write_text(
             "[project]\nname = 'demo'\n", encoding="utf-8"
         )
-        result = runner.invoke(cli, ["onboard", "--no-login"])
+        result = runner.invoke(cli, ["onboard"])
 
     assert result.exit_code == 0
     assert "Traigent onboarding plan (non-interactive)" in result.output
@@ -56,7 +78,9 @@ def test_onboard_non_tty_emits_human_and_json_plan(
     assert PLAN_JSON_END in result.output
 
     plan = _extract_plan(result.output)
-    assert plan["auth_status"] == "not_authenticated"
+    assert plan["auth_status"] == "not_checked"
+    assert plan["auth_check_command"] == "traigent auth status"
+    assert plan["login_command"] == "traigent onboard --login"
     assert plan["detected_agents"] == ["codex"]
     assert plan["python_project"] is True
 
@@ -65,9 +89,10 @@ def test_onboard_non_tty_emits_human_and_json_plan(
     command_by_id = {
         command["id"]: command for command in commands if isinstance(command, dict)
     }
-    assert (
-        command_by_id["add_dependency"]["command"] == "uv add 'traigent[integrations]'"
+    assert command_by_id["add_dependency"]["command"] == (
+        "uv add 'traigent[integrations]'"
     )
+    assert command_by_id["device_login"]["command"] == "traigent onboard --login"
     assert (
         command_by_id["install_agent_skills"]["command"]
         == "npx skills add Traigent/agents-skills"
@@ -89,6 +114,99 @@ def test_onboard_non_tty_emits_human_and_json_plan(
         "verification",
         "first_prompt",
     }
+
+
+def test_onboard_non_tty_without_flags_does_not_call_network_or_write_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from traigent.cli import auth_commands
+
+    session = _RecordingSession()
+    store = _RecordingSecureStore()
+    assert auth_commands.aiohttp is not None
+    monkeypatch.setattr(
+        auth_commands.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: session,
+    )
+    monkeypatch.setattr(auth_commands, "get_secure_credential_store", lambda: store)
+    monkeypatch.setattr(onboard_commands, "_detect_coding_agents", lambda _cwd: [])
+    monkeypatch.setattr(onboard_commands, "_mcp_help_succeeds", lambda: False)
+    monkeypatch.setenv("TRAIGENT_API_KEY", "sk_" + "a" * 43)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["onboard"])
+        env_exists = Path(".env").exists()
+
+    assert result.exit_code == 0
+    assert session.post_calls == []
+    assert store.saved == []
+    assert env_exists is False
+
+
+def test_onboard_non_tty_check_auth_opts_into_live_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+
+    async def fake_auth_status(auth_cli) -> str:
+        calls.append(auth_cli)
+        return "authenticated"
+
+    monkeypatch.setattr(onboard_commands, "_auth_status", fake_auth_status)
+    monkeypatch.setattr(onboard_commands, "_detect_coding_agents", lambda _cwd: [])
+    monkeypatch.setattr(onboard_commands, "_mcp_help_succeeds", lambda: False)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["onboard", "--check-auth"])
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    plan = _extract_plan(result.output)
+    assert plan["auth_status"] == "authenticated"
+
+
+def test_onboard_non_tty_login_flag_runs_device_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeAuthCLI:
+        def __init__(self, backend_url_override: str | None = None) -> None:
+            self.backend_url_override = backend_url_override
+
+        async def device_login(self, **kwargs: object) -> bool:
+            calls.append(
+                {"backend_url": self.backend_url_override, "kwargs": kwargs}
+            )
+            return True
+
+    monkeypatch.setattr(onboard_commands, "TraigentAuthCLI", FakeAuthCLI)
+    monkeypatch.setattr(onboard_commands, "_detect_coding_agents", lambda _cwd: [])
+    monkeypatch.setattr(onboard_commands, "_mcp_help_succeeds", lambda: False)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "onboard",
+                "--login",
+                "--write-env",
+                "--backend-url",
+                "https://backend.example.test",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["backend_url"] == "https://backend.example.test"
+    kwargs = calls[0]["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["save_env_file"] is True
+    assert kwargs["write_env_explicit"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_onboard_commands.py
+++ b/tests/unit/cli/test_onboard_commands.py
@@ -1,0 +1,153 @@
+"""Tests for Traigent onboarding CLI commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from traigent.cli import onboard_commands
+from traigent.cli.main import cli
+from traigent.cli.onboard_commands import (
+    PLAN_JSON_BEGIN,
+    PLAN_JSON_END,
+    AgentName,
+    build_first_prompt,
+)
+
+
+def _extract_plan(output: str) -> dict[str, object]:
+    start = output.index(PLAN_JSON_BEGIN) + len(PLAN_JSON_BEGIN)
+    end = output.index(PLAN_JSON_END)
+    return json.loads(output[start:end].strip())
+
+
+def test_onboard_non_tty_emits_human_and_json_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_auth_status(_auth_cli) -> str:
+        return "not_authenticated"
+
+    monkeypatch.setattr(onboard_commands, "_auth_status", fake_auth_status)
+    monkeypatch.setattr(
+        onboard_commands, "_detect_coding_agents", lambda _cwd: ["codex"]
+    )
+    monkeypatch.setattr(onboard_commands, "_mcp_help_succeeds", lambda: False)
+    monkeypatch.setattr(
+        onboard_commands,
+        "_dependency_command",
+        lambda _markers: ["uv", "add", "traigent[integrations]"],
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("pyproject.toml").write_text(
+            "[project]\nname = 'demo'\n", encoding="utf-8"
+        )
+        result = runner.invoke(cli, ["onboard", "--no-login"])
+
+    assert result.exit_code == 0
+    assert "Traigent onboarding plan (non-interactive)" in result.output
+    assert PLAN_JSON_BEGIN in result.output
+    assert PLAN_JSON_END in result.output
+
+    plan = _extract_plan(result.output)
+    assert plan["auth_status"] == "not_authenticated"
+    assert plan["detected_agents"] == ["codex"]
+    assert plan["python_project"] is True
+
+    commands = plan["commands"]
+    assert isinstance(commands, list)
+    command_by_id = {
+        command["id"]: command for command in commands if isinstance(command, dict)
+    }
+    assert (
+        command_by_id["add_dependency"]["command"] == "uv add 'traigent[integrations]'"
+    )
+    assert (
+        command_by_id["install_agent_skills"]["command"]
+        == "npx skills add Traigent/agents-skills"
+    )
+    assert command_by_id["verify_quickstart"]["command"] == "traigent quickstart"
+    assert (
+        command_by_id["first_prompt"]["command"]
+        == "traigent first-prompt --agent codex"
+    )
+
+    steps = plan["steps"]
+    assert isinstance(steps, list)
+    assert {step["id"] for step in steps if isinstance(step, dict)} >= {
+        "python_version",
+        "project_dependency",
+        "device_login",
+        "agent_skills",
+        "mcp_registration",
+        "verification",
+        "first_prompt",
+    }
+
+
+@pytest.mark.parametrize(
+    ("agent", "tool_line"),
+    [
+        (
+            "claude",
+            "Use Claude Code tools to inspect code and propose the smallest safe change.",
+        ),
+        (
+            "cursor",
+            "Use Cursor agent tools to inspect code and propose the smallest safe change.",
+        ),
+        (
+            "codex",
+            "Use Codex tools to inspect code and propose the smallest safe change.",
+        ),
+    ],
+)
+def test_first_prompt_golden_outputs(agent: AgentName, tool_line: str) -> None:
+    expected = "\n".join(
+        [
+            "You are using Traigent in this project: /work/project",
+            "Read the agent guide first: https://traigent.ai/agent.md",
+            tool_line,
+            "Always run Traigent in dry-run/mock mode first.",
+            "Never spend real provider tokens or start paid optimization without my approval.",
+            "Treat scaffolded evals as drafts until I approve their dataset and metrics.",
+            "When approved for real execution, keep cost estimates and limits visible.",
+            "Finish with evidence, changed files, test results, and a PR-ready summary.",
+        ]
+    )
+
+    assert build_first_prompt(agent, Path("/work/project")) == expected
+
+
+def test_first_prompt_command_outputs_selected_agent() -> None:
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["first-prompt", "--agent", "claude"])
+
+    assert result.exit_code == 0
+    assert "https://traigent.ai/agent.md" in result.output
+    assert "Use Claude Code tools" in result.output
+    assert "Never spend real provider tokens" in result.output
+
+
+def test_quickstart_command_wraps_packaged_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[bool] = []
+    fake_module = types.ModuleType("traigent.examples.quickstart.__main__")
+    fake_module.main = lambda: called.append(True)
+    monkeypatch.setitem(
+        sys.modules, "traigent.examples.quickstart.__main__", fake_module
+    )
+
+    result = CliRunner().invoke(cli, ["quickstart"])
+
+    assert result.exit_code == 0
+    assert called == [True]

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -81,6 +82,11 @@ _ENV_FILE_KEYS = (
     PROJECT_ENV_VAR,
     "TRAIGENT_BACKEND_URL",
 )
+_ENV_ASSIGNMENT_RE = re.compile(
+    r"^(?P<leading>\s*)(?P<export>export\s+)?" r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*="
+)
+MAX_DEVICE_POLL_TIMEOUT_SECONDS = 30.0
+MAX_DEVICE_POLL_TRANSPORT_ERRORS = 3
 
 
 async def _read_json_body(response: Any) -> dict[str, Any]:
@@ -119,6 +125,18 @@ def _format_env_value(value: str) -> str:
     if re.fullmatch(r"[A-Za-z0-9_./:@+-]+", value):
         return value
     return json.dumps(value)
+
+
+def _env_assignment_key(line: str) -> str | None:
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    return match.group("key") if match else None
+
+
+def _format_env_assignment_from_existing(line: str, key: str, value: str) -> str:
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    leading = match.group("leading") if match else ""
+    export_prefix = match.group("export") if match else None
+    return f"{leading}{export_prefix or ''}{key}={_format_env_value(value)}"
 
 
 class TraigentAuthCLI:
@@ -282,10 +300,13 @@ class TraigentAuthCLI:
                 next_lines.append(line)
                 continue
 
-            key = line.split("=", 1)[0].strip()
-            if key in updates:
-                next_lines.append(f"{key}={_format_env_value(updates[key])}")
-                seen.add(key)
+            key = _env_assignment_key(line)
+            if key is not None and key in updates:
+                if key not in seen:
+                    next_lines.append(
+                        _format_env_assignment_from_existing(line, key, updates[key])
+                    )
+                    seen.add(key)
             else:
                 next_lines.append(line)
 
@@ -474,7 +495,7 @@ class TraigentAuthCLI:
         return error_name, details if isinstance(details, dict) else {}
 
     async def _poll_device_token_once(
-        self, session: Any, device_code: str
+        self, session: Any, device_code: str, request_timeout: float
     ) -> tuple[str, dict[str, Any] | None, int | None]:
         """Poll the token endpoint once."""
         url = f"{self.backend_api_url}/auth/device/token"
@@ -487,7 +508,7 @@ class TraigentAuthCLI:
             url,
             json={"device_code": device_code},
             headers=headers,
-            timeout=aiohttp.ClientTimeout(total=30) if aiohttp else None,
+            timeout=aiohttp.ClientTimeout(total=request_timeout) if aiohttp else None,
         ) as response:
             status_code = response.status
             data = await _read_json_body(response)
@@ -514,16 +535,52 @@ class TraigentAuthCLI:
         session: Any,
         authorization: dict[str, Any],
         sleep: Any,
+        clock: Callable[[], float] | None = None,
     ) -> dict[str, Any] | None:
         """Poll the token endpoint until success, denial, or expiry."""
         interval = int(authorization["interval"])
-        deadline = time.monotonic() + int(authorization["expires_in"])
+        now = clock or time.monotonic
+        deadline = now() + int(authorization["expires_in"])
         device_code = str(authorization["device_code"])
+        consecutive_transport_errors = 0
 
-        while time.monotonic() < deadline:
-            status, credentials, new_interval = await self._poll_device_token_once(
-                session, device_code
-            )
+        while True:
+            remaining = deadline - now()
+            if remaining <= 0:
+                console.print(
+                    "[red]Device login expired before authorization completed.[/red]"
+                )
+                return None
+
+            try:
+                status, credentials, new_interval = await self._poll_device_token_once(
+                    session,
+                    device_code,
+                    min(MAX_DEVICE_POLL_TIMEOUT_SECONDS, remaining),
+                )
+                consecutive_transport_errors = 0
+            except NETWORK_ERRORS as exc:
+                consecutive_transport_errors += 1
+                if consecutive_transport_errors >= MAX_DEVICE_POLL_TRANSPORT_ERRORS:
+                    console.print(
+                        "[red]Device token polling failed after "
+                        f"{consecutive_transport_errors} consecutive transport "
+                        "errors. Please check your network and run login again.[/red]"
+                    )
+                    return None
+                sleep_seconds = min(float(interval), max(0.0, deadline - now()))
+                if sleep_seconds <= 0:
+                    console.print(
+                        "[red]Device login expired before authorization completed.[/red]"
+                    )
+                    return None
+                console.print(
+                    "[yellow]Device token polling transport error "
+                    f"({type(exc).__name__}); retrying in {sleep_seconds:g}s.[/yellow]"
+                )
+                await sleep(sleep_seconds)
+                continue
+
             if status == "success":
                 return credentials
             if status == "access_denied":
@@ -544,10 +601,13 @@ class TraigentAuthCLI:
                     f"[yellow]Backend requested slower polling; waiting {interval}s.[/yellow]"
                 )
 
-            await sleep(interval)
-
-        console.print("[red]Device login expired before authorization completed.[/red]")
-        return None
+            sleep_seconds = min(float(interval), max(0.0, deadline - now()))
+            if sleep_seconds <= 0:
+                console.print(
+                    "[red]Device login expired before authorization completed.[/red]"
+                )
+                return None
+            await sleep(sleep_seconds)
 
     def _display_device_authorization(self, authorization: dict[str, Any]) -> None:
         """Print the browser URL and user code prominently."""
@@ -565,34 +625,48 @@ class TraigentAuthCLI:
         *,
         save_env_file: bool,
         env_file: str | Path,
+        write_env_explicit: bool = False,
     ) -> str | None:
         """Persist device credentials through existing credential machinery."""
         storage_location = self._save_credentials(credentials)
         if save_env_file:
-            try:
-                saved_path = self._save_api_key_to_env_file(
-                    str(credentials["api_key"]),
-                    tenant_id=str(credentials["tenant_id"]),
-                    project_id=str(credentials["project_id"]),
-                    backend_url=str(credentials["backend_url"]),
-                    path=env_file,
-                )
+            if storage_location != STORAGE_SECURE and not write_env_explicit:
                 console.print(
-                    f"[green]✅ Project auth environment updated:[/green] {saved_path}"
+                    "[yellow]Skipping .env write because secure credential storage "
+                    "failed.[/yellow]"
                 )
-            except (OSError, ValueError) as exc:
-                console.print(
-                    "[yellow]Could not update local .env file; encrypted CLI "
-                    f"credentials were still attempted. Reason: {exc}[/yellow]"
-                )
+            else:
+                if storage_location != STORAGE_SECURE:
+                    console.print(
+                        "[yellow]Secure credential storage failed; writing .env "
+                        "because --write-env was explicitly passed.[/yellow]"
+                    )
+                try:
+                    saved_path = self._save_api_key_to_env_file(
+                        str(credentials["api_key"]),
+                        tenant_id=str(credentials["tenant_id"]),
+                        project_id=str(credentials["project_id"]),
+                        backend_url=str(credentials["backend_url"]),
+                        path=env_file,
+                    )
+                    console.print(
+                        f"[green]✅ Project auth environment updated:[/green] {saved_path}"
+                    )
+                except (OSError, ValueError) as exc:
+                    console.print(
+                        "[yellow]Could not update local .env file. Reason: "
+                        f"{exc}[/yellow]"
+                    )
         return storage_location
 
     async def device_login(
         self,
         *,
-        save_env_file: bool = True,
+        save_env_file: bool = False,
         env_file: str | Path = ".env",
+        write_env_explicit: bool = False,
         sleep: Any | None = None,
+        clock: Callable[[], float] | None = None,
     ) -> bool:
         """Authenticate with the browser-based device-code flow."""
         import aiohttp
@@ -606,7 +680,7 @@ class TraigentAuthCLI:
                 authorization = await self._start_device_authorization(session)
                 self._display_device_authorization(authorization)
                 credentials = await self._poll_device_token(
-                    session, authorization, poll_sleep
+                    session, authorization, poll_sleep, clock=clock
                 )
         except AuthenticationError as exc:
             console.print(f"[red]❌ Device authentication failed: {exc}[/red]")
@@ -628,6 +702,7 @@ class TraigentAuthCLI:
             credentials,
             save_env_file=save_env_file,
             env_file=env_file,
+            write_env_explicit=write_env_explicit,
         )
         if not storage_location:
             self._display_storage_location(storage_location)
@@ -1349,16 +1424,22 @@ def login(
     "--env-file",
     default=".env",
     type=click.Path(dir_okay=False, path_type=Path),
-    help="Local .env file to update with project-scoped credentials",
+    help="Local .env file to update when --write-env is set.",
+)
+@click.option(
+    "--write-env",
+    is_flag=True,
+    help="Also write project-scoped credentials to a local .env file.",
 )
 @click.option(
     "--no-env-file",
     is_flag=True,
-    help="Store encrypted CLI credentials only; do not update .env",
+    hidden=True,
 )
 def device_login(
     backend_url: str | None,
     env_file: Path,
+    write_env: bool,
     no_env_file: bool,
 ) -> None:
     """Authenticate through browser device-code login.
@@ -1366,9 +1447,24 @@ def device_login(
     The command prints a browser URL and one-time code, then polls until
     the backend returns a project-scoped API key or the request expires.
     """
+    save_env_file = False
+    write_env_explicit = False
+    if write_env:
+        save_env_file = True
+        write_env_explicit = True
+    elif not no_env_file and sys.stdin.isatty():
+        save_env_file = click.confirm(
+            "Write project credentials to this directory's .env file?",
+            default=False,
+        )
+
     cli = TraigentAuthCLI(backend_url_override=backend_url)
     success = asyncio.run(
-        cli.device_login(save_env_file=not no_env_file, env_file=env_file)
+        cli.device_login(
+            save_env_file=save_env_file,
+            env_file=env_file,
+            write_env_explicit=write_env_explicit,
+        )
     )
     sys.exit(0 if success else 1)
 

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
 import click
 from rich.console import Console
+from rich.panel import Panel
 
 # Try to import aiohttp for exception handling
 try:
@@ -61,6 +64,61 @@ SECURE_CLI_CREDENTIAL_NAME = "cli_credentials"
 # Common user-facing messages (avoid duplication per SonarCloud S1192)
 MSG_CHECK_NETWORK = "Please check your network connection and try again.\n"
 MSG_RUN_LOGIN_AGAIN = "Please run [cyan]traigent auth login[/cyan] again.\n"
+
+_DEVICE_CODE_RE = re.compile(r"^[A-Za-z0-9_-]{43,}$")
+_USER_CODE_RE = re.compile(
+    r"^[BCDFGHJKMNPQRSTVWXYZ23456789]{4}-[BCDFGHJKMNPQRSTVWXYZ23456789]{4}$"
+)
+_DEVICE_ERROR_NAMES = {
+    "authorization_pending",
+    "slow_down",
+    "access_denied",
+    "expired_token",
+}
+_ENV_FILE_KEYS = (
+    "TRAIGENT_API_KEY",
+    TENANT_ENV_VAR,
+    PROJECT_ENV_VAR,
+    "TRAIGENT_BACKEND_URL",
+)
+
+
+async def _read_json_body(response: Any) -> dict[str, Any]:
+    """Read a JSON object response body, failing closed on malformed data."""
+    try:
+        response_text = await response.text()
+    except Exception as exc:
+        raise AuthenticationError("Unable to read backend response body") from exc
+
+    try:
+        data = json.loads(response_text)
+    except json.JSONDecodeError as exc:
+        raise AuthenticationError("Invalid JSON response from backend") from exc
+
+    if not isinstance(data, dict):
+        raise AuthenticationError("Backend response must be a JSON object")
+    return data
+
+
+def _require_non_empty_str(data: dict[str, Any], field: str) -> str:
+    value = data.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise AuthenticationError(f"Malformed device auth response: missing {field}")
+    return value.strip()
+
+
+def _require_positive_int(data: dict[str, Any], field: str) -> int:
+    value = data.get(field)
+    if not isinstance(value, int) or value <= 0:
+        raise AuthenticationError(f"Malformed device auth response: invalid {field}")
+    return value
+
+
+def _format_env_value(value: str) -> str:
+    """Format a value for a dotenv assignment."""
+    if re.fullmatch(r"[A-Za-z0-9_./:@+-]+", value):
+        return value
+    return json.dumps(value)
 
 
 class TraigentAuthCLI:
@@ -194,6 +252,60 @@ class TraigentAuthCLI:
             )
         return resolved
 
+    def _save_api_key_to_env_file(
+        self,
+        api_key: str,
+        *,
+        tenant_id: str,
+        project_id: str,
+        backend_url: str,
+        path: str | Path = ".env",
+    ) -> Path:
+        """Persist auth environment values to a local .env file with 0600 perms."""
+        env_path = self._resolve_env_file_path(path)
+        existing_lines: list[str] = []
+        if env_path.exists():
+            existing_lines = env_path.read_text(encoding="utf-8").splitlines()
+
+        updates = {
+            "TRAIGENT_API_KEY": api_key,
+            TENANT_ENV_VAR: tenant_id,
+            PROJECT_ENV_VAR: project_id,
+            "TRAIGENT_BACKEND_URL": backend_url,
+        }
+        seen: set[str] = set()
+        next_lines: list[str] = []
+
+        for line in existing_lines:
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith("#") or "=" not in line:
+                next_lines.append(line)
+                continue
+
+            key = line.split("=", 1)[0].strip()
+            if key in updates:
+                next_lines.append(f"{key}={_format_env_value(updates[key])}")
+                seen.add(key)
+            else:
+                next_lines.append(line)
+
+        if next_lines and next_lines[-1] != "":
+            next_lines.append("")
+        for key in _ENV_FILE_KEYS:
+            if key not in seen:
+                next_lines.append(f"{key}={_format_env_value(updates[key])}")
+
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(
+            env_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(next_lines).rstrip() + "\n")
+        env_path.chmod(0o600)
+        return env_path
+
     async def _validate_api_key(
         self, api_key: str, verbose: bool = False
     ) -> dict[str, Any] | None:
@@ -242,6 +354,292 @@ class TraigentAuthCLI:
             if verbose:
                 console.print(f"[dim]Connection error: {e}[/dim]")
             return None
+
+    def _validate_device_authorize_payload(
+        self, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Validate the device authorization response contract."""
+        device_code = _require_non_empty_str(data, "device_code")
+        if not _DEVICE_CODE_RE.fullmatch(device_code):
+            raise AuthenticationError(
+                "Malformed device auth response: invalid device_code"
+            )
+
+        user_code = _require_non_empty_str(data, "user_code")
+        if not _USER_CODE_RE.fullmatch(user_code):
+            raise AuthenticationError(
+                "Malformed device auth response: invalid user_code"
+            )
+
+        verification_uri = _require_non_empty_str(data, "verification_uri")
+        verification_uri_complete = _require_non_empty_str(
+            data, "verification_uri_complete"
+        )
+        expires_in = _require_positive_int(data, "expires_in")
+        interval = _require_positive_int(data, "interval")
+
+        return {
+            "device_code": device_code,
+            "user_code": user_code,
+            "verification_uri": verification_uri,
+            "verification_uri_complete": verification_uri_complete,
+            "expires_in": expires_in,
+            "interval": interval,
+        }
+
+    async def _start_device_authorization(self, session: Any) -> dict[str, Any]:
+        """Start the RFC 8628 device authorization flow."""
+        url = f"{self.backend_api_url}/auth/device/authorize"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "Traigent-SDK-CLI/1.0",
+        }
+        async with session.post(
+            url,
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=30) if aiohttp else None,
+        ) as response:
+            data = await _read_json_body(response)
+            if response.status != 200:
+                raise AuthenticationError(
+                    f"Device authorization failed (HTTP {response.status})"
+                )
+            return self._validate_device_authorize_payload(data)
+
+    def _validate_device_token_success(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Validate and normalize a successful device token envelope."""
+        if data.get("success") is not True:
+            raise AuthenticationError(
+                "Malformed device token response: success missing"
+            )
+        token_data = data.get("data")
+        if not isinstance(token_data, dict):
+            raise AuthenticationError("Malformed device token response: data missing")
+
+        api_key = _require_non_empty_str(token_data, "api_key")
+        if not api_key.startswith("sk_"):
+            raise AuthenticationError(
+                "Malformed device token response: invalid api_key"
+            )
+
+        tenant_id = _require_non_empty_str(token_data, "tenant_id")
+        project_id = _require_non_empty_str(token_data, "project_id")
+        subscription_tier = _require_non_empty_str(token_data, "subscription_tier")
+
+        user = token_data.get("user")
+        if not isinstance(user, dict):
+            raise AuthenticationError("Malformed device token response: user missing")
+        normalized_user = {
+            "id": _require_non_empty_str(user, "id"),
+            "email": _require_non_empty_str(user, "email"),
+        }
+
+        quota = token_data.get("quota")
+        if not isinstance(quota, dict):
+            raise AuthenticationError("Malformed device token response: quota missing")
+        trial_limit = quota.get("trial_limit")
+        api_call_limit = quota.get("api_call_limit")
+        if not isinstance(trial_limit, int) or not isinstance(api_call_limit, int):
+            raise AuthenticationError("Malformed device token response: invalid quota")
+
+        return {
+            "api_key": api_key,
+            "tenant_id": tenant_id,
+            "project_id": project_id,
+            "user": normalized_user,
+            "subscription_tier": subscription_tier,
+            "quota": {
+                "trial_limit": trial_limit,
+                "api_call_limit": api_call_limit,
+            },
+            "backend_url": self.backend_url,
+        }
+
+    @staticmethod
+    def _device_error_from_envelope(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        """Return a known RFC 8628 error name and details from an error envelope."""
+        raw_error = data.get("error")
+        raw_error_code = data.get("error_code")
+        if raw_error and raw_error_code and raw_error != raw_error_code:
+            raise AuthenticationError(
+                "Malformed device token error response: error mismatch"
+            )
+
+        error_name = raw_error_code or raw_error
+        if not isinstance(error_name, str) or error_name not in _DEVICE_ERROR_NAMES:
+            raise AuthenticationError("Unexpected device token response from backend")
+
+        details = data.get("details")
+        return error_name, details if isinstance(details, dict) else {}
+
+    async def _poll_device_token_once(
+        self, session: Any, device_code: str
+    ) -> tuple[str, dict[str, Any] | None, int | None]:
+        """Poll the token endpoint once."""
+        url = f"{self.backend_api_url}/auth/device/token"
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "Traigent-SDK-CLI/1.0",
+        }
+        async with session.post(
+            url,
+            json={"device_code": device_code},
+            headers=headers,
+            timeout=aiohttp.ClientTimeout(total=30) if aiohttp else None,
+        ) as response:
+            status_code = response.status
+            data = await _read_json_body(response)
+
+        if data.get("success") is True:
+            if status_code != 200:
+                raise AuthenticationError(
+                    f"Device token request failed (HTTP {status_code})"
+                )
+            return "success", self._validate_device_token_success(data), None
+
+        error_name, details = self._device_error_from_envelope(data)
+        if error_name == "slow_down":
+            new_interval = details.get("interval")
+            if not isinstance(new_interval, int) or new_interval < 6:
+                raise AuthenticationError(
+                    "Malformed slow_down response: details.interval must be >= 6"
+                )
+            return error_name, None, new_interval
+        return error_name, None, None
+
+    async def _poll_device_token(
+        self,
+        session: Any,
+        authorization: dict[str, Any],
+        sleep: Any,
+    ) -> dict[str, Any] | None:
+        """Poll the token endpoint until success, denial, or expiry."""
+        interval = int(authorization["interval"])
+        deadline = time.monotonic() + int(authorization["expires_in"])
+        device_code = str(authorization["device_code"])
+
+        while time.monotonic() < deadline:
+            status, credentials, new_interval = await self._poll_device_token_once(
+                session, device_code
+            )
+            if status == "success":
+                return credentials
+            if status == "access_denied":
+                console.print("[red]Device login was denied in the browser.[/red]")
+                return None
+            if status == "expired_token":
+                console.print(
+                    "[red]Device login expired. Please run login again.[/red]"
+                )
+                return None
+            if status == "slow_down":
+                if new_interval is None:
+                    raise AuthenticationError(
+                        "Malformed slow_down response: missing interval"
+                    )
+                interval = new_interval
+                console.print(
+                    f"[yellow]Backend requested slower polling; waiting {interval}s.[/yellow]"
+                )
+
+            await sleep(interval)
+
+        console.print("[red]Device login expired before authorization completed.[/red]")
+        return None
+
+    def _display_device_authorization(self, authorization: dict[str, Any]) -> None:
+        """Print the browser URL and user code prominently."""
+        body = (
+            f"Open this URL:\n[bold cyan]{authorization['verification_uri_complete']}[/bold cyan]\n\n"
+            f"Code:\n[bold yellow]{authorization['user_code']}[/bold yellow]"
+        )
+        console.print(
+            Panel.fit(body, title="Traigent Device Login", border_style="blue")
+        )
+
+    def _persist_device_credentials(
+        self,
+        credentials: dict[str, Any],
+        *,
+        save_env_file: bool,
+        env_file: str | Path,
+    ) -> str | None:
+        """Persist device credentials through existing credential machinery."""
+        storage_location = self._save_credentials(credentials)
+        if save_env_file:
+            try:
+                saved_path = self._save_api_key_to_env_file(
+                    str(credentials["api_key"]),
+                    tenant_id=str(credentials["tenant_id"]),
+                    project_id=str(credentials["project_id"]),
+                    backend_url=str(credentials["backend_url"]),
+                    path=env_file,
+                )
+                console.print(
+                    f"[green]✅ Project auth environment updated:[/green] {saved_path}"
+                )
+            except (OSError, ValueError) as exc:
+                console.print(
+                    "[yellow]Could not update local .env file; encrypted CLI "
+                    f"credentials were still attempted. Reason: {exc}[/yellow]"
+                )
+        return storage_location
+
+    async def device_login(
+        self,
+        *,
+        save_env_file: bool = True,
+        env_file: str | Path = ".env",
+        sleep: Any | None = None,
+    ) -> bool:
+        """Authenticate with the browser-based device-code flow."""
+        import aiohttp
+
+        poll_sleep = sleep or asyncio.sleep
+        console.print("\n[bold blue]Traigent Device Authentication[/bold blue]")
+        console.print(f"Authenticating with: [cyan]{self.backend_url}[/cyan]\n")
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                authorization = await self._start_device_authorization(session)
+                self._display_device_authorization(authorization)
+                credentials = await self._poll_device_token(
+                    session, authorization, poll_sleep
+                )
+        except AuthenticationError as exc:
+            console.print(f"[red]❌ Device authentication failed: {exc}[/red]")
+            return False
+        except TimeoutError as exc:
+            console.print(f"[red]❌ Device authentication timed out: {exc}[/red]")
+            console.print(MSG_CHECK_NETWORK)
+            return False
+        except NETWORK_ERRORS as exc:
+            error_type = type(exc).__name__
+            console.print(f"[red]❌ Connection error ({error_type}): {exc}[/red]")
+            console.print(MSG_CHECK_NETWORK)
+            return False
+
+        if not credentials:
+            return False
+
+        storage_location = self._persist_device_credentials(
+            credentials,
+            save_env_file=save_env_file,
+            env_file=env_file,
+        )
+        if not storage_location:
+            self._display_storage_location(storage_location)
+            return False
+
+        user = credentials.get("user", {})
+        console.print(
+            f"[green]✅ Authenticated as {user.get('email', 'Traigent user')}[/green]"
+        )
+        console.print("[green]✅ API key received and stored securely[/green]")
+        self._display_storage_location(storage_location)
+        return True
 
     def _clear_credentials(self) -> bool:
         """Clear stored credentials.
@@ -938,6 +1336,40 @@ def login(
     """
     cli = TraigentAuthCLI(backend_url_override=backend_url)
     success = asyncio.run(cli.login(email, non_interactive))
+    sys.exit(0 if success else 1)
+
+
+@auth.command("device-login")
+@click.option(
+    "--backend-url",
+    default=None,
+    help="Backend URL to authenticate against",
+)
+@click.option(
+    "--env-file",
+    default=".env",
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Local .env file to update with project-scoped credentials",
+)
+@click.option(
+    "--no-env-file",
+    is_flag=True,
+    help="Store encrypted CLI credentials only; do not update .env",
+)
+def device_login(
+    backend_url: str | None,
+    env_file: Path,
+    no_env_file: bool,
+) -> None:
+    """Authenticate through browser device-code login.
+
+    The command prints a browser URL and one-time code, then polls until
+    the backend returns a project-scoped API key or the request expires.
+    """
+    cli = TraigentAuthCLI(backend_url_override=backend_url)
+    success = asyncio.run(
+        cli.device_login(save_env_file=not no_env_file, env_file=env_file)
+    )
     sys.exit(0 if success else 1)
 
 

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -2086,5 +2086,10 @@ from traigent.cli.generate_config_command import generate_config  # noqa: E402
 
 cli.add_command(generate_config)
 
+from traigent.cli.onboard_commands import first_prompt, onboard  # noqa: E402
+
+cli.add_command(onboard)
+cli.add_command(first_prompt)
+
 if __name__ == "__main__":
     cli()  # pylint: disable=no-value-for-parameter

--- a/traigent/cli/onboard_commands.py
+++ b/traigent/cli/onboard_commands.py
@@ -1,0 +1,499 @@
+"""Guided onboarding commands for the Traigent CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from traigent.cli.auth_commands import TraigentAuthCLI
+
+console = Console()
+
+AgentName = Literal["claude", "cursor", "codex"]
+
+AGENT_LABELS: dict[AgentName, str] = {
+    "claude": "Claude Code",
+    "cursor": "Cursor",
+    "codex": "Codex",
+}
+FIRST_PROMPT_TOOL_LINE: dict[AgentName, str] = {
+    "claude": "Use Claude Code tools to inspect code and propose the smallest safe change.",
+    "cursor": "Use Cursor agent tools to inspect code and propose the smallest safe change.",
+    "codex": "Use Codex tools to inspect code and propose the smallest safe change.",
+}
+PLAN_JSON_BEGIN = "BEGIN_TRAIGENT_ONBOARD_PLAN_JSON"
+PLAN_JSON_END = "END_TRAIGENT_ONBOARD_PLAN_JSON"
+SKILLS_COMMAND = ["npx", "skills", "add", "Traigent/agents-skills"]
+
+
+def _stdin_is_tty() -> bool:
+    return bool(sys.stdin.isatty())
+
+
+def _command_text(command: list[str]) -> str:
+    return shlex.join(command)
+
+
+def _detect_python_project(cwd: Path) -> list[str]:
+    markers = [
+        "pyproject.toml",
+        "setup.py",
+        "setup.cfg",
+        "requirements.txt",
+        "Pipfile",
+        "poetry.lock",
+        "uv.lock",
+    ]
+    return [marker for marker in markers if (cwd / marker).exists()]
+
+
+def _dependency_command(project_markers: list[str]) -> list[str]:
+    if shutil.which("uv") and (
+        "pyproject.toml" in project_markers or "uv.lock" in project_markers
+    ):
+        return ["uv", "add", "traigent[integrations]"]
+    return [sys.executable, "-m", "pip", "install", "traigent[integrations]"]
+
+
+def _detect_coding_agents(cwd: Path, home: Path | None = None) -> list[AgentName]:
+    resolved_home = home or Path.home()
+    agents: list[AgentName] = []
+    if (resolved_home / ".claude").exists() or shutil.which("claude"):
+        agents.append("claude")
+    if (resolved_home / ".cursor").exists() or (cwd / ".cursor").exists():
+        agents.append("cursor")
+    if (resolved_home / ".codex").exists() or (cwd / "AGENTS.md").exists():
+        agents.append("codex")
+    return agents
+
+
+def _mcp_help_succeeds() -> bool:
+    executable = shutil.which("traigent")
+    if not executable:
+        return False
+    try:
+        result = subprocess.run(
+            [executable, "mcp", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _mcp_registration_command(agent: AgentName) -> list[str]:
+    return ["traigent", "mcp", "register", "--agent", agent]
+
+
+def _run_command(command: list[str]) -> bool:
+    console.print(f"[dim]$ {_command_text(command)}[/dim]")
+    try:
+        result = subprocess.run(command, check=False)
+    except OSError as exc:
+        console.print(f"[red]Command failed to start: {exc}[/red]")
+        return False
+    if result.returncode != 0:
+        console.print(f"[red]Command exited with status {result.returncode}[/red]")
+        return False
+    return True
+
+
+async def _auth_status(auth_cli: TraigentAuthCLI) -> str:
+    if await auth_cli._check_stored_api_key():
+        return "authenticated"
+    if await auth_cli._check_env_api_key():
+        return "authenticated"
+    return "not_authenticated"
+
+
+def _python_version_step() -> dict[str, Any]:
+    version = (
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
+    status = "passed" if sys.version_info >= (3, 11) else "failed"
+    return {
+        "id": "python_version",
+        "status": status,
+        "description": f"Python {version}; Traigent requires Python >=3.11",
+    }
+
+
+def _select_prompt_agent(agents: list[AgentName]) -> AgentName:
+    if "codex" in agents:
+        return "codex"
+    if agents:
+        return agents[0]
+    return "codex"
+
+
+def build_first_prompt(agent: AgentName | None, project_path: Path) -> str:
+    """Build the paste block printed by `traigent first-prompt`."""
+    tool_line = (
+        FIRST_PROMPT_TOOL_LINE[agent]
+        if agent is not None
+        else "Use your coding-agent tools to inspect code and propose the smallest safe change."
+    )
+    lines = [
+        f"You are using Traigent in this project: {project_path}",
+        "Read the agent guide first: https://traigent.ai/agent.md",
+        tool_line,
+        "Always run Traigent in dry-run/mock mode first.",
+        "Never spend real provider tokens or start paid optimization without my approval.",
+        "Treat scaffolded evals as drafts until I approve their dataset and metrics.",
+        "When approved for real execution, keep cost estimates and limits visible.",
+        "Finish with evidence, changed files, test results, and a PR-ready summary.",
+    ]
+    return "\n".join(lines)
+
+
+def _build_non_tty_plan(
+    *,
+    cwd: Path,
+    project_markers: list[str],
+    detected_agents: list[AgentName],
+    auth_status: str,
+    mcp_available: bool,
+    no_login: bool,
+) -> dict[str, Any]:
+    commands: list[dict[str, object]] = []
+    steps: list[dict[str, object]] = [_python_version_step()]
+
+    if project_markers:
+        dependency_command = _dependency_command(project_markers)
+        commands.append(
+            {
+                "id": "add_dependency",
+                "command": _command_text(dependency_command),
+                "argv": dependency_command,
+                "requires_consent": True,
+            }
+        )
+        steps.append(
+            {
+                "id": "project_dependency",
+                "status": "planned",
+                "description": "Offer adding traigent[integrations] to this Python project.",
+                "commands": [_command_text(dependency_command)],
+            }
+        )
+    else:
+        steps.append(
+            {
+                "id": "project_dependency",
+                "status": "skipped",
+                "description": "No Python project marker detected in the current directory.",
+            }
+        )
+
+    if auth_status == "authenticated":
+        steps.append(
+            {
+                "id": "device_login",
+                "status": "skipped",
+                "description": "Existing credentials validated successfully.",
+            }
+        )
+    elif no_login:
+        steps.append(
+            {
+                "id": "device_login",
+                "status": "skipped",
+                "description": "--no-login was set.",
+            }
+        )
+    else:
+        login_command = ["traigent", "auth", "device-login"]
+        commands.append(
+            {
+                "id": "device_login",
+                "command": _command_text(login_command),
+                "argv": login_command,
+                "requires_consent": False,
+                "requires_browser_action": True,
+            }
+        )
+        steps.append(
+            {
+                "id": "device_login",
+                "status": "planned",
+                "description": "Start browser device login; the human approves in the browser.",
+                "commands": [_command_text(login_command)],
+            }
+        )
+
+    if detected_agents:
+        skills_text = _command_text(SKILLS_COMMAND)
+        commands.append(
+            {
+                "id": "install_agent_skills",
+                "command": skills_text,
+                "argv": SKILLS_COMMAND,
+                "requires_consent": True,
+                "agents": detected_agents,
+            }
+        )
+        steps.append(
+            {
+                "id": "agent_skills",
+                "status": "planned",
+                "description": "Offer installing Traigent agent skills for each detected coding agent.",
+                "commands": [skills_text],
+            }
+        )
+    else:
+        steps.append(
+            {
+                "id": "agent_skills",
+                "status": "skipped",
+                "description": "No supported coding agent markers detected.",
+            }
+        )
+
+    if mcp_available and detected_agents:
+        mcp_commands = [_mcp_registration_command(agent) for agent in detected_agents]
+        for command in mcp_commands:
+            commands.append(
+                {
+                    "id": "register_mcp",
+                    "command": _command_text(command),
+                    "argv": command,
+                    "requires_consent": True,
+                }
+            )
+        steps.append(
+            {
+                "id": "mcp_registration",
+                "status": "planned",
+                "description": "Offer MCP registration because `traigent mcp --help` succeeded.",
+                "commands": [_command_text(command) for command in mcp_commands],
+            }
+        )
+    else:
+        steps.append(
+            {
+                "id": "mcp_registration",
+                "status": "skipped",
+                "description": "`traigent mcp` is not available yet; MCP registration skipped.",
+            }
+        )
+
+    quickstart_command = ["traigent", "quickstart"]
+    first_prompt_agent = _select_prompt_agent(detected_agents)
+    first_prompt_command = ["traigent", "first-prompt", "--agent", first_prompt_agent]
+    commands.extend(
+        [
+            {
+                "id": "verify_quickstart",
+                "command": _command_text(quickstart_command),
+                "argv": quickstart_command,
+                "requires_consent": False,
+            },
+            {
+                "id": "first_prompt",
+                "command": _command_text(first_prompt_command),
+                "argv": first_prompt_command,
+                "requires_consent": False,
+            },
+        ]
+    )
+    steps.extend(
+        [
+            {
+                "id": "verification",
+                "status": "planned",
+                "description": "Run the packaged mock quickstart to verify zero-cost local execution.",
+                "commands": [_command_text(quickstart_command)],
+            },
+            {
+                "id": "first_prompt",
+                "status": "ready",
+                "description": "Print the coding-agent paste block.",
+                "commands": [_command_text(first_prompt_command)],
+            },
+        ]
+    )
+
+    return {
+        "project_path": str(cwd),
+        "python_project": bool(project_markers),
+        "project_markers": project_markers,
+        "detected_agents": detected_agents,
+        "auth_status": auth_status,
+        "mcp_available": mcp_available,
+        "steps": steps,
+        "commands": commands,
+    }
+
+
+def _print_non_tty_plan(plan: dict[str, Any]) -> None:
+    console.print("[bold]Traigent onboarding plan (non-interactive)[/bold]")
+    console.print(f"Project: {plan['project_path']}")
+    agents = plan["detected_agents"]
+    console.print(
+        "Detected agents: "
+        + (", ".join(str(agent) for agent in agents) if agents else "none")
+    )
+    console.print(f"Auth status: {plan['auth_status']}")
+    console.print("Commands are listed below for a caller to run with human consent.")
+    for command in plan["commands"]:
+        if isinstance(command, dict):
+            console.print(f"  - {command['command']}")
+    console.print(PLAN_JSON_BEGIN)
+    click.echo(json.dumps(plan, indent=2))
+    console.print(PLAN_JSON_END)
+
+
+def _print_detection_table(project_markers: list[str], agents: list[AgentName]) -> None:
+    table = Table(show_header=False, box=None)
+    table.add_column("Field", style="cyan")
+    table.add_column("Value")
+    table.add_row(
+        "Python project",
+        ", ".join(project_markers) if project_markers else "not detected",
+    )
+    table.add_row(
+        "Coding agents",
+        (
+            ", ".join(AGENT_LABELS[agent] for agent in agents)
+            if agents
+            else "none detected"
+        ),
+    )
+    console.print(table)
+
+
+def _run_quickstart_verification() -> bool:
+    console.print("\n[bold]Verification[/bold]")
+    console.print("Running packaged mock quickstart...")
+    try:
+        from traigent.examples.quickstart.__main__ import main as run_quickstart
+
+        run_quickstart()
+    except Exception as exc:
+        console.print(f"[red]Mock quickstart failed: {exc}[/red]")
+        return False
+    console.print("[green]Mock quickstart completed.[/green]")
+    return True
+
+
+def _run_interactive_onboard(no_login: bool, backend_url: str | None) -> bool:
+    cwd = Path.cwd().resolve()
+    project_markers = _detect_python_project(cwd)
+    detected_agents = _detect_coding_agents(cwd)
+    python_step = _python_version_step()
+
+    console.print("\n[bold blue]Traigent Onboarding[/bold blue]")
+    console.print(python_step["description"])
+    if python_step["status"] != "passed":
+        raise click.ClickException("Python >=3.11 is required.")
+
+    _print_detection_table(project_markers, detected_agents)
+
+    if project_markers:
+        dependency_command = _dependency_command(project_markers)
+        if click.confirm(
+            f"Add the SDK to this project with `{_command_text(dependency_command)}`?",
+            default=False,
+        ):
+            _run_command(dependency_command)
+    else:
+        console.print("No Python project marker found; dependency install skipped.")
+
+    auth_cli = TraigentAuthCLI(backend_url_override=backend_url)
+    current_auth_status = asyncio.run(_auth_status(auth_cli))
+    if current_auth_status != "authenticated":
+        if no_login:
+            console.print("Device login skipped because --no-login was set.")
+        else:
+            if not asyncio.run(auth_cli.device_login()):
+                return False
+
+    for agent in detected_agents:
+        if click.confirm(
+            f"Install Traigent agent skills for {AGENT_LABELS[agent]}?",
+            default=False,
+        ):
+            _run_command(SKILLS_COMMAND)
+
+    if _mcp_help_succeeds():
+        for agent in detected_agents:
+            command = _mcp_registration_command(agent)
+            if click.confirm(
+                f"Register Traigent MCP for {AGENT_LABELS[agent]}?",
+                default=False,
+            ):
+                _run_command(command)
+    else:
+        console.print(
+            "`traigent mcp` is not available in this SDK build yet; "
+            "MCP registration skipped."
+        )
+
+    if not _run_quickstart_verification():
+        return False
+
+    prompt_agent = _select_prompt_agent(detected_agents)
+    console.print("\n[bold]First Prompt[/bold]")
+    click.echo(build_first_prompt(prompt_agent, cwd))
+    return True
+
+
+@click.command()
+@click.option("--no-login", is_flag=True, help="Skip device-code login.")
+@click.option(
+    "--backend-url",
+    default=None,
+    help="Backend URL to authenticate against during device login.",
+)
+def onboard(no_login: bool, backend_url: str | None) -> None:
+    """Run guided setup for Traigent in this project."""
+    cwd = Path.cwd().resolve()
+
+    if not _stdin_is_tty():
+        project_markers = _detect_python_project(cwd)
+        detected_agents = _detect_coding_agents(cwd)
+        auth_cli = TraigentAuthCLI(backend_url_override=backend_url)
+        current_auth_status = asyncio.run(_auth_status(auth_cli))
+        mcp_available = _mcp_help_succeeds()
+        plan = _build_non_tty_plan(
+            cwd=cwd,
+            project_markers=project_markers,
+            detected_agents=detected_agents,
+            auth_status=current_auth_status,
+            mcp_available=mcp_available,
+            no_login=no_login,
+        )
+        _print_non_tty_plan(plan)
+        if current_auth_status != "authenticated" and not no_login:
+            success = asyncio.run(auth_cli.device_login())
+            raise SystemExit(0 if success else 1)
+        return
+
+    success = _run_interactive_onboard(no_login=no_login, backend_url=backend_url)
+    raise SystemExit(0 if success else 1)
+
+
+@click.command("first-prompt")
+@click.option(
+    "--agent",
+    type=click.Choice(["claude", "cursor", "codex"], case_sensitive=False),
+    default=None,
+    help="Coding agent flavor for the paste block.",
+)
+def first_prompt(agent: str | None) -> None:
+    """Print the Traigent coding-agent first prompt."""
+    normalized_agent = cast(AgentName, agent.lower()) if agent else None
+    click.echo(build_first_prompt(normalized_agent, Path.cwd().resolve()))

--- a/traigent/cli/onboard_commands.py
+++ b/traigent/cli/onboard_commands.py
@@ -34,6 +34,7 @@ FIRST_PROMPT_TOOL_LINE: dict[AgentName, str] = {
 PLAN_JSON_BEGIN = "BEGIN_TRAIGENT_ONBOARD_PLAN_JSON"
 PLAN_JSON_END = "END_TRAIGENT_ONBOARD_PLAN_JSON"
 SKILLS_COMMAND = ["npx", "skills", "add", "Traigent/agents-skills"]
+AUTH_STATUS_COMMAND = ["traigent", "auth", "status"]
 
 
 def _stdin_is_tty() -> bool:
@@ -42,6 +43,17 @@ def _stdin_is_tty() -> bool:
 
 def _command_text(command: list[str]) -> str:
     return shlex.join(command)
+
+
+def _onboard_login_command(
+    *, backend_url: str | None = None, write_env: bool = False
+) -> list[str]:
+    command = ["traigent", "onboard", "--login"]
+    if write_env:
+        command.append("--write-env")
+    if backend_url:
+        command.extend(["--backend-url", backend_url])
+    return command
 
 
 def _detect_python_project(cwd: Path) -> list[str]:
@@ -166,7 +178,7 @@ def _build_non_tty_plan(
     detected_agents: list[AgentName],
     auth_status: str,
     mcp_available: bool,
-    no_login: bool,
+    login_command: list[str],
 ) -> dict[str, Any]:
     commands: list[dict[str, object]] = []
     steps: list[dict[str, object]] = [_python_version_step()]
@@ -206,16 +218,7 @@ def _build_non_tty_plan(
                 "description": "Existing credentials validated successfully.",
             }
         )
-    elif no_login:
-        steps.append(
-            {
-                "id": "device_login",
-                "status": "skipped",
-                "description": "--no-login was set.",
-            }
-        )
     else:
-        login_command = ["traigent", "auth", "device-login"]
         commands.append(
             {
                 "id": "device_login",
@@ -229,7 +232,7 @@ def _build_non_tty_plan(
             {
                 "id": "device_login",
                 "status": "planned",
-                "description": "Start browser device login; the human approves in the browser.",
+                "description": "Run this explicit login command when ready; non-interactive onboarding does not start login by default.",
                 "commands": [_command_text(login_command)],
             }
         )
@@ -332,6 +335,9 @@ def _build_non_tty_plan(
         "project_markers": project_markers,
         "detected_agents": detected_agents,
         "auth_status": auth_status,
+        "auth_check_command": _command_text(AUTH_STATUS_COMMAND),
+        "login_command": _command_text(login_command),
+        "login_argv": login_command,
         "mcp_available": mcp_available,
         "steps": steps,
         "commands": commands,
@@ -346,7 +352,14 @@ def _print_non_tty_plan(plan: dict[str, Any]) -> None:
         "Detected agents: "
         + (", ".join(str(agent) for agent in agents) if agents else "none")
     )
-    console.print(f"Auth status: {plan['auth_status']}")
+    auth_status = plan["auth_status"]
+    if auth_status == "not_checked":
+        console.print(
+            f"Auth status: {auth_status} (run `{plan['auth_check_command']}`)"
+        )
+    else:
+        console.print(f"Auth status: {auth_status}")
+    console.print(f"Login command: {plan['login_command']}")
     console.print("Commands are listed below for a caller to run with human consent.")
     for command in plan["commands"]:
         if isinstance(command, dict):
@@ -389,7 +402,9 @@ def _run_quickstart_verification() -> bool:
     return True
 
 
-def _run_interactive_onboard(no_login: bool, backend_url: str | None) -> bool:
+def _run_interactive_onboard(
+    no_login: bool, backend_url: str | None, write_env: bool
+) -> bool:
     cwd = Path.cwd().resolve()
     project_markers = _detect_python_project(cwd)
     detected_agents = _detect_coding_agents(cwd)
@@ -418,7 +433,16 @@ def _run_interactive_onboard(no_login: bool, backend_url: str | None) -> bool:
         if no_login:
             console.print("Device login skipped because --no-login was set.")
         else:
-            if not asyncio.run(auth_cli.device_login()):
+            save_env_file = write_env or click.confirm(
+                "Write project credentials to this directory's .env file?",
+                default=False,
+            )
+            if not asyncio.run(
+                auth_cli.device_login(
+                    save_env_file=save_env_file,
+                    write_env_explicit=write_env,
+                )
+            ):
                 return False
 
     for agent in detected_agents:
@@ -454,35 +478,76 @@ def _run_interactive_onboard(no_login: bool, backend_url: str | None) -> bool:
 @click.command()
 @click.option("--no-login", is_flag=True, help="Skip device-code login.")
 @click.option(
+    "--login",
+    "run_login",
+    is_flag=True,
+    help="In non-TTY mode, execute device-code login after printing the plan.",
+)
+@click.option(
+    "--write-env",
+    is_flag=True,
+    help="Allow device login to write project credentials to .env.",
+)
+@click.option(
+    "--check-auth",
+    is_flag=True,
+    help="Validate current credentials while building the non-TTY plan.",
+)
+@click.option(
     "--backend-url",
     default=None,
     help="Backend URL to authenticate against during device login.",
 )
-def onboard(no_login: bool, backend_url: str | None) -> None:
+def onboard(
+    no_login: bool,
+    run_login: bool,
+    write_env: bool,
+    check_auth: bool,
+    backend_url: str | None,
+) -> None:
     """Run guided setup for Traigent in this project."""
     cwd = Path.cwd().resolve()
+    if no_login and run_login:
+        raise click.ClickException("--login and --no-login cannot be used together.")
 
     if not _stdin_is_tty():
         project_markers = _detect_python_project(cwd)
         detected_agents = _detect_coding_agents(cwd)
-        auth_cli = TraigentAuthCLI(backend_url_override=backend_url)
-        current_auth_status = asyncio.run(_auth_status(auth_cli))
+        auth_cli: TraigentAuthCLI | None = None
+        current_auth_status = "not_checked"
+        if check_auth:
+            auth_cli = TraigentAuthCLI(backend_url_override=backend_url)
+            current_auth_status = asyncio.run(_auth_status(auth_cli))
         mcp_available = _mcp_help_succeeds()
+        login_command = _onboard_login_command(
+            backend_url=backend_url,
+            write_env=write_env,
+        )
         plan = _build_non_tty_plan(
             cwd=cwd,
             project_markers=project_markers,
             detected_agents=detected_agents,
             auth_status=current_auth_status,
             mcp_available=mcp_available,
-            no_login=no_login,
+            login_command=login_command,
         )
         _print_non_tty_plan(plan)
-        if current_auth_status != "authenticated" and not no_login:
-            success = asyncio.run(auth_cli.device_login())
+        if run_login:
+            auth_cli = auth_cli or TraigentAuthCLI(backend_url_override=backend_url)
+            success = asyncio.run(
+                auth_cli.device_login(
+                    save_env_file=write_env,
+                    write_env_explicit=write_env,
+                )
+            )
             raise SystemExit(0 if success else 1)
         return
 
-    success = _run_interactive_onboard(no_login=no_login, backend_url=backend_url)
+    success = _run_interactive_onboard(
+        no_login=no_login,
+        backend_url=backend_url,
+        write_env=write_env,
+    )
     raise SystemExit(0 if success else 1)
 
 


### PR DESCRIPTION
## Summary
**Stacked on #1116** (catalog API) — retarget to `develop` after it merges. Implements the SDK side of the self-service onboarding funnel against the TraigentSchema #94 contracts:

- **`traigent auth device-login`** — RFC 8628 flow: displays `verification_uri_complete` + `user_code`, polls honoring `interval`/`slow_down` (adopts the server's new interval) with a hard `expires_in` deadline cap and bounded transport-error retries; distinct handling for `authorization_pending`/`access_denied`/`expired_token`. Success payload validated against the contract **before** persisting (contract-pinning test references `device_token_success_schema.json` / TraigentSchema#94). Secure credential storage by default; **`.env` writes only with explicit `--write-env`/default-No consent, never after a failed secure save**; `export`-prefixed lines rewritten without plaintext duplicates; api_key never printed/logged.
- **`traigent onboard`** — guided setup: Python check → consented project-dependency install (`uv add 'traigent[integrations]'`/pip) → device login (or skip if authenticated) → coding-agent detection (Claude Code/Cursor/Codex) with **consent-first** skills install (`npx skills add Traigent/agents-skills`); MCP registration only behind a capability check (honestly skipped until `traigent mcp` ships) → zero-cost mock quickstart verification → prints the first-prompt. **Non-TTY = plan-only**: prints human-readable plan + machine-readable JSON (`auth_status: "not_checked"`, exact commands), executes nothing; `--login`/`--check-auth` opt in.
- **`traigent first-prompt --agent claude|cursor|codex`** — 8-line paste block pointing at `https://traigent.ai/agent.md` (ships in traigent-web#64), dry-run-first + approval + draft-eval rules baked in.

## Review cycle
Codex xhigh adversarial review (REQUEST-CHANGES) → captain-adjudicated: one P1 **rejected with evidence** (reviewer claimed contract field `tier`; actual schema requires `subscription_tier` — code was correct; contract-pinning test added so drift fails loudly either way); P1 non-TTY-executes-login **adopted as a spec improvement** (plan-only default); P1 `.env` consent + P2 poll hardening + P2 probe opt-in all fixed in `818b7104`.

## PR checklist
1. **Worst-case prod path** — client-side auth flow; fail-closed on malformed payloads (nothing persisted); no server-side policy change.
2. **Production-branch test** — N/A (client CLI); fail-closed tests: malformed-payload rejection, expiry cap, retry bound, consent defaults (`tests/unit/cli/test_device_auth_commands.py`, `test_onboard_commands.py`).
3. **Contract regeneration** — implements TraigentSchema#94 (merge-blocking ordering: #94 → backend endpoints → this). JS SDK parity deferred per program decision (Python first).
4. **Public surface delta** — new CLI commands `onboard`, `first-prompt`, `auth device-login` + flags; help text matches behavior; nothing stubbed (MCP step capability-checked + honestly skipped).
5. **Review threads** — adjudications documented above; threads will be resolved per policy.
6. **Quality gates** — none relaxed; ruff/mypy/pytest green (178 CLI tests), commit hooks (bandit/secrets) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)