### PR TITLE
fix(orchestrator): guard terminal objectives[0] for objectives-free runs (#1108 review NB)

### DIFF
--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -767,6 +767,12 @@ class TestOptimizationOrchestrator:
         summary = result.metadata["session_summary"]
         assert summary["reason_code"] == "NO_RANKING_ELIGIBLE_TRIALS"
         assert "no objectives declared" in summary["reason"]
+        # the selector's full no-eligible shape, ranking summary included
+        ranking = summary["ranking"]
+        assert ranking["total_input_trials"] == 1
+        assert ranking["total_successful_trials"] == 1
+        assert ranking["eligible_count"] == 0
+        assert ranking["excluded_count"] == 1
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -741,6 +741,33 @@ class TestOptimizationOrchestrator:
         assert ranking["non_successful_count"] == 1
         assert ranking["eligible_count"] == 1
 
+    def test_create_optimization_result_with_empty_objectives(self, orchestrator):
+        """RED before the fix: objectives-free runs (a supported BaseOptimizer
+        mode — weighted scoring disabled) hit an unguarded objectives[0] at
+        the terminal selection and crashed with IndexError (#1108 review NB).
+        The honest result is the selector's no-eligible shape."""
+        orchestrator.optimizer.objectives = []
+        orchestrator._trials = [
+            TrialResult(
+                trial_id="trial_no_obj",
+                config={"param1": 1},
+                metrics={"accuracy": 0.9},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=datetime.now(UTC),
+                metadata={},
+            )
+        ]
+        orchestrator._status = OptimizationStatus.COMPLETED
+
+        result = orchestrator._create_optimization_result()
+
+        assert result.best_config == {}
+        assert result.best_score is None
+        summary = result.metadata["session_summary"]
+        assert summary["reason_code"] == "NO_RANKING_ELIGIBLE_TRIALS"
+        assert "no objectives declared" in summary["reason"]
+
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)
     async def test_optimize_optimizer_exception(

--- a/tests/unit/core/test_result_selection.py
+++ b/tests/unit/core/test_result_selection.py
@@ -567,6 +567,57 @@ def test_legacy_mode_keeps_historic_unknown_trials_rankable():
     assert result.best_score == pytest.approx(0.8)
 
 
+def test_none_primary_objective_returns_no_eligible_shape():
+    """Objectives-free runs (#1108 review NB): ranking is disabled — the
+    selector returns its honest no-eligible shape, never a winner-by-score."""
+    trial = FakeTrial(metrics={"accuracy": 0.8}, config={"model": "candidate"})
+
+    result = select_best_configuration(
+        trials=[trial],
+        primary_objective=None,
+        config_space_keys={"model"},
+        aggregate_configs=False,
+    )
+
+    assert result.best_config == {}
+    assert result.best_score is None
+    assert result.reason_code == "NO_RANKING_ELIGIBLE_TRIALS"
+    ranking = result.session_summary["ranking"]
+    assert ranking["total_input_trials"] == 1
+    assert ranking["total_successful_trials"] == 1
+    assert ranking["eligible_count"] == 0
+    assert ranking["excluded_count"] == 1
+
+
+def test_none_primary_objective_strict_mode_stays_certificate_driven():
+    """Strict mode never reads the primary objective: a certified incumbent
+    is honored, and its absence fails closed — regardless of objectives."""
+    trial = FakeTrial(metrics={"accuracy": 0.8}, config={"model": "candidate"})
+
+    certified = select_best_configuration(
+        trials=[trial],
+        primary_objective=None,
+        config_space_keys={"model"},
+        aggregate_configs=False,
+        require_certified=True,
+        certified_config={"model": "incumbent"},
+        certified_score=0.7,
+    )
+    assert certified.best_config == {"model": "incumbent"}
+    assert certified.best_score == pytest.approx(0.7)
+
+    uncertified = select_best_configuration(
+        trials=[trial],
+        primary_objective=None,
+        config_space_keys={"model"},
+        aggregate_configs=False,
+        require_certified=True,
+        certified_config=None,
+    )
+    assert uncertified.best_config == {}
+    assert uncertified.reason_code == "NO_CERTIFIED_SELECTION"
+
+
 class TestMinimizationObjectiveTieBreaker:
     """Tests for tie-breaker with minimization objectives."""
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -72,7 +72,12 @@ from traigent.core.parallel_execution_manager import (
     PermittedTrialResult,
 )
 from traigent.core.progress_manager import ProgressManager
-from traigent.core.result_selection import TieBreaker, select_best_configuration
+from traigent.core.result_selection import (
+    NO_RANKING_ELIGIBLE_TRIALS,
+    SelectionResult,
+    TieBreaker,
+    select_best_configuration,
+)
 from traigent.core.sample_budget import SampleBudgetManager
 from traigent.core.stat_significance import compute_significance
 from traigent.core.stop_condition_manager import StopConditionManager
@@ -2753,18 +2758,43 @@ class OptimizationOrchestrator:
                 if primary and hasattr(incumbent, "get_metric")
                 else None
             )
-        selection = select_best_configuration(
-            trials=self._trials,
-            primary_objective=self.optimizer.objectives[0],
-            config_space_keys=set(getattr(self.optimizer, "config_space", {}).keys()),
-            aggregate_configs=not self.traigent_config.is_edge_analytics_mode(),
-            tie_breakers=self._tie_breakers or None,
-            band_target=self._band_target,
-            comparability_mode=self.traigent_config.get_comparability_mode(),
-            require_certified=strict_mode,
-            certified_config=certified_config,
-            certified_score=certified_score,
-        )
+        if not self.optimizer.objectives and not strict_mode:
+            # Objectives-free runs are supported (weighted scoring disabled,
+            # see BaseOptimizer) but have no primary metric to rank by —
+            # every sibling objectives[0] site in this module guards this;
+            # the terminal selection must too (#1108 review NB). Honest
+            # degenerate result, mirroring the selector's own no-eligible
+            # shape, instead of an IndexError at finalization. Strict runs
+            # bypass this: their selection is certificate-driven and never
+            # reads the primary objective.
+            selection = SelectionResult(
+                best_config={},
+                best_score=None,
+                session_summary={
+                    "reason": "no objectives declared; ranking disabled",
+                    "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
+                },
+                reason_code=NO_RANKING_ELIGIBLE_TRIALS,
+            )
+        else:
+            selection = select_best_configuration(
+                trials=self._trials,
+                # strict mode never reads the primary objective (certificate
+                # short-circuit), so "" is unreachable as a ranking key here
+                primary_objective=(
+                    self.optimizer.objectives[0] if self.optimizer.objectives else ""
+                ),
+                config_space_keys=set(
+                    getattr(self.optimizer, "config_space", {}).keys()
+                ),
+                aggregate_configs=not self.traigent_config.is_edge_analytics_mode(),
+                tie_breakers=self._tie_breakers or None,
+                band_target=self._band_target,
+                comparability_mode=self.traigent_config.get_comparability_mode(),
+                require_certified=strict_mode,
+                certified_config=certified_config,
+                certified_score=certified_score,
+            )
         best_config = selection.best_config
         best_score = selection.best_score
         session_summary = selection.session_summary

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -72,12 +72,7 @@ from traigent.core.parallel_execution_manager import (
     PermittedTrialResult,
 )
 from traigent.core.progress_manager import ProgressManager
-from traigent.core.result_selection import (
-    NO_RANKING_ELIGIBLE_TRIALS,
-    SelectionResult,
-    TieBreaker,
-    select_best_configuration,
-)
+from traigent.core.result_selection import TieBreaker, select_best_configuration
 from traigent.core.sample_budget import SampleBudgetManager
 from traigent.core.stat_significance import compute_significance
 from traigent.core.stop_condition_manager import StopConditionManager
@@ -2758,43 +2753,25 @@ class OptimizationOrchestrator:
                 if primary and hasattr(incumbent, "get_metric")
                 else None
             )
-        if not self.optimizer.objectives and not strict_mode:
+        selection = select_best_configuration(
+            trials=self._trials,
             # Objectives-free runs are supported (weighted scoring disabled,
-            # see BaseOptimizer) but have no primary metric to rank by —
-            # every sibling objectives[0] site in this module guards this;
-            # the terminal selection must too (#1108 review NB). Honest
-            # degenerate result, mirroring the selector's own no-eligible
-            # shape, instead of an IndexError at finalization. Strict runs
-            # bypass this: their selection is certificate-driven and never
-            # reads the primary objective.
-            selection = SelectionResult(
-                best_config={},
-                best_score=None,
-                session_summary={
-                    "reason": "no objectives declared; ranking disabled",
-                    "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
-                },
-                reason_code=NO_RANKING_ELIGIBLE_TRIALS,
-            )
-        else:
-            selection = select_best_configuration(
-                trials=self._trials,
-                # strict mode never reads the primary objective (certificate
-                # short-circuit), so "" is unreachable as a ranking key here
-                primary_objective=(
-                    self.optimizer.objectives[0] if self.optimizer.objectives else ""
-                ),
-                config_space_keys=set(
-                    getattr(self.optimizer, "config_space", {}).keys()
-                ),
-                aggregate_configs=not self.traigent_config.is_edge_analytics_mode(),
-                tie_breakers=self._tie_breakers or None,
-                band_target=self._band_target,
-                comparability_mode=self.traigent_config.get_comparability_mode(),
-                require_certified=strict_mode,
-                certified_config=certified_config,
-                certified_score=certified_score,
-            )
+            # see BaseOptimizer); every sibling objectives[0] site in this
+            # module guards this and the terminal selection must too (#1108
+            # review NB). None ⇒ the selector's honest no-eligible shape;
+            # strict mode is certificate-driven and never reads it.
+            primary_objective=(
+                self.optimizer.objectives[0] if self.optimizer.objectives else None
+            ),
+            config_space_keys=set(getattr(self.optimizer, "config_space", {}).keys()),
+            aggregate_configs=not self.traigent_config.is_edge_analytics_mode(),
+            tie_breakers=self._tie_breakers or None,
+            band_target=self._band_target,
+            comparability_mode=self.traigent_config.get_comparability_mode(),
+            require_certified=strict_mode,
+            certified_config=certified_config,
+            certified_score=certified_score,
+        )
         best_config = selection.best_config
         best_score = selection.best_score
         session_summary = selection.session_summary

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -558,7 +558,7 @@ def _trial_produced_outputs(trial: TrialResult) -> bool:
 
 def select_best_configuration(
     trials: Iterable[TrialResult],
-    primary_objective: str,
+    primary_objective: str | None,
     *,
     config_space_keys: Iterable[str],
     aggregate_configs: bool,
@@ -580,7 +580,10 @@ def select_best_configuration(
 
     Args:
         trials: Iterable of completed trial results.
-        primary_objective: Name of the primary objective to optimize.
+        primary_objective: Name of the primary objective to optimize, or
+            ``None`` for objectives-free runs (a supported BaseOptimizer
+            mode) — ranking is disabled and the selector returns its honest
+            no-eligible shape instead of a winner-by-score.
         config_space_keys: Keys that define the configuration space.
         aggregate_configs: Whether to aggregate results by config.
         tie_breakers: Optional dict mapping objectives to tie-breaker strategies.
@@ -615,6 +618,28 @@ def select_best_configuration(
     trial_list = list(trials)
     successful_trials = [t for t in trial_list if _trial_produced_outputs(t)]
     non_successful_count = len(trial_list) - len(successful_trials)
+
+    if primary_objective is None:
+        # Objectives-free run: nothing to rank by. The honest result is the
+        # same no-eligible shape as below — never a winner-by-score.
+        return SelectionResult(
+            best_config={},
+            best_score=None,
+            session_summary={
+                "reason": "no objectives declared; ranking disabled",
+                "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
+                "ranking": _build_ranking_summary(
+                    total_input_trials=len(trial_list),
+                    total_successful=len(successful_trials),
+                    non_successful_count=non_successful_count,
+                    eligible_count=0,
+                    excluded_count=len(successful_trials),
+                    unknown_count=0,
+                    comparability_mode=comparability_mode,
+                ),
+            },
+            reason_code=NO_RANKING_ELIGIBLE_TRIALS,
+        )
     if not successful_trials:
         return SelectionResult(
             best_config={},


### PR DESCRIPTION
## What

Phase 7 follow-up (ChangeSession `cs_ca64fcc251f489b1`): closes the #1108 consolidation-review NB. Objectives-free runs are a supported `BaseOptimizer` mode ("weighted scoring disabled"), and every sibling `objectives[0]` site in `orchestrator.py` guards it — except the terminal `select_best_configuration` call, which raised `IndexError` at finalization. Proven red-first (`IndexError: list index out of range`).

## Design (review round 1 — codex 2 rounds → ACCEPT)

The objectives-free handling lives in the **selector chokepoint**, not a hand-built shape in the orchestrator: `select_best_configuration` now accepts `primary_objective: str | None` and returns its full honest no-eligible shape for `None` (`best_config {}`, `reason_code NO_RANKING_ELIGIBLE_TRIALS`, complete `ranking` summary with all successful trials excluded — byte-consistent with its other no-eligible branches). The orchestrator keeps a single call path passing `objectives[0] if objectives else None`.

**Strict runs (require_calibration)**: byte-identical — the certificate shortcut runs before any `primary_objective` read; pinned by a selector-level test for `None`+strict (certified incumbent honored; absence fails closed with `NO_CERTIFIED_SELECTION`).

## Tests

- Orchestrator: red-first empty-objectives test (full shape incl. ranking summary).
- Selector: `None` no-eligible shape + `None`+strict certificate-driven test.
- Module **delta-clean vs develop baseline**: identical 8 pre-existing failures (plateau/timing), +new passing tests; result_selection + safeguards neighbors green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)