### PR TITLE
feat: publish best config through backend

### DIFF
--- a/tests/unit/cloud/test_best_config_cloud_client.py
+++ b/tests/unit/cloud/test_best_config_cloud_client.py
@@ -1,0 +1,107 @@
+"""Tests for backend cloud best-config client methods."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from traigent.cloud.backend_client import BackendIntegratedClient
+
+FAKE_TRAIGENT_API_KEY = "tg_" + "x" * 61  # pragma: allowlist secret
+
+
+def _spec() -> dict:
+    return {
+        "schema_version": "traigent.best_config.v1",
+        "config_id": "answerer",
+        "function_ref": "pkg.answer:run",
+        "environment": "staging",
+        "config": {"temperature": 0.2},
+    }
+
+
+@patch("requests.post")
+def test_publish_best_config_sync_posts_to_backend(mock_post, monkeypatch):
+    monkeypatch.setenv("TRAIGENT_PROJECT_ID", "project_cloud_123")
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    response = MagicMock(status_code=201, text="ok")
+    response.json.return_value = {
+        "success": True,
+        "data": {"config_id": "answerer", "version": 1},
+    }
+    mock_post.return_value = response
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        result = client.publish_best_config_sync(
+            _spec(),
+            environment="staging",
+            if_match='W/"1-old"',
+        )
+
+    assert result == {"config_id": "answerer", "version": 1}
+    call_args = mock_post.call_args
+    assert call_args.args[0].endswith("/api/v1/best-configs")
+    assert call_args.kwargs["json"]["spec"]["config_id"] == "answerer"
+    assert call_args.kwargs["json"]["environment"] == "staging"
+    assert call_args.kwargs["headers"]["If-Match"] == 'W/"1-old"'
+    assert call_args.kwargs["headers"]["Authorization"] == "Bearer test-token"
+    assert call_args.kwargs["headers"]["X-Project-Id"] == "project_cloud_123"
+
+
+@patch("requests.get")
+def test_fetch_best_config_sync_gets_current_config(mock_get):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    response = MagicMock(status_code=200, text="ok")
+    response.json.return_value = {
+        "success": True,
+        "data": {
+            "config_id": "answerer",
+            "etag": 'W/"1-abcdef123456"',
+            "spec": _spec(),
+        },
+    }
+    mock_get.return_value = response
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        result = client.fetch_best_config_sync(
+            "answerer",
+            environment="staging",
+            function_ref="pkg.answer:run",
+            etag='W/"1-old"',
+        )
+
+    assert result is not None
+    assert result["spec"]["config"]["temperature"] == 0.2
+    call_args = mock_get.call_args
+    assert call_args.args[0].endswith("/api/v1/best-configs/answerer")
+    assert call_args.kwargs["params"] == {
+        "environment": "staging",
+        "function_ref": "pkg.answer:run",
+    }
+    assert call_args.kwargs["headers"]["If-None-Match"] == 'W/"1-old"'
+
+
+@patch("requests.get")
+def test_fetch_best_config_sync_returns_none_for_not_found(mock_get):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_get.return_value = MagicMock(status_code=404, text="missing")
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        assert client.fetch_best_config_sync("missing") is None

--- a/tests/unit/core/test_best_config_runtime_integration.py
+++ b/tests/unit/core/test_best_config_runtime_integration.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -19,10 +27,16 @@ from traigent.core.best_config_runtime import (
     BestConfigSource,
     CloudPublishUnavailable,
     CloudPublishUnavailableReason,
+    canonical_json,
+    compute_spec_hash,
     function_ref_for,
+    sha256_digest,
     write_repo_best_config,
 )
 from traigent.core.optimized_function import OptimizedFunction
+from traigent.utils.exceptions import ConfigurationError
+
+FAKE_TRAIGENT_API_KEY = "tg_" + "x" * 61  # pragma: allowlist secret
 
 
 def plain_answer(text: str, **kwargs):
@@ -167,25 +181,30 @@ def test_off_source_does_not_read_repo_or_cloud(tmp_path, monkeypatch):
     assert opt_func.best_config_snapshot.source == BestConfigSource.DEFAULT.value
 
 
-def test_cloud_fetch_unimplemented_falls_back_with_warning(tmp_path, monkeypatch):
-    warnings = []
+def test_cloud_fetch_failure_fails_closed_for_cloud_mode(tmp_path, monkeypatch):
+    class FailingBestConfigClient:
+        def fetch_best_config_sync(self, *args, **kwargs):  # noqa: ARG002
+            raise RuntimeError("backend unavailable")
+
+    import traigent.cloud.backend_client as backend_client
+
     monkeypatch.setattr(
-        "traigent.core.config_state_manager.logger.warning",
-        lambda message, *args: warnings.append(message % args if args else message),
+        backend_client,
+        "get_backend_client",
+        lambda **kwargs: FailingBestConfigClient(),
     )
 
-    opt_func = OptimizedFunction(
-        func=plain_answer,
-        config_space={"temperature": [0.1, 0.3]},
-        config_id="answerer",
-        best_config_source="cloud",
-        best_config_cache_dir=str(tmp_path / "missing-cache"),
-        default_config={"temperature": 0.1},
-    )
+    with pytest.raises(CloudPublishUnavailable) as exc_info:
+        OptimizedFunction(
+            func=plain_answer,
+            config_space={"temperature": [0.1, 0.3]},
+            config_id="answerer",
+            best_config_source="cloud",
+            best_config_cache_dir=str(tmp_path / "missing-cache"),
+            default_config={"temperature": 0.1},
+        )
 
-    assert opt_func.current_config["temperature"] == 0.1
-    assert opt_func.best_config_snapshot.source == BestConfigSource.DEFAULT.value
-    assert any("Cloud best-config fetch is not implemented" in item for item in warnings)
+    assert exc_info.value.reason is CloudPublishUnavailableReason.REQUEST_FAILED
 
 
 def test_invocation_does_not_re_resolve_repo(tmp_path, monkeypatch):
@@ -224,17 +243,217 @@ def test_export_best_config_writes_repo_spec(tmp_path):
     assert (spec_path.parent / "manifest.json").exists()
 
 
-def test_publish_best_config_fails_closed_by_mode():
+def test_fresh_process_cloud_publish_then_fetch_uses_backend_network_contract(tmp_path):
+    seen_requests: list[dict[str, object]] = []
+    state: dict[str, dict[str, object]] = {}
+
+    class ContractBackend(BaseHTTPRequestHandler):
+        def _send_json(self, status_code: int, payload: dict[str, object]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):  # noqa: N802
+            parsed = urlparse(self.path)
+            seen_requests.append(
+                {
+                    "method": "GET",
+                    "path": parsed.path,
+                    "query": parse_qs(parsed.query),
+                    "api_key": self.headers.get("X-API-Key"),
+                }
+            )
+            if (
+                parsed.path != "/api/v1/best-configs/fresh-promote"
+                or "spec" not in state
+            ):
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            spec = state["spec"]
+            self._send_json(
+                200,
+                {
+                    "success": True,
+                    "data": {
+                        "config_id": "fresh-promote",
+                        "environment": "staging",
+                        "version": 1,
+                        "etag": 'W/"1-freshpublish"',
+                        "spec_hash": compute_spec_hash(spec),
+                        "config_hash": sha256_digest(canonical_json(spec["config"])),
+                        "spec": spec,
+                    },
+                },
+            )
+
+        def do_POST(self):  # noqa: N802
+            parsed = urlparse(self.path)
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(content_length)
+            body = json.loads(raw_body.decode("utf-8"))
+            if parsed.path == "/api/v1/keys/validate":
+                self._send_json(200, {"valid": True})
+                return
+            spec = body["spec"]
+            state["spec"] = spec
+            seen_requests.append(
+                {
+                    "method": "POST",
+                    "path": parsed.path,
+                    "api_key": self.headers.get("X-API-Key"),
+                    "if_match": self.headers.get("If-Match"),
+                    "environment": body.get("environment"),
+                    "spec": spec,
+                }
+            )
+            self._send_json(
+                201,
+                {
+                    "success": True,
+                    "data": {
+                        "config_id": spec["config_id"],
+                        "environment": spec["environment"],
+                        "version": 1,
+                        "etag": 'W/"1-freshpublish"',
+                        "spec_hash": compute_spec_hash(spec),
+                        "config_hash": sha256_digest(canonical_json(spec["config"])),
+                        "spec": spec,
+                    },
+                },
+            )
+
+        def log_message(self, format, *args):  # noqa: A002
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ContractBackend)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        backend_url = f"http://127.0.0.1:{server.server_port}"
+        api_key = FAKE_TRAIGENT_API_KEY
+        publish_script = textwrap.dedent("""
+            import json
+
+            from traigent.cloud.auth import AuthManager
+            from traigent.core.optimized_function import OptimizedFunction
+
+            async def _trust_contract_backend(self, api_key):
+                return None
+
+            AuthManager._validate_api_key_with_backend = _trust_contract_backend
+
+            def fresh_answer(text: str, **kwargs):
+                return f"{text}:{kwargs.get('temperature')}"
+
+            wrapped = OptimizedFunction(
+                func=fresh_answer,
+                config_space={"temperature": [0.1, 0.77]},
+                config_id="fresh-promote",
+                best_config_environment="staging",
+                default_config={"temperature": 0.1},
+            )
+            wrapped.set_config({"temperature": 0.77})
+            result = wrapped.publish_best_config()
+            print(json.dumps({
+                "config_id": result["config_id"],
+                "version": result["version"],
+            }, sort_keys=True))
+            """)
+        fetch_script = textwrap.dedent("""
+            import json
+            import os
+
+            from traigent.cloud.auth import AuthManager
+            from traigent.core.optimized_function import OptimizedFunction
+
+            async def _trust_contract_backend(self, api_key):
+                return None
+
+            AuthManager._validate_api_key_with_backend = _trust_contract_backend
+
+            def fresh_answer(text: str, **kwargs):
+                return f"{text}:{kwargs.get('temperature')}"
+
+            wrapped = OptimizedFunction(
+                func=fresh_answer,
+                config_space={"temperature": [0.1, 0.77]},
+                config_id="fresh-promote",
+                best_config_source="cloud",
+                best_config_cache_dir=os.environ["TRAIGENT_BEST_CONFIG_CACHE"],
+                best_config_environment="staging",
+                default_config={"temperature": 0.1},
+            )
+            print(json.dumps({
+                "temperature": wrapped.current_config["temperature"],
+                "source": wrapped.best_config_snapshot.source,
+            }, sort_keys=True))
+            """)
+        env = os.environ.copy()
+        env.update(
+            {
+                "TRAIGENT_API_KEY": api_key,
+                "TRAIGENT_BACKEND_URL": backend_url,
+                "TRAIGENT_API_URL": f"{backend_url}/api/v1",
+                "TRAIGENT_BEST_CONFIG_CACHE": str(tmp_path / "fetch-cache"),
+            }
+        )
+        repo_root = Path(__file__).resolve().parents[3]
+        publish_result = subprocess.run(
+            [sys.executable, "-c", publish_script],
+            cwd=repo_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=20,
+            check=False,
+        )
+        fetch_result = subprocess.run(
+            [sys.executable, "-c", fetch_script],
+            cwd=repo_root,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=20,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert publish_result.returncode == 0, publish_result.stderr
+    assert json.loads(publish_result.stdout.strip().splitlines()[-1]) == {
+        "config_id": "fresh-promote",
+        "version": 1,
+    }
+    assert fetch_result.returncode == 0, fetch_result.stderr
+    assert json.loads(fetch_result.stdout.strip().splitlines()[-1]) == {
+        "source": BestConfigSource.CLOUD_FETCH.value,
+        "temperature": 0.77,
+    }
+    assert [request["method"] for request in seen_requests] == ["GET", "POST", "GET"]
+    assert seen_requests[1]["path"] == "/api/v1/best-configs"
+    assert seen_requests[1]["if_match"] is None
+    assert seen_requests[1]["environment"] == "staging"
+    assert seen_requests[1]["spec"]["config"] == {"temperature": 0.77}
+
+
+def test_publish_best_config_fails_without_active_best_config():
     opt_func = OptimizedFunction(
         func=plain_answer,
         config_space={"temperature": [0.1, 0.3]},
         best_config_source="repo",
     )
 
-    with pytest.raises(CloudPublishUnavailable) as exc_info:
+    with pytest.raises(ConfigurationError) as exc_info:
         opt_func.publish_best_config()
 
-    assert exc_info.value.reason is CloudPublishUnavailableReason.DISABLED_BY_CONFIG
+    assert "No best configuration available" in str(exc_info.value)
 
 
 def test_decorator_passes_best_config_runtime_options(tmp_path, monkeypatch):
@@ -419,7 +638,6 @@ async def test_optimization_completion_refreshes_best_config_snapshot():
 
     assert opt_func("hello") == "hello:0.9"
     assert (
-        opt_func.best_config_snapshot.source
-        == BestConfigSource.APPLY_BEST_CONFIG.value
+        opt_func.best_config_snapshot.source == BestConfigSource.APPLY_BEST_CONFIG.value
     )
     assert dict(opt_func.best_config_snapshot.config) == {"temperature": 0.9}

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -55,6 +55,7 @@ from traigent.cloud.session_types import SessionCreationResult
 from traigent.cloud.subset_selection import SmartSubsetSelector
 from traigent.cloud.trial_operations import TrialOperations
 from traigent.config.backend_config import BackendConfig
+from traigent.config.project import read_optional_project_env
 from traigent.evaluators.base import Dataset
 from traigent.security.session_manager import SessionManager as SecuritySessionManager
 from traigent.utils.logging import get_logger
@@ -805,6 +806,9 @@ class BackendIntegratedClient:
         merged_headers = dict(headers or {})
         merged_headers.setdefault("Content-Type", _JSON_CONTENT_TYPE)
         merged_headers.setdefault("User-Agent", _SDK_USER_AGENT)
+        project_id = read_optional_project_env()
+        if project_id:
+            merged_headers.setdefault("X-Project-Id", project_id)
         return merged_headers
 
     def _build_feature_upload_url(self, experiment_run_id: str) -> str | None:
@@ -840,6 +844,137 @@ class BackendIntegratedClient:
                 parsed._replace(path=upload_path, params="", query="", fragment="")
             ),
         )
+
+    def _build_best_config_url(self, config_id: str | None = None) -> str | None:
+        """Return a sanitized best-config URL for the configured backend API."""
+        parsed = urlparse(self.api_base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return None
+        if (
+            parsed.username
+            or parsed.password
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+
+        best_config_path = f"{parsed.path.rstrip('/')}/best-configs"
+        if config_id:
+            best_config_path = f"{best_config_path}/{quote(config_id, safe='')}"
+        return cast(
+            str,
+            urlunparse(
+                parsed._replace(path=best_config_path, params="", query="", fragment="")
+            ),
+        )
+
+    @staticmethod
+    def _extract_backend_data(response: Any) -> dict[str, Any]:
+        try:
+            payload = response.json()
+        except Exception as exc:  # noqa: BLE001
+            raise CloudServiceError("Backend returned a non-JSON response") from exc
+        if not isinstance(payload, dict):
+            raise CloudServiceError("Backend returned an invalid JSON response")
+        data = payload.get("data", payload)
+        if not isinstance(data, dict):
+            raise CloudServiceError("Backend response data was not an object")
+        return data
+
+    def publish_best_config_sync(
+        self,
+        spec: dict[str, Any],
+        *,
+        environment: str | None = None,
+        if_match: str | None = None,
+    ) -> dict[str, Any]:
+        """Publish a canonical best-config spec to the backend."""
+        try:
+            import requests
+        except ImportError as exc:  # pragma: no cover - requests is required
+            raise CloudServiceError("requests is unavailable") from exc
+
+        url = self._build_best_config_url()
+        if not url:
+            raise CloudServiceError("Backend best-config URL is invalid")
+
+        headers = self._get_sync_auth_headers(target="backend")
+        if if_match:
+            headers["If-Match"] = if_match
+        payload: dict[str, Any] = {"spec": spec}
+        if environment:
+            payload["environment"] = environment
+
+        try:
+            response = requests.post(  # nosec B113 - timeout is provided
+                url,
+                json=payload,
+                headers=headers,
+                timeout=min(self.timeout, 30.0),
+            )
+        except AuthenticationError:
+            raise
+        except Exception as exc:
+            raise CloudServiceError(f"Best-config publish failed: {exc}") from exc
+
+        if response.status_code >= 400:
+            raise CloudServiceError(
+                f"Best-config publish rejected with HTTP {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+        return self._extract_backend_data(response)
+
+    def fetch_best_config_sync(
+        self,
+        config_id: str,
+        *,
+        environment: str | None = None,
+        function_ref: str | None = None,
+        etag: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Fetch the current backend best config, returning None on 304/404."""
+        try:
+            import requests
+        except ImportError as exc:  # pragma: no cover - requests is required
+            raise CloudServiceError("requests is unavailable") from exc
+
+        url = self._build_best_config_url(config_id)
+        if not url:
+            raise CloudServiceError("Backend best-config URL is invalid")
+
+        headers = self._get_sync_auth_headers(target="backend")
+        if etag:
+            headers["If-None-Match"] = etag
+        params = {
+            key: value
+            for key, value in {
+                "environment": environment,
+                "function_ref": function_ref,
+            }.items()
+            if value
+        }
+
+        try:
+            response = requests.get(  # nosec B113 - timeout is provided
+                url,
+                params=params or None,
+                headers=headers,
+                timeout=min(self.timeout, 30.0),
+            )
+        except AuthenticationError:
+            raise
+        except Exception as exc:
+            raise CloudServiceError(f"Best-config fetch failed: {exc}") from exc
+
+        if response.status_code in {304, 404}:
+            return None
+        if response.status_code >= 400:
+            raise CloudServiceError(
+                f"Best-config fetch rejected with HTTP {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+        return self._extract_backend_data(response)
 
     def upload_example_features(
         self,

--- a/traigent/core/best_config_runtime.py
+++ b/traigent/core/best_config_runtime.py
@@ -122,6 +122,8 @@ class CloudPublishUnavailableReason(StrEnum):
 
     DISABLED_BY_CONFIG = "disabled_by_config"
     BACKEND_NOT_IMPLEMENTED = "backend_not_implemented"
+    REQUEST_FAILED = "request_failed"
+    INTEGRITY_FAILED = "integrity_failed"
 
 
 class CloudPublishUnavailable(ConfigurationError):
@@ -453,6 +455,57 @@ def write_repo_best_config(
     return spec_path
 
 
+def write_cloud_cache_best_config(
+    directory: str | Path,
+    spec: dict[str, Any],
+    *,
+    etag: str | None = None,
+    version: int | str | None = None,
+    loaded_at: datetime | None = None,
+) -> Path:
+    """Write a fetched cloud best-config spec into the local cloud cache."""
+
+    if not etag and version is None:
+        raise ConfigurationError("Cloud cache metadata requires etag or version")
+
+    snapshot = snapshot_from_spec(spec, source=BestConfigSource.CLOUD_CACHE.value)
+    safe_config_id = _validate_config_id(snapshot.config_id)
+    output_dir = Path(directory)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    normalized_spec = _normalize_json_value(copy.deepcopy(spec))
+    if not isinstance(normalized_spec, dict):
+        raise ConfigurationError("Best config spec must be a JSON object")
+    config_hash = sha256_digest(canonical_json(normalized_spec["config"]))
+    spec_hash = compute_spec_hash(normalized_spec)
+    spec_path = output_dir / f"{safe_config_id}.json"
+    _write_json_atomic(spec_path, normalized_spec)
+
+    manifest_path = output_dir / "manifest.json"
+    loaded_manifest = load_manifest(output_dir) if manifest_path.exists() else None
+    manifest: dict[str, Any] = loaded_manifest or {
+        "schema_version": BEST_CONFIG_MANIFEST_SCHEMA_VERSION,
+        "configs": {},
+    }
+    configs = manifest["configs"]
+    if not isinstance(configs, dict):
+        raise ConfigurationError("Best config manifest requires a configs object")
+
+    entry: dict[str, Any] = {
+        "path": spec_path.name,
+        "spec_hash": spec_hash,
+        "config_hash": config_hash,
+        "loaded_at": (loaded_at or datetime.now(UTC)).isoformat(),
+    }
+    if etag:
+        entry["etag"] = etag
+    if version is not None:
+        entry["version"] = version
+    configs[safe_config_id] = entry
+    _write_json_atomic(manifest_path, manifest)
+    return spec_path
+
+
 def resolve_repo_best_config(
     *,
     config_id: str | None,
@@ -751,5 +804,6 @@ __all__ = [
     "snapshot_from_spec",
     "source_order_for_mode",
     "thaw_config",
+    "write_cloud_cache_best_config",
     "write_repo_best_config",
 ]

--- a/traigent/core/config_state_manager.py
+++ b/traigent/core/config_state_manager.py
@@ -26,12 +26,17 @@ from traigent.core.best_config_runtime import (
     BestConfigSourceMode,
     CloudPublishUnavailable,
     CloudPublishUnavailableReason,
+    canonical_json,
+    compute_spec_hash,
     function_ref_for,
     load_best_config_spec,
     resolve_cloud_cache_best_config,
     resolve_repo_best_config,
+    sha256_digest,
+    snapshot_from_spec,
     source_order_for_mode,
     thaw_config,
+    write_cloud_cache_best_config,
     write_repo_best_config,
 )
 from traigent.utils.exceptions import ConfigurationError, OptimizationStateError
@@ -46,6 +51,10 @@ from traigent.utils.secure_path import (
 logger = get_logger(__name__)
 
 DEFAULT_OPTIMIZATION_HISTORY_LIMIT = 100
+
+
+class CloudBestConfigIntegrityError(ConfigurationError):
+    """Raised when a cloud best-config response fails hash integrity checks."""
 
 
 class OptimizationState(Enum):
@@ -87,6 +96,7 @@ class ConfigStateManager:
         best_config_cache_dir: str | None = None,
         best_config_cache_ttl_seconds: int = 24 * 60 * 60,
         best_config_stale_ok_ttl_seconds: int | None = None,
+        best_config_environment: str | None = None,
         enable_auto_load_dev_logs: bool | None = None,
         optimization_history_limit: int = DEFAULT_OPTIMIZATION_HISTORY_LIMIT,
     ) -> None:
@@ -116,6 +126,9 @@ class ConfigStateManager:
         self.best_config_cache_dir = best_config_cache_dir
         self.best_config_cache_ttl_seconds = best_config_cache_ttl_seconds
         self.best_config_stale_ok_ttl_seconds = best_config_stale_ok_ttl_seconds
+        self.best_config_environment = self._resolve_best_config_environment(
+            best_config_environment
+        )
         self.enable_auto_load_dev_logs = (
             auto_load_best
             if enable_auto_load_dev_logs is None
@@ -322,32 +335,173 @@ class ConfigStateManager:
             )
             return None
 
+    @staticmethod
+    def _resolve_best_config_environment(explicit: str | None) -> str:
+        raw = (
+            explicit or os.environ.get("TRAIGENT_BEST_CONFIG_ENVIRONMENT") or "default"
+        )
+        normalized = raw.strip().lower()
+        return normalized or "default"
+
+    @staticmethod
+    def _verify_cloud_response_hashes(
+        data: dict[str, Any], spec: dict[str, Any]
+    ) -> None:
+        response_spec_hash = data.get("spec_hash")
+        response_config_hash = data.get("config_hash")
+        if not isinstance(response_spec_hash, str) or not response_spec_hash:
+            raise CloudBestConfigIntegrityError(
+                "Cloud best-config response did not include spec_hash"
+            )
+        if not isinstance(response_config_hash, str) or not response_config_hash:
+            raise CloudBestConfigIntegrityError(
+                "Cloud best-config response did not include config_hash"
+            )
+        config = spec.get("config")
+        if not isinstance(config, dict):
+            raise CloudBestConfigIntegrityError(
+                "Cloud best-config spec.config must be an object"
+            )
+
+        actual_spec_hash = compute_spec_hash(spec)
+        actual_config_hash = sha256_digest(canonical_json(config))
+        if response_spec_hash != actual_spec_hash:
+            raise CloudBestConfigIntegrityError("Cloud best-config spec_hash mismatch")
+        if response_config_hash != actual_config_hash:
+            raise CloudBestConfigIntegrityError(
+                "Cloud best-config config_hash mismatch"
+            )
+
+    def _is_pure_cloud_source_mode(self) -> bool:
+        mode_value = (
+            self.best_config_source.value
+            if isinstance(self.best_config_source, BestConfigSourceMode)
+            else str(self.best_config_source)
+        )
+        return mode_value == BestConfigSourceMode.CLOUD.value
+
+    def _resolve_cloud_fetch_best_config(self) -> BestConfigSnapshot | None:
+        if not self.config_id:
+            return None
+
+        from traigent.cloud.backend_client import get_backend_client
+
+        client = get_backend_client(enable_fallback=False)
+        data = client.fetch_best_config_sync(
+            self.config_id,
+            environment=self.best_config_environment,
+            function_ref=function_ref_for(self.func),
+        )
+        if not data:
+            if self._is_pure_cloud_source_mode():
+                raise CloudPublishUnavailable(
+                    CloudPublishUnavailableReason.REQUEST_FAILED,
+                    "Cloud best-config fetch returned no active config",
+                )
+            return None
+        spec = data.get("spec")
+        if not isinstance(spec, dict):
+            raise ConfigurationError(
+                "Cloud best-config response did not include a spec"
+            )
+        self._verify_cloud_response_hashes(data, spec)
+
+        if self.best_config_cache_dir:
+            try:
+                write_cloud_cache_best_config(
+                    self.best_config_cache_dir,
+                    spec,
+                    etag=(
+                        data.get("etag") if isinstance(data.get("etag"), str) else None
+                    ),
+                    version=data.get("version"),
+                )
+            except Exception as cache_exc:
+                if self.best_config_strict:
+                    raise ConfigurationError(
+                        f"Failed to update cloud best-config cache: {cache_exc}"
+                    ) from cache_exc
+                logger.warning(
+                    "Fetched cloud best config but failed to update cache: %s",
+                    cache_exc,
+                )
+
+        snapshot = snapshot_from_spec(
+            spec,
+            configuration_space=self.configuration_space,
+            expected_config_id=self.config_id,
+            expected_function_ref=function_ref_for(self.func),
+            source=BestConfigSource.CLOUD_FETCH.value,
+        )
+        merged = {**self.default_config, **thaw_config(snapshot.config)}
+        return BestConfigSnapshot.from_config(
+            merged,
+            config_id=snapshot.config_id,
+            source=BestConfigSource.CLOUD_FETCH.value,
+            spec_hash=snapshot.spec_hash,
+            loaded_at=snapshot.loaded_at,
+            provenance=thaw_config(snapshot.provenance),
+        )
+
     def _resolve_mode_snapshot(self) -> BestConfigSnapshot | None:
         for source in source_order_for_mode(self.best_config_source):
-            if source is BestConfigSource.REPO:
-                snapshot = resolve_repo_best_config(
-                    config_id=self.config_id,
-                    repo_root=Path.cwd(),
-                    configuration_space=self.configuration_space,
-                    expected_function_ref=function_ref_for(self.func),
-                    strict=self.best_config_strict,
+            try:
+                if source is BestConfigSource.REPO:
+                    snapshot = resolve_repo_best_config(
+                        config_id=self.config_id,
+                        repo_root=Path.cwd(),
+                        configuration_space=self.configuration_space,
+                        expected_function_ref=function_ref_for(self.func),
+                        strict=self.best_config_strict,
+                    )
+                elif source is BestConfigSource.CLOUD_CACHE:
+                    snapshot = resolve_cloud_cache_best_config(
+                        config_id=self.config_id,
+                        cache_dir=self.best_config_cache_dir,
+                        configuration_space=self.configuration_space,
+                        ttl_seconds=self.best_config_cache_ttl_seconds,
+                        stale_ok_ttl_seconds=self.best_config_stale_ok_ttl_seconds,
+                        strict=self.best_config_strict,
+                    )
+                elif source is BestConfigSource.CLOUD_FETCH:
+                    snapshot = self._resolve_cloud_fetch_best_config()
+                else:
+                    snapshot = None
+            except Exception as exc:
+                mode_value = (
+                    self.best_config_source.value
+                    if isinstance(self.best_config_source, BestConfigSourceMode)
+                    else str(self.best_config_source)
                 )
-            elif source is BestConfigSource.CLOUD_CACHE:
-                snapshot = resolve_cloud_cache_best_config(
-                    config_id=self.config_id,
-                    cache_dir=self.best_config_cache_dir,
-                    configuration_space=self.configuration_space,
-                    ttl_seconds=self.best_config_cache_ttl_seconds,
-                    stale_ok_ttl_seconds=self.best_config_stale_ok_ttl_seconds,
-                    strict=self.best_config_strict,
-                )
-            elif source is BestConfigSource.CLOUD_FETCH:
-                logger.warning(
-                    "Cloud best-config fetch is not implemented in this SDK build; "
-                    "falling through to the next configured source."
-                )
-                snapshot = None
-            else:
+                if source is BestConfigSource.CLOUD_FETCH and (
+                    mode_value == BestConfigSourceMode.CLOUD.value
+                    or self.best_config_strict
+                ):
+                    if isinstance(exc, CloudPublishUnavailable):
+                        raise
+                    if isinstance(exc, CloudBestConfigIntegrityError):
+                        raise CloudPublishUnavailable(
+                            CloudPublishUnavailableReason.INTEGRITY_FAILED,
+                            f"Cloud best-config integrity check failed: {exc}",
+                        ) from exc
+                    raise CloudPublishUnavailable(
+                        CloudPublishUnavailableReason.REQUEST_FAILED,
+                        f"Cloud best-config fetch failed: {exc}",
+                    ) from exc
+                if self.best_config_strict:
+                    raise
+                if isinstance(exc, CloudBestConfigIntegrityError):
+                    logger.error(
+                        "Cloud best-config integrity failure; ignoring %s source: %s",
+                        source.value,
+                        exc,
+                    )
+                else:
+                    logger.warning(
+                        "Ignoring %s best-config source after failure: %s",
+                        source.value,
+                        exc,
+                    )
                 snapshot = None
             if snapshot is not None:
                 merged = {**self.default_config, **thaw_config(snapshot.config)}
@@ -745,23 +899,71 @@ class ConfigStateManager:
             config=self._best_config,
             function_ref=function_ref_for(self.func),
             provenance=provenance,
+            environment=self.best_config_environment,
         )
 
-    def publish_best_config(self, *, target: str = "cloud") -> None:
-        """Fail closed until durable cloud best-config publishing is implemented."""
-        if self.best_config_source in {
-            BestConfigSourceMode.OFF.value,
-            BestConfigSourceMode.REPO.value,
-        }:
+    def publish_best_config(self, *, target: str = "cloud") -> dict[str, Any]:
+        """Publish the active best config to durable backend cloud storage."""
+        if target != "cloud":
             raise CloudPublishUnavailable(
                 CloudPublishUnavailableReason.DISABLED_BY_CONFIG,
-                "Cloud best-config publish is disabled by best_config_source.",
+                "Only target='cloud' is reserved for best-config publishing. "
+                "Use export_best_config() for local repo artifacts.",
             )
-        raise CloudPublishUnavailable(
-            CloudPublishUnavailableReason.BACKEND_NOT_IMPLEMENTED,
-            "Cloud best-config publish is not implemented in this SDK build; "
-            "use export_best_config() to write a repo spec.",
-        )
+        if not self._best_config:
+            raise ConfigurationError(
+                "No best configuration available to publish. "
+                "Please run optimization first using .optimize() or load a config."
+            )
+
+        from traigent.cloud.backend_client import get_backend_client
+
+        effective_config_id = self.config_id or self.func.__name__
+        provenance: dict[str, Any] = {
+            "source": self._best_config_snapshot.source,
+            "published_at": datetime.now(UTC).isoformat(),
+        }
+        if self._optimization_results:
+            provenance["optimization_id"] = self._optimization_results.optimization_id
+        spec = {
+            "schema_version": BEST_CONFIG_SCHEMA_VERSION,
+            "config_id": effective_config_id,
+            "function_ref": function_ref_for(self.func),
+            "environment": self.best_config_environment,
+            "config": thaw_config(self._best_config),
+            "provenance": provenance,
+        }
+        try:
+            client = get_backend_client(enable_fallback=False)
+            current = client.fetch_best_config_sync(
+                effective_config_id,
+                environment=self.best_config_environment,
+                function_ref=function_ref_for(self.func),
+            )
+            if_match = (
+                current.get("etag")
+                if isinstance(current, dict) and isinstance(current.get("etag"), str)
+                else None
+            )
+            result = client.publish_best_config_sync(
+                spec,
+                environment=self.best_config_environment,
+                if_match=if_match,
+            )
+            self._verify_cloud_response_hashes(result, spec)
+            return result
+        except CloudPublishUnavailable:
+            raise
+        except CloudBestConfigIntegrityError as exc:
+            raise CloudPublishUnavailable(
+                CloudPublishUnavailableReason.INTEGRITY_FAILED,
+                f"Cloud best-config publish integrity check failed: {exc}",
+            ) from exc
+        except Exception as exc:
+            raise CloudPublishUnavailable(
+                CloudPublishUnavailableReason.REQUEST_FAILED,
+                f"Cloud best-config publish failed: {exc}",
+            ) from exc
 
     def _create_slim_export(self, include_metadata: bool) -> dict[str, Any]:
         """Create a slim export suitable for git and deployment."""

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -296,6 +296,7 @@ class OptimizedFunction:
         self._best_config_stale_ok_ttl_seconds = kwargs.pop(
             "best_config_stale_ok_ttl_seconds", None
         )
+        self._best_config_environment = kwargs.pop("best_config_environment", None)
         self._enable_auto_load_dev_logs = kwargs.pop("enable_auto_load_dev_logs", None)
         # Guided-generation defaults configured at decoration time; consumed by
         # optimize_with_guidance when not overridden at the call site.
@@ -692,6 +693,7 @@ class OptimizedFunction:
             best_config_stale_ok_ttl_seconds=getattr(
                 self, "_best_config_stale_ok_ttl_seconds", None
             ),
+            best_config_environment=getattr(self, "_best_config_environment", None),
             enable_auto_load_dev_logs=getattr(self, "_enable_auto_load_dev_logs", None),
             optimization_history_limit=self.optimization_history_limit,
         )
@@ -2431,9 +2433,9 @@ class OptimizedFunction:
             directory, config_id=config_id, include_metadata=include_metadata
         )
 
-    def publish_best_config(self, *, target: str = "cloud") -> None:
+    def publish_best_config(self, *, target: str = "cloud") -> dict[str, Any]:
         """Publish the best config to a durable remote target when supported."""
-        self._csm.publish_best_config(target=target)
+        return self._csm.publish_best_config(target=target)
 
     def _load_config_from_path(self, path: str) -> dict[str, Any] | None:
         """Load config from a file path. Delegates to ConfigStateManager."""


### PR DESCRIPTION
## Summary
- Add SDK backend best-config publish and fetch methods over /api/v1/best-configs.
- Wire cloud best-config fetch and explicit publish through ConfigStateManager with spec/config hash verification and fail-closed errors.
- Add tracked branch evidence for backend network contracts, including a fresh-process publish-then-fetch test.

## Spine / Risk
- ChangeSession dry-run: cs_a7412125fce59237
- Risk: high
- Admission state: pending owner approval
- This is intentionally a draft PR. Do not merge until owner approval resolves the high-risk public SDK/API surface obligation.

## Verification
- python3 -m pytest -n 0 tests/unit/core/test_best_config_runtime.py tests/unit/cloud/test_best_config_cloud_client.py tests/unit/core/test_best_config_runtime_integration.py -q -> 37 passed
- git diff --check
- Commit hooks passed: isort, black, ruff, detect-secrets, bandit, mypy, public assertion contracts, cost guardrails

## Production Safety Checklist
1. Worst-case prod path: SDK clients can publish or fetch a promoted best config from the configured backend. Failures raise CloudPublishUnavailable or CloudServiceError; they do not silently fabricate success.
2. Production-branch test: tests/unit/core/test_best_config_runtime_integration.py::test_fresh_process_cloud_publish_then_fetch_uses_backend_network_contract and tests/unit/cloud/test_best_config_cloud_client.py cover the backend network contract and hash checks.
3. Contract regeneration: no schema shape change in this PR. It uses the existing best-config schema and backend route contract.
4. Public surface delta: OptimizedFunction.publish_best_config now returns the backend publish receipt instead of dropping the delegate result. PR is draft for review and approval.
5. Review threads resolved: pending. This draft must not merge with unresolved review threads.
6. Quality gates not relaxed: no thresholds changed.