### PR TITLE
feat(mcp): traigent mcp serve — local stdio MCP server for coding agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,11 @@ hybrid = [
     "mcp>=1.27.0",  # CVE-2025-66416, AIKIDO-2026-10472 fix (claude-code-sdk dependency)
 ]
 
+# Local stdio MCP server for coding agents.
+mcp = [
+    "mcp>=1.27.0",
+]
+
 # Internal schema validation support for DTO strict-validation paths.
 internal_schema = [
     "traigent-schema @ git+https://github.com/Traigent/TraigentSchema.git@96c30d3c6f4f0ab32748093357bbedfab89b80a5",

--- a/tests/unit/cli/test_mcp_commands.py
+++ b/tests/unit/cli/test_mcp_commands.py
@@ -1,0 +1,32 @@
+"""Tests for the Traigent MCP CLI command group."""
+
+from __future__ import annotations
+
+import builtins
+
+from click.testing import CliRunner
+
+from traigent.cli.main import cli
+
+
+def test_mcp_help_does_not_require_optional_dependency() -> None:
+    result = CliRunner().invoke(cli, ["mcp", "--help"])
+
+    assert result.exit_code == 0
+    assert "serve" in result.output
+
+
+def test_mcp_serve_without_extra_prints_install_hint(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "mcp.server.fastmcp":
+            raise ImportError("mcp missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    result = CliRunner().invoke(cli, ["mcp", "serve"])
+
+    assert result.exit_code != 0
+    assert "pip install 'traigent[mcp]'" in result.output

--- a/tests/unit/mcp/test_local_server.py
+++ b/tests/unit/mcp/test_local_server.py
@@ -1,0 +1,273 @@
+"""Tests for the local stdio MCP server surface."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from traigent.mcp.server import create_server
+from traigent.mcp.tools import V1_TOOL_NAMES
+
+
+@pytest.fixture(autouse=True)
+def reset_traigent_mock_mode() -> None:
+    yield
+    from traigent.testing import _reset_for_tests
+
+    _reset_for_tests()
+
+
+@asynccontextmanager
+async def mcp_session() -> AsyncIterator[ClientSession]:
+    server = create_server()
+    async with create_connected_server_and_client_session(server) as session:
+        yield session
+
+
+async def call_tool(
+    session: ClientSession,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = await session.call_tool(name, arguments or {})
+    assert result.structuredContent is not None
+    return dict(result.structuredContent)
+
+
+def write_fixture_agent(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "import traigent",
+                "",
+                "@traigent.optimize(",
+                "    eval_dataset=[",
+                "        {'input': {'query': 'a'}, 'expected': 'A'},",
+                "        {'input': {'query': 'b'}, 'expected': 'B'},",
+                "    ],",
+                "    objectives=['accuracy'],",
+                "    configuration_space={'temperature': [0.0, 1.0]},",
+                ")",
+                "def answer(query: str) -> str:",
+                "    temperature = 0.0",
+                "    return {'a': 'A', 'b': 'B'}[query]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_fixture_dataset(path: Path) -> None:
+    rows = [
+        {"input": {"query": "a"}, "output": "A"},
+        {"input": {"query": "b"}, "output": "B"},
+        {"input": {"query": "c"}, "output": "C"},
+    ]
+    path.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+async def test_tool_listing_matches_v1_set() -> None:
+    async with mcp_session() as session:
+        result = await session.list_tools()
+
+    assert [tool.name for tool in result.tools] == list(V1_TOOL_NAMES)
+    assert "scaffold_eval" not in {tool.name for tool in result.tools}
+    assert "export_evidence" not in {tool.name for tool in result.tools}
+    assert "significant_variables" not in {tool.name for tool in result.tools}
+    assert "generate_examples" not in {tool.name for tool in result.tools}
+
+
+async def test_catalog_and_recommend_happy_path(
+) -> None:
+    async with mcp_session() as session:
+        types_payload = await call_tool(session, "list_recommendation_agent_types")
+        recommendation = await call_tool(
+            session,
+            "recommend_configuration_space",
+            {"agent_type": "rag", "min_impact": "low", "min_confidence": "low"},
+        )
+
+    assert types_payload["ok"] is True
+    assert "rag" in types_payload["agent_types"]
+    assert recommendation["ok"] is True
+    assert recommendation["recommendation"]["agent_type"] == "rag"
+    assert "configuration_space" in recommendation["recommendation"]
+
+
+async def test_detect_validate_and_estimate_happy_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    agent_file = tmp_path / "agent.py"
+    dataset = tmp_path / "eval.jsonl"
+    write_fixture_agent(agent_file)
+    write_fixture_dataset(dataset)
+    monkeypatch.setenv("TRAIGENT_DATASET_ROOT", str(tmp_path))
+
+    async with mcp_session() as session:
+        detected = await call_tool(
+            session,
+            "detect_tvars",
+            {"file_path": "agent.py", "function_name": "answer"},
+        )
+        validation = await call_tool(session, "validate_dataset", {"path": "eval.jsonl"})
+        estimate = await call_tool(
+            session,
+            "estimate_cost",
+            {
+                "dataset_path": "eval.jsonl",
+                "max_trials": 4,
+                "model": "gpt-4o-mini",
+            },
+        )
+
+    assert detected["ok"] is True
+    assert detected["results"][0]["function_name"] == "answer"
+    assert any(
+        candidate["name"] == "temperature"
+        for candidate in detected["results"][0]["candidates"]
+    )
+
+    assert validation["ok"] is True
+    assert validation["errors"] == []
+
+    assert estimate["ok"] is True
+    assert estimate["dataset_examples"] == 3
+    assert estimate["llm_calls_upper_bound"] == 12
+    assert estimate["estimated_total_cost_usd"] is not None
+    assert any("max_trials * dataset" in item for item in estimate["assumptions"])
+
+
+async def test_run_optimization_refusal_matrix_and_mock_happy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    agent_file = tmp_path / "agent.py"
+    write_fixture_agent(agent_file)
+
+    async with mcp_session() as session:
+        no_confirm = await call_tool(
+            session,
+            "run_optimization",
+            {"script_path": "agent.py", "mode": "real"},
+        )
+        no_cost_limit = await call_tool(
+            session,
+            "run_optimization",
+            {"script_path": "agent.py", "mode": "real", "confirm": True},
+        )
+        mock_run = await call_tool(
+            session,
+            "run_optimization",
+            {"script_path": "agent.py", "max_trials": 2, "algorithm": "random"},
+        )
+        listed = await call_tool(session, "get_results")
+        shown = await call_tool(
+            session,
+            "get_results",
+            {"result_name": mock_run["results"][0]["result_name"]},
+        )
+
+    assert no_confirm["ok"] is False
+    assert no_confirm["refused"] is True
+    assert "confirm=true" in no_confirm["message"]
+
+    assert no_cost_limit["ok"] is False
+    assert no_cost_limit["refused"] is True
+    assert "cost_limit" in no_cost_limit["message"]
+
+    assert mock_run["ok"] is True
+    assert mock_run["mode"] == "mock"
+    assert mock_run["results"][0]["total_trials"] == 2
+    assert mock_run["results"][0]["result_name"]
+    from traigent.testing import is_mock_mode_enabled
+
+    assert is_mock_mode_enabled() is False
+
+    result_names = {item["name"] for item in listed["results"]}
+    assert mock_run["results"][0]["result_name"] in result_names
+
+    assert shown["ok"] is True
+    assert shown["result"]["best_config"] is not None
+
+
+async def test_auth_status_masks_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_key = "sk_test_secret_1234567890"
+    monkeypatch.setattr(
+        "traigent.mcp.tools.CredentialManager.get_credentials",
+        lambda: {
+            "api_key": full_key,
+            "backend_url": "https://backend.example.test",
+            "tenant_id": "tenant_123",
+            "project_id": "project_456",
+            "source": "test",
+        },
+    )
+
+    async with mcp_session() as session:
+        payload = await call_tool(session, "auth_status")
+    serialized = json.dumps(payload)
+
+    assert payload["ok"] is True
+    assert payload["api_key"]["present"] is True
+    assert payload["api_key"]["prefix"] == "sk_t"
+    assert payload["api_key"]["last4"] == "7890"
+    assert full_key not in serialized
+
+
+async def test_path_containment_rejections(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    (outside / "agent.py").write_text("def answer(): pass\n", encoding="utf-8")
+    (outside / "eval.jsonl").write_text(
+        '{"input": "x", "output": "y"}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(root)
+    monkeypatch.setenv("TRAIGENT_DATASET_ROOT", str(root))
+
+    async with mcp_session() as session:
+        detect = await call_tool(
+            session,
+            "detect_tvars",
+            {"file_path": str(outside / "agent.py")},
+        )
+        validate = await call_tool(
+            session,
+            "validate_dataset",
+            {"path": str(outside / "eval.jsonl")},
+        )
+        run = await call_tool(
+            session,
+            "run_optimization",
+            {"script_path": str(outside / "agent.py")},
+        )
+
+    assert detect["ok"] is False
+    assert detect["code"] == "path_rejected"
+
+    assert validate["ok"] is False
+    assert validate["code"] == "path_rejected"
+
+    assert run["ok"] is False
+    assert run["code"] == "path_rejected"

--- a/tests/unit/mcp/test_local_server.py
+++ b/tests/unit/mcp/test_local_server.py
@@ -88,8 +88,7 @@ async def test_tool_listing_matches_v1_set() -> None:
     assert "generate_examples" not in {tool.name for tool in result.tools}
 
 
-async def test_catalog_and_recommend_happy_path(
-) -> None:
+async def test_catalog_and_recommend_happy_path() -> None:
     async with mcp_session() as session:
         types_payload = await call_tool(session, "list_recommendation_agent_types")
         recommendation = await call_tool(
@@ -122,7 +121,9 @@ async def test_detect_validate_and_estimate_happy_paths(
             "detect_tvars",
             {"file_path": "agent.py", "function_name": "answer"},
         )
-        validation = await call_tool(session, "validate_dataset", {"path": "eval.jsonl"})
+        validation = await call_tool(
+            session, "validate_dataset", {"path": "eval.jsonl"}
+        )
         estimate = await call_tool(
             session,
             "estimate_cost",
@@ -271,3 +272,146 @@ async def test_path_containment_rejections(
 
     assert run["ok"] is False
     assert run["code"] == "path_rejected"
+
+
+async def test_auth_status_check_swallows_validator_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_key = "sk_live_supersecret_abcdefghijklmnop"
+    backend_url = "https://backend.example.test"
+    monkeypatch.setattr(
+        "traigent.mcp.tools.CredentialManager.get_credentials",
+        lambda: {
+            "api_key": full_key,
+            "backend_url": backend_url,
+            "source": "test",
+        },
+    )
+
+    leaky_url = "https://internal.secret.test/keys/validate"
+
+    async def _raise(self: Any, api_key: str, verbose: bool = False) -> Any:
+        raise RuntimeError(f"backend returned 500 for key {full_key} at {leaky_url}")
+
+    monkeypatch.setattr(
+        "traigent.cli.auth_commands.TraigentAuthCLI._validate_api_key",
+        _raise,
+    )
+
+    async with mcp_session() as session:
+        payload = await call_tool(session, "auth_status", {"check": True})
+    serialized = json.dumps(payload)
+
+    # Exception must not propagate; structured failure with a generic message.
+    assert payload["ok"] is True
+    assert payload["validity"]["checked"] is True
+    assert payload["validity"]["valid"] is None
+    assert payload["validity"]["source"] == "backend"
+    assert payload["validity"]["message"] == "Live validation could not be completed."
+    # Neither the full key nor the leaky URL may appear anywhere in the output.
+    assert full_key not in serialized
+    assert leaky_url not in serialized
+    assert "internal.secret.test" not in serialized
+
+
+async def test_auth_status_strips_userinfo_from_backend_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "traigent.mcp.tools.CredentialManager.get_credentials",
+        lambda: {
+            "api_key": "sk_test_1234567890",  # pragma: allowlist secret
+            "backend_url": "https://alice:hunter2@backend.example.test:8443/api",  # pragma: allowlist secret
+            "source": "test",
+        },
+    )
+
+    async with mcp_session() as session:
+        payload = await call_tool(session, "auth_status")
+    serialized = json.dumps(payload)
+
+    assert payload["backend_url"] == "https://backend.example.test:8443/api"
+    assert "hunter2" not in serialized
+    assert "alice" not in serialized
+    assert "alice:hunter2@" not in serialized
+
+
+async def test_validate_dataset_symlink_escape_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    secret = outside / "secret.jsonl"
+    secret.write_text('{"input": "x", "output": "y"}\n', encoding="utf-8")
+    # Symlink lives *inside* the dataset root but points outside it.
+    link = root / "linked.jsonl"
+    link.symlink_to(secret)
+
+    monkeypatch.chdir(root)
+    monkeypatch.setenv("TRAIGENT_DATASET_ROOT", str(root))
+
+    async with mcp_session() as session:
+        validate = await call_tool(
+            session,
+            "validate_dataset",
+            {"path": "linked.jsonl"},
+        )
+
+    assert validate["ok"] is False
+    assert validate["code"] == "path_rejected"
+
+
+async def test_validate_dataset_missing_dataset_root_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    missing = tmp_path / "does_not_exist"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRAIGENT_DATASET_ROOT", str(missing))
+
+    async with mcp_session() as session:
+        validate = await call_tool(
+            session,
+            "validate_dataset",
+            {"path": "eval.jsonl"},
+        )
+
+    # A missing TRAIGENT_DATASET_ROOT must not crash the tool call.
+    assert validate["ok"] is False
+    assert validate["code"] == "path_rejected"
+
+
+async def test_run_optimization_real_refused_when_mock_mode_forced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    agent_file = tmp_path / "agent.py"
+    write_fixture_agent(agent_file)
+
+    from traigent.testing import enable_mock_mode_for_quickstart
+
+    # Force process-local mock mode on, then request a real run with a valid
+    # confirm + positive cost_limit. The server must honestly refuse rather than
+    # silently executing a mock run labeled as real.
+    enable_mock_mode_for_quickstart()
+
+    async with mcp_session() as session:
+        result = await call_tool(
+            session,
+            "run_optimization",
+            {
+                "script_path": "agent.py",
+                "mode": "real",
+                "confirm": True,
+                "cost_limit": 5.0,
+            },
+        )
+
+    assert result["ok"] is False
+    assert result["refused"] is True
+    assert "mock mode" in result["message"]
+    assert "results" not in result

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -397,6 +397,32 @@ def quickstart() -> None:
     run_quickstart()
 
 
+@cli.group("mcp")
+def mcp_commands() -> None:
+    """Run Traigent local MCP integrations."""
+
+
+@mcp_commands.command("serve")
+def mcp_serve() -> None:
+    """Run the local stdio MCP server for coding agents.
+
+    Requires the optional MCP dependency:
+        pip install 'traigent[mcp]'
+    """
+    try:
+        from traigent.mcp.server import run_stdio_server
+    except ImportError as exc:
+        raise click.ClickException(
+            "The optional MCP dependency is not installed. "
+            "Install it with: pip install 'traigent[mcp]'"
+        ) from exc
+
+    try:
+        run_stdio_server()
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
 @cli.command()
 def info() -> None:
     """Show Traigent SDK version and system information."""

--- a/traigent/mcp/__init__.py
+++ b/traigent/mcp/__init__.py
@@ -1,0 +1,7 @@
+"""Local MCP server support for the Traigent SDK."""
+
+from __future__ import annotations
+
+from traigent.mcp.tools import V1_TOOL_NAMES
+
+__all__ = ["V1_TOOL_NAMES"]

--- a/traigent/mcp/server.py
+++ b/traigent/mcp/server.py
@@ -124,7 +124,9 @@ def create_server() -> Any:
             "script. Defaults to mode='mock' dry-run. Real mode spends provider "
             "tokens/money and refuses unless confirm=true and cost_limit is set. "
             "Path security: script_path must resolve under the current working "
-            "directory."
+            "directory. Note: this runs synchronously and blocks the MCP stdio "
+            "loop for the full duration of the run (single-agent v1 limitation); "
+            "real-run stdout/stderr are redacted from the response."
         )
     )
     def run_optimization(

--- a/traigent/mcp/server.py
+++ b/traigent/mcp/server.py
@@ -1,0 +1,161 @@
+"""Local stdio MCP server for Traigent SDK tools."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from traigent.mcp.tools import (
+    auth_status_tool,
+    detect_tvars_tool,
+    estimate_cost_tool,
+    get_results_tool,
+    list_recommendation_agent_types_tool,
+    recommend_configuration_space_tool,
+    run_optimization_tool,
+    validate_dataset_tool,
+)
+
+_MCP_INSTALL_MESSAGE = (
+    "The optional MCP dependency is not installed. "
+    "Install it with: pip install 'traigent[mcp]'"
+)
+
+
+def create_server() -> Any:
+    """Create the local Traigent MCP server.
+
+    The optional ``mcp`` package is imported lazily so ``traigent mcp --help``
+    still works in environments that have not installed ``traigent[mcp]``.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:  # pragma: no cover - covered by CLI test
+        raise RuntimeError(_MCP_INSTALL_MESSAGE) from exc
+
+    server = FastMCP(
+        "traigent",
+        instructions=(
+            "Local-first Traigent SDK MCP server. Tools run against local code "
+            "and local auth storage; API keys are never returned."
+        ),
+    )
+
+    @server.tool(
+        description=(
+            "Return local Traigent auth status from existing credential storage. "
+            "API key output is masked to prefix and last4 only. No network call is "
+            "made unless check=true."
+        )
+    )
+    async def auth_status(check: bool = False) -> dict[str, Any]:
+        return await auth_status_tool(check=check)
+
+    @server.tool(
+        description=(
+            "List valid local public catalog agent/task types for configuration "
+            "space recommendations. No network call."
+        )
+    )
+    def list_recommendation_agent_types() -> dict[str, Any]:
+        return list_recommendation_agent_types_tool()
+
+    @server.tool(
+        description=(
+            "Return the versioned public catalog recommendation response for an "
+            "agent/task type. Optional min_impact and min_confidence filters "
+            "accept low, medium, or high. No network call."
+        )
+    )
+    def recommend_configuration_space(
+        agent_type: str,
+        min_impact: Literal["low", "medium", "high"] | None = None,
+        min_confidence: Literal["low", "medium", "high"] | None = None,
+    ) -> dict[str, Any]:
+        return recommend_configuration_space_tool(
+            agent_type=agent_type,
+            min_impact=min_impact,
+            min_confidence=min_confidence,
+        )
+
+    @server.tool(
+        description=(
+            "Detect tuned variable candidates in a Python file using the local "
+            "TunedVariableDetector. Path security: file_path must resolve under "
+            "the MCP server's current working directory."
+        )
+    )
+    def detect_tvars(
+        file_path: str,
+        function_name: str | None = None,
+    ) -> dict[str, Any]:
+        return detect_tvars_tool(file_path=file_path, function_name=function_name)
+
+    @server.tool(
+        description=(
+            "Validate a JSON/JSONL dataset using Validators.validate_dataset. "
+            "Path security: path must resolve under TRAIGENT_DATASET_ROOT when "
+            "set, otherwise under the MCP server's current working directory."
+        )
+    )
+    def validate_dataset(path: str) -> dict[str, Any]:
+        return validate_dataset_tool(path=path)
+
+    @server.tool(
+        description=(
+            "Estimate optimization scale using the dry-run-first arithmetic: "
+            "max_trials multiplied by dataset examples. Path security matches "
+            "validate_dataset. Optional model pricing uses local SDK estimates."
+        )
+    )
+    def estimate_cost(
+        dataset_path: str,
+        max_trials: int,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        return estimate_cost_tool(
+            dataset_path=dataset_path,
+            max_trials=max_trials,
+            model=model,
+        )
+
+    @server.tool(
+        description=(
+            "Run local optimization for @traigent.optimize functions in a Python "
+            "script. Defaults to mode='mock' dry-run. Real mode spends provider "
+            "tokens/money and refuses unless confirm=true and cost_limit is set. "
+            "Path security: script_path must resolve under the current working "
+            "directory."
+        )
+    )
+    def run_optimization(
+        script_path: str | None = None,
+        mode: Literal["mock", "real"] = "mock",
+        confirm: bool = False,
+        cost_limit: float | None = None,
+        max_trials: int | None = None,
+        algorithm: str | None = None,
+    ) -> dict[str, Any]:
+        return run_optimization_tool(
+            script_path=script_path,
+            mode=mode,
+            confirm=confirm,
+            cost_limit=cost_limit,
+            max_trials=max_trials,
+            algorithm=algorithm,
+        )
+
+    @server.tool(
+        description=(
+            "List local optimization results from .traigent, or show one result "
+            "by result_name using the existing PersistenceManager."
+        )
+    )
+    def get_results(result_name: str | None = None) -> dict[str, Any]:
+        return get_results_tool(result_name=result_name)
+
+    return server
+
+
+def run_stdio_server() -> None:
+    """Run the local Traigent MCP server over stdio."""
+    create_server().run("stdio")

--- a/traigent/mcp/tools.py
+++ b/traigent/mcp/tools.py
@@ -1,0 +1,648 @@
+"""Tool implementations for the local Traigent MCP server."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import inspect
+import io
+import json
+import os
+import sys
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Literal, cast
+
+from traigent.api.functions import (
+    list_recommendation_agent_types as public_list_recommendation_agent_types,
+)
+from traigent.api.functions import (
+    recommend_configuration_space as public_recommend_configuration_space,
+)
+from traigent.cloud.credential_manager import CredentialManager
+from traigent.config.backend_config import BackendConfig
+from traigent.config.project import read_optional_project_env
+from traigent.config.tenant import TENANT_ENV_VAR, read_optional_env
+from traigent.evaluators.base import DATASET_ROOT_ENV, _resolve_dataset_source
+from traigent.hooks.validator import DEFAULT_TOKENS_PER_QUERY, MODEL_COST_PER_1K
+from traigent.tuned_variables.detection_types import DetectionResult
+from traigent.tuned_variables.detector import TunedVariableDetector
+from traigent.utils.exceptions import ValidationError as TraigentValidationError
+from traigent.utils.function_identity import sanitize_identifier
+from traigent.utils.persistence import PersistenceManager
+from traigent.utils.secure_path import PathTraversalError, validate_path
+from traigent.utils.validation import ValidationResult, Validators
+
+V1_TOOL_NAMES: tuple[str, ...] = (
+    "auth_status",
+    "list_recommendation_agent_types",
+    "recommend_configuration_space",
+    "detect_tvars",
+    "validate_dataset",
+    "estimate_cost",
+    "run_optimization",
+    "get_results",
+)
+
+_REAL_SPEND_MESSAGE = (
+    "Real optimization spends provider tokens/money. Re-run with confirm=true "
+    "and an explicit positive cost_limit to start a real run."
+)
+
+
+class ToolInputError(ValueError):
+    """Raised for user-correctable MCP tool input errors."""
+
+
+def _failure(message: str, *, code: str = "invalid_input") -> dict[str, Any]:
+    return {"ok": False, "code": code, "message": message}
+
+
+def _serialize_validation_result(result: ValidationResult) -> dict[str, Any]:
+    return {
+        "ok": result.is_valid,
+        "errors": [
+            {
+                "field": error.field,
+                "message": error.message,
+                "error_code": error.error_code,
+                "severity": error.severity,
+                "suggestions": list(error.suggestions),
+                "context": dict(error.context),
+            }
+            for error in result.errors
+        ],
+        "warnings": [
+            {
+                "field": warning.field,
+                "message": warning.message,
+                "error_code": warning.error_code,
+                "severity": warning.severity,
+                "suggestions": list(warning.suggestions),
+                "context": dict(warning.context),
+            }
+            for warning in result.warnings
+        ],
+        "suggestions": list(result.suggestions),
+        "feedback": result.get_feedback(),
+    }
+
+
+def _resolve_cwd_file(
+    file_path: str | Path,
+    *,
+    field_name: str,
+    suffix: str | None = None,
+) -> Path:
+    root = Path.cwd().resolve()
+    try:
+        resolved = validate_path(Path(file_path).expanduser(), root, must_exist=True)
+    except FileNotFoundError as exc:
+        raise ToolInputError(f"{field_name} does not exist: {file_path}") from exc
+    except PathTraversalError as exc:
+        raise ToolInputError(
+            f"{field_name} must stay under the current working directory: {root}"
+        ) from exc
+
+    if not resolved.is_file():
+        raise ToolInputError(f"{field_name} must be a file: {resolved}")
+    if suffix is not None and resolved.suffix != suffix:
+        raise ToolInputError(f"{field_name} must be a {suffix} file: {resolved}")
+    return cast(Path, resolved)
+
+
+def _dataset_root() -> Path:
+    configured = os.environ.get(DATASET_ROOT_ENV)
+    if configured:
+        return Path(configured).expanduser().resolve(strict=True)
+    return Path.cwd().resolve()
+
+
+def _resolve_dataset_path(path: str | Path) -> tuple[Path, Path]:
+    root = _dataset_root()
+    try:
+        resolved_path, _registry_entry = _resolve_dataset_source(str(path))
+    except TraigentValidationError as exc:
+        raise ToolInputError(str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise ToolInputError(str(exc)) from exc
+
+    try:
+        resolved_path.relative_to(root)
+    except ValueError as exc:
+        raise ToolInputError(
+            f"Dataset path must stay under {DATASET_ROOT_ENV or 'cwd'} ({root}): "
+            f"{resolved_path}"
+        ) from exc
+    return resolved_path, root
+
+
+def _mask_api_key(api_key: str | None) -> dict[str, Any]:
+    if not api_key:
+        return {"present": False, "prefix": None, "last4": None, "masked": None}
+
+    prefix = api_key[:4]
+    last4 = api_key[-4:] if len(api_key) > 8 else None
+    masked = f"{prefix}...{last4}" if last4 is not None else f"{prefix}..."
+    return {"present": True, "prefix": prefix, "last4": last4, "masked": masked}
+
+
+async def auth_status_tool(check: bool = False) -> dict[str, Any]:
+    """Return local auth status with masked key metadata only."""
+    credentials = CredentialManager.get_credentials()
+    api_key = credentials.get("api_key")
+    if api_key is not None and not isinstance(api_key, str):
+        api_key = None
+
+    tenant_id = credentials.get("tenant_id") or read_optional_env(TENANT_ENV_VAR)
+    project_id = credentials.get("project_id") or read_optional_project_env()
+    backend_url = credentials.get("backend_url") or BackendConfig.get_backend_url()
+    authenticated = bool(api_key or credentials.get("jwt_token"))
+    validity: dict[str, Any] = {
+        "checked": False,
+        "valid": None,
+        "source": "not_checked",
+    }
+
+    if check:
+        if not api_key:
+            validity = {
+                "checked": True,
+                "valid": False,
+                "source": "local",
+                "message": "No API key is available to validate.",
+            }
+        else:
+            from traigent.cli.auth_commands import TraigentAuthCLI
+
+            auth_cli = TraigentAuthCLI(backend_url_override=cast(str, backend_url))
+            metadata = await auth_cli._validate_api_key(api_key, verbose=False)
+            validity = {
+                "checked": True,
+                "valid": metadata is not None,
+                "source": "backend",
+            }
+
+    return {
+        "ok": True,
+        "authenticated": authenticated,
+        "credential_source": credentials.get("source") or "none",
+        "api_key": _mask_api_key(api_key),
+        "auth_type": (
+            "api_key"
+            if api_key
+            else ("jwt" if credentials.get("jwt_token") else "none")
+        ),
+        "tenant_id": tenant_id,
+        "project_id": project_id,
+        "backend_url": backend_url,
+        "validity": validity,
+    }
+
+
+def list_recommendation_agent_types_tool() -> dict[str, Any]:
+    """Return the local public recommendation catalog's agent types."""
+    return {
+        "ok": True,
+        "agent_types": list(public_list_recommendation_agent_types()),
+    }
+
+
+def recommend_configuration_space_tool(
+    agent_type: str,
+    min_impact: Literal["low", "medium", "high"] | None = None,
+    min_confidence: Literal["low", "medium", "high"] | None = None,
+) -> dict[str, Any]:
+    """Return a versioned local public recommendation response."""
+    try:
+        data = public_recommend_configuration_space(
+            agent_type,
+            min_impact=min_impact,
+            min_confidence=min_confidence,
+        )
+    except ValueError as exc:
+        return _failure(str(exc))
+    return {"ok": True, "recommendation": data}
+
+
+def _serialize_detection_result(result: DetectionResult) -> dict[str, Any]:
+    candidates: list[dict[str, Any]] = []
+    for candidate in result.candidates:
+        suggested_range = candidate.suggested_range
+        candidates.append(
+            {
+                "name": candidate.name,
+                "type": candidate.candidate_type.value,
+                "confidence": candidate.confidence.value,
+                "line": candidate.location.line,
+                "col_offset": candidate.location.col_offset,
+                "current_value": candidate.current_value,
+                "canonical_name": candidate.canonical_name,
+                "reasoning": candidate.reasoning,
+                "detection_source": candidate.detection_source,
+                "suggested_range": (
+                    {
+                        "range_type": suggested_range.range_type,
+                        "kwargs": dict(suggested_range.kwargs),
+                        "code": suggested_range.to_parameter_range_code(),
+                    }
+                    if suggested_range
+                    else None
+                ),
+            }
+        )
+
+    return {
+        "function_name": result.function_name,
+        "count": result.count,
+        "source_hash": result.source_hash,
+        "detection_strategies_used": list(result.detection_strategies_used),
+        "warnings": list(result.warnings),
+        "configuration_space": result.to_configuration_space(min_confidence="low"),
+        "candidates": candidates,
+    }
+
+
+def detect_tvars_tool(
+    file_path: str,
+    function_name: str | None = None,
+) -> dict[str, Any]:
+    """Detect tuned variables in a Python file contained by cwd."""
+    try:
+        resolved = _resolve_cwd_file(file_path, field_name="file_path", suffix=".py")
+    except ToolInputError as exc:
+        return _failure(str(exc), code="path_rejected")
+
+    detector = TunedVariableDetector()
+    results = detector.detect_from_file(resolved, function_name)
+    return {
+        "ok": True,
+        "file_path": str(resolved),
+        "path_policy": "file_path must resolve under the current working directory.",
+        "results": [_serialize_detection_result(result) for result in results],
+    }
+
+
+def validate_dataset_tool(path: str) -> dict[str, Any]:
+    """Validate a dataset path contained by TRAIGENT_DATASET_ROOT/cwd."""
+    try:
+        resolved_path, root = _resolve_dataset_path(path)
+    except ToolInputError as exc:
+        return _failure(str(exc), code="path_rejected")
+
+    result = Validators.validate_dataset(str(resolved_path))
+    payload = _serialize_validation_result(result)
+    payload.update(
+        {
+            "dataset_path": str(resolved_path),
+            "dataset_root": str(root),
+            "path_policy": (
+                f"path must resolve under {DATASET_ROOT_ENV} when set; "
+                "otherwise under the current working directory."
+            ),
+        }
+    )
+    return payload
+
+
+def _count_dataset_examples(path: Path) -> int:
+    if path.suffix == ".jsonl":
+        with path.open(encoding="utf-8") as handle:
+            return sum(1 for line in handle if line.strip())
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return len(payload)
+    if isinstance(payload, dict) and isinstance(payload.get("examples"), list):
+        return len(payload["examples"])
+    return 1
+
+
+def _estimate_model_cost_per_call(model: str | None) -> tuple[float | None, str | None]:
+    if not model:
+        return None, None
+
+    normalized = model.lower()
+    cost_per_1k = MODEL_COST_PER_1K.get(normalized)
+    if cost_per_1k is None:
+        for known_model, known_cost in MODEL_COST_PER_1K.items():
+            if known_model in normalized or normalized in known_model:
+                cost_per_1k = known_cost
+                break
+
+    if cost_per_1k is None:
+        return None, None
+    return cost_per_1k * (DEFAULT_TOKENS_PER_QUERY / 1000), "sdk_estimation_table"
+
+
+def estimate_cost_tool(
+    dataset_path: str,
+    max_trials: int,
+    model: str | None = None,
+) -> dict[str, Any]:
+    """Estimate dry-run/real-run scale from trials multiplied by examples."""
+    if max_trials <= 0:
+        return _failure("max_trials must be a positive integer.")
+
+    validation = validate_dataset_tool(dataset_path)
+    if not validation.get("ok"):
+        return validation
+
+    resolved_path = Path(cast(str, validation["dataset_path"]))
+    example_count = _count_dataset_examples(resolved_path)
+    llm_calls_upper_bound = max_trials * example_count
+    cost_per_call, pricing_source = _estimate_model_cost_per_call(model)
+    estimated_total_cost = (
+        llm_calls_upper_bound * cost_per_call if cost_per_call is not None else None
+    )
+
+    assumptions = [
+        "Upper-bound LLM calls = max_trials * dataset example count.",
+        "Assumes one model invocation per trial/example and no retries/tool fan-out.",
+        (
+            "When model pricing is available, the SDK hook pricing table is used "
+            f"with {DEFAULT_TOKENS_PER_QUERY} tokens per call."
+        ),
+        "Actual provider billing depends on prompt size, output size, retries, tools, and provider pricing.",
+    ]
+    return {
+        "ok": True,
+        "dataset_path": str(resolved_path),
+        "dataset_root": validation["dataset_root"],
+        "dataset_examples": example_count,
+        "max_trials": max_trials,
+        "llm_calls_upper_bound": llm_calls_upper_bound,
+        "model": model,
+        "estimated_cost_per_call_usd": cost_per_call,
+        "estimated_total_cost_usd": estimated_total_cost,
+        "pricing_source": pricing_source,
+        "assumptions": assumptions,
+    }
+
+
+def _is_optimizable_function(obj: Any) -> bool:
+    if inspect.isfunction(obj) and hasattr(obj, "optimize"):
+        return True
+    if hasattr(obj, "__class__") and obj.__class__.__name__ == "OptimizedFunction":
+        return True
+    optimize_method = getattr(obj, "optimize", None)
+    return callable(optimize_method) and (hasattr(obj, "func") or callable(obj))
+
+
+def _load_user_module(script_path: Path) -> ModuleType:
+    module_name = (
+        f"_traigent_mcp_{sanitize_identifier(script_path.stem)}_"
+        f"{abs(hash(str(script_path)))}"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise ToolInputError(f"Could not load Python module from {script_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    parent = str(script_path.parent)
+    inserted = False
+    if parent not in sys.path:
+        sys.path.insert(0, parent)
+        inserted = True
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if inserted:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(parent)
+    return module
+
+
+def _find_optimizable_functions(module: ModuleType) -> list[tuple[str, Any]]:
+    functions: list[tuple[str, Any]] = []
+    for name, obj in inspect.getmembers(module):
+        if name.startswith("_") or inspect.ismodule(obj):
+            continue
+        if _is_optimizable_function(obj):
+            functions.append((name, obj))
+    return functions
+
+
+@contextlib.contextmanager
+def _temporary_env(updates: dict[str, str | None]) -> Iterator[None]:
+    previous = {key: os.environ.get(key) for key in updates}
+    for key, value in updates.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _serialize_optimization_result_summary(
+    function_name: str,
+    result_name: str,
+    result: Any,
+) -> dict[str, Any]:
+    successful_trials = getattr(result, "successful_trials", None) or []
+    trials = getattr(result, "trials", None) or []
+    return {
+        "function_name": function_name,
+        "result_name": result_name,
+        "algorithm": getattr(result, "algorithm", None),
+        "best_config": getattr(result, "best_config", None),
+        "best_score": getattr(result, "best_score", None),
+        "best_metrics": getattr(result, "best_metrics", None),
+        "total_trials": len(trials),
+        "successful_trials": len(successful_trials),
+        "stop_reason": getattr(result, "stop_reason", None),
+        "duration": getattr(result, "duration", None),
+    }
+
+
+def _run_loaded_optimizations(
+    script_path: Path,
+    *,
+    mode: Literal["mock", "real"],
+    cost_limit: float | None,
+    max_trials: int,
+    algorithm: str,
+) -> tuple[list[dict[str, Any]], str, str]:
+    module = _load_user_module(script_path)
+    optimizable_functions = _find_optimizable_functions(module)
+    if not optimizable_functions:
+        raise ToolInputError(f"No @traigent.optimize functions found in {script_path}.")
+
+    stdout_buffer = io.StringIO()
+    stderr_buffer = io.StringIO()
+    persistence = PersistenceManager(".traigent")
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    summaries: list[dict[str, Any]] = []
+    with (
+        contextlib.redirect_stdout(stdout_buffer),
+        contextlib.redirect_stderr(stderr_buffer),
+    ):
+        for function_name, function in optimizable_functions:
+            kwargs: dict[str, Any] = {
+                "algorithm": algorithm,
+                "max_trials": max_trials,
+                "progress_bar": False,
+            }
+            if mode == "real":
+                kwargs["cost_limit"] = cost_limit
+            result = function.optimize_sync(**kwargs)
+            result_name = f"{sanitize_identifier(function_name)}_{algorithm}_{max_trials}_{timestamp}"
+            persistence.save_result(result, result_name)
+            summaries.append(
+                _serialize_optimization_result_summary(
+                    function_name, result_name, result
+                )
+            )
+
+    return summaries, stdout_buffer.getvalue(), stderr_buffer.getvalue()
+
+
+def run_optimization_tool(
+    script_path: str | None = None,
+    mode: Literal["mock", "real"] = "mock",
+    confirm: bool = False,
+    cost_limit: float | None = None,
+    max_trials: int | None = None,
+    algorithm: str | None = None,
+) -> dict[str, Any]:
+    """Run local optimization; real mode is gated by confirm and cost_limit."""
+    if mode not in {"mock", "real"}:
+        return _failure("mode must be either 'mock' or 'real'.")
+
+    if mode == "real":
+        if not confirm:
+            return {"ok": False, "refused": True, "message": _REAL_SPEND_MESSAGE}
+        if cost_limit is None or cost_limit <= 0:
+            return {
+                "ok": False,
+                "refused": True,
+                "message": "Real optimization requires an explicit positive cost_limit.",
+            }
+        from traigent.utils.env_config import is_mock_llm
+
+        if is_mock_llm():
+            return {
+                "ok": False,
+                "refused": True,
+                "message": (
+                    "Real optimization cannot run while mock mode is active in this "
+                    "server process. Restart the MCP server without mock mode for a "
+                    "real spend run."
+                ),
+            }
+
+    if script_path is None:
+        return _failure("script_path is required for run_optimization v1.")
+
+    if max_trials is not None and max_trials <= 0:
+        return _failure("max_trials must be a positive integer when provided.")
+
+    try:
+        resolved_script = _resolve_cwd_file(
+            script_path, field_name="script_path", suffix=".py"
+        )
+    except ToolInputError as exc:
+        return _failure(str(exc), code="path_rejected")
+
+    effective_trials = max_trials or (4 if mode == "mock" else 10)
+    effective_algorithm = algorithm or "random"
+
+    try:
+        if mode == "mock":
+            env = {
+                "TRAIGENT_MOCK_LLM": "true",
+                "TRAIGENT_OFFLINE_MODE": "true",
+                "TRAIGENT_API_KEY": None,
+                "TRAIGENT_DEV_API_KEY": None,
+            }
+            with _temporary_env(env):
+                summaries, stdout_text, stderr_text = _run_loaded_optimizations(
+                    resolved_script,
+                    mode=mode,
+                    cost_limit=None,
+                    max_trials=effective_trials,
+                    algorithm=effective_algorithm,
+                )
+        else:
+            summaries, stdout_text, stderr_text = _run_loaded_optimizations(
+                resolved_script,
+                mode=mode,
+                cost_limit=cost_limit,
+                max_trials=effective_trials,
+                algorithm=effective_algorithm,
+            )
+    except Exception as exc:
+        return _failure(str(exc), code="optimization_failed")
+
+    return {
+        "ok": True,
+        "mode": mode,
+        "script_path": str(resolved_script),
+        "max_trials": effective_trials,
+        "algorithm": effective_algorithm,
+        "path_policy": "script_path must resolve under the current working directory.",
+        "results": summaries,
+        "stdout": stdout_text[-4000:],
+        "stderr": stderr_text[-4000:],
+    }
+
+
+def _serialize_loaded_result(result: Any) -> dict[str, Any]:
+    trials = []
+    for trial in getattr(result, "trials", []) or []:
+        trials.append(
+            {
+                "trial_id": getattr(trial, "trial_id", None),
+                "config": getattr(trial, "config", None),
+                "metrics": getattr(trial, "metrics", None),
+                "status": str(getattr(trial, "status", "")),
+                "duration": getattr(trial, "duration", None),
+            }
+        )
+
+    return {
+        "algorithm": getattr(result, "algorithm", None),
+        "objectives": list(getattr(result, "objectives", []) or []),
+        "best_config": getattr(result, "best_config", None),
+        "best_score": getattr(result, "best_score", None),
+        "best_metrics": getattr(result, "best_metrics", None),
+        "status": str(getattr(result, "status", "")),
+        "duration": getattr(result, "duration", None),
+        "metadata": dict(getattr(result, "metadata", {}) or {}),
+        "trials": trials,
+    }
+
+
+def get_results_tool(result_name: str | None = None) -> dict[str, Any]:
+    """List or show local optimization results from the .traigent store."""
+    persistence = PersistenceManager(".traigent")
+    if result_name is None:
+        return {
+            "ok": True,
+            "storage_dir": str(persistence.base_dir),
+            "results": persistence.list_results(),
+        }
+
+    try:
+        result = persistence.load_result(result_name)
+    except FileNotFoundError as exc:
+        return _failure(str(exc), code="not_found")
+    except (PathTraversalError, ValueError) as exc:
+        return _failure(str(exc), code="path_rejected")
+
+    return {
+        "ok": True,
+        "storage_dir": str(persistence.base_dir),
+        "result_name": result_name,
+        "result": _serialize_loaded_result(result),
+    }

--- a/traigent/mcp/tools.py
+++ b/traigent/mcp/tools.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Literal, cast
+from urllib.parse import urlsplit, urlunsplit
 
 from traigent.api.functions import (
     list_recommendation_agent_types as public_list_recommendation_agent_types,
@@ -116,7 +117,16 @@ def _resolve_cwd_file(
 def _dataset_root() -> Path:
     configured = os.environ.get(DATASET_ROOT_ENV)
     if configured:
-        return Path(configured).expanduser().resolve(strict=True)
+        # resolve(strict=True) raises FileNotFoundError when the configured root
+        # is missing; surface it as a structured path_rejected failure instead of
+        # letting it crash the tool call.
+        try:
+            return Path(configured).expanduser().resolve(strict=True)
+        except FileNotFoundError as exc:
+            raise ToolInputError(
+                f"{DATASET_ROOT_ENV} points at a directory that does not exist: "
+                f"{configured}"
+            ) from exc
     return Path.cwd().resolve()
 
 
@@ -129,14 +139,20 @@ def _resolve_dataset_path(path: str | Path) -> tuple[Path, Path]:
     except FileNotFoundError as exc:
         raise ToolInputError(str(exc)) from exc
 
+    # Resolve to the REAL path before the containment check. A lexical
+    # relative_to() on a possibly-unresolved path would let a symlink inside the
+    # dataset root point outside and pass. validate_path() resolves symlinks and
+    # re-checks containment against the resolved root.
     try:
-        resolved_path.relative_to(root)
-    except ValueError as exc:
+        contained = validate_path(resolved_path, root, must_exist=True)
+    except FileNotFoundError as exc:
+        raise ToolInputError(f"Dataset path does not exist: {resolved_path}") from exc
+    except PathTraversalError as exc:
         raise ToolInputError(
             f"Dataset path must stay under {DATASET_ROOT_ENV or 'cwd'} ({root}): "
             f"{resolved_path}"
         ) from exc
-    return resolved_path, root
+    return cast(Path, contained), root
 
 
 def _mask_api_key(api_key: str | None) -> dict[str, Any]:
@@ -147,6 +163,25 @@ def _mask_api_key(api_key: str | None) -> dict[str, Any]:
     last4 = api_key[-4:] if len(api_key) > 8 else None
     masked = f"{prefix}...{last4}" if last4 is not None else f"{prefix}..."
     return {"present": True, "prefix": prefix, "last4": last4, "masked": masked}
+
+
+def _sanitize_backend_url(url: str | None) -> str | None:
+    """Strip any userinfo (``user:pass@``) from a backend URL before returning it.
+
+    Credentials embedded in the URL must never leak into the MCP payload.
+    """
+    if not url:
+        return url
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return None
+    if parts.username or parts.password:
+        host = parts.hostname or ""
+        if parts.port is not None:
+            host = f"{host}:{parts.port}"
+        parts = parts._replace(netloc=host)
+    return urlunsplit(parts)
 
 
 async def auth_status_tool(check: bool = False) -> dict[str, Any]:
@@ -175,15 +210,27 @@ async def auth_status_tool(check: bool = False) -> dict[str, Any]:
                 "message": "No API key is available to validate.",
             }
         else:
-            from traigent.cli.auth_commands import TraigentAuthCLI
+            try:
+                from traigent.cli.auth_commands import TraigentAuthCLI
 
-            auth_cli = TraigentAuthCLI(backend_url_override=cast(str, backend_url))
-            metadata = await auth_cli._validate_api_key(api_key, verbose=False)
-            validity = {
-                "checked": True,
-                "valid": metadata is not None,
-                "source": "backend",
-            }
+                auth_cli = TraigentAuthCLI(backend_url_override=cast(str, backend_url))
+                metadata = await auth_cli._validate_api_key(api_key, verbose=False)
+            except Exception:
+                # Live validation must NEVER propagate an exception into the MCP
+                # payload — its message could embed response bodies or URLs.
+                # Return a structured failure with a generic message instead.
+                validity = {
+                    "checked": True,
+                    "valid": None,
+                    "source": "backend",
+                    "message": "Live validation could not be completed.",
+                }
+            else:
+                validity = {
+                    "checked": True,
+                    "valid": metadata is not None,
+                    "source": "backend",
+                }
 
     return {
         "ok": True,
@@ -197,7 +244,7 @@ async def auth_status_tool(check: bool = False) -> dict[str, Any]:
         ),
         "tenant_id": tenant_id,
         "project_id": project_id,
-        "backend_url": backend_url,
+        "backend_url": _sanitize_backend_url(cast("str | None", backend_url)),
         "validity": validity,
     }
 
@@ -557,6 +604,10 @@ def run_optimization_tool(
     effective_trials = max_trials or (4 if mode == "mock" else 10)
     effective_algorithm = algorithm or "random"
 
+    # v1 single-agent limitation: optimization runs synchronously below and
+    # blocks the MCP stdio event loop for the full duration of the run. No other
+    # tool requests are serviced until it returns. This is acceptable for the
+    # local single-client v1 server; concurrency is deferred to a later version.
     try:
         if mode == "mock":
             env = {
@@ -584,6 +635,20 @@ def run_optimization_tool(
     except Exception as exc:
         return _failure(str(exc), code="optimization_failed")
 
+    if mode == "real":
+        # Real runs touch live providers; captured stdout/stderr can contain
+        # prompts, completions, or other sensitive provider data. Scrub the tails
+        # rather than returning them. Mock mode output is canned and harmless.
+        stdout_payload = (
+            "<redacted: real-run stdout suppressed to avoid leaking provider data>"
+        )
+        stderr_payload = (
+            "<redacted: real-run stderr suppressed to avoid leaking provider data>"
+        )
+    else:
+        stdout_payload = stdout_text[-4000:]
+        stderr_payload = stderr_text[-4000:]
+
     return {
         "ok": True,
         "mode": mode,
@@ -592,8 +657,8 @@ def run_optimization_tool(
         "algorithm": effective_algorithm,
         "path_policy": "script_path must resolve under the current working directory.",
         "results": summaries,
-        "stdout": stdout_text[-4000:],
-        "stderr": stderr_text[-4000:],
+        "stdout": stdout_payload,
+        "stderr": stderr_payload,
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -6255,6 +6255,9 @@ integrations = [
 internal-schema = [
     { name = "traigent-schema" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 ml = [
     { name = "matplotlib" },
     { name = "numpy" },
@@ -6368,6 +6371,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'analytics'", specifier = ">=3.5.0" },
     { name = "matplotlib", marker = "extra == 'visualization'", specifier = ">=3.5.0" },
     { name = "mcp", marker = "extra == 'hybrid'", specifier = ">=1.27.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.4.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
@@ -6425,7 +6429,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'security'", specifier = ">=0.18.0" },
     { name = "wandb", marker = "extra == 'integrations'", specifier = ">=0.15.0" },
 ]
-provides-extras = ["analytics", "bayesian", "integrations", "dspy", "pydanticai", "security", "visualization", "hybrid", "internal-schema", "test", "tracing", "dev", "docs", "ml", "deepeval", "cloud", "recommended", "all", "enterprise"]
+provides-extras = ["analytics", "bayesian", "integrations", "dspy", "pydanticai", "security", "visualization", "hybrid", "mcp", "internal-schema", "test", "tracing", "dev", "docs", "ml", "deepeval", "cloud", "recommended", "all", "enterprise"]
 
 [[package]]
 name = "traigent-schema"


### PR DESCRIPTION
## Summary
Local-first stdio MCP server (`traigent mcp serve`) so coding agents (Claude Code / Cursor / Codex) drive Traigent via tools. New optional extra `[mcp]` (mcp>=1.27.0); `traigent mcp --help` stays probe-friendly without the extra (the `onboard` command's capability check now activates automatically), `serve` degrades with the install hint.

**v1 tools (existing-backed only — `scaffold_eval`/`export_evidence`/`significant_variables`/`generate_examples` deliberately deferred, not stubbed):** `auth_status` (masked key prefix+last4 only; optional `check=true` live validation with exception-path leak guard; backend_url userinfo stripped) · `list_recommendation_agent_types` + `recommend_configuration_space` (versioned catalog passthrough) · `detect_tvars` · `validate_dataset` (real-path symlink-safe containment under `TRAIGENT_DATASET_ROOT`) · `estimate_cost` (documented assumptions) · `run_optimization` (**mock by default; real refuses without `confirm=true` + positive `cost_limit`, which is forwarded and enforced; real-mode stdout/stderr redacted; blocking-loop limitation documented**) · `get_results`.

## Review cycle
Adversarial review (Claude opus, codex rate-limited) → APPROVE-WITH-FIXES → all 4 P2 + 3 P3 fixed in `0955a7d6`: auth-check exception path can't leak (tested with fake-key-bearing exception), symlink-escape containment (tested with real symlink), userinfo stripping, missing-dataset-root structured failure, real-mode output redaction, blocking note, mock-forced refusal test. The agent never sees the api key through any tool output (asserted in tests).

## PR checklist
1. **Worst-case prod path** — local tool surface; spend double-gated; secrets masked; paths contained (real-path resolution).
2. **Production-branch test** — refusal matrix + leak/containment tests: `tests/unit/mcp/test_local_server.py` (11), CLI degradation: `tests/unit/cli/test_mcp_commands.py`.
3. **Contract regeneration** — none (local tools over existing SDK APIs); MCP tool I/O schemas are SDK-local v1.
4. **Public surface delta** — new CLI group `traigent mcp` + `[mcp]` extra; tool list exact-matched in tests; docs match runtime; deferred tools not listed anywhere.
5. **Review threads** — to be resolved per policy.
6. **Quality gates** — none relaxed; ruff/mypy green; 191 tests; `uv lock --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)