### PR TITLE
fix(cli): device-login live-E2E fixes — contract bodies, URL base, envelopes, 429 backoff

### DIFF
--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -17,6 +17,7 @@ API_KEY = "sk_" + "a" * 43  # pragma: allowlist secret
 DEVICE_CODE = "A" * 43
 DEVICE_LOGIN_CLIENT_ID = "traigent-sdk-cli"
 DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+# Contract source: TraigentSchema#94 device_authorization_response_schema.json
 DEVICE_AUTHORIZE_ENVELOPE_REQUIRED_KEYS = ["success", "message", "data"]
 DEVICE_AUTHORIZE_DATA_REQUIRED_KEYS = [
     "device_code",

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -55,10 +55,15 @@ class _FakeSecureStore:
 
 
 class _FakeResponse:
-    def __init__(self, status: int, payload: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        status: int,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self.status = status
         self.payload = payload
-        self.headers: dict[str, str] = {}
+        self.headers = headers or {}
 
     async def __aenter__(self) -> _FakeResponse:
         return self
@@ -155,6 +160,19 @@ def _error_payload(error: str, details: dict[str, Any] | None = None) -> dict[st
     if details is not None:
         payload["details"] = details
     return payload
+
+
+def _rate_limit_response(retry_after: str | None = None) -> _FakeResponse:
+    headers = {"Retry-After": retry_after} if retry_after is not None else None
+    return _FakeResponse(
+        429,
+        {
+            "success": False,
+            "message": "Rate limit exceeded",
+            "error": "rate_limit_exceeded",
+        },
+        headers=headers,
+    )
 
 
 def _install_device_test_fakes(
@@ -447,6 +465,70 @@ def test_device_flow_pending_then_slow_down_honors_authoritative_interval(
 
     assert result is True
     assert sleeps == [1, 7]
+
+
+def test_device_poll_rate_limit_retry_after_continues_and_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload(interval=1)),
+            _rate_limit_response(retry_after="2"),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    result = asyncio.run(_make_cli().device_login(sleep=fake_sleep))
+
+    assert result is True
+    assert sleeps == [2]
+    token_calls = [
+        call for call in session.post_calls if call["url"].endswith("/auth/device/token")
+    ]
+    assert len(token_calls) == 2
+
+
+def test_device_poll_rate_limit_retry_after_still_honors_expiry_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload(interval=1, expires_in=3)),
+            _rate_limit_response(retry_after="10"),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+    now = 0.0
+    sleeps: list[float] = []
+
+    def fake_clock() -> float:
+        return now
+
+    async def fake_sleep(seconds: float) -> None:
+        nonlocal now
+        sleeps.append(seconds)
+        now += seconds
+
+    result = asyncio.run(
+        _make_cli().device_login(sleep=fake_sleep, clock=fake_clock)
+    )
+
+    assert result is False
+    assert sleeps == [3]
+    token_calls = [
+        call for call in session.post_calls if call["url"].endswith("/auth/device/token")
+    ]
+    assert len(token_calls) == 1
 
 
 def test_device_poll_caps_sleep_and_timeout_to_expiry_deadline(

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -161,8 +161,10 @@ def _install_device_test_fakes(
     return store, session
 
 
-def _make_cli() -> TraigentAuthCLI:
-    return TraigentAuthCLI(backend_url_override="https://backend.example.test")
+def _make_cli(
+    backend_url_override: str = "https://backend.example.test",
+) -> TraigentAuthCLI:
+    return TraigentAuthCLI(backend_url_override=backend_url_override)
 
 
 def test_device_token_success_schema_contract_pins_subscription_tier() -> None:
@@ -226,6 +228,41 @@ def test_device_flow_happy_path_persists_credentials_secure_only_by_default(
     captured = capsys.readouterr()
     assert API_KEY not in captured.out
     assert API_KEY not in captured.err
+
+
+@pytest.mark.parametrize(
+    ("backend_url", "expected_api_base"),
+    [
+        ("http://localhost:5000", "http://localhost:5000/api/v1"),
+        ("http://localhost:5000/api/v1", "http://localhost:5000/api/v1"),
+    ],
+)
+def test_device_flow_composes_authorize_and_token_urls_from_api_base(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    backend_url: str,
+    expected_api_base: str,
+) -> None:
+    _store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+
+    result = asyncio.run(
+        _make_cli(backend_url_override=backend_url).device_login(
+            sleep=lambda _seconds: _noop_sleep()
+        )
+    )
+
+    assert result is True
+    assert [call["url"] for call in session.post_calls] == [
+        f"{expected_api_base}/auth/device/authorize",
+        f"{expected_api_base}/auth/device/token",
+    ]
 
 
 def test_device_flow_env_file_consent_writes_with_0600(

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -15,6 +15,8 @@ from traigent.security.credentials import CredentialType
 
 API_KEY = "sk_" + "a" * 43  # pragma: allowlist secret
 DEVICE_CODE = "A" * 43
+DEVICE_LOGIN_CLIENT_ID = "traigent-sdk-cli"
+DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 
 
 class _FakeSecureStore:
@@ -71,6 +73,14 @@ class _FakeSession:
         return False
 
     def post(self, url: str, **kwargs: Any) -> _FakeResponse:
+        if url.endswith("/auth/device/authorize"):
+            assert kwargs.get("json") == {"client_id": DEVICE_LOGIN_CLIENT_ID}
+        elif url.endswith("/auth/device/token"):
+            assert kwargs.get("json") == {
+                "grant_type": DEVICE_CODE_GRANT_TYPE,
+                "device_code": DEVICE_CODE,
+                "client_id": DEVICE_LOGIN_CLIENT_ID,
+            }
         self.post_calls.append({"url": url, **kwargs})
         if not self.responses:
             raise AssertionError(f"Unexpected POST: {url}")
@@ -206,8 +216,13 @@ def test_device_flow_happy_path_persists_credentials_secure_only_by_default(
     assert not (tmp_path / ".env").exists()
 
     assert session.post_calls[0]["url"].endswith("/auth/device/authorize")
+    assert session.post_calls[0]["json"] == {"client_id": DEVICE_LOGIN_CLIENT_ID}
     assert session.post_calls[1]["url"].endswith("/auth/device/token")
-    assert session.post_calls[1]["json"] == {"device_code": DEVICE_CODE}
+    assert session.post_calls[1]["json"] == {
+        "grant_type": DEVICE_CODE_GRANT_TYPE,
+        "device_code": DEVICE_CODE,
+        "client_id": DEVICE_LOGIN_CLIENT_ID,
+    }
     captured = capsys.readouterr()
     assert API_KEY not in captured.out
     assert API_KEY not in captured.err
@@ -447,6 +462,35 @@ def test_device_flow_malformed_success_fails_closed(
 
     assert result is False
     assert store.saved is None
+
+
+def test_device_authorize_error_reports_status_and_backend_message(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store, _session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(
+                400,
+                {
+                    "success": False,
+                    "message": "Validation error",
+                    "error": "client_id: Missing data for required field.",
+                },
+            ),
+        ],
+    )
+
+    result = asyncio.run(_make_cli().device_login(sleep=lambda _seconds: _noop_sleep()))
+
+    assert result is False
+    assert store.saved is None
+    output = capsys.readouterr().out
+    assert "HTTP 400" in output
+    assert "Validation error" in output
 
 
 async def _noop_sleep() -> None:

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -17,6 +17,15 @@ API_KEY = "sk_" + "a" * 43  # pragma: allowlist secret
 DEVICE_CODE = "A" * 43
 DEVICE_LOGIN_CLIENT_ID = "traigent-sdk-cli"
 DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+DEVICE_AUTHORIZE_ENVELOPE_REQUIRED_KEYS = ["success", "message", "data"]
+DEVICE_AUTHORIZE_DATA_REQUIRED_KEYS = [
+    "device_code",
+    "user_code",
+    "verification_uri",
+    "verification_uri_complete",
+    "expires_in",
+    "interval",
+]
 
 
 class _FakeSecureStore:
@@ -90,7 +99,7 @@ class _FakeSession:
         return response
 
 
-def _authorize_payload(interval: int = 1, expires_in: int = 600) -> dict[str, Any]:
+def _authorization_data(interval: int = 1, expires_in: int = 600) -> dict[str, Any]:
     return {
         "device_code": DEVICE_CODE,
         "user_code": "BCDF-2345",
@@ -101,7 +110,16 @@ def _authorize_payload(interval: int = 1, expires_in: int = 600) -> dict[str, An
     }
 
 
-# Required by TraigentSchema#94 device_token_success_schema.json.
+def _authorize_payload(interval: int = 1, expires_in: int = 600) -> dict[str, Any]:
+    return {
+        "success": True,
+        "message": "Device authorization created",
+        "data": _authorization_data(interval=interval, expires_in=expires_in),
+    }
+
+
+# Required by TraigentSchema#94 device_token_response_schema.json.
+DEVICE_TOKEN_SUCCESS_ENVELOPE_REQUIRED_KEYS = ["success", "message", "data"]
 DEVICE_TOKEN_SUCCESS_REQUIRED_KEYS = [
     "api_key",
     "tenant_id",
@@ -115,12 +133,13 @@ DEVICE_TOKEN_SUCCESS_REQUIRED_KEYS = [
 def _success_payload() -> dict[str, Any]:
     return {
         "success": True,
+        "message": "Device token issued",
         "data": {
             "api_key": API_KEY,
             "tenant_id": "tenant_123",
             "project_id": "project_456",
             "user": {"id": "user_1", "email": "dev@example.test"},
-            "subscription_tier": "trial",
+            "subscription_tier": "free",
             "quota": {"trial_limit": 25, "api_call_limit": 1000},
         },
     }
@@ -129,6 +148,7 @@ def _success_payload() -> dict[str, Any]:
 def _error_payload(error: str, details: dict[str, Any] | None = None) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "success": False,
+        "message": error.replace("_", " "),
         "error": error,
         "error_code": error,
     }
@@ -162,21 +182,39 @@ def _install_device_test_fakes(
 
 
 def _make_cli(
-    backend_url_override: str = "https://backend.example.test",
+    backend_url_override: str | None = "https://backend.example.test",
 ) -> TraigentAuthCLI:
     return TraigentAuthCLI(backend_url_override=backend_url_override)
+
+
+def test_device_authorize_schema_contract_pins_success_envelope() -> None:
+    cli = TraigentAuthCLI.__new__(TraigentAuthCLI)
+
+    payload = _authorize_payload()
+    assert list(payload.keys()) == DEVICE_AUTHORIZE_ENVELOPE_REQUIRED_KEYS
+    assert list(payload["data"].keys()) == DEVICE_AUTHORIZE_DATA_REQUIRED_KEYS
+
+    validated = cli._validate_device_authorize_payload(payload)
+
+    assert validated["device_code"] == DEVICE_CODE
+    assert validated["user_code"] == "BCDF-2345"
+
+    with pytest.raises(auth_commands.AuthenticationError, match="success missing"):
+        cli._validate_device_authorize_payload(_authorization_data())
 
 
 def test_device_token_success_schema_contract_pins_subscription_tier() -> None:
     cli = TraigentAuthCLI.__new__(TraigentAuthCLI)
     cli.backend_url = "https://backend.example.test"
-    token_data = _success_payload()["data"]
+    payload = _success_payload()
+    assert list(payload.keys()) == DEVICE_TOKEN_SUCCESS_ENVELOPE_REQUIRED_KEYS
+    token_data = payload["data"]
     assert isinstance(token_data, dict)
     assert list(token_data.keys()) == DEVICE_TOKEN_SUCCESS_REQUIRED_KEYS
 
     validated = cli._validate_device_token_success(_success_payload())
 
-    assert validated["subscription_tier"] == "trial"
+    assert validated["subscription_tier"] == "free"
 
     missing_subscription_tier = _success_payload()
     missing_data = missing_subscription_tier["data"]
@@ -263,6 +301,38 @@ def test_device_flow_composes_authorize_and_token_urls_from_api_base(
         f"{expected_api_base}/auth/device/authorize",
         f"{expected_api_base}/auth/device/token",
     ]
+
+
+def test_device_flow_env_api_url_precedence_banner_matches_transport_host(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("TRAIGENT_BACKEND_URL", "http://localhost:5000")
+    monkeypatch.setenv("TRAIGENT_API_URL", "https://api.example.test/custom/v1")
+    _store, session = _install_device_test_fakes(
+        monkeypatch,
+        tmp_path,
+        [
+            _FakeResponse(200, _authorize_payload()),
+            _FakeResponse(200, _success_payload()),
+        ],
+    )
+
+    result = asyncio.run(
+        _make_cli(backend_url_override=None).device_login(
+            sleep=lambda _seconds: _noop_sleep()
+        )
+    )
+
+    assert result is True
+    assert [call["url"] for call in session.post_calls] == [
+        "https://api.example.test/custom/v1/auth/device/authorize",
+        "https://api.example.test/custom/v1/auth/device/token",
+    ]
+    output = capsys.readouterr().out
+    assert "Authenticating with: https://api.example.test/custom/v1" in output
+    assert "Authenticating with: http://localhost:5000" not in output
 
 
 def test_device_flow_env_file_consent_writes_with_0600(

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -76,6 +76,8 @@ _DEVICE_ERROR_NAMES = {
     "access_denied",
     "expired_token",
 }
+DEVICE_LOGIN_CLIENT_ID = "traigent-sdk-cli"
+DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 _ENV_FILE_KEYS = (
     "TRAIGENT_API_KEY",
     TENANT_ENV_VAR,
@@ -104,6 +106,22 @@ async def _read_json_body(response: Any) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise AuthenticationError("Backend response must be a JSON object")
     return data
+
+
+def _format_backend_error_message(
+    prefix: str, status_code: int, data: dict[str, Any]
+) -> str:
+    """Format a backend error envelope without losing HTTP status context."""
+    parts: list[str] = []
+    for field in ("message", "error", "error_code"):
+        value = data.get(field)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized and normalized not in parts:
+                parts.append(normalized)
+
+    suffix = f": {' - '.join(parts)}" if parts else ""
+    return f"{prefix} (HTTP {status_code}){suffix}"
 
 
 def _require_non_empty_str(data: dict[str, Any], field: str) -> str:
@@ -418,13 +436,16 @@ class TraigentAuthCLI:
         }
         async with session.post(
             url,
+            json={"client_id": DEVICE_LOGIN_CLIENT_ID},
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=30) if aiohttp else None,
         ) as response:
             data = await _read_json_body(response)
             if response.status != 200:
                 raise AuthenticationError(
-                    f"Device authorization failed (HTTP {response.status})"
+                    _format_backend_error_message(
+                        "Device authorization failed", response.status, data
+                    )
                 )
             return self._validate_device_authorize_payload(data)
 
@@ -506,7 +527,11 @@ class TraigentAuthCLI:
         }
         async with session.post(
             url,
-            json={"device_code": device_code},
+            json={
+                "grant_type": DEVICE_CODE_GRANT_TYPE,
+                "device_code": device_code,
+                "client_id": DEVICE_LOGIN_CLIENT_ID,
+            },
             headers=headers,
             timeout=aiohttp.ClientTimeout(total=request_timeout) if aiohttp else None,
         ) as response:
@@ -520,7 +545,16 @@ class TraigentAuthCLI:
                 )
             return "success", self._validate_device_token_success(data), None
 
-        error_name, details = self._device_error_from_envelope(data)
+        try:
+            error_name, details = self._device_error_from_envelope(data)
+        except AuthenticationError as exc:
+            if status_code != 200:
+                raise AuthenticationError(
+                    _format_backend_error_message(
+                        "Device token request failed", status_code, data
+                    )
+                ) from exc
+            raise
         if error_name == "slow_down":
             new_interval = details.get("interval")
             if not isinstance(new_interval, int) or new_interval < 6:

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -15,7 +15,7 @@ import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import click
 from rich.console import Console
@@ -124,6 +124,20 @@ def _format_backend_error_message(
     return f"{prefix} (HTTP {status_code}){suffix}"
 
 
+def _resolve_api_base_url(base_url: str) -> str:
+    """Return an API base URL with a version path, without duplicating it."""
+    origin, path = BackendConfig.split_api_url(base_url)
+    if not origin:
+        return cast(str, BackendConfig.build_api_base(base_url))
+    if path:
+        return f"{origin}{path.rstrip('/')}"
+    return cast(str, BackendConfig.build_api_base(origin))
+
+
+def _compose_api_url(base_url: str, path: str) -> str:
+    return f"{_resolve_api_base_url(base_url)}/{path.lstrip('/')}"
+
+
 def _require_non_empty_str(data: dict[str, Any], field: str) -> str:
     value = data.get(field)
     if not isinstance(value, str) or not value.strip():
@@ -180,6 +194,10 @@ class TraigentAuthCLI:
 
         # Ensure config directory exists
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    def _api_url(self, path: str) -> str:
+        """Compose an API endpoint URL from the resolved API base."""
+        return _compose_api_url(self.backend_api_url, path)
 
     def _load_stored_credentials(self) -> dict[str, Any] | None:
         """Load stored credentials from local file.
@@ -359,7 +377,7 @@ class TraigentAuthCLI:
         """
         import aiohttp
 
-        url = f"{self.backend_api_url}/keys/validate"
+        url = self._api_url("keys/validate")
         headers = {"X-API-Key": api_key}
 
         if verbose:
@@ -428,7 +446,7 @@ class TraigentAuthCLI:
 
     async def _start_device_authorization(self, session: Any) -> dict[str, Any]:
         """Start the RFC 8628 device authorization flow."""
-        url = f"{self.backend_api_url}/auth/device/authorize"
+        url = self._api_url("auth/device/authorize")
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -519,7 +537,7 @@ class TraigentAuthCLI:
         self, session: Any, device_code: str, request_timeout: float
     ) -> tuple[str, dict[str, Any] | None, int | None]:
         """Poll the token endpoint once."""
-        url = f"{self.backend_api_url}/auth/device/token"
+        url = self._api_url("auth/device/token")
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -1665,7 +1683,7 @@ async def _check_api_key(backend_api_url: str, key: str) -> bool:
         )
         return False
 
-    url = f"{backend_api_url}/keys/validate"
+    url = _compose_api_url(backend_api_url, "keys/validate")
     headers = {
         "Accept": "application/json",
         "Content-Type": "application/json",

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -138,10 +138,12 @@ def _compose_api_url(base_url: str, path: str) -> str:
     return f"{_resolve_api_base_url(base_url)}/{path.lstrip('/')}"
 
 
-def _require_non_empty_str(data: dict[str, Any], field: str) -> str:
+def _require_non_empty_str(
+    data: dict[str, Any], field: str, *, context: str = "device auth"
+) -> str:
     value = data.get(field)
     if not isinstance(value, str) or not value.strip():
-        raise AuthenticationError(f"Malformed device auth response: missing {field}")
+        raise AuthenticationError(f"Malformed {context} response: missing {field}")
     return value.strip()
 
 
@@ -150,6 +152,18 @@ def _require_positive_int(data: dict[str, Any], field: str) -> int:
     if not isinstance(value, int) or value <= 0:
         raise AuthenticationError(f"Malformed device auth response: invalid {field}")
     return value
+
+
+def _require_success_envelope(data: dict[str, Any], *, context: str) -> dict[str, Any]:
+    """Return the data payload from a Traigent standard success envelope."""
+    if data.get("success") is not True:
+        raise AuthenticationError(f"Malformed {context} response: success missing")
+
+    _require_non_empty_str(data, "message", context=context)
+    payload = data.get("data")
+    if not isinstance(payload, dict):
+        raise AuthenticationError(f"Malformed {context} response: data missing")
+    return payload
 
 
 def _format_env_value(value: str) -> str:
@@ -185,15 +199,33 @@ class TraigentAuthCLI:
         self.credentials_file = CREDENTIALS_FILE
         self.auth_manager = AuthManager()
         if backend_url_override:
-            normalized = BackendConfig.normalize_backend_origin(backend_url_override)
+            origin, path = BackendConfig.split_api_url(backend_url_override)
+            normalized = origin or BackendConfig.normalize_backend_origin(
+                backend_url_override
+            )
             self.backend_url = normalized or backend_url_override
-            self.backend_api_url = BackendConfig.build_api_base(self.backend_url)
+            self.backend_api_url = (
+                f"{normalized}{path or BackendConfig.get_default_api_path()}"
+                if normalized
+                else BackendConfig.build_api_base(self.backend_url)
+            )
         else:
             self.backend_url = BackendConfig.get_cloud_backend_url()
             self.backend_api_url = BackendConfig.get_cloud_api_url()
 
         # Ensure config directory exists
         self.config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    @property
+    def device_login_target_url(self) -> str:
+        """URL displayed for device login; it matches the HTTP API base.
+
+        Device-login endpoint precedence follows the SDK cloud-client path:
+        an explicit CLI backend override wins; otherwise the configured API
+        base is used, so TRAIGENT_API_URL controls the called API host/path
+        when set and TRAIGENT_BACKEND_URL is only the backend origin fallback.
+        """
+        return _resolve_api_base_url(self.backend_api_url)
 
     def _api_url(self, path: str) -> str:
         """Compose an API endpoint URL from the resolved API base."""
@@ -416,24 +448,26 @@ class TraigentAuthCLI:
         self, data: dict[str, Any]
     ) -> dict[str, Any]:
         """Validate the device authorization response contract."""
-        device_code = _require_non_empty_str(data, "device_code")
+        payload = _require_success_envelope(data, context="device auth")
+
+        device_code = _require_non_empty_str(payload, "device_code")
         if not _DEVICE_CODE_RE.fullmatch(device_code):
             raise AuthenticationError(
                 "Malformed device auth response: invalid device_code"
             )
 
-        user_code = _require_non_empty_str(data, "user_code")
+        user_code = _require_non_empty_str(payload, "user_code")
         if not _USER_CODE_RE.fullmatch(user_code):
             raise AuthenticationError(
                 "Malformed device auth response: invalid user_code"
             )
 
-        verification_uri = _require_non_empty_str(data, "verification_uri")
+        verification_uri = _require_non_empty_str(payload, "verification_uri")
         verification_uri_complete = _require_non_empty_str(
-            data, "verification_uri_complete"
+            payload, "verification_uri_complete"
         )
-        expires_in = _require_positive_int(data, "expires_in")
-        interval = _require_positive_int(data, "interval")
+        expires_in = _require_positive_int(payload, "expires_in")
+        interval = _require_positive_int(payload, "interval")
 
         return {
             "device_code": device_code,
@@ -469,30 +503,30 @@ class TraigentAuthCLI:
 
     def _validate_device_token_success(self, data: dict[str, Any]) -> dict[str, Any]:
         """Validate and normalize a successful device token envelope."""
-        if data.get("success") is not True:
-            raise AuthenticationError(
-                "Malformed device token response: success missing"
-            )
-        token_data = data.get("data")
-        if not isinstance(token_data, dict):
-            raise AuthenticationError("Malformed device token response: data missing")
+        token_data = _require_success_envelope(data, context="device token")
 
-        api_key = _require_non_empty_str(token_data, "api_key")
+        api_key = _require_non_empty_str(token_data, "api_key", context="device token")
         if not api_key.startswith("sk_"):
             raise AuthenticationError(
                 "Malformed device token response: invalid api_key"
             )
 
-        tenant_id = _require_non_empty_str(token_data, "tenant_id")
-        project_id = _require_non_empty_str(token_data, "project_id")
-        subscription_tier = _require_non_empty_str(token_data, "subscription_tier")
+        tenant_id = _require_non_empty_str(
+            token_data, "tenant_id", context="device token"
+        )
+        project_id = _require_non_empty_str(
+            token_data, "project_id", context="device token"
+        )
+        subscription_tier = _require_non_empty_str(
+            token_data, "subscription_tier", context="device token"
+        )
 
         user = token_data.get("user")
         if not isinstance(user, dict):
             raise AuthenticationError("Malformed device token response: user missing")
         normalized_user = {
-            "id": _require_non_empty_str(user, "id"),
-            "email": _require_non_empty_str(user, "email"),
+            "id": _require_non_empty_str(user, "id", context="device token"),
+            "email": _require_non_empty_str(user, "email", context="device token"),
         }
 
         quota = token_data.get("quota")
@@ -519,6 +553,10 @@ class TraigentAuthCLI:
     @staticmethod
     def _device_error_from_envelope(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         """Return a known RFC 8628 error name and details from an error envelope."""
+        if data.get("success") is not False:
+            raise AuthenticationError("Unexpected device token response from backend")
+        _require_non_empty_str(data, "message", context="device token error")
+
         raw_error = data.get("error")
         raw_error_code = data.get("error_code")
         if raw_error and raw_error_code and raw_error != raw_error_code:
@@ -725,7 +763,9 @@ class TraigentAuthCLI:
 
         poll_sleep = sleep or asyncio.sleep
         console.print("\n[bold blue]Traigent Device Authentication[/bold blue]")
-        console.print(f"Authenticating with: [cyan]{self.backend_url}[/cyan]\n")
+        console.print(
+            f"Authenticating with: [cyan]{self.device_login_target_url}[/cyan]\n"
+        )
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -89,6 +89,7 @@ _ENV_ASSIGNMENT_RE = re.compile(
 )
 MAX_DEVICE_POLL_TIMEOUT_SECONDS = 30.0
 MAX_DEVICE_POLL_TRANSPORT_ERRORS = 3
+MAX_DEVICE_POLL_RATE_LIMITS_WITHOUT_RETRY_AFTER = 10
 
 
 async def _read_json_body(response: Any) -> dict[str, Any]:
@@ -122,6 +123,25 @@ def _format_backend_error_message(
 
     suffix = f": {' - '.join(parts)}" if parts else ""
     return f"{prefix} (HTTP {status_code}){suffix}"
+
+
+def _retry_after_seconds(headers: Any) -> int | None:
+    """Return a positive Retry-After delay in seconds, if one was supplied."""
+    getter = getattr(headers, "get", None)
+    if getter is None:
+        return None
+
+    raw_value = getter("Retry-After")
+    if raw_value is None:
+        raw_value = getter("retry-after")
+    if raw_value is None:
+        return None
+
+    try:
+        seconds = int(str(raw_value).strip())
+    except ValueError:
+        return None
+    return seconds if seconds > 0 else None
 
 
 def _resolve_api_base_url(base_url: str) -> str:
@@ -592,6 +612,8 @@ class TraigentAuthCLI:
             timeout=aiohttp.ClientTimeout(total=request_timeout) if aiohttp else None,
         ) as response:
             status_code = response.status
+            if status_code == 429:
+                return "rate_limited", None, _retry_after_seconds(response.headers)
             data = await _read_json_body(response)
 
         if data.get("success") is True:
@@ -633,6 +655,7 @@ class TraigentAuthCLI:
         deadline = now() + int(authorization["expires_in"])
         device_code = str(authorization["device_code"])
         consecutive_transport_errors = 0
+        consecutive_rate_limits_without_retry_after = 0
 
         while True:
             remaining = deadline - now()
@@ -651,6 +674,7 @@ class TraigentAuthCLI:
                 consecutive_transport_errors = 0
             except NETWORK_ERRORS as exc:
                 consecutive_transport_errors += 1
+                consecutive_rate_limits_without_retry_after = 0
                 if consecutive_transport_errors >= MAX_DEVICE_POLL_TRANSPORT_ERRORS:
                     console.print(
                         "[red]Device token polling failed after "
@@ -670,6 +694,42 @@ class TraigentAuthCLI:
                 )
                 await sleep(sleep_seconds)
                 continue
+
+            if status == "rate_limited":
+                if new_interval is None:
+                    consecutive_rate_limits_without_retry_after += 1
+                    if (
+                        consecutive_rate_limits_without_retry_after
+                        >= MAX_DEVICE_POLL_RATE_LIMITS_WITHOUT_RETRY_AFTER
+                    ):
+                        console.print(
+                            "[red]Device token polling is still rate-limited after "
+                            f"{consecutive_rate_limits_without_retry_after} "
+                            "consecutive 429 responses without Retry-After. "
+                            "Please run login again later.[/red]"
+                        )
+                        return None
+                    retry_after = interval + 5
+                    reason = "without Retry-After"
+                else:
+                    consecutive_rate_limits_without_retry_after = 0
+                    retry_after = new_interval
+                    reason = "per Retry-After"
+
+                sleep_seconds = min(float(retry_after), max(0.0, deadline - now()))
+                if sleep_seconds <= 0:
+                    console.print(
+                        "[red]Device login expired before authorization completed.[/red]"
+                    )
+                    return None
+                console.print(
+                    "[yellow]Device token polling rate-limited "
+                    f"({reason}); retrying in {sleep_seconds:g}s.[/yellow]"
+                )
+                await sleep(sleep_seconds)
+                continue
+
+            consecutive_rate_limits_without_retry_after = 0
 
             if status == "success":
                 return credentials


### PR DESCRIPTION
## Summary
Five fixes found by running the REAL device-login flow against the live local stack (BE+FE on merged develop) — none visible to the previously-green 185-test suite, because the mock fixtures shared the client's misreadings:

1. **Contract bodies** (`3ce941a2`): authorize now sends `{client_id}`, token poll sends `{grant_type, device_code, client_id}` (the BE constant-time-binds `client_id` across the flow); error path surfaces the true HTTP status + server envelope message.
2. **URL base** (`4dcb4740`): all device endpoints resolve through one `/api/v1` composer (shared with keys/validate); bases already ending in `/api/v1` don't double.
3. **Envelope unwrap + display/actual unification** (`92ecddc7`): authorize/token success parsed per the `{success,message,data}` contract envelopes; the banner now prints the URL the transport actually calls (previously `TRAIGENT_BACKEND_URL` was displayed while `TRAIGENT_API_URL` was called). **All fixtures now mirror the schema files exactly** so envelope drift can never pass mocks again.
4. **429 backoff** (`c41fd8ef`): token-poll 429s honor Retry-After and continue (bounded), with the `expires_in` deadline as a hard cap — verified live: an 885s Retry-After correctly terminated as "Device login expired" instead of over-sleeping.
5. Review P3: authorize fixture names its schema source.

## Live verification
Full funnel completed end-to-end with this branch: device codes issued → portal approval (decision payload carried **no api_key**) → project-scoped `sk_` key received **once** → encrypted store (`secure_credentials.enc`, 0600) → `auth status` authenticated → `recommend` + `mcp serve` (8 tools) working with the stored key. Evidence: spine `features/FR-BE-SELF-SERVICE-ONBOARDING-V1/evidence/live-e2e-2026-06-05-local-stack.md`.

## Review cycle
Codex xhigh adversarial review of the full branch diff: **no P1/P2 findings**; secret hygiene, URL matrix, fail-closed envelope parsing, and deadline-capped backoff all confirmed; single P3 fixed.

## Checklist
Worst-case prod path: client-side auth flow, fail-closed parsing, nothing persisted on malformed payloads. Contract regen: implements merged TraigentSchema#94 exactly. Public surface: behavior fixes only, no new commands. Quality gates: none relaxed (ruff/mypy/pytest 187 green). Follow-ups tracked: store pre-flight before starting the flow, weak-credential heuristic blob-matching, quickstart mock summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)