### PR TITLE
fix(quickstart): mock summary must agree with the rendered trial table

### DIFF
--- a/tests/integration/test_quickstart_smoke.py
+++ b/tests/integration/test_quickstart_smoke.py
@@ -27,7 +27,7 @@ website funnel is broken before a user has any chance to see value.
 from __future__ import annotations
 
 import os
-import shutil
+import site as python_site
 import subprocess
 import sys
 from pathlib import Path
@@ -90,6 +90,7 @@ def hermetic_subprocess_env(tmp_path: Path) -> dict[str, str]:
     env: dict[str, str] = {
         "PATH": os.environ.get("PATH", ""),
         "HOME": str(tmp_path),
+        "PYTHONUSERBASE": python_site.getuserbase(),
         # PYTHONPATH: site (for sitecustomize) + worktree (so `import
         # traigent` finds my changes, not the editable install).
         "PYTHONPATH": f"{site}:{Path(__file__).resolve().parents[2]}",
@@ -192,6 +193,13 @@ def test_python_dash_m_runs_with_no_keys(
     # And the optimization actually ranked a winner.
     assert "Trial Results" in combined or "Best" in combined, (
         "Expected a results table or best-config line. Got:\n" + combined
+    )
+    assert "All trials failed" not in combined, (
+        "Quickstart showed scored trial rows but ended with the failed-trials "
+        "summary:\n" + combined
+    )
+    assert "Legend:" in combined and "Overall Best" in combined, (
+        "Expected the successful final summary legend. Got:\n" + combined
     )
 
 

--- a/tests/unit/utils/test_results_table.py
+++ b/tests/unit/utils/test_results_table.py
@@ -102,6 +102,21 @@ class TestTrialsAllFailed:
         ]
         assert _trials_all_failed(trials) is True
 
+    def test_positive_quality_metric_overrides_zero_success_metadata(self) -> None:
+        trials = [
+            _trial(
+                {"model": "m1"},
+                {"accuracy": 0.65},
+                metadata={"successful_examples": 0},
+            ),
+            _trial(
+                {"model": "m2"},
+                {"accuracy": 0.85},
+                metadata={"successful_examples": 0},
+            ),
+        ]
+        assert _trials_all_failed(trials) is False
+
     def test_non_numeric_metric_value_is_skipped(self) -> None:
         # Defensive: shouldn't crash on a stray non-numeric metric, and missing
         # success counts should still preserve legacy rankability.
@@ -171,6 +186,31 @@ class TestPrintResultsTableBanner:
         trials = [
             _trial({"model": "m1"}, {"accuracy": 0.0}),
             _trial({"model": "m2"}, {"accuracy": 0.0}),
+        ]
+        print_results_table(
+            self._build_results(trials),
+            config_space={"model": ["m1", "m2"]},
+            objectives=["accuracy"],
+        )
+
+        out = capsys.readouterr().out
+        assert "All trials failed" not in out
+        assert "Overall Best" in out
+
+    def test_positive_quality_metric_emits_legend_even_with_zero_success_metadata(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        trials = [
+            _trial(
+                {"model": "m1"},
+                {"accuracy": 0.65},
+                metadata={"successful_examples": 0},
+            ),
+            _trial(
+                {"model": "m2"},
+                {"accuracy": 0.85},
+                metadata={"successful_examples": 0},
+            ),
         ]
         print_results_table(
             self._build_results(trials),

--- a/traigent/utils/results_table.py
+++ b/traigent/utils/results_table.py
@@ -133,6 +133,26 @@ def _find_best_trial(trials: list, metric_names: list[str]) -> Any:
     return best_trial
 
 
+def _has_positive_quality_metric(trial: Any) -> bool:
+    """Return True when the displayed metrics prove at least one scored example."""
+    quality_metric_names = {"accuracy", "score", "success_rate"}
+    metrics = getattr(trial, "metrics", {}) or {}
+
+    for raw_name, raw_value in metrics.items():
+        metric_name = str(raw_name).lower()
+        if metric_name not in quality_metric_names and not metric_name.endswith(
+            "_accuracy"
+        ):
+            continue
+        try:
+            if float(raw_value) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+
+    return False
+
+
 def _trials_all_failed(trials: list) -> bool:
     """True iff every completed trial explicitly recorded zero successful examples.
 
@@ -140,10 +160,16 @@ def _trials_all_failed(trials: list) -> bool:
     because no winner can be honestly named. When older/external evaluators do
     not report ``metadata["successful_examples"]``, fall back to the completed
     trial status so honest 0.0 quality scores and cost-only runs remain rankable.
+    If the table is displaying positive quality metrics, treat that as scored
+    evidence too; otherwise mock/demo runs can show accuracy values and then
+    contradict themselves with a failed-trials banner.
     """
     for trial in trials:
         if not getattr(trial, "is_successful", False):
             continue
+
+        if _has_positive_quality_metric(trial):
+            return False
 
         metadata = getattr(trial, "metadata", {}) or {}
         successful = metadata.get("successful_examples")


### PR DESCRIPTION
## Summary
Fixes #1125 (live-E2E find): `traigent quickstart` rendered its 6-trial mock results table and then printed "⚠ All trials failed — no examples succeeded."

**Root cause**: the failed-summary predicate read `trial.metadata["successful_examples"]` while the table renders from `trial.metrics` — mock/demo runs can carry zero `successful_examples` metadata alongside positive quality metrics.

**Fix**: `results_table` treats positive quality metrics (`accuracy`, `score`, `success_rate`, `*_accuracy`) as scored evidence; the all-failed banner remains for genuine zero-success/error-only runs (honesty preserved both directions).

## Verification
15 tests (new predicate unit coverage + quickstart E2E smoke asserting table + consistent summary); ruff/mypy clean. Captain re-verified with a live mock `traigent quickstart` run from this branch: ends with the legend, no false failure banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)