### PR TITLE
fix(auth): credential-store pre-flight before device flow + secrets-only weak-credential checks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -925,28 +925,28 @@
         "filename": "tests/unit/security/test_credentials.py",
         "hashed_secret": "abb024ce40e5b84dce8710ae9610c31e3bef35af",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/security/test_credentials.py",
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_verified": false,
-        "line_number": 316
+        "line_number": 361
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/security/test_credentials.py",
         "hashed_secret": "bc58608dc1ce7310e5555fe44c4b319f383d3763",
         "is_verified": false,
-        "line_number": 346
+        "line_number": 391
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/security/test_credentials.py",
         "hashed_secret": "6f1991ff4238307f653a5fc5fcc31266fdf59ff5",
         "is_verified": false,
-        "line_number": 350
+        "line_number": 395
       }
     ],
     "tests/unit/security/test_crypto_utils.py": [
@@ -1179,28 +1179,28 @@
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 70
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 71
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 72
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "26eae588d0859648be8edcf9cd2cf19bbdfacd43",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 75
       }
     ],
     "traigent/utils/example_id.py": [
@@ -1231,5 +1231,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-04T20:16:07Z"
+  "generated_at": "2026-06-05T20:47:11Z"
 }

--- a/tests/unit/cli/test_auth_commands_secure_storage.py
+++ b/tests/unit/cli/test_auth_commands_secure_storage.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+
+import pytest
 
 from traigent.cli.auth_commands import (
     SECURE_CLI_CREDENTIAL_NAME,
     STORAGE_SECURE,
     TraigentAuthCLI,
 )
-from traigent.security.credentials import CredentialType
+from traigent.security.credentials import CredentialType, EnhancedCredentialStore
+
+STRONG_API_KEY = "sk_" + "a" * 43  # pragma: allowlist secret
 
 
 class _FakeSecureStore:
@@ -17,6 +22,7 @@ class _FakeSecureStore:
         self.payload = payload
         self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
         self.deleted: list[str] = []
+        self.secret_fields: dict[str, str] | None = None
 
     def get(self, name: str, check_env: bool = True) -> str | None:
         assert name == SECURE_CLI_CREDENTIAL_NAME
@@ -29,8 +35,10 @@ class _FakeSecureStore:
         value: str,
         credential_type: CredentialType,
         metadata: dict[str, str] | None = None,
+        secret_fields: dict[str, str] | None = None,
     ) -> None:
         self.saved = (name, value, credential_type, metadata)
+        self.secret_fields = secret_fields
         self.payload = value
 
     def delete_secure(self, name: str) -> bool:
@@ -44,6 +52,13 @@ def _auth_cli(tmp_path) -> TraigentAuthCLI:
     cli.config_dir = tmp_path
     cli.credentials_file = tmp_path / "credentials.json"
     return cli
+
+
+def _real_store(tmp_path: Path) -> EnhancedCredentialStore:
+    return EnhancedCredentialStore(
+        master_password="strong-test-passphrase-12345",  # noqa: S106 - test credential  # pragma: allowlist secret
+        storage_path=tmp_path / "secure_credentials.enc",
+    )
 
 
 def test_save_credentials_uses_secure_store_not_plaintext_file(
@@ -69,8 +84,73 @@ def test_save_credentials_uses_secure_store_not_plaintext_file(
     assert name == SECURE_CLI_CREDENTIAL_NAME
     assert credential_type is CredentialType.TOKEN
     assert metadata == {"source": "traigent-cli"}
+    assert store.secret_fields == {"api_key": "secure-api-key"}  # pragma: allowlist secret
     assert json.loads(serialized)["api_key"] == "secure-api-key"  # pragma: allowlist secret
     assert not cli.credentials_file.exists()
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "admin@dev.local",
+        "demo@company.com",
+        "dev@example.com",
+    ],
+)
+def test_save_credentials_allows_placeholder_words_in_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    email: str,
+) -> None:
+    store = _real_store(tmp_path)
+    monkeypatch.setattr(
+        "traigent.cli.auth_commands.get_secure_credential_store", lambda: store
+    )
+    cli = _auth_cli(tmp_path)
+
+    storage = cli._save_credentials(
+        {
+            "api_key": STRONG_API_KEY,
+            "tenant_id": "tenant_demo",
+            "project_id": "project_example",
+            "user": {"id": "user_admin", "email": email},
+            "backend_url": "https://api.example.com",
+        }
+    )
+
+    assert storage == STORAGE_SECURE
+    serialized = store.get(SECURE_CLI_CREDENTIAL_NAME, check_env=False)
+    assert serialized is not None
+    saved = json.loads(serialized)
+    assert saved["api_key"] == STRONG_API_KEY
+    assert saved["user"]["email"] == email
+
+
+def test_save_credentials_rejects_weak_api_key_without_master_password_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _real_store(tmp_path)
+    monkeypatch.setattr(
+        "traigent.cli.auth_commands.get_secure_credential_store", lambda: store
+    )
+    cli = _auth_cli(tmp_path)
+
+    storage = cli._save_credentials(
+        {
+            "api_key": "sk_demo_placeholder_value_abcdefghi",  # pragma: allowlist secret
+            "user": {"email": "user@safe.local"},
+            "backend_url": "https://api.safe.local",
+        }
+    )
+    cli._display_storage_location(storage)
+
+    assert storage is None
+    output = capsys.readouterr().out
+    assert "api_key" in output
+    assert "demo" in output
+    assert "TRAIGENT_MASTER_PASSWORD" not in output
 
 
 def test_load_stored_credentials_ignores_plaintext_without_opt_in(

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -35,6 +35,7 @@ class _FakeSecureStore:
         self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
         self.set_calls: list[tuple[str, str, CredentialType, dict[str, str] | None]] = []
         self.deleted: list[str] = []
+        self.secret_fields: dict[str, str] | None = None
 
     def get(self, name: str, check_env: bool = True) -> str | None:
         assert name == SECURE_CLI_CREDENTIAL_NAME
@@ -47,10 +48,12 @@ class _FakeSecureStore:
         value: str,
         credential_type: CredentialType,
         metadata: dict[str, str] | None = None,
+        secret_fields: dict[str, str] | None = None,
     ) -> None:
         if self.fail_on_set:
             raise auth_commands.SecurityError("secure store unavailable")
         self.set_calls.append((name, value, credential_type, metadata))
+        self.secret_fields = secret_fields
         if name == SECURE_CLI_CREDENTIAL_NAME:
             self.saved = (name, value, credential_type, metadata)
 

--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -33,6 +33,8 @@ class _FakeSecureStore:
     def __init__(self, *, fail_on_set: bool = False) -> None:
         self.fail_on_set = fail_on_set
         self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
+        self.set_calls: list[tuple[str, str, CredentialType, dict[str, str] | None]] = []
+        self.deleted: list[str] = []
 
     def get(self, name: str, check_env: bool = True) -> str | None:
         assert name == SECURE_CLI_CREDENTIAL_NAME
@@ -48,10 +50,12 @@ class _FakeSecureStore:
     ) -> None:
         if self.fail_on_set:
             raise auth_commands.SecurityError("secure store unavailable")
-        self.saved = (name, value, credential_type, metadata)
+        self.set_calls.append((name, value, credential_type, metadata))
+        if name == SECURE_CLI_CREDENTIAL_NAME:
+            self.saved = (name, value, credential_type, metadata)
 
     def delete_secure(self, name: str) -> bool:
-        assert name == SECURE_CLI_CREDENTIAL_NAME
+        self.deleted.append(name)
         return True
 
 
@@ -385,17 +389,15 @@ def test_device_flow_env_file_consent_writes_with_0600(
     assert "TRAIGENT_BACKEND_URL=https://backend.example.test" in env_text
 
 
-def test_device_flow_secure_store_failure_without_explicit_flag_skips_env_file(
+def test_device_flow_secure_store_preflight_failure_never_authorizes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    store, _session = _install_device_test_fakes(
+    store, session = _install_device_test_fakes(
         monkeypatch,
         tmp_path,
-        [
-            _FakeResponse(200, _authorize_payload()),
-            _FakeResponse(200, _success_payload()),
-        ],
+        [],
         fail_secure_store=True,
     )
 
@@ -408,7 +410,11 @@ def test_device_flow_secure_store_failure_without_explicit_flag_skips_env_file(
 
     assert result is False
     assert store.saved is None
+    assert session.post_calls == []
     assert not (tmp_path / ".env").exists()
+    output = capsys.readouterr().out
+    assert "TRAIGENT_MASTER_PASSWORD" in output
+    assert "No device authorization request was sent" in output
 
 
 def test_env_file_rewrite_replaces_export_prefixed_api_key(

--- a/tests/unit/cli/test_onboard_commands.py
+++ b/tests/unit/cli/test_onboard_commands.py
@@ -21,14 +21,24 @@ from traigent.cli.onboard_commands import (
 
 
 class _RecordingSecureStore:
-    def __init__(self) -> None:
+    def __init__(self, *, fail_on_set: bool = False) -> None:
+        self.fail_on_set = fail_on_set
         self.saved: list[tuple[object, ...]] = []
+        self.deleted: list[str] = []
 
     def get(self, name: str, check_env: bool = True) -> str | None:
         return None
 
     def set(self, *args: object, **_kwargs: object) -> None:
+        if self.fail_on_set:
+            from traigent.cli import auth_commands
+
+            raise auth_commands.SecurityError("secure store unavailable")
         self.saved.append(args)
+
+    def delete_secure(self, name: str) -> bool:
+        self.deleted.append(name)
+        return True
 
 
 class _RecordingSession:
@@ -207,6 +217,34 @@ def test_onboard_non_tty_login_flag_runs_device_flow(
     assert isinstance(kwargs, dict)
     assert kwargs["save_env_file"] is True
     assert kwargs["write_env_explicit"] is True
+
+
+def test_onboard_login_store_preflight_failure_never_calls_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from traigent.cli import auth_commands
+
+    session = _RecordingSession()
+    store = _RecordingSecureStore(fail_on_set=True)
+    assert auth_commands.aiohttp is not None
+    monkeypatch.setattr(
+        auth_commands.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: session,
+    )
+    monkeypatch.setattr(auth_commands, "get_secure_credential_store", lambda: store)
+    monkeypatch.setattr(onboard_commands, "_detect_coding_agents", lambda _cwd: [])
+    monkeypatch.setattr(onboard_commands, "_mcp_help_succeeds", lambda: False)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["onboard", "--login"])
+
+    assert result.exit_code == 1
+    assert session.post_calls == []
+    assert store.saved == []
+    assert "TRAIGENT_MASTER_PASSWORD" in result.output
+    assert "No device authorization request was sent" in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/security/test_credentials.py
+++ b/tests/unit/security/test_credentials.py
@@ -1,5 +1,6 @@
 """Comprehensive unit tests for secure credential management."""
 
+import json
 import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -11,6 +12,7 @@ from traigent.security.credentials import (
     EnhancedCredentialStore,
     SecureCredential,
     SecureString,
+    SecurityError,
     SecurityLevel,
 )
 from traigent.utils.exceptions import AuthenticationError
@@ -196,6 +198,49 @@ class TestEnhancedCredentialStore:
 
         # Verify credential exists
         assert store.get("meta-test") is not None
+
+    def test_structured_credential_ignores_non_secret_metadata_weak_words(self, store):
+        """Metadata values such as emails and URLs must not trip secret heuristics."""
+        strong_key = "sk_" + "a" * 43  # pragma: allowlist secret
+        payload = {
+            "api_key": strong_key,
+            "tenant_id": "tenant_demo",
+            "project_id": "project_example",
+            "user": {"id": "user_admin", "email": "admin@dev.local"},
+            "backend_url": "https://api.example.com",
+        }
+
+        store.set(
+            name="cli_credentials",
+            value=json.dumps(payload, separators=(",", ":")),
+            credential_type=CredentialType.TOKEN,
+            secret_fields={"api_key": strong_key},
+        )
+
+        retrieved = store.get("cli_credentials", check_env=False)
+        assert retrieved is not None
+        assert json.loads(retrieved)["user"]["email"] == "admin@dev.local"
+
+    def test_structured_credential_rejects_weak_secret_field_by_name(self, store):
+        """Weak checks still apply to actual secret fields and name the field."""
+        weak_key = "sk_demo_placeholder_value_abcdefghi"  # pragma: allowlist secret
+        payload = {
+            "api_key": weak_key,
+            "user": {"email": "user@safe.local"},
+            "backend_url": "https://api.safe.local",
+        }
+
+        with pytest.raises(SecurityError) as exc_info:
+            store.set(
+                name="cli_credentials",
+                value=json.dumps(payload, separators=(",", ":")),
+                credential_type=CredentialType.TOKEN,
+                secret_fields={"api_key": weak_key},
+            )
+
+        message = str(exc_info.value)
+        assert "api_key" in message
+        assert "demo" in message
 
     def test_credential_with_expiration(self, store):
         """Test storing credential with expiration."""

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -86,12 +86,33 @@ _ENV_FILE_KEYS = (
     PROJECT_ENV_VAR,
     "TRAIGENT_BACKEND_URL",
 )
+_CLI_SECRET_CREDENTIAL_FIELDS = (
+    "api_key",
+    "jwt_token",
+    "access_token",
+    "refresh_token",
+    "token",
+    "password",
+    "client_secret",
+    "service_key",
+    "private_key",
+)
 _ENV_ASSIGNMENT_RE = re.compile(
     r"^(?P<leading>\s*)(?P<export>export\s+)?" r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*="
 )
 MAX_DEVICE_POLL_TIMEOUT_SECONDS = 30.0
 MAX_DEVICE_POLL_TRANSPORT_ERRORS = 3
 MAX_DEVICE_POLL_RATE_LIMITS_WITHOUT_RETRY_AFTER = 10
+
+
+def _credential_secret_fields(credentials: dict[str, Any]) -> dict[str, str]:
+    """Return only secret-bearing credential fields for strength checks."""
+    secret_fields: dict[str, str] = {}
+    for field in _CLI_SECRET_CREDENTIAL_FIELDS:
+        value = credentials.get(field)
+        if isinstance(value, str) and value:
+            secret_fields[field] = value
+    return secret_fields
 
 
 async def _read_json_body(response: Any) -> dict[str, Any]:
@@ -327,6 +348,7 @@ class TraigentAuthCLI:
         Returns:
             Storage location string if saved successfully, None if failed
         """
+        self._last_credential_save_error = None
         try:
             store = get_secure_credential_store()
             store.set(
@@ -334,15 +356,25 @@ class TraigentAuthCLI:
                 json.dumps(credentials, separators=(",", ":")),
                 CredentialType.TOKEN,
                 metadata={"source": "traigent-cli"},
+                secret_fields=_credential_secret_fields(credentials),
             )
             logger.debug("Credentials saved to secure credential store")
             return STORAGE_SECURE
-        except (OSError, SecurityError) as e:
+        except OSError as e:
+            self._last_credential_save_error = (
+                f"{e}. Set TRAIGENT_MASTER_PASSWORD before running auth commands "
+                "or fix credential-store file permissions."
+            )
             logger.error(
                 "Failed to save credentials securely: %s. Set "
-                "TRAIGENT_MASTER_PASSWORD before running auth commands.",
+                "TRAIGENT_MASTER_PASSWORD before running auth commands or fix "
+                "credential-store file permissions.",
                 e,
             )
+            return None
+        except (SecurityError, ValueError) as e:
+            self._last_credential_save_error = str(e)
+            logger.error("Failed to save credentials securely: %s", e)
             return None
 
     def _preflight_secure_credential_store(self) -> bool:
@@ -1226,10 +1258,17 @@ class TraigentAuthCLI:
                 f"[cyan]{self.credentials_file}[/cyan]"
             )
         else:
-            console.print(
-                "\n[yellow]Could not save credentials securely. Set "
-                "TRAIGENT_MASTER_PASSWORD and rerun the command.[/yellow]"
-            )
+            reason = getattr(self, "_last_credential_save_error", None)
+            if reason:
+                console.print(
+                    "\n[yellow]Could not save credentials securely. "
+                    f"Reason: {reason}[/yellow]"
+                )
+            else:
+                console.print(
+                    "\n[yellow]Could not save credentials securely. Set "
+                    "TRAIGENT_MASTER_PASSWORD and rerun the command.[/yellow]"
+                )
 
     async def login(
         self, email: str | None = None, non_interactive: bool = False

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import os
 import re
+import secrets
 import sys
 import time
 from collections.abc import Callable
@@ -61,6 +62,7 @@ BACKEND_RESPONSE_HEADER = "\n[red]--- Backend Response ---[/red]"
 STORAGE_FILE = "file"
 STORAGE_SECURE = "secure"
 SECURE_CLI_CREDENTIAL_NAME = "cli_credentials"
+SECURE_STORE_PREFLIGHT_NAME = "__traigent_cli_store_preflight__"
 
 # Common user-facing messages (avoid duplication per SonarCloud S1192)
 MSG_CHECK_NETWORK = "Please check your network connection and try again.\n"
@@ -342,6 +344,34 @@ class TraigentAuthCLI:
                 e,
             )
             return None
+
+    def _preflight_secure_credential_store(self) -> bool:
+        """Verify secure credential storage before starting a device grant."""
+        sentinel_value = "traigent-cli-store-preflight-" + secrets.token_urlsafe(24)
+        try:
+            store = get_secure_credential_store()
+            store.set(
+                SECURE_STORE_PREFLIGHT_NAME,
+                sentinel_value,
+                CredentialType.TOKEN,
+                metadata={"source": "traigent-cli-preflight"},
+            )
+            if not store.delete_secure(SECURE_STORE_PREFLIGHT_NAME):
+                raise SecurityError(
+                    "credential-store preflight cleanup did not delete the sentinel"
+                )
+        except (OSError, SecurityError, ValueError) as exc:
+            logger.error("Secure credential store preflight failed: %s", exc)
+            console.print("[red]❌ Secure credential storage is unavailable.[/red]")
+            console.print(f"[yellow]Reason:[/yellow] {exc}")
+            console.print(
+                "[yellow]Set TRAIGENT_MASTER_PASSWORD before running auth commands, "
+                "or fix permissions on the Traigent credential-store files. "
+                "No device authorization request was sent; rerun login after "
+                "secure storage is working.[/yellow]"
+            )
+            return False
+        return True
 
     @staticmethod
     def _resolve_env_file_path(path: str | Path = ".env") -> Path:
@@ -826,6 +856,9 @@ class TraigentAuthCLI:
         console.print(
             f"Authenticating with: [cyan]{self.device_login_target_url}[/cyan]\n"
         )
+
+        if not self._preflight_secure_credential_store():
+            return False
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/traigent/security/credentials.py
+++ b/traigent/security/credentials.py
@@ -38,7 +38,7 @@ from traigent.utils.exceptions import AuthenticationError as SecurityError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
-_SECRET_ENV_SUFFIX = "PASS" + "WORD"
+_SECRET_ENV_SUFFIX = "PASS" + "WORD"  # pragma: allowlist secret
 _MASTER_SECRET_ENV = f"TRAIGENT_MASTER_{_SECRET_ENV_SUFFIX}"
 _ALLOW_LEGACY_MASTER_SECRET_ENV = (
     f"TRAIGENT_ALLOW_LEGACY_LOCAL_MASTER_{_SECRET_ENV_SUFFIX}"
@@ -189,7 +189,18 @@ class EnhancedCredentialStore:
     NONCE_LENGTH = 12  # 96 bits for GCM
     MAX_CREDENTIAL_AGE_DAYS = 90  # Force rotation after 90 days
     MAX_ACCESS_COUNT = 10000  # Force rotation after 10k accesses
+    MIN_CREDENTIAL_VALUE_LENGTH = 8
     MASTER_PASSWORD_FILENAME = ".master_password"
+    WEAK_CREDENTIAL_PATTERNS = (
+        "password123",
+        "12345",
+        "admin",
+        "demo",
+        "your-",
+        "xxx",
+        "placeholder",
+        "example",
+    )
 
     def __init__(
         self,
@@ -657,6 +668,73 @@ class EnhancedCredentialStore:
                 self._security_event("get_failed", {"name": name, "error": str(e)})
                 raise SecurityError(f"Failed to retrieve credential: {e}") from e
 
+    @staticmethod
+    def _is_test_credential_value(lower_value: str) -> bool:
+        return (
+            lower_value.startswith(("test_", "test-"))
+            or lower_value.endswith(("_test", "-test"))
+            or lower_value.startswith(("dummy", "sample"))
+        )
+
+    def _validate_secret_field_strength(
+        self,
+        *,
+        name: str,
+        field: str,
+        field_value: str,
+        flags: Any,
+    ) -> None:
+        if field_value is None:
+            raise ValueError(f"Credential field '{field}' cannot be None")
+        if len(field_value) == 0:
+            raise ValueError(f"Credential field '{field}' cannot be empty")
+        if len(field_value) < self.MIN_CREDENTIAL_VALUE_LENGTH:
+            with self._lock:
+                self._access_metrics["short_value_blocked"] += 1
+            self._security_event(
+                "rejected_short_credential_value",
+                {
+                    "name": name,
+                    "field": field,
+                    "length": len(field_value),
+                    "profile": flags.profile.value,
+                    "minimum_length": self.MIN_CREDENTIAL_VALUE_LENGTH,
+                },
+            )
+            logger.warning(
+                "Rejecting short credential field %s for %s (length=%d) under profile %s",
+                field,
+                name,
+                len(field_value),
+                flags.profile.value,
+            )
+            raise ValueError(
+                f"Credential field '{field}' too short; minimum length is "
+                f"{self.MIN_CREDENTIAL_VALUE_LENGTH} characters"
+            )
+
+        lower_value = field_value.lower()
+        weak_pattern = next(
+            (
+                pattern
+                for pattern in self.WEAK_CREDENTIAL_PATTERNS
+                if pattern in lower_value
+            ),
+            None,
+        )
+        if weak_pattern and (
+            not flags.allow_weak_credentials
+            or not self._is_test_credential_value(lower_value)
+        ):
+            self._security_event(
+                "weak_credential_detected",
+                {"name": name, "field": field, "reason": f"contains {weak_pattern}"},
+            )
+            raise SecurityError(
+                f"Credential field '{field}' appears to be weak or a placeholder: "
+                f"contains '{weak_pattern}'"
+            )
+
     def set(
         self,
         name: str,
@@ -664,6 +742,7 @@ class EnhancedCredentialStore:
         credential_type: CredentialType = CredentialType.SECRET,
         *,
         metadata: dict[str, Any] | None = None,
+        secret_fields: dict[str, str] | None = None,
         expires_in_days: int | None = None,
         expires_at: datetime | None = None,
         **kwargs: Any,
@@ -675,6 +754,8 @@ class EnhancedCredentialStore:
             value: Credential value (will be encrypted)
             credential_type: Type of credential
             metadata: Optional metadata
+            secret_fields: Secret-bearing fields to check for weak values when
+                value is a structured credential blob
             expires_in_days: Optional expiration in days
         """
         if "cred_type" in kwargs:
@@ -690,51 +771,18 @@ class EnhancedCredentialStore:
             raise ValueError("Credential value cannot be None")
         if len(value) == 0:
             raise ValueError("Credential value cannot be empty")
-        reference_length = 8
-        if len(value) < reference_length:
-            with self._lock:
-                self._access_metrics["short_value_blocked"] += 1
-            self._security_event(
-                "rejected_short_credential_value",
-                {
-                    "name": name,
-                    "length": len(value),
-                    "profile": flags.profile.value,
-                    "minimum_length": reference_length,
-                },
-            )
-            logger.warning(
-                "Rejecting short credential value for %s (length=%d) under profile %s",
-                name,
-                len(value),
-                flags.profile.value,
-            )
-            raise ValueError(
-                f"Credential value too short; minimum length is {reference_length} characters"
-            )
 
-        # Check for weak/placeholder values (relaxed for testing)
-        weak_patterns = [
-            "password123",
-            "12345",
-            "admin",
-            "demo",
-            "your-",
-            "xxx",
-            "placeholder",
-            "example",
-        ]
-        lower_value = value.lower()
-        is_test_value = (
-            lower_value.startswith(("test_", "test-"))
-            or lower_value.endswith(("_test", "-test"))
-            or lower_value.startswith(("dummy", "sample"))
-        )
-        if (not flags.allow_weak_credentials or not is_test_value) and any(
-            pattern in value.lower() for pattern in weak_patterns
-        ):
-            self._security_event("weak_credential_detected", {"name": name})
-            raise SecurityError("Credential appears to be weak or a placeholder")
+        # Structured credential blobs may include non-secret metadata such as
+        # emails, URLs, ids, and display names. Apply weak-value heuristics only
+        # to the fields that contain actual secret material.
+        validation_fields = secret_fields or {"value": value}
+        for field, field_value in validation_fields.items():
+            self._validate_secret_field_strength(
+                name=name,
+                field=field,
+                field_value=field_value,
+                flags=flags,
+            )
 
         # Encrypt the value
         ciphertext, nonce, associated_data = self._encrypt_value(value)


### PR DESCRIPTION
## Summary
Fixes #1123 and #1124 (live-E2E finds — two grants were burned and a legitimate user blocked during the funnel run):

**#1123 — pre-flight the store before the flow** (`946785c0`): `traigent auth device-login` (and `onboard --login`) now validates secure storage with a real sentinel set/delete **before opening any HTTP session** — storage unavailable → immediate actionable exit, no `/device/authorize` call, no grant issued, no key minted-and-lost. Live-verified from this branch: failure precedes any backend request (0 requests logged server-side).

**#1124 — weak/placeholder checks on secret fields only** (`b631b366`): the heuristic previously ran over the whole serialized credential blob — `admin@dev.local` as the *user email* poisoned the save (demo@/example.com likewise), and the error blamed `TRAIGENT_MASTER_PASSWORD`. Now: explicit secrets-only view passed to the store; strictness preserved for actual secret values; rejection messages name the offending field and reason. Regressions: admin-email metadata + strong key saves; weak api-key value still rejected with field-named error; demo/example variants covered.

## Verification
1,044 passed (tests/unit/cli + tests/unit/security), ruff/mypy clean; captain live-verified the pre-flight ordering against the running stack.

## Checklist
Policy surface (credential handling): both changes are fail-closed-preserving — pre-flight only adds an earlier denial; the heuristic keeps full strictness on secret values while unblocking legitimate metadata. No contract changes. Gates: none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)