### PR TITLE
fix(auth): preflight device-login credential store

### DIFF
--- a/tests/unit/cli/test_device_auth_commands.py
+++ b/tests/unit/cli/test_device_auth_commands.py
@@ -10,7 +10,11 @@ from typing import Any
 import pytest
 
 from traigent.cli import auth_commands
-from traigent.cli.auth_commands import SECURE_CLI_CREDENTIAL_NAME, TraigentAuthCLI
+from traigent.cli.auth_commands import (
+    SECURE_CLI_CREDENTIAL_NAME,
+    SECURE_CLI_PREFLIGHT_NAME,
+    TraigentAuthCLI,
+)
 from traigent.security.credentials import CredentialType
 
 API_KEY = "sk_" + "a" * 43  # pragma: allowlist secret
@@ -33,6 +37,10 @@ class _FakeSecureStore:
     def __init__(self, *, fail_on_set: bool = False) -> None:
         self.fail_on_set = fail_on_set
         self.saved: tuple[str, str, CredentialType, dict[str, str] | None] | None = None
+        self.set_calls: list[
+            tuple[str, str, CredentialType, dict[str, str] | None]
+        ] = []
+        self.deleted: list[str] = []
 
     def get(self, name: str, check_env: bool = True) -> str | None:
         assert name == SECURE_CLI_CREDENTIAL_NAME
@@ -48,10 +56,14 @@ class _FakeSecureStore:
     ) -> None:
         if self.fail_on_set:
             raise auth_commands.SecurityError("secure store unavailable")
+        self.set_calls.append((name, value, credential_type, metadata))
         self.saved = (name, value, credential_type, metadata)
 
     def delete_secure(self, name: str) -> bool:
-        assert name == SECURE_CLI_CREDENTIAL_NAME
+        assert name in {SECURE_CLI_CREDENTIAL_NAME, SECURE_CLI_PREFLIGHT_NAME}
+        self.deleted.append(name)
+        if self.saved and self.saved[0] == name:
+            self.saved = None
         return True
 
 
@@ -262,6 +274,8 @@ def test_device_flow_happy_path_persists_credentials_secure_only_by_default(
 
     assert result is True
     assert store.saved is not None
+    assert store.set_calls[0][0] == SECURE_CLI_PREFLIGHT_NAME
+    assert store.deleted == [SECURE_CLI_PREFLIGHT_NAME]
     name, serialized, credential_type, metadata = store.saved
     assert name == SECURE_CLI_CREDENTIAL_NAME
     assert credential_type is CredentialType.TOKEN
@@ -385,11 +399,12 @@ def test_device_flow_env_file_consent_writes_with_0600(
     assert "TRAIGENT_BACKEND_URL=https://backend.example.test" in env_text
 
 
-def test_device_flow_secure_store_failure_without_explicit_flag_skips_env_file(
+def test_device_flow_secure_store_failure_prevents_backend_authorization(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    store, _session = _install_device_test_fakes(
+    store, session = _install_device_test_fakes(
         monkeypatch,
         tmp_path,
         [
@@ -408,7 +423,9 @@ def test_device_flow_secure_store_failure_without_explicit_flag_skips_env_file(
 
     assert result is False
     assert store.saved is None
+    assert session.post_calls == []
     assert not (tmp_path / ".env").exists()
+    assert "Secure credential storage is not ready" in capsys.readouterr().out
 
 
 def test_env_file_rewrite_replaces_export_prefixed_api_key(
@@ -491,7 +508,9 @@ def test_device_poll_rate_limit_retry_after_continues_and_succeeds(
     assert result is True
     assert sleeps == [2]
     token_calls = [
-        call for call in session.post_calls if call["url"].endswith("/auth/device/token")
+        call
+        for call in session.post_calls
+        if call["url"].endswith("/auth/device/token")
     ]
     assert len(token_calls) == 2
 
@@ -520,14 +539,14 @@ def test_device_poll_rate_limit_retry_after_still_honors_expiry_deadline(
         sleeps.append(seconds)
         now += seconds
 
-    result = asyncio.run(
-        _make_cli().device_login(sleep=fake_sleep, clock=fake_clock)
-    )
+    result = asyncio.run(_make_cli().device_login(sleep=fake_sleep, clock=fake_clock))
 
     assert result is False
     assert sleeps == [3]
     token_calls = [
-        call for call in session.post_calls if call["url"].endswith("/auth/device/token")
+        call
+        for call in session.post_calls
+        if call["url"].endswith("/auth/device/token")
     ]
     assert len(token_calls) == 1
 
@@ -555,9 +574,7 @@ def test_device_poll_caps_sleep_and_timeout_to_expiry_deadline(
         sleeps.append(seconds)
         now += seconds
 
-    result = asyncio.run(
-        _make_cli().device_login(sleep=fake_sleep, clock=fake_clock)
-    )
+    result = asyncio.run(_make_cli().device_login(sleep=fake_sleep, clock=fake_clock))
 
     assert result is False
     assert sleeps == [3]
@@ -593,7 +610,9 @@ def test_device_poll_transport_error_retry_bound(
     assert store.saved is None
     assert sleeps == [1, 1]
     token_calls = [
-        call for call in session.post_calls if call["url"].endswith("/auth/device/token")
+        call
+        for call in session.post_calls
+        if call["url"].endswith("/auth/device/token")
     ]
     assert len(token_calls) == 3
     assert "failed after 3 consecutive transport errors" in capsys.readouterr().out

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import os
 import re
+import secrets
 import sys
 import time
 from collections.abc import Callable
@@ -61,6 +62,7 @@ BACKEND_RESPONSE_HEADER = "\n[red]--- Backend Response ---[/red]"
 STORAGE_FILE = "file"
 STORAGE_SECURE = "secure"
 SECURE_CLI_CREDENTIAL_NAME = "cli_credentials"
+SECURE_CLI_PREFLIGHT_NAME = "__cli_device_login_preflight__"
 
 # Common user-facing messages (avoid duplication per SonarCloud S1192)
 MSG_CHECK_NETWORK = "Please check your network connection and try again.\n"
@@ -353,6 +355,37 @@ class TraigentAuthCLI:
                     e,
                 )
             return None
+
+    def _preflight_secure_credential_store(self) -> bool:
+        """Verify secure CLI credential storage is writable before auth starts."""
+        try:
+            store = get_secure_credential_store()
+            probe = json.dumps(
+                {"token": secrets.token_urlsafe(32)}, separators=(",", ":")
+            )
+            store.set(
+                SECURE_CLI_PREFLIGHT_NAME,
+                probe,
+                CredentialType.TOKEN,
+                metadata={
+                    "source": "traigent-cli",
+                    "purpose": "device-login-preflight",
+                },
+            )
+            store.delete_secure(SECURE_CLI_PREFLIGHT_NAME)
+            return True
+        except (OSError, SecurityError, ValueError) as exc:
+            logger.error(
+                "Secure credential store preflight failed: %s. Set "
+                "TRAIGENT_MASTER_PASSWORD before running device login.",
+                exc,
+            )
+            console.print(
+                "[red]❌ Secure credential storage is not ready.[/red]\n"
+                "[yellow]Set TRAIGENT_MASTER_PASSWORD and run "
+                "`traigent auth device-login` again.[/yellow]"
+            )
+            return False
 
     @staticmethod
     def _resolve_env_file_path(path: str | Path = ".env") -> Path:
@@ -837,6 +870,9 @@ class TraigentAuthCLI:
         console.print(
             f"Authenticating with: [cyan]{self.device_login_target_url}[/cyan]\n"
         )
+
+        if not self._preflight_secure_credential_store():
+            return False
 
         try:
             async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## Summary
Fixes #1123. Device login now verifies encrypted credential storage is writable before starting the backend device-code flow, so a missing/unusable TRAIGENT_MASTER_PASSWORD fails locally before /auth/device/authorize can issue a grant or mint a key.

The preflight writes a random sentinel credential and deletes it immediately through the same secure-store path used by the final save.

## Verification
- python3 -m ruff check traigent/cli/auth_commands.py tests/unit/cli/test_device_auth_commands.py
- python3 -m ruff format --check traigent/cli/auth_commands.py tests/unit/cli/test_device_auth_commands.py
- python3 -m pytest -n0 tests/unit/cli/test_device_auth_commands.py tests/unit/cli/test_auth_commands_secure_storage.py -q --tb=short
- commit hook: isort, black, ruff, detect-secrets, bandit, mypy, guardrails passed

## Notes
Local push hook skipped SonarQube because sonar-scanner is not installed; GitHub CodeQL/Aikido checks are expected to run on the PR.