### PR TITLE
fix(security): keep audit contract imports lightweight

### DIFF
--- a/tests/unit/security/test_security_package_imports.py
+++ b/tests/unit/security/test_security_package_imports.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run_fresh_python(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_audit_event_type_import_keeps_enterprise_modules_lazy() -> None:
+    result = run_fresh_python(
+        """
+import sys
+
+from traigent.security.audit import AuditEventType
+
+assert AuditEventType.USER_LOGIN.value == "user_login"
+for module_name in (
+    "traigent.security.auth",
+    "traigent.security.deployment",
+    "traigent.security.encryption",
+    "traigent.security.tenant",
+    "jwt",
+    "pyotp",
+    "twilio",
+):
+    assert module_name not in sys.modules, module_name
+"""
+    )
+
+    assert result.stderr == ""
+
+
+def test_security_package_lazy_export_preserves_legacy_import_surface() -> None:
+    result = run_fresh_python(
+        """
+from traigent.security import MultiFactorAuth
+
+assert MultiFactorAuth.__name__ == "MultiFactorAuth"
+"""
+    )
+
+    assert result.stderr == ""

--- a/traigent/security/__init__.py
+++ b/traigent/security/__init__.py
@@ -4,26 +4,40 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any
+
 from .audit import (
+    AuditEvent,
+    AuditEventType,
     AuditLogger,
+    AuditSeverity,
+    ComplianceFramework,
     EnrichmentProviderUnavailableError,
     EventProcessor,
     SecurityMonitor,
 )
-from .auth import MultiFactorAuth
-from .deployment import BackupManager, DeploymentManager, HealthChecker, SLAMonitor
-from .encryption import DataClassifier, EncryptionManager, PIIDetector, SecureStorage
-from .tenant import (
-    BillingIntegration,
-    Tenant,
-    TenantContext,
-    TenantIsolation,
-    TenantManager,
-    TenantQuotas,
-    TenantStatus,
-    TenantTier,
-    TenantUsage,
-)
+
+_LAZY_EXPORTS = {
+    "MultiFactorAuth": "traigent.security.auth",
+    "DeploymentManager": "traigent.security.deployment",
+    "SLAMonitor": "traigent.security.deployment",
+    "HealthChecker": "traigent.security.deployment",
+    "BackupManager": "traigent.security.deployment",
+    "EncryptionManager": "traigent.security.encryption",
+    "PIIDetector": "traigent.security.encryption",
+    "DataClassifier": "traigent.security.encryption",
+    "SecureStorage": "traigent.security.encryption",
+    "TenantManager": "traigent.security.tenant",
+    "TenantContext": "traigent.security.tenant",
+    "TenantIsolation": "traigent.security.tenant",
+    "BillingIntegration": "traigent.security.tenant",
+    "Tenant": "traigent.security.tenant",
+    "TenantQuotas": "traigent.security.tenant",
+    "TenantUsage": "traigent.security.tenant",
+    "TenantTier": "traigent.security.tenant",
+    "TenantStatus": "traigent.security.tenant",
+}
 
 __all__ = [
     # Authentication & Authorization
@@ -34,6 +48,10 @@ __all__ = [
     "DataClassifier",
     "SecureStorage",
     # Audit & Compliance
+    "AuditSeverity",
+    "AuditEvent",
+    "AuditEventType",
+    "ComplianceFramework",
     "AuditLogger",
     "SecurityMonitor",
     "EventProcessor",
@@ -54,3 +72,18 @@ __all__ = [
     "HealthChecker",
     "BackupManager",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module = import_module(module_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))


### PR DESCRIPTION
## Summary
- keep audit exports direct but load security auth/deployment/encryption/tenant exports lazily
- preserve legacy from-traigent.security import surface via __getattr__
- add a fresh-interpreter regression test proving AuditEventType import does not load heavy enterprise modules

## Evidence
- python3 -m ruff check traigent/security/__init__.py tests/unit/security/test_security_package_imports.py
- python3 -m ruff format --check traigent/security/__init__.py tests/unit/security/test_security_package_imports.py
- python3 -m pytest -n0 tests/unit/security/test_audit.py tests/unit/security/test_security_package_imports.py -q --tb=short
- PYTHONPATH=/home/nimrodbu/Traigent_enterprise/worktrees/spine-gaps/sdk-audit-import-contract ops/_validation/.venv/bin/validation contract run --catalog ops/_validation/catalog/contracts.yaml --filter AuditEventType_importable --out /tmp/audit-event-type-contract.json --python /usr/bin/python3

Spine blocker: AuditEventType_importable now passes locally in 111 ms against the 5 second contract budget.