### PR TITLE
fix(sdk): TRAIGENT_MOCK_LLM litellm path returns ModelResponse shape, not {text} dict

### DIFF
--- a/tests/unit/integrations/test_mock_adapter.py
+++ b/tests/unit/integrations/test_mock_adapter.py
@@ -177,6 +177,31 @@ class TestMockAdapterGetMockResponse:
         assert "meta" in response
         assert "billed_units" in response["meta"]
 
+    def test_litellm_mock_response_matches_model_response_shape(self) -> None:
+        """LiteLLM mock response supports production-style attribute access."""
+        response = MockAdapter.get_mock_response(
+            "litellm", response_text="LiteLLM mock text", model="gpt-4o"
+        )
+
+        assert response.model == "gpt-4o"
+        assert response.choices[0].message.content == "LiteLLM mock text"
+        assert response.usage.prompt_tokens == MockResponse.prompt_tokens
+        assert response["choices"][0]["message"]["content"] == "LiteLLM mock text"
+        assert response["usage"]["prompt_tokens"] == MockResponse.prompt_tokens
+
+    def test_litellm_mock_response_falls_back_to_duck_type(self) -> None:
+        """LiteLLM mock response keeps both access styles when LiteLLM is absent."""
+        with patch.dict("sys.modules", {"litellm": None}):
+            response = MockAdapter.get_mock_response(
+                "litellm", response_text="Fallback text", model="fallback-model"
+            )
+
+        assert response.model == "fallback-model"
+        assert response.choices[0].message.content == "Fallback text"
+        assert response.usage.prompt_tokens == MockResponse.prompt_tokens
+        assert response["choices"][0]["message"]["content"] == "Fallback text"
+        assert response["usage"]["prompt_tokens"] == MockResponse.prompt_tokens
+
     def test_unknown_provider_uses_generic(self) -> None:
         """Test unknown provider uses generic format."""
         response = MockAdapter.get_mock_response("unknown_provider")

--- a/tests/unit/utils/test_litellm_interceptor.py
+++ b/tests/unit/utils/test_litellm_interceptor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import types
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -71,7 +72,9 @@ class TestPatchLiteLLM:
     """Patching litellm.completion and litellm.acompletion."""
 
     def test_patch_returns_true(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         result = patch_litellm_for_metadata_capture()
         assert result is True
@@ -86,7 +89,9 @@ class TestPatchLiteLLM:
         assert result is False
 
     def test_patch_is_idempotent(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         # Second call should skip (already patched)
@@ -102,7 +107,9 @@ class TestSyncCapture:
     """Sync litellm.completion response capture."""
 
     def test_captures_response(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -112,7 +119,9 @@ class TestSyncCapture:
         assert captured[0] is response
 
     def test_injects_timing(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -121,7 +130,9 @@ class TestSyncCapture:
         assert response.response_time_ms > 0
 
     def test_preserves_usage(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -131,7 +142,9 @@ class TestSyncCapture:
         assert response.usage.total_tokens == 150
 
     def test_preserves_return_value(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -140,7 +153,9 @@ class TestSyncCapture:
         assert response.choices[0].message.content == "Hello world"
 
     def test_multiple_calls_captured_in_order(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         litellm_module.completion(model="gpt-4o", messages=[])
@@ -150,12 +165,34 @@ class TestSyncCapture:
         captured = get_all_captured_responses()
         assert len(captured) == 3
 
+    def test_mock_mode_returns_litellm_response_shape(self, litellm_module):
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        patch_litellm_for_metadata_capture()
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            response = litellm_module.completion(model="gpt-4o", messages=[])
+
+        assert response.model == "gpt-4o"
+        assert response.choices[0].message.content == "This is a mock response for testing."
+        assert response.usage.prompt_tokens == 10
+        assert response["choices"][0]["message"]["content"] == (
+            "This is a mock response for testing."
+        )
+        assert response["usage"]["prompt_tokens"] == 10
+
 
 class TestAsyncCapture:
     """Async litellm.acompletion response capture."""
 
     def test_captures_response(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = asyncio.run(litellm_module.acompletion(model="gpt-4o", messages=[]))
@@ -165,13 +202,62 @@ class TestAsyncCapture:
         assert captured[0] is response
 
     def test_injects_timing(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = asyncio.run(litellm_module.acompletion(model="gpt-4o", messages=[]))
 
         assert hasattr(response, "response_time_ms")
         assert response.response_time_ms > 0
+
+    def test_mock_mode_returns_litellm_response_shape(self, litellm_module):
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        patch_litellm_for_metadata_capture()
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            response = asyncio.run(
+                litellm_module.acompletion(model="gpt-4o", messages=[])
+            )
+
+        assert response.model == "gpt-4o"
+        assert response.choices[0].message.content == "This is a mock response for testing."
+        assert response.usage.prompt_tokens == 10
+        assert response["choices"][0]["message"]["content"] == (
+            "This is a mock response for testing."
+        )
+        assert response["usage"]["prompt_tokens"] == 10
+
+    def test_mock_mode_optimize_async_user_code_reads_message_content(
+        self, litellm_module
+    ):
+        from traigent.api.decorators import optimize
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        patch_litellm_for_metadata_capture()
+
+        @optimize(configuration_space={"model": ["gpt-4o"]})
+        async def litellm_user_code() -> str:
+            import litellm
+
+            response = await litellm.acompletion(model="gpt-4o", messages=[])
+            return cast(str, response.choices[0].message.content)
+
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            result = asyncio.run(litellm_user_code())
+
+        assert result == "This is a mock response for testing."
 
 
 class TestLiteLLMPlugin:

--- a/traigent/integrations/utils/mock_adapter.py
+++ b/traigent/integrations/utils/mock_adapter.py
@@ -28,7 +28,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,19 @@ class MockResponse:
     response_id: str = "mock-response-id"
 
 
+class _LiteLLMMockObject(dict[str, Any]):
+    """Dict with attribute access for LiteLLM fallback response objects."""
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        self[name] = value
+
+
 class MockAdapter:
     """Lightweight mock adapter for testing without API calls.
 
@@ -111,7 +124,7 @@ class MockAdapter:
         del provider  # signature compatibility only
         from traigent.utils.env_config import is_mock_llm
 
-        return is_mock_llm()
+        return cast(bool, is_mock_llm())
 
     @classmethod
     def _apply_mock_delay(cls, provider: str) -> None:
@@ -184,6 +197,7 @@ class MockAdapter:
             "anthropic": cls._build_anthropic_mock,
             "gemini": cls._build_gemini_mock,
             "cohere": cls._build_cohere_mock,
+            "litellm": cls._build_litellm_mock,
         }
 
         builder = builders.get(provider.lower(), cls._build_generic_mock)
@@ -275,6 +289,61 @@ class MockAdapter:
                 }
             },
         }
+
+    @classmethod
+    def _build_litellm_mock(cls, data: MockResponse) -> Any:
+        """Build LiteLLM ModelResponse-compatible mock response."""
+        payload = cls._build_litellm_payload(data)
+
+        try:
+            from litellm import ModelResponse
+        except (AttributeError, ImportError):
+            return cls._build_litellm_duck_mock(payload)
+
+        return ModelResponse(**payload)
+
+    @classmethod
+    def _build_litellm_payload(cls, data: MockResponse) -> dict[str, Any]:
+        return {
+            "id": data.response_id,
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": data.model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": data.text,
+                    },
+                    "finish_reason": data.finish_reason,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": data.prompt_tokens,
+                "completion_tokens": data.completion_tokens,
+                "total_tokens": data.total_tokens,
+            },
+        }
+
+    @classmethod
+    def _build_litellm_duck_mock(cls, payload: dict[str, Any]) -> _LiteLLMMockObject:
+        choice = payload["choices"][0]
+        message = _LiteLLMMockObject(choice["message"])
+        return _LiteLLMMockObject(
+            {
+                **payload,
+                "choices": [
+                    _LiteLLMMockObject(
+                        {
+                            **choice,
+                            "message": message,
+                        }
+                    )
+                ],
+                "usage": _LiteLLMMockObject(payload["usage"]),
+            }
+        )
 
     @classmethod
     def _build_generic_mock(cls, data: MockResponse) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #1092. In mock mode the litellm path returned a plain `{"text":...}` dict (via `_build_generic_mock`) instead of a litellm `ModelResponse` with `.choices[0].message.content`, so user code doing the normal `resp.choices[0].message.content` crashed **only** in dry-run.

Fix: added a litellm mock builder returning a ModelResponse-compatible object (`.choices[0].message.content`, `.usage.prompt_tokens/completion_tokens/total_tokens`), wired into the builder map for "litellm" so both `completion` and `acompletion` interceptor paths return the correct shape. openai/anthropic/etc unchanged.

Verified: an `@optimize` async litellm call returning `resp.choices[0].message.content` now works in mock mode (captain ran the repro → mock content returned). 48 tests (mock_adapter + litellm_interceptor); ruff/mypy clean. Gates not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)