### PR TITLE
fix(injection): stop shadowing the per-trial ConfigurationContext in parameter mode

### DIFF
--- a/tests/unit/config/test_parameter_injection_per_trial.py
+++ b/tests/unit/config/test_parameter_injection_per_trial.py
@@ -1,0 +1,112 @@
+"""Regression coverage for #1109 parameter-mode trial injection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import traigent
+from traigent.config.context import get_config
+from traigent.config.types import TraigentConfig
+from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        [
+            EvaluationExample({"text": "case-0"}, "fast"),
+            EvaluationExample({"text": "case-1"}, "fast"),
+        ],
+        name="parameter_injection_per_trial",
+    )
+
+
+def _config_value(config: TraigentConfig | dict[str, Any], key: str) -> Any:
+    if isinstance(config, TraigentConfig):
+        return config.get(key)
+    return config.get(key)
+
+
+def _recorded_variants(result: Any) -> set[str]:
+    return {trial.config.get("variant") for trial in result.trials}
+
+
+def _assert_function_saw_recorded_trials(
+    seen: list[dict[str, str]],
+    result: Any,
+) -> None:
+    recorded = _recorded_variants(result)
+    param_seen = {entry["param_variant"] for entry in seen}
+    context_seen = {entry["context_variant"] for entry in seen}
+
+    assert recorded == {"slow", "fast"}
+    assert param_seen == recorded
+    assert context_seen == recorded
+    assert all(entry["param_variant"] == entry["context_variant"] for entry in seen)
+
+
+@pytest.mark.asyncio
+async def test_parameter_mode_sync_function_uses_per_trial_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
+    seen: list[dict[str, str]] = []
+
+    @traigent.optimize(
+        eval_dataset=_dataset(),
+        objectives=["accuracy"],
+        configuration_space={"variant": ["slow", "fast"]},
+        default_config={"variant": "slow"},
+        injection_mode="parameter",
+    )
+    def answer(text: str, config: TraigentConfig) -> str:
+        context_config = get_config()
+        param_variant = str(config.get("variant"))
+        context_variant = str(_config_value(context_config, "variant"))
+        seen.append(
+            {
+                "text": text,
+                "param_variant": param_variant,
+                "context_variant": context_variant,
+            }
+        )
+        return param_variant
+
+    result = await answer.optimize(algorithm="grid", max_trials=3)
+
+    _assert_function_saw_recorded_trials(seen, result)
+
+
+@pytest.mark.asyncio
+async def test_parameter_mode_async_function_uses_per_trial_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
+    seen: list[dict[str, str]] = []
+
+    @traigent.optimize(
+        eval_dataset=_dataset(),
+        objectives=["accuracy"],
+        configuration_space={"variant": ["slow", "fast"]},
+        default_config={"variant": "slow"},
+        injection_mode="parameter",
+    )
+    async def answer(text: str, config: TraigentConfig) -> str:
+        context_config = get_config()
+        param_variant = str(config.get("variant"))
+        context_variant = str(_config_value(context_config, "variant"))
+        seen.append(
+            {
+                "text": text,
+                "param_variant": param_variant,
+                "context_variant": context_variant,
+            }
+        )
+        return param_variant
+
+    result = await answer.optimize(algorithm="grid", max_trials=3)
+
+    _assert_function_saw_recorded_trials(seen, result)

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -276,7 +276,15 @@ class ParameterBasedProvider(ConfigurationProvider):
         # Create TraigentConfig from dict if needed
         config_obj = TraigentConfig.from_dict(config)
 
-        def _effective_config() -> TraigentConfig:
+        def _active_applied_config() -> TraigentConfig | dict[str, Any] | None:
+            try:
+                return applied_config_context.get()
+            except LookupError:
+                return None
+
+        def _parameter_config(
+            active: TraigentConfig | dict[str, Any] | None,
+        ) -> TraigentConfig:
             """Prefer an APPLIED configuration over the wrap-time snapshot.
 
             During optimization the evaluator wraps every trial call in
@@ -291,10 +299,6 @@ class ParameterBasedProvider(ConfigurationProvider):
             — a bare global ``set_config()`` does not, so direct calls keep
             the wrap-time default.
             """
-            try:
-                active = applied_config_context.get()
-            except LookupError:
-                active = None
             if active is None:
                 return config_obj
             if isinstance(active, TraigentConfig):
@@ -305,10 +309,13 @@ class ParameterBasedProvider(ConfigurationProvider):
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            effective = _effective_config()
+            active = _active_applied_config()
+            effective = _parameter_config(active)
             # Only inject configuration if not already provided
             if param_name not in kwargs:
                 kwargs[param_name] = effective
+            if active is not None:
+                return func(*args, **kwargs)
             with ConfigurationContext(effective):
                 return func(*args, **kwargs)
 
@@ -317,10 +324,13 @@ class ParameterBasedProvider(ConfigurationProvider):
 
             @wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                effective = _effective_config()
+                active = _active_applied_config()
+                effective = _parameter_config(active)
                 # Only inject configuration if not already provided
                 if param_name not in kwargs:
                     kwargs[param_name] = effective
+                if active is not None:
+                    return await func(*args, **kwargs)
                 with ConfigurationContext(effective):
                     return await func(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
Closes #1109 (remaining scope — core per-trial delivery was already fixed by #1111 / a3c540d2, which is in develop).

What was left from the #1109 analysis: in parameter mode the wrapper still **unconditionally opened a nested `ConfigurationContext`**, re-wrapping (and for dict applied-contexts, type-morphing) the evaluator's own per-trial context for `get_config()` readers.

## Changes
- `traigent/config/providers.py`: when an applied trial context is active, inject the per-trial config param and call through **without** opening a nested `ConfigurationContext` — the evaluator's context (set via `ConfigurationContext.__enter__`, restored in worker threads by `ContextRestorer`) already serves `get_config()`. Direct calls with no active context keep today's wrap-time default + context push.
- New unit regression `tests/unit/config/test_parameter_injection_per_trial.py`: records function-visible values per trial and asserts BOTH the injected param and `get_config()` vary with the per-trial suggestion (sync + async). Complements #1111's integration test (per-trial delivery, direct-call default, explicit-kwarg precedence).

## Verification
- Full unit suite: 12727 passed; only pre-existing develop reds remain (strategy-preset sibling-schema test, workflow-traces env-default test, load-flaky auth-stress perf test) — all also fail on base.
- ruff / mypy / black / isort clean.

## PR checklist
1. **Worst-case prod path** — config injection only; no policy surface. Failure mode unchanged (wrap-time default on direct calls).
2. **Production-branch test** — n/a (not a policy surface).
3. **Contract regeneration** — none; no payload/DTO change. JS parity: traigent-js has no parameter-injection mode equivalent gap (context-based only).
4. **Public surface delta** — none.
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed.