### PR TITLE
fix(cloud): loopback dev override for key validation + hybrid payload fixes (sdk_version, execution_mode, per-example measures)

### DIFF
--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -99,6 +99,17 @@ def _auth_manager_with_public_backend() -> AuthManager:
     return manager
 
 
+def _clear_backend_validation_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove policy env knobs that affect loopback backend validation."""
+    for key in (
+        "ENVIRONMENT",
+        "TRAIGENT_ENV",
+        "TRAIGENT_ENVIRONMENT",
+        "TRAIGENT_ALLOW_INSECURE_BACKEND",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
 @pytest.mark.asyncio
 async def test_validate_rejects_string_false_payload():
     """A backend returning ``{"valid": "false"}`` must NOT authenticate."""
@@ -149,8 +160,7 @@ async def test_validate_posts_json_payload_to_backend():
     assert _FakeSession.last_post_kwargs is not None
     assert _FakeSession.last_post_kwargs["json"] == {"api_key": api_key}
     assert (
-        _FakeSession.last_post_kwargs["headers"]["Content-Type"]
-        == "application/json"
+        _FakeSession.last_post_kwargs["headers"]["Content-Type"] == "application/json"
     )
 
 
@@ -223,6 +233,94 @@ async def test_validate_rejects_plaintext_backend_validation_url():
     post.assert_not_called()
 
 
+def test_backend_validation_url_default_denies_http_localhost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loopback HTTP remains denied by default."""
+    _clear_backend_validation_env(monkeypatch)
+
+    reason = AuthManager._validate_backend_validation_url(
+        "http://localhost:8006/api/v1/keys/validate"
+    )
+
+    assert reason is not None
+    assert "ENVIRONMENT=development" in reason
+    assert "TRAIGENT_ALLOW_INSECURE_BACKEND=true" in reason
+
+
+def test_backend_validation_url_override_without_environment_still_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Policy surface fails closed when the insecure override is set outside explicit dev."""
+    _clear_backend_validation_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_ALLOW_INSECURE_BACKEND", "true")
+
+    reason = AuthManager._validate_backend_validation_url(
+        "http://localhost:8006/api/v1/keys/validate"
+    )
+
+    assert reason is not None
+    assert "TRAIGENT_ALLOW_INSECURE_BACKEND=true" in reason
+
+
+def test_backend_validation_url_dev_override_allows_loopback_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit non-production plus override allows only loopback HTTP."""
+    _clear_backend_validation_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_ALLOW_INSECURE_BACKEND", "true")
+
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://localhost:8006/api/v1/keys/validate"
+        )
+        is None
+    )
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://127.42.0.1:8006/api/v1/keys/validate"
+        )
+        is None
+    )
+
+
+def test_backend_validation_url_dev_override_does_not_allow_non_loopback_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The insecure dev override does not widen private-range or public HTTP URLs."""
+    _clear_backend_validation_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_ALLOW_INSECURE_BACKEND", "true")
+
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://192.168.1.10:8006/api/v1/keys/validate"
+        )
+        == "backend validation URL host is not allowed"
+    )
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://example.com/api/v1/keys/validate"
+        )
+        == "backend validation URL must use HTTPS"
+    )
+
+
+def test_backend_validation_url_https_global_hosts_unaffected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HTTPS global hosts remain valid without the loopback override."""
+    _clear_backend_validation_env(monkeypatch)
+
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "https://example.com/api/v1/keys/validate"
+        )
+        is None
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "backend_url",
@@ -244,5 +342,9 @@ async def test_validate_rejects_non_global_backend_validation_hosts(backend_url)
     ):
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
 
-    assert reason == "backend validation URL host is not allowed"
+    if "127.0.0.1" in backend_url or "localhost" in backend_url:
+        assert reason is not None
+        assert "TRAIGENT_ALLOW_INSECURE_BACKEND=true" in reason
+    else:
+        assert reason == "backend validation URL host is not allowed"
     post.assert_not_called()

--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -1153,3 +1153,32 @@ class TestExampleMeasure:
 
         assert "ExampleMeasure" in repr_str
         assert "ex_repr_test" in repr_str
+
+
+class TestLocalDtoHelpers:
+    """Regression tests for local DTO helper metadata."""
+
+    def test_local_experiment_metadata_uses_mode_not_execution_mode(self):
+        """Local experiment helper should not emit raw SDK execution_mode metadata."""
+        experiment = cloud_dtos.create_local_experiment(
+            experiment_id="exp-local",
+            name="Local Experiment",
+            description="Local helper payload",
+            configuration_space={"temperature": [0.1, 0.2]},
+        )
+
+        assert experiment.metadata["mode"] == "local"
+        assert "execution_mode" not in experiment.metadata
+
+    def test_local_experiment_run_metadata_uses_mode_not_execution_mode(self):
+        """Local run helper should not emit raw SDK execution_mode metadata."""
+        run = cloud_dtos.create_local_experiment_run(
+            run_id="run-local",
+            experiment_id="exp-local",
+            function_name="optimize_me",
+            configuration_space={"temperature": [0.1, 0.2]},
+            objectives=["accuracy"],
+        )
+
+        assert run.metadata["mode"] == "local"
+        assert "execution_mode" not in run.metadata

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -132,6 +132,32 @@ class TestBackendDescription:
 class TestMeasuresDictValidationInSubmission:
     """Test MeasuresDict validation warning path in submit_trial_result_via_session."""
 
+    def test_trial_result_metadata_uses_sdk_version_and_drops_execution_mode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Trial result metadata uses SDK version and does not emit raw execution_mode."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "9.8.6")
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.auth_manager = Mock()
+        ops = TrialOperations(mock_client)
+
+        result_data = ops._build_trial_result_data(
+            trial_id="trial_001",
+            config={"temperature": 0.2},
+            clean_metrics={"accuracy": 0.95},
+            backend_status="COMPLETED",
+            mode="local",
+            metadata={"execution_mode": "edge_analytics", "custom": "value"},
+        )
+
+        metadata = result_data["metadata"]
+        assert metadata["mode"] == "local"
+        assert metadata["sdk_version"] == "9.8.6"
+        assert metadata["custom"] == "value"
+        assert "execution_mode" not in metadata
+
     @pytest.mark.asyncio
     async def test_hybrid_trial_submission_uses_session_results_endpoint(self) -> None:
         """Hybrid/backend tracking posts trial metrics to the session results API."""
@@ -390,6 +416,66 @@ class TestMeasuresDictValidationInSubmission:
             call_args = ops._handle_trial_success_response.call_args
             assert call_args is not None
             assert call_args.args[5] == {"accuracy": 0.95}
+
+    @pytest.mark.asyncio
+    async def test_summary_stats_metadata_uses_sdk_version_without_execution_mode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Summary stats submission metadata uses package version and omits execution_mode."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "8.7.6")
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://api.example.com"
+        mock_client.backend_config.api_base_url = "https://api.example.com"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="completed")
+
+        ops = TrialOperations(mock_client)
+
+        mock_response = Mock()
+        mock_response.status = 201
+
+        mock_post_ctx = AsyncMock()
+        mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_post_ctx)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+
+            result = await ops.submit_summary_stats(
+                session_id="test-session",
+                trial_id="test-trial",
+                config={"model": "gpt-4"},
+                summary_stats={"metrics": {"accuracy": 0.95}},
+                status="completed",
+            )
+
+        assert result is True
+        payload = mock_session.post.call_args.kwargs["json"]
+        metadata = payload["metadata"]
+        assert metadata["mode"] == "privacy"
+        assert metadata["sdk_version"] == "8.7.6"
+        assert "execution_mode" not in metadata
 
 
 class TestSummaryStatsValidation:

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -806,6 +806,52 @@ class TestStatisticalSignificanceWiring:
         assert "statistical_significance" in inner_metadata
         assert inner_metadata["statistical_significance"] == sig_data
 
+    def test_aggregation_summary_uses_sdk_version_resolver(
+        self,
+        mock_backend_client,
+        mock_optimizer,
+        objective_schema,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Session aggregation summary metadata uses the SDK version resolver."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "7.6.5")
+        config = TraigentConfig()
+        config.execution_mode = "hybrid"
+
+        manager = BackendSessionManager(
+            backend_client=mock_backend_client,
+            traigent_config=config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-version-wiring",
+            optimization_status=OptimizationStatus.COMPLETED,
+        )
+
+        result = Mock(spec=OptimizationResult)
+        result.trials = []
+        result.best_config = {"model": "gpt-4o"}
+        result.best_score = 0.95
+        result.duration = 10.0
+        result.success_rate = 1.0
+        result.metrics = {"accuracy": 0.95}
+        result.metadata = {
+            "session_summary": {
+                "metrics": {"accuracy": 0.95},
+                "samples_per_config": {"gpt-4o": 5},
+            },
+        }
+
+        manager.submit_session_aggregation(result, "test-session-id")
+
+        call_kwargs = mock_backend_client.submit_result.call_args
+        payload_metadata = call_kwargs.kwargs.get(
+            "metadata", call_kwargs[1].get("metadata", {})
+        )
+        summary_stats = payload_metadata.get("summary_stats", {})
+        inner_metadata = summary_stats.get("metadata", {})
+        assert inner_metadata["sdk_version"] == "7.6.5"
+
     def test_strategy_preset_metadata_included_in_aggregation_payload(
         self, mock_backend_client, mock_optimizer, objective_schema
     ):

--- a/tests/unit/core/test_metadata_helpers.py
+++ b/tests/unit/core/test_metadata_helpers.py
@@ -6,16 +6,19 @@ for trial and session results.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, TrialResult
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.core.metadata_helpers import (
     _build_measures_full,
     _build_measures_privacy,
+    _validate_measure_dict,
     build_backend_metadata,
     merge_run_metrics_into_session_summary,
 )
@@ -163,7 +166,7 @@ class TestBuildBackendMetadataBasic:
 
         assert "duration" in metadata
         assert "trial_id" in metadata
-        assert "execution_mode" in metadata
+        assert "execution_mode" not in metadata
         assert metadata["trial_id"] == "trial_123"
         assert metadata["duration"] == 1.5
 
@@ -236,8 +239,23 @@ class TestBuildBackendMetadataSummaryStats:
 
         summary_stats = metadata["summary_stats"]
         assert "metadata" in summary_stats
-        assert summary_stats["metadata"]["sdk_version"] == "2.0.0"
+        assert summary_stats["metadata"]["sdk_version"] == get_version()
         assert summary_stats["metadata"]["aggregation_level"] == "trial"
+
+    def test_summary_stats_sdk_version_uses_package_version(
+        self,
+        mock_trial_result,
+        mock_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """summary_stats metadata uses the SDK version resolver, not a constant."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "9.8.7")
+        mock_trial_result.summary_stats = {"mean": 0.85}
+        mock_config.execution_mode = "edge_analytics"
+
+        metadata = build_backend_metadata(mock_trial_result, "accuracy", mock_config)
+
+        assert metadata["summary_stats"]["metadata"]["sdk_version"] == "9.8.7"
 
     def test_summary_stats_with_existing_metadata(self, mock_trial_result, mock_config):
         """Test summary_stats with existing metadata field."""
@@ -389,6 +407,112 @@ class TestBuildMeasuresFull:
         assert metrics["latency"] == 0.5
         # String values are excluded per MeasuresDict constraints
         assert "model" not in metrics
+
+    def test_per_example_numeric_metrics_flow_through(self, example_result):
+        """Numeric per-example evaluation results populate measure metrics."""
+        example_result.metrics = {
+            "accuracy": 0.91,
+            "latency_ms": 123.4,
+            "raw_output": "private text",
+        }
+
+        measures = _build_measures_full([example_result], "accuracy")
+
+        assert measures[0]["metrics"]["accuracy"] == 0.91
+        assert measures[0]["metrics"]["latency_ms"] == 123.4
+        assert "raw_output" not in measures[0]["metrics"]
+
+    def test_dict_payload_example_results_populate_measures(self):
+        """Redacted to_dict() example payloads (the real trial-metadata form)
+        must populate per-example metrics, not silently read as empty."""
+        payload = {
+            "example_id": "ex0",
+            "input_data": {"text": "hello"},
+            "expected_output": "hi",
+            "actual_output": "hi",
+            "metrics": {"accuracy": 1.0, "total_tokens": 15, "total_cost": 0.0015},
+            "execution_time": 0.01,
+            "success": True,
+            "error_message": None,
+            "metadata": {},
+        }
+
+        full = _build_measures_full([payload], "accuracy")
+        assert len(full) == 1
+        assert full[0]["metrics"]["accuracy"] == 1.0
+        assert full[0]["metrics"]["score"] == 1.0
+        assert full[0]["metrics"]["response_time_ms"] == 10.0
+
+        sanitized = _build_measures_privacy([payload], "accuracy")
+        assert len(sanitized) == 1
+        assert sanitized[0]["metrics"]["score"] == 1.0
+        assert sanitized[0]["metrics"]["total_tokens"] == 15
+        assert "input_data" not in sanitized[0]
+        assert "actual_output" not in json.dumps(sanitized)
+
+    def test_empty_metric_measure_entries_are_omitted(self):
+        """Examples with no numeric metrics do not produce empty measure stubs."""
+        empty_example = Mock()
+        empty_example.metrics = {"raw_output": "private text"}
+        empty_example.execution_time = None
+        empty_example.expected_output = None
+        empty_example.actual_output = None
+        populated_example = Mock()
+        populated_example.metrics = {"accuracy": 0.7}
+        populated_example.execution_time = None
+        populated_example.expected_output = None
+        populated_example.actual_output = None
+
+        measures = _build_measures_full(
+            [empty_example, populated_example],
+            "accuracy",
+        )
+
+        assert len(measures) == 1
+        assert measures[0]["metrics"] == {"accuracy": 0.7, "score": 0.7}
+        assert all(measure["metrics"] for measure in measures)
+
+    def test_validate_measure_dict_rejects_empty_metrics(self):
+        """Validation rejects hand-built measure stubs with an empty metrics dict."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_measure_dict({"example_id": "ex_empty", "metrics": {}}, 0)
+
+    def test_measures_payload_drops_list_when_all_entries_empty(
+        self,
+        mock_trial_result,
+        mock_config,
+    ):
+        """Outgoing metadata omits measures entirely if every entry is empty."""
+        empty_example = Mock()
+        empty_example.metrics = {"raw_output": "private text"}
+        empty_example.execution_time = None
+        empty_example.expected_output = None
+        empty_example.actual_output = None
+        mock_trial_result.metadata = {"example_results": [empty_example]}
+
+        metadata = build_backend_metadata(mock_trial_result, "accuracy", mock_config)
+
+        assert "measures" not in metadata
+
+    def test_measure_payload_privacy_canary_excludes_text_fields(self):
+        """Expected/actual/output sentinel text must never appear in measures."""
+        sentinel = "SDK_PRIVACY_SENTINEL_DO_NOT_EMIT"
+        example = Mock()
+        example.metrics = {
+            "accuracy": 0.88,
+            "raw_output": sentinel,
+            "model_output": sentinel,
+        }
+        example.execution_time = None
+        example.expected_output = sentinel
+        example.actual_output = sentinel
+        example.output = sentinel
+        example.raw_text = sentinel
+
+        measures = _build_measures_full([example], "accuracy")
+
+        assert measures[0]["metrics"]["accuracy"] == 0.88
+        assert sentinel not in json.dumps(measures)
 
     def test_include_execution_time(self, example_result):
         """Test execution_time is exported in explicit and legacy timing keys."""

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -19,6 +19,7 @@ import logging
 import os
 import time
 import uuid
+import warnings
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -32,6 +33,7 @@ from traigent.cloud.credential_resolver import CredentialResolver
 from traigent.cloud.password_auth_handler import PasswordAuthHandler
 from traigent.cloud.token_manager import TokenManager
 from traigent.cloud.url_security import validate_cloud_base_url_async
+from traigent.utils.env_config import is_truthy, treat_as_production
 from traigent.utils.exceptions import AuthenticationError as TraigentAuthenticationError
 from traigent.utils.url_security import UnsafeUrlError
 
@@ -42,6 +44,33 @@ TOKEN_REFRESH_THRESHOLD = 300  # Refresh 5 minutes before expiry
 MAX_TOKEN_AGE = 86400  # Maximum token age in seconds (24 hours)
 MIN_TOKEN_LENGTH = 20  # Minimum acceptable token length
 API_KEY_TOKEN_TTL = 31536000  # 365 days
+_LOOPBACK_BACKEND_DEV_HINT = (
+    "backend validation URL host is not allowed for loopback HTTP. "
+    "For local backend development, set ENVIRONMENT=development and "
+    "TRAIGENT_ALLOW_INSECURE_BACKEND=true."
+)
+
+
+def _is_loopback_backend_host(normalized_host: str) -> bool:
+    """Return True for localhost names and loopback IP literals only."""
+    host_for_match = normalized_host.rstrip(".")
+    if host_for_match == "localhost" or host_for_match.endswith(".localhost"):
+        return True
+    try:
+        host_ip = ipaddress.ip_address(host_for_match)
+    except ValueError:
+        return False
+    return host_ip.is_loopback
+
+
+def _allow_insecure_loopback_backend_validation() -> bool:
+    """Permit loopback backend validation only for explicit non-prod dev opt-in."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        non_production = not treat_as_production()
+    return non_production and is_truthy(
+        os.environ.get("TRAIGENT_ALLOW_INSECURE_BACKEND")
+    )
 
 
 class _AsyncBool:
@@ -1499,10 +1528,10 @@ class AuthManager:
         if not hostname:
             return "backend validation URL is invalid"
         normalized_host = hostname.strip("[]").lower()
-        if normalized_host in {"localhost", "localhost."} or normalized_host.endswith(
-            ".localhost"
-        ):
-            return "backend validation URL host is not allowed"
+        if _is_loopback_backend_host(normalized_host):
+            if _allow_insecure_loopback_backend_validation():
+                return None
+            return _LOOPBACK_BACKEND_DEV_HINT
         try:
             host_ip = ipaddress.ip_address(normalized_host)
         except ValueError:

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -924,7 +924,7 @@ def create_local_experiment(
             "configuration_space": configuration_space,
         },
         metadata={
-            "execution_mode": "edge_analytics",
+            "mode": "local",
             "privacy_mode": True,
             "dataset_size": dataset_size,
             "created_with": "traigent-local",
@@ -961,7 +961,7 @@ def create_local_experiment_run(
             },
             "metadata": {"dataset_size": dataset_size, "privacy_mode": True},
         },
-        metadata={"execution_mode": "edge_analytics", "privacy_mode": True},
+        metadata={"mode": "local", "privacy_mode": True},
         status="not_started",  # Set correct status for backend compatibility
     )
 

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -13,6 +13,7 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.cloud.dtos import MeasuresDict
 from traigent.cloud.validators import validate_configuration_run_submission
 from traigent.config.backend_config import BackendConfig
@@ -393,8 +394,9 @@ class TrialOperations:
     ) -> dict[str, Any]:
         """Build the trial result data dict."""
         result_metadata = dict(metadata or {})
+        result_metadata.pop("execution_mode", None)
         result_metadata["mode"] = mode
-        result_metadata["sdk_version"] = "2.0.0"
+        result_metadata["sdk_version"] = get_version()
         result_data: dict[str, Any] = {
             "trial_id": trial_id,
             "config": config,
@@ -710,13 +712,11 @@ class TrialOperations:
 
             # Prepare metadata - REQUIRED by backend to avoid NoneType errors
             submission_metadata = {
-                "mode": "privacy",  # Explicitly set mode for summary stats
-                "sdk_version": "2.0.0",
-                "aggregation_method": "pandas.describe",
-                "execution_mode": "privacy",  # Use "privacy" not "edge_analytics"
-                "total_examples": summary_stats.get("total_examples", 0),
-                # Include summary_stats metadata
                 **summary_stats.get("metadata", {}),
+                "mode": "privacy",  # Explicitly set mode for summary stats
+                "sdk_version": get_version(),
+                "aggregation_method": "pandas.describe",
+                "total_examples": summary_stats.get("total_examples", 0),
             }
 
             # IMPORTANT: Backend always expects metrics field

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -9,6 +9,7 @@ import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.api.types import (
     AgentConfiguration,
     OptimizationResult,
@@ -923,7 +924,7 @@ class BackendSessionManager:
                 "aggregation_level": "session",
                 "aggregation_summary": session_summary,
                 "trial_id": aggregated_trial_id,
-                "sdk_version": "2.0.0",
+                "sdk_version": get_version(),
             },
         }
 

--- a/traigent/core/metadata_helpers.py
+++ b/traigent/core/metadata_helpers.py
@@ -3,8 +3,10 @@
 # Traceability: CONC-Layer-Core CONC-Quality-Maintainability FUNC-ORCH-LIFECYCLE REQ-ORCH-003 SYNC-OptimizationFlow
 
 import json
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, TrialResult
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.utils.example_id import compute_dataset_hash, generate_stable_example_id
@@ -35,6 +37,8 @@ def _validate_metrics_field(measure: dict[str, Any], example_index: int) -> dict
             f"Example {example_index}: 'metrics' must be dict, "
             f"got {type(measure['metrics']).__name__}"
         )
+    if not measure["metrics"]:
+        raise ValueError(f"Example {example_index}: 'metrics' must not be empty")
     return measure["metrics"]
 
 
@@ -158,7 +162,7 @@ def _add_summary_stats(
     if "metadata" not in enhanced_summary_stats:
         enhanced_summary_stats["metadata"] = {}
     enhanced_summary_stats["metadata"]["aggregation_level"] = "trial"
-    enhanced_summary_stats["metadata"]["sdk_version"] = "2.0.0"
+    enhanced_summary_stats["metadata"]["sdk_version"] = get_version()
     trial_metadata["summary_stats"] = enhanced_summary_stats
     logger.debug(
         "Adding summary_stats for %s mode with aggregation_level=trial",
@@ -190,22 +194,28 @@ def _add_measures_to_metadata(
         measures = _build_measures_full(
             example_results, primary_objective, dataset_name
         )
-        trial_metadata["measures"] = measures
-        logger.debug(
-            "Collected %s per-example MeasureResults for %s mode",
-            len(measures),
-            execution_mode,
-        )
-        _log_measures_debug(measures)
+        if measures:
+            trial_metadata["measures"] = measures
+            logger.debug(
+                "Collected %s per-example MeasureResults for %s mode",
+                len(measures),
+                execution_mode,
+            )
+            _log_measures_debug(measures)
+        else:
+            trial_metadata.pop("measures", None)
     elif privacy_on:
         measures = _build_measures_privacy(
             example_results, primary_objective, dataset_name
         )
-        trial_metadata["measures"] = measures
-        logger.debug(
-            "Using sanitized MeasureResults for privacy mode: %s examples",
-            len(measures),
-        )
+        if measures:
+            trial_metadata["measures"] = measures
+            logger.debug(
+                "Using sanitized MeasureResults for privacy mode: %s examples",
+                len(measures),
+            )
+        else:
+            trial_metadata.pop("measures", None)
     else:
         trial_metadata.pop("measures", None)
 
@@ -295,7 +305,10 @@ def _add_tvar_observation(
             config_space_id=source_metadata.get("config_space_id"),
             effectuation_events=source_metadata.get("effectuation_events"),
         )
-        return merge_tvar_observation_metadata(trial_metadata, observation)
+        return cast(
+            dict[str, Any],
+            merge_tvar_observation_metadata(trial_metadata, observation),
+        )
     except Exception as exc:
         logger.debug(
             "Skipping TVAR observation metadata for trial %s: %s",
@@ -339,7 +352,6 @@ def build_backend_metadata(
     trial_metadata: dict[str, Any] = {
         "duration": trial_result.duration,
         "trial_id": trial_result.trial_id,
-        "execution_mode": traigent_config.execution_mode,
     }
 
     if not traigent_config.minimal_logging:
@@ -400,10 +412,22 @@ def _extract_score_from_metrics(
     return None
 
 
+def _example_field(example_result: Any, name: str, default: Any = None) -> Any:
+    """Read a field from an example result object OR its dict payload form.
+
+    Trial metadata stores example results as redacted ``to_dict()`` payloads
+    (see ``trial_result_factory._to_redactable_payloads``), so the measure
+    builders must read plain dicts as well as ``ExampleResult`` objects.
+    """
+    if isinstance(example_result, Mapping):
+        return example_result.get(name, default)
+    return getattr(example_result, name, default)
+
+
 def _calculate_fallback_score(example_result: Any) -> float | None:
     """Calculate fallback score from expected vs actual output."""
-    expected = getattr(example_result, "expected_output", None)
-    actual = getattr(example_result, "actual_output", None)
+    expected = _example_field(example_result, "expected_output")
+    actual = _example_field(example_result, "actual_output")
     if expected is not None and actual is not None:
         return 1.0 if actual == expected else 0.0
     return None
@@ -418,7 +442,7 @@ def _add_execution_time_metrics(
     canonical optimization payload key is `response_time_ms`, but the legacy
     `response_time` key remains for one compatibility window.
     """
-    execution_time = getattr(example_result, "execution_time", None)
+    execution_time = _example_field(example_result, "execution_time")
     if execution_time is None or not isinstance(execution_time, (int, float)):
         return
 
@@ -427,22 +451,29 @@ def _add_execution_time_metrics(
     metrics_dict["response_time"] = response_time_seconds
 
 
+def _is_measure_metric_value(value: Any) -> bool:
+    """Return True for MeasuresDict metric values accepted by the SDK."""
+    return value is None or (
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+    )
+
+
 def _build_single_measure_full(
     example_result: Any,
     idx: int,
     dataset_hash: str,
     primary_objective: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a single full measure for non-privacy mode."""
     example_id = generate_stable_example_id(dataset_hash, idx)
     metrics_dict: dict[str, Any] = {}
-    eval_metrics = getattr(example_result, "metrics", {}) or {}
+    eval_metrics = _example_field(example_result, "metrics") or {}
 
     if eval_metrics:
         logger.debug("Example %s metrics: %s", idx, eval_metrics)
         # Add all scalar metrics (numeric only per MeasuresDict constraints)
         for metric_key, metric_value in eval_metrics.items():
-            if isinstance(metric_value, (int, float)) or metric_value is None:
+            if _is_measure_metric_value(metric_value):
                 metrics_dict[metric_key] = metric_value
 
     # Extract or calculate score
@@ -453,6 +484,10 @@ def _build_single_measure_full(
         metrics_dict["score"] = float(example_score)
 
     _add_execution_time_metrics(metrics_dict, example_result)
+
+    if not metrics_dict:
+        logger.debug("Skipping measure %s because it has no numeric metrics", idx)
+        return None
 
     measure_result = {"example_id": example_id, "metrics": metrics_dict}
     _validate_measure_dict(measure_result, idx)
@@ -485,10 +520,14 @@ def _build_measures_full(
         ValueError: If measures violate MeasuresDict constraints
     """
     dataset_hash = compute_dataset_hash(dataset_name)
-    return [
-        _build_single_measure_full(example_result, idx, dataset_hash, primary_objective)
-        for idx, example_result in enumerate(example_results)
-    ]
+    measures: list[dict[str, Any]] = []
+    for idx, example_result in enumerate(example_results):
+        measure = _build_single_measure_full(
+            example_result, idx, dataset_hash, primary_objective
+        )
+        if measure is not None:
+            measures.append(measure)
+    return measures
 
 
 _PRIVACY_TOKEN_KEYS = ("input_tokens", "output_tokens", "total_tokens")
@@ -500,10 +539,14 @@ def _add_privacy_safe_metrics(
 ) -> None:
     """Add token and cost metrics which are privacy-safe."""
     for token_key in _PRIVACY_TOKEN_KEYS:
-        if token_key in eval_metrics:
+        if token_key in eval_metrics and _is_measure_metric_value(
+            eval_metrics[token_key]
+        ):
             metrics_dict[token_key] = eval_metrics[token_key]
     for cost_key in _PRIVACY_COST_KEYS:
-        if cost_key in eval_metrics:
+        if cost_key in eval_metrics and _is_measure_metric_value(
+            eval_metrics[cost_key]
+        ):
             metrics_dict[cost_key] = eval_metrics[cost_key]
 
 
@@ -512,11 +555,11 @@ def _build_single_measure_privacy(
     idx: int,
     dataset_hash: str,
     primary_objective: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a single sanitized measure for privacy mode."""
     example_id = generate_stable_example_id(dataset_hash, idx)
     metrics_dict: dict[str, Any] = {}
-    eval_metrics = getattr(example_result, "metrics", {}) or {}
+    eval_metrics = _example_field(example_result, "metrics") or {}
 
     # Extract or calculate score
     example_score = _extract_score_from_metrics(eval_metrics, primary_objective)
@@ -530,6 +573,12 @@ def _build_single_measure_privacy(
     # Add privacy-safe token and cost metrics
     if eval_metrics:
         _add_privacy_safe_metrics(metrics_dict, eval_metrics)
+
+    if not metrics_dict:
+        logger.debug(
+            "Skipping sanitized measure %s because it has no numeric metrics", idx
+        )
+        return None
 
     measure_result = {"example_id": example_id, "metrics": metrics_dict}
     _validate_measure_dict(measure_result, idx)
@@ -564,9 +613,11 @@ def _build_measures_privacy(
         ValueError: If measures violate MeasuresDict constraints
     """
     dataset_hash = compute_dataset_hash(dataset_name)
-    return [
-        _build_single_measure_privacy(
+    measures: list[dict[str, Any]] = []
+    for idx, example_result in enumerate(example_results):
+        measure = _build_single_measure_privacy(
             example_result, idx, dataset_hash, primary_objective
         )
-        for idx, example_result in enumerate(example_results)
-    ]
+        if measure is not None:
+            measures.append(measure)
+    return measures


### PR DESCRIPTION
## Summary
Closes #1083. Closes #1086 (SDK-side remaining scope; the backend 400-rejecter half landed via TraigentBackend#798 / #793).

### #1083 — env-gated dev override for loopback backend key validation (policy surface)
`_validate_backend_validation_url` unconditionally rejected loopback, so hybrid optimize against `http://localhost:8006` (the documented dev flow) could never validate a key. Loopback HTTP now passes ONLY when **both** `not treat_as_production()` (centralized helper, fail-CLOSED on unset env) **and** `TRAIGENT_ALLOW_INSECURE_BACKEND=true`. Override is loopback-only (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`); private/global hosts + HTTPS requirements unchanged; default still denies with an actionable dev-recipe hint.

### #1086 — hybrid payload fixes
- `sdk_version` hardcoded `"2.0.0"` at **four** sites (the 3 from the issue + a 4th found in `backend_session_manager`) → all read the real version via `traigent._version.get_version()`.
- Raw `metadata.execution_mode` no longer emitted (consumers read normalized `metadata.mode`; verified by grep — `integration_manager.py` reads `mode`).
- **Per-example measures root cause went deeper than the issue**: trial metadata stores example results as redacted `to_dict()` dict payloads, but builders read them with `getattr()` only → every entry shipped `{"metrics": {}}`. Builders now read dicts AND objects, populate real numeric per-example metrics (bools excluded), skip no-data entries, omit empty lists, and `_validate_measure_dict` rejects empty metrics. Privacy path keeps score/tokens/cost only.

## Verification
- New tests: 5 loopback policy tests incl. **production-branch deny** (`tests/unit/cloud/test_api_key_strict_bool.py:251` — override set, env unset → denied); sdk_version at all 4 sites (`TRAIGENT_FORCE_VERSION` override); execution_mode stripped; dict-payload measures regression (`tests/unit/core/test_metadata_helpers.py::test_dict_payload_example_results_populate_measures`); privacy canary (sentinel in expected/actual/output never serializes into measures).
- Full unit suite: 12741 passed; remaining fails are pre-existing on base (strategy-preset sibling-schema, workflow-traces env-default) or load flakes (auth-stress perf, hypothesis deadline) — all reproduce on unmodified develop.
- ruff / mypy (433 files) / black / isort clean.

## PR checklist
1. **Worst-case prod path** — auth pre-validation: in production (or unset env) the override is inert; loopback still denied. Fail-closed proven by test.
2. **Production-branch test** — `tests/unit/cloud/test_api_key_strict_bool.py:251-263` (override without explicit dev env → denies).
3. **Contract regeneration** — no schema shape change (fields removed/corrected, none added). **JS parity flag:** traigent-js should be checked for the same hardcoded `sdk_version` and raw `execution_mode` emission — follow-up noted in #1086 closure.
4. **Public surface delta** — none (env var `TRAIGENT_ALLOW_INSECURE_BACKEND` is new, documented in the deny hint).
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed.