### PR TITLE
docs(security): credential & data trust model (#1094)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,7 +167,7 @@
         "filename": "docs/features/authentication.md",
         "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
         "is_verified": false,
-        "line_number": 387
+        "line_number": 399
       }
     ],
     "docs/installation-guide-offline.md": [
@@ -1231,5 +1231,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T20:38:13Z"
+  "generated_at": "2026-06-05T22:36:58Z"
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,35 @@ Traigent SDK implements:
 - No hardcoded credentials (environment variables only)
 - Secure defaults for all execution modes
 
+## Credential & data trust model
+
+Traigent separates Traigent backend credentials from model-provider
+credentials.
+
+- A Traigent API key authenticates SDK and CLI calls to the Traigent
+  portal/backend. It is resolved from `TRAIGENT_API_KEY` or CLI-managed
+  credentials and is attached to Traigent backend requests as Traigent auth
+  material.
+- Model-provider credentials are customer credentials. Examples include
+  `OPENAI_API_KEY`, Anthropic/Cohere/Mistral keys, Azure OpenAI credentials,
+  and AWS credentials for Bedrock. The supported local and hybrid execution
+  paths execute model calls from the customer's process, so provider SDKs use
+  the customer's local provider configuration.
+- Traigent does not provide or use a shared Traigent-owned model-provider key
+  for customer model calls.
+- Provider credentials are not part of Traigent backend session, trial, or
+  trace payloads. Backend and trace clients use Traigent API credentials for
+  Traigent endpoints. See the [telemetry and content logging controls](docs/api-reference/telemetry.md)
+  for the metrics, metadata, and optional content logs the SDK can collect.
+- The optional Bedrock helper imports `boto3` only when Bedrock is used and
+  creates a local `bedrock-runtime` client through the AWS SDK credential
+  chain. `AWS_BEARER_TOKEN_BEDROCK`, when used by local AWS credential
+  tooling, is also a customer/provider credential and follows the same
+  boundary.
+
+Current local and hybrid modes run trials locally. The `cloud` remote
+execution mode is reserved for future use and fails closed in this SDK.
+
 ## Best Practices
 
 When using Traigent:

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -159,6 +159,18 @@ Credentials saved by `traigent auth login` and `traigent auth configure` are wri
 - `TRAIGENT_API_KEY`
 - Useful for CI/CD environments
 
+## Backend vs provider credentials
+
+This guide covers Traigent backend authentication: the API key that lets the
+SDK and CLI talk to the Traigent portal/backend. Model-provider credentials
+such as `OPENAI_API_KEY` or AWS credentials for Bedrock are separate customer
+credentials resolved by the provider SDKs on the local machine. They are not
+Traigent API keys and are not sent to Traigent backend endpoints.
+
+For the full boundary, including Bedrock and telemetry/content logging, see
+the [Credential & data trust model](../../SECURITY.md#credential--data-trust-model)
+and the [telemetry documentation](../api-reference/telemetry.md).
+
 ## Priority Order
 
 The SDK checks for credentials in this order:

--- a/docs/guides/secrets_management.md
+++ b/docs/guides/secrets_management.md
@@ -148,7 +148,9 @@ PY
 
 ## Best Practices & Notes
 
-- **SDK remains clean**: No boto3/aws-cli imports inside `traigent`.
+- **SDK remains dependency-light**: Core optimization and backend paths do not
+  import AWS SDKs. The optional Bedrock integration imports `boto3`/`aioboto3`
+  lazily only when that integration is used.
 - **Principle of least privilege**: Use IAM policies that grant read
   access to the secret for CI and read/write for a small ops group.
 - **Auditing**: Secrets Manager tracks versions and rotation history.

--- a/docs/operations/bedrock.md
+++ b/docs/operations/bedrock.md
@@ -29,6 +29,21 @@ export AWS_PROFILE=traigent-bedrock
 # export BEDROCK_MOCK=true
 ```
 
+## Credential Boundary
+
+Bedrock credentials are AWS/customer credentials. The SDK's optional Bedrock
+client creates a local `boto3`/`aioboto3` Bedrock Runtime client and relies on
+the AWS SDK credential chain on the machine where the optimization runs. The
+SDK does not use a Traigent API key as an AWS credential and does not send AWS
+credentials to the Traigent backend.
+
+If you use `AWS_BEARER_TOKEN_BEDROCK`, treat it as a short-lived AWS/provider
+credential with the same boundary. It belongs in your local AWS credential
+environment or tooling, not in Traigent backend configuration.
+
+For the broader credential and telemetry boundary, see the
+[Credential & data trust model](../../SECURITY.md#credential--data-trust-model).
+
 ## Dependency Installation
 Ensure you installed integration dependencies:
 ```bash

--- a/examples/tvl/hello_tvl/hello_tvl.tvl.yml
+++ b/examples/tvl/hello_tvl/hello_tvl.tvl.yml
@@ -7,7 +7,7 @@ tvl_version: "0.0.1"
 
 metadata:
   owner: "team@example.com"
-  # Legacy operational promotion hints (pre-0.9 'promotion:' block); the
+  # Legacy operational promotion hints preserved under metadata; the
   # statistical gate lives in promotion_policy.
   legacy_promotion:
     gate: manual_review


### PR DESCRIPTION
## Summary
Closes #1094. (#1107 is closed separately — its corpus was already fixed on develop by #1110 / `826c048a`; this PR only refreshes one stale YAML comment and re-verifies the strict validator passes 16/16.)

Adds the canonical **Credential & data trust model** to `SECURITY.md`, cross-linked from `docs/features/authentication.md` and `docs/operations/bedrock.md`:
- Two distinct credentials: Traigent API key (backend auth) vs model-provider credentials (customer-owned, resolved client-side).
- No shared Traigent-owned provider key; model calls run from the customer's process in supported local/hybrid modes; `cloud` remote mode is reserved and fails closed.
- Provider credentials are not part of backend session/trial/trace payloads (links telemetry/content-logging controls for what IS sent).
- Bedrock: lazy optional `boto3`/`aioboto3`, local `bedrock-runtime` client, AWS credential chain; `AWS_BEARER_TOKEN_BEDROCK` same boundary.
- Fixes an outdated absolute claim in `secrets_management.md` ('no boto3 imports' → 'core paths import no AWS SDK; optional Bedrock integration imports lazily').

## Verification (claims vs code, worker-verified + captain spot-checked)
- `X-API-Key` header construction `traigent/cloud/auth.py:812-826`; `/keys/validate` posts only `{api_key}` to the Traigent backend `auth.py:1386-1450`; trace ingest auth `workflow_traces.py:752-818`.
- `bedrock_client.py:29-38` lazy `_require_boto3()`; `:101-112` local client via AWS chain; request payloads carry model/messages, no credentials (`:141-156`).
- No package read of `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN`/`AWS_BEARER_TOKEN_BEDROCK`.
- `pre-commit run validate-tvl-specs --all-files` PASS; strict validator 16/16; `tests/unit/tvl` 439 passed; bedrock client tests 57 passed; docs links resolve.

## PR checklist
1. **Worst-case prod path** — docs-only; no runtime change.
2. **Production-branch test** — n/a.
3. **Contract regeneration** — none.
4. **Public surface delta** — none (docs match runtime; one inaccurate doc claim corrected).
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed.