### PR TITLE
fix(test): make preset schema-shape test publish-portable (unblocks v0.12.0)

### DIFF
--- a/tests/unit/api/test_strategy_presets.py
+++ b/tests/unit/api/test_strategy_presets.py
@@ -202,6 +202,14 @@ def test_strategy_preset_metadata_shape_matches_schema_component():
         / "optimization"
         / "strategy_preset_schema.json"
     )
+    if not schema_path.exists():
+        import pytest
+
+        pytest.skip(
+            "Sibling TraigentSchema checkout not present "
+            f"({schema_path}); schema-shape consistency is verified in monorepo "
+            "CI, not in isolated/published-package environments."
+        )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
     required_keys = {"preset_name", "params", "selection_grade"}


### PR DESCRIPTION
The v0.12.0 publish failed in the pre-publish `pytest tests/unit/` step: `test_strategy_preset_metadata_shape_matches_schema_component` (added in #1131) hard-reads the sibling `../TraigentSchema/.../strategy_preset_schema.json`, which isn't checked out in the isolated publish CI. Added the same `pytest.skip`-if-absent guard that tests/cross_sdk_oracles/* use, so the schema-consistency check still runs in monorepo CI but doesn't break isolated/published-package environments. No assertion logic changed. 🤖 Generated with [Claude Code](https://claude.com/claude-code)