### PR TITLE
chore(release): promote 0.12.0 to main (v4 — incl. publish-test fix)

### DIFF
--- a/tests/unit/api/test_strategy_presets.py
+++ b/tests/unit/api/test_strategy_presets.py
@@ -202,6 +202,14 @@ def test_strategy_preset_metadata_shape_matches_schema_component():
         / "optimization"
         / "strategy_preset_schema.json"
     )
+    if not schema_path.exists():
+        import pytest
+
+        pytest.skip(
+            "Sibling TraigentSchema checkout not present "
+            f"({schema_path}); schema-shape consistency is verified in monorepo "
+            "CI, not in isolated/published-package environments."
+        )
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
     required_keys = {"preset_name", "params", "selection_grade"}


### PR DESCRIPTION
Re-promotion to main carrying the one additional commit beyond #1134: the publish-portability test guard (#1141) that unblocks the pre-publish `pytest tests/unit/` step. Same 0.12.0 content otherwise; version 0.12.0. After merge: move v0.12.0 tag here → re-trigger PyPI publish (the prior publish failed pre-upload on the test, so nothing reached PyPI; tag is safely movable). Sonar new-code coverage is the same documented batch-promotion aggregate (reliability A; no threshold relaxed). 🤖 Generated with [Claude Code](https://claude.com/claude-code)