### PR TITLE
fix(sdk): drop empty per-example measures + real sdk_version + normalized execution_mode (#1086)

### DIFF
--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -1047,16 +1047,16 @@ class TestExampleMeasure:
 
         assert measure.example_id is None
 
-    def test_accepts_empty_metrics(self):
-        """Should accept empty metrics dict."""
+    def test_rejects_empty_metrics(self):
+        """Nested per-example measures must include at least one metric."""
         data = {
             "example_id": "ex_test_2",
             "metrics": {},
         }
-        measure = ExampleMeasure(data)
-
-        assert measure.example_id == "ex_test_2"
-        assert measure.metrics == {}
+        with pytest.raises(
+            ValueError, match="metrics must contain at least one entry"
+        ):
+            ExampleMeasure(data)
 
     def test_accepts_none_metric_values(self):
         """Should accept None values in metrics."""

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from traigent._version import get_version
 from traigent.cloud.trial_operations import TrialOperations
 
 
@@ -185,6 +186,7 @@ class TestMeasuresDictValidationInSubmission:
                 metrics={"accuracy": 0.95},
                 status="completed",
                 execution_mode="hybrid",
+                metadata={"execution_mode": "hybrid", "caller": "test"},
             )
 
         assert result is True
@@ -193,6 +195,11 @@ class TestMeasuresDictValidationInSubmission:
             == "https://api.example.com/api/v1/sessions/session_123/results"
         )
         mock_client._normalize_execution_mode.assert_called_once_with("hybrid")
+        payload = mock_session.post.call_args.kwargs["json"]
+        assert payload["metadata"]["mode"] == "local"
+        assert payload["metadata"]["execution_mode"] == "local"
+        assert payload["metadata"]["sdk_version"] == get_version()
+        assert payload["metadata"]["caller"] == "test"
 
     @pytest.mark.asyncio
     async def test_invalid_configuration_run_submission_does_not_post(self) -> None:

--- a/tests/unit/cloud/test_validators.py
+++ b/tests/unit/cloud/test_validators.py
@@ -172,13 +172,16 @@ class TestValidateMeasureResults:
         }
         assert validate_measure_results(measure) is True
 
-    def test_nested_format_with_empty_metrics(self) -> None:
-        """Test nested format with empty metrics dict."""
+    def test_nested_format_with_empty_metrics_raises_error(self) -> None:
+        """Nested per-example measures must include at least one metric."""
         measure = {
             "example_id": "example_1",
             "metrics": {},
         }
-        assert validate_measure_results(measure) is True
+        with pytest.raises(
+            ValueError, match="metrics must contain at least one entry"
+        ):
+            validate_measure_results(measure)
 
     def test_nested_format_with_mixed_metric_types(self) -> None:
         """Test nested format with mixed metric value types."""
@@ -347,6 +350,15 @@ class TestValidateComparabilityMetadata:
         """Test validation of array containing empty dicts."""
         measures = [{}, {}, {}]
         assert validate_measures_array(measures) is True
+
+    def test_measures_array_with_empty_nested_metrics_raises_error(self) -> None:
+        """Nested per-example measures with empty metrics are invalid."""
+        measures = [
+            {"example_id": "example_1", "metrics": {"accuracy": 0.95}},
+            {"example_id": "example_2", "metrics": {}},
+        ]
+        with pytest.raises(ValueError, match="Invalid measure at index 1"):
+            validate_measures_array(measures)
 
     def test_measures_array_not_list_raises_error(self) -> None:
         """Test that non-list measures array raises ValueError."""

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, OptimizationStatus, TrialResult
 from traigent.cloud.session_types import SessionCreationResult
 from traigent.config.types import TraigentConfig
@@ -897,6 +898,7 @@ class TestStatisticalSignificanceWiring:
         summary_stats = payload_metadata.get("summary_stats", {})
         inner_metadata = summary_stats.get("metadata", {})
         assert "statistical_significance" not in inner_metadata
+        assert inner_metadata["sdk_version"] == get_version()
 
 
 class TestHandleSessionCreationResult:

--- a/tests/unit/core/test_metadata_helpers.py
+++ b/tests/unit/core/test_metadata_helpers.py
@@ -7,15 +7,19 @@ for trial and session results.
 from __future__ import annotations
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, TrialResult
+from traigent.cloud.validators import validate_measures_array
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.core.metadata_helpers import (
     _build_measures_full,
     _build_measures_privacy,
+    _validate_measure_dict,
     build_backend_metadata,
     merge_run_metrics_into_session_summary,
 )
@@ -236,7 +240,7 @@ class TestBuildBackendMetadataSummaryStats:
 
         summary_stats = metadata["summary_stats"]
         assert "metadata" in summary_stats
-        assert summary_stats["metadata"]["sdk_version"] == "2.0.0"
+        assert summary_stats["metadata"]["sdk_version"] == get_version()
         assert summary_stats["metadata"]["aggregation_level"] == "trial"
 
     def test_summary_stats_with_existing_metadata(self, mock_trial_result, mock_config):
@@ -306,6 +310,11 @@ class TestBuildBackendMetadataPrivacy:
 
 class TestBuildMeasuresFull:
     """Test _build_measures_full function."""
+
+    def test_validate_measure_dict_rejects_empty_metrics(self):
+        """Nested per-example measures must not contain empty metrics."""
+        with pytest.raises(ValueError, match="metrics must contain at least one entry"):
+            _validate_measure_dict({"example_id": "ex_1", "metrics": {}}, 0)
 
     def test_generates_nested_format(self, example_result):
         """Should generate {example_id, metrics: {...}} structure."""
@@ -423,6 +432,22 @@ class TestBuildMeasuresFull:
         assert "cost" in measures[0]["metrics"]
         assert measures[0]["metrics"]["cost"] is None
 
+    def test_mixed_examples_drop_empty_metrics_and_pass_validator(self):
+        """Hybrid-safe measures should include only examples with real metrics."""
+        empty = SimpleNamespace(metrics={})
+        with_metrics = SimpleNamespace(metrics={"accuracy": 0.91})
+        non_numeric_only = SimpleNamespace(metrics={"model": "gpt-4o"})
+
+        measures = _build_measures_full(
+            [empty, with_metrics, non_numeric_only],
+            "accuracy",
+        )
+
+        assert len(measures) == 1
+        assert measures[0]["metrics"] == {"accuracy": 0.91, "score": 0.91}
+        assert all(measure["metrics"] for measure in measures)
+        assert validate_measures_array(measures) is True
+
 
 class TestBuildMeasuresPrivacy:
     """Test _build_measures_privacy function."""
@@ -529,6 +554,40 @@ class TestBuildMeasuresPrivacy:
 
 class TestBuildBackendMetadataIntegration:
     """Test integration scenarios for build_backend_metadata."""
+
+    def test_hybrid_metadata_drops_empty_per_example_measures(
+        self, mock_trial_result, mock_config
+    ):
+        """Hybrid submissions must not carry per-example empty metrics stubs."""
+        mock_config.execution_mode = "hybrid"
+        mock_config.execution_mode_enum = ExecutionMode.HYBRID
+        mock_trial_result.metadata = {
+            "example_results": [
+                SimpleNamespace(metrics={}),
+                SimpleNamespace(metrics={"accuracy": 0.93}),
+            ]
+        }
+
+        metadata = build_backend_metadata(mock_trial_result, "accuracy", mock_config)
+
+        assert "measures" in metadata
+        assert len(metadata["measures"]) == 1
+        assert all(measure["metrics"] for measure in metadata["measures"])
+        assert validate_measures_array(metadata["measures"]) is True
+
+    def test_omits_measures_when_all_examples_have_no_metrics(
+        self, mock_trial_result, mock_config
+    ):
+        """If every example lacks metrics, omit the measures field entirely."""
+        mock_config.execution_mode = "hybrid"
+        mock_config.execution_mode_enum = ExecutionMode.HYBRID
+        mock_trial_result.metadata = {
+            "example_results": [SimpleNamespace(metrics={})]
+        }
+
+        metadata = build_backend_metadata(mock_trial_result, "accuracy", mock_config)
+
+        assert "measures" not in metadata
 
     def test_complete_metadata_pipeline(
         self, mock_trial_result, mock_config, example_result

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -189,6 +189,8 @@ class ExampleMeasure:
             raise ValueError(
                 f"metrics must be a dict, got {type(self.metrics).__name__}"
             )
+        if not self.metrics:
+            raise ValueError("metrics must contain at least one entry")
 
         # Check max keys
         if len(self.metrics) > self.MAX_METRICS:

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -13,6 +13,7 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.cloud.dtos import MeasuresDict
 from traigent.cloud.validators import validate_configuration_run_submission
 from traigent.config.backend_config import BackendConfig
@@ -394,7 +395,8 @@ class TrialOperations:
         """Build the trial result data dict."""
         result_metadata = dict(metadata or {})
         result_metadata["mode"] = mode
-        result_metadata["sdk_version"] = "2.0.0"
+        result_metadata["execution_mode"] = mode
+        result_metadata["sdk_version"] = get_version()
         result_data: dict[str, Any] = {
             "trial_id": trial_id,
             "config": config,
@@ -711,7 +713,7 @@ class TrialOperations:
             # Prepare metadata - REQUIRED by backend to avoid NoneType errors
             submission_metadata = {
                 "mode": "privacy",  # Explicitly set mode for summary stats
-                "sdk_version": "2.0.0",
+                "sdk_version": get_version(),
                 "aggregation_method": "pandas.describe",
                 "execution_mode": "privacy",  # Use "privacy" not "edge_analytics"
                 "total_examples": summary_stats.get("total_examples", 0),

--- a/traigent/cloud/validators.py
+++ b/traigent/cloud/validators.py
@@ -186,6 +186,8 @@ def validate_measure_results(measure: Any) -> bool:
         metrics = measure.get("metrics")
         if not isinstance(metrics, dict):
             raise ValueError(f"metrics must be a dict, got {type(metrics)}")
+        if not metrics:
+            raise ValueError("metrics must contain at least one entry")
 
         _validate_metric_entries(metrics, "metric", "Metric")
     else:

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -9,6 +9,7 @@ import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.api.types import (
     AgentConfiguration,
     OptimizationResult,
@@ -923,7 +924,7 @@ class BackendSessionManager:
                 "aggregation_level": "session",
                 "aggregation_summary": session_summary,
                 "trial_id": aggregated_trial_id,
-                "sdk_version": "2.0.0",
+                "sdk_version": get_version(),
             },
         }
 

--- a/traigent/core/metadata_helpers.py
+++ b/traigent/core/metadata_helpers.py
@@ -3,8 +3,9 @@
 # Traceability: CONC-Layer-Core CONC-Quality-Maintainability FUNC-ORCH-LIFECYCLE REQ-ORCH-003 SYNC-OptimizationFlow
 
 import json
-from typing import Any
+from typing import Any, cast
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, TrialResult
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.utils.example_id import compute_dataset_hash, generate_stable_example_id
@@ -77,6 +78,11 @@ def _validate_measure_dict(measure: dict[str, Any], example_index: int) -> None:
     """
     _validate_example_id(measure, example_index)
     metrics = _validate_metrics_field(measure, example_index)
+
+    if not metrics:
+        raise ValueError(
+            f"Example {example_index}: metrics must contain at least one entry"
+        )
 
     if len(metrics) > 50:
         raise ValueError(
@@ -158,7 +164,7 @@ def _add_summary_stats(
     if "metadata" not in enhanced_summary_stats:
         enhanced_summary_stats["metadata"] = {}
     enhanced_summary_stats["metadata"]["aggregation_level"] = "trial"
-    enhanced_summary_stats["metadata"]["sdk_version"] = "2.0.0"
+    enhanced_summary_stats["metadata"]["sdk_version"] = get_version()
     trial_metadata["summary_stats"] = enhanced_summary_stats
     logger.debug(
         "Adding summary_stats for %s mode with aggregation_level=trial",
@@ -190,22 +196,33 @@ def _add_measures_to_metadata(
         measures = _build_measures_full(
             example_results, primary_objective, dataset_name
         )
-        trial_metadata["measures"] = measures
-        logger.debug(
-            "Collected %s per-example MeasureResults for %s mode",
-            len(measures),
-            execution_mode,
-        )
-        _log_measures_debug(measures)
+        if measures:
+            trial_metadata["measures"] = measures
+            logger.debug(
+                "Collected %s per-example MeasureResults for %s mode",
+                len(measures),
+                execution_mode,
+            )
+            _log_measures_debug(measures)
+        else:
+            trial_metadata.pop("measures", None)
+            logger.debug(
+                "No per-example MeasureResults with metrics for %s mode",
+                execution_mode,
+            )
     elif privacy_on:
         measures = _build_measures_privacy(
             example_results, primary_objective, dataset_name
         )
-        trial_metadata["measures"] = measures
-        logger.debug(
-            "Using sanitized MeasureResults for privacy mode: %s examples",
-            len(measures),
-        )
+        if measures:
+            trial_metadata["measures"] = measures
+            logger.debug(
+                "Using sanitized MeasureResults for privacy mode: %s examples",
+                len(measures),
+            )
+        else:
+            trial_metadata.pop("measures", None)
+            logger.debug("No privacy-safe per-example MeasureResults with metrics")
     else:
         trial_metadata.pop("measures", None)
 
@@ -295,7 +312,10 @@ def _add_tvar_observation(
             config_space_id=source_metadata.get("config_space_id"),
             effectuation_events=source_metadata.get("effectuation_events"),
         )
-        return merge_tvar_observation_metadata(trial_metadata, observation)
+        return cast(
+            dict[str, Any],
+            merge_tvar_observation_metadata(trial_metadata, observation),
+        )
     except Exception as exc:
         logger.debug(
             "Skipping TVAR observation metadata for trial %s: %s",
@@ -432,7 +452,7 @@ def _build_single_measure_full(
     idx: int,
     dataset_hash: str,
     primary_objective: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a single full measure for non-privacy mode."""
     example_id = generate_stable_example_id(dataset_hash, idx)
     metrics_dict: dict[str, Any] = {}
@@ -453,6 +473,10 @@ def _build_single_measure_full(
         metrics_dict["score"] = float(example_score)
 
     _add_execution_time_metrics(metrics_dict, example_result)
+
+    if not metrics_dict:
+        logger.debug("Skipping measure %s because it has no metrics", idx)
+        return None
 
     measure_result = {"example_id": example_id, "metrics": metrics_dict}
     _validate_measure_dict(measure_result, idx)
@@ -485,10 +509,14 @@ def _build_measures_full(
         ValueError: If measures violate MeasuresDict constraints
     """
     dataset_hash = compute_dataset_hash(dataset_name)
-    return [
-        _build_single_measure_full(example_result, idx, dataset_hash, primary_objective)
-        for idx, example_result in enumerate(example_results)
-    ]
+    measures: list[dict[str, Any]] = []
+    for idx, example_result in enumerate(example_results):
+        measure = _build_single_measure_full(
+            example_result, idx, dataset_hash, primary_objective
+        )
+        if measure is not None:
+            measures.append(measure)
+    return measures
 
 
 _PRIVACY_TOKEN_KEYS = ("input_tokens", "output_tokens", "total_tokens")
@@ -512,7 +540,7 @@ def _build_single_measure_privacy(
     idx: int,
     dataset_hash: str,
     primary_objective: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a single sanitized measure for privacy mode."""
     example_id = generate_stable_example_id(dataset_hash, idx)
     metrics_dict: dict[str, Any] = {}
@@ -530,6 +558,10 @@ def _build_single_measure_privacy(
     # Add privacy-safe token and cost metrics
     if eval_metrics:
         _add_privacy_safe_metrics(metrics_dict, eval_metrics)
+
+    if not metrics_dict:
+        logger.debug("Skipping privacy measure %s because it has no metrics", idx)
+        return None
 
     measure_result = {"example_id": example_id, "metrics": metrics_dict}
     _validate_measure_dict(measure_result, idx)
@@ -564,9 +596,11 @@ def _build_measures_privacy(
         ValueError: If measures violate MeasuresDict constraints
     """
     dataset_hash = compute_dataset_hash(dataset_name)
-    return [
-        _build_single_measure_privacy(
+    measures: list[dict[str, Any]] = []
+    for idx, example_result in enumerate(example_results):
+        measure = _build_single_measure_privacy(
             example_result, idx, dataset_hash, primary_objective
         )
-        for idx, example_result in enumerate(example_results)
-    ]
+        if measure is not None:
+            measures.append(measure)
+    return measures


### PR DESCRIPTION
Fixes #1086. Hybrid trial-result submission emitted per-example measures with empty `metrics: {}` → backend `validate_measures_list` rejected (400) → trial measures/status never persisted (configuration_runs stuck RUNNING).

- Empty-metrics per-example entries are now dropped (and `_validate_measure_dict` rejects empty metrics as defense-in-depth); measures field omitted rather than sending empty stubs.
- `execution_mode` normalized in metadata (same as `mode`).
- Hardcoded `sdk_version="2.0.0"` at 3 sites replaced with the real installed version via `traigent._version.get_version()`.

292 tests on touched modules; ruff/mypy clean. Backend companion: TraigentBackend#795. Gates not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)