### PR TITLE
feat(sdk): hard cost-coverage preflight — fail closed on unpriced models (#1096)

### DIFF
--- a/tests/unit/core/test_cost_estimator.py
+++ b/tests/unit/core/test_cost_estimator.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from dataclasses import dataclass, field
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from traigent.core.cost_estimator import CostEstimator
+import traigent.utils.cost_calculator as cost_calculator
+from traigent.core.cost_estimator import (
+    ALLOW_UNPRICED_MODELS_ENV,
+    CUSTOM_PRICING_FILE_ENV,
+    CUSTOM_PRICING_JSON_ENV,
+    CostCoverageError,
+    CostEstimator,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -28,6 +37,28 @@ class _FakeDataset:
 class _FakeTrialResult:
     metrics: dict | None = None
     metadata: dict | None = None
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cost_pricing_state(monkeypatch):
+    """Keep custom-pricing env/cache and mock-mode state local to each test."""
+    from traigent import testing as traigent_testing
+
+    old_cache = cost_calculator._CUSTOM_PRICING_CACHE
+    old_key = cost_calculator._CUSTOM_PRICING_CACHE_KEY
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+    traigent_testing._reset_for_tests()
+    monkeypatch.delenv(ALLOW_UNPRICED_MODELS_ENV, raising=False)
+    monkeypatch.delenv(CUSTOM_PRICING_JSON_ENV, raising=False)
+    monkeypatch.delenv(CUSTOM_PRICING_FILE_ENV, raising=False)
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+    try:
+        yield
+    finally:
+        cost_calculator._CUSTOM_PRICING_CACHE = old_cache
+        cost_calculator._CUSTOM_PRICING_CACHE_KEY = old_key
+        traigent_testing._reset_for_tests()
 
 
 # ---------------------------------------------------------------------------
@@ -88,10 +119,38 @@ class TestEstimateOptimizationCost:
         # Total = 50 * 10 * 0.002 * 1.2 = 1.2
         assert cost == pytest.approx(1.2)
 
-    def test_unknown_model_falls_back_to_conservative_pricing(self) -> None:
-        """Unknown model should trigger conservative fallback pricing."""
+    def test_unknown_model_fails_closed_without_override(self) -> None:
+        """Unknown real-run model pricing should fail before estimation fallback."""
         from traigent.utils.cost_calculator import UnknownModelError
 
+        enforcer = MagicMock(is_mock_mode=False)
+        estimator = CostEstimator(
+            enforcer,
+            max_trials=None,
+            max_total_examples=None,
+            model_name="unknown-private-model",
+        )
+        dataset = _FakeDataset()
+
+        with patch(
+            "traigent.core.cost_estimator.get_model_token_pricing",
+            side_effect=UnknownModelError("unknown model"),
+        ):
+            with pytest.raises(CostCoverageError) as exc_info:
+                estimator.estimate_optimization_cost(dataset)
+
+        assert "unknown-private-model" in str(exc_info.value)
+        assert CUSTOM_PRICING_JSON_ENV in str(exc_info.value)
+        assert ALLOW_UNPRICED_MODELS_ENV in str(exc_info.value)
+
+    def test_unknown_model_uses_conservative_pricing_with_override(
+        self, monkeypatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Explicit override keeps the conservative fallback visible."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        monkeypatch.setenv(ALLOW_UNPRICED_MODELS_ENV, "true")
+        caplog.set_level(logging.WARNING, logger="traigent.core.cost_estimator")
         enforcer = MagicMock(is_mock_mode=False)
         estimator = CostEstimator(
             enforcer,
@@ -108,9 +167,40 @@ class TestEstimateOptimizationCost:
             cost = estimator.estimate_optimization_cost(dataset)
 
         assert cost == pytest.approx(40.5)
+        assert ALLOW_UNPRICED_MODELS_ENV in caplog.text
+        assert "conservative_fallback" in caplog.text
 
-    def test_model_pricing_exception_falls_back_to_conservative_pricing(self) -> None:
-        """Unexpected pricing lookup failures should preserve conservative approval."""
+    def test_unknown_model_uses_custom_pricing_json(self, monkeypatch) -> None:
+        """Custom rates satisfy coverage and drive the estimate."""
+        monkeypatch.setenv(
+            CUSTOM_PRICING_JSON_ENV,
+            json.dumps(
+                {
+                    "unknown-private-model": {
+                        "input_cost_per_token": 1e-6,
+                        "output_cost_per_token": 2e-6,
+                    }
+                }
+            ),
+        )
+
+        enforcer = MagicMock(is_mock_mode=False)
+        estimator = CostEstimator(
+            enforcer,
+            max_trials=None,
+            max_total_examples=None,
+            model_name="unknown-private-model",
+        )
+        dataset = _FakeDataset()
+
+        cost = estimator.estimate_optimization_cost(dataset)
+
+        # Base = (2000 * 1e-6) + (500 * 2e-6) = 0.003
+        # Total = 50 * 10 * 0.003 * 1.2 = 1.8
+        assert cost == pytest.approx(1.8)
+
+    def test_model_pricing_exception_fails_closed_without_override(self) -> None:
+        """Unexpected pricing lookup failures should fail before fallback."""
         enforcer = MagicMock(is_mock_mode=False)
         estimator = CostEstimator(
             enforcer,
@@ -123,6 +213,28 @@ class TestEstimateOptimizationCost:
         with patch(
             "traigent.core.cost_estimator.get_model_token_pricing",
             side_effect=RuntimeError("pricing backend unavailable"),
+        ):
+            with pytest.raises(CostCoverageError, match="gpt-4o-mini"):
+                estimator.estimate_optimization_cost(dataset)
+
+    def test_unknown_model_in_mock_mode_does_not_fail_coverage(self) -> None:
+        """Mock runs can keep conservative estimates because no spend happens."""
+        from traigent import testing as traigent_testing
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        traigent_testing.enable_mock_mode_for_quickstart()
+        enforcer = MagicMock(is_mock_mode=False)
+        estimator = CostEstimator(
+            enforcer,
+            max_trials=None,
+            max_total_examples=None,
+            model_name="unknown-private-model",
+        )
+        dataset = _FakeDataset()
+
+        with patch(
+            "traigent.core.cost_estimator.get_model_token_pricing",
+            side_effect=UnknownModelError("unknown model"),
         ):
             cost = estimator.estimate_optimization_cost(dataset)
 
@@ -156,10 +268,41 @@ class TestEstimateOptimizationCost:
         # Total = 50 * 10 * 0.01 * 1.2 = 6.0
         assert cost == pytest.approx(6.0)
 
-    def test_unknown_candidate_model_falls_back_to_conservative_pricing(self) -> None:
-        """Unknown candidate pricing should keep approval conservative."""
+    def test_unknown_candidate_model_fails_closed_without_override(self) -> None:
+        """Unknown config-space model pricing should fail closed for real runs."""
         from traigent.utils.cost_calculator import UnknownModelError
 
+        enforcer = MagicMock(is_mock_mode=False)
+        estimator = CostEstimator(
+            enforcer,
+            max_trials=10,
+            max_total_examples=None,
+            candidate_models=["gpt-4o-mini", "unknown-private-model"],
+        )
+        dataset = _FakeDataset()
+
+        def pricing(model: str) -> tuple[float, float, str]:
+            if model == "gpt-4o-mini":
+                return (0.15e-6, 0.6e-6, "litellm")
+            raise UnknownModelError(model)
+
+        with patch(
+            "traigent.core.cost_estimator.get_model_token_pricing",
+            side_effect=pricing,
+        ):
+            with pytest.raises(CostCoverageError) as exc_info:
+                estimator.estimate_optimization_cost(dataset)
+
+        assert "unknown-private-model" in str(exc_info.value)
+
+    def test_unknown_candidate_model_uses_conservative_pricing_with_override(
+        self, monkeypatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Override-gated candidate fallback keeps the existing conservative math."""
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        monkeypatch.setenv(ALLOW_UNPRICED_MODELS_ENV, "true")
+        caplog.set_level(logging.WARNING, logger="traigent.core.cost_estimator")
         enforcer = MagicMock(is_mock_mode=False)
         estimator = CostEstimator(
             enforcer,
@@ -181,11 +324,13 @@ class TestEstimateOptimizationCost:
             cost = estimator.estimate_optimization_cost(dataset)
 
         assert cost == pytest.approx(40.5)
+        assert "unknown-private-model" in caplog.text
+        assert "conservative_fallback" in caplog.text
 
-    def test_candidate_model_pricing_exception_falls_back_to_conservative_pricing(
+    def test_candidate_model_pricing_exception_fails_closed_without_override(
         self,
     ) -> None:
-        """Unexpected candidate pricing failures should preserve conservative approval."""
+        """Unexpected candidate pricing failures should fail before fallback."""
         enforcer = MagicMock(is_mock_mode=False)
         estimator = CostEstimator(
             enforcer,
@@ -199,9 +344,8 @@ class TestEstimateOptimizationCost:
             "traigent.core.cost_estimator.get_model_token_pricing",
             side_effect=RuntimeError("pricing backend unavailable"),
         ):
-            cost = estimator.estimate_optimization_cost(dataset)
-
-        assert cost == pytest.approx(40.5)
+            with pytest.raises(CostCoverageError, match="gpt-4o"):
+                estimator.estimate_optimization_cost(dataset)
 
     def test_explicit_model_takes_precedence_over_candidate_models(self) -> None:
         """A fixed run model should override config-space candidates."""
@@ -262,10 +406,13 @@ class TestEstimateOptimizationCost:
         # Total = 50 * 10 * 0.00075 * 1.2 = 0.45
         assert cost == pytest.approx(0.45)
 
-    def test_estimated_tokens_apply_to_conservative_fallback_pricing(self) -> None:
+    def test_estimated_tokens_apply_to_override_gated_conservative_fallback_pricing(
+        self, monkeypatch
+    ) -> None:
         """Token estimate metadata should still improve the conservative fallback."""
         from traigent.utils.cost_calculator import UnknownModelError
 
+        monkeypatch.setenv(ALLOW_UNPRICED_MODELS_ENV, "true")
         enforcer = MagicMock(is_mock_mode=False)
         estimator = CostEstimator(
             enforcer,

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -28,6 +28,7 @@ import pytest
 
 from traigent.api.types import OptimizationStatus, TrialResult, TrialStatus
 from traigent.config.types import TraigentConfig
+from traigent.core.cost_estimator import CostCoverageError
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.core.orchestrator_helpers import allocate_parallel_ceilings
@@ -2357,6 +2358,45 @@ class TestCostEstimation:
 
         assert base_cost == pytest.approx(0.01)
         assert pricing_source == "litellm:config_space_max(gpt-4o)"
+
+    @pytest.mark.asyncio
+    async def test_optimize_fails_closed_on_unpriced_model_before_trials(
+        self,
+        monkeypatch,
+        mock_evaluator: MockEvaluator,
+        sample_dataset: Dataset,
+    ) -> None:
+        """Real optimization entrypoint must fail before running unpriced models."""
+        from traigent import testing as traigent_testing
+        from traigent.utils.cost_calculator import UnknownModelError
+
+        traigent_testing._reset_for_tests()
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+        monkeypatch.delenv("TRAIGENT_ALLOW_UNPRICED_MODELS", raising=False)
+
+        async def mock_function(input_data: dict[str, Any], **config: Any) -> Any:
+            return input_data.get("query", "default response")
+
+        optimizer = MockOptimizer(
+            config_space={"model": ["unknown-private-model"]},
+            objectives=["accuracy"],
+        )
+        orchestrator = OptimizationOrchestrator(
+            optimizer=optimizer,
+            evaluator=mock_evaluator,
+            max_trials=1,
+            cost_approved=True,
+        )
+
+        with patch(
+            "traigent.core.cost_estimator.get_model_token_pricing",
+            side_effect=UnknownModelError("unknown model"),
+        ):
+            with pytest.raises(CostCoverageError) as exc_info:
+                await orchestrator.optimize(mock_function, sample_dataset)
+
+        assert "unknown-private-model" in str(exc_info.value)
+        assert mock_evaluator.evaluation_count == 0
 
     def test_cost_estimator_uses_hybrid_token_estimate_metadata(
         self,

--- a/traigent/core/cost_estimator.py
+++ b/traigent/core/cost_estimator.py
@@ -4,12 +4,14 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
 
 from traigent.api.types import TrialResult
 from traigent.core.cost_enforcement import CostEnforcer
 from traigent.evaluators.base import Dataset
 from traigent.utils.cost_calculator import UnknownModelError, get_model_token_pricing
+from traigent.utils.exceptions import ConfigurationError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -18,6 +20,35 @@ _ESTIMATED_INPUT_TOKENS_PER_EXAMPLE = 2000
 _ESTIMATED_OUTPUT_TOKENS_PER_EXAMPLE = 500
 _CONSERVATIVE_INPUT_COST_PER_TOKEN = 15.0e-6
 _CONSERVATIVE_OUTPUT_COST_PER_TOKEN = 75.0e-6
+ALLOW_UNPRICED_MODELS_ENV = "TRAIGENT_ALLOW_UNPRICED_MODELS"
+CUSTOM_PRICING_JSON_ENV = "TRAIGENT_CUSTOM_MODEL_PRICING_JSON"
+CUSTOM_PRICING_FILE_ENV = "TRAIGENT_CUSTOM_MODEL_PRICING_FILE"
+
+
+class CostCoverageError(ConfigurationError):
+    """Raised when a real optimization run includes unpriced model candidates."""
+
+    def __init__(self, unpriced_models: Sequence[str]) -> None:
+        self.unpriced_models = tuple(sorted(dict.fromkeys(unpriced_models)))
+        models = ", ".join(repr(model) for model in self.unpriced_models)
+        super().__init__(
+            "Cost coverage preflight failed: pricing could not be resolved for "
+            f"model(s): {models}. Provide explicit custom rates with "
+            f"{CUSTOM_PRICING_JSON_ENV} or {CUSTOM_PRICING_FILE_ENV}, or set "
+            f"{ALLOW_UNPRICED_MODELS_ENV}=true to allow conservative fallback "
+            "estimates for this run."
+        )
+
+
+def _is_truthy_env(name: str) -> bool:
+    value = os.getenv(name)
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_cost_coverage_mock_mode() -> bool:
+    from traigent.utils.env_config import is_mock_llm
+
+    return bool(is_mock_llm())
 
 
 class CostEstimator:
@@ -91,6 +122,57 @@ class CostEstimator:
                 else _ESTIMATED_OUTPUT_TOKENS_PER_EXAMPLE
             ),
         )
+
+    def _models_requiring_pricing(self) -> tuple[str, ...]:
+        """Return fixed and config-space model names that require pricing."""
+        models: list[str] = []
+        if self._model_name and self._model_name.strip():
+            models.append(self._model_name.strip())
+        models.extend(self._candidate_models)
+        return tuple(dict.fromkeys(models))
+
+    def _collect_unpriced_models(self) -> tuple[str, ...]:
+        """Return model names whose pricing cannot be resolved."""
+        unpriced_models: list[str] = []
+        for model_name in self._models_requiring_pricing():
+            try:
+                get_model_token_pricing(model_name)
+            except UnknownModelError:
+                unpriced_models.append(model_name)
+            except Exception:
+                logger.debug(
+                    "Pricing coverage preflight failed for model %r",
+                    model_name,
+                    exc_info=True,
+                )
+                unpriced_models.append(model_name)
+        return tuple(unpriced_models)
+
+    def _unpriced_models_allowed(self) -> bool:
+        """Return whether conservative fallback may cover unpriced models."""
+        return (
+            _is_truthy_env(ALLOW_UNPRICED_MODELS_ENV) or _is_cost_coverage_mock_mode()
+        )
+
+    def _check_pricing_coverage(self) -> None:
+        """Fail closed for unpriced real-run model candidates."""
+        unpriced_models = self._collect_unpriced_models()
+        if not unpriced_models:
+            return
+
+        if self._unpriced_models_allowed():
+            logger.warning(
+                "Proceeding with unpriced model(s) %s because %s=true or mock mode "
+                "is enabled; using conservative_fallback estimates. Configure %s "
+                "or %s for priced estimates.",
+                sorted(unpriced_models),
+                ALLOW_UNPRICED_MODELS_ENV,
+                CUSTOM_PRICING_JSON_ENV,
+                CUSTOM_PRICING_FILE_ENV,
+            )
+            return
+
+        raise CostCoverageError(unpriced_models)
 
     def _base_cost_for_rates(self, input_rate: float, output_rate: float) -> float:
         """Compute per-example base cost from token rates."""
@@ -230,6 +312,7 @@ class CostEstimator:
         Returns:
             Estimated cost in USD.
         """
+        self._check_pricing_coverage()
         base_cost_per_example, pricing_source = self._estimate_base_cost_per_example()
 
         # Get dataset size


### PR DESCRIPTION
Fixes #1096. Unknown/unpriced models silently used a conservative $0-ish fallback, defeating budget protection. Now a REAL run fails closed (CostCoverageError naming the unpriced model) unless the user explicitly opts in:
- `TRAIGENT_ALLOW_UNPRICED_MODELS=true` → conservative estimate WITH a visible warning, or
- custom rates via the existing `TRAIGENT_CUSTOM_MODEL_PRICING_JSON`/`_FILE`.
Conservative fallback is no longer the silent default for real runs; mock runs are unaffected (no spend). Preflight wired into the real-run entry before any trials.

Existing fallback tests UPDATED (not deleted) to assert the new gated behavior: default fail-closed, override→warn+estimate, custom→priced, mock→no failure, orchestrator fails before trials. 1,914 core tests pass. Policy/budget surface fail-closed; gates not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)