### PR TITLE
fix(sdk): instrument Bedrock for cost/token capture + mock interception (#1089)

### DIFF
--- a/tests/unit/core/test_llm_processor.py
+++ b/tests/unit/core/test_llm_processor.py
@@ -350,6 +350,36 @@ class TestExtractMetricsFromResponse:
         assert result is not None
         assert result["total_tokens"] == 75  # 50 + 25
 
+    def test_extract_metrics_normalizes_bedrock_usage_keys(
+        self, processor: LLMResponseProcessor
+    ) -> None:
+        """Test Bedrock input/output usage aliases are not dropped."""
+        response = Mock()
+        response.usage = {"input_tokens": 100, "output_tokens": 50}
+        response.cost = Mock(input_cost=0.0, output_cost=0.0, total_cost=0.0)
+
+        result = processor._extract_metrics_from_response(response, "claude-3-haiku")
+
+        assert result is not None
+        assert result["input_tokens"] == 100
+        assert result["output_tokens"] == 50
+        assert result["total_tokens"] == 150
+
+    def test_extract_metrics_normalizes_bedrock_camel_case_usage_keys(
+        self, processor: LLMResponseProcessor
+    ) -> None:
+        """Test Bedrock camelCase usage aliases are not dropped."""
+        response = Mock()
+        response.usage = {"inputTokens": 11, "outputTokens": 22}
+        response.cost = Mock(input_cost=0.0, output_cost=0.0, total_cost=0.0)
+
+        result = processor._extract_metrics_from_response(response, "claude-3-haiku")
+
+        assert result is not None
+        assert result["input_tokens"] == 11
+        assert result["output_tokens"] == 22
+        assert result["total_tokens"] == 33
+
     def test_extract_metrics_calculates_total_cost(
         self, processor: LLMResponseProcessor
     ) -> None:

--- a/tests/unit/integrations/test_bedrock_client.py
+++ b/tests/unit/integrations/test_bedrock_client.py
@@ -11,10 +11,13 @@ normalized response parsing and mocked boto3 interactions.
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
 from traigent.integrations.bedrock_client import (
     BedrockChatClient,
     BedrockChatResponse,
@@ -24,6 +27,22 @@ from traigent.integrations.bedrock_client import (
     _require_boto3,
     resolve_default_bedrock_model_id,
 )
+from traigent.utils.langchain_interceptor import (
+    clear_captured_responses,
+    get_all_captured_responses,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock_mode(monkeypatch: pytest.MonkeyPatch):
+    from traigent.testing import _reset_for_tests
+
+    _reset_for_tests()
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+    clear_captured_responses()
+    yield
+    _reset_for_tests()
+    clear_captured_responses()
 
 
 def _mock_invoke_client(payload: dict) -> MagicMock:
@@ -87,7 +106,7 @@ class TestHelperFunctions:
 
     def test_coerce_user_messages_with_list_of_dicts(self) -> None:
         """Test _coerce_user_messages passes through list of message dicts."""
-        messages = [
+        messages: list[Mapping[str, Any]] = [
             {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
             {"role": "assistant", "content": [{"type": "text", "text": "Hi"}]},
         ]
@@ -150,6 +169,18 @@ class TestBedrockChatResponseDataclass:
         usage = {"input_tokens": 10, "output_tokens": 20}
         response = BedrockChatResponse(text="test", raw={}, usage=usage)
         assert response.usage == usage
+
+    def test_bedrock_chat_response_with_model_and_latency(self) -> None:
+        """Test BedrockChatResponse stores capture metadata."""
+        response = BedrockChatResponse(
+            text="test",
+            raw={},
+            usage=None,
+            model="anthropic.claude-3-haiku-20240307-v1:0",
+            response_time_ms=12.5,
+        )
+        assert response.model == "anthropic.claude-3-haiku-20240307-v1:0"
+        assert response.response_time_ms == 12.5
 
 
 class TestBedrockChatClientInit:
@@ -237,6 +268,65 @@ class TestBedrockChatClientInvoke:
         assert response.usage["output_tokens"] == 10
         mock_client.invoke_model.assert_called_once()
 
+    def test_invoke_short_circuits_when_traigent_mock_llm_is_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test TRAIGENT_MOCK_LLM fabricates a response without AWS."""
+        clear_captured_responses()
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="Hello world",
+            max_tokens=16,
+        )
+
+        assert response.text == "This is a mock response for testing."
+        assert response.raw["mock"] is True
+        assert response.usage is not None
+        assert response.usage["prompt_tokens"] == 10
+        assert response.usage["completion_tokens"] == 20
+        mock_client.invoke_model.assert_not_called()
+        assert get_all_captured_responses() == [response]
+        clear_captured_responses()
+
+    def test_invoke_captures_normalized_usage_for_cost(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test Bedrock input/output usage is captured with cost-capable keys."""
+        clear_captured_responses()
+        monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+        mock_client = _mock_invoke_client(
+            {
+                "content": [{"type": "text", "text": "Response text"}],
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(
+            model_id="anthropic.claude-3-haiku-20240307-v1:0",
+            messages="Hello world",
+        )
+
+        assert response.usage is not None
+        assert response.usage["prompt_tokens"] == 100
+        assert response.usage["completion_tokens"] == 50
+        assert response.usage["total_tokens"] == 150
+        captured = get_all_captured_responses()
+        assert captured == [response]
+
+        metrics = extract_llm_metrics(
+            captured[0],
+            model_name="claude-3-haiku-20240307",
+        )
+        assert metrics.tokens.input_tokens == 100
+        assert metrics.tokens.output_tokens == 50
+        assert metrics.cost.total_cost > 0
+        clear_captured_responses()
+
     def test_invoke_with_list_messages(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -246,7 +336,7 @@ class TestBedrockChatClientInvoke:
         )
         client = BedrockChatClient(client=mock_client)
 
-        messages = [
+        messages: list[Mapping[str, Any]] = [
             {"role": "user", "content": [{"type": "text", "text": "First"}]},
             {"role": "user", "content": [{"type": "text", "text": "Last message"}]},
         ]
@@ -330,6 +420,7 @@ class TestBedrockChatClientInvoke:
         )
 
         assert response.text == "Response text"
+        assert response.usage is not None
         assert response.usage["input_tokens"] == 5
         mock_client.invoke_model.assert_called_once()
 
@@ -446,7 +537,7 @@ class TestBedrockChatClientInvokeAI21:
         )
         client = BedrockChatClient(client=mock_client)
 
-        messages = [
+        messages: list[Mapping[str, Any]] = [
             {"role": "user", "content": [{"type": "text", "text": "First"}]},
             {"role": "user", "content": [{"type": "text", "text": "Second"}]},
         ]
@@ -500,6 +591,7 @@ class TestBedrockChatClientInvokeAI21:
         )
 
         assert response.text == "AI21 response"
+        assert response.usage is not None
         assert response.usage["input_tokens"] == 8
 
     @patch("traigent.integrations.bedrock_client._require_boto3")
@@ -547,7 +639,7 @@ class TestBedrockChatClientInvokeAI21:
         )
         client = BedrockChatClient(client=mock_client)
 
-        messages = [
+        messages: list[Mapping[str, Any]] = [
             {
                 "role": "user",
                 "content": [
@@ -594,6 +686,30 @@ class TestBedrockChatClientInvokeStream:
         assert chunks == ["Stream", "response"]
         assert not any("[MOCK:" in c for c in chunks)
         mock_client.invoke_model_with_response_stream.assert_called_once()
+
+    def test_invoke_stream_short_circuits_when_traigent_mock_llm_is_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test TRAIGENT_MOCK_LLM streams a mock chunk without AWS."""
+        clear_captured_responses()
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        chunks = list(
+            client.invoke_stream(
+                model_id="anthropic.claude-3-opus-20240229-v1:0",
+                messages="Stream test",
+                max_tokens=512,
+            )
+        )
+
+        assert chunks == ["This is a mock response for testing."]
+        mock_client.invoke_model_with_response_stream.assert_not_called()
+        captured = get_all_captured_responses()
+        assert len(captured) == 1
+        assert captured[0].usage["prompt_tokens"] == 10
+        clear_captured_responses()
 
     def test_invoke_stream_sends_coerced_message(
         self, monkeypatch: pytest.MonkeyPatch
@@ -727,6 +843,30 @@ class TestBedrockChatClientAsyncInvoke:
         mock_invoke.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_ainvoke_short_circuits_when_traigent_mock_llm_is_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test TRAIGENT_MOCK_LLM async invoke avoids aioboto3 and sync AWS."""
+        clear_captured_responses()
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        client = BedrockChatClient()
+
+        with patch.object(client, "_ainvoke_aioboto3") as mock_aioboto3:
+            with patch.object(client, "invoke") as mock_sync_invoke:
+                response = await client.ainvoke(
+                    model_id="anthropic.claude-3-haiku-20240307-v1:0",
+                    messages="Async test",
+                    max_tokens=32,
+                )
+
+        assert response.text == "This is a mock response for testing."
+        assert response.raw["mock"] is True
+        mock_aioboto3.assert_not_called()
+        mock_sync_invoke.assert_not_called()
+        assert get_all_captured_responses() == [response]
+        clear_captured_responses()
+
+    @pytest.mark.asyncio
     async def test_ainvoke_falls_back_to_sync_without_aioboto3(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -785,6 +925,7 @@ class TestBedrockChatClientAsyncInvoke:
             response = await client.ainvoke(model_id="test-model", messages="test")
 
         assert response.text == "Async response"
+        assert response.usage is not None
         assert response.usage["input_tokens"] == 7
 
 

--- a/tests/unit/integrations/test_bedrock_client_no_mock.py
+++ b/tests/unit/integrations/test_bedrock_client_no_mock.py
@@ -1,44 +1,49 @@
-"""Regression tests proving BEDROCK_MOCK is ignored by production code."""
+"""Regression tests for native Bedrock mock interception."""
 
 from __future__ import annotations
 
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
+
+import pytest
 
 from traigent.integrations.bedrock_client import BedrockChatClient
+from traigent.utils.langchain_interceptor import (
+    clear_captured_responses,
+    get_all_captured_responses,
+)
 
 
-def test_bedrock_mock_env_does_not_short_circuit_invoke(monkeypatch) -> None:
-    """Setting BEDROCK_MOCK still uses the boto3 Bedrock Runtime client."""
-    monkeypatch.setenv("BEDROCK_MOCK", "true")
+@pytest.fixture(autouse=True)
+def _reset_mock_mode(monkeypatch: pytest.MonkeyPatch):
+    from traigent.testing import _reset_for_tests
 
-    mock_boto3 = MagicMock()
-    mock_session = MagicMock()
-    mock_client = MagicMock()
-    mock_client.invoke_model.return_value = {
-        "body": MagicMock(
-            read=lambda: json.dumps(
-                {"content": [{"type": "text", "text": "from mocked boto3"}]}
-            ).encode()
-        )
-    }
-    mock_session.client.return_value = mock_client
-    mock_boto3.session.Session.return_value = mock_session
+    _reset_for_tests()
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+    clear_captured_responses()
+    yield
+    _reset_for_tests()
+    clear_captured_responses()
 
-    with patch(
-        "traigent.integrations.bedrock_client._require_boto3",
-        return_value=mock_boto3,
-    ) as mock_require_boto3:
+
+def test_traigent_mock_llm_short_circuits_bedrock_invoke(monkeypatch) -> None:
+    """TRAIGENT_MOCK_LLM returns a Bedrock-shaped mock without boto3/AWS."""
+    clear_captured_responses()
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+
+    with patch("traigent.integrations.bedrock_client._require_boto3") as mock_require:
         response = BedrockChatClient(region_name="us-east-1").invoke(
             model_id="anthropic.claude-3-sonnet-20240229-v1:0",
             messages="hello",
         )
 
-    mock_require_boto3.assert_called_once()
-    mock_session.client.assert_called_once_with(
-        "bedrock-runtime", region_name="us-east-1"
-    )
-    mock_client.invoke_model.assert_called_once()
-    assert response.text == "from mocked boto3"
-    assert "[MOCK:" not in response.text
-    assert response.raw.get("mock") is None
+    mock_require.assert_not_called()
+    assert response.text == "This is a mock response for testing."
+    assert response.raw["mock"] is True
+    assert response.raw["provider"] == "bedrock"
+    assert response.usage is not None
+    assert response.usage["prompt_tokens"] == 10
+    assert response.usage["completion_tokens"] == 20
+
+    captured = get_all_captured_responses()
+    assert captured == [response]
+    clear_captured_responses()

--- a/tests/unit/utils/test_langchain_interceptor.py
+++ b/tests/unit/utils/test_langchain_interceptor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import threading
 import time
+from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -27,6 +28,18 @@ from traigent.utils.langchain_interceptor import (
     langchain_metadata_context,
     patch_langchain_for_metadata_capture,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock_mode(monkeypatch: pytest.MonkeyPatch):
+    from traigent.testing import _reset_for_tests
+
+    _reset_for_tests()
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+    clear_captured_responses()
+    yield
+    _reset_for_tests()
+    clear_captured_responses()
 
 
 class TestLangChainMetadataCapture:
@@ -716,6 +729,125 @@ class TestPatchLangChainForMetadataCapture:
         result = patch_langchain_for_metadata_capture()
         # Result depends on whether LangChain is installed
         assert isinstance(result, bool)
+
+    def test_patch_captures_chat_bedrock_response(self) -> None:
+        """Test ChatBedrock invoke is patched and captured when langchain_aws exists."""
+        fake_aws: Any = ModuleType("langchain_aws")
+
+        class FakeChatBedrock:
+            invoke_calls = 0
+
+            def __init__(self) -> None:
+                self.model_id = "anthropic.claude-3-haiku-20240307-v1:0"
+
+            def invoke(self, *args: Any, **kwargs: Any) -> Any:
+                type(self).invoke_calls += 1
+                return SimpleNamespace(
+                    content="real bedrock response",
+                    response_metadata={},
+                    usage_metadata={"input_tokens": 7, "output_tokens": 8},
+                )
+
+        fake_aws.ChatBedrock = FakeChatBedrock
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "langchain_anthropic": None,
+                "langchain_openai": None,
+                "langchain_aws": fake_aws,
+            },
+        ):
+            assert patch_langchain_for_metadata_capture() is True
+            response = FakeChatBedrock().invoke("hello")
+
+        assert FakeChatBedrock.invoke_calls == 1
+        assert response.response_metadata["response_time_ms"] >= 0
+        assert response.response_metadata["model_name"] == (
+            "anthropic.claude-3-haiku-20240307-v1:0"
+        )
+        assert response.usage_metadata["input_tokens"] == 7
+        assert response.usage_metadata["output_tokens"] == 8
+        assert response.usage_metadata["total_tokens"] == 15
+        assert get_captured_response() is response
+
+    def test_patch_chat_bedrock_and_converse_mock_short_circuit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test Bedrock LangChain classes mock without calling original invoke."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        fake_aws: Any = ModuleType("langchain_aws")
+        fake_core: Any = ModuleType("langchain_core")
+        fake_messages: Any = ModuleType("langchain_core.messages")
+
+        class FakeAIMessage:
+            def __init__(
+                self,
+                *,
+                content: str,
+                response_metadata: dict[str, Any],
+                usage_metadata: dict[str, Any],
+            ) -> None:
+                self.content = content
+                self.response_metadata = response_metadata
+                self.usage_metadata = usage_metadata
+
+        class FakeChatBedrock:
+            invoke_calls = 0
+
+            def __init__(self) -> None:
+                self.model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+            def invoke(self, *args: Any, **kwargs: Any) -> Any:
+                type(self).invoke_calls += 1
+                raise AssertionError("original ChatBedrock.invoke should not run")
+
+        class FakeChatBedrockConverse:
+            invoke_calls = 0
+
+            def __init__(self) -> None:
+                self.model = "anthropic.claude-3-haiku-20240307-v1:0"
+
+            def invoke(self, *args: Any, **kwargs: Any) -> Any:
+                type(self).invoke_calls += 1
+                raise AssertionError(
+                    "original ChatBedrockConverse.invoke should not run"
+                )
+
+        fake_aws.ChatBedrock = FakeChatBedrock
+        fake_aws.ChatBedrockConverse = FakeChatBedrockConverse
+        fake_messages.AIMessage = FakeAIMessage
+        fake_core.messages = fake_messages
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "langchain_anthropic": None,
+                "langchain_openai": None,
+                "langchain_aws": fake_aws,
+                "langchain_core": fake_core,
+                "langchain_core.messages": fake_messages,
+            },
+        ):
+            assert patch_langchain_for_metadata_capture() is True
+            bedrock_response = FakeChatBedrock().invoke("hello")
+            converse_response = FakeChatBedrockConverse().invoke("hello")
+
+        assert FakeChatBedrock.invoke_calls == 0
+        assert FakeChatBedrockConverse.invoke_calls == 0
+        for response in (bedrock_response, converse_response):
+            assert response.content == "This is a mock response for testing."
+            assert response.response_metadata["provider"] == "bedrock"
+            assert response.usage_metadata == {
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "total_tokens": 30,
+            }
+
+        assert get_all_captured_responses() == [
+            bedrock_response,
+            converse_response,
+        ]
 
     def test_clear_removes_storage_correctly(self) -> None:
         """Test that clear operation removes all stored responses."""

--- a/traigent/core/llm_processor.py
+++ b/traigent/core/llm_processor.py
@@ -167,10 +167,28 @@ class LLMResponseProcessor:
         """
         try:
             # Extract token information
-            input_tokens = safe_get_nested_attr(response, "usage.prompt_tokens", 0)
-            output_tokens = safe_get_nested_attr(response, "usage.completion_tokens", 0)
-            total_tokens = safe_get_nested_attr(
-                response, "usage.total_tokens", input_tokens + output_tokens
+            input_tokens = self._extract_token_count(
+                response,
+                (
+                    "usage.prompt_tokens",
+                    "usage.input_tokens",
+                    "usage.inputTokens",
+                    "usage.input",
+                ),
+            )
+            output_tokens = self._extract_token_count(
+                response,
+                (
+                    "usage.completion_tokens",
+                    "usage.output_tokens",
+                    "usage.outputTokens",
+                    "usage.output",
+                ),
+            )
+            total_tokens = self._extract_token_count(
+                response,
+                ("usage.total_tokens", "usage.totalTokens"),
+                default=input_tokens + output_tokens,
             )
 
             # Extract cost information (if available)
@@ -202,6 +220,20 @@ class LLMResponseProcessor:
         except Exception as e:
             logger.debug(f"Failed to extract metrics from response: {e}")
             return None
+
+    @staticmethod
+    def _extract_token_count(
+        response: Any, paths: tuple[str, ...], default: int = 0
+    ) -> int:
+        for path in paths:
+            value = safe_get_nested_attr(response, path, None)
+            if value is None:
+                continue
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                continue
+        return default
 
     def enhance_example_result(
         self, example_result: Any, llm_metrics: LLMMetrics | None, execution_time: float

--- a/traigent/integrations/bedrock_client.py
+++ b/traigent/integrations/bedrock_client.py
@@ -18,9 +18,14 @@ import asyncio
 import concurrent.futures
 import json
 import os
+import time
 from collections.abc import AsyncGenerator, Generator, Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+
+from traigent.integrations.utils.mock_adapter import MockAdapter
+from traigent.testing import is_mock_mode_enabled
+from traigent.utils.env_config import is_production_strict_env, is_truthy
 
 if TYPE_CHECKING:
     pass
@@ -82,6 +87,8 @@ class BedrockChatResponse:
     text: str
     raw: Mapping[str, Any]
     usage: Mapping[str, Any] | None = None
+    model: str | None = None
+    response_time_ms: float = 0.0
 
 
 class BedrockChatClient:
@@ -112,6 +119,122 @@ class BedrockChatClient:
         )
         return self._client
 
+    @staticmethod
+    def _coerce_token_count(value: Any) -> int | None:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _normalize_usage(cls, usage: Mapping[str, Any] | None) -> dict[str, Any] | None:
+        if not isinstance(usage, Mapping):
+            return None
+
+        normalized = dict(usage)
+        input_tokens = cls._coerce_token_count(
+            normalized.get("prompt_tokens")
+            if normalized.get("prompt_tokens") is not None
+            else normalized.get("input_tokens")
+        )
+        if input_tokens is None:
+            input_tokens = cls._coerce_token_count(
+                normalized.get("inputTokens")
+                if normalized.get("inputTokens") is not None
+                else normalized.get("input")
+            )
+
+        output_tokens = cls._coerce_token_count(
+            normalized.get("completion_tokens")
+            if normalized.get("completion_tokens") is not None
+            else normalized.get("output_tokens")
+        )
+        if output_tokens is None:
+            output_tokens = cls._coerce_token_count(
+                normalized.get("outputTokens")
+                if normalized.get("outputTokens") is not None
+                else normalized.get("output")
+            )
+
+        total_tokens = cls._coerce_token_count(
+            normalized.get("total_tokens")
+            if normalized.get("total_tokens") is not None
+            else normalized.get("totalTokens")
+        )
+
+        if input_tokens is not None:
+            normalized["input_tokens"] = input_tokens
+            normalized["prompt_tokens"] = input_tokens
+        if output_tokens is not None:
+            normalized["output_tokens"] = output_tokens
+            normalized["completion_tokens"] = output_tokens
+        if total_tokens is None and (
+            input_tokens is not None or output_tokens is not None
+        ):
+            total_tokens = (input_tokens or 0) + (output_tokens or 0)
+        if total_tokens is not None:
+            normalized["total_tokens"] = total_tokens
+
+        if not any(
+            key in normalized
+            for key in ("prompt_tokens", "completion_tokens", "input_tokens")
+        ):
+            return None
+        return normalized
+
+    @classmethod
+    def _extract_usage(cls, data: Any) -> dict[str, Any] | None:
+        if not isinstance(data, Mapping):
+            return None
+        for key in ("usage", "tokenUsage", "amazon-bedrock-invocationMetrics"):
+            value = data.get(key)
+            if isinstance(value, Mapping):
+                usage = cls._normalize_usage(value)
+                if usage is not None:
+                    return usage
+        return cls._normalize_usage(data)
+
+    @staticmethod
+    def _is_mock_enabled() -> bool:
+        if is_production_strict_env():
+            return False
+        return bool(
+            is_mock_mode_enabled() or is_truthy(os.environ.get("TRAIGENT_MOCK_LLM"))
+        )
+
+    @classmethod
+    def _build_mock_response(cls, model_id: str) -> BedrockChatResponse:
+        mock_data = MockAdapter.get_mock_response("anthropic", model=model_id)
+        usage = cls._normalize_usage(mock_data.get("usage"))
+        raw = dict(mock_data)
+        raw["mock"] = True
+        raw["provider"] = "bedrock"
+        return BedrockChatResponse(
+            text=_extract_text_from_messages_response(raw),
+            raw=raw,
+            usage=usage,
+            model=model_id,
+            response_time_ms=0.0,
+        )
+
+    @classmethod
+    def _capture_response(
+        cls,
+        response: BedrockChatResponse,
+        start_time: float,
+    ) -> BedrockChatResponse:
+        response.response_time_ms = (time.perf_counter() - start_time) * 1000
+        response.usage = cls._normalize_usage(response.usage)
+        try:
+            from traigent.utils.langchain_interceptor import capture_langchain_response
+
+            capture_langchain_response(response)
+        except Exception:  # noqa: BLE001 - capture must not break the LLM call
+            pass
+        return response
+
     def invoke(
         self,
         *,
@@ -126,6 +249,12 @@ class BedrockChatClient:
 
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        start_time = time.perf_counter()
+        if self._is_mock_enabled():
+            return self._capture_response(
+                self._build_mock_response(model_id),
+                start_time,
+            )
 
         client = self._ensure_client()
 
@@ -164,8 +293,11 @@ class BedrockChatClient:
             data = json.loads(raw_body)
 
         text = _extract_text_from_messages_response(data)
-        usage = data.get("usage") if isinstance(data, Mapping) else None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        usage = self._extract_usage(data)
+        return self._capture_response(
+            BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id),
+            start_time,
+        )
 
     def _invoke_ai21(
         self,
@@ -177,6 +309,7 @@ class BedrockChatClient:
         top_p: float | None,
     ) -> BedrockChatResponse:
         """Invoke an AI21 Jamba family model via Bedrock."""
+        start_time = time.perf_counter()
 
         if isinstance(messages, str):
             request_messages = [{"role": "user", "content": messages}]
@@ -224,11 +357,14 @@ class BedrockChatClient:
                     text = str(message.get("content", "")).strip()
             if not text:
                 text = str(data.get("outputText", "")).strip()
-            usage = data.get("usage") or data.get("tokenUsage")
+            usage = self._extract_usage(data)
         else:
             text = str(data)
             usage = None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return self._capture_response(
+            BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id),
+            start_time,
+        )
 
     def invoke_stream(
         self,
@@ -241,6 +377,14 @@ class BedrockChatClient:
         extra_params: Mapping[str, Any] | None = None,
     ) -> Generator[str, None, BedrockChatResponse]:  # pragma: no cover - streaming path
         """Stream chat invocation; yields text chunks and returns final response."""
+        start_time = time.perf_counter()
+        if self._is_mock_enabled():
+            response = self._capture_response(
+                self._build_mock_response(model_id),
+                start_time,
+            )
+            yield response.text
+            return response
 
         client = self._ensure_client()
 
@@ -256,6 +400,7 @@ class BedrockChatClient:
             payload.update(dict(extra_params))
 
         final_text_parts: list[str] = []
+        usage: dict[str, Any] | None = None
         resp = client.invoke_model_with_response_stream(
             modelId=model_id,
             accept="application/json",
@@ -273,6 +418,9 @@ class BedrockChatClient:
                     data = json.loads(chunk.get("bytes").decode("utf-8"))
                 except Exception:  # noqa: BLE001 - defensive
                     continue
+                event_usage = self._extract_usage(data)
+                if event_usage is not None:
+                    usage = event_usage
                 # Extract incremental text if present
                 text_piece = _extract_text_from_messages_response(data)
                 if text_piece:
@@ -280,7 +428,16 @@ class BedrockChatClient:
                     yield text_piece
 
         final = "".join(final_text_parts)
-        return BedrockChatResponse(text=final, raw={"streamed": True}, usage=None)
+        response = self._capture_response(
+            BedrockChatResponse(
+                text=final,
+                raw={"streamed": True},
+                usage=usage,
+                model=model_id,
+            ),
+            start_time,
+        )
+        return response
 
     async def ainvoke(
         self,
@@ -297,6 +454,13 @@ class BedrockChatClient:
         Uses aioboto3 for true async or falls back to an isolated sync worker.
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        start_time = time.perf_counter()
+        if self._is_mock_enabled():
+            return self._capture_response(
+                self._build_mock_response(model_id),
+                start_time,
+            )
+
         # Try aioboto3 for true async
         try:
             import aioboto3  # noqa: F401 - used for availability check and async method
@@ -335,6 +499,7 @@ class BedrockChatClient:
         extra_params: Mapping[str, Any] | None,
     ) -> BedrockChatResponse:
         """Internal async implementation using aioboto3."""
+        start_time = time.perf_counter()
         import aioboto3
 
         payload: dict[str, Any] = {
@@ -370,8 +535,11 @@ class BedrockChatClient:
                 data = json.loads(raw_body)
 
         text = _extract_text_from_messages_response(data)
-        usage = data.get("usage") if isinstance(data, Mapping) else None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        usage = self._extract_usage(data)
+        return self._capture_response(
+            BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id),
+            start_time,
+        )
 
     async def ainvoke_stream(
         self,
@@ -388,6 +556,15 @@ class BedrockChatClient:
         Uses aioboto3 for true async streaming or falls back to sync streaming
         wrapped in an executor.
         """
+        start_time = time.perf_counter()
+        if self._is_mock_enabled():
+            response = self._capture_response(
+                self._build_mock_response(model_id),
+                start_time,
+            )
+            yield response.text
+            return
+
         # Try aioboto3 for true async streaming
         try:
             import aioboto3  # noqa: F401 - used for availability check and async stream
@@ -432,6 +609,7 @@ class BedrockChatClient:
         extra_params: Mapping[str, Any] | None,
     ) -> AsyncGenerator[str, None]:
         """Internal async streaming implementation using aioboto3."""
+        start_time = time.perf_counter()
         import aioboto3
 
         payload: dict[str, Any] = {
@@ -445,6 +623,8 @@ class BedrockChatClient:
         if extra_params:
             payload.update(dict(extra_params))
 
+        final_text_parts: list[str] = []
+        usage: dict[str, Any] | None = None
         session = (
             aioboto3.Session(profile_name=self._profile_name)
             if self._profile_name
@@ -469,9 +649,22 @@ class BedrockChatClient:
                         data = json.loads(chunk.get("bytes").decode("utf-8"))
                     except Exception:  # noqa: BLE001 - defensive
                         continue
+                    event_usage = self._extract_usage(data)
+                    if event_usage is not None:
+                        usage = event_usage
                     text_piece = _extract_text_from_messages_response(data)
                     if text_piece:
+                        final_text_parts.append(text_piece)
                         yield text_piece
+        self._capture_response(
+            BedrockChatResponse(
+                text="".join(final_text_parts),
+                raw={"streamed": True},
+                usage=usage,
+                model=model_id,
+            ),
+            start_time,
+        )
 
 
 def resolve_default_bedrock_model_id(model_hint: str | None) -> str:

--- a/traigent/utils/langchain_interceptor.py
+++ b/traigent/utils/langchain_interceptor.py
@@ -9,7 +9,7 @@ that would otherwise be lost when functions return only strings.
 import threading
 import time
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 
 from traigent.utils.logging import get_logger
 
@@ -173,6 +173,117 @@ def _create_astream_wrapper(original_meth: Any) -> Any:
             capture_langchain_response(last)
 
     return astream_wrapper
+
+
+def _extract_bedrock_model_name(instance: Any) -> str:
+    return str(
+        getattr(instance, "model_id", None)
+        or getattr(instance, "model", None)
+        or getattr(instance, "model_name", None)
+        or "mock-model"
+    )
+
+
+def _normalize_langchain_usage_metadata(response: Any) -> None:
+    """Normalize provider usage aliases into LangChain usage_metadata keys."""
+    usage = getattr(response, "usage_metadata", None)
+    if not isinstance(usage, dict):
+        metadata = getattr(response, "response_metadata", None)
+        if isinstance(metadata, dict):
+            candidate = metadata.get("usage") or metadata.get("token_usage")
+            usage = candidate if isinstance(candidate, dict) else None
+    if not isinstance(usage, dict):
+        return
+
+    input_tokens = (
+        usage.get("input_tokens")
+        if usage.get("input_tokens") is not None
+        else usage.get("prompt_tokens")
+    )
+    if input_tokens is None:
+        input_tokens = usage.get("inputTokens")
+    output_tokens = (
+        usage.get("output_tokens")
+        if usage.get("output_tokens") is not None
+        else usage.get("completion_tokens")
+    )
+    if output_tokens is None:
+        output_tokens = usage.get("outputTokens")
+    total_tokens = (
+        usage.get("total_tokens")
+        if usage.get("total_tokens") is not None
+        else usage.get("totalTokens")
+    )
+
+    normalized: dict[str, int] = {}
+    try:
+        if input_tokens is not None:
+            normalized["input_tokens"] = int(input_tokens)
+        if output_tokens is not None:
+            normalized["output_tokens"] = int(output_tokens)
+        if total_tokens is not None:
+            normalized["total_tokens"] = int(total_tokens)
+        elif normalized:
+            normalized["total_tokens"] = normalized.get(
+                "input_tokens", 0
+            ) + normalized.get("output_tokens", 0)
+    except (TypeError, ValueError):
+        return
+
+    if normalized:
+        response.usage_metadata = normalized
+
+
+def _create_bedrock_invoke_wrapper(original_invoke: Any) -> Any:
+    def invoke_with_capture_bedrock(self: Any, *args: Any, **kwargs: Any) -> Any:
+        """Wrapped invoke method that captures Bedrock responses with timing."""
+        from traigent.integrations.utils.mock_adapter import MockAdapter
+
+        model_name = _extract_bedrock_model_name(self)
+        if MockAdapter.is_mock_enabled("bedrock"):
+            from langchain_core.messages import AIMessage
+
+            mock_data = MockAdapter.get_mock_response("anthropic", model=model_name)
+            content = mock_data["content"][0]["text"]
+            input_tokens = int(mock_data["usage"]["input_tokens"])
+            output_tokens = int(mock_data["usage"]["output_tokens"])
+            response = AIMessage(
+                content=content,
+                response_metadata={
+                    "model_name": mock_data["model"],
+                    "provider": "bedrock",
+                    "stop_reason": mock_data["stop_reason"],
+                    "response_time_ms": 0.0,
+                },
+                usage_metadata={
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens,
+                },
+            )
+            capture_langchain_response(response)
+            return response
+
+        start_time = time.perf_counter()
+        response = original_invoke(self, *args, **kwargs)
+        response_time_ms = (time.perf_counter() - start_time) * 1000
+
+        if not hasattr(response, "response_metadata"):
+            response.response_metadata = {}
+        response.response_metadata["response_time_ms"] = response_time_ms
+        if "model_name" not in response.response_metadata:
+            response.response_metadata["model_name"] = model_name
+        _normalize_langchain_usage_metadata(response)
+
+        capture_langchain_response(response)
+        logger.debug(
+            "Captured Bedrock LangChain invoke usage: %s, response_time_ms: %.2f",
+            getattr(response, "usage_metadata", None),
+            response_time_ms,
+        )
+        return response
+
+    return invoke_with_capture_bedrock
 
 
 def patch_langchain_for_metadata_capture() -> bool:
@@ -351,6 +462,57 @@ def patch_langchain_for_metadata_capture() -> bool:
         logger.debug("ChatOpenAI not available, skipping")
     except Exception as e:
         logger.error(f"Failed to patch ChatOpenAI: {e}")
+
+    # Patch ChatBedrock / ChatBedrockConverse
+    try:
+        import langchain_aws
+
+        bedrock_classes: list[tuple[str, Any]] = []
+        for name in ("ChatBedrock", "ChatBedrockConverse"):
+            chat_cls = getattr(langchain_aws, name, None)
+            if chat_cls is not None:
+                bedrock_classes.append((name, cast(Any, chat_cls)))
+
+        if not bedrock_classes:
+            logger.debug("LangChain AWS Bedrock chat models not available, skipping")
+
+        for class_name, chat_cls in bedrock_classes:
+            if getattr(chat_cls, "_traigent_patched_invoke", False) is False:
+                original_invoke_bedrock = chat_cls.invoke
+                chat_cls.invoke = _create_bedrock_invoke_wrapper(
+                    original_invoke_bedrock
+                )
+                chat_cls._traigent_patched_invoke = True
+                logger.info(f"✅ Patched {class_name}.invoke for metadata capture")
+                patched_any = True
+
+            for meth_name, flag in [
+                ("stream", "_traigent_patched_stream"),
+                ("astream", "_traigent_patched_astream"),
+            ]:
+                if hasattr(chat_cls, meth_name) and not getattr(chat_cls, flag, False):
+                    original_meth = getattr(chat_cls, meth_name)
+                    if meth_name == "stream":
+                        setattr(
+                            chat_cls,
+                            meth_name,
+                            _create_stream_wrapper(original_meth),
+                        )
+                    else:
+                        setattr(
+                            chat_cls,
+                            meth_name,
+                            _create_astream_wrapper(original_meth),
+                        )
+                    setattr(chat_cls, flag, True)
+                    logger.info(
+                        f"✅ Patched {class_name}.{meth_name} for metadata capture"
+                    )
+
+    except ImportError:
+        logger.debug("langchain_aws not available, skipping Bedrock chat models")
+    except Exception as e:
+        logger.error(f"Failed to patch LangChain AWS Bedrock models: {e}")
 
     if not patched_any:
         logger.debug("No LangChain models could be patched for metadata capture")


### PR DESCRIPTION
Fixes #1089. Auto-instrumentation only patched ChatOpenAI/ChatAnthropic/litellm — Bedrock via LangChain `ChatBedrock`/`ChatBedrockConverse` or the native `BedrockChatClient` got silent $0/0-token metrics, and `TRAIGENT_MOCK_LLM` didn't make Bedrock dry-runs free (real AWS spend).

- LangChain interceptor: added ChatBedrock + ChatBedrockConverse branches (capture + mock short-circuit), optional-import guarded.
- Native BedrockChatClient: invoke/ainvoke/invoke_stream/ainvoke_stream short-circuit before boto3/aioboto3 in mock mode and capture responses.
- Usage normalization: `input_tokens`/`output_tokens` (+ camelCase variants) → `prompt_tokens`/`completion_tokens`/`total_tokens` so token+cost capture works.
- `test_bedrock_client_no_mock.py` UPDATED: now asserts mock DOES intercept without boto3/AWS (the documented bug is fixed).

2,980 tests (integrations+utils); ruff/mypy clean. Closes the Bedrock observability gap. Gates not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)