### PR TITLE
feat(cost): pre-run cost-coverage preflight + scheduled coverage check

### DIFF
--- a/.github/workflows/cost-coverage.yml
+++ b/.github/workflows/cost-coverage.yml
@@ -1,0 +1,35 @@
+name: Cost Coverage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  model-price-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/install_sdk_requirements.sh -e ".[test]"
+
+      - name: Run static model price coverage check
+        env:
+          LITELLM_LOCAL_MODEL_COST_MAP: "True"
+          PYTHONPATH: .
+          TRAIGENT_OFFLINE_MODE: "true"
+        run: |
+          # No AWS credentials here: this enumerates a static curated catalog,
+          # not live Bedrock list_inference_profiles output.
+          pytest tests/cost_coverage/test_model_price_coverage.py -q --tb=short --timeout=60

--- a/tests/cost_coverage/test_model_price_coverage.py
+++ b/tests/cost_coverage/test_model_price_coverage.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from traigent.utils.cost_calculator import cost_from_tokens
+
+# Static catalog only: do not call AWS list_inference_profiles in CI. This keeps
+# the scheduled check credential-free and catches bundled litellm price-map drift.
+CURATED_BEDROCK_INFERENCE_PROFILE_IDS = [
+    # Seeded from the SDK's Bedrock catalog/skill material:
+    # - traigent/config_generator/catalog/tvar_catalog.v1.json uses
+    #   bedrock/us.anthropic.claude-haiku-4-5.
+    # - traigent/config/models.yaml lists the Bedrock Anthropic and Meta families.
+    # - examples/integrations/bedrock/bedrock_hello.py anchors Amazon Bedrock usage.
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "us.anthropic.claude-3-haiku-20240307-v1:0",
+    "us.amazon.nova-micro-v1:0",
+    "us.amazon.nova-lite-v1:0",
+    "us.meta.llama3-1-8b-instruct-v1:0",
+    "us.meta.llama3-1-70b-instruct-v1:0",
+]
+
+COMMON_EXAMPLE_MODEL_IDS = [
+    "gpt-4o-mini",
+    "gpt-4o",
+    "claude-3-haiku-20240307",
+    "claude-3-5-sonnet-20241022",
+    "claude-haiku-4-5-20251001",
+]
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    CURATED_BEDROCK_INFERENCE_PROFILE_IDS + COMMON_EXAMPLE_MODEL_IDS,
+)
+def test_catalog_model_resolves_nonzero_price(model_id: str) -> None:
+    input_cost, output_cost = cost_from_tokens(
+        1,
+        1,
+        model_id,
+        strict=True,
+    )
+    assert input_cost + output_cost > 0.0

--- a/tests/unit/core/test_cost_coverage_preflight.py
+++ b/tests/unit/core/test_cost_coverage_preflight.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import warnings
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import traigent.utils.cost_calculator as cost_calculator
+from traigent.api.types import OptimizationResult, OptimizationStatus
+from traigent.core.optimized_function import OptimizedFunction
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.utils.cost_calculator import UnknownModelError
+
+FAKE_MODEL = "us.fake.unpriced-model-v9:0"
+
+
+class CountedFunction:
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.__name__ = "counted_function"
+
+    def __call__(self, text: str = "", **_kwargs: object) -> str:
+        self.call_count += 1
+        return text
+
+
+@pytest.fixture(autouse=True)
+def reset_cost_preflight_state(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TRAIGENT_STRICT_COST_ACCOUNTING", raising=False)
+    monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
+    monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
+    monkeypatch.setattr("traigent.core.optimized_function._COST_WARNING_EMITTED", True)
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+    yield
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+
+
+@pytest.fixture
+def one_example_dataset() -> Dataset:
+    return Dataset(
+        [EvaluationExample(input_data={"text": "hello"}, expected_output="hello")]
+    )
+
+
+def _completed_result() -> OptimizationResult:
+    return OptimizationResult(
+        trials=[],
+        best_config={"model": "gpt-4o"},
+        best_score=1.0,
+        optimization_id="cost-preflight-test",
+        duration=0.0,
+        convergence_info={},
+        status=OptimizationStatus.COMPLETED,
+        objectives=["accuracy"],
+        algorithm="random",
+        timestamp=datetime.now(UTC),
+        metadata={},
+    )
+
+
+async def _run_with_mocked_orchestrator(
+    opt_func: OptimizedFunction,
+) -> OptimizationResult:
+    with patch(
+        "traigent.core.optimized_function.OptimizationOrchestrator"
+    ) as mock_orchestrator_cls:
+        mock_orchestrator = mock_orchestrator_cls.return_value
+        mock_orchestrator.optimize = AsyncMock(return_value=_completed_result())
+        result = await opt_func.optimize(progress_bar=False)
+        mock_orchestrator.optimize.assert_awaited_once()
+        return result
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_warns_once_with_exact_unpriced_models(
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": ["gpt-4o", FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    preflight_warnings = [
+        str(warning.message)
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+    assert preflight_warnings == [
+        "Cost for `us.fake.unpriced-model-v9:0` is unavailable — results will "
+        "report $0 for it. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+        "Traigent to add coverage."
+    ]
+    assert "`gpt-4o`" not in preflight_warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_strict_blocks_before_any_trial(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    counted = CountedFunction()
+    opt_func = OptimizedFunction(
+        func=counted,
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+
+    with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
+        with pytest.raises(UnknownModelError, match=FAKE_MODEL):
+            await opt_func.optimize(progress_bar=False)
+
+    assert counted.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_fully_priced_space_has_no_warning(
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": ["gpt-4o", "gpt-4o-mini"]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert not [
+        warning
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_custom_pricing_json_counts_as_covered(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    monkeypatch.setenv(
+        "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+        json.dumps(
+            {
+                FAKE_MODEL: {
+                    "input_cost_per_token": 1e-6,
+                    "output_cost_per_token": 2e-6,
+                }
+            }
+        ),
+    )
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert not [
+        warning
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_mock_mode_skips_warning_and_strict_block(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=True),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert not [
+        warning
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_checks_default_model_when_model_is_fixed(
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"temperature": [0.0, 0.5]},
+        default_config={"model": FAKE_MODEL},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert [
+        warning
+        for warning in captured
+        if FAKE_MODEL in str(warning.message)
+        and "results will report $0" in str(warning.message)
+    ]

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -82,7 +82,11 @@ from traigent.integrations.framework_override import override_context
 from traigent.optimizers import get_optimizer
 from traigent.tvl.options import TVLOptions
 from traigent.tvl.spec_loader import load_tvl_spec
-from traigent.utils.env_config import is_mock_llm
+from traigent.utils.cost_calculator import (
+    UnknownModelError,
+    find_models_missing_price_coverage,
+)
+from traigent.utils.env_config import is_mock_llm, is_strict_cost_accounting
 from traigent.utils.exceptions import (
     AuthenticationError,
     ConfigurationError,
@@ -160,6 +164,60 @@ _COST_WARNING_EMITTED = False
 _CONFIG_SPACE_TYPE_ERROR = "Configuration space must be a dictionary"
 
 _CLOUD_FALLBACK_POLICIES = frozenset({"auto", "warn", "never"})
+_MODEL_CONFIG_KEYS = frozenset({"model", "model_name", "model_id", "engine"})
+
+
+def _is_model_config_key(key: object) -> bool:
+    return isinstance(key, str) and key.strip().lower() in _MODEL_CONFIG_KEYS
+
+
+def _iter_config_model_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+
+    if isinstance(value, Mapping):
+        choices = value.get("values") or value.get("choices")
+        if choices is not None:
+            return _iter_config_model_values(choices)
+        fixed_value = value.get("value")
+        if isinstance(fixed_value, str):
+            return [fixed_value]
+        return []
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [item for item in value if isinstance(item, str) and item.strip()]
+
+    range_values = getattr(value, "values", None)
+    if isinstance(range_values, Sequence) and not isinstance(
+        range_values, (str, bytes, bytearray)
+    ):
+        return [item for item in range_values if isinstance(item, str) and item.strip()]
+
+    return []
+
+
+def _dedupe_model_ids(model_ids: list[str]) -> list[str]:
+    return list(dict.fromkeys(model_ids))
+
+
+def _extract_config_space_model_ids(config_space: Mapping[str, Any]) -> list[str]:
+    model_ids: list[str] = []
+    for key, value in config_space.items():
+        if _is_model_config_key(key):
+            model_ids.extend(_iter_config_model_values(value))
+    return _dedupe_model_ids(model_ids)
+
+
+def _extract_config_model_ids(config: Mapping[str, Any]) -> list[str]:
+    model_ids: list[str] = []
+    for key, value in config.items():
+        if _is_model_config_key(key) and isinstance(value, str) and value.strip():
+            model_ids.append(value)
+    return _dedupe_model_ids(model_ids)
+
+
+def _format_model_id_list(model_ids: Sequence[str]) -> str:
+    return ", ".join(f"`{model_id}`" for model_id in model_ids)
 
 
 def _emit_cost_warning_once() -> None:
@@ -1862,6 +1920,50 @@ class OptimizedFunction:
         """
         return algorithm
 
+    def _preflight_model_cost_coverage(
+        self, effective_config_space: Mapping[str, Any]
+    ) -> None:
+        """Warn or fail before trials when a real run includes unpriced models."""
+        if is_mock_llm():
+            return
+
+        model_ids = _extract_config_space_model_ids(effective_config_space)
+        if not model_ids:
+            model_ids = _dedupe_model_ids(
+                _extract_config_model_ids(getattr(self, "_current_config", {}))
+                + _extract_config_model_ids(getattr(self, "default_config", {}))
+            )
+        if not model_ids:
+            return
+
+        missing = find_models_missing_price_coverage(model_ids)
+        if not missing:
+            return
+
+        formatted = _format_model_id_list(missing)
+        if is_strict_cost_accounting():
+            raise UnknownModelError(
+                "Cost coverage preflight failed before any optimization trial "
+                f"started: pricing is unavailable for {formatted}. "
+                "Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON or "
+                "TRAIGENT_CUSTOM_MODEL_PRICING_FILE with explicit per-token "
+                "pricing, or contact Traigent to add coverage."
+            )
+
+        if len(missing) == 1:
+            message = (
+                f"Cost for {formatted} is unavailable — results will report $0 "
+                "for it. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+                "Traigent to add coverage."
+            )
+        else:
+            message = (
+                f"Costs for {formatted} are unavailable — results will report $0 "
+                "for them. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+                "Traigent to add coverage."
+            )
+        warnings.warn(message, UserWarning, stacklevel=3)
+
     async def _execute_optimization(
         self,
         *,
@@ -1957,6 +2059,9 @@ class OptimizedFunction:
         )
         if max_total_examples_value is not None:
             self.max_total_examples = max_total_examples_value
+
+        # Phase 3.5: cost coverage preflight before any cloud or local trial dispatch.
+        self._preflight_model_cost_coverage(effective_config_space)
 
         # Phase 4: Try cloud execution if applicable
         cloud_result = await self._try_cloud_execution(

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -15,6 +15,7 @@ import os
 import re
 import threading
 import warnings
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -1146,6 +1147,28 @@ def cost_from_tokens(
         _CUSTOM_PRICING_JSON_ENV,
     )
     return 0.0, 0.0
+
+
+def model_has_nonzero_price_coverage(model_name: str) -> bool:
+    """Return whether a model resolves to non-zero pricing via the real path."""
+    try:
+        input_cost, output_cost = cost_from_tokens(1, 1, model_name, strict=True)
+    except (RuntimeError, UnknownModelError):
+        return False
+    return (input_cost + output_cost) > 0.0
+
+
+def find_models_missing_price_coverage(models: Iterable[str]) -> list[str]:
+    """Return deduplicated model IDs without non-zero pricing coverage."""
+    missing: list[str] = []
+    seen: set[str] = set()
+    for model_name in models:
+        if model_name in seen:
+            continue
+        seen.add(model_name)
+        if not model_has_nonzero_price_coverage(model_name):
+            missing.append(model_name)
+    return missing
 
 
 # Convenience functions for simple usage


### PR DESCRIPTION
## Summary
Closes #1096. Never let an unpriced model run as silent $0.

1. **Pre-run preflight** (`_preflight_model_cost_coverage`, wired before any cloud/local trial dispatch): every model that can appear in the run (model/model_name/model_id/engine in the effective config space; falls back to current/default config when the model knob isn't searched) must resolve a non-zero price through the **real cost path** (`cost_from_tokens` strict probe — same resolution as billing, so warnings can't be false positives vs what billing would do). Unpriced IDs → one visible `UserWarning` listing them verbatim + remediation; under `TRAIGENT_STRICT_COST_ACCOUNTING` → `UnknownModelError` **before any trial** listing ALL missing IDs (previously failed mid-run on the first offender). Mock runs skip it (`is_mock_llm()` carries the production hard-block).
2. **Scheduled coverage check**: `tests/cost_coverage/` asserts a static curated catalog (8 Bedrock `us.*` inference profiles + 5 common OpenAI/Anthropic IDs, sources cited inline) resolves non-zero pricing; `.github/workflows/cost-coverage.yml` runs weekly + on dispatch, credential-free (static catalog by design — cannot detect brand-new AWS profiles until curated; noted inline).

## Verification
- New tests: warning lists exactly the unpriced IDs; strict raises before any trial executes (counted function never called); fully-priced space silent; `TRAIGENT_CUSTOM_MODEL_PRICING_JSON` makes an unpriced model pass; mock-mode skip; fixed-default-model checked when model isn't searched. Catalog test 13/13.
- Captain full unit suite: 12744 passed; 3 fails all pre-existing/load-flake (strategy-preset sibling schema [fixed on develop by #1141], auth-stress perf, fresh-process best-config test — passes isolated in 24.8s).
- `bash scripts/hooks/check-cost-strictness.sh` PASS (gate not weakened); ruff/mypy/black/isort clean.
- Note: spaces containing the legacy `gpt-3.5` alias now warn in real runs — TRUE positive (that alias prices $0 on the real path today).

## PR checklist
1. **Worst-case prod path** — preflight can only warn or fail-CLOSED (strict). No pricing values changed.
2. **Production-branch test** — mock-skip relies on `is_mock_llm()` production hard-block (existing tested helper); strict-block test `tests/unit/core/test_cost_coverage_preflight.py` (raises before trial 1).
3. **Contract regeneration** — none (no payload change).
4. **Public surface delta** — none (no new public API; warning text documents env remediation).
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed; new scheduled gate ADDED.
