### PR TITLE
fix(integrations): Bedrock cost/token capture + litellm-shaped mock responses

### DIFF
--- a/tests/unit/core/test_llm_processor.py
+++ b/tests/unit/core/test_llm_processor.py
@@ -9,6 +9,7 @@ and response parsing logic.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -349,6 +350,24 @@ class TestExtractMetricsFromResponse:
         result = processor._extract_metrics_from_response(response, "test-model")
         assert result is not None
         assert result["total_tokens"] == 75  # 50 + 25
+
+    def test_extract_metrics_accepts_bedrock_usage_keys(
+        self, processor: LLMResponseProcessor
+    ) -> None:
+        """Test Bedrock input_tokens/output_tokens usage normalization."""
+        response = SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=40, output_tokens=12),
+            cost=SimpleNamespace(input_cost=0.0, output_cost=0.0, total_cost=0.0),
+            response_time_ms=123.0,
+        )
+
+        result = processor._extract_metrics_from_response(response, "bedrock-model")
+
+        assert result is not None
+        assert result["input_tokens"] == 40
+        assert result["output_tokens"] == 12
+        assert result["total_tokens"] == 52
+        assert result["response_time_ms"] == 123.0
 
     def test_extract_metrics_calculates_total_cost(
         self, processor: LLMResponseProcessor

--- a/tests/unit/integrations/test_bedrock_client.py
+++ b/tests/unit/integrations/test_bedrock_client.py
@@ -11,10 +11,12 @@ normalized response parsing and mocked boto3 interactions.
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
 from traigent.integrations.bedrock_client import (
     BedrockChatClient,
     BedrockChatResponse,
@@ -24,6 +26,21 @@ from traigent.integrations.bedrock_client import (
     _require_boto3,
     resolve_default_bedrock_model_id,
 )
+from traigent.utils.langchain_interceptor import (
+    clear_captured_responses,
+    get_captured_response,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_llm_mock_for_bedrock_client_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    """Most Bedrock client tests exercise fake boto clients, not mock mode."""
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+    clear_captured_responses()
+    yield
+    clear_captured_responses()
 
 
 def _mock_invoke_client(payload: dict) -> MagicMock:
@@ -151,6 +168,11 @@ class TestBedrockChatResponseDataclass:
         response = BedrockChatResponse(text="test", raw={}, usage=usage)
         assert response.usage == usage
 
+    def test_bedrock_chat_response_default_response_time(self) -> None:
+        """Test BedrockChatResponse exposes latency for capture paths."""
+        response = BedrockChatResponse(text="test", raw={})
+        assert response.response_time_ms == 0.0
+
 
 class TestBedrockChatClientInit:
     """Tests for BedrockChatClient initialization."""
@@ -237,9 +259,7 @@ class TestBedrockChatClientInvoke:
         assert response.usage["output_tokens"] == 10
         mock_client.invoke_model.assert_called_once()
 
-    def test_invoke_with_list_messages(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_invoke_with_list_messages(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invoke sends list messages to Bedrock payload."""
         mock_client = _mock_invoke_client(
             {"content": [{"type": "text", "text": "List response"}]}
@@ -406,6 +426,148 @@ class TestBedrockChatClientInvoke:
 
         assert response.text == "AI21 response"
         mock_client.invoke_model.assert_called_once()
+
+
+class TestBedrockChatClientCaptureAndMock:
+    """Native Bedrock client capture and mock-mode short-circuit behavior."""
+
+    def teardown_method(self) -> None:
+        clear_captured_responses()
+
+    def test_invoke_captures_tokens_cost_and_latency(self) -> None:
+        mock_client = _mock_invoke_client(
+            {
+                "content": [{"type": "text", "text": "Captured response"}],
+                "usage": {"input_tokens": 13, "output_tokens": 8},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+        captured = get_captured_response()
+        assert captured is response
+        assert response.response_time_ms > 0
+        metrics = extract_llm_metrics(captured, model_name="claude-3-5-sonnet-20241022")
+        assert metrics.tokens.input_tokens == 13
+        assert metrics.tokens.output_tokens == 8
+        assert metrics.tokens.total_tokens == 21
+        assert metrics.cost.total_cost > 0
+        assert metrics.response.response_time_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_captures_tokens_cost_and_latency(self) -> None:
+        mock_client = _mock_invoke_client(
+            {
+                "content": [{"type": "text", "text": "Async captured response"}],
+                "usage": {"input_tokens": 17, "output_tokens": 9},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        with patch.dict("sys.modules", {"aioboto3": None}):
+            response = await client.ainvoke(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages="hello",
+            )
+
+        captured = get_captured_response()
+        assert captured is response
+        metrics = extract_llm_metrics(captured, model_name="claude-3-5-sonnet-20241022")
+        assert metrics.tokens.input_tokens == 17
+        assert metrics.tokens.output_tokens == 9
+        assert metrics.tokens.total_tokens == 26
+        assert metrics.cost.total_cost > 0
+        assert metrics.response.response_time_ms > 0
+
+    def test_invoke_stream_captures_final_response_latency(self) -> None:
+        mock_client = _mock_stream_client(
+            {"content": [{"type": "text", "text": "streamed"}]}
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        chunks = list(
+            client.invoke_stream(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages="hello",
+            )
+        )
+
+        assert chunks == ["streamed"]
+        captured = get_captured_response()
+        assert isinstance(captured, BedrockChatResponse)
+        assert captured.text == "streamed"
+        assert captured.response_time_ms > 0
+
+    def test_mock_invoke_short_circuits_underlying_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+        assert response.text == "This is a mock response for testing."
+        assert response.usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
+        mock_client.invoke_model.assert_not_called()
+        assert get_captured_response() is response
+
+    @pytest.mark.asyncio
+    async def test_mock_ainvoke_short_circuits_underlying_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        response = await client.ainvoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+        assert response.text == "This is a mock response for testing."
+        assert response.usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
+        mock_client.invoke_model.assert_not_called()
+        assert get_captured_response() is response
+
+    def test_mock_invoke_stream_short_circuits_underlying_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        chunks = list(
+            client.invoke_stream(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages="hello",
+            )
+        )
+
+        assert chunks == ["This is a mock response for testing."]
+        mock_client.invoke_model_with_response_stream.assert_not_called()
+        captured = get_captured_response()
+        assert isinstance(captured, BedrockChatResponse)
+        assert captured.usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
 
 
 class TestBedrockChatClientInvokeAI21:

--- a/tests/unit/integrations/test_bedrock_client_no_mock.py
+++ b/tests/unit/integrations/test_bedrock_client_no_mock.py
@@ -11,6 +11,7 @@ from traigent.integrations.bedrock_client import BedrockChatClient
 def test_bedrock_mock_env_does_not_short_circuit_invoke(monkeypatch) -> None:
     """Setting BEDROCK_MOCK still uses the boto3 Bedrock Runtime client."""
     monkeypatch.setenv("BEDROCK_MOCK", "true")
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
 
     mock_boto3 = MagicMock()
     mock_session = MagicMock()

--- a/tests/unit/utils/test_langchain_interceptor.py
+++ b/tests/unit/utils/test_langchain_interceptor.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import threading
 import time
+import types
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
 from traigent.utils.langchain_interceptor import (
     LangChainMetadataCapture,
     _create_astream_wrapper,
@@ -27,6 +29,74 @@ from traigent.utils.langchain_interceptor import (
     langchain_metadata_context,
     patch_langchain_for_metadata_capture,
 )
+
+
+class _FakeAIMessage:
+    def __init__(
+        self,
+        content: str,
+        response_metadata: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.content = content
+        self.response_metadata = response_metadata or {}
+        self.usage_metadata = usage_metadata or {}
+
+
+def _make_fake_bedrock_class(class_name: str) -> type:
+    class _FakeBedrock:
+        _traigent_patched_invoke = False
+        _traigent_patched_stream = False
+        _traigent_patched_astream = False
+        calls = 0
+
+        def __init__(
+            self, model_id: str = "claude-3-5-sonnet-20241022", **kwargs: Any
+        ) -> None:
+            self.model_id = model_id
+            self.model = kwargs.get("model", model_id)
+
+        def invoke(self, *args: Any, **kwargs: Any) -> _FakeAIMessage:
+            del args, kwargs
+            type(self).calls += 1
+            return _FakeAIMessage(
+                content="bedrock response",
+                response_metadata={"model_name": self.model_id},
+                usage_metadata={
+                    "input_tokens": 11,
+                    "output_tokens": 7,
+                    "total_tokens": 18,
+                },
+            )
+
+        def stream(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            yield _FakeAIMessage("stream chunk")
+
+        async def astream(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            yield _FakeAIMessage("astream chunk")
+
+    _FakeBedrock.__name__ = class_name
+    return _FakeBedrock
+
+
+def _make_fake_langchain_modules() -> dict[str, Any]:
+    langchain_aws = types.ModuleType("langchain_aws")
+    langchain_aws.ChatBedrock = _make_fake_bedrock_class("ChatBedrock")
+    langchain_aws.ChatBedrockConverse = _make_fake_bedrock_class("ChatBedrockConverse")
+
+    langchain_core = types.ModuleType("langchain_core")
+    messages = types.ModuleType("langchain_core.messages")
+    messages.AIMessage = _FakeAIMessage
+
+    return {
+        "langchain_anthropic": None,
+        "langchain_openai": None,
+        "langchain_aws": langchain_aws,
+        "langchain_core": langchain_core,
+        "langchain_core.messages": messages,
+    }
 
 
 class TestLangChainMetadataCapture:
@@ -859,3 +929,70 @@ class TestPatchLangChainForMetadataCapture:
 
         # Each thread should retrieve its own response
         assert len(results) == 5
+
+
+class TestPatchLangChainBedrock:
+    """LangChain AWS Bedrock interception."""
+
+    def teardown_method(self) -> None:
+        clear_captured_responses()
+
+    @pytest.mark.parametrize("class_name", ["ChatBedrock", "ChatBedrockConverse"])
+    def test_bedrock_invoke_captures_tokens_cost_and_latency(
+        self, class_name: str
+    ) -> None:
+        modules = _make_fake_langchain_modules()
+        langchain_aws = modules["langchain_aws"]
+        target_cls = getattr(langchain_aws, class_name)
+
+        with (
+            patch.dict("sys.modules", modules),
+            patch(
+                "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+                return_value=False,
+            ),
+        ):
+            assert patch_langchain_for_metadata_capture() is True
+            llm = target_cls(model_id="claude-3-5-sonnet-20241022")
+            response = llm.invoke("hello")
+
+        assert response.content == "bedrock response"
+        assert target_cls.calls == 1
+
+        captured = get_captured_response()
+        assert captured is response
+        metrics = extract_llm_metrics(captured, model_name="claude-3-5-sonnet-20241022")
+        assert metrics.tokens.input_tokens == 11
+        assert metrics.tokens.output_tokens == 7
+        assert metrics.tokens.total_tokens == 18
+        assert metrics.cost.total_cost > 0
+        assert metrics.response.response_time_ms > 0
+
+    @pytest.mark.parametrize("class_name", ["ChatBedrock", "ChatBedrockConverse"])
+    def test_bedrock_mock_mode_short_circuits_underlying_invoke(
+        self, class_name: str
+    ) -> None:
+        modules = _make_fake_langchain_modules()
+        langchain_aws = modules["langchain_aws"]
+        target_cls = getattr(langchain_aws, class_name)
+
+        with (
+            patch.dict("sys.modules", modules),
+            patch(
+                "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+                return_value=True,
+            ),
+        ):
+            assert patch_langchain_for_metadata_capture() is True
+            llm = target_cls(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
+            response = llm.invoke("hello")
+
+        assert target_cls.calls == 0
+        assert response.content == "This is a mock response for testing."
+        assert response.usage_metadata == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
+        captured = get_captured_response()
+        assert captured is response

--- a/tests/unit/utils/test_litellm_interceptor.py
+++ b/tests/unit/utils/test_litellm_interceptor.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -71,7 +71,9 @@ class TestPatchLiteLLM:
     """Patching litellm.completion and litellm.acompletion."""
 
     def test_patch_returns_true(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         result = patch_litellm_for_metadata_capture()
         assert result is True
@@ -86,7 +88,9 @@ class TestPatchLiteLLM:
         assert result is False
 
     def test_patch_is_idempotent(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         # Second call should skip (already patched)
@@ -102,7 +106,9 @@ class TestSyncCapture:
     """Sync litellm.completion response capture."""
 
     def test_captures_response(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -112,7 +118,9 @@ class TestSyncCapture:
         assert captured[0] is response
 
     def test_injects_timing(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -121,7 +129,9 @@ class TestSyncCapture:
         assert response.response_time_ms > 0
 
     def test_preserves_usage(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -131,7 +141,9 @@ class TestSyncCapture:
         assert response.usage.total_tokens == 150
 
     def test_preserves_return_value(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -140,7 +152,9 @@ class TestSyncCapture:
         assert response.choices[0].message.content == "Hello world"
 
     def test_multiple_calls_captured_in_order(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         litellm_module.completion(model="gpt-4o", messages=[])
@@ -155,7 +169,9 @@ class TestAsyncCapture:
     """Async litellm.acompletion response capture."""
 
     def test_captures_response(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = asyncio.run(litellm_module.acompletion(model="gpt-4o", messages=[]))
@@ -165,13 +181,97 @@ class TestAsyncCapture:
         assert captured[0] is response
 
     def test_injects_timing(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = asyncio.run(litellm_module.acompletion(model="gpt-4o", messages=[]))
 
         assert hasattr(response, "response_time_ms")
         assert response.response_time_ms > 0
+
+
+class TestMockModeLiteLLMShape:
+    """LiteLLM mock mode must preserve ModelResponse access patterns."""
+
+    @pytest.mark.asyncio
+    async def test_async_mock_mode_supports_choices_message_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+        from litellm import ModelResponse
+
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        underlying = AsyncMock(side_effect=AssertionError("real LiteLLM called"))
+        monkeypatch.setattr(litellm, "acompletion", underlying)
+        monkeypatch.setattr(
+            litellm, "_traigent_patched_acompletion", False, raising=False
+        )
+
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            patch_litellm_for_metadata_capture()
+
+            async def user_code() -> str:
+                resp = await litellm.acompletion(
+                    model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+                assert isinstance(resp, ModelResponse)
+                assert resp.usage.prompt_tokens == 10
+                assert resp.usage.completion_tokens == 20
+                assert resp.usage.total_tokens == 30
+                return resp.choices[0].message.content
+
+            content = await user_code()
+
+        assert content == "This is a mock response for testing."
+        underlying.assert_not_called()
+        captured = get_all_captured_responses()
+        assert len(captured) == 1
+        assert isinstance(captured[0], ModelResponse)
+
+    def test_sync_mock_mode_supports_choices_message_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+        from litellm import ModelResponse
+
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        underlying = MagicMock(side_effect=AssertionError("real LiteLLM called"))
+        monkeypatch.setattr(litellm, "completion", underlying)
+        monkeypatch.setattr(
+            litellm, "_traigent_patched_completion", False, raising=False
+        )
+
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            patch_litellm_for_metadata_capture()
+            resp = litellm.completion(
+                model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert isinstance(resp, ModelResponse)
+        assert resp.choices[0].message.content == "This is a mock response for testing."
+        assert resp.usage.prompt_tokens == 10
+        assert resp.usage.completion_tokens == 20
+        assert resp.usage.total_tokens == 30
+        underlying.assert_not_called()
+        captured = get_all_captured_responses()
+        assert len(captured) == 1
+        assert captured[0] is resp
 
 
 class TestLiteLLMPlugin:

--- a/traigent/core/llm_processor.py
+++ b/traigent/core/llm_processor.py
@@ -167,11 +167,29 @@ class LLMResponseProcessor:
         """
         try:
             # Extract token information
-            input_tokens = safe_get_nested_attr(response, "usage.prompt_tokens", 0)
-            output_tokens = safe_get_nested_attr(response, "usage.completion_tokens", 0)
-            total_tokens = safe_get_nested_attr(
-                response, "usage.total_tokens", input_tokens + output_tokens
+            def _first_numeric_token(*paths: str) -> int:
+                for path in paths:
+                    value = safe_get_nested_attr(response, path, None)
+                    if isinstance(value, (int, float)):
+                        return int(value)
+                return 0
+
+            input_tokens = _first_numeric_token(
+                "usage.prompt_tokens",
+                "usage.input_tokens",
+                "usage.inputTokens",
             )
+            output_tokens = _first_numeric_token(
+                "usage.completion_tokens",
+                "usage.output_tokens",
+                "usage.outputTokens",
+            )
+            total_tokens = _first_numeric_token(
+                "usage.total_tokens",
+                "usage.totalTokens",
+            )
+            if total_tokens == 0:
+                total_tokens = input_tokens + output_tokens
 
             # Extract cost information (if available)
             input_cost = safe_get_nested_attr(response, "cost.input_cost", 0.0)

--- a/traigent/integrations/bedrock_client.py
+++ b/traigent/integrations/bedrock_client.py
@@ -18,6 +18,7 @@ import asyncio
 import concurrent.futures
 import json
 import os
+import time
 from collections.abc import AsyncGenerator, Generator, Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -82,6 +83,8 @@ class BedrockChatResponse:
     text: str
     raw: Mapping[str, Any]
     usage: Mapping[str, Any] | None = None
+    response_time_ms: float = 0.0
+    model: str | None = None
 
 
 class BedrockChatClient:
@@ -97,6 +100,53 @@ class BedrockChatClient:
         self._client = client
         self._region_name = region_name
         self._profile_name = profile_name
+
+    @staticmethod
+    def _is_mock_enabled() -> bool:
+        try:
+            from traigent.integrations.utils.mock_adapter import MockAdapter
+        except ImportError:
+            return False
+
+        return MockAdapter.is_mock_enabled("bedrock")
+
+    @staticmethod
+    def _capture_response(
+        response: BedrockChatResponse,
+        *,
+        model_id: str,
+        start_time: float,
+        capture: bool = True,
+    ) -> BedrockChatResponse:
+        response.response_time_ms = (time.perf_counter() - start_time) * 1000
+        response.model = response.model or model_id
+        if not capture:
+            return response
+
+        try:
+            from traigent.utils.langchain_interceptor import capture_langchain_response
+        except ImportError:
+            return response
+
+        capture_langchain_response(response)
+        return response
+
+    @staticmethod
+    def _mock_response(model_id: str) -> BedrockChatResponse:
+        from traigent.integrations.utils.mock_adapter import MockAdapter
+        from traigent.utils.langchain_interceptor import capture_langchain_response
+
+        mock_data = MockAdapter.get_mock_response("bedrock", model=model_id)
+        usage = dict(mock_data["usage"])
+        response = BedrockChatResponse(
+            text=mock_data["content"][0]["text"],
+            raw={**mock_data, "mock": True},
+            usage=usage,
+            response_time_ms=0.0,
+            model=model_id,
+        )
+        capture_langchain_response(response)
+        return response
 
     def _ensure_client(self):  # pragma: no cover - network client guard
         if self._client is not None:
@@ -121,21 +171,30 @@ class BedrockChatClient:
         temperature: float = 0.5,
         top_p: float | None = None,
         extra_params: Mapping[str, Any] | None = None,
+        _capture: bool = True,
     ) -> BedrockChatResponse:
         """Perform a non-streaming chat invocation.
 
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        if self._is_mock_enabled():
+            return self._mock_response(model_id)
 
+        start_time = time.perf_counter()
         client = self._ensure_client()
 
         if str(model_id).startswith("ai21."):
-            return self._invoke_ai21(
+            return self._capture_response(
+                self._invoke_ai21(
+                    model_id=model_id,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                ),
                 model_id=model_id,
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
+                start_time=start_time,
+                capture=_capture,
             )
 
         payload: dict[str, Any] = {
@@ -165,7 +224,12 @@ class BedrockChatClient:
 
         text = _extract_text_from_messages_response(data)
         usage = data.get("usage") if isinstance(data, Mapping) else None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return self._capture_response(
+            BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id),
+            model_id=model_id,
+            start_time=start_time,
+            capture=_capture,
+        )
 
     def _invoke_ai21(
         self,
@@ -228,7 +292,7 @@ class BedrockChatClient:
         else:
             text = str(data)
             usage = None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id)
 
     def invoke_stream(
         self,
@@ -241,7 +305,13 @@ class BedrockChatClient:
         extra_params: Mapping[str, Any] | None = None,
     ) -> Generator[str, None, BedrockChatResponse]:  # pragma: no cover - streaming path
         """Stream chat invocation; yields text chunks and returns final response."""
+        if self._is_mock_enabled():
+            response = self._mock_response(model_id)
+            if response.text:
+                yield response.text
+            return response
 
+        start_time = time.perf_counter()
         client = self._ensure_client()
 
         payload: dict[str, Any] = {
@@ -280,7 +350,16 @@ class BedrockChatClient:
                     yield text_piece
 
         final = "".join(final_text_parts)
-        return BedrockChatResponse(text=final, raw={"streamed": True}, usage=None)
+        return self._capture_response(
+            BedrockChatResponse(
+                text=final,
+                raw={"streamed": True},
+                usage=None,
+                model=model_id,
+            ),
+            model_id=model_id,
+            start_time=start_time,
+        )
 
     async def ainvoke(
         self,
@@ -297,22 +376,31 @@ class BedrockChatClient:
         Uses aioboto3 for true async or falls back to an isolated sync worker.
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        if self._is_mock_enabled():
+            return self._mock_response(model_id)
+
         # Try aioboto3 for true async
         try:
             import aioboto3  # noqa: F401 - used for availability check and async method
 
-            return await self._ainvoke_aioboto3(
+            start_time = time.perf_counter()
+            return self._capture_response(
+                await self._ainvoke_aioboto3(
+                    model_id=model_id,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    extra_params=extra_params,
+                ),
                 model_id=model_id,
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                extra_params=extra_params,
+                start_time=start_time,
             )
         except ImportError:
+            start_time = time.perf_counter()
             loop = asyncio.get_running_loop()
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                return await loop.run_in_executor(
+                response = await loop.run_in_executor(
                     executor,
                     lambda: self.invoke(
                         model_id=model_id,
@@ -321,8 +409,14 @@ class BedrockChatClient:
                         temperature=temperature,
                         top_p=top_p,
                         extra_params=extra_params,
+                        _capture=False,
                     ),
                 )
+            return self._capture_response(
+                response,
+                model_id=model_id,
+                start_time=start_time,
+            )
 
     async def _ainvoke_aioboto3(
         self,
@@ -371,7 +465,7 @@ class BedrockChatClient:
 
         text = _extract_text_from_messages_response(data)
         usage = data.get("usage") if isinstance(data, Mapping) else None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id)
 
     async def ainvoke_stream(
         self,

--- a/traigent/integrations/utils/mock_adapter.py
+++ b/traigent/integrations/utils/mock_adapter.py
@@ -28,6 +28,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
@@ -182,8 +183,10 @@ class MockAdapter:
             "openai": cls._build_openai_mock,
             "azure_openai": cls._build_openai_mock,  # Same format
             "anthropic": cls._build_anthropic_mock,
+            "bedrock": cls._build_bedrock_mock,
             "gemini": cls._build_gemini_mock,
             "cohere": cls._build_cohere_mock,
+            "litellm": cls._build_litellm_mock,
         }
 
         builder = builders.get(provider.lower(), cls._build_generic_mock)
@@ -275,6 +278,78 @@ class MockAdapter:
                 }
             },
         }
+
+    @classmethod
+    def _build_bedrock_mock(cls, data: MockResponse) -> dict[str, Any]:
+        """Build Bedrock Anthropic Messages API-like response dict."""
+        return {
+            "id": data.response_id,
+            "type": "message",
+            "role": "assistant",
+            "model": data.model,
+            "content": [
+                {
+                    "type": "text",
+                    "text": data.text,
+                }
+            ],
+            "stop_reason": data.finish_reason,
+            "usage": {
+                "input_tokens": data.prompt_tokens,
+                "output_tokens": data.completion_tokens,
+                "total_tokens": data.total_tokens,
+            },
+        }
+
+    @classmethod
+    def _build_litellm_mock(cls, data: MockResponse) -> Any:
+        """Build a LiteLLM ModelResponse-like mock response."""
+        try:
+            from litellm import ModelResponse
+        except Exception as exc:  # pragma: no cover - exercised only without litellm
+            logger.debug("LiteLLM ModelResponse unavailable, using fallback: %s", exc)
+            return SimpleNamespace(
+                id=data.response_id,
+                object="chat.completion",
+                created=int(time.time()),
+                model=data.model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        message=SimpleNamespace(
+                            role="assistant",
+                            content=data.text,
+                        ),
+                        finish_reason=data.finish_reason,
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=data.prompt_tokens,
+                    completion_tokens=data.completion_tokens,
+                    total_tokens=data.total_tokens,
+                ),
+            )
+
+        return ModelResponse(
+            id=data.response_id,
+            model=data.model,
+            object="chat.completion",
+            choices=[
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": data.text,
+                    },
+                    "finish_reason": data.finish_reason,
+                }
+            ],
+            usage={
+                "prompt_tokens": data.prompt_tokens,
+                "completion_tokens": data.completion_tokens,
+                "total_tokens": data.total_tokens,
+            },
+        )
 
     @classmethod
     def _build_generic_mock(cls, data: MockResponse) -> dict[str, Any]:

--- a/traigent/utils/langchain_interceptor.py
+++ b/traigent/utils/langchain_interceptor.py
@@ -175,6 +175,84 @@ def _create_astream_wrapper(original_meth: Any) -> Any:
     return astream_wrapper
 
 
+def _patch_langchain_bedrock_model(model_cls: Any, class_name: str) -> bool:
+    """Patch one langchain_aws Bedrock chat class for response capture."""
+    patched_any = False
+
+    if getattr(model_cls, "_traigent_patched_invoke", False) is False:
+        original_invoke = model_cls.invoke
+
+        def invoke_with_capture_bedrock(self: Any, *args: Any, **kwargs: Any) -> Any:
+            """Wrapped invoke method that captures Bedrock usage metadata."""
+            from traigent.integrations.utils.mock_adapter import MockAdapter
+
+            if MockAdapter.is_mock_enabled("bedrock"):
+                from langchain_core.messages import AIMessage
+
+                model_name = (
+                    getattr(self, "model_id", None)
+                    or getattr(self, "model", None)
+                    or "mock-model"
+                )
+                mock_data = MockAdapter.get_mock_response(
+                    "bedrock", model=str(model_name)
+                )
+                usage = mock_data["usage"]
+                response = AIMessage(
+                    content=mock_data["content"][0]["text"],
+                    response_metadata={
+                        "model_name": mock_data["model"],
+                        "stop_reason": mock_data["stop_reason"],
+                        "response_time_ms": 0.0,
+                    },
+                    usage_metadata={
+                        "input_tokens": usage["input_tokens"],
+                        "output_tokens": usage["output_tokens"],
+                        "total_tokens": usage["total_tokens"],
+                    },
+                )
+                capture_langchain_response(response)
+                return response
+
+            start_time = time.perf_counter()
+            response = original_invoke(self, *args, **kwargs)
+            response_time_ms = (time.perf_counter() - start_time) * 1000
+
+            if not hasattr(response, "response_metadata"):
+                response.response_metadata = {}
+            response.response_metadata["response_time_ms"] = response_time_ms
+
+            capture_langchain_response(response)
+            logger.debug(
+                "Captured %s invoke usage: %s, response_time_ms: %.2f",
+                class_name,
+                getattr(response, "usage_metadata", None),
+                response_time_ms,
+            )
+            return response
+
+        model_cls.invoke = invoke_with_capture_bedrock
+        model_cls._traigent_patched_invoke = True
+        logger.info("✅ Patched %s.invoke for metadata capture", class_name)
+        patched_any = True
+
+    for meth_name, flag in [
+        ("stream", "_traigent_patched_stream"),
+        ("astream", "_traigent_patched_astream"),
+    ]:
+        if hasattr(model_cls, meth_name) and not getattr(model_cls, flag, False):
+            original_meth = getattr(model_cls, meth_name)
+            if meth_name == "stream":
+                setattr(model_cls, meth_name, _create_stream_wrapper(original_meth))
+            else:
+                setattr(model_cls, meth_name, _create_astream_wrapper(original_meth))
+            setattr(model_cls, flag, True)
+            logger.info("✅ Patched %s.%s for metadata capture", class_name, meth_name)
+            patched_any = True
+
+    return patched_any
+
+
 def patch_langchain_for_metadata_capture() -> bool:
     """Monkey-patch LangChain to automatically capture response metadata.
 
@@ -351,6 +429,23 @@ def patch_langchain_for_metadata_capture() -> bool:
         logger.debug("ChatOpenAI not available, skipping")
     except Exception as e:
         logger.error(f"Failed to patch ChatOpenAI: {e}")
+
+    # Patch langchain_aws Bedrock chat models
+    try:
+        import langchain_aws
+
+        for class_name in ("ChatBedrock", "ChatBedrockConverse"):
+            model_cls = getattr(langchain_aws, class_name, None)
+            if model_cls is None:
+                logger.debug("langchain_aws.%s not available, skipping", class_name)
+                continue
+            if _patch_langchain_bedrock_model(model_cls, f"langchain_aws.{class_name}"):
+                patched_any = True
+
+    except ImportError:
+        logger.debug("langchain_aws not available, skipping Bedrock")
+    except Exception as e:
+        logger.error(f"Failed to patch langchain_aws Bedrock models: {e}")
 
     if not patched_any:
         logger.debug("No LangChain models could be patched for metadata capture")

--- a/traigent/utils/litellm_interceptor.py
+++ b/traigent/utils/litellm_interceptor.py
@@ -54,6 +54,8 @@ def patch_litellm_for_metadata_capture() -> bool:
                         "litellm",
                         model=kwargs.get("model", args[0] if args else "mock-model"),
                     )
+                    mock_data.response_time_ms = 0.0
+                    capture_langchain_response(mock_data)
                     return mock_data
 
                 start_time = time.perf_counter()
@@ -101,6 +103,8 @@ def patch_litellm_for_metadata_capture() -> bool:
                         "litellm",
                         model=kwargs.get("model", args[0] if args else "mock-model"),
                     )
+                    mock_data.response_time_ms = 0.0
+                    capture_langchain_response(mock_data)
                     return mock_data
 
                 start_time = time.perf_counter()


### PR DESCRIPTION
## Summary
Closes #1089. Closes #1092.

### #1092 — litellm mock shape
`TRAIGENT_MOCK_LLM` returned `{"text": ...}` for the litellm path → user code using the REAL shape (`resp.choices[0].message.content`) crashed only in dry-runs. The mock now builds a real `litellm.ModelResponse` (attribute-equivalent fallback only when litellm absent); `.usage` matches the real shape; sync+async interceptors capture it like a real call. Regression test = the exact user pattern, unchanged, under mock.

### #1089 — Bedrock instrumentation
- **langchain_aws `ChatBedrock` / `ChatBedrockConverse`**: import-guarded invoke/stream/astream patches — token/cost/latency capture AND mock short-circuit (proper `AIMessage` with `usage_metadata`). Idempotent patch flags.
- **Native `BedrockChatClient`** invoke/ainvoke/invoke_stream: direct instrumentation (`BedrockPlugin.get_target_methods()` is dead code for capture; `METHOD_MAPPINGS` is parameter-override plumbing — per the issue's no-fake-plumbing warning). **Mock check precedes client creation: zero AWS calls in mock mode.** Mock gating delegates to `is_mock_llm()` incl. its production hard-block.
- **Usage normalization**: extractor accepts `input_tokens/output_tokens` (+ `inputTokens/outputTokens`) where `prompt_tokens/completion_tokens` were assumed.

Known limitation (documented): real `invoke_stream` usage stays `None` — the existing stream parser doesn't surface Bedrock usage events; mock streaming returns usage.

## Verification
- New tests (all stub/fake-based, zero network): ChatBedrock + ChatBedrockConverse capture & short-circuit (`tests/unit/utils/test_langchain_interceptor.py:940-998`); native client capture & short-circuit asserting the underlying client is NEVER invoked (`tests/unit/integrations/test_bedrock_client.py:445-570`); litellm user-pattern regression (`tests/unit/utils/test_litellm_interceptor.py:198-274`); usage normalization (`tests/unit/core/test_llm_processor.py:354-370`).
- Captain gates: full unit 12739 passed (3 pre-existing/load-flake fails, all reproduce on base or pass isolated); `tests/integration/test_mock_mode_metrics.py` + `backend/test_backend_integration_mock.py` 15/15; ruff/mypy/black/isort clean.

## PR checklist
1. **Worst-case prod path** — interception adds capture only; mock short-circuits are gated by `is_mock_llm()` whose production hard-block rejects the env-var path in prod.
2. **Production-branch test** — `is_mock_llm` production hard-block is pre-existing tested behavior; capture paths add no policy branch.
3. **Contract regeneration** — none. **JS parity:** traigent-js litellm-equivalent mock shape worth checking — flagged in #1092 closure.
4. **Public surface delta** — `BedrockChatResponse` gains `response_time_ms`/`model` fields (additive).
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed.
