### PR TITLE
fix(ci): publish example-smoke env for 0.12.0 guards (run-approval + dataset-root)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,14 @@ jobs:
         TRAIGENT_MOCK_LLM: "true"
         TRAIGENT_OFFLINE_MODE: "true"
         TRAIGENT_COST_APPROVED: "true"
+        # 0.12.0 added a CI/CD run-approval gate (TRAIGENT_RUN_APPROVED); examples
+        # run in mock+offline mode (zero spend), so approve this controlled release smoke.
+        TRAIGENT_RUN_APPROVED: "1"
+        TRAIGENT_APPROVED_BY: "ci-release-smoke"
+        # examples load shared fixtures from examples/datasets/, outside each
+        # example dir; 0.12.0's dataset-path containment needs the root widened
+        # to the examples tree for the smoke.
+        TRAIGENT_DATASET_ROOT: "${{ github.workspace }}/examples"
         ANTHROPIC_API_KEY: "sk-ant-test-mock-key-for-ci" # pragma: allowlist secret
         OPENAI_API_KEY: "sk-openai-test-mock-key-for-ci" # pragma: allowlist secret
         TRAIGENT_API_KEY: "test-traigent-api-key-for-ci" # pragma: allowlist secret


### PR DESCRIPTION
The v0.12.0 publish failed in 'Run example smoke before publishing' because 0.12.0 added two fail-closed guards the smoke predates: the CI run-approval gate (needs TRAIGENT_RUN_APPROVED, the workflow only set the old TRAIGENT_COST_APPROVED) and dataset-path containment (examples load examples/datasets/* from outside each example dir). Set TRAIGENT_RUN_APPROVED=1 + TRAIGENT_APPROVED_BY and widen TRAIGENT_DATASET_ROOT to the examples tree. Examples run mock+offline (zero spend). Verified locally with [dev,all] deps: quickstart(3) + docs(2) + a core example run to completion. Follow-up filed: examples should self-document TRAIGENT_DATASET_ROOT for end users. 🤖 Generated with [Claude Code](https://claude.com/claude-code)