### PR TITLE
chore(release): promote 0.12.0 to main (v5 — final, incl. SDK issue fixes + publish smoke env)

### DIFF
--- a/.github/workflows/cost-coverage.yml
+++ b/.github/workflows/cost-coverage.yml
@@ -1,0 +1,35 @@
+name: Cost Coverage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  model-price-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          bash scripts/ci/install_sdk_requirements.sh -e ".[test]"
+
+      - name: Run static model price coverage check
+        env:
+          LITELLM_LOCAL_MODEL_COST_MAP: "True"
+          PYTHONPATH: .
+          TRAIGENT_OFFLINE_MODE: "true"
+        run: |
+          # No AWS credentials here: this enumerates a static curated catalog,
+          # not live Bedrock list_inference_profiles output.
+          pytest tests/cost_coverage/test_model_price_coverage.py -q --tb=short --timeout=60

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,14 @@ jobs:
         TRAIGENT_MOCK_LLM: "true"
         TRAIGENT_OFFLINE_MODE: "true"
         TRAIGENT_COST_APPROVED: "true"
+        # 0.12.0 added a CI/CD run-approval gate (TRAIGENT_RUN_APPROVED); examples
+        # run in mock+offline mode (zero spend), so approve this controlled release smoke.
+        TRAIGENT_RUN_APPROVED: "1"
+        TRAIGENT_APPROVED_BY: "ci-release-smoke"
+        # examples load shared fixtures from examples/datasets/, outside each
+        # example dir; 0.12.0's dataset-path containment needs the root widened
+        # to the examples tree for the smoke.
+        TRAIGENT_DATASET_ROOT: "${{ github.workspace }}/examples"
         ANTHROPIC_API_KEY: "sk-ant-test-mock-key-for-ci" # pragma: allowlist secret
         OPENAI_API_KEY: "sk-openai-test-mock-key-for-ci" # pragma: allowlist secret
         TRAIGENT_API_KEY: "test-traigent-api-key-for-ci" # pragma: allowlist secret

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -167,7 +167,7 @@
         "filename": "docs/features/authentication.md",
         "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
         "is_verified": false,
-        "line_number": 387
+        "line_number": 399
       }
     ],
     "docs/installation-guide-offline.md": [
@@ -1231,5 +1231,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-05T20:38:13Z"
+  "generated_at": "2026-06-05T22:36:58Z"
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,35 @@ Traigent SDK implements:
 - No hardcoded credentials (environment variables only)
 - Secure defaults for all execution modes
 
+## Credential & data trust model
+
+Traigent separates Traigent backend credentials from model-provider
+credentials.
+
+- A Traigent API key authenticates SDK and CLI calls to the Traigent
+  portal/backend. It is resolved from `TRAIGENT_API_KEY` or CLI-managed
+  credentials and is attached to Traigent backend requests as Traigent auth
+  material.
+- Model-provider credentials are customer credentials. Examples include
+  `OPENAI_API_KEY`, Anthropic/Cohere/Mistral keys, Azure OpenAI credentials,
+  and AWS credentials for Bedrock. The supported local and hybrid execution
+  paths execute model calls from the customer's process, so provider SDKs use
+  the customer's local provider configuration.
+- Traigent does not provide or use a shared Traigent-owned model-provider key
+  for customer model calls.
+- Provider credentials are not part of Traigent backend session, trial, or
+  trace payloads. Backend and trace clients use Traigent API credentials for
+  Traigent endpoints. See the [telemetry and content logging controls](docs/api-reference/telemetry.md)
+  for the metrics, metadata, and optional content logs the SDK can collect.
+- The optional Bedrock helper imports `boto3` only when Bedrock is used and
+  creates a local `bedrock-runtime` client through the AWS SDK credential
+  chain. `AWS_BEARER_TOKEN_BEDROCK`, when used by local AWS credential
+  tooling, is also a customer/provider credential and follows the same
+  boundary.
+
+Current local and hybrid modes run trials locally. The `cloud` remote
+execution mode is reserved for future use and fails closed in this SDK.
+
 ## Best Practices
 
 When using Traigent:

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -159,6 +159,18 @@ Credentials saved by `traigent auth login` and `traigent auth configure` are wri
 - `TRAIGENT_API_KEY`
 - Useful for CI/CD environments
 
+## Backend vs provider credentials
+
+This guide covers Traigent backend authentication: the API key that lets the
+SDK and CLI talk to the Traigent portal/backend. Model-provider credentials
+such as `OPENAI_API_KEY` or AWS credentials for Bedrock are separate customer
+credentials resolved by the provider SDKs on the local machine. They are not
+Traigent API keys and are not sent to Traigent backend endpoints.
+
+For the full boundary, including Bedrock and telemetry/content logging, see
+the [Credential & data trust model](../../SECURITY.md#credential--data-trust-model)
+and the [telemetry documentation](../api-reference/telemetry.md).
+
 ## Priority Order
 
 The SDK checks for credentials in this order:

--- a/docs/guides/secrets_management.md
+++ b/docs/guides/secrets_management.md
@@ -148,7 +148,9 @@ PY
 
 ## Best Practices & Notes
 
-- **SDK remains clean**: No boto3/aws-cli imports inside `traigent`.
+- **SDK remains dependency-light**: Core optimization and backend paths do not
+  import AWS SDKs. The optional Bedrock integration imports `boto3`/`aioboto3`
+  lazily only when that integration is used.
 - **Principle of least privilege**: Use IAM policies that grant read
   access to the secret for CI and read/write for a small ops group.
 - **Auditing**: Secrets Manager tracks versions and rotation history.

--- a/docs/operations/bedrock.md
+++ b/docs/operations/bedrock.md
@@ -29,6 +29,21 @@ export AWS_PROFILE=traigent-bedrock
 # export BEDROCK_MOCK=true
 ```
 
+## Credential Boundary
+
+Bedrock credentials are AWS/customer credentials. The SDK's optional Bedrock
+client creates a local `boto3`/`aioboto3` Bedrock Runtime client and relies on
+the AWS SDK credential chain on the machine where the optimization runs. The
+SDK does not use a Traigent API key as an AWS credential and does not send AWS
+credentials to the Traigent backend.
+
+If you use `AWS_BEARER_TOKEN_BEDROCK`, treat it as a short-lived AWS/provider
+credential with the same boundary. It belongs in your local AWS credential
+environment or tooling, not in Traigent backend configuration.
+
+For the broader credential and telemetry boundary, see the
+[Credential & data trust model](../../SECURITY.md#credential--data-trust-model).
+
 ## Dependency Installation
 Ensure you installed integration dependencies:
 ```bash

--- a/examples/tvl/hello_tvl/hello_tvl.tvl.yml
+++ b/examples/tvl/hello_tvl/hello_tvl.tvl.yml
@@ -7,7 +7,7 @@ tvl_version: "0.0.1"
 
 metadata:
   owner: "team@example.com"
-  # Legacy operational promotion hints (pre-0.9 'promotion:' block); the
+  # Legacy operational promotion hints preserved under metadata; the
   # statistical gate lives in promotion_policy.
   legacy_promotion:
     gate: manual_review

--- a/tests/cost_coverage/test_model_price_coverage.py
+++ b/tests/cost_coverage/test_model_price_coverage.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from traigent.utils.cost_calculator import cost_from_tokens
+
+# Static catalog only: do not call AWS list_inference_profiles in CI. This keeps
+# the scheduled check credential-free and catches bundled litellm price-map drift.
+CURATED_BEDROCK_INFERENCE_PROFILE_IDS = [
+    # Seeded from the SDK's Bedrock catalog/skill material:
+    # - traigent/config_generator/catalog/tvar_catalog.v1.json uses
+    #   bedrock/us.anthropic.claude-haiku-4-5.
+    # - traigent/config/models.yaml lists the Bedrock Anthropic and Meta families.
+    # - examples/integrations/bedrock/bedrock_hello.py anchors Amazon Bedrock usage.
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "us.anthropic.claude-3-haiku-20240307-v1:0",
+    "us.amazon.nova-micro-v1:0",
+    "us.amazon.nova-lite-v1:0",
+    "us.meta.llama3-1-8b-instruct-v1:0",
+    "us.meta.llama3-1-70b-instruct-v1:0",
+]
+
+COMMON_EXAMPLE_MODEL_IDS = [
+    "gpt-4o-mini",
+    "gpt-4o",
+    "claude-3-haiku-20240307",
+    "claude-3-5-sonnet-20241022",
+    "claude-haiku-4-5-20251001",
+]
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    CURATED_BEDROCK_INFERENCE_PROFILE_IDS + COMMON_EXAMPLE_MODEL_IDS,
+)
+def test_catalog_model_resolves_nonzero_price(model_id: str) -> None:
+    input_cost, output_cost = cost_from_tokens(
+        1,
+        1,
+        model_id,
+        strict=True,
+    )
+    assert input_cost + output_cost > 0.0

--- a/tests/unit/cloud/test_api_key_strict_bool.py
+++ b/tests/unit/cloud/test_api_key_strict_bool.py
@@ -99,6 +99,17 @@ def _auth_manager_with_public_backend() -> AuthManager:
     return manager
 
 
+def _clear_backend_validation_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove policy env knobs that affect loopback backend validation."""
+    for key in (
+        "ENVIRONMENT",
+        "TRAIGENT_ENV",
+        "TRAIGENT_ENVIRONMENT",
+        "TRAIGENT_ALLOW_INSECURE_BACKEND",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
 @pytest.mark.asyncio
 async def test_validate_rejects_string_false_payload():
     """A backend returning ``{"valid": "false"}`` must NOT authenticate."""
@@ -149,8 +160,7 @@ async def test_validate_posts_json_payload_to_backend():
     assert _FakeSession.last_post_kwargs is not None
     assert _FakeSession.last_post_kwargs["json"] == {"api_key": api_key}
     assert (
-        _FakeSession.last_post_kwargs["headers"]["Content-Type"]
-        == "application/json"
+        _FakeSession.last_post_kwargs["headers"]["Content-Type"] == "application/json"
     )
 
 
@@ -223,6 +233,94 @@ async def test_validate_rejects_plaintext_backend_validation_url():
     post.assert_not_called()
 
 
+def test_backend_validation_url_default_denies_http_localhost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loopback HTTP remains denied by default."""
+    _clear_backend_validation_env(monkeypatch)
+
+    reason = AuthManager._validate_backend_validation_url(
+        "http://localhost:8006/api/v1/keys/validate"
+    )
+
+    assert reason is not None
+    assert "ENVIRONMENT=development" in reason
+    assert "TRAIGENT_ALLOW_INSECURE_BACKEND=true" in reason
+
+
+def test_backend_validation_url_override_without_environment_still_denies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Policy surface fails closed when the insecure override is set outside explicit dev."""
+    _clear_backend_validation_env(monkeypatch)
+    monkeypatch.setenv("TRAIGENT_ALLOW_INSECURE_BACKEND", "true")
+
+    reason = AuthManager._validate_backend_validation_url(
+        "http://localhost:8006/api/v1/keys/validate"
+    )
+
+    assert reason is not None
+    assert "TRAIGENT_ALLOW_INSECURE_BACKEND=true" in reason
+
+
+def test_backend_validation_url_dev_override_allows_loopback_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit non-production plus override allows only loopback HTTP."""
+    _clear_backend_validation_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_ALLOW_INSECURE_BACKEND", "true")
+
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://localhost:8006/api/v1/keys/validate"
+        )
+        is None
+    )
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://127.42.0.1:8006/api/v1/keys/validate"
+        )
+        is None
+    )
+
+
+def test_backend_validation_url_dev_override_does_not_allow_non_loopback_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The insecure dev override does not widen private-range or public HTTP URLs."""
+    _clear_backend_validation_env(monkeypatch)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_ALLOW_INSECURE_BACKEND", "true")
+
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://192.168.1.10:8006/api/v1/keys/validate"
+        )
+        == "backend validation URL host is not allowed"
+    )
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "http://example.com/api/v1/keys/validate"
+        )
+        == "backend validation URL must use HTTPS"
+    )
+
+
+def test_backend_validation_url_https_global_hosts_unaffected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HTTPS global hosts remain valid without the loopback override."""
+    _clear_backend_validation_env(monkeypatch)
+
+    assert (
+        AuthManager._validate_backend_validation_url(
+            "https://example.com/api/v1/keys/validate"
+        )
+        is None
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "backend_url",
@@ -244,5 +342,9 @@ async def test_validate_rejects_non_global_backend_validation_hosts(backend_url)
     ):
         reason = await manager._validate_api_key_with_backend("tg_" + "x" * 61)
 
-    assert reason == "backend validation URL host is not allowed"
+    if "127.0.0.1" in backend_url or "localhost" in backend_url:
+        assert reason is not None
+        assert "TRAIGENT_ALLOW_INSECURE_BACKEND=true" in reason
+    else:
+        assert reason == "backend validation URL host is not allowed"
     post.assert_not_called()

--- a/tests/unit/cloud/test_dtos.py
+++ b/tests/unit/cloud/test_dtos.py
@@ -1153,3 +1153,32 @@ class TestExampleMeasure:
 
         assert "ExampleMeasure" in repr_str
         assert "ex_repr_test" in repr_str
+
+
+class TestLocalDtoHelpers:
+    """Regression tests for local DTO helper metadata."""
+
+    def test_local_experiment_metadata_uses_mode_not_execution_mode(self):
+        """Local experiment helper should not emit raw SDK execution_mode metadata."""
+        experiment = cloud_dtos.create_local_experiment(
+            experiment_id="exp-local",
+            name="Local Experiment",
+            description="Local helper payload",
+            configuration_space={"temperature": [0.1, 0.2]},
+        )
+
+        assert experiment.metadata["mode"] == "local"
+        assert "execution_mode" not in experiment.metadata
+
+    def test_local_experiment_run_metadata_uses_mode_not_execution_mode(self):
+        """Local run helper should not emit raw SDK execution_mode metadata."""
+        run = cloud_dtos.create_local_experiment_run(
+            run_id="run-local",
+            experiment_id="exp-local",
+            function_name="optimize_me",
+            configuration_space={"temperature": [0.1, 0.2]},
+            objectives=["accuracy"],
+        )
+
+        assert run.metadata["mode"] == "local"
+        assert "execution_mode" not in run.metadata

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -132,6 +132,32 @@ class TestBackendDescription:
 class TestMeasuresDictValidationInSubmission:
     """Test MeasuresDict validation warning path in submit_trial_result_via_session."""
 
+    def test_trial_result_metadata_uses_sdk_version_and_drops_execution_mode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Trial result metadata uses SDK version and does not emit raw execution_mode."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "9.8.6")
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.auth_manager = Mock()
+        ops = TrialOperations(mock_client)
+
+        result_data = ops._build_trial_result_data(
+            trial_id="trial_001",
+            config={"temperature": 0.2},
+            clean_metrics={"accuracy": 0.95},
+            backend_status="COMPLETED",
+            mode="local",
+            metadata={"execution_mode": "edge_analytics", "custom": "value"},
+        )
+
+        metadata = result_data["metadata"]
+        assert metadata["mode"] == "local"
+        assert metadata["sdk_version"] == "9.8.6"
+        assert metadata["custom"] == "value"
+        assert "execution_mode" not in metadata
+
     @pytest.mark.asyncio
     async def test_hybrid_trial_submission_uses_session_results_endpoint(self) -> None:
         """Hybrid/backend tracking posts trial metrics to the session results API."""
@@ -390,6 +416,66 @@ class TestMeasuresDictValidationInSubmission:
             call_args = ops._handle_trial_success_response.call_args
             assert call_args is not None
             assert call_args.args[5] == {"accuracy": 0.95}
+
+    @pytest.mark.asyncio
+    async def test_summary_stats_metadata_uses_sdk_version_without_execution_mode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Summary stats submission metadata uses package version and omits execution_mode."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "8.7.6")
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://api.example.com"
+        mock_client.backend_config.api_base_url = "https://api.example.com"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="completed")
+
+        ops = TrialOperations(mock_client)
+
+        mock_response = Mock()
+        mock_response.status = 201
+
+        mock_post_ctx = AsyncMock()
+        mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_post_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_post_ctx)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+
+            result = await ops.submit_summary_stats(
+                session_id="test-session",
+                trial_id="test-trial",
+                config={"model": "gpt-4"},
+                summary_stats={"metrics": {"accuracy": 0.95}},
+                status="completed",
+            )
+
+        assert result is True
+        payload = mock_session.post.call_args.kwargs["json"]
+        metadata = payload["metadata"]
+        assert metadata["mode"] == "privacy"
+        assert metadata["sdk_version"] == "8.7.6"
+        assert "execution_mode" not in metadata
 
 
 class TestSummaryStatsValidation:

--- a/tests/unit/config/test_parameter_injection_per_trial.py
+++ b/tests/unit/config/test_parameter_injection_per_trial.py
@@ -1,0 +1,112 @@
+"""Regression coverage for #1109 parameter-mode trial injection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import traigent
+from traigent.config.context import get_config
+from traigent.config.types import TraigentConfig
+from traigent.evaluators.base import Dataset, EvaluationExample
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        [
+            EvaluationExample({"text": "case-0"}, "fast"),
+            EvaluationExample({"text": "case-1"}, "fast"),
+        ],
+        name="parameter_injection_per_trial",
+    )
+
+
+def _config_value(config: TraigentConfig | dict[str, Any], key: str) -> Any:
+    if isinstance(config, TraigentConfig):
+        return config.get(key)
+    return config.get(key)
+
+
+def _recorded_variants(result: Any) -> set[str]:
+    return {trial.config.get("variant") for trial in result.trials}
+
+
+def _assert_function_saw_recorded_trials(
+    seen: list[dict[str, str]],
+    result: Any,
+) -> None:
+    recorded = _recorded_variants(result)
+    param_seen = {entry["param_variant"] for entry in seen}
+    context_seen = {entry["context_variant"] for entry in seen}
+
+    assert recorded == {"slow", "fast"}
+    assert param_seen == recorded
+    assert context_seen == recorded
+    assert all(entry["param_variant"] == entry["context_variant"] for entry in seen)
+
+
+@pytest.mark.asyncio
+async def test_parameter_mode_sync_function_uses_per_trial_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
+    seen: list[dict[str, str]] = []
+
+    @traigent.optimize(
+        eval_dataset=_dataset(),
+        objectives=["accuracy"],
+        configuration_space={"variant": ["slow", "fast"]},
+        default_config={"variant": "slow"},
+        injection_mode="parameter",
+    )
+    def answer(text: str, config: TraigentConfig) -> str:
+        context_config = get_config()
+        param_variant = str(config.get("variant"))
+        context_variant = str(_config_value(context_config, "variant"))
+        seen.append(
+            {
+                "text": text,
+                "param_variant": param_variant,
+                "context_variant": context_variant,
+            }
+        )
+        return param_variant
+
+    result = await answer.optimize(algorithm="grid", max_trials=3)
+
+    _assert_function_saw_recorded_trials(seen, result)
+
+
+@pytest.mark.asyncio
+async def test_parameter_mode_async_function_uses_per_trial_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
+    seen: list[dict[str, str]] = []
+
+    @traigent.optimize(
+        eval_dataset=_dataset(),
+        objectives=["accuracy"],
+        configuration_space={"variant": ["slow", "fast"]},
+        default_config={"variant": "slow"},
+        injection_mode="parameter",
+    )
+    async def answer(text: str, config: TraigentConfig) -> str:
+        context_config = get_config()
+        param_variant = str(config.get("variant"))
+        context_variant = str(_config_value(context_config, "variant"))
+        seen.append(
+            {
+                "text": text,
+                "param_variant": param_variant,
+                "context_variant": context_variant,
+            }
+        )
+        return param_variant
+
+    result = await answer.optimize(algorithm="grid", max_trials=3)
+
+    _assert_function_saw_recorded_trials(seen, result)

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -806,6 +806,52 @@ class TestStatisticalSignificanceWiring:
         assert "statistical_significance" in inner_metadata
         assert inner_metadata["statistical_significance"] == sig_data
 
+    def test_aggregation_summary_uses_sdk_version_resolver(
+        self,
+        mock_backend_client,
+        mock_optimizer,
+        objective_schema,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Session aggregation summary metadata uses the SDK version resolver."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "7.6.5")
+        config = TraigentConfig()
+        config.execution_mode = "hybrid"
+
+        manager = BackendSessionManager(
+            backend_client=mock_backend_client,
+            traigent_config=config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-version-wiring",
+            optimization_status=OptimizationStatus.COMPLETED,
+        )
+
+        result = Mock(spec=OptimizationResult)
+        result.trials = []
+        result.best_config = {"model": "gpt-4o"}
+        result.best_score = 0.95
+        result.duration = 10.0
+        result.success_rate = 1.0
+        result.metrics = {"accuracy": 0.95}
+        result.metadata = {
+            "session_summary": {
+                "metrics": {"accuracy": 0.95},
+                "samples_per_config": {"gpt-4o": 5},
+            },
+        }
+
+        manager.submit_session_aggregation(result, "test-session-id")
+
+        call_kwargs = mock_backend_client.submit_result.call_args
+        payload_metadata = call_kwargs.kwargs.get(
+            "metadata", call_kwargs[1].get("metadata", {})
+        )
+        summary_stats = payload_metadata.get("summary_stats", {})
+        inner_metadata = summary_stats.get("metadata", {})
+        assert inner_metadata["sdk_version"] == "7.6.5"
+
     def test_strategy_preset_metadata_included_in_aggregation_payload(
         self, mock_backend_client, mock_optimizer, objective_schema
     ):

--- a/tests/unit/core/test_cost_coverage_preflight.py
+++ b/tests/unit/core/test_cost_coverage_preflight.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import warnings
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import traigent.utils.cost_calculator as cost_calculator
+from traigent.api.types import OptimizationResult, OptimizationStatus
+from traigent.core.optimized_function import OptimizedFunction
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.utils.cost_calculator import UnknownModelError
+
+FAKE_MODEL = "us.fake.unpriced-model-v9:0"
+
+
+class CountedFunction:
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.__name__ = "counted_function"
+
+    def __call__(self, text: str = "", **_kwargs: object) -> str:
+        self.call_count += 1
+        return text
+
+
+@pytest.fixture(autouse=True)
+def reset_cost_preflight_state(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("TRAIGENT_STRICT_COST_ACCOUNTING", raising=False)
+    monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
+    monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
+    monkeypatch.setattr("traigent.core.optimized_function._COST_WARNING_EMITTED", True)
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+    yield
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+
+
+@pytest.fixture
+def one_example_dataset() -> Dataset:
+    return Dataset(
+        [EvaluationExample(input_data={"text": "hello"}, expected_output="hello")]
+    )
+
+
+def _completed_result() -> OptimizationResult:
+    return OptimizationResult(
+        trials=[],
+        best_config={"model": "gpt-4o"},
+        best_score=1.0,
+        optimization_id="cost-preflight-test",
+        duration=0.0,
+        convergence_info={},
+        status=OptimizationStatus.COMPLETED,
+        objectives=["accuracy"],
+        algorithm="random",
+        timestamp=datetime.now(UTC),
+        metadata={},
+    )
+
+
+async def _run_with_mocked_orchestrator(
+    opt_func: OptimizedFunction,
+) -> OptimizationResult:
+    with patch(
+        "traigent.core.optimized_function.OptimizationOrchestrator"
+    ) as mock_orchestrator_cls:
+        mock_orchestrator = mock_orchestrator_cls.return_value
+        mock_orchestrator.optimize = AsyncMock(return_value=_completed_result())
+        result = await opt_func.optimize(progress_bar=False)
+        mock_orchestrator.optimize.assert_awaited_once()
+        return result
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_warns_once_with_exact_unpriced_models(
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": ["gpt-4o", FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    preflight_warnings = [
+        str(warning.message)
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+    assert preflight_warnings == [
+        "Cost for `us.fake.unpriced-model-v9:0` is unavailable — results will "
+        "report $0 for it. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+        "Traigent to add coverage."
+    ]
+    assert "`gpt-4o`" not in preflight_warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_strict_blocks_before_any_trial(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    counted = CountedFunction()
+    opt_func = OptimizedFunction(
+        func=counted,
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+
+    with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
+        with pytest.raises(UnknownModelError, match=FAKE_MODEL):
+            await opt_func.optimize(progress_bar=False)
+
+    assert counted.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_fully_priced_space_has_no_warning(
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": ["gpt-4o", "gpt-4o-mini"]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert not [
+        warning
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_custom_pricing_json_counts_as_covered(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    monkeypatch.setenv(
+        "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+        json.dumps(
+            {
+                FAKE_MODEL: {
+                    "input_cost_per_token": 1e-6,
+                    "output_cost_per_token": 2e-6,
+                }
+            }
+        ),
+    )
+    cost_calculator._CUSTOM_PRICING_CACHE = None
+    cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert not [
+        warning
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_mock_mode_skips_warning_and_strict_block(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=True),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert not [
+        warning
+        for warning in captured
+        if "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_checks_default_model_when_model_is_fixed(
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"temperature": [0.0, 0.5]},
+        default_config={"model": FAKE_MODEL},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert [
+        warning
+        for warning in captured
+        if FAKE_MODEL in str(warning.message)
+        and "results will report $0" in str(warning.message)
+    ]

--- a/tests/unit/core/test_llm_processor.py
+++ b/tests/unit/core/test_llm_processor.py
@@ -9,6 +9,7 @@ and response parsing logic.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -349,6 +350,24 @@ class TestExtractMetricsFromResponse:
         result = processor._extract_metrics_from_response(response, "test-model")
         assert result is not None
         assert result["total_tokens"] == 75  # 50 + 25
+
+    def test_extract_metrics_accepts_bedrock_usage_keys(
+        self, processor: LLMResponseProcessor
+    ) -> None:
+        """Test Bedrock input_tokens/output_tokens usage normalization."""
+        response = SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=40, output_tokens=12),
+            cost=SimpleNamespace(input_cost=0.0, output_cost=0.0, total_cost=0.0),
+            response_time_ms=123.0,
+        )
+
+        result = processor._extract_metrics_from_response(response, "bedrock-model")
+
+        assert result is not None
+        assert result["input_tokens"] == 40
+        assert result["output_tokens"] == 12
+        assert result["total_tokens"] == 52
+        assert result["response_time_ms"] == 123.0
 
     def test_extract_metrics_calculates_total_cost(
         self, processor: LLMResponseProcessor

--- a/tests/unit/core/test_metadata_helpers.py
+++ b/tests/unit/core/test_metadata_helpers.py
@@ -6,16 +6,19 @@ for trial and session results.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, TrialResult
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.core.metadata_helpers import (
     _build_measures_full,
     _build_measures_privacy,
+    _validate_measure_dict,
     build_backend_metadata,
     merge_run_metrics_into_session_summary,
 )
@@ -163,7 +166,7 @@ class TestBuildBackendMetadataBasic:
 
         assert "duration" in metadata
         assert "trial_id" in metadata
-        assert "execution_mode" in metadata
+        assert "execution_mode" not in metadata
         assert metadata["trial_id"] == "trial_123"
         assert metadata["duration"] == 1.5
 
@@ -236,8 +239,23 @@ class TestBuildBackendMetadataSummaryStats:
 
         summary_stats = metadata["summary_stats"]
         assert "metadata" in summary_stats
-        assert summary_stats["metadata"]["sdk_version"] == "2.0.0"
+        assert summary_stats["metadata"]["sdk_version"] == get_version()
         assert summary_stats["metadata"]["aggregation_level"] == "trial"
+
+    def test_summary_stats_sdk_version_uses_package_version(
+        self,
+        mock_trial_result,
+        mock_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """summary_stats metadata uses the SDK version resolver, not a constant."""
+        monkeypatch.setenv("TRAIGENT_FORCE_VERSION", "9.8.7")
+        mock_trial_result.summary_stats = {"mean": 0.85}
+        mock_config.execution_mode = "edge_analytics"
+
+        metadata = build_backend_metadata(mock_trial_result, "accuracy", mock_config)
+
+        assert metadata["summary_stats"]["metadata"]["sdk_version"] == "9.8.7"
 
     def test_summary_stats_with_existing_metadata(self, mock_trial_result, mock_config):
         """Test summary_stats with existing metadata field."""
@@ -389,6 +407,112 @@ class TestBuildMeasuresFull:
         assert metrics["latency"] == 0.5
         # String values are excluded per MeasuresDict constraints
         assert "model" not in metrics
+
+    def test_per_example_numeric_metrics_flow_through(self, example_result):
+        """Numeric per-example evaluation results populate measure metrics."""
+        example_result.metrics = {
+            "accuracy": 0.91,
+            "latency_ms": 123.4,
+            "raw_output": "private text",
+        }
+
+        measures = _build_measures_full([example_result], "accuracy")
+
+        assert measures[0]["metrics"]["accuracy"] == 0.91
+        assert measures[0]["metrics"]["latency_ms"] == 123.4
+        assert "raw_output" not in measures[0]["metrics"]
+
+    def test_dict_payload_example_results_populate_measures(self):
+        """Redacted to_dict() example payloads (the real trial-metadata form)
+        must populate per-example metrics, not silently read as empty."""
+        payload = {
+            "example_id": "ex0",
+            "input_data": {"text": "hello"},
+            "expected_output": "hi",
+            "actual_output": "hi",
+            "metrics": {"accuracy": 1.0, "total_tokens": 15, "total_cost": 0.0015},
+            "execution_time": 0.01,
+            "success": True,
+            "error_message": None,
+            "metadata": {},
+        }
+
+        full = _build_measures_full([payload], "accuracy")
+        assert len(full) == 1
+        assert full[0]["metrics"]["accuracy"] == 1.0
+        assert full[0]["metrics"]["score"] == 1.0
+        assert full[0]["metrics"]["response_time_ms"] == 10.0
+
+        sanitized = _build_measures_privacy([payload], "accuracy")
+        assert len(sanitized) == 1
+        assert sanitized[0]["metrics"]["score"] == 1.0
+        assert sanitized[0]["metrics"]["total_tokens"] == 15
+        assert "input_data" not in sanitized[0]
+        assert "actual_output" not in json.dumps(sanitized)
+
+    def test_empty_metric_measure_entries_are_omitted(self):
+        """Examples with no numeric metrics do not produce empty measure stubs."""
+        empty_example = Mock()
+        empty_example.metrics = {"raw_output": "private text"}
+        empty_example.execution_time = None
+        empty_example.expected_output = None
+        empty_example.actual_output = None
+        populated_example = Mock()
+        populated_example.metrics = {"accuracy": 0.7}
+        populated_example.execution_time = None
+        populated_example.expected_output = None
+        populated_example.actual_output = None
+
+        measures = _build_measures_full(
+            [empty_example, populated_example],
+            "accuracy",
+        )
+
+        assert len(measures) == 1
+        assert measures[0]["metrics"] == {"accuracy": 0.7, "score": 0.7}
+        assert all(measure["metrics"] for measure in measures)
+
+    def test_validate_measure_dict_rejects_empty_metrics(self):
+        """Validation rejects hand-built measure stubs with an empty metrics dict."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_measure_dict({"example_id": "ex_empty", "metrics": {}}, 0)
+
+    def test_measures_payload_drops_list_when_all_entries_empty(
+        self,
+        mock_trial_result,
+        mock_config,
+    ):
+        """Outgoing metadata omits measures entirely if every entry is empty."""
+        empty_example = Mock()
+        empty_example.metrics = {"raw_output": "private text"}
+        empty_example.execution_time = None
+        empty_example.expected_output = None
+        empty_example.actual_output = None
+        mock_trial_result.metadata = {"example_results": [empty_example]}
+
+        metadata = build_backend_metadata(mock_trial_result, "accuracy", mock_config)
+
+        assert "measures" not in metadata
+
+    def test_measure_payload_privacy_canary_excludes_text_fields(self):
+        """Expected/actual/output sentinel text must never appear in measures."""
+        sentinel = "SDK_PRIVACY_SENTINEL_DO_NOT_EMIT"
+        example = Mock()
+        example.metrics = {
+            "accuracy": 0.88,
+            "raw_output": sentinel,
+            "model_output": sentinel,
+        }
+        example.execution_time = None
+        example.expected_output = sentinel
+        example.actual_output = sentinel
+        example.output = sentinel
+        example.raw_text = sentinel
+
+        measures = _build_measures_full([example], "accuracy")
+
+        assert measures[0]["metrics"]["accuracy"] == 0.88
+        assert sentinel not in json.dumps(measures)
 
     def test_include_execution_time(self, example_result):
         """Test execution_time is exported in explicit and legacy timing keys."""

--- a/tests/unit/integrations/test_bedrock_client.py
+++ b/tests/unit/integrations/test_bedrock_client.py
@@ -11,10 +11,12 @@ normalized response parsing and mocked boto3 interactions.
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
 from traigent.integrations.bedrock_client import (
     BedrockChatClient,
     BedrockChatResponse,
@@ -24,6 +26,21 @@ from traigent.integrations.bedrock_client import (
     _require_boto3,
     resolve_default_bedrock_model_id,
 )
+from traigent.utils.langchain_interceptor import (
+    clear_captured_responses,
+    get_captured_response,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_llm_mock_for_bedrock_client_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    """Most Bedrock client tests exercise fake boto clients, not mock mode."""
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+    clear_captured_responses()
+    yield
+    clear_captured_responses()
 
 
 def _mock_invoke_client(payload: dict) -> MagicMock:
@@ -151,6 +168,11 @@ class TestBedrockChatResponseDataclass:
         response = BedrockChatResponse(text="test", raw={}, usage=usage)
         assert response.usage == usage
 
+    def test_bedrock_chat_response_default_response_time(self) -> None:
+        """Test BedrockChatResponse exposes latency for capture paths."""
+        response = BedrockChatResponse(text="test", raw={})
+        assert response.response_time_ms == 0.0
+
 
 class TestBedrockChatClientInit:
     """Tests for BedrockChatClient initialization."""
@@ -237,9 +259,7 @@ class TestBedrockChatClientInvoke:
         assert response.usage["output_tokens"] == 10
         mock_client.invoke_model.assert_called_once()
 
-    def test_invoke_with_list_messages(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_invoke_with_list_messages(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test invoke sends list messages to Bedrock payload."""
         mock_client = _mock_invoke_client(
             {"content": [{"type": "text", "text": "List response"}]}
@@ -406,6 +426,148 @@ class TestBedrockChatClientInvoke:
 
         assert response.text == "AI21 response"
         mock_client.invoke_model.assert_called_once()
+
+
+class TestBedrockChatClientCaptureAndMock:
+    """Native Bedrock client capture and mock-mode short-circuit behavior."""
+
+    def teardown_method(self) -> None:
+        clear_captured_responses()
+
+    def test_invoke_captures_tokens_cost_and_latency(self) -> None:
+        mock_client = _mock_invoke_client(
+            {
+                "content": [{"type": "text", "text": "Captured response"}],
+                "usage": {"input_tokens": 13, "output_tokens": 8},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+        captured = get_captured_response()
+        assert captured is response
+        assert response.response_time_ms > 0
+        metrics = extract_llm_metrics(captured, model_name="claude-3-5-sonnet-20241022")
+        assert metrics.tokens.input_tokens == 13
+        assert metrics.tokens.output_tokens == 8
+        assert metrics.tokens.total_tokens == 21
+        assert metrics.cost.total_cost > 0
+        assert metrics.response.response_time_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_captures_tokens_cost_and_latency(self) -> None:
+        mock_client = _mock_invoke_client(
+            {
+                "content": [{"type": "text", "text": "Async captured response"}],
+                "usage": {"input_tokens": 17, "output_tokens": 9},
+            }
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        with patch.dict("sys.modules", {"aioboto3": None}):
+            response = await client.ainvoke(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages="hello",
+            )
+
+        captured = get_captured_response()
+        assert captured is response
+        metrics = extract_llm_metrics(captured, model_name="claude-3-5-sonnet-20241022")
+        assert metrics.tokens.input_tokens == 17
+        assert metrics.tokens.output_tokens == 9
+        assert metrics.tokens.total_tokens == 26
+        assert metrics.cost.total_cost > 0
+        assert metrics.response.response_time_ms > 0
+
+    def test_invoke_stream_captures_final_response_latency(self) -> None:
+        mock_client = _mock_stream_client(
+            {"content": [{"type": "text", "text": "streamed"}]}
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        chunks = list(
+            client.invoke_stream(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages="hello",
+            )
+        )
+
+        assert chunks == ["streamed"]
+        captured = get_captured_response()
+        assert isinstance(captured, BedrockChatResponse)
+        assert captured.text == "streamed"
+        assert captured.response_time_ms > 0
+
+    def test_mock_invoke_short_circuits_underlying_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+        assert response.text == "This is a mock response for testing."
+        assert response.usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
+        mock_client.invoke_model.assert_not_called()
+        assert get_captured_response() is response
+
+    @pytest.mark.asyncio
+    async def test_mock_ainvoke_short_circuits_underlying_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        response = await client.ainvoke(
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages="hello",
+        )
+
+        assert response.text == "This is a mock response for testing."
+        assert response.usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
+        mock_client.invoke_model.assert_not_called()
+        assert get_captured_response() is response
+
+    def test_mock_invoke_stream_short_circuits_underlying_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+        mock_client = MagicMock()
+        client = BedrockChatClient(client=mock_client)
+
+        chunks = list(
+            client.invoke_stream(
+                model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages="hello",
+            )
+        )
+
+        assert chunks == ["This is a mock response for testing."]
+        mock_client.invoke_model_with_response_stream.assert_not_called()
+        captured = get_captured_response()
+        assert isinstance(captured, BedrockChatResponse)
+        assert captured.usage == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
 
 
 class TestBedrockChatClientInvokeAI21:

--- a/tests/unit/integrations/test_bedrock_client_no_mock.py
+++ b/tests/unit/integrations/test_bedrock_client_no_mock.py
@@ -11,6 +11,7 @@ from traigent.integrations.bedrock_client import BedrockChatClient
 def test_bedrock_mock_env_does_not_short_circuit_invoke(monkeypatch) -> None:
     """Setting BEDROCK_MOCK still uses the boto3 Bedrock Runtime client."""
     monkeypatch.setenv("BEDROCK_MOCK", "true")
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
 
     mock_boto3 = MagicMock()
     mock_session = MagicMock()

--- a/tests/unit/utils/test_langchain_interceptor.py
+++ b/tests/unit/utils/test_langchain_interceptor.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import threading
 import time
+import types
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
 from traigent.utils.langchain_interceptor import (
     LangChainMetadataCapture,
     _create_astream_wrapper,
@@ -27,6 +29,74 @@ from traigent.utils.langchain_interceptor import (
     langchain_metadata_context,
     patch_langchain_for_metadata_capture,
 )
+
+
+class _FakeAIMessage:
+    def __init__(
+        self,
+        content: str,
+        response_metadata: dict[str, Any] | None = None,
+        usage_metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.content = content
+        self.response_metadata = response_metadata or {}
+        self.usage_metadata = usage_metadata or {}
+
+
+def _make_fake_bedrock_class(class_name: str) -> type:
+    class _FakeBedrock:
+        _traigent_patched_invoke = False
+        _traigent_patched_stream = False
+        _traigent_patched_astream = False
+        calls = 0
+
+        def __init__(
+            self, model_id: str = "claude-3-5-sonnet-20241022", **kwargs: Any
+        ) -> None:
+            self.model_id = model_id
+            self.model = kwargs.get("model", model_id)
+
+        def invoke(self, *args: Any, **kwargs: Any) -> _FakeAIMessage:
+            del args, kwargs
+            type(self).calls += 1
+            return _FakeAIMessage(
+                content="bedrock response",
+                response_metadata={"model_name": self.model_id},
+                usage_metadata={
+                    "input_tokens": 11,
+                    "output_tokens": 7,
+                    "total_tokens": 18,
+                },
+            )
+
+        def stream(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            yield _FakeAIMessage("stream chunk")
+
+        async def astream(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            yield _FakeAIMessage("astream chunk")
+
+    _FakeBedrock.__name__ = class_name
+    return _FakeBedrock
+
+
+def _make_fake_langchain_modules() -> dict[str, Any]:
+    langchain_aws = types.ModuleType("langchain_aws")
+    langchain_aws.ChatBedrock = _make_fake_bedrock_class("ChatBedrock")
+    langchain_aws.ChatBedrockConverse = _make_fake_bedrock_class("ChatBedrockConverse")
+
+    langchain_core = types.ModuleType("langchain_core")
+    messages = types.ModuleType("langchain_core.messages")
+    messages.AIMessage = _FakeAIMessage
+
+    return {
+        "langchain_anthropic": None,
+        "langchain_openai": None,
+        "langchain_aws": langchain_aws,
+        "langchain_core": langchain_core,
+        "langchain_core.messages": messages,
+    }
 
 
 class TestLangChainMetadataCapture:
@@ -859,3 +929,70 @@ class TestPatchLangChainForMetadataCapture:
 
         # Each thread should retrieve its own response
         assert len(results) == 5
+
+
+class TestPatchLangChainBedrock:
+    """LangChain AWS Bedrock interception."""
+
+    def teardown_method(self) -> None:
+        clear_captured_responses()
+
+    @pytest.mark.parametrize("class_name", ["ChatBedrock", "ChatBedrockConverse"])
+    def test_bedrock_invoke_captures_tokens_cost_and_latency(
+        self, class_name: str
+    ) -> None:
+        modules = _make_fake_langchain_modules()
+        langchain_aws = modules["langchain_aws"]
+        target_cls = getattr(langchain_aws, class_name)
+
+        with (
+            patch.dict("sys.modules", modules),
+            patch(
+                "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+                return_value=False,
+            ),
+        ):
+            assert patch_langchain_for_metadata_capture() is True
+            llm = target_cls(model_id="claude-3-5-sonnet-20241022")
+            response = llm.invoke("hello")
+
+        assert response.content == "bedrock response"
+        assert target_cls.calls == 1
+
+        captured = get_captured_response()
+        assert captured is response
+        metrics = extract_llm_metrics(captured, model_name="claude-3-5-sonnet-20241022")
+        assert metrics.tokens.input_tokens == 11
+        assert metrics.tokens.output_tokens == 7
+        assert metrics.tokens.total_tokens == 18
+        assert metrics.cost.total_cost > 0
+        assert metrics.response.response_time_ms > 0
+
+    @pytest.mark.parametrize("class_name", ["ChatBedrock", "ChatBedrockConverse"])
+    def test_bedrock_mock_mode_short_circuits_underlying_invoke(
+        self, class_name: str
+    ) -> None:
+        modules = _make_fake_langchain_modules()
+        langchain_aws = modules["langchain_aws"]
+        target_cls = getattr(langchain_aws, class_name)
+
+        with (
+            patch.dict("sys.modules", modules),
+            patch(
+                "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+                return_value=True,
+            ),
+        ):
+            assert patch_langchain_for_metadata_capture() is True
+            llm = target_cls(model_id="anthropic.claude-3-sonnet-20240229-v1:0")
+            response = llm.invoke("hello")
+
+        assert target_cls.calls == 0
+        assert response.content == "This is a mock response for testing."
+        assert response.usage_metadata == {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+        }
+        captured = get_captured_response()
+        assert captured is response

--- a/tests/unit/utils/test_litellm_interceptor.py
+++ b/tests/unit/utils/test_litellm_interceptor.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import types
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -71,7 +71,9 @@ class TestPatchLiteLLM:
     """Patching litellm.completion and litellm.acompletion."""
 
     def test_patch_returns_true(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         result = patch_litellm_for_metadata_capture()
         assert result is True
@@ -86,7 +88,9 @@ class TestPatchLiteLLM:
         assert result is False
 
     def test_patch_is_idempotent(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         # Second call should skip (already patched)
@@ -102,7 +106,9 @@ class TestSyncCapture:
     """Sync litellm.completion response capture."""
 
     def test_captures_response(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -112,7 +118,9 @@ class TestSyncCapture:
         assert captured[0] is response
 
     def test_injects_timing(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -121,7 +129,9 @@ class TestSyncCapture:
         assert response.response_time_ms > 0
 
     def test_preserves_usage(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -131,7 +141,9 @@ class TestSyncCapture:
         assert response.usage.total_tokens == 150
 
     def test_preserves_return_value(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = litellm_module.completion(model="gpt-4o", messages=[])
@@ -140,7 +152,9 @@ class TestSyncCapture:
         assert response.choices[0].message.content == "Hello world"
 
     def test_multiple_calls_captured_in_order(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         litellm_module.completion(model="gpt-4o", messages=[])
@@ -155,7 +169,9 @@ class TestAsyncCapture:
     """Async litellm.acompletion response capture."""
 
     def test_captures_response(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = asyncio.run(litellm_module.acompletion(model="gpt-4o", messages=[]))
@@ -165,13 +181,97 @@ class TestAsyncCapture:
         assert captured[0] is response
 
     def test_injects_timing(self, litellm_module):
-        from traigent.utils.litellm_interceptor import patch_litellm_for_metadata_capture
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
 
         patch_litellm_for_metadata_capture()
         response = asyncio.run(litellm_module.acompletion(model="gpt-4o", messages=[]))
 
         assert hasattr(response, "response_time_ms")
         assert response.response_time_ms > 0
+
+
+class TestMockModeLiteLLMShape:
+    """LiteLLM mock mode must preserve ModelResponse access patterns."""
+
+    @pytest.mark.asyncio
+    async def test_async_mock_mode_supports_choices_message_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+        from litellm import ModelResponse
+
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        underlying = AsyncMock(side_effect=AssertionError("real LiteLLM called"))
+        monkeypatch.setattr(litellm, "acompletion", underlying)
+        monkeypatch.setattr(
+            litellm, "_traigent_patched_acompletion", False, raising=False
+        )
+
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            patch_litellm_for_metadata_capture()
+
+            async def user_code() -> str:
+                resp = await litellm.acompletion(
+                    model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+                assert isinstance(resp, ModelResponse)
+                assert resp.usage.prompt_tokens == 10
+                assert resp.usage.completion_tokens == 20
+                assert resp.usage.total_tokens == 30
+                return resp.choices[0].message.content
+
+            content = await user_code()
+
+        assert content == "This is a mock response for testing."
+        underlying.assert_not_called()
+        captured = get_all_captured_responses()
+        assert len(captured) == 1
+        assert isinstance(captured[0], ModelResponse)
+
+    def test_sync_mock_mode_supports_choices_message_content(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import litellm
+        from litellm import ModelResponse
+
+        from traigent.utils.litellm_interceptor import (
+            patch_litellm_for_metadata_capture,
+        )
+
+        underlying = MagicMock(side_effect=AssertionError("real LiteLLM called"))
+        monkeypatch.setattr(litellm, "completion", underlying)
+        monkeypatch.setattr(
+            litellm, "_traigent_patched_completion", False, raising=False
+        )
+
+        with patch(
+            "traigent.integrations.utils.mock_adapter.MockAdapter.is_mock_enabled",
+            return_value=True,
+        ):
+            patch_litellm_for_metadata_capture()
+            resp = litellm.completion(
+                model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert isinstance(resp, ModelResponse)
+        assert resp.choices[0].message.content == "This is a mock response for testing."
+        assert resp.usage.prompt_tokens == 10
+        assert resp.usage.completion_tokens == 20
+        assert resp.usage.total_tokens == 30
+        underlying.assert_not_called()
+        captured = get_all_captured_responses()
+        assert len(captured) == 1
+        assert captured[0] is resp
 
 
 class TestLiteLLMPlugin:

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -19,6 +19,7 @@ import logging
 import os
 import time
 import uuid
+import warnings
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -32,6 +33,7 @@ from traigent.cloud.credential_resolver import CredentialResolver
 from traigent.cloud.password_auth_handler import PasswordAuthHandler
 from traigent.cloud.token_manager import TokenManager
 from traigent.cloud.url_security import validate_cloud_base_url_async
+from traigent.utils.env_config import is_truthy, treat_as_production
 from traigent.utils.exceptions import AuthenticationError as TraigentAuthenticationError
 from traigent.utils.url_security import UnsafeUrlError
 
@@ -42,6 +44,33 @@ TOKEN_REFRESH_THRESHOLD = 300  # Refresh 5 minutes before expiry
 MAX_TOKEN_AGE = 86400  # Maximum token age in seconds (24 hours)
 MIN_TOKEN_LENGTH = 20  # Minimum acceptable token length
 API_KEY_TOKEN_TTL = 31536000  # 365 days
+_LOOPBACK_BACKEND_DEV_HINT = (
+    "backend validation URL host is not allowed for loopback HTTP. "
+    "For local backend development, set ENVIRONMENT=development and "
+    "TRAIGENT_ALLOW_INSECURE_BACKEND=true."
+)
+
+
+def _is_loopback_backend_host(normalized_host: str) -> bool:
+    """Return True for localhost names and loopback IP literals only."""
+    host_for_match = normalized_host.rstrip(".")
+    if host_for_match == "localhost" or host_for_match.endswith(".localhost"):
+        return True
+    try:
+        host_ip = ipaddress.ip_address(host_for_match)
+    except ValueError:
+        return False
+    return host_ip.is_loopback
+
+
+def _allow_insecure_loopback_backend_validation() -> bool:
+    """Permit loopback backend validation only for explicit non-prod dev opt-in."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        non_production = not treat_as_production()
+    return non_production and is_truthy(
+        os.environ.get("TRAIGENT_ALLOW_INSECURE_BACKEND")
+    )
 
 
 class _AsyncBool:
@@ -1499,10 +1528,10 @@ class AuthManager:
         if not hostname:
             return "backend validation URL is invalid"
         normalized_host = hostname.strip("[]").lower()
-        if normalized_host in {"localhost", "localhost."} or normalized_host.endswith(
-            ".localhost"
-        ):
-            return "backend validation URL host is not allowed"
+        if _is_loopback_backend_host(normalized_host):
+            if _allow_insecure_loopback_backend_validation():
+                return None
+            return _LOOPBACK_BACKEND_DEV_HINT
         try:
             host_ip = ipaddress.ip_address(normalized_host)
         except ValueError:

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -924,7 +924,7 @@ def create_local_experiment(
             "configuration_space": configuration_space,
         },
         metadata={
-            "execution_mode": "edge_analytics",
+            "mode": "local",
             "privacy_mode": True,
             "dataset_size": dataset_size,
             "created_with": "traigent-local",
@@ -961,7 +961,7 @@ def create_local_experiment_run(
             },
             "metadata": {"dataset_size": dataset_size, "privacy_mode": True},
         },
-        metadata={"execution_mode": "edge_analytics", "privacy_mode": True},
+        metadata={"mode": "local", "privacy_mode": True},
         status="not_started",  # Set correct status for backend compatibility
     )
 

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -13,6 +13,7 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.cloud.dtos import MeasuresDict
 from traigent.cloud.validators import validate_configuration_run_submission
 from traigent.config.backend_config import BackendConfig
@@ -393,8 +394,9 @@ class TrialOperations:
     ) -> dict[str, Any]:
         """Build the trial result data dict."""
         result_metadata = dict(metadata or {})
+        result_metadata.pop("execution_mode", None)
         result_metadata["mode"] = mode
-        result_metadata["sdk_version"] = "2.0.0"
+        result_metadata["sdk_version"] = get_version()
         result_data: dict[str, Any] = {
             "trial_id": trial_id,
             "config": config,
@@ -710,13 +712,11 @@ class TrialOperations:
 
             # Prepare metadata - REQUIRED by backend to avoid NoneType errors
             submission_metadata = {
-                "mode": "privacy",  # Explicitly set mode for summary stats
-                "sdk_version": "2.0.0",
-                "aggregation_method": "pandas.describe",
-                "execution_mode": "privacy",  # Use "privacy" not "edge_analytics"
-                "total_examples": summary_stats.get("total_examples", 0),
-                # Include summary_stats metadata
                 **summary_stats.get("metadata", {}),
+                "mode": "privacy",  # Explicitly set mode for summary stats
+                "sdk_version": get_version(),
+                "aggregation_method": "pandas.describe",
+                "total_examples": summary_stats.get("total_examples", 0),
             }
 
             # IMPORTANT: Backend always expects metrics field

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -276,7 +276,15 @@ class ParameterBasedProvider(ConfigurationProvider):
         # Create TraigentConfig from dict if needed
         config_obj = TraigentConfig.from_dict(config)
 
-        def _effective_config() -> TraigentConfig:
+        def _active_applied_config() -> TraigentConfig | dict[str, Any] | None:
+            try:
+                return applied_config_context.get()
+            except LookupError:
+                return None
+
+        def _parameter_config(
+            active: TraigentConfig | dict[str, Any] | None,
+        ) -> TraigentConfig:
             """Prefer an APPLIED configuration over the wrap-time snapshot.
 
             During optimization the evaluator wraps every trial call in
@@ -291,10 +299,6 @@ class ParameterBasedProvider(ConfigurationProvider):
             — a bare global ``set_config()`` does not, so direct calls keep
             the wrap-time default.
             """
-            try:
-                active = applied_config_context.get()
-            except LookupError:
-                active = None
             if active is None:
                 return config_obj
             if isinstance(active, TraigentConfig):
@@ -305,10 +309,13 @@ class ParameterBasedProvider(ConfigurationProvider):
 
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            effective = _effective_config()
+            active = _active_applied_config()
+            effective = _parameter_config(active)
             # Only inject configuration if not already provided
             if param_name not in kwargs:
                 kwargs[param_name] = effective
+            if active is not None:
+                return func(*args, **kwargs)
             with ConfigurationContext(effective):
                 return func(*args, **kwargs)
 
@@ -317,10 +324,13 @@ class ParameterBasedProvider(ConfigurationProvider):
 
             @wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                effective = _effective_config()
+                active = _active_applied_config()
+                effective = _parameter_config(active)
                 # Only inject configuration if not already provided
                 if param_name not in kwargs:
                     kwargs[param_name] = effective
+                if active is not None:
+                    return await func(*args, **kwargs)
                 with ConfigurationContext(effective):
                     return await func(*args, **kwargs)
 

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -9,6 +9,7 @@ import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.api.types import (
     AgentConfiguration,
     OptimizationResult,
@@ -923,7 +924,7 @@ class BackendSessionManager:
                 "aggregation_level": "session",
                 "aggregation_summary": session_summary,
                 "trial_id": aggregated_trial_id,
-                "sdk_version": "2.0.0",
+                "sdk_version": get_version(),
             },
         }
 

--- a/traigent/core/llm_processor.py
+++ b/traigent/core/llm_processor.py
@@ -167,11 +167,29 @@ class LLMResponseProcessor:
         """
         try:
             # Extract token information
-            input_tokens = safe_get_nested_attr(response, "usage.prompt_tokens", 0)
-            output_tokens = safe_get_nested_attr(response, "usage.completion_tokens", 0)
-            total_tokens = safe_get_nested_attr(
-                response, "usage.total_tokens", input_tokens + output_tokens
+            def _first_numeric_token(*paths: str) -> int:
+                for path in paths:
+                    value = safe_get_nested_attr(response, path, None)
+                    if isinstance(value, (int, float)):
+                        return int(value)
+                return 0
+
+            input_tokens = _first_numeric_token(
+                "usage.prompt_tokens",
+                "usage.input_tokens",
+                "usage.inputTokens",
             )
+            output_tokens = _first_numeric_token(
+                "usage.completion_tokens",
+                "usage.output_tokens",
+                "usage.outputTokens",
+            )
+            total_tokens = _first_numeric_token(
+                "usage.total_tokens",
+                "usage.totalTokens",
+            )
+            if total_tokens == 0:
+                total_tokens = input_tokens + output_tokens
 
             # Extract cost information (if available)
             input_cost = safe_get_nested_attr(response, "cost.input_cost", 0.0)

--- a/traigent/core/metadata_helpers.py
+++ b/traigent/core/metadata_helpers.py
@@ -3,8 +3,10 @@
 # Traceability: CONC-Layer-Core CONC-Quality-Maintainability FUNC-ORCH-LIFECYCLE REQ-ORCH-003 SYNC-OptimizationFlow
 
 import json
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationResult, TrialResult
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.utils.example_id import compute_dataset_hash, generate_stable_example_id
@@ -35,6 +37,8 @@ def _validate_metrics_field(measure: dict[str, Any], example_index: int) -> dict
             f"Example {example_index}: 'metrics' must be dict, "
             f"got {type(measure['metrics']).__name__}"
         )
+    if not measure["metrics"]:
+        raise ValueError(f"Example {example_index}: 'metrics' must not be empty")
     return measure["metrics"]
 
 
@@ -158,7 +162,7 @@ def _add_summary_stats(
     if "metadata" not in enhanced_summary_stats:
         enhanced_summary_stats["metadata"] = {}
     enhanced_summary_stats["metadata"]["aggregation_level"] = "trial"
-    enhanced_summary_stats["metadata"]["sdk_version"] = "2.0.0"
+    enhanced_summary_stats["metadata"]["sdk_version"] = get_version()
     trial_metadata["summary_stats"] = enhanced_summary_stats
     logger.debug(
         "Adding summary_stats for %s mode with aggregation_level=trial",
@@ -190,22 +194,28 @@ def _add_measures_to_metadata(
         measures = _build_measures_full(
             example_results, primary_objective, dataset_name
         )
-        trial_metadata["measures"] = measures
-        logger.debug(
-            "Collected %s per-example MeasureResults for %s mode",
-            len(measures),
-            execution_mode,
-        )
-        _log_measures_debug(measures)
+        if measures:
+            trial_metadata["measures"] = measures
+            logger.debug(
+                "Collected %s per-example MeasureResults for %s mode",
+                len(measures),
+                execution_mode,
+            )
+            _log_measures_debug(measures)
+        else:
+            trial_metadata.pop("measures", None)
     elif privacy_on:
         measures = _build_measures_privacy(
             example_results, primary_objective, dataset_name
         )
-        trial_metadata["measures"] = measures
-        logger.debug(
-            "Using sanitized MeasureResults for privacy mode: %s examples",
-            len(measures),
-        )
+        if measures:
+            trial_metadata["measures"] = measures
+            logger.debug(
+                "Using sanitized MeasureResults for privacy mode: %s examples",
+                len(measures),
+            )
+        else:
+            trial_metadata.pop("measures", None)
     else:
         trial_metadata.pop("measures", None)
 
@@ -295,7 +305,10 @@ def _add_tvar_observation(
             config_space_id=source_metadata.get("config_space_id"),
             effectuation_events=source_metadata.get("effectuation_events"),
         )
-        return merge_tvar_observation_metadata(trial_metadata, observation)
+        return cast(
+            dict[str, Any],
+            merge_tvar_observation_metadata(trial_metadata, observation),
+        )
     except Exception as exc:
         logger.debug(
             "Skipping TVAR observation metadata for trial %s: %s",
@@ -339,7 +352,6 @@ def build_backend_metadata(
     trial_metadata: dict[str, Any] = {
         "duration": trial_result.duration,
         "trial_id": trial_result.trial_id,
-        "execution_mode": traigent_config.execution_mode,
     }
 
     if not traigent_config.minimal_logging:
@@ -400,10 +412,22 @@ def _extract_score_from_metrics(
     return None
 
 
+def _example_field(example_result: Any, name: str, default: Any = None) -> Any:
+    """Read a field from an example result object OR its dict payload form.
+
+    Trial metadata stores example results as redacted ``to_dict()`` payloads
+    (see ``trial_result_factory._to_redactable_payloads``), so the measure
+    builders must read plain dicts as well as ``ExampleResult`` objects.
+    """
+    if isinstance(example_result, Mapping):
+        return example_result.get(name, default)
+    return getattr(example_result, name, default)
+
+
 def _calculate_fallback_score(example_result: Any) -> float | None:
     """Calculate fallback score from expected vs actual output."""
-    expected = getattr(example_result, "expected_output", None)
-    actual = getattr(example_result, "actual_output", None)
+    expected = _example_field(example_result, "expected_output")
+    actual = _example_field(example_result, "actual_output")
     if expected is not None and actual is not None:
         return 1.0 if actual == expected else 0.0
     return None
@@ -418,7 +442,7 @@ def _add_execution_time_metrics(
     canonical optimization payload key is `response_time_ms`, but the legacy
     `response_time` key remains for one compatibility window.
     """
-    execution_time = getattr(example_result, "execution_time", None)
+    execution_time = _example_field(example_result, "execution_time")
     if execution_time is None or not isinstance(execution_time, (int, float)):
         return
 
@@ -427,22 +451,29 @@ def _add_execution_time_metrics(
     metrics_dict["response_time"] = response_time_seconds
 
 
+def _is_measure_metric_value(value: Any) -> bool:
+    """Return True for MeasuresDict metric values accepted by the SDK."""
+    return value is None or (
+        isinstance(value, (int, float)) and not isinstance(value, bool)
+    )
+
+
 def _build_single_measure_full(
     example_result: Any,
     idx: int,
     dataset_hash: str,
     primary_objective: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a single full measure for non-privacy mode."""
     example_id = generate_stable_example_id(dataset_hash, idx)
     metrics_dict: dict[str, Any] = {}
-    eval_metrics = getattr(example_result, "metrics", {}) or {}
+    eval_metrics = _example_field(example_result, "metrics") or {}
 
     if eval_metrics:
         logger.debug("Example %s metrics: %s", idx, eval_metrics)
         # Add all scalar metrics (numeric only per MeasuresDict constraints)
         for metric_key, metric_value in eval_metrics.items():
-            if isinstance(metric_value, (int, float)) or metric_value is None:
+            if _is_measure_metric_value(metric_value):
                 metrics_dict[metric_key] = metric_value
 
     # Extract or calculate score
@@ -453,6 +484,10 @@ def _build_single_measure_full(
         metrics_dict["score"] = float(example_score)
 
     _add_execution_time_metrics(metrics_dict, example_result)
+
+    if not metrics_dict:
+        logger.debug("Skipping measure %s because it has no numeric metrics", idx)
+        return None
 
     measure_result = {"example_id": example_id, "metrics": metrics_dict}
     _validate_measure_dict(measure_result, idx)
@@ -485,10 +520,14 @@ def _build_measures_full(
         ValueError: If measures violate MeasuresDict constraints
     """
     dataset_hash = compute_dataset_hash(dataset_name)
-    return [
-        _build_single_measure_full(example_result, idx, dataset_hash, primary_objective)
-        for idx, example_result in enumerate(example_results)
-    ]
+    measures: list[dict[str, Any]] = []
+    for idx, example_result in enumerate(example_results):
+        measure = _build_single_measure_full(
+            example_result, idx, dataset_hash, primary_objective
+        )
+        if measure is not None:
+            measures.append(measure)
+    return measures
 
 
 _PRIVACY_TOKEN_KEYS = ("input_tokens", "output_tokens", "total_tokens")
@@ -500,10 +539,14 @@ def _add_privacy_safe_metrics(
 ) -> None:
     """Add token and cost metrics which are privacy-safe."""
     for token_key in _PRIVACY_TOKEN_KEYS:
-        if token_key in eval_metrics:
+        if token_key in eval_metrics and _is_measure_metric_value(
+            eval_metrics[token_key]
+        ):
             metrics_dict[token_key] = eval_metrics[token_key]
     for cost_key in _PRIVACY_COST_KEYS:
-        if cost_key in eval_metrics:
+        if cost_key in eval_metrics and _is_measure_metric_value(
+            eval_metrics[cost_key]
+        ):
             metrics_dict[cost_key] = eval_metrics[cost_key]
 
 
@@ -512,11 +555,11 @@ def _build_single_measure_privacy(
     idx: int,
     dataset_hash: str,
     primary_objective: str,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Build a single sanitized measure for privacy mode."""
     example_id = generate_stable_example_id(dataset_hash, idx)
     metrics_dict: dict[str, Any] = {}
-    eval_metrics = getattr(example_result, "metrics", {}) or {}
+    eval_metrics = _example_field(example_result, "metrics") or {}
 
     # Extract or calculate score
     example_score = _extract_score_from_metrics(eval_metrics, primary_objective)
@@ -530,6 +573,12 @@ def _build_single_measure_privacy(
     # Add privacy-safe token and cost metrics
     if eval_metrics:
         _add_privacy_safe_metrics(metrics_dict, eval_metrics)
+
+    if not metrics_dict:
+        logger.debug(
+            "Skipping sanitized measure %s because it has no numeric metrics", idx
+        )
+        return None
 
     measure_result = {"example_id": example_id, "metrics": metrics_dict}
     _validate_measure_dict(measure_result, idx)
@@ -564,9 +613,11 @@ def _build_measures_privacy(
         ValueError: If measures violate MeasuresDict constraints
     """
     dataset_hash = compute_dataset_hash(dataset_name)
-    return [
-        _build_single_measure_privacy(
+    measures: list[dict[str, Any]] = []
+    for idx, example_result in enumerate(example_results):
+        measure = _build_single_measure_privacy(
             example_result, idx, dataset_hash, primary_objective
         )
-        for idx, example_result in enumerate(example_results)
-    ]
+        if measure is not None:
+            measures.append(measure)
+    return measures

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -82,7 +82,11 @@ from traigent.integrations.framework_override import override_context
 from traigent.optimizers import get_optimizer
 from traigent.tvl.options import TVLOptions
 from traigent.tvl.spec_loader import load_tvl_spec
-from traigent.utils.env_config import is_mock_llm
+from traigent.utils.cost_calculator import (
+    UnknownModelError,
+    find_models_missing_price_coverage,
+)
+from traigent.utils.env_config import is_mock_llm, is_strict_cost_accounting
 from traigent.utils.exceptions import (
     AuthenticationError,
     ConfigurationError,
@@ -160,6 +164,60 @@ _COST_WARNING_EMITTED = False
 _CONFIG_SPACE_TYPE_ERROR = "Configuration space must be a dictionary"
 
 _CLOUD_FALLBACK_POLICIES = frozenset({"auto", "warn", "never"})
+_MODEL_CONFIG_KEYS = frozenset({"model", "model_name", "model_id", "engine"})
+
+
+def _is_model_config_key(key: object) -> bool:
+    return isinstance(key, str) and key.strip().lower() in _MODEL_CONFIG_KEYS
+
+
+def _iter_config_model_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+
+    if isinstance(value, Mapping):
+        choices = value.get("values") or value.get("choices")
+        if choices is not None:
+            return _iter_config_model_values(choices)
+        fixed_value = value.get("value")
+        if isinstance(fixed_value, str):
+            return [fixed_value]
+        return []
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [item for item in value if isinstance(item, str) and item.strip()]
+
+    range_values = getattr(value, "values", None)
+    if isinstance(range_values, Sequence) and not isinstance(
+        range_values, (str, bytes, bytearray)
+    ):
+        return [item for item in range_values if isinstance(item, str) and item.strip()]
+
+    return []
+
+
+def _dedupe_model_ids(model_ids: list[str]) -> list[str]:
+    return list(dict.fromkeys(model_ids))
+
+
+def _extract_config_space_model_ids(config_space: Mapping[str, Any]) -> list[str]:
+    model_ids: list[str] = []
+    for key, value in config_space.items():
+        if _is_model_config_key(key):
+            model_ids.extend(_iter_config_model_values(value))
+    return _dedupe_model_ids(model_ids)
+
+
+def _extract_config_model_ids(config: Mapping[str, Any]) -> list[str]:
+    model_ids: list[str] = []
+    for key, value in config.items():
+        if _is_model_config_key(key) and isinstance(value, str) and value.strip():
+            model_ids.append(value)
+    return _dedupe_model_ids(model_ids)
+
+
+def _format_model_id_list(model_ids: Sequence[str]) -> str:
+    return ", ".join(f"`{model_id}`" for model_id in model_ids)
 
 
 def _emit_cost_warning_once() -> None:
@@ -1862,6 +1920,50 @@ class OptimizedFunction:
         """
         return algorithm
 
+    def _preflight_model_cost_coverage(
+        self, effective_config_space: Mapping[str, Any]
+    ) -> None:
+        """Warn or fail before trials when a real run includes unpriced models."""
+        if is_mock_llm():
+            return
+
+        model_ids = _extract_config_space_model_ids(effective_config_space)
+        if not model_ids:
+            model_ids = _dedupe_model_ids(
+                _extract_config_model_ids(getattr(self, "_current_config", {}))
+                + _extract_config_model_ids(getattr(self, "default_config", {}))
+            )
+        if not model_ids:
+            return
+
+        missing = find_models_missing_price_coverage(model_ids)
+        if not missing:
+            return
+
+        formatted = _format_model_id_list(missing)
+        if is_strict_cost_accounting():
+            raise UnknownModelError(
+                "Cost coverage preflight failed before any optimization trial "
+                f"started: pricing is unavailable for {formatted}. "
+                "Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON or "
+                "TRAIGENT_CUSTOM_MODEL_PRICING_FILE with explicit per-token "
+                "pricing, or contact Traigent to add coverage."
+            )
+
+        if len(missing) == 1:
+            message = (
+                f"Cost for {formatted} is unavailable — results will report $0 "
+                "for it. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+                "Traigent to add coverage."
+            )
+        else:
+            message = (
+                f"Costs for {formatted} are unavailable — results will report $0 "
+                "for them. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+                "Traigent to add coverage."
+            )
+        warnings.warn(message, UserWarning, stacklevel=3)
+
     async def _execute_optimization(
         self,
         *,
@@ -1957,6 +2059,9 @@ class OptimizedFunction:
         )
         if max_total_examples_value is not None:
             self.max_total_examples = max_total_examples_value
+
+        # Phase 3.5: cost coverage preflight before any cloud or local trial dispatch.
+        self._preflight_model_cost_coverage(effective_config_space)
 
         # Phase 4: Try cloud execution if applicable
         cloud_result = await self._try_cloud_execution(

--- a/traigent/integrations/bedrock_client.py
+++ b/traigent/integrations/bedrock_client.py
@@ -18,6 +18,7 @@ import asyncio
 import concurrent.futures
 import json
 import os
+import time
 from collections.abc import AsyncGenerator, Generator, Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -82,6 +83,8 @@ class BedrockChatResponse:
     text: str
     raw: Mapping[str, Any]
     usage: Mapping[str, Any] | None = None
+    response_time_ms: float = 0.0
+    model: str | None = None
 
 
 class BedrockChatClient:
@@ -97,6 +100,53 @@ class BedrockChatClient:
         self._client = client
         self._region_name = region_name
         self._profile_name = profile_name
+
+    @staticmethod
+    def _is_mock_enabled() -> bool:
+        try:
+            from traigent.integrations.utils.mock_adapter import MockAdapter
+        except ImportError:
+            return False
+
+        return MockAdapter.is_mock_enabled("bedrock")
+
+    @staticmethod
+    def _capture_response(
+        response: BedrockChatResponse,
+        *,
+        model_id: str,
+        start_time: float,
+        capture: bool = True,
+    ) -> BedrockChatResponse:
+        response.response_time_ms = (time.perf_counter() - start_time) * 1000
+        response.model = response.model or model_id
+        if not capture:
+            return response
+
+        try:
+            from traigent.utils.langchain_interceptor import capture_langchain_response
+        except ImportError:
+            return response
+
+        capture_langchain_response(response)
+        return response
+
+    @staticmethod
+    def _mock_response(model_id: str) -> BedrockChatResponse:
+        from traigent.integrations.utils.mock_adapter import MockAdapter
+        from traigent.utils.langchain_interceptor import capture_langchain_response
+
+        mock_data = MockAdapter.get_mock_response("bedrock", model=model_id)
+        usage = dict(mock_data["usage"])
+        response = BedrockChatResponse(
+            text=mock_data["content"][0]["text"],
+            raw={**mock_data, "mock": True},
+            usage=usage,
+            response_time_ms=0.0,
+            model=model_id,
+        )
+        capture_langchain_response(response)
+        return response
 
     def _ensure_client(self):  # pragma: no cover - network client guard
         if self._client is not None:
@@ -121,21 +171,30 @@ class BedrockChatClient:
         temperature: float = 0.5,
         top_p: float | None = None,
         extra_params: Mapping[str, Any] | None = None,
+        _capture: bool = True,
     ) -> BedrockChatResponse:
         """Perform a non-streaming chat invocation.
 
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        if self._is_mock_enabled():
+            return self._mock_response(model_id)
 
+        start_time = time.perf_counter()
         client = self._ensure_client()
 
         if str(model_id).startswith("ai21."):
-            return self._invoke_ai21(
+            return self._capture_response(
+                self._invoke_ai21(
+                    model_id=model_id,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                ),
                 model_id=model_id,
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
+                start_time=start_time,
+                capture=_capture,
             )
 
         payload: dict[str, Any] = {
@@ -165,7 +224,12 @@ class BedrockChatClient:
 
         text = _extract_text_from_messages_response(data)
         usage = data.get("usage") if isinstance(data, Mapping) else None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return self._capture_response(
+            BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id),
+            model_id=model_id,
+            start_time=start_time,
+            capture=_capture,
+        )
 
     def _invoke_ai21(
         self,
@@ -228,7 +292,7 @@ class BedrockChatClient:
         else:
             text = str(data)
             usage = None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id)
 
     def invoke_stream(
         self,
@@ -241,7 +305,13 @@ class BedrockChatClient:
         extra_params: Mapping[str, Any] | None = None,
     ) -> Generator[str, None, BedrockChatResponse]:  # pragma: no cover - streaming path
         """Stream chat invocation; yields text chunks and returns final response."""
+        if self._is_mock_enabled():
+            response = self._mock_response(model_id)
+            if response.text:
+                yield response.text
+            return response
 
+        start_time = time.perf_counter()
         client = self._ensure_client()
 
         payload: dict[str, Any] = {
@@ -280,7 +350,16 @@ class BedrockChatClient:
                     yield text_piece
 
         final = "".join(final_text_parts)
-        return BedrockChatResponse(text=final, raw={"streamed": True}, usage=None)
+        return self._capture_response(
+            BedrockChatResponse(
+                text=final,
+                raw={"streamed": True},
+                usage=None,
+                model=model_id,
+            ),
+            model_id=model_id,
+            start_time=start_time,
+        )
 
     async def ainvoke(
         self,
@@ -297,22 +376,31 @@ class BedrockChatClient:
         Uses aioboto3 for true async or falls back to an isolated sync worker.
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        if self._is_mock_enabled():
+            return self._mock_response(model_id)
+
         # Try aioboto3 for true async
         try:
             import aioboto3  # noqa: F401 - used for availability check and async method
 
-            return await self._ainvoke_aioboto3(
+            start_time = time.perf_counter()
+            return self._capture_response(
+                await self._ainvoke_aioboto3(
+                    model_id=model_id,
+                    messages=messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    extra_params=extra_params,
+                ),
                 model_id=model_id,
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                extra_params=extra_params,
+                start_time=start_time,
             )
         except ImportError:
+            start_time = time.perf_counter()
             loop = asyncio.get_running_loop()
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                return await loop.run_in_executor(
+                response = await loop.run_in_executor(
                     executor,
                     lambda: self.invoke(
                         model_id=model_id,
@@ -321,8 +409,14 @@ class BedrockChatClient:
                         temperature=temperature,
                         top_p=top_p,
                         extra_params=extra_params,
+                        _capture=False,
                     ),
                 )
+            return self._capture_response(
+                response,
+                model_id=model_id,
+                start_time=start_time,
+            )
 
     async def _ainvoke_aioboto3(
         self,
@@ -371,7 +465,7 @@ class BedrockChatClient:
 
         text = _extract_text_from_messages_response(data)
         usage = data.get("usage") if isinstance(data, Mapping) else None
-        return BedrockChatResponse(text=text, raw=data, usage=usage)
+        return BedrockChatResponse(text=text, raw=data, usage=usage, model=model_id)
 
     async def ainvoke_stream(
         self,

--- a/traigent/integrations/utils/mock_adapter.py
+++ b/traigent/integrations/utils/mock_adapter.py
@@ -28,6 +28,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, ClassVar
 
 logger = logging.getLogger(__name__)
@@ -182,8 +183,10 @@ class MockAdapter:
             "openai": cls._build_openai_mock,
             "azure_openai": cls._build_openai_mock,  # Same format
             "anthropic": cls._build_anthropic_mock,
+            "bedrock": cls._build_bedrock_mock,
             "gemini": cls._build_gemini_mock,
             "cohere": cls._build_cohere_mock,
+            "litellm": cls._build_litellm_mock,
         }
 
         builder = builders.get(provider.lower(), cls._build_generic_mock)
@@ -275,6 +278,78 @@ class MockAdapter:
                 }
             },
         }
+
+    @classmethod
+    def _build_bedrock_mock(cls, data: MockResponse) -> dict[str, Any]:
+        """Build Bedrock Anthropic Messages API-like response dict."""
+        return {
+            "id": data.response_id,
+            "type": "message",
+            "role": "assistant",
+            "model": data.model,
+            "content": [
+                {
+                    "type": "text",
+                    "text": data.text,
+                }
+            ],
+            "stop_reason": data.finish_reason,
+            "usage": {
+                "input_tokens": data.prompt_tokens,
+                "output_tokens": data.completion_tokens,
+                "total_tokens": data.total_tokens,
+            },
+        }
+
+    @classmethod
+    def _build_litellm_mock(cls, data: MockResponse) -> Any:
+        """Build a LiteLLM ModelResponse-like mock response."""
+        try:
+            from litellm import ModelResponse
+        except Exception as exc:  # pragma: no cover - exercised only without litellm
+            logger.debug("LiteLLM ModelResponse unavailable, using fallback: %s", exc)
+            return SimpleNamespace(
+                id=data.response_id,
+                object="chat.completion",
+                created=int(time.time()),
+                model=data.model,
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        message=SimpleNamespace(
+                            role="assistant",
+                            content=data.text,
+                        ),
+                        finish_reason=data.finish_reason,
+                    )
+                ],
+                usage=SimpleNamespace(
+                    prompt_tokens=data.prompt_tokens,
+                    completion_tokens=data.completion_tokens,
+                    total_tokens=data.total_tokens,
+                ),
+            )
+
+        return ModelResponse(
+            id=data.response_id,
+            model=data.model,
+            object="chat.completion",
+            choices=[
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": data.text,
+                    },
+                    "finish_reason": data.finish_reason,
+                }
+            ],
+            usage={
+                "prompt_tokens": data.prompt_tokens,
+                "completion_tokens": data.completion_tokens,
+                "total_tokens": data.total_tokens,
+            },
+        )
 
     @classmethod
     def _build_generic_mock(cls, data: MockResponse) -> dict[str, Any]:

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -15,6 +15,7 @@ import os
 import re
 import threading
 import warnings
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -1146,6 +1147,28 @@ def cost_from_tokens(
         _CUSTOM_PRICING_JSON_ENV,
     )
     return 0.0, 0.0
+
+
+def model_has_nonzero_price_coverage(model_name: str) -> bool:
+    """Return whether a model resolves to non-zero pricing via the real path."""
+    try:
+        input_cost, output_cost = cost_from_tokens(1, 1, model_name, strict=True)
+    except (RuntimeError, UnknownModelError):
+        return False
+    return (input_cost + output_cost) > 0.0
+
+
+def find_models_missing_price_coverage(models: Iterable[str]) -> list[str]:
+    """Return deduplicated model IDs without non-zero pricing coverage."""
+    missing: list[str] = []
+    seen: set[str] = set()
+    for model_name in models:
+        if model_name in seen:
+            continue
+        seen.add(model_name)
+        if not model_has_nonzero_price_coverage(model_name):
+            missing.append(model_name)
+    return missing
 
 
 # Convenience functions for simple usage

--- a/traigent/utils/langchain_interceptor.py
+++ b/traigent/utils/langchain_interceptor.py
@@ -175,6 +175,84 @@ def _create_astream_wrapper(original_meth: Any) -> Any:
     return astream_wrapper
 
 
+def _patch_langchain_bedrock_model(model_cls: Any, class_name: str) -> bool:
+    """Patch one langchain_aws Bedrock chat class for response capture."""
+    patched_any = False
+
+    if getattr(model_cls, "_traigent_patched_invoke", False) is False:
+        original_invoke = model_cls.invoke
+
+        def invoke_with_capture_bedrock(self: Any, *args: Any, **kwargs: Any) -> Any:
+            """Wrapped invoke method that captures Bedrock usage metadata."""
+            from traigent.integrations.utils.mock_adapter import MockAdapter
+
+            if MockAdapter.is_mock_enabled("bedrock"):
+                from langchain_core.messages import AIMessage
+
+                model_name = (
+                    getattr(self, "model_id", None)
+                    or getattr(self, "model", None)
+                    or "mock-model"
+                )
+                mock_data = MockAdapter.get_mock_response(
+                    "bedrock", model=str(model_name)
+                )
+                usage = mock_data["usage"]
+                response = AIMessage(
+                    content=mock_data["content"][0]["text"],
+                    response_metadata={
+                        "model_name": mock_data["model"],
+                        "stop_reason": mock_data["stop_reason"],
+                        "response_time_ms": 0.0,
+                    },
+                    usage_metadata={
+                        "input_tokens": usage["input_tokens"],
+                        "output_tokens": usage["output_tokens"],
+                        "total_tokens": usage["total_tokens"],
+                    },
+                )
+                capture_langchain_response(response)
+                return response
+
+            start_time = time.perf_counter()
+            response = original_invoke(self, *args, **kwargs)
+            response_time_ms = (time.perf_counter() - start_time) * 1000
+
+            if not hasattr(response, "response_metadata"):
+                response.response_metadata = {}
+            response.response_metadata["response_time_ms"] = response_time_ms
+
+            capture_langchain_response(response)
+            logger.debug(
+                "Captured %s invoke usage: %s, response_time_ms: %.2f",
+                class_name,
+                getattr(response, "usage_metadata", None),
+                response_time_ms,
+            )
+            return response
+
+        model_cls.invoke = invoke_with_capture_bedrock
+        model_cls._traigent_patched_invoke = True
+        logger.info("✅ Patched %s.invoke for metadata capture", class_name)
+        patched_any = True
+
+    for meth_name, flag in [
+        ("stream", "_traigent_patched_stream"),
+        ("astream", "_traigent_patched_astream"),
+    ]:
+        if hasattr(model_cls, meth_name) and not getattr(model_cls, flag, False):
+            original_meth = getattr(model_cls, meth_name)
+            if meth_name == "stream":
+                setattr(model_cls, meth_name, _create_stream_wrapper(original_meth))
+            else:
+                setattr(model_cls, meth_name, _create_astream_wrapper(original_meth))
+            setattr(model_cls, flag, True)
+            logger.info("✅ Patched %s.%s for metadata capture", class_name, meth_name)
+            patched_any = True
+
+    return patched_any
+
+
 def patch_langchain_for_metadata_capture() -> bool:
     """Monkey-patch LangChain to automatically capture response metadata.
 
@@ -351,6 +429,23 @@ def patch_langchain_for_metadata_capture() -> bool:
         logger.debug("ChatOpenAI not available, skipping")
     except Exception as e:
         logger.error(f"Failed to patch ChatOpenAI: {e}")
+
+    # Patch langchain_aws Bedrock chat models
+    try:
+        import langchain_aws
+
+        for class_name in ("ChatBedrock", "ChatBedrockConverse"):
+            model_cls = getattr(langchain_aws, class_name, None)
+            if model_cls is None:
+                logger.debug("langchain_aws.%s not available, skipping", class_name)
+                continue
+            if _patch_langchain_bedrock_model(model_cls, f"langchain_aws.{class_name}"):
+                patched_any = True
+
+    except ImportError:
+        logger.debug("langchain_aws not available, skipping Bedrock")
+    except Exception as e:
+        logger.error(f"Failed to patch langchain_aws Bedrock models: {e}")
 
     if not patched_any:
         logger.debug("No LangChain models could be patched for metadata capture")

--- a/traigent/utils/litellm_interceptor.py
+++ b/traigent/utils/litellm_interceptor.py
@@ -54,6 +54,8 @@ def patch_litellm_for_metadata_capture() -> bool:
                         "litellm",
                         model=kwargs.get("model", args[0] if args else "mock-model"),
                     )
+                    mock_data.response_time_ms = 0.0
+                    capture_langchain_response(mock_data)
                     return mock_data
 
                 start_time = time.perf_counter()
@@ -101,6 +103,8 @@ def patch_litellm_for_metadata_capture() -> bool:
                         "litellm",
                         model=kwargs.get("model", args[0] if args else "mock-model"),
                     )
+                    mock_data.response_time_ms = 0.0
+                    capture_langchain_response(mock_data)
                     return mock_data
 
                 start_time = time.perf_counter()


### PR DESCRIPTION
Final 0.12.0 promotion. Beyond v4 (already on main), develop has accumulated the merged SDK issue fixes and the publish-smoke env fix — all included here:
- Publish smoke env (#1148): TRAIGENT_RUN_APPROVED + TRAIGENT_DATASET_ROOT (the prior tag-publish failed on these 0.12.0 guards; verified locally quickstart/docs/core run to completion).
- SDK issue fixes merged to develop: loopback dev-override **default-closed** (#1139, verified: requires non-prod AND TRAIGENT_ALLOW_INSECURE_BACKEND), cost-coverage preflight **strict-blocks before any trial** (#1146), Bedrock capture + litellm mock shape (#1147), per-example measures + sdk_version (#1139), param-injection (#1138), trust-model docs (#1140).
Version 0.12.0. After merge: move v0.12.0 tag here → publish.yml smoke now passes → PyPI. Sonar new-code coverage remains the documented batch-promotion aggregate (no threshold relaxed). 🤖 Generated with [Claude Code](https://claude.com/claude-code)