### PR TITLE
fix(tests): drive optimizer-validation reproducibility through the canonical seeded path

### DIFF
--- a/tests/optimizer_validation/conftest.py
+++ b/tests/optimizer_validation/conftest.py
@@ -29,6 +29,52 @@ if TYPE_CHECKING:
     from .tracing.capture import CapturedTrace
 
 
+_CANONICALIZED_MOCK_OPTIMIZER_KEYS = frozenset({"optimizer", "sampler", "random_seed"})
+
+
+def _resolve_mock_algorithm(mock_config: dict[str, Any] | None) -> str | None:
+    """Resolve legacy scenario optimizer keys to the canonical algorithm name."""
+    if not mock_config:
+        return None
+
+    optimizer = mock_config.get("optimizer")
+    sampler = mock_config.get("sampler")
+    if sampler is not None and (
+        optimizer is None or str(optimizer).strip().lower() == "optuna"
+    ):
+        sampler_name = str(sampler).strip().lower()
+        return f"optuna_{sampler_name}" if sampler_name else None
+
+    if optimizer is None:
+        return None
+
+    algorithm = str(optimizer).strip()
+    return algorithm or None
+
+
+def _resolve_mock_random_seed(scenario: TestScenario) -> int | None:
+    """Resolve the canonical runtime seed for optimizer-validation scenarios."""
+    mock_config = scenario.mock_mode_config or {}
+    if "random_seed" in mock_config:
+        return mock_config["random_seed"]
+
+    # Use a stable hash to avoid process-randomized Python hash() output.
+    seed_bytes = hashlib.sha256(scenario.name.encode("utf-8")).digest()
+    return int.from_bytes(seed_bytes[:8], "big") % (2**31)
+
+
+def _mock_payload_for_decorator(mock_config: dict[str, Any] | None) -> dict[str, Any]:
+    """Keep non-optimizer mock payload keys after canonicalizing optimizer knobs."""
+    if not mock_config:
+        return {}
+
+    return {
+        key: value
+        for key, value in mock_config.items()
+        if key not in _CANONICALIZED_MOCK_OPTIMIZER_KEYS
+    }
+
+
 def _serialize_config_space(config_space: dict[str, Any]) -> dict[str, Any]:
     """Serialize config space with cardinality analysis for evidence JSON."""
     result = {}
@@ -358,14 +404,8 @@ def _resolve_gist_template(
     # injection_mode() - from scenario
     values["injection_mode"] = str(scenario.injection_mode)
 
-    # algorithm() - from mock_mode_config
-    if scenario.mock_mode_config:
-        algo = scenario.mock_mode_config.get("optimizer", "")
-        if not algo and scenario.mock_mode_config.get("sampler"):
-            algo = f"optuna_{scenario.mock_mode_config.get('sampler')}"
-        values["algorithm"] = algo or "--"
-    else:
-        values["algorithm"] = "--"
+    # algorithm() - from canonicalized legacy scenario optimizer keys
+    values["algorithm"] = _resolve_mock_algorithm(scenario.mock_mode_config) or "--"
 
     # expected_outcome() - what the test expects
     values["expected_outcome"] = scenario.expected.outcome.name
@@ -432,12 +472,8 @@ def emit_test_evidence(
     # Load dataset samples and get actual file size
     samples, actual_size = _load_dataset_info(actual_path)
 
-    # Extract algorithm from mock_mode_config if present
-    algorithm = None
-    if scenario.mock_mode_config:
-        algorithm = scenario.mock_mode_config.get("optimizer")
-        if not algorithm and scenario.mock_mode_config.get("sampler"):
-            algorithm = f"optuna_{scenario.mock_mode_config.get('sampler')}"
+    # Extract algorithm from the same canonical path used by run_scenario.
+    algorithm = _resolve_mock_algorithm(scenario.mock_mode_config)
 
     # Extract parallel mode
     parallel_mode = None
@@ -790,15 +826,11 @@ def scenario_runner(
         # Note: attribute mode + parallel trials is now unconditionally blocked.
         # Test scenarios should not use this combination - it will raise ValueError.
 
-        # Generate per-test seed for mock mode reproducibility
-        # Use scenario name to create deterministic seed unique to each test
-        mock_config = (
-            dict(scenario.mock_mode_config) if scenario.mock_mode_config else {}
-        )
-        if "random_seed" not in mock_config:
-            # Use a stable hash to avoid process-randomized Python hash() output.
-            seed_bytes = hashlib.sha256(scenario.name.encode("utf-8")).digest()
-            mock_config["random_seed"] = int.from_bytes(seed_bytes[:8], "big") % (2**31)
+        # Canonicalize legacy scenario optimizer keys before applying the decorator.
+        # The remaining mock payload is only for inert score/evaluator dry-run keys.
+        mock_config = _mock_payload_for_decorator(scenario.mock_mode_config)
+        algorithm = _resolve_mock_algorithm(scenario.mock_mode_config)
+        random_seed = _resolve_mock_random_seed(scenario)
 
         # Apply decorator
         try:
@@ -836,6 +868,9 @@ def scenario_runner(
                 "max_trials": scenario.max_trials,
                 "timeout": scenario.timeout,
             }
+            if algorithm is not None:
+                optimize_kwargs["algorithm"] = algorithm
+            optimize_kwargs["random_seed"] = random_seed
             if parallel_config is not None:
                 optimize_kwargs["parallel_config"] = parallel_config
 

--- a/tests/optimizer_validation/dimensions/test_reproducibility.py
+++ b/tests/optimizer_validation/dimensions/test_reproducibility.py
@@ -6,8 +6,8 @@ Tests that verify:
 - Grid search is inherently deterministic
 - Parallel execution reproducibility
 
-The random_seed from mock_mode_config is now properly propagated to optimizers,
-enabling reproducible test runs.
+Legacy scenario optimizer keys are canonicalized by the harness into
+decorated.optimize(algorithm=..., random_seed=...), enabling reproducible test runs.
 """
 
 from __future__ import annotations

--- a/tests/unit/core/test_seeded_optimizer_reproducibility.py
+++ b/tests/unit/core/test_seeded_optimizer_reproducibility.py
@@ -1,0 +1,78 @@
+"""Regression tests for canonical optimizer seeding and retired mock keys."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from traigent.api.decorators import optimize
+from traigent.api.types import OptimizationResult
+from traigent.optimizers.registry import register_optuna_optimizers
+
+CONFIG_SPACE = {
+    "model": ["gpt-3.5-turbo", "gpt-4"],
+    "temperature": [0.3, 0.7],
+}
+EVAL_DATASET = [{"input": {"text": "hello"}, "expected": "hello"}]
+
+
+def _build_decorated_target(*, mock: dict[str, Any] | None = None) -> Any:
+    @optimize(
+        configuration_space=CONFIG_SPACE,
+        objectives=["accuracy"],
+        injection={"injection_mode": "parameter", "config_param": "traigent_config"},
+        evaluation={"eval_dataset": EVAL_DATASET},
+        mock=mock,
+    )
+    def target(text: str, traigent_config: dict[str, Any] | None = None) -> str:
+        return text
+
+    return target
+
+
+def _trial_configs(result: OptimizationResult) -> list[dict[str, Any]]:
+    return [dict(trial.config) for trial in result.trials]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("algorithm", ["grid", "optuna_tpe", "optuna_random"])
+async def test_seeded_canonical_optimizer_runs_produce_identical_trial_configs(
+    algorithm: str,
+) -> None:
+    if algorithm.startswith("optuna"):
+        register_optuna_optimizers(force=True)
+
+    first = _build_decorated_target()
+    second = _build_decorated_target()
+
+    result1 = await first.optimize(
+        algorithm=algorithm,
+        random_seed=42,
+        max_trials=4,
+    )
+    result2 = await second.optimize(
+        algorithm=algorithm,
+        random_seed=42,
+        max_trials=4,
+    )
+
+    assert _trial_configs(result1) == _trial_configs(result2)
+
+
+@pytest.mark.asyncio
+async def test_legacy_mock_optimizer_keys_warn_without_changing_algorithm(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    decorated = _build_decorated_target(mock={"optimizer": "grid", "random_seed": 42})
+
+    caplog.set_level(logging.WARNING, logger="traigent.core.optimized_function")
+    result = await decorated.optimize(max_trials=2)
+
+    assert result.algorithm == "RandomSearchOptimizer"
+    assert any(
+        "inert post-F5" in record.getMessage()
+        and "decorated.optimize(algorithm=..., random_seed=...)" in record.getMessage()
+        for record in caplog.records
+    )

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1860,6 +1860,20 @@ class OptimizedFunction:
         seed, so we now ignore it entirely. Real seeding should go through
         the normal ``algorithm_kwargs`` / ``random_seed`` parameter path.
         """
+        mock_config = self.mock_mode_config
+        if not isinstance(mock_config, Mapping):
+            return algorithm
+
+        inert_keys = sorted(
+            key for key in ("optimizer", "sampler", "random_seed") if key in mock_config
+        )
+        if inert_keys:
+            logger.warning(
+                "mock_mode_config keys %s are inert post-F5 and no longer select "
+                "optimizers or seed runs; pass algorithm/random_seed via "
+                "decorated.optimize(algorithm=..., random_seed=...) instead.",
+                ", ".join(inert_keys),
+            )
         return algorithm
 
     async def _execute_optimization(


### PR DESCRIPTION
## Summary
Closes #1085.

**The real defect was not optimizer nondeterminism.** The optimizer-validation harness passed algorithm selection + `random_seed` through the legacy `mock=` bundle, which the F5 retirement deliberately made **inert** (a stray production config once silently rerouted real optimizations to a different algorithm with a fixed seed). So 'seeded grid/Optuna' scenarios actually ran the **default algorithm, unseeded** — the reproducibility suite was asserting determinism of noise. Grid iteration is already deterministic (`traigent/optimizers/grid.py:213-231`); Optuna seeds correctly once `random_seed` reaches it (`optuna_optimizer.py:145-160`).

### Changes
- **Harness** (`tests/optimizer_validation/conftest.py`): legacy scenario keys canonicalized → `decorated.optimize(algorithm=..., random_seed=...)` (the path the F5 docstring prescribes); other mock keys still flow via `mock=`; evidence serialization uses the same resolver the run uses.
- **SDK**: `_apply_mock_config_overrides` remains the F5 no-op but now **warns loudly** when `mock_mode_config` carries `optimizer`/`sampler`/`random_seed`, so the silent-degradation failure mode can't recur. No optimizer-selection or seeding behavior change.
- **Regressions** (`tests/unit/core/test_seeded_optimizer_reproducibility.py`): identical seeded runs → identical full trial-config sequences (grid, optuna_tpe, optuna_random); legacy keys warn AND the default algorithm demonstrably still runs (asserts `RandomSearchOptimizer` despite `mock={'optimizer': 'grid'}`).

> Captain process note: a first-pass fix that re-animated the retired mock-bundle surface (mock-gated) was **rejected on direction** — it recreated the rerouting surface and made mock dry-runs use a different algorithm than real runs. This PR is the corrected approach.

## Verification
- `tests/optimizer_validation/dimensions/test_reproducibility.py`: **13/13**, stable under `PYTHONHASHSEED=0` and `=1` (was: 8 reproducibility failures per the issue).
- Captain full unit suite: 12729 passed; 3 fails pre-existing on base (strategy-preset sibling schema [fixed forward by #1141], workflow-traces env default, auth-stress load flake).
- ruff / mypy / black / isort clean.

## PR checklist
1. **Worst-case prod path** — none: SDK change is a warning; selection/seeding unchanged (regression-tested).
2. **Production-branch test** — the F5 inertness itself is re-asserted by `test_legacy_mock_optimizer_keys_warn_without_changing_algorithm`.
3. **Contract regeneration** — none.
4. **Public surface delta** — none.
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed (optimizer_validation reproducibility suite goes 8-failing → green by fixing the harness, not the assertions).
