### PR TITLE
feat(observability): public add_agent_span API — per-agent trace nodes from inside @optimize

### DIFF
--- a/tests/unit/observability/test_agent_spans.py
+++ b/tests/unit/observability/test_agent_spans.py
@@ -1,0 +1,217 @@
+"""Tests for public agent workflow span emission."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from contextlib import ExitStack
+from types import SimpleNamespace
+from typing import Any
+
+from traigent.api.types import AgentDefinition
+from traigent.config.context import (
+    TrialContext,
+    WorkflowTraceContext,
+    copy_context_to_thread,
+)
+from traigent.core.backend_session_manager import BackendSessionManager
+from traigent.core.orchestrator import OptimizationOrchestrator
+from traigent.core.workflow_trace_manager import WorkflowTraceManager
+from traigent.evaluators.base import BaseEvaluator, Dataset
+from traigent.observability import add_agent_span
+from traigent.optimizers.base import BaseOptimizer
+
+
+class _BackendClient:
+    def get_session_mapping(self, session_id: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            experiment_id="exp_agent_spans",
+            experiment_run_id=f"run_{session_id}",
+        )
+
+
+class _Optimizer(BaseOptimizer):
+    def __init__(self, config_space: dict[str, Any]) -> None:
+        super().__init__(config_space=config_space, objectives=[])
+
+    def suggest_next_trial(self, history: list[Any]) -> dict[str, Any]:
+        return {}
+
+    def should_stop(self, history: list[Any]) -> bool:
+        return True
+
+
+class _Evaluator(BaseEvaluator):
+    async def evaluate(
+        self,
+        func: Callable[..., Any],
+        config: dict[str, Any],
+        dataset: Dataset,
+        **kwargs: Any,
+    ) -> Any:
+        raise AssertionError("not used by agent span graph registration tests")
+
+
+def _manager() -> WorkflowTraceManager:
+    return WorkflowTraceManager(
+        workflow_traces_tracker=object(),
+        backend_client=_BackendClient(),
+        function_descriptor=SimpleNamespace(identifier="mock_optimized_function"),
+        optimizer_config_space={"temperature": object()},
+        max_trials=2,
+        optimizer_class_name="MockOptimizer",
+        optimization_id="trace-agent-spans",
+    )
+
+
+def _active_trial(manager: WorkflowTraceManager) -> ExitStack:
+    stack = ExitStack()
+    stack.enter_context(TrialContext(trial_id="trial-1", metadata={"config": {}}))
+    stack.enter_context(
+        WorkflowTraceContext(
+            {
+                "configuration_run_id": "config-run-1",
+                "workflow_trace_id": "trace-agent-spans",
+                "workflow_trace_manager": manager,
+            }
+        )
+    )
+    return stack
+
+
+def _graph_node_ids(manager: WorkflowTraceManager) -> set[str]:
+    graph = manager._create_optimization_workflow_graph("session-1")
+    assert graph is not None
+    return {node.id for node in graph.nodes}
+
+
+def test_add_agent_span_inside_trial_collects_span_and_registers_node() -> None:
+    manager = _manager()
+
+    with _active_trial(manager):
+        add_agent_span(
+            "planner",
+            input_tokens=12,
+            output_tokens=5,
+            cost_usd=0.03,
+            latency_ms=42,
+            metadata={"retrieval_count": 3},
+        )
+
+    spans_by_run = manager._group_spans_by_config_run()
+    span = spans_by_run["config-run-1"][0]
+    payload = span.to_dict()
+
+    assert span.node_id == "planner"
+    assert span.trace_id == "trace-agent-spans"
+    assert span.configuration_run_id == "config-run-1"
+    assert span.input_tokens == 12
+    assert span.output_tokens == 5
+    assert span.cost_usd == 0.03
+    assert payload["metadata"]["retrieval_count"] == 3
+    assert payload["metadata"]["latency_ms"] == 42.0
+    assert "input_data" not in payload
+    assert "output_data" not in payload
+    assert "planner" in _graph_node_ids(manager)
+
+
+def test_add_agent_span_registers_two_distinct_nodes() -> None:
+    manager = _manager()
+
+    with _active_trial(manager):
+        add_agent_span("planner", input_tokens=1)
+        add_agent_span("critic", output_tokens=2)
+
+    node_ids = _graph_node_ids(manager)
+    assert {"planner", "critic"}.issubset(node_ids)
+
+
+def test_add_agent_span_outside_trial_is_debug_noop(
+    caplog: Any,
+) -> None:
+    with caplog.at_level(logging.DEBUG):
+        add_agent_span("planner", input_tokens=1)
+
+    assert "no active optimization trial context" in caplog.text
+
+
+def test_add_agent_span_drops_text_metadata() -> None:
+    manager = _manager()
+
+    with _active_trial(manager):
+        add_agent_span(
+            "privacy_node",
+            metadata={
+                "prompt": "do not ship",
+                "expected": "do not ship",
+                "actual_output": "do not ship",
+                "completion": "do not ship",
+                "safe_score": 0.91,
+                "freeform_label": "do not ship",
+            },
+        )
+
+    span = manager._group_spans_by_config_run()["config-run-1"][0]
+    payload_text = str(span.to_dict())
+
+    assert span.metadata == {"safe_score": 0.91}
+    assert "do not ship" not in payload_text
+
+
+def test_declared_agents_and_agent_prefixes_register_graph_nodes(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(
+        BackendSessionManager,
+        "create_backend_client",
+        staticmethod(lambda config: _BackendClient()),
+    )
+
+    explicit_orchestrator = OptimizationOrchestrator(
+        optimizer=_Optimizer({"planner_model": ["gpt-4"], "critic_model": ["gpt-4"]}),
+        evaluator=_Evaluator(),
+        max_trials=1,
+        workflow_traces_tracker=object(),
+        agents={
+            "planner": AgentDefinition(
+                display_name="Planner",
+                parameter_keys=["planner_model"],
+            ),
+            "critic": AgentDefinition(
+                display_name="Critic",
+                parameter_keys=["critic_model"],
+            ),
+        },
+    )
+    explicit_nodes = _graph_node_ids(explicit_orchestrator._workflow_trace_manager)
+    assert {"planner", "critic"}.issubset(explicit_nodes)
+
+    prefix_orchestrator = OptimizationOrchestrator(
+        optimizer=_Optimizer({"planner_model": ["gpt-4"]}),
+        evaluator=_Evaluator(),
+        max_trials=1,
+        workflow_traces_tracker=object(),
+        agent_prefixes=["planner"],
+    )
+    prefix_nodes = _graph_node_ids(prefix_orchestrator._workflow_trace_manager)
+    assert "planner" in prefix_nodes
+
+
+def test_add_agent_span_works_with_restored_thread_context() -> None:
+    manager = _manager()
+
+    with _active_trial(manager):
+        snapshot = copy_context_to_thread()
+
+    def worker() -> None:
+        with snapshot.restore():
+            add_agent_span("threaded_agent", input_tokens=7)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=5)
+
+    spans = manager._group_spans_by_config_run()["config-run-1"]
+    assert spans[0].node_id == "threaded_agent"
+    assert "threaded_agent" in _graph_node_ids(manager)

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -358,6 +358,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
         "traigent.observability",
         "get_default_observability_client",
     ),
+    "add_agent_span": ("traigent.observability", "add_agent_span"),
     "observe": ("traigent.observability", "observe"),
     "set_default_observability_client": (
         "traigent.observability",
@@ -568,6 +569,7 @@ __all__ = [
     "TraceListResponse",
     "TraceObservationsResponse",
     "TraceRecord",
+    "add_agent_span",
     "get_default_observability_client",
     "observe",
     "set_default_observability_client",

--- a/traigent/config/context.py
+++ b/traigent/config/context.py
@@ -31,6 +31,9 @@ config_space_context: ContextVar[dict[str, Any] | None] = ContextVar(
 trial_context: ContextVar[dict[str, Any] | None] = ContextVar(
     "traigent_trial_context", default=None
 )
+workflow_trace_context: ContextVar[dict[str, Any] | None] = ContextVar(
+    "traigent_workflow_trace_context", default=None
+)
 
 
 def get_config() -> TraigentConfig | dict[str, Any]:
@@ -256,6 +259,23 @@ def set_trial_context(payload: dict[str, Any] | None) -> Token[dict[str, Any] | 
     return trial_context.set(payload)
 
 
+def get_workflow_trace_context() -> dict[str, Any] | None:
+    """Return the active workflow trace context if one is set."""
+
+    try:
+        return workflow_trace_context.get()
+    except LookupError:
+        return None
+
+
+def set_workflow_trace_context(
+    payload: dict[str, Any] | None,
+) -> Token[dict[str, Any] | None]:
+    """Set the active workflow trace context payload."""
+
+    return workflow_trace_context.set(payload)
+
+
 class ContextSnapshot:
     """Snapshot of all Traigent context variables for thread propagation.
 
@@ -281,6 +301,7 @@ class ContextSnapshot:
     def __init__(
         self,
         trial_ctx: dict[str, Any] | None,
+        workflow_trace_ctx: dict[str, Any] | None,
         config: TraigentConfig | dict[str, Any] | None,
         config_space: dict[str, Any] | None,
         applied_config: TraigentConfig | dict[str, Any] | None,
@@ -289,11 +310,13 @@ class ContextSnapshot:
 
         Args:
             trial_ctx: Trial context dict or None
+            workflow_trace_ctx: Workflow trace context dict or None
             config: Configuration (TraigentConfig or dict) or None
             config_space: Configuration space dict or None
             applied_config: Applied configuration dict or TraigentConfig or None
         """
         self.trial_context = trial_ctx
+        self.workflow_trace_context = workflow_trace_ctx
         self.config = config
         self.config_space = config_space
         self.applied_config = applied_config
@@ -317,6 +340,7 @@ class ContextSnapshot:
         """Return True if any context is set."""
         return bool(
             self.trial_context
+            or self.workflow_trace_context
             or self.config
             or self.config_space
             or self.applied_config
@@ -335,6 +359,10 @@ class ContextRestorer:
         if self.snapshot.trial_context:
             token = trial_context.set(self.snapshot.trial_context)
             self._tokens.append((trial_context, token))
+
+        if self.snapshot.workflow_trace_context:
+            token = workflow_trace_context.set(self.snapshot.workflow_trace_context)
+            self._tokens.append((workflow_trace_context, token))
 
         if self.snapshot.config is not None:
             token = config_context.set(self.snapshot.config)  # type: ignore[assignment]
@@ -408,6 +436,7 @@ def copy_context_to_thread() -> ContextSnapshot:
     """
     return ContextSnapshot(
         trial_ctx=get_trial_context(),
+        workflow_trace_ctx=get_workflow_trace_context(),
         config=get_config(),
         config_space=get_config_space(),
         applied_config=get_applied_config(),
@@ -457,6 +486,47 @@ class TrialContext:
                 )
             finally:
                 # Clear token to prevent double-reset attempts
+                self._token = None
+        return False
+
+    async def __aenter__(self) -> dict[str, Any]:
+        return self.__enter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> Literal[False]:
+        return self.__exit__(exc_type, exc_val, exc_tb)
+
+
+class WorkflowTraceContext:
+    """Context manager to expose private workflow trace metadata to observability."""
+
+    def __init__(self, metadata: dict[str, Any] | None = None) -> None:
+        self.metadata = metadata or {}
+        self._token: Token[dict[str, Any] | None] | None = None
+
+    def __enter__(self) -> dict[str, Any]:
+        self._token = set_workflow_trace_context(self.metadata)
+        return self.metadata
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> Literal[False]:
+        if self._token is not None:
+            try:
+                workflow_trace_context.reset(self._token)
+            except ValueError:
+                logger.warning(
+                    "Stale workflow trace context token detected during cleanup. "
+                    "This may indicate a double-exit or context mismatch."
+                )
+            finally:
                 self._token = None
         return False
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -244,6 +244,7 @@ class OptimizationOrchestrator:
             optimizer_class_name=self.optimizer.__class__.__name__,
             optimization_id=self._optimization_id,
         )
+        self._register_declared_workflow_trace_nodes()
 
         self.backend_session_manager = BackendSessionManager(
             backend_client=self.backend_client,
@@ -390,6 +391,8 @@ class OptimizationOrchestrator:
         """Initialize multi-agent configuration from kwargs."""
         explicit_agents: dict[str, AgentDefinition] | None = kwargs.pop("agents", None)
         agent_prefixes: list[str] | None = kwargs.pop("agent_prefixes", None)
+        self._declared_trace_agents = dict(explicit_agents or {})
+        self._declared_trace_agent_prefixes = list(agent_prefixes or [])
         agent_measures: dict[str, list[str]] | None = kwargs.pop("agent_measures", None)
         global_measures: list[str] | None = kwargs.pop("global_measures", None)
         tvl_parameter_agents: dict[str, str] | None = kwargs.pop(
@@ -425,6 +428,48 @@ class OptimizationOrchestrator:
                 parameter_agents=parameter_agents,
             ),
         )
+
+    @staticmethod
+    def _workflow_node_type_for_agent(agent: AgentDefinition) -> str:
+        """Map public agent types to workflow graph node types."""
+
+        if agent.agent_type in {"llm", "retriever", "router", "tool"}:
+            return agent.agent_type
+        return "agent"
+
+    def _register_declared_workflow_trace_nodes(self) -> None:
+        """Register declared multi-agent nodes in the workflow trace graph."""
+
+        manager = getattr(self, "_workflow_trace_manager", None)
+        if manager is None:
+            return
+
+        registered: set[str] = set()
+        if self._agent_configuration is not None:
+            for agent_id, agent in self._agent_configuration.agents.items():
+                manager.register_node(
+                    agent_id,
+                    node_type=self._workflow_node_type_for_agent(agent),
+                    display_name=agent.display_name,
+                    tunable_params=list(agent.parameter_keys),
+                    metadata={
+                        "source": "declared_agent",
+                        "measure_ids": list(agent.measure_ids),
+                        "primary_model": agent.primary_model,
+                        "order": agent.order,
+                        "auto_inferred": self._agent_configuration.auto_inferred,
+                    },
+                )
+                registered.add(agent_id)
+
+        for prefix in getattr(self, "_declared_trace_agent_prefixes", []):
+            if prefix in registered:
+                continue
+            manager.register_node(
+                str(prefix),
+                node_type="agent",
+                metadata={"source": "agent_prefixes"},
+            )
 
     def _compute_band_target(self) -> float | None:
         """Derive band_target from objective_schema if available."""

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -20,7 +20,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from traigent.config.context import TrialContext
+from traigent.config.context import TrialContext, WorkflowTraceContext
 from traigent.core.orchestrator_helpers import (
     enforce_constraints,
     extract_cost_from_results,
@@ -336,12 +336,23 @@ class TrialLifecycle:
             # Phase 3: Execute evaluation within TrialContext
             evaluate_kwargs = self._build_evaluate_kwargs(progress_callback, lease)
 
-            async with TrialContext(
-                trial_id=trial_id,
-                metadata={
-                    "config": evaluation_config,
-                    "optuna_trial_id": optuna_trial_id,
-                },
+            async with (
+                TrialContext(
+                    trial_id=trial_id,
+                    metadata={
+                        "config": evaluation_config,
+                        "optuna_trial_id": optuna_trial_id,
+                    },
+                ),
+                WorkflowTraceContext(
+                    {
+                        "configuration_run_id": trial_id,
+                        "workflow_trace_id": orchestrator._optimization_id,
+                        "workflow_trace_manager": getattr(
+                            orchestrator, "_workflow_trace_manager", None
+                        ),
+                    }
+                ),
             ):
                 eval_result = await orchestrator.evaluator.evaluate(
                     func, evaluation_config, dataset, **evaluate_kwargs

--- a/traigent/core/workflow_trace_manager.py
+++ b/traigent/core/workflow_trace_manager.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import threading
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
@@ -73,6 +74,20 @@ class WorkflowTraceManager:
         self._optimizer_class_name = optimizer_class_name
         self._optimization_id = optimization_id
         self._collected_spans: list[SpanPayload] = []
+        self._registered_nodes: dict[str, dict[str, Any]] = {}
+        self._lock = threading.RLock()
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return True when workflow trace collection has an active transport."""
+
+        return self._workflow_traces_tracker is not None
+
+    @staticmethod
+    def _display_name_from_node_id(node_id: str) -> str:
+        """Return a readable display name derived only from the node identifier."""
+
+        return node_id.replace("_", " ").replace("-", " ").title()
 
     def collect_span(self, span_data: SpanPayload) -> None:
         """Collect a workflow span for later submission to backend.
@@ -81,7 +96,61 @@ class WorkflowTraceManager:
             span_data: Span payload to collect
         """
         if self._workflow_traces_tracker is not None:
-            self._collected_spans.append(span_data)
+            with self._lock:
+                self._collected_spans.append(span_data)
+
+    def register_node(
+        self,
+        node_id: str,
+        *,
+        node_type: str = "agent",
+        display_name: str | None = None,
+        tunable_params: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Register a workflow graph node for collected spans.
+
+        Registration is intentionally independent from span collection: declared
+        agents can appear in the graph even if no span is emitted for them.
+        """
+
+        normalized_node_id = node_id.strip()
+        if not normalized_node_id or normalized_node_id in {
+            "__start__",
+            "optimization_run",
+            "__end__",
+        }:
+            return
+
+        with self._lock:
+            existing = self._registered_nodes.get(normalized_node_id)
+            if existing is None:
+                self._registered_nodes[normalized_node_id] = {
+                    "type": node_type or "agent",
+                    "display_name": (
+                        display_name
+                        or self._display_name_from_node_id(normalized_node_id)
+                    ),
+                    "tunable_params": list(tunable_params or []),
+                    "metadata": dict(metadata or {}),
+                }
+                return
+
+            if display_name and not existing.get("display_name"):
+                existing["display_name"] = display_name
+            if tunable_params:
+                merged = list(
+                    dict.fromkeys(existing["tunable_params"] + tunable_params)
+                )
+                existing["tunable_params"] = merged
+            if metadata:
+                existing["metadata"].update(metadata)
+
+    def registered_node_ids(self) -> list[str]:
+        """Return currently registered dynamic workflow node ids."""
+
+        with self._lock:
+            return list(self._registered_nodes)
 
     async def submit_traces(self, session_id: str | None = None) -> None:
         """Submit collected workflow spans and graph to backend.
@@ -98,7 +167,10 @@ class WorkflowTraceManager:
         if self._workflow_traces_tracker is None:
             return
 
-        if not self._collected_spans:
+        with self._lock:
+            collected_spans = list(self._collected_spans)
+
+        if not collected_spans:
             logger.debug("No workflow spans to submit")
             return
 
@@ -107,7 +179,8 @@ class WorkflowTraceManager:
         # in the backend database, so trace ingestion would fail with 404
         if is_backend_offline():
             logger.debug("Skipping workflow trace submission: backend is offline")
-            self._collected_spans = []
+            with self._lock:
+                self._collected_spans = []
             return
 
         # Check if session_id is a mock ID (created when backend was unavailable)
@@ -118,18 +191,19 @@ class WorkflowTraceManager:
             logger.debug(
                 f"Skipping workflow trace submission: mock session '{session_id}'"
             )
-            self._collected_spans = []
+            with self._lock:
+                self._collected_spans = []
             return
 
         try:
             # Get trace_id from first span (all spans share same trace)
-            trace_id = self._collected_spans[0].trace_id
+            trace_id = collected_spans[0].trace_id
 
             # Try to create workflow graph for visualization (only submit once)
             graph = self._create_optimization_workflow_graph(session_id)
 
             # Group spans by configuration_run_id so each trial gets trace_id in its metadata
-            spans_by_config_run = self._group_spans_by_config_run()
+            spans_by_config_run = self._group_spans_by_config_run(collected_spans)
 
             # Submit each group separately
             total_submitted = 0
@@ -174,12 +248,19 @@ class WorkflowTraceManager:
             logger.warning(f"Workflow trace submission failed: {exc}")
         finally:
             # Clear collected spans after submission attempt
-            self._collected_spans = []
+            with self._lock:
+                self._collected_spans = []
 
-    def _group_spans_by_config_run(self) -> dict[str, list]:
+    def _group_spans_by_config_run(
+        self, spans: list[SpanPayload] | None = None
+    ) -> dict[str, list]:
         """Group collected spans by configuration_run_id."""
         spans_by_config_run: dict[str, list] = defaultdict(list)
-        for span in self._collected_spans:
+        source_spans = spans
+        if source_spans is None:
+            with self._lock:
+                source_spans = list(self._collected_spans)
+        for span in source_spans:
             spans_by_config_run[span.configuration_run_id].append(span)
         return dict(spans_by_config_run)
 
@@ -229,6 +310,26 @@ class WorkflowTraceManager:
             else "optimization"
         )
 
+        with self._lock:
+            registered_nodes = {
+                node_id: dict(node_data)
+                for node_id, node_data in self._registered_nodes.items()
+            }
+
+        dynamic_nodes = [
+            WorkflowNode(
+                id=node_id,
+                type=str(node_data.get("type") or "agent"),
+                display_name=str(
+                    node_data.get("display_name")
+                    or self._display_name_from_node_id(node_id)
+                ),
+                tunable_params=list(node_data.get("tunable_params") or []),
+                metadata=dict(node_data.get("metadata") or {}),
+            )
+            for node_id, node_data in registered_nodes.items()
+        ]
+
         # Create nodes for the optimization workflow
         nodes = [
             WorkflowNode(
@@ -253,6 +354,7 @@ class WorkflowTraceManager:
                     "algorithm": self._optimizer_class_name,
                 },
             ),
+            *dynamic_nodes,
             WorkflowNode(
                 id="__end__",
                 type="exit",
@@ -266,6 +368,13 @@ class WorkflowTraceManager:
             WorkflowEdge(from_node="__start__", to_node="optimization_run"),
             WorkflowEdge(from_node="optimization_run", to_node="__end__"),
         ]
+        for node in dynamic_nodes:
+            edges.extend(
+                [
+                    WorkflowEdge(from_node="optimization_run", to_node=node.id),
+                    WorkflowEdge(from_node=node.id, to_node="__end__"),
+                ]
+            )
 
         return WorkflowGraphPayload(
             experiment_id=experiment_id,

--- a/traigent/observability/__init__.py
+++ b/traigent/observability/__init__.py
@@ -1,5 +1,6 @@
 """Public observability API for Traigent SDK."""
 
+from traigent.observability.agent_spans import add_agent_span
 from traigent.observability.client import ObservabilityClient
 from traigent.observability.config import ObservabilityConfig
 from traigent.observability.decorators import (
@@ -59,6 +60,7 @@ __all__ = [
     "TraceListResponse",
     "TraceObservationsResponse",
     "TraceRecord",
+    "add_agent_span",
     "get_default_observability_client",
     "observe",
     "set_default_observability_client",

--- a/traigent/observability/agent_spans.py
+++ b/traigent/observability/agent_spans.py
@@ -1,0 +1,210 @@
+"""Public helpers for SDK workflow trace spans emitted inside optimization trials."""
+
+from __future__ import annotations
+
+import math
+import re
+import uuid
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from traigent.config.context import get_workflow_trace_context
+from traigent.integrations.observability.workflow_traces import (
+    SpanPayload,
+    SpanStatus,
+    SpanType,
+)
+from traigent.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_MODEL_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:/@+-]{1,128}$")
+_SENSITIVE_METADATA_MARKERS = (
+    "actual",
+    "completion",
+    "expected",
+    "output",
+    "prompt",
+    "response",
+)
+_SPAN_TYPE_ALIASES = {
+    "agent": SpanType.NODE.value,
+}
+_VALID_SPAN_TYPES = {span_type.value for span_type in SpanType}
+
+
+def _is_safe_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def _coerce_non_negative_int(value: int | None, *, field_name: str) -> int:
+    if value is None:
+        return 0
+    if not _is_safe_number(value):
+        logger.debug("Ignoring non-numeric %s for agent span", field_name)
+        return 0
+    coerced = int(value)
+    if coerced < 0:
+        logger.debug("Ignoring negative %s for agent span", field_name)
+        return 0
+    return coerced
+
+
+def _coerce_non_negative_float(value: float | None, *, field_name: str) -> float:
+    if value is None:
+        return 0.0
+    if not _is_safe_number(value):
+        logger.debug("Ignoring non-numeric %s for agent span", field_name)
+        return 0.0
+    coerced = float(value)
+    if coerced < 0:
+        logger.debug("Ignoring negative %s for agent span", field_name)
+        return 0.0
+    return coerced
+
+
+def _normalize_node_id(node_id: str) -> str | None:
+    if not isinstance(node_id, str):
+        logger.debug("Skipping agent span: node_id must be a string")
+        return None
+
+    normalized = node_id.strip()
+    if not normalized:
+        logger.debug("Skipping agent span: node_id is empty")
+        return None
+    if normalized in {"__start__", "__end__"}:
+        logger.debug("Skipping agent span for reserved workflow node %s", normalized)
+        return None
+    return normalized
+
+
+def _normalize_span_type(span_type: str) -> str:
+    raw_span_type = str(span_type).strip().lower()
+    raw_span_type = _SPAN_TYPE_ALIASES.get(raw_span_type, raw_span_type)
+    if raw_span_type in _VALID_SPAN_TYPES:
+        return raw_span_type
+
+    logger.debug("Unknown agent span_type %r; defaulting to node", span_type)
+    return SpanType.NODE.value
+
+
+def _is_sensitive_metadata_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_").replace(".", "_")
+    return any(marker in normalized for marker in _SENSITIVE_METADATA_MARKERS)
+
+
+def _sanitize_metadata(metadata: Mapping[str, Any] | None) -> dict[str, float | int]:
+    sanitized: dict[str, float | int] = {}
+    if not metadata:
+        return sanitized
+
+    for raw_key, value in metadata.items():
+        key = str(raw_key)
+        if _is_sensitive_metadata_key(key):
+            logger.debug("Dropping sensitive agent span metadata key %s", key)
+            continue
+        if not _is_safe_number(value):
+            logger.debug("Dropping non-numeric agent span metadata key %s", key)
+            continue
+        sanitized[key] = int(value) if isinstance(value, int) else float(value)
+
+    return sanitized
+
+
+def _sanitize_model(model: str | None) -> str | None:
+    if model is None:
+        return None
+    if not isinstance(model, str):
+        logger.debug("Dropping non-string model for agent span")
+        return None
+
+    candidate = model.strip()
+    if not candidate or not _MODEL_ID_PATTERN.fullmatch(candidate):
+        logger.debug("Dropping unsafe model identifier for agent span")
+        return None
+    return candidate
+
+
+def add_agent_span(
+    node_id: str,
+    *,
+    span_type: str = "agent",
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_usd: float | None = None,
+    latency_ms: float | None = None,
+    model: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    """Add an agent workflow span for the active optimization trial.
+
+    The helper is safe to call from user code: when no optimization trial or
+    workflow trace transport is active, it logs at DEBUG and returns.
+    """
+
+    trace_context = get_workflow_trace_context()
+    if not trace_context:
+        logger.debug("Skipping agent span: no active optimization trial context")
+        return
+
+    workflow_trace_manager = trace_context.get("workflow_trace_manager")
+    if workflow_trace_manager is None:
+        logger.debug("Skipping agent span: no workflow trace manager in trial context")
+        return
+
+    if not bool(getattr(workflow_trace_manager, "is_enabled", False)):
+        logger.debug("Skipping agent span: workflow trace collection is disabled")
+        return
+
+    normalized_node_id = _normalize_node_id(node_id)
+    if normalized_node_id is None:
+        return
+
+    configuration_run_id = trace_context.get("configuration_run_id")
+    trace_id = trace_context.get("workflow_trace_id")
+    if not configuration_run_id or not trace_id:
+        logger.debug("Skipping agent span: trial context has no trace/run linkage")
+        return
+
+    safe_metadata: dict[str, Any] = _sanitize_metadata(metadata)
+    safe_latency_ms = _coerce_non_negative_float(latency_ms, field_name="latency_ms")
+    if safe_latency_ms:
+        safe_metadata["latency_ms"] = safe_latency_ms
+    safe_model = _sanitize_model(model)
+    if safe_model is not None:
+        safe_metadata["model"] = safe_model
+
+    end_time = datetime.now(UTC)
+    start_time = end_time - timedelta(milliseconds=safe_latency_ms)
+
+    span = SpanPayload(
+        span_id=uuid.uuid4().hex[:16],
+        trace_id=str(trace_id),
+        configuration_run_id=str(configuration_run_id),
+        span_name=normalized_node_id,
+        span_type=_normalize_span_type(span_type),
+        start_time=start_time.isoformat(),
+        end_time=end_time.isoformat(),
+        node_id=normalized_node_id,
+        status=SpanStatus.COMPLETED.value,
+        input_tokens=_coerce_non_negative_int(input_tokens, field_name="input_tokens"),
+        output_tokens=_coerce_non_negative_int(
+            output_tokens, field_name="output_tokens"
+        ),
+        cost_usd=_coerce_non_negative_float(cost_usd, field_name="cost_usd"),
+        metadata=safe_metadata,
+    )
+
+    try:
+        workflow_trace_manager.register_node(
+            normalized_node_id,
+            node_type="agent",
+        )
+        workflow_trace_manager.collect_span(span)
+    except Exception:
+        logger.debug("Failed to collect agent workflow span", exc_info=True)


### PR DESCRIPTION
## Summary
Closes #1090. Multi-agent runs showed as one opaque `optimization_run` box; there was no public API to emit per-agent spans.

- **`traigent.observability.add_agent_span(node_id, *, span_type='node', input_tokens=, output_tokens=, cost_usd=, latency_ms=, model=, metadata=)`** (also top-level `traigent.add_agent_span`): resolves the active trial/run context automatically (new `workflow_trace_context` contextvar, captured/restored for worker threads via the existing `ContextSnapshot`/`ContextRestorer`), registers the node in the trial's workflow graph, queues the span through the **existing** WorkflowTracesTracker transport. Outside an active traced trial: guaranteed no-raise debug no-op.
- **Declared `agents={...}` / `agent_prefixes`** auto-register graph nodes (registration only — no fabricated spans/costs, per the no-fake-completion rule).
- **Privacy:** no `input_data`/`output_data`; metadata numeric-only with text-marker keys (actual/completion/expected/output/prompt/response) dropped; `model` pattern-restricted; NaN/inf/bool/negatives rejected.
- Thread-safe: RLock'd node registry + span collection; graph builder appends `optimization_run → node → __end__` so ingest accepts the node ids. `'agent'` span_type alias → transport's `'node'`.

## Verification
- New `tests/unit/observability/test_agent_spans.py`: emission with trial/trace linkage + graph registration; two node_ids → two nodes; outside-trial silent no-op; privacy drops; declared-agents registration; `copy_context_to_thread()` restore. Focused obs suites: 95 passed.
- Captain full unit suite: **12732 passed**; only the 2 known base reds (strategy-preset sibling schema — fixed forward by #1141 — and auth-stress load flake).
- ruff / mypy (434 files) / black / isort clean. No external `ContextSnapshot` constructors (verified) — only the updated factory.
- Report-vs-code note (captain): worker report said 'no new contextvar'; the final code DOES add `workflow_trace_context`, correctly wired through snapshot/restore. Code is right; report drifted.

## PR checklist
1. **Worst-case prod path** — telemetry-only; emission is no-raise; transport gating (trace-enable env) unchanged.
2. **Production-branch test** — n/a policy-wise; no-op-outside-trial is tested.
3. **Contract regeneration** — span payload uses the existing ingest contract (node-keyed spans already consumed by BE/FE). **JS parity:** `@traigent/sdk` needs `addAgentSpan` — flagged in #1090 closure for the cross-SDK backlog.
4. **Public surface delta** — `traigent.add_agent_span` + `traigent.observability.add_agent_span` added to `__all__`; executes end-to-end (no stub).
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none relaxed.
