### PR TITLE
feat(cloud): typed governed wire + certified-selection report (Phase 8 P3)

### DIFF
--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -291,14 +291,37 @@ class TestBuildSessionPayload:
         mock_client = Mock()
         self.ops = ApiOperations(mock_client)
 
-    def test_basic_payload(self):
-        """Test basic payload structure."""
+    def test_basic_payload_is_typed_since_phase8(self):
+        """The default contract is the TYPED shape (Phase 8) — the legacy
+        problem_statement/search_space shape survives only behind
+        TRAIGENT_SESSION_CONTRACT=legacy (see the legacy test below)."""
+        request = Mock()
+        request.function_name = "test_func"
+        request.metadata = None
+        request.dataset_metadata = {"size": 100}
+        request.configuration_space = {"param": [1, 2, 3]}
+        request.objectives = ["accuracy"]
+        request.promotion_policy = None
+        request.tvl_governance = None
+
+        payload = self.ops._build_session_payload(request, 10)
+
+        assert payload["function_name"] == "test_func"
+        assert payload["configuration_space"] == {"param": [1, 2, 3]}
+        assert payload["objectives"] == ["accuracy"]
+        assert payload["max_trials"] == 10
+        assert "problem_statement" not in payload
+
+    def test_legacy_payload_behind_contract_flag(self, monkeypatch):
+        monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "legacy")
         request = Mock()
         request.function_name = "test_func"
         request.metadata = None
         request.dataset_metadata = {"size": 100}
         request.configuration_space = {"param": [1, 2, 3]}
         request.objectives = ["maximize"]
+        request.promotion_policy = None
+        request.tvl_governance = None
 
         payload = self.ops._build_session_payload(request, 10)
 
@@ -323,14 +346,17 @@ class TestBuildSessionPayload:
         assert payload["metadata"]["custom_key"] == "value"
         assert payload["metadata"]["function_name"] == "test_func"
 
-    def test_payload_empty_objectives(self):
-        """Test payload with empty objectives uses default."""
+    def test_payload_empty_objectives(self, monkeypatch):
+        """Legacy contract: empty objectives fall back to the maximize goal."""
+        monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "legacy")
         request = Mock()
         request.function_name = "test_func"
         request.metadata = None
         request.dataset_metadata = {}
         request.configuration_space = {}
         request.objectives = []
+        request.promotion_policy = None
+        request.tvl_governance = None
 
         payload = self.ops._build_session_payload(request, 10)
 

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -339,6 +339,9 @@ class TestBuildSessionPayload:
         request.dataset_metadata = {}
         request.configuration_space = {}
         request.objectives = []
+        # bare Mock auto-attributes must not reach the policy serializer
+        request.promotion_policy = None
+        request.tvl_governance = None
 
         payload = self.ops._build_session_payload(request, 20)
 

--- a/tests/unit/cloud/test_certified_selection_report.py
+++ b/tests/unit/cloud/test_certified_selection_report.py
@@ -107,10 +107,11 @@ class TestBuildCertifiedSelection:
 class _OrchestratorStub:
     """Minimal host for the real _build_certified_selection_report method."""
 
-    def __init__(self, *, strict, incumbent, resolver):
+    def __init__(self, *, strict, incumbent, resolver, promotions=1):
         self._strict = strict
         self._best_trial_cached = incumbent
         self.knob_resolver = resolver
+        self._certified_promotions = promotions
 
     def _is_strict_evidence_mode(self):
         return self._strict
@@ -190,6 +191,21 @@ class TestOrchestratorReportConditions:
             strict=True,
             incumbent=types.SimpleNamespace(trial_id="trial_7"),
             resolver=_resolver(governed=True, with_certificate=False),
+        )
+        assert _bind_report_method(stub)() is None
+
+    def test_no_report_without_certified_promotion(self):
+        """Review round 2 (codex): the FIRST trial seeds the incumbent as
+        comparison initialization, NOT as certification — terminal strict
+        selection requires _certified_promotions > 0 before naming a winner
+        (test_fail_closed_promotion pins it). The wire report must mirror
+        that guard or it overclaims a winner the SDK result itself refuses
+        to certify."""
+        stub = _OrchestratorStub(
+            strict=True,
+            incumbent=types.SimpleNamespace(trial_id="trial_7"),
+            resolver=_resolver(governed=True, with_certificate=True),
+            promotions=0,
         )
         assert _bind_report_method(stub)() is None
 

--- a/tests/unit/cloud/test_certified_selection_report.py
+++ b/tests/unit/cloud/test_certified_selection_report.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
+# Copyright (c) 2024-2026 Traigent Ltd. Dual-licensed: AGPL-3.0 or commercial.
+"""Phase 8 P3b: the client-attested certified-selection finalize report.
+
+The builder mirrors the SERVER's fail-closed coverage rule client-side:
+a report exists only when every governed CVAR carries a CERTIFIED
+certificate with an issued hash — any gap means NO report (honest
+no-winner), never a partial one. Content-free (RFC 0001 P8).
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from unittest.mock import Mock
+
+import pytest
+
+from traigent.cloud.governance import build_certified_selection
+from traigent.knobs.canonical import canonical_hash
+from traigent.knobs.certificates import (
+    CertificateDecision,
+    EvidenceRef,
+    FreshnessContext,
+    TargetProperty,
+    issue_certificate,
+)
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="accuracy", mode="require_calibration")
+
+
+def _ctx(cvar: str = "theta") -> FreshnessContext:
+    return FreshnessContext(
+        cvar_name=cvar,
+        tuned_parent_values=(("model", "a"),),
+        calibration_source_id="margin_calibration",
+        signal_spec_hash=canonical_hash({"signal": "margin"}),
+        calibrator_id="cal",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target=_target(),
+    )
+
+
+def _certified(cvar: str = "theta"):
+    return issue_certificate(cvar, "float", 0.5, _ctx(cvar))
+
+
+class TestBuildCertifiedSelection:
+    def test_full_coverage_builds_report(self):
+        cert = _certified()
+        report = build_certified_selection("trial_42", {"theta": cert})
+        assert report == {
+            "trial_id": "trial_42",
+            "certificates": [
+                {
+                    "cvar_name": "theta",
+                    "decision": "CERTIFIED_SELECTION",
+                    "freshness_hash": cert.issued_hash,
+                }
+            ],
+            "attestation": "sdk_client_attested",
+        }
+
+    def test_non_certified_decision_withholds_report(self):
+        cert = _certified()
+        uncertified = types.SimpleNamespace(
+            decision=CertificateDecision.NO_DECISION,
+            issued_hash=cert.issued_hash,
+        )
+        assert (
+            build_certified_selection(
+                "trial_42", {"theta": cert, "phi": uncertified}
+            )
+            is None
+        )
+
+    def test_missing_issued_hash_withholds_report(self):
+        broken = types.SimpleNamespace(
+            decision=CertificateDecision.CERTIFIED, issued_hash=""
+        )
+        assert build_certified_selection("trial_42", {"theta": broken}) is None
+
+    def test_empty_inputs_withhold_report(self):
+        assert build_certified_selection("trial_42", {}) is None
+        assert build_certified_selection("", {"theta": _certified()}) is None
+        assert build_certified_selection(None, None) is None
+
+    def test_report_is_content_free(self):
+        """P8 canary: the calibrated VALUE's hash, evidence counts, pool
+        hashes, and target details must never serialize."""
+        cert = _certified()
+        blob = json.dumps(build_certified_selection("trial_42", {"theta": cert}))
+        assert cert.subject_value_hash not in blob
+        assert "evidence" not in blob
+        assert "ds_v1" not in blob
+        assert "accuracy" not in blob
+        assert "0.5" not in blob
+
+
+class _OrchestratorStub:
+    """Minimal host for the real _build_certified_selection_report method."""
+
+    def __init__(self, *, strict, incumbent, resolver):
+        self._strict = strict
+        self._best_trial_cached = incumbent
+        self.knob_resolver = resolver
+
+    def _is_strict_evidence_mode(self):
+        return self._strict
+
+
+def _bind_report_method(stub):
+    from traigent.core.orchestrator import OptimizationOrchestrator
+
+    return types.MethodType(
+        OptimizationOrchestrator._build_certified_selection_report, stub
+    )
+
+
+def _resolver(*, governed: bool, with_certificate: bool):
+    from traigent.api.parameter_ranges import Choices
+    from traigent.knobs.bindings import Calibrated, Knob, Tuned
+    from traigent.knobs.signals import SignalSpec
+
+    binding = Calibrated(
+        signal=SignalSpec(
+            name="margin",
+            version="1",
+            score_function="sf",
+            score_function_version="1",
+            comparator="ge",
+            comparator_version="1",
+        ),
+        target=_target(),
+        value_type="float",
+        require_calibration=governed,
+    )
+    space = types.SimpleNamespace(
+        knobs={
+            "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"]))),
+            "theta": Knob(name="theta", binding=binding),
+        }
+    )
+    calibrated_inputs = {}
+    if with_certificate:
+        calibrated_inputs["theta"] = types.SimpleNamespace(
+            certificate=_certified("theta")
+        )
+    return types.SimpleNamespace(_space=space, _calibrated_inputs=calibrated_inputs)
+
+
+class TestOrchestratorReportConditions:
+    def test_report_built_when_all_conditions_hold(self):
+        stub = _OrchestratorStub(
+            strict=True,
+            incumbent=types.SimpleNamespace(trial_id="trial_7"),
+            resolver=_resolver(governed=True, with_certificate=True),
+        )
+        report = _bind_report_method(stub)()
+        assert report is not None
+        assert report["trial_id"] == "trial_7"
+        assert report["certificates"][0]["cvar_name"] == "theta"
+
+    def test_no_report_when_not_strict(self):
+        stub = _OrchestratorStub(
+            strict=False,
+            incumbent=types.SimpleNamespace(trial_id="trial_7"),
+            resolver=_resolver(governed=True, with_certificate=True),
+        )
+        assert _bind_report_method(stub)() is None
+
+    def test_no_report_without_incumbent(self):
+        stub = _OrchestratorStub(
+            strict=True,
+            incumbent=None,
+            resolver=_resolver(governed=True, with_certificate=True),
+        )
+        assert _bind_report_method(stub)() is None
+
+    def test_no_report_when_governed_cvar_lacks_certificate(self):
+        """Fail closed: a coverage gap means NO report, never a partial one."""
+        stub = _OrchestratorStub(
+            strict=True,
+            incumbent=types.SimpleNamespace(trial_id="trial_7"),
+            resolver=_resolver(governed=True, with_certificate=False),
+        )
+        assert _bind_report_method(stub)() is None
+
+    def test_no_report_without_resolver_trial_binding(self):
+        """backend_guided risk: no resolver/space ⇒ no report (fail closed)."""
+        stub = _OrchestratorStub(
+            strict=True,
+            incumbent=types.SimpleNamespace(trial_id="trial_7"),
+            resolver=None,
+        )
+        assert _bind_report_method(stub)() is None
+
+
+class TestWireThreading:
+    @pytest.mark.asyncio
+    async def test_finalize_body_carries_report_top_level(self, monkeypatch):
+        """The report rides the finalize body at the TOP level (never under
+        metadata) and is omitted entirely when absent."""
+        from traigent.cloud.session_operations import SessionOperations
+
+        ops = SessionOperations.__new__(SessionOperations)
+        ops.client = Mock()
+        captured: dict = {}
+
+        class FakeResponse:
+            status = 200
+
+            async def json(self):
+                return {"session_id": "s-1", "best_config": {"m": 1}}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+        class FakeSession:
+            def __init__(self, *a, **k):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            def post(self, url, *, json=None, headers=None, timeout=None):
+                captured["body"] = json
+                return FakeResponse()
+
+        async def fake_headers(base):
+            return base
+
+        ops.client.auth_manager.augment_headers = fake_headers
+        ops.client.backend_config.api_base_url = "http://localhost:5000/api/v1"
+        monkeypatch.setattr(
+            "traigent.cloud.session_operations.aiohttp",
+            types.SimpleNamespace(
+                ClientSession=FakeSession,
+                ClientTimeout=lambda total=None: None,
+                ClientError=Exception,
+            ),
+        )
+        monkeypatch.setattr(
+            "traigent.cloud.session_operations.AIOHTTP_AVAILABLE", True
+        )
+
+        report = {"trial_id": "t1", "certificates": [], "attestation": "sdk_client_attested"}
+        await ops._finalize_session_via_api("s-1", "r-1", certified_selection=report)
+        assert captured["body"]["certified_selection"] == report
+        assert "certified_selection" not in captured["body"].get("metadata", {})
+
+        captured.clear()
+        await ops._finalize_session_via_api("s-1", "r-1")
+        assert "certified_selection" not in captured["body"]
+
+    def test_manager_drops_report_on_failed_runs(self):
+        """A failed optimization must never carry a certified winner."""
+        from traigent.api.types import OptimizationStatus
+        from traigent.core.backend_session_manager import BackendSessionManager
+
+        manager = BackendSessionManager.__new__(BackendSessionManager)
+        manager._backend_tracking_enabled = True
+        client = Mock(spec=["finalize_session_sync"])
+        client.finalize_session_sync = Mock(return_value={"ok": True})
+        manager._backend_client = client
+
+        report = {"trial_id": "t1"}
+        manager.finalize_session("s-1", OptimizationStatus.FAILED, certified_selection=report)
+        assert client.finalize_session_sync.call_args.kwargs["certified_selection"] is None
+
+        manager.finalize_session(
+            "s-1", OptimizationStatus.COMPLETED, certified_selection=report
+        )
+        assert (
+            client.finalize_session_sync.call_args.kwargs["certified_selection"]
+            == report
+        )

--- a/tests/unit/cloud/test_typed_session_contract.py
+++ b/tests/unit/cloud/test_typed_session_contract.py
@@ -299,7 +299,9 @@ class TestGovernedNoSilentFallback:
         assert result.session_id == "local_fallback_1"
         ops._create_local_fallback_session.assert_called_once()
 
-    def test_governed_without_api_key_stays_local_by_design(self, monkeypatch):
+    def test_governed_without_api_key_stays_local_by_design(
+        self, monkeypatch, caplog
+    ):
         """ADJUDICATED (round 3): no API key is an explicit local-only
         configuration, NOT a cloud failure — strict enforcement runs fully
         locally and NO backend record exists that could launder strict mode
@@ -310,13 +312,19 @@ class TestGovernedNoSilentFallback:
         monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
         ops = self._session_ops(AssertionError("backend must not be called"))
         ops.client.auth_manager.has_api_key = Mock(return_value=False)
-        result = ops.create_session(
-            function_name="answer_question",
-            search_space={"model": {"choices": ["a"]}},
-            promotion_policy=STRICT_POLICY,
-        )
+        with caplog.at_level("WARNING", logger="traigent.cloud.session_operations"):
+            result = ops.create_session(
+                function_name="answer_question",
+                search_space={"model": {"choices": ["a"]}},
+                promotion_policy=STRICT_POLICY,
+            )
         assert result.session_id == "local_fallback_1"
         ops.client._create_traigent_session_via_api.assert_not_called()
+        # the governance/no-cloud mismatch must be VISIBLE, not silent
+        assert any(
+            "no API key" in record.message and "Governed" in record.message
+            for record in caplog.records
+        )
 
 
 class TestGovernanceBuilders:

--- a/tests/unit/cloud/test_typed_session_contract.py
+++ b/tests/unit/cloud/test_typed_session_contract.py
@@ -178,6 +178,72 @@ class TestPayloadChokePoint:
         assert payload["promotion_policy"]["require_calibration"]["enabled"] is True
 
 
+class TestContractErrorSurvivesWrapping:
+    @pytest.mark.asyncio
+    async def test_invalid_contract_propagates_through_create_api(self, monkeypatch):
+        """Review round 3 (codex): the broad exception handler in
+        create_traigent_session_via_api re-wrapped SessionContractError as a
+        plain CloudServiceError, so an UNGOVERNED session with an invalid
+        TRAIGENT_SESSION_CONTRACT was absorbed into the local fallback. The
+        contract error must survive to the caller AS ITSELF."""
+        from traigent.cloud.client import SessionContractError
+
+        monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "yolo")
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        ops = _ops()
+        ops.client.auth_manager.augment_headers = AsyncMock(return_value={})
+        monkeypatch.setattr(ops, "_build_connector", lambda: None)
+        with pytest.raises(SessionContractError):
+            await ops.create_traigent_session_via_api(_request())
+
+
+class TestGovernanceChokePoint:
+    def test_typed_payload_filters_governance_at_the_wire(self, monkeypatch):
+        """Review round 3 (codex): tvl_governance rode the payload VERBATIM —
+        a direct SessionCreationRequest caller could put value/evidence
+        blobs on the wire (the leak happens at TRANSMISSION, even if the
+        new BE normalizer would reject it). Allowlist at the choke point."""
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        leaky_governance = {
+            "cvars": [
+                {
+                    "name": "retriever.k",
+                    "type": "int",
+                    "governed": True,
+                    "examples": ["SECRET_VALUE_c4d9"],
+                }
+            ],
+            "certificates": [
+                {
+                    "cvar_name": "retriever.k",
+                    "decision": "CERTIFIED_SELECTION",
+                    "freshness_hash": "a" * 64,
+                    "evidence": {"n": 20},
+                }
+            ],
+            "internal_debug_blob": {"signals": [0.42]},
+        }
+        payload = _ops()._build_session_payload(
+            _request(tvl_governance=leaky_governance), 5
+        )
+        blob = json.dumps(payload["tvl_governance"])
+        assert "SECRET_VALUE_c4d9" not in blob
+        assert "examples" not in blob
+        assert "evidence" not in blob
+        assert "internal_debug_blob" not in blob
+        # the contract-known fields survive intact
+        assert payload["tvl_governance"]["cvars"] == [
+            {"name": "retriever.k", "type": "int", "governed": True}
+        ]
+        assert payload["tvl_governance"]["certificates"] == [
+            {
+                "cvar_name": "retriever.k",
+                "decision": "CERTIFIED_SELECTION",
+                "freshness_hash": "a" * 64,
+            }
+        ]
+
+
 class TestGovernedNoSilentFallback:
     """Review round 2 (codex): SessionOperations.create_session caught every
     CloudServiceError into a LOCAL fallback — masking laundering refusals,
@@ -232,6 +298,25 @@ class TestGovernedNoSilentFallback:
         )
         assert result.session_id == "local_fallback_1"
         ops._create_local_fallback_session.assert_called_once()
+
+    def test_governed_without_api_key_stays_local_by_design(self, monkeypatch):
+        """ADJUDICATED (round 3): no API key is an explicit local-only
+        configuration, NOT a cloud failure — strict enforcement runs fully
+        locally and NO backend record exists that could launder strict mode
+        (nothing is falsely certified anywhere). Failing loud here would
+        break every local strict-mode user. The fallback stays, with a
+        WARNING so the declared governance / missing-cloud mismatch is
+        visible."""
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        ops = self._session_ops(AssertionError("backend must not be called"))
+        ops.client.auth_manager.has_api_key = Mock(return_value=False)
+        result = ops.create_session(
+            function_name="answer_question",
+            search_space={"model": {"choices": ["a"]}},
+            promotion_policy=STRICT_POLICY,
+        )
+        assert result.session_id == "local_fallback_1"
+        ops.client._create_traigent_session_via_api.assert_not_called()
 
 
 class TestGovernanceBuilders:

--- a/tests/unit/cloud/test_typed_session_contract.py
+++ b/tests/unit/cloud/test_typed_session_contract.py
@@ -144,6 +144,96 @@ class TestAutoFallback:
         assert len(attempts) == 1  # NO legacy retry for governed sessions
 
 
+class TestPayloadChokePoint:
+    def test_typed_payload_filters_policy_at_the_wire(self, monkeypatch):
+        """Review round 2 (codex): promotion_policy_to_wire is allowlist-style
+        but the typed payload sent the request's policy VERBATIM — a direct
+        SessionCreationRequest caller could serialize value/evidence-shaped
+        blobs. The serializer must sit on the actual request-body choke
+        point, not only on the orchestrator path."""
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        leaky_policy = {
+            **STRICT_POLICY,
+            "internal_debug_blob": {"signals": [0.42, 0.43]},
+            "chance_constraints": [
+                {
+                    "metric": "accuracy",
+                    "threshold": 0.9,
+                    "confidence": 0.95,
+                    "examples": ["SECRET_PROMPT_b7e1"],
+                }
+            ],
+        }
+        payload = _ops()._build_session_payload(
+            _request(promotion_policy=leaky_policy), 5
+        )
+        blob = json.dumps(payload["promotion_policy"])
+        assert "internal_debug_blob" not in blob
+        assert "SECRET_PROMPT_b7e1" not in blob
+        assert "examples" not in blob
+        # the contract-known fields survive intact
+        assert payload["promotion_policy"]["chance_constraints"] == [
+            {"metric": "accuracy", "threshold": 0.9, "confidence": 0.95}
+        ]
+        assert payload["promotion_policy"]["require_calibration"]["enabled"] is True
+
+
+class TestGovernedNoSilentFallback:
+    """Review round 2 (codex): SessionOperations.create_session caught every
+    CloudServiceError into a LOCAL fallback — masking laundering refusals,
+    invalid contract env values, and governed typed-create rejection from an
+    old BE as a quiet local-only run. Governed/contract failures fail LOUD."""
+
+    @staticmethod
+    def _session_ops(create_error):
+        from traigent.cloud.session_operations import SessionOperations
+
+        ops = SessionOperations.__new__(SessionOperations)
+        ops.client = Mock()
+        ops.client.auth_manager.has_api_key = Mock(return_value=True)
+        ops.client._create_traigent_session_via_api = AsyncMock(
+            side_effect=create_error
+        )
+        ops._create_local_fallback_session = Mock(return_value="local_fallback_1")
+        return ops
+
+    def test_governed_create_failure_raises_never_falls_back(self, monkeypatch):
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        ops = self._session_ops(CloudServiceError("typed create rejected"))
+        with pytest.raises(CloudServiceError):
+            ops.create_session(
+                function_name="answer_question",
+                search_space={"model": {"choices": ["a"]}},
+                promotion_policy=STRICT_POLICY,
+            )
+        ops._create_local_fallback_session.assert_not_called()
+
+    def test_contract_error_raises_even_for_ungoverned(self, monkeypatch):
+        from traigent.cloud.client import SessionContractError
+
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        ops = self._session_ops(
+            SessionContractError("TRAIGENT_SESSION_CONTRACT must be one of ...")
+        )
+        with pytest.raises(SessionContractError):
+            ops.create_session(
+                function_name="answer_question",
+                search_space={"model": {"choices": ["a"]}},
+            )
+        ops._create_local_fallback_session.assert_not_called()
+
+    def test_ungoverned_backend_failure_still_falls_back(self, monkeypatch):
+        """The availability fallback is FOR non-governed sessions — keep it."""
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        ops = self._session_ops(CloudServiceError("backend unavailable"))
+        result = ops.create_session(
+            function_name="answer_question",
+            search_space={"model": {"choices": ["a"]}},
+        )
+        assert result.session_id == "local_fallback_1"
+        ops._create_local_fallback_session.assert_called_once()
+
+
 class TestGovernanceBuilders:
     def test_promotion_policy_dataclass_to_wire(self):
         from traigent.tvl.models import PromotionPolicy, RequireCalibration

--- a/tests/unit/cloud/test_typed_session_contract.py
+++ b/tests/unit/cloud/test_typed_session_contract.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
+# Copyright (c) 2024-2026 Traigent Ltd. Dual-licensed: AGPL-3.0 or commercial.
+"""Phase 8: the typed session-create contract + content-free governance wire.
+
+Red-first regressions for the scope-defining finding: the cloud client posted
+the LEGACY shape (problem_statement/search_space) with NO promotion_policy —
+strict governance was unreachable from the Python SDK. Contract source of
+truth: TraigentSchema sdk_tuning (typed create) + promotion_policy_schema +
+tvl_governance_schema (v4.5.0).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from traigent.cloud.api_operations import ApiOperations
+from traigent.cloud.client import CloudServiceError
+from traigent.cloud.governance import build_tvl_governance, promotion_policy_to_wire
+from traigent.cloud.models import SessionCreationRequest
+
+STRICT_POLICY = {
+    "dominance": "epsilon_pareto",
+    "alpha": 0.05,
+    "require_calibration": {"enabled": True, "hash_covered_context": ["model_versions"]},
+}
+
+GOVERNANCE = {"cvars": [{"name": "retriever.k", "type": "int", "governed": True}]}
+
+
+def _request(**overrides) -> SessionCreationRequest:
+    base = {
+        "function_name": "answer_question",
+        "configuration_space": {
+            "model": {"type": "categorical", "choices": ["cheap", "strong"]}
+        },
+        "objectives": ["accuracy"],
+        "dataset_metadata": {"size": 12, "privacy_mode": True},
+        "max_trials": 5,
+        "metadata": {"evaluation_set": "dev"},
+    }
+    base.update(overrides)
+    return SessionCreationRequest(**base)
+
+
+def _ops() -> ApiOperations:
+    return ApiOperations(Mock())
+
+
+class TestContractGate:
+    def test_default_contract_builds_typed_payload(self, monkeypatch):
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        payload = _ops()._build_session_payload(
+            _request(promotion_policy=STRICT_POLICY, tvl_governance=GOVERNANCE), 5
+        )
+        # typed selectors at TOP level — this is what routes the backend's
+        # governed path (is_typed_create_request)
+        assert payload["function_name"] == "answer_question"
+        assert payload["configuration_space"]["model"]["choices"] == ["cheap", "strong"]
+        assert payload["objectives"] == ["accuracy"]
+        assert payload["dataset_metadata"]["size"] == 12
+        assert payload["promotion_policy"] == STRICT_POLICY
+        assert payload["tvl_governance"] == GOVERNANCE
+        # the legacy selectors must be GONE
+        assert "problem_statement" not in payload
+        assert "search_space" not in payload
+
+    def test_legacy_contract_refuses_governed_sessions(self, monkeypatch):
+        """The Phase 7 laundering bug must be impossible to reintroduce via
+        the compatibility flag: legacy CANNOT carry strict mode."""
+        monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "legacy")
+        with pytest.raises(CloudServiceError, match="launder|legacy"):
+            _ops()._build_session_payload(
+                _request(promotion_policy=STRICT_POLICY), 5
+            )
+
+    def test_legacy_contract_for_ungoverned_keeps_old_shape(self, monkeypatch):
+        monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "legacy")
+        payload = _ops()._build_session_payload(_request(), 5)
+        assert payload["problem_statement"] == "answer_question"
+        assert "configuration_space" not in payload
+        assert "promotion_policy" not in payload
+
+    def test_invalid_contract_value_fails_loud(self, monkeypatch):
+        monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "yolo")
+        with pytest.raises(CloudServiceError, match="auto|typed|legacy"):
+            _ops()._build_session_payload(_request(), 5)
+
+    def test_typed_dataset_size_clamped_positive(self, monkeypatch):
+        """The backend's typed path requires a positive dataset size."""
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        payload = _ops()._build_session_payload(
+            _request(dataset_metadata={"size": 0, "privacy_mode": True}), 5
+        )
+        assert payload["dataset_metadata"]["size"] == 1
+
+
+class TestAutoFallback:
+    @pytest.mark.asyncio
+    async def test_ungoverned_typed_failure_falls_back_to_legacy_once(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        ops = _ops()
+        ops.client.auth_manager.augment_headers = AsyncMock(return_value={})
+        attempts: list[dict] = []
+
+        async def fake_post(payload, headers, connector):
+            attempts.append(payload)
+            if "problem_statement" not in payload:
+                raise CloudServiceError("typed create rejected")
+            return ("s-1", "e-1", "r-1")
+
+        monkeypatch.setattr(ops, "_post_session_creation", fake_post)
+        monkeypatch.setattr(ops, "_build_connector", lambda: None)
+
+        result = await ops.create_traigent_session_via_api(_request())
+        assert result == ("s-1", "e-1", "r-1")
+        assert len(attempts) == 2
+        assert "problem_statement" in attempts[1]
+
+    @pytest.mark.asyncio
+    async def test_governed_typed_failure_raises_no_laundering(self, monkeypatch):
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        ops = _ops()
+        ops.client.auth_manager.augment_headers = AsyncMock(return_value={})
+        attempts: list[dict] = []
+
+        async def fake_post(payload, headers, connector):
+            attempts.append(payload)
+            raise CloudServiceError("typed create rejected")
+
+        monkeypatch.setattr(ops, "_post_session_creation", fake_post)
+        monkeypatch.setattr(ops, "_build_connector", lambda: None)
+
+        with pytest.raises(CloudServiceError):
+            await ops.create_traigent_session_via_api(
+                _request(promotion_policy=STRICT_POLICY)
+            )
+        assert len(attempts) == 1  # NO legacy retry for governed sessions
+
+
+class TestGovernanceBuilders:
+    def test_promotion_policy_dataclass_to_wire(self):
+        from traigent.tvl.models import PromotionPolicy, RequireCalibration
+
+        policy = PromotionPolicy(
+            alpha=0.05,
+            min_effect={"accuracy": 0.01},
+            require_calibration=RequireCalibration(
+                enabled=True, hash_covered_context=["model_versions"]
+            ),
+        )
+        wire = promotion_policy_to_wire(policy)
+        assert wire["require_calibration"] == {
+            "enabled": True,
+            "hash_covered_context": ["model_versions"],
+        }
+        assert wire["min_effect"] == {"accuracy": 0.01}
+        assert wire["dominance"] == "epsilon_pareto"
+
+    def test_dict_policy_passthrough_filters_unknown_keys(self):
+        wire = promotion_policy_to_wire(
+            {**STRICT_POLICY, "internal_debug_blob": {"signals": [1, 2, 3]}}
+        )
+        assert "internal_debug_blob" not in wire
+        assert wire["require_calibration"]["enabled"] is True
+
+    def test_none_policy_is_none(self):
+        assert promotion_policy_to_wire(None) is None
+
+    @staticmethod
+    def _calibrated(*, governed: bool, signal_name: str = "margin_signal"):
+        from traigent.knobs.bindings import Calibrated
+        from traigent.knobs.certificates import TargetProperty
+        from traigent.knobs.signals import SignalSpec
+
+        return Calibrated(
+            signal=SignalSpec(
+                name=signal_name,
+                version="1",
+                score_function="sf",
+                score_function_version="1",
+                comparator="ge",
+                comparator_version="1",
+            ),
+            target=TargetProperty(name="accuracy", mode="require_calibration"),
+            value_type="int",
+            require_calibration=governed,
+        )
+
+    def test_build_tvl_governance_from_declared_bindings(self):
+        from traigent.api.parameter_ranges import Choices
+        from traigent.knobs.bindings import Fixed, Knob, Tuned
+
+        class Space:
+            knobs = {
+                "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"]))),
+                "retriever.k": Knob(
+                    name="retriever.k", binding=self._calibrated(governed=True)
+                ),
+                "timeout": Knob(name="timeout", binding=Fixed(value=30)),
+            }
+
+        governance = build_tvl_governance(Space())
+        assert governance == {
+            "cvars": [{"name": "retriever.k", "type": "int", "governed": True}]
+        }
+
+    def test_governance_is_content_free(self):
+        """P8 canary: no signal/source/target detail may serialize."""
+        from traigent.knobs.bindings import Knob
+
+        class Space:
+            knobs = {
+                "k": Knob(
+                    name="k",
+                    binding=self._calibrated(
+                        governed=True, signal_name="SECRET_SIGNAL_a8f2"
+                    ),
+                ),
+            }
+
+        blob = json.dumps(build_tvl_governance(Space()))
+        assert "SECRET_SIGNAL_a8f2" not in blob
+        assert "accuracy" not in blob  # target detail never crosses
+
+    def test_ungoverned_space_yields_none(self):
+        from traigent.api.parameter_ranges import Choices
+        from traigent.knobs.bindings import Knob, Tuned
+
+        class Space:
+            knobs = {
+                "model": Knob(name="model", binding=Tuned(range=Choices(["a", "b"])))
+            }
+
+        assert build_tvl_governance(Space()) is None

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -448,7 +448,7 @@ class TestBackendSessionManagerFinalization:
 
         assert summary == {"status": "completed"}
         mock_backend_client.finalize_session_sync.assert_called_once_with(
-            "test-session-id", True
+            "test-session-id", True, certified_selection=None
         )
 
     def test_finalize_session_without_backend(

--- a/tests/unit/core/test_robustness_cherrypicks.py
+++ b/tests/unit/core/test_robustness_cherrypicks.py
@@ -179,7 +179,7 @@ class TestSessionMappingRecovery:
         assert mapping.experiment_id == "exp-42"
         assert mapping.experiment_run_id == "run-42"
         client._session_ops._finalize_session_via_api.assert_awaited_once_with(
-            session_id, "run-42"
+            session_id, "run-42", certified_selection=None
         )
 
     @pytest.mark.asyncio

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -239,9 +239,31 @@ class ApiOperations:
             headers = await self.client.auth_manager.augment_headers(
                 {"Content-Type": _JSON_CONTENT_TYPE}
             )
-            return await self._post_session_creation(
-                session_payload, headers, connector
-            )
+            try:
+                return await self._post_session_creation(
+                    session_payload, headers, connector
+                )
+            except CloudServiceError:
+                # auto-contract fallback: a failed TYPED create may retry the
+                # legacy shape ONCE — and only for NON-governed sessions
+                # (governed sessions must fail loudly; the legacy contract
+                # cannot carry strict mode and silently degrading would
+                # launder it — RFC 0001 P7).
+                if self._session_contract() != "auto" or self._is_governed_request(
+                    session_request
+                ):
+                    raise
+                logger.warning(
+                    "Typed session create failed; retrying once with the "
+                    "legacy contract (non-governed session, "
+                    "TRAIGENT_SESSION_CONTRACT=auto)"
+                )
+                legacy_payload = self._build_legacy_session_payload(
+                    session_request, max_trials_value
+                )
+                return await self._post_session_creation(
+                    legacy_payload, headers, connector
+                )
         except aiohttp.ClientConnectorError as e:
             self._handle_connector_error(e)
         except aiohttp.ClientError as e:
@@ -259,11 +281,95 @@ class ApiOperations:
             return 10
         return value
 
+    @staticmethod
+    def _session_contract() -> str:
+        """Resolve the session-create contract (TRAIGENT_SESSION_CONTRACT).
+
+        auto (default): typed create; for NON-governed sessions a failed
+        typed create may fall back to the legacy shape once.
+        typed: typed create only — failures raise.
+        legacy: legacy shape — REFUSED for governed/strict sessions
+        (falling back would silently launder strict mode; RFC 0001 P7).
+        """
+        import os
+
+        contract = os.getenv("TRAIGENT_SESSION_CONTRACT", "auto").strip().lower()
+        if contract not in {"auto", "typed", "legacy"}:
+            raise CloudServiceError(
+                "TRAIGENT_SESSION_CONTRACT must be one of auto|typed|legacy; "
+                f"got {contract!r}"
+            )
+        return contract
+
+    @staticmethod
+    def _is_governed_request(session_request: SessionCreationRequest) -> bool:
+        """A session is governed when it declares a promotion policy or any
+        TVL governance — governed sessions must NEVER take the legacy path
+        (the legacy contract cannot carry them; dropping them silently is
+        the Phase 7 laundering bug all over again)."""
+        return bool(session_request.promotion_policy or session_request.tvl_governance)
+
     def _build_session_payload(
         self, session_request: SessionCreationRequest, max_trials: int
     ) -> dict[str, Any]:
-        """Build the payload sent to the cloud session creation endpoint."""
+        """Build the payload sent to the cloud session creation endpoint.
 
+        Contract-gated (Phase 8): the TYPED shape is the default — it is the
+        only shape the backend's governed path accepts (promotion_policy,
+        tvl_governance, experiment records for FE hydration). The legacy
+        shape survives behind TRAIGENT_SESSION_CONTRACT=legacy for
+        non-governed compatibility only.
+        """
+        contract = self._session_contract()
+        if contract == "legacy":
+            if self._is_governed_request(session_request):
+                raise CloudServiceError(
+                    "strict/governed sessions require the typed session "
+                    "contract; TRAIGENT_SESSION_CONTRACT=legacy cannot carry "
+                    "promotion_policy/tvl_governance (refusing to launder "
+                    "strict mode)"
+                )
+            return self._build_legacy_session_payload(session_request, max_trials)
+        return self._build_typed_session_payload(session_request, max_trials)
+
+    def _build_typed_session_payload(
+        self, session_request: SessionCreationRequest, max_trials: int
+    ) -> dict[str, Any]:
+        """The typed interactive-session contract (TraigentSchema sdk_tuning):
+        function_name + configuration_space + objectives at top level select
+        the backend's typed path, which preserves governance and creates the
+        experiment records the FE hydrates."""
+        metadata = dict(session_request.metadata or {})
+        evaluation_set = metadata.get("evaluation_set", "default")
+        dataset_metadata = dict(session_request.dataset_metadata or {})
+        # The typed path requires a positive dataset size.
+        size = dataset_metadata.get("size")
+        if not isinstance(size, int) or size <= 0:
+            dataset_metadata["size"] = 1
+
+        payload: dict[str, Any] = {
+            "function_name": session_request.function_name,
+            "configuration_space": session_request.configuration_space,
+            "objectives": list(session_request.objectives or []),
+            "dataset_metadata": dataset_metadata,
+            "max_trials": max_trials,
+            "metadata": {
+                "function_name": session_request.function_name,
+                "evaluation_set": evaluation_set,
+                **metadata,
+            },
+        }
+        if session_request.promotion_policy:
+            payload["promotion_policy"] = session_request.promotion_policy
+        if session_request.tvl_governance:
+            payload["tvl_governance"] = session_request.tvl_governance
+        return payload
+
+    def _build_legacy_session_payload(
+        self, session_request: SessionCreationRequest, max_trials: int
+    ) -> dict[str, Any]:
+        """The pre-Phase-8 legacy shape (problem_statement/search_space) —
+        non-governed compatibility only."""
         metadata = session_request.metadata or {}
         evaluation_set = metadata.get("evaluation_set", "default")
 

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -16,7 +16,7 @@ from traigent.cloud.client import (
     CloudServiceError,
     SessionContractError,
 )
-from traigent.cloud.governance import promotion_policy_to_wire
+from traigent.cloud.governance import promotion_policy_to_wire, tvl_governance_to_wire
 from traigent.cloud.models import (
     AgentExecutionRequest,
     AgentExecutionResponse,
@@ -266,6 +266,12 @@ class ApiOperations:
                 return await self._post_session_creation(
                     legacy_payload, headers, connector
                 )
+        except SessionContractError:
+            # Review round 3: contract failures must reach the caller AS
+            # THEMSELVES — the generic wrap below would demote them to a
+            # plain CloudServiceError and the local-fallback layer would
+            # absorb them.
+            raise
         except aiohttp.ClientConnectorError as e:
             self._handle_connector_error(e)
         except aiohttp.ClientError as e:
@@ -368,10 +374,9 @@ class ApiOperations:
         wire_policy = promotion_policy_to_wire(session_request.promotion_policy)
         if wire_policy:
             payload["promotion_policy"] = wire_policy
-        if session_request.tvl_governance:
-            # already the closed name/type/governed summary; the BE
-            # normalizer rejects anything else loudly (allowlist rebuild).
-            payload["tvl_governance"] = session_request.tvl_governance
+        wire_governance = tvl_governance_to_wire(session_request.tvl_governance)
+        if wire_governance:
+            payload["tvl_governance"] = wire_governance
         return payload
 
     def _build_legacy_session_payload(

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -14,7 +14,9 @@ from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.client import (
     CloudRemoteExecutionUnavailableError,
     CloudServiceError,
+    SessionContractError,
 )
+from traigent.cloud.governance import promotion_policy_to_wire
 from traigent.cloud.models import (
     AgentExecutionRequest,
     AgentExecutionResponse,
@@ -295,7 +297,7 @@ class ApiOperations:
 
         contract = os.getenv("TRAIGENT_SESSION_CONTRACT", "auto").strip().lower()
         if contract not in {"auto", "typed", "legacy"}:
-            raise CloudServiceError(
+            raise SessionContractError(
                 "TRAIGENT_SESSION_CONTRACT must be one of auto|typed|legacy; "
                 f"got {contract!r}"
             )
@@ -323,7 +325,7 @@ class ApiOperations:
         contract = self._session_contract()
         if contract == "legacy":
             if self._is_governed_request(session_request):
-                raise CloudServiceError(
+                raise SessionContractError(
                     "strict/governed sessions require the typed session "
                     "contract; TRAIGENT_SESSION_CONTRACT=legacy cannot carry "
                     "promotion_policy/tvl_governance (refusing to launder "
@@ -359,9 +361,16 @@ class ApiOperations:
                 **metadata,
             },
         }
-        if session_request.promotion_policy:
-            payload["promotion_policy"] = session_request.promotion_policy
+        # CHOKE POINT (review round 2): the allowlist serializer runs on the
+        # actual request body, not only on the orchestrator path — a direct
+        # SessionCreationRequest caller must not be able to serialize
+        # unknown/value-shaped policy data (RFC 0001 P8 content freedom).
+        wire_policy = promotion_policy_to_wire(session_request.promotion_policy)
+        if wire_policy:
+            payload["promotion_policy"] = wire_policy
         if session_request.tvl_governance:
+            # already the closed name/type/governed summary; the BE
+            # normalizer rejects anything else loudly (allowlist rebuild).
             payload["tvl_governance"] = session_request.tvl_governance
         return payload
 

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -643,11 +643,22 @@ class BackendIntegratedClient:
         search_space: dict[str, Any],
         optimization_goal: str = "maximize",
         metadata: dict[str, Any] | None = None,
+        objectives: list[Any] | None = None,
+        promotion_policy: dict[str, Any] | None = None,
+        tvl_governance: dict[str, Any] | None = None,
     ) -> SessionCreationResult:
         """Synchronous wrapper for creating a session.
-        Delegates to session_operations module."""
+        Delegates to session_operations module. Phase 8: objectives are
+        METRIC names for the typed contract; promotion_policy/tvl_governance
+        are the content-free governance wire (RFC 0001 P8)."""
         return self._session_ops.create_session(
-            function_name, search_space, optimization_goal, metadata
+            function_name,
+            search_space,
+            optimization_goal,
+            metadata,
+            objectives=objectives,
+            promotion_policy=promotion_policy,
+            tvl_governance=tvl_governance,
         )
 
     async def create_hybrid_session(

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -694,12 +694,16 @@ class BackendIntegratedClient:
         )
 
     async def finalize_session(
-        self, session_id: str, include_full_history: bool = False
+        self,
+        session_id: str,
+        include_full_history: bool = False,
+        certified_selection: dict[str, Any] | None = None,
     ) -> OptimizationFinalizationResponse:
         """Finalize optimization session and get results.
-        Delegates to session_operations module."""
+        Delegates to session_operations module. Phase 8: an optional
+        client-attested certified-selection report (content-free)."""
         return await self._session_ops.finalize_session(
-            session_id, include_full_history
+            session_id, include_full_history, certified_selection=certified_selection
         )
 
     async def delete_session(self, session_id: str, cascade: bool = True) -> bool:
@@ -708,11 +712,16 @@ class BackendIntegratedClient:
         return cast(bool, await self._session_ops.delete_session(session_id, cascade))
 
     def finalize_session_sync(
-        self, session_id: str, include_full_history: bool = False
+        self,
+        session_id: str,
+        include_full_history: bool = False,
+        certified_selection: dict[str, Any] | None = None,
     ) -> OptimizationFinalizationResponse | None:
         """Synchronous wrapper for finalize_session.
         Delegates to session_operations module."""
-        return self._session_ops.finalize_session_sync(session_id, include_full_history)
+        return self._session_ops.finalize_session_sync(
+            session_id, include_full_history, certified_selection=certified_selection
+        )
 
     def delete_session_sync(self, session_id: str, cascade: bool = True) -> bool:
         """Synchronous wrapper for delete_session.

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -1962,6 +1962,13 @@ class CloudServiceError(StandardizedClientError):
         super().__init__(message, "cloud_service", original_error)
 
 
+class SessionContractError(CloudServiceError):
+    """A session-create CONTRACT failure (Phase 8): an invalid
+    TRAIGENT_SESSION_CONTRACT value or a governed/strict session forced onto
+    the legacy shape. NEVER absorbed into the local-fallback path — silently
+    degrading a contract refusal would launder strict mode (RFC 0001 P7)."""
+
+
 class CloudRemoteExecutionUnavailableError(CloudServiceError):
     """Raised when remote cloud execution endpoints are intentionally unavailable."""
 

--- a/traigent/cloud/governance.py
+++ b/traigent/cloud/governance.py
@@ -149,6 +149,62 @@ def build_tvl_governance(config_space: Any) -> dict[str, Any] | None:
     return {"cvars": cvars}
 
 
+def tvl_governance_to_wire(governance: Any) -> dict[str, Any] | None:
+    """Project a governance summary onto the closed wire shape (allowlist).
+
+    Review round 3 (codex): the summary rode the create payload VERBATIM, so
+    a direct SessionCreationRequest caller could put value/evidence blobs on
+    the wire — and the leak happens at TRANSMISSION, regardless of what the
+    backend's normalizer later rejects. Only the contract-known fields
+    survive: cvars {name, type, governed}, certificates {cvar_name,
+    decision, freshness_hash}, policies {name, strategy}. A projection, not
+    a validator — the backend's allowlist rebuild is the enforcement point.
+    """
+    if not isinstance(governance, dict) or not governance:
+        return None
+
+    wire: dict[str, Any] = {}
+
+    cvars = governance.get("cvars")
+    if isinstance(cvars, list):
+        projected = [
+            {key: entry[key] for key in ("name", "type", "governed") if key in entry}
+            for entry in cvars
+            if isinstance(entry, dict)
+        ]
+        projected = [entry for entry in projected if entry.get("name")]
+        if projected:
+            wire["cvars"] = projected
+
+    certificates = governance.get("certificates")
+    if isinstance(certificates, list):
+        projected = [
+            {
+                key: entry[key]
+                for key in ("cvar_name", "decision", "freshness_hash")
+                if key in entry
+            }
+            for entry in certificates
+            if isinstance(entry, dict)
+        ]
+        projected = [entry for entry in projected if entry.get("cvar_name")]
+        if projected:
+            wire["certificates"] = projected
+
+    policies = governance.get("policies")
+    if isinstance(policies, list):
+        projected = [
+            {key: entry[key] for key in ("name", "strategy") if key in entry}
+            for entry in policies
+            if isinstance(entry, dict)
+        ]
+        projected = [entry for entry in projected if entry.get("name")]
+        if projected:
+            wire["policies"] = projected
+
+    return wire or None
+
+
 def build_certified_selection(
     trial_id: Any, certificates_by_cvar: Any
 ) -> dict[str, Any] | None:

--- a/traigent/cloud/governance.py
+++ b/traigent/cloud/governance.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
+# Copyright (c) 2024-2026 Traigent Ltd. Dual-licensed: AGPL-3.0 or commercial.
+"""Content-free governance serializers for the typed session wire.
+
+RFC 0001 P8: anything that crosses the wire is restricted to names, types,
+decisions, and sha256 freshness hashes — never calibrated values, signals,
+evidence, or prompts. These builders are the ONLY place the SDK shapes
+governance for the backend; keep them allowlist-style so nothing new leaks
+by accident. Contract source of truth: TraigentSchema
+``promotion_policy_schema.json`` + ``tvl_governance_schema.json`` (v4.5.0).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: The promotion-policy keys the wire contract knows (mirrors the backend's
+#: top-level-closed normalizer — anything else would be rejected there).
+_POLICY_WIRE_KEYS = (
+    "dominance",
+    "alpha",
+    "min_effect",
+    "adjust",
+    "chance_constraints",
+    "tie_breakers",
+    "require_calibration",
+)
+
+
+def promotion_policy_to_wire(policy: Any) -> dict[str, Any] | None:
+    """Serialize a promotion policy (PromotionPolicy dataclass or raw dict)
+    into the closed wire shape. Returns None when there is nothing to send.
+
+    Only contract-known keys are emitted; ``require_calibration`` keeps the
+    strict {enabled, hash_covered_context} shape. Values must already be
+    JSON-safe — this is a projection, not a validator (the backend's
+    normalizer is the enforcement point).
+    """
+    if policy is None:
+        return None
+
+    if isinstance(policy, dict):
+        source: dict[str, Any] = policy
+    else:
+        source = {}
+        for key in _POLICY_WIRE_KEYS:
+            value = getattr(policy, key, None)
+            if value is None:
+                continue
+            source[key] = value
+
+    wire: dict[str, Any] = {}
+    for key in _POLICY_WIRE_KEYS:
+        if key not in source or source[key] is None:
+            continue
+        value = source[key]
+        if key == "require_calibration":
+            enabled = bool(
+                getattr(value, "enabled", None)
+                or (isinstance(value, dict) and value.get("enabled"))
+            )
+            covered = getattr(value, "hash_covered_context", None)
+            if covered is None and isinstance(value, dict):
+                covered = value.get("hash_covered_context")
+            entry: dict[str, Any] = {"enabled": enabled}
+            if covered:
+                entry["hash_covered_context"] = [str(item) for item in covered]
+            wire[key] = entry
+        elif key == "chance_constraints":
+            serialized = [_chance_constraint_to_wire(item) for item in value]
+            serialized = [item for item in serialized if item]
+            if serialized:
+                wire[key] = serialized
+        elif key == "tie_breakers":
+            if isinstance(value, dict) and value:
+                wire[key] = {
+                    str(metric): {
+                        "strategy": str(
+                            getattr(rule, "strategy", None)
+                            or (
+                                rule.get("strategy") if isinstance(rule, dict) else rule
+                            )
+                        )
+                    }
+                    for metric, rule in value.items()
+                }
+        elif key == "min_effect":
+            if isinstance(value, dict) and value:
+                wire[key] = {str(metric): float(eps) for metric, eps in value.items()}
+        else:
+            wire[key] = value
+
+    return wire or None
+
+
+def _chance_constraint_to_wire(constraint: Any) -> dict[str, Any] | None:
+    """Project a chance constraint to its wire fields (names + numbers only)."""
+    if isinstance(constraint, dict):
+        getter = constraint.get
+    else:
+
+        def getter(name: str, default: Any = None) -> Any:  # noqa: E306
+            return getattr(constraint, name, default)
+
+    entry: dict[str, Any] = {}
+    for field_name in ("metric", "objective", "threshold", "confidence", "direction"):
+        value = getter(field_name)
+        if value is not None:
+            entry[field_name] = value
+    return entry or None
+
+
+def build_tvl_governance(config_space: Any) -> dict[str, Any] | None:
+    """Build the content-free governance summary from DECLARED bindings.
+
+    Emits ONLY: cvar name, declared TVL value type, governed flag — straight
+    from the ConfigSpace knob declarations (never runtime/calibrated state).
+    Returns None when the space declares no calibrated variables, so
+    ungoverned sessions stay byte-identical on the wire.
+    """
+    knobs = getattr(config_space, "knobs", None)
+    if not knobs:
+        return None
+
+    try:
+        from traigent.knobs.bindings import Calibrated, is_governed
+    except Exception:  # pragma: no cover - knobs is a hard dep of ConfigSpace
+        logger.warning("knobs bindings unavailable; omitting tvl_governance")
+        return None
+
+    cvars: list[dict[str, Any]] = []
+    for name, knob in dict(knobs).items():
+        binding = getattr(knob, "binding", None)
+        if not isinstance(binding, Calibrated):
+            continue
+        cvars.append(
+            {
+                "name": str(getattr(knob, "name", name)),
+                "type": str(getattr(binding, "value_type", "float")),
+                "governed": bool(is_governed(binding)),
+            }
+        )
+
+    if not cvars:
+        return None
+    return {"cvars": cvars}

--- a/traigent/cloud/governance.py
+++ b/traigent/cloud/governance.py
@@ -147,3 +147,52 @@ def build_tvl_governance(config_space: Any) -> dict[str, Any] | None:
     if not cvars:
         return None
     return {"cvars": cvars}
+
+
+def build_certified_selection(
+    trial_id: Any, certificates_by_cvar: Any
+) -> dict[str, Any] | None:
+    """Build the client-attested certified-selection finalize report.
+
+    Mirrors TraigentSchema ``certified_selection_schema.json`` AND the
+    server's coverage rule CLIENT-side: a report is built only when EVERY
+    entry is a CERTIFIED decision with an issued (freshness) hash — any gap
+    means NO report (the honest no-winner), never a partial one (the server
+    would 400 it; partial reports are bugs, not flows).
+
+    Content-free (RFC 0001 P8): cvar names, the decision enum value, and the
+    certificate's issued hash ONLY — never subject_value_hash (dictionary-
+    invertible on low-entropy calibrated values), evidence counts, pool
+    hashes, or target details.
+    """
+    if not trial_id or not certificates_by_cvar:
+        return None
+
+    entries: list[dict[str, Any]] = []
+    for name, certificate in dict(certificates_by_cvar).items():
+        decision = getattr(certificate, "decision", None)
+        decision_value = getattr(decision, "value", None) or (
+            str(decision) if decision is not None else ""
+        )
+        issued_hash = getattr(certificate, "issued_hash", None)
+        if decision_value != "CERTIFIED_SELECTION" or not issued_hash:
+            logger.debug(
+                "certified_selection withheld: cvar %s decision=%s issued=%s",
+                name,
+                decision_value or "<none>",
+                bool(issued_hash),
+            )
+            return None
+        entries.append(
+            {
+                "cvar_name": str(name),
+                "decision": "CERTIFIED_SELECTION",
+                "freshness_hash": str(issued_hash),
+            }
+        )
+
+    return {
+        "trial_id": str(trial_id),
+        "certificates": entries,
+        "attestation": "sdk_client_attested",
+    }

--- a/traigent/cloud/models.py
+++ b/traigent/cloud/models.py
@@ -189,6 +189,9 @@ class SessionCreationRequest:
     constraints: dict[str, Any] | None = None
     default_config: dict[str, Any] | None = None
     promotion_policy: dict[str, Any] | None = None
+    # Content-free TVL governance summary (RFC 0001 P8): cvar names/types/
+    # governed flags only — built by traigent.cloud.governance, never ad hoc.
+    tvl_governance: dict[str, Any] | None = None
     optimization_strategy: dict[str, Any] | None = None
     user_id: str | None = None
     billing_tier: str = "standard"

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -247,6 +247,9 @@ class SessionOperations:
         search_space: dict[str, Any],
         optimization_goal: str = "maximize",
         metadata: dict[str, Any] | None = None,
+        objectives: list[Any] | None = None,
+        promotion_policy: dict[str, Any] | None = None,
+        tvl_governance: dict[str, Any] | None = None,
     ) -> SessionCreationResult:
         """Create a session with backend metadata submission.
 
@@ -305,12 +308,18 @@ class SessionOperations:
             session_request = SessionCreationRequest(
                 function_name=function_name,
                 configuration_space=search_space,
-                objectives=[optimization_goal],
+                # Typed contract: objectives are METRIC names/objects. The
+                # legacy [optimization_goal] placeholder survives only as the
+                # fallback when the caller supplied none (legacy shape keeps
+                # reading objectives[0] as its optimization_goal).
+                objectives=list(objectives) if objectives else [optimization_goal],
                 dataset_metadata={
                     "size": metadata.get("dataset_size", 0) if metadata else 0,
                     "privacy_mode": True,
                 },
                 max_trials=max_trials_from_metadata,
+                promotion_policy=promotion_policy,
+                tvl_governance=tvl_governance,
                 optimization_strategy={"mode": "local_execution"},
                 user_id=None,  # Privacy preserving
                 billing_tier="privacy",

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.backend_bridges import SessionExperimentMapping
-from traigent.cloud.client import CloudServiceError
+from traigent.cloud.client import CloudServiceError, SessionContractError
 from traigent.cloud.models import (
     OptimizationFinalizationResponse,
     OptimizationSession,
@@ -271,6 +271,16 @@ class SessionOperations:
         if metadata is not None and not isinstance(metadata, dict):
             raise ValidationException("metadata must be a dictionary if provided")
 
+        # Phase 8 (review round 2): the local-availability fallback is for
+        # NON-governed sessions only. A governed/strict session that cannot
+        # be created on the backend fails LOUD — quietly degrading to a
+        # local-only run would mask laundering refusals, contract
+        # misconfiguration, and old-BE typed rejection as success.
+        governed = bool(promotion_policy or tvl_governance)
+
+        def _must_fail_loud(exc: Exception) -> bool:
+            return governed or isinstance(exc, SessionContractError)
+
         async def _create_session_async() -> SessionCreationResult:
             # Preflight: check if API key exists before attempting any HTTP call
             has_key = self.client.auth_manager.has_api_key()
@@ -419,6 +429,8 @@ class SessionOperations:
 
             except AuthenticationError as e:
                 await self._reset_client_session("create_session auth_failure")
+                if _must_fail_loud(e):
+                    raise
                 logger.debug("Backend auth failed for '%s': %s", function_name, e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
@@ -431,6 +443,8 @@ class SessionOperations:
 
             except (TimeoutError, CloudServiceError, OSError) as e:
                 await self._reset_client_session("create_session fallback")
+                if _must_fail_loud(e):
+                    raise
                 logger.debug("Backend unavailable for '%s': %s", function_name, e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
@@ -466,6 +480,8 @@ class SessionOperations:
             raise  # User input errors must propagate
 
         except AuthenticationError as exc:
+            if _must_fail_loud(exc):
+                raise
             logger.debug(
                 "Backend auth failed for '%s': %s",
                 function_name,
@@ -481,6 +497,8 @@ class SessionOperations:
             )
 
         except (TimeoutError, CloudServiceError, OSError) as exc:
+            if _must_fail_loud(exc):
+                raise
             logger.debug(
                 "Error in create_session for function '%s': %s",
                 function_name,
@@ -499,7 +517,10 @@ class SessionOperations:
         except Exception as exc:
             # Last-resort fallback for unexpected errors (e.g. from
             # session_bridge or event loop machinery).  Ensures SDK
-            # never crashes during session creation.
+            # never crashes during session creation — except for
+            # governed/contract failures, which must stay loud.
+            if _must_fail_loud(exc):
+                raise
             logger.debug(
                 "Unexpected error in create_session for function '%s': %s",
                 function_name,

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -285,6 +285,19 @@ class SessionOperations:
             # Preflight: check if API key exists before attempting any HTTP call
             has_key = self.client.auth_manager.has_api_key()
             if not has_key:
+                if governed:
+                    # ADJUDICATED (review round 3): no API key is an explicit
+                    # local-only configuration, not a cloud failure — strict
+                    # enforcement runs fully locally and no backend record
+                    # exists that could launder strict mode. Stay local, but
+                    # make the governance/no-cloud mismatch VISIBLE.
+                    logger.warning(
+                        "Governed session '%s' declared promotion_policy/"
+                        "tvl_governance but no API key is configured — "
+                        "running local-only (strict enforcement stays local; "
+                        "no backend session or certified record is created)",
+                        function_name,
+                    )
                 logger.debug(
                     "No API key configured — skipping backend session creation"
                 )

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -699,7 +699,10 @@ class SessionOperations:
             raise CloudServiceError(f"Network error: {e}") from None
 
     async def finalize_session(
-        self, session_id: str, include_full_history: bool = False
+        self,
+        session_id: str,
+        include_full_history: bool = False,
+        certified_selection: dict[str, Any] | None = None,
     ) -> OptimizationFinalizationResponse:
         """Finalize optimization session and get results.
 
@@ -757,7 +760,9 @@ class SessionOperations:
         if mapping:
             try:
                 backend_payload = await self._finalize_session_via_api(
-                    session_id, mapping.experiment_run_id
+                    session_id,
+                    mapping.experiment_run_id,
+                    certified_selection=certified_selection,
                 )
             except CloudServiceError:
                 raise
@@ -909,7 +914,10 @@ class SessionOperations:
         return response
 
     async def _finalize_session_via_api(
-        self, session_id: str, experiment_run_id: str
+        self,
+        session_id: str,
+        experiment_run_id: str,
+        certified_selection: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Call backend session finalization endpoint.
 
@@ -944,12 +952,18 @@ class SessionOperations:
                 )
                 url = f"{api_base}/sessions/{session_id}/finalize"
 
+                finalize_body: dict[str, Any] = {
+                    "reason": "sdk_explicit_finalization",
+                    "experiment_run_id": experiment_run_id,
+                }
+                if certified_selection is not None:
+                    # Phase 8: the client-attested, content-free certified-
+                    # selection report — TOP-LEVEL key only (the backend
+                    # rejects metadata-tunneled reports).
+                    finalize_body["certified_selection"] = certified_selection
                 async with session.post(
                     url,
-                    json={
-                        "reason": "sdk_explicit_finalization",
-                        "experiment_run_id": experiment_run_id,
-                    },
+                    json=finalize_body,
                     headers=headers,
                     timeout=aiohttp.ClientTimeout(total=10),
                 ) as response:
@@ -1024,7 +1038,10 @@ class SessionOperations:
         return deleted
 
     def finalize_session_sync(
-        self, session_id: str, include_full_history: bool = False
+        self,
+        session_id: str,
+        include_full_history: bool = False,
+        certified_selection: dict[str, Any] | None = None,
     ) -> OptimizationFinalizationResponse | None:
         """Synchronous wrapper for finalize_session."""
         import concurrent.futures
@@ -1037,7 +1054,11 @@ class SessionOperations:
             asyncio.set_event_loop(new_loop)
             try:
                 return new_loop.run_until_complete(
-                    self.finalize_session(session_id, include_full_history)
+                    self.finalize_session(
+                        session_id,
+                        include_full_history,
+                        certified_selection=certified_selection,
+                    )
                 )
             finally:
                 new_loop.close()

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -329,6 +329,9 @@ class BackendSessionManager:
         start_time: float,
         max_total_examples: int | None = None,
         agent_configuration: AgentConfiguration | None = None,
+        objectives: list[Any] | None = None,
+        promotion_policy: dict[str, Any] | None = None,
+        tvl_governance: dict[str, Any] | None = None,
     ) -> SessionContext:
         """Create backend session and return context.
 
@@ -397,6 +400,9 @@ class BackendSessionManager:
                 search_space=getattr(self._optimizer, "config_space", {}),
                 optimization_goal="maximize",
                 metadata=session_metadata,
+                objectives=objectives,
+                promotion_policy=promotion_policy,
+                tvl_governance=tvl_governance,
             )
             result = self.normalize_session_creation_result(raw_result)
             session_id = self.handle_session_creation_result(result)

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -983,6 +983,7 @@ class BackendSessionManager:
         self,
         session_id: str | None,
         optimization_status: OptimizationStatus,
+        certified_selection: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Finalize backend session and return summary.
 
@@ -1006,14 +1007,22 @@ class BackendSessionManager:
             else "failed"
         )
 
+        # The certified report only accompanies a COMPLETED finalize — a
+        # failed run must never carry a certified winner.
+        report = certified_selection if final_status == "completed" else None
+
         if hasattr(self._backend_client, "finalize_session_sync"):
             result: dict[str, Any] | None = self._backend_client.finalize_session_sync(  # type: ignore[assignment]
-                session_id, final_status == "completed"
+                session_id,
+                final_status == "completed",
+                certified_selection=report,
             )
             return result
 
         result = self._backend_client.finalize_session(  # type: ignore[assignment]
-            session_id, final_status == "completed"
+            session_id,
+            final_status == "completed",
+            certified_selection=report,
         )
         return result
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -884,6 +884,14 @@ class OptimizationOrchestrator:
         """
         if not self._is_strict_evidence_mode():
             return None
+        # The FIRST trial seeds the incumbent as comparison initialization,
+        # NOT as certification — terminal strict selection only names a
+        # winner after >=1 explicit gate promotion (the _certified_promotions
+        # guard in result assembly). Mirror it here so the wire report can
+        # never overclaim a winner the SDK result itself refuses to certify.
+        # An absent attribute reads 0 ⇒ fail closed.
+        if not getattr(self, "_certified_promotions", 0):
+            return None
         incumbent = self._best_trial_cached
         if incumbent is None or not getattr(incumbent, "trial_id", None):
             return None

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -844,6 +844,33 @@ class OptimizationOrchestrator:
             return True
         return bool(getattr(policy, "chance_constraints", None))
 
+    def _build_wire_governance(
+        self,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        """Project the declared governance onto the wire (RFC 0001 P8).
+
+        promotion_policy: from the promotion gate's declared policy.
+        tvl_governance: cvar names/types/governed flags from the resolver's
+        DECLARED bindings (the same source _is_strict_evidence_mode trusts) —
+        never runtime or calibrated state. Both None for ungoverned sessions
+        so their wire payload stays byte-identical.
+        """
+        from traigent.cloud.governance import (
+            build_tvl_governance,
+            promotion_policy_to_wire,
+        )
+
+        gate = self._promotion_gate
+        policy = getattr(gate, "policy", None) if gate is not None else None
+        wire_policy = promotion_policy_to_wire(policy)
+
+        wire_governance = None
+        resolver = getattr(self, "knob_resolver", None)
+        space = getattr(resolver, "_space", None) if resolver is not None else None
+        if space is not None:
+            wire_governance = build_tvl_governance(space)
+        return wire_policy, wire_governance
+
     def _withhold_promotion(self, reason: str) -> bool:
         """Fail closed: record + log a strict-mode withheld promotion."""
         self._strict_withheld_promotions.append(reason)
@@ -1893,7 +1920,10 @@ class OptimizationOrchestrator:
                 descriptor.identifier,
             )
 
-        # Create backend session using manager
+        # Create backend session using manager. Governance crosses the wire
+        # content-free (Phase 8): the declared promotion policy and the
+        # cvar summary from DECLARED bindings — never values or evidence.
+        wire_policy, wire_governance = self._build_wire_governance()
         session_context = self.backend_session_manager.create_session(
             func=func,
             dataset=dataset,
@@ -1902,6 +1932,9 @@ class OptimizationOrchestrator:
             max_total_examples=self.max_total_examples,
             start_time=self._start_time or time.time(),
             agent_configuration=self._agent_configuration,
+            objectives=list(self.optimizer.objectives or []),
+            promotion_policy=wire_policy,
+            tvl_governance=wire_governance,
         )
         session_id: str | None = session_context.session_id
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -871,6 +871,58 @@ class OptimizationOrchestrator:
             wire_governance = build_tvl_governance(space)
         return wire_policy, wire_governance
 
+    def _build_certified_selection_report(self) -> dict[str, Any] | None:
+        """Phase 8: the client-attested certified-selection finalize report.
+
+        Built ONLY when every condition holds (mirror of the server's
+        fail-closed rules so a 400 means a bug, not a flow): strict evidence
+        mode, a certified incumbent exists, the resolver's DECLARED governed
+        cvars are each backed by a CERTIFIED certificate with an issued
+        hash. Any gap ⇒ None ⇒ the honest no-winner finalize. The incumbent's
+        trial_id is the BACKEND id (trials are submitted under it), so the
+        server can bind the winner to its own record.
+        """
+        if not self._is_strict_evidence_mode():
+            return None
+        incumbent = self._best_trial_cached
+        if incumbent is None or not getattr(incumbent, "trial_id", None):
+            return None
+        resolver = getattr(self, "knob_resolver", None)
+        space = getattr(resolver, "_space", None) if resolver is not None else None
+        if space is None:
+            return None
+
+        try:
+            from traigent.knobs.bindings import Calibrated, is_governed
+        except Exception:  # pragma: no cover - knobs is a hard dependency
+            return None
+
+        governed = [
+            name
+            for name, knob in dict(getattr(space, "knobs", {}) or {}).items()
+            if isinstance(getattr(knob, "binding", None), Calibrated)
+            and is_governed(knob.binding)
+        ]
+        if not governed:
+            return None
+
+        calibrated_inputs = getattr(resolver, "_calibrated_inputs", {}) or {}
+        certificates: dict[str, Any] = {}
+        for name in governed:
+            certificate = getattr(calibrated_inputs.get(name), "certificate", None)
+            if certificate is None:
+                logger.debug(
+                    "certified_selection withheld: governed cvar %s has no "
+                    "certificate at finalize",
+                    name,
+                )
+                return None
+            certificates[name] = certificate
+
+        from traigent.cloud.governance import build_certified_selection
+
+        return build_certified_selection(incumbent.trial_id, certificates)
+
     def _withhold_promotion(self, reason: str) -> bool:
         """Fail closed: record + log a strict-mode withheld promotion."""
         self._strict_withheld_promotions.append(reason)
@@ -2390,7 +2442,9 @@ class OptimizationOrchestrator:
         self.backend_session_manager.submit_session_aggregation(result, session_id)
 
         session_summary = self.backend_session_manager.finalize_session(
-            session_id, self._status
+            session_id,
+            self._status,
+            certified_selection=self._build_certified_selection_report(),
         )
         self.backend_session_manager.attach_session_metadata(
             result, session_id, session_summary


### PR DESCRIPTION
## What (Phase 8 — ChangeSession `cs_71df3e7fe8f8b9a0`; SoT TraigentSchema v4.5.0 #101 merged; BE counterpart #824)

Two stacked commits closing the Phase 8 SDK gap — **strict governance was unreachable from the Python SDK** (the cloud client posted the legacy `problem_statement`/`search_space` shape with `SessionCreationRequest.promotion_policy` unused):

### P3a — typed session-create contract (`8137758f`)
- `TRAIGENT_SESSION_CONTRACT=auto|typed|legacy`: **typed is the default** (routes the BE's governed path + creates the experiment records the FE hydrates). `legacy` survives for NON-governed compatibility only — governed sessions on legacy **fail loud** (refusing to re-launder strict mode); `auto` retries legacy ONCE on typed failure for non-governed sessions only.
- NEW `traigent/cloud/governance.py` — the only place governance is shaped for the wire (P8): `promotion_policy_to_wire` (contract-known keys only) + `build_tvl_governance` (cvar name/type/governed from DECLARED bindings).
- Full threading: orchestrator → manager → client facade → session ops → typed payload; typed `objectives` carry METRIC names.

### P3b — certified-selection finalize report (`ac7d5e65`)
- `build_certified_selection`: `Certificate → {cvar_name, decision, freshness_hash=issued_hash}` + `sdk_client_attested`. Mirrors the server's coverage rule client-side: any governed cvar below CERTIFIED ⇒ **no report** (honest no-winner), never a partial one. `subject_value_hash`/evidence/pool-hashes/target details never serialize.
- Orchestrator builds the report only when: strict mode ∧ certified incumbent ∧ declared-governed coverage ∧ resolver present (backend_guided ⇒ fail closed). Incumbent `trial_id` IS the backend id → server-side trial binding.
- Finalize body carries the report at the TOP-LEVEL key only; FAILED runs never carry one.

## Tests
25 new across two batteries (contract gate red-proven via stash; P8 canaries; condition matrices; wire-body threading). Suites: cloud+core **3275 passed**, knobs 104; pre-commit (black/isort/ruff/mypy/bandit) green — mypy caught a facade signature gap mid-development.

## Checklist
- Contract regeneration: mirrors TraigentSchema v4.5.0; BE #824 is the server counterpart (same phase, merge-ordered after this).
- Public surface delta: `SessionCreationRequest.tvl_governance`; new env var `TRAIGENT_SESSION_CONTRACT`; additive `certified_selection` kwargs.
- Spine packet `pkt_cb1b36d477a9ceb7` verified **pass**.

⏳ **Merge hold**: codex gpt-5.5 xhigh review queued (provider quota resets ~04:25); merging after its verdict per the phase's review protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)