### PR TITLE
fix(config): redact invalid backend URLs in logs

### DIFF
--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -119,6 +120,19 @@ class TestBackendConfigStoredBackendUrl:
             result = BackendConfig.get_backend_url()
 
         assert result == BackendConfig.DEFAULT_PROD_URL
+
+    def test_invalid_configured_urls_do_not_log_raw_values(self, caplog):
+        """Invalid configured URLs may contain credentials and must not be logged raw."""
+
+        raw_url = "http://?api_key=tg_secret_backend_url"
+
+        with caplog.at_level(logging.WARNING, logger="traigent.config.backend_config"):
+            assert BackendConfig.normalize_backend_origin(raw_url) is None
+            assert BackendConfig.split_api_url(raw_url) == (None, None)
+
+        logged_text = "\n".join(caplog.messages)
+        assert raw_url not in logged_text
+        assert "tg_secret_backend_url" not in logged_text
 
 
 class TestBackendConfigDefaultBehavior:

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -76,7 +76,7 @@ class BackendConfig:
             parsed = urlparse(f"https://{parsed.path}")
 
         if not parsed.scheme or not parsed.netloc:
-            logger.warning("Failed to normalize backend origin from '%s'", value)
+            logger.warning("Failed to normalize configured backend origin")
             return None
 
         normalized = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
@@ -103,7 +103,7 @@ class BackendConfig:
             parsed = urlparse(f"https://{parsed.path}")
 
         if not parsed.scheme or not parsed.netloc:
-            logger.warning("Failed to parse backend url '%s'", value)
+            logger.warning("Failed to parse configured backend URL")
             return (None, None)
 
         origin = urlunparse((parsed.scheme, parsed.netloc, "", "", "", "")).rstrip("/")


### PR DESCRIPTION
## Summary
- stop logging raw invalid configured backend URLs on the develop train
- add a regression test for credential-bearing invalid URL values

## Verification
- pytest tests/unit/config/test_backend_config_stored_creds.py -q -n0 (25 passed)

## Production safety
- Policy surface: privacy/redaction in logging
- Fail-closed behavior: unchanged; invalid configured URLs still return None
- Schema/API changes: none
- Generated artifacts: none