### PR TITLE
chore(deps): gate Chroma integration extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ integrations = [
     "langchain-community>=0.3.27",
     "langchain-anthropic>=0.2.0",
     "langchain-openai>=1.1.14",  # GHSA-r7w7-9xr2-qq2r (SSRF) fix
-    "langchain-chroma>=0.2.5",
     "langchain-text-splitters>=0.3.8",  # Document chunking for RAG
     "langchain-google-genai>=2.1.4",  # Google Gemini support via LangChain
     "openai>=2.0.0",
@@ -88,6 +87,13 @@ integrations = [
     "boto3>=1.28.0",
     "botocore>=1.31.0",
     "faiss-cpu>=1.7.0; sys_platform != 'win32'",  # RAG vector search (not available on Windows)
+]
+
+# Chroma is explicit opt-in while chromadb has no patched release for
+# GHSA-f4j7-r4q5-qw2c / CVE-2026-45829. Do not add this to broad bundles until
+# the advisory publishes a first_patched_version and the lock resolves to it.
+chroma = [
+    "langchain-chroma>=0.2.5",
 ]
 
 # DSPy prompt optimization integration
@@ -209,16 +215,19 @@ cloud = [
 
 # Recommended bundle for end users — everything needed to run optimizations
 # out of the box without dev/test/docs overhead
+# Excludes chroma until chromadb has a patched release for CVE-2026-45829.
 recommended = [
     "traigent[integrations,analytics,bayesian,visualization,hybrid,pydanticai]",
 ]
 
 # All optional features combined (playground/examples moved to TraigentDemo)
+# Excludes chroma until chromadb has a patched release for CVE-2026-45829.
 all = [
     "traigent[analytics,bayesian,integrations,pydanticai,security,visualization,test,tracing,hybrid]"
 ]
 
 # Enterprise bundle with all features (playground/examples moved to TraigentDemo)
+# Excludes chroma until chromadb has a patched release for CVE-2026-45829.
 enterprise = [
     "traigent[analytics,bayesian,integrations,security,visualization,test,tracing,ml,cloud,hybrid]",
 ]

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -10,10 +10,11 @@ requirements/
 ├── requirements-analytics.txt    # Analytics and intelligence features
 ├── requirements-bayesian.txt     # Bayesian optimization (includes Optuna)
 ├── requirements-integrations.txt # Framework integrations (LangChain, OpenAI, etc.)
+├── requirements-chroma.txt       # Chroma integration, explicit opt-in
 ├── requirements-security.txt     # Enterprise security features
 ├── requirements-test.txt         # Testing dependencies
 ├── requirements-dev.txt          # Development tools + all features
-└── requirements-all.txt          # All optional features combined
+└── requirements-all.txt          # Safe broad optional features combined
 ```
 
 ## Installation Methods
@@ -33,9 +34,15 @@ pip install -r requirements/requirements-dev.txt
 ```bash
 pip install -e ".[test,dev,integrations,analytics,bayesian,security]"
 
-# Install everything
+# Install broad safe optional features
 pip install -e ".[all]"
+
+# Opt into Chroma explicitly
+pip install -e ".[chroma]"
 ```
+
+Chroma is not included in `integrations`, `recommended`, `all`, `enterprise`, or the broad
+requirements bundles while `chromadb` has no patched release for CVE-2026-45829.
 
 ## Recent Changes (2024-10-14)
 

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -1,5 +1,6 @@
 # Traigent SDK Complete Dependencies
 # All features and dependencies for full installation
+# Excludes Chroma until chromadb has a patched release for CVE-2026-45829.
 
 -r requirements.txt
 -r requirements-analytics.txt

--- a/requirements/requirements-chroma.txt
+++ b/requirements/requirements-chroma.txt
@@ -1,0 +1,6 @@
+# Traigent SDK Chroma integration dependencies
+# Opt-in only while chromadb has no patched release for CVE-2026-45829.
+
+-r requirements.txt
+
+langchain-chroma>=0.2.5

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,5 +1,6 @@
 # Traigent SDK Development Dependencies
 # Required for development and testing
+# Excludes Chroma until chromadb has a patched release for CVE-2026-45829.
 
 -r requirements.txt
 -r requirements-analytics.txt

--- a/requirements/requirements-integrations.txt
+++ b/requirements/requirements-integrations.txt
@@ -9,7 +9,6 @@ langchain-core>=1.2.28
 langchain-community>=0.3.27
 langchain-anthropic>=0.2.0
 langchain-openai>=1.1.14
-langchain-chroma>=0.2.5
 langchain-google-genai>=2.1.4
 openai>=2.0.0
 anthropic>=0.18.0

--- a/tests/unit/tools/test_chroma_extra_scope.py
+++ b/tests/unit/tools/test_chroma_extra_scope.py
@@ -1,0 +1,20 @@
+"""Packaging guard for the Chroma integration dependency scope."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_chroma_is_explicit_opt_in_extra_only() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text())
+    extras = pyproject["project"]["optional-dependencies"]
+
+    assert "chroma" in extras
+    assert any(dep.startswith("langchain-chroma") for dep in extras["chroma"])
+
+    broad_extras = {"integrations", "recommended", "all", "enterprise"}
+    for extra in broad_extras:
+        assert extra in extras
+        assert not any("chroma" in dep.lower() for dep in extras[extra])

--- a/traigent/utils/diagnostics.py
+++ b/traigent/utils/diagnostics.py
@@ -108,7 +108,6 @@ class TraigentDiagnostics:
         ("traigent", "Traigent SDK", None),
         ("langchain", "LangChain", "langchain"),
         ("langchain_openai", "LangChain OpenAI", "langchain-openai"),
-        ("langchain_chroma", "LangChain Chroma", "langchain-chroma"),
         ("openai", "OpenAI", "openai"),
         ("dotenv", "Python-dotenv", "python-dotenv"),
         ("numpy", "NumPy", "numpy"),
@@ -116,6 +115,7 @@ class TraigentDiagnostics:
     ]
 
     OPTIONAL_PACKAGES: list[tuple[str, str, str | None]] = [
+        ("langchain_chroma", "LangChain Chroma", "traigent[chroma]"),
         ("mlflow", "MLflow", "mlflow"),
         ("wandb", "Weights & Biases", "wandb"),
         ("streamlit", "Streamlit", "streamlit"),

--- a/traigent/utils/error_handler.py
+++ b/traigent/utils/error_handler.py
@@ -105,7 +105,7 @@ class ErrorHandler:
     IMPORT_FIXES = {
         "langchain": "pip install langchain",
         "langchain_openai": "pip install langchain-openai",
-        "langchain_chroma": "pip install langchain-chroma",
+        "langchain_chroma": "pip install 'traigent[chroma]'",
         "openai": "pip install openai",
         "dotenv": "pip install python-dotenv",
         "numpy": "pip install numpy",

--- a/uv.lock
+++ b/uv.lock
@@ -6105,7 +6105,6 @@ all = [
     { name = "hypothesis" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
-    { name = "langchain-chroma" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -6149,6 +6148,9 @@ analytics = [
 bayesian = [
     { name = "scikit-learn" },
     { name = "scipy" },
+]
+chroma = [
+    { name = "langchain-chroma" },
 ]
 cloud = [
     { name = "boto3" },
@@ -6206,7 +6208,6 @@ enterprise = [
     { name = "hypothesis" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
-    { name = "langchain-chroma" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -6256,7 +6257,6 @@ integrations = [
     { name = "groq" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
-    { name = "langchain-chroma" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -6296,7 +6296,6 @@ recommended = [
     { name = "httpx", extra = ["http2"] },
     { name = "langchain" },
     { name = "langchain-anthropic" },
-    { name = "langchain-chroma" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -6377,7 +6376,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0.0" },
     { name = "langchain", marker = "extra == 'integrations'", specifier = ">=0.0.200" },
     { name = "langchain-anthropic", marker = "extra == 'integrations'", specifier = ">=0.2.0" },
-    { name = "langchain-chroma", marker = "extra == 'integrations'", specifier = ">=0.2.5" },
+    { name = "langchain-chroma", marker = "extra == 'chroma'", specifier = ">=0.2.5" },
     { name = "langchain-community", marker = "extra == 'integrations'", specifier = ">=0.3.27" },
     { name = "langchain-core", marker = "extra == 'integrations'", specifier = ">=1.2.28" },
     { name = "langchain-google-genai", marker = "extra == 'integrations'", specifier = ">=2.1.4" },
@@ -6445,7 +6444,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'security'", specifier = ">=0.18.0" },
     { name = "wandb", marker = "extra == 'integrations'", specifier = ">=0.15.0" },
 ]
-provides-extras = ["analytics", "bayesian", "integrations", "dspy", "pydanticai", "security", "visualization", "hybrid", "mcp", "internal-schema", "test", "tracing", "dev", "docs", "ml", "deepeval", "cloud", "recommended", "all", "enterprise"]
+provides-extras = ["analytics", "bayesian", "integrations", "chroma", "dspy", "pydanticai", "security", "visualization", "hybrid", "mcp", "internal-schema", "test", "tracing", "dev", "docs", "ml", "deepeval", "cloud", "recommended", "all", "enterprise"]
 
 [[package]]
 name = "traigent-schema"


### PR DESCRIPTION
## Summary
- move `langchain-chroma` out of the broad `integrations`, `recommended`, `all`, and `enterprise` install paths into an explicit `chroma` extra
- add `requirements/requirements-chroma.txt` and update install hints so Chroma users opt in deliberately
- add a packaging regression test that prevents Chroma from re-entering broad bundles before upstream patches `chromadb`

## Security posture
This mitigates the Chroma alert by reducing default/broad install blast radius. It does not claim the upstream vulnerability is fixed. `chromadb` still has no patched version for GHSA-f4j7-r4q5-qw2c / CVE-2026-45829, and `uv.lock` still contains it because the explicit `chroma` extra remains available.

After merge, the Dependabot alert should be dismissed as risk-accepted / no-fix-available with this rationale: Traigent does not run or expose a Chroma server endpoint; Chroma is now explicit opt-in; restore broad inclusion only after the advisory publishes `first_patched_version` and the lock resolves to that patched release.

## Verification
- `uv lock`
- `uv run pytest tests/unit/tools/test_chroma_extra_scope.py tests/unit/tools/test_check_dep_floor_drift.py tests/unit/utils/test_error_handler.py tests/unit/utils/test_diagnostics.py -q -n0`
- `uv run python scripts/ci/check_dep_floor_drift.py`
- `uv run pytest tests/unit/integrations/test_plugin_registry_builtin_plugins.py tests/unit/integrations/test_vector_store_plugins.py -q -n0`
- `uv run ruff check tests/unit/tools/test_chroma_extra_scope.py traigent/utils/diagnostics.py traigent/utils/error_handler.py`
- `uv run black --check tests/unit/tools/test_chroma_extra_scope.py traigent/utils/diagnostics.py traigent/utils/error_handler.py`
- pre-commit on commit: isort, black, ruff, detect-secrets, bandit, mypy, TVL spec check, cost guardrails, public assertion contracts, dependency-floor drift
