### PR TITLE
chore(changelog): stamp 0.12.0 — 2026-06-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-06
+
 ### Added
 - **Content-logging opt-out for optimization logs** (#1069). `TRAIGENT_LOG_EXAMPLE_CONTENT=false`
   (or `OptimizationLogger(..., log_example_content=False)`) keeps per-trial ids and metrics on


### PR DESCRIPTION
0.12.0 shipped to PyPI (tag v0.12.0, GitHub Release published) but the changelog content was still under [Unreleased] — the v3+ promotions fast-forwarded develop, superseding the v2 resolver's stamp. Stamps the section; fresh [Unreleased] on top. Rides to main with the next promotion. 🤖 Generated with [Claude Code](https://claude.com/claude-code)