### PR TITLE
feat(knobs): composite-knob IR + pattern catalog v1 (RFC 0002 P5)

### DIFF
--- a/tests/unit/knobs/test_composites_model.py
+++ b/tests/unit/knobs/test_composites_model.py
@@ -726,7 +726,7 @@ class TestCalFoldBoundary:
         ens = CompositeNode(
             name="ens",
             kind=CompositeKind.ENSEMBLE,
-            ensemble=EnsembleBody(
+            body=EnsembleBody(
                 arms=(StageArm("a"),),
                 cardinality="k",
                 aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),

--- a/tests/unit/knobs/test_composites_model.py
+++ b/tests/unit/knobs/test_composites_model.py
@@ -716,3 +716,28 @@ class TestDerivedFunctions:
         prog = CompositeProgram(composites={"solo": node})
         validate_program(prog)
         assert cal_fold(prog) == frozenset()
+
+
+class TestCalFoldBoundary:
+    def test_cal_fold_never_returns_a_tuned_cardinality(self):
+        """Dual of the leafT boundary (codex delta round): with an EMPTY cvar
+        namespace the fold must STILL intersect — a tuned cardinality is a
+        leafT member (§3.5), never a Cal member (§3.6)."""
+        ens = CompositeNode(
+            name="ens",
+            kind=CompositeKind.ENSEMBLE,
+            ensemble=EnsembleBody(
+                arms=(StageArm("a"),),
+                cardinality="k",
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+            ),
+        )
+        prog = CompositeProgram(
+            composites={"ens": ens},
+            tvars=frozenset({"k"}),
+            tvar_types={"k": "int"},
+            cvars=frozenset(),
+        )
+        validate_program(prog)
+        assert "k" in leaf_tvars(prog, CompositeArm("ens"))
+        assert cal_fold(prog) == frozenset()

--- a/tests/unit/knobs/test_composites_model.py
+++ b/tests/unit/knobs/test_composites_model.py
@@ -24,6 +24,7 @@ from traigent.knobs.composites import (
     GateKind,
     LoopBody,
     Placement,
+    Scope,
     SignalUse,
     StageArm,
     StopDecl,
@@ -111,6 +112,59 @@ class TestNodeLocalRejections:
                 gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
             )
         assert _code(e) == "duplicate_stage"
+
+    def test_duplicate_stage_includes_ensemble_judge(self):
+        # F4b (§3.2 item 6): a judge stage that duplicates a committee arm is a
+        # duplicate WITHIN one composite — the judge is in the stage scope.
+        with pytest.raises(ValueError) as e:
+            EnsembleBody(
+                arms=(StageArm("a"), StageArm("b")),
+                aggregate=AggregateDecl(
+                    kind=AggregateKind.JUDGE_MAX, judge=StageArm("a")
+                ),
+            )
+        assert _code(e) == "duplicate_stage"
+
+    def test_sampling_ensemble_judge_duplicates_sole_arm(self):
+        # The single-arm (sampling) form, too: judge == the arm is a duplicate.
+        with pytest.raises(ValueError) as e:
+            EnsembleBody(
+                arms=(StageArm("a"),),
+                aggregate=AggregateDecl(
+                    kind=AggregateKind.JUDGE_MAX, judge=StageArm("a")
+                ),
+                cardinality="k",
+            )
+        assert _code(e) == "duplicate_stage"
+
+    def test_distinct_judge_stage_is_accepted(self):
+        # A judge with a DISTINCT name is well-formed (the happy path).
+        body = EnsembleBody(
+            arms=(StageArm("a"),),
+            aggregate=AggregateDecl(
+                kind=AggregateKind.JUDGE_MAX, judge=StageArm("judge")
+            ),
+            cardinality="k",
+        )
+        assert body.aggregate.judge == StageArm("judge")
+
+    def test_empty_external_accept_predicate_rejects(self):
+        # F5 (§3.11 missing_stop_predicate): an empty predicate identifier is a
+        # missing predicate, not a valid one (previously only None was caught).
+        with pytest.raises(ValueError) as e:
+            StopDecl(kind=StopKind.EXTERNAL_ACCEPT, predicate="")
+        assert _code(e) == "missing_stop_predicate"
+
+    def test_empty_signal_accept_threshold_rejects(self):
+        # F5 sweep: the same empty-string hole on the signal_accept threshold
+        # Ident — an empty threshold is a missing threshold.
+        with pytest.raises(ValueError) as e:
+            StopDecl(
+                kind=StopKind.SIGNAL_ACCEPT,
+                threshold="",
+                signal=SignalUse(signal="q"),
+            )
+        assert _code(e) == "missing_stop_threshold"
 
     def test_unknown_gate_kind(self):
         with pytest.raises(ValueError) as e:
@@ -237,6 +291,53 @@ class TestNodeLocalRejections:
         assert node.kind is CompositeKind.CASCADE
 
 
+class TestScopeCarryOver:
+    """F3 (§3.2 / §4): a composite carries the RFC 0001 scope_spec verbatim."""
+
+    def test_scope_optional_default_none(self):
+        node = _post_cascade()
+        assert node.scope is None
+
+    def test_scope_carried_verbatim(self):
+        # node/agent/workflow ownership fields, same shape as PolicyDecl.scope.
+        scope = Scope(node="n1", agent="agentA", workflow="wfX")
+        node = CompositeNode(
+            name="casc",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+            ),
+            scope=scope,
+        )
+        assert node.scope is scope
+        assert node.scope.node == "n1"
+        assert node.scope.agent == "agentA"
+        assert node.scope.workflow == "wfX"
+        # A program with a scoped composite still validates (scope is metadata).
+        validate_program(_program(node))
+
+    def test_scope_partial_fields(self):
+        # agent-only / workflow-only are expressible (RFC 0001 alternation).
+        assert Scope(agent="a").agent == "a"
+        assert Scope(workflow="w").node is None
+
+    def test_scope_empty_field_rejects(self):
+        with pytest.raises(ValueError) as e:
+            Scope(node="")
+        assert _code(e) == "invalid_arm_shape"
+
+    def test_non_scope_object_rejects(self):
+        with pytest.raises(ValueError) as e:
+            CompositeNode(
+                name="casc",
+                kind=CompositeKind.CASCADE,
+                body=CascadeBody(arms=(StageArm("a"),)),
+                scope="agentA",  # type: ignore[arg-type]
+            )
+        assert _code(e) == "unknown_composite_field"
+
+
 # --------------------------------------------------------------------------- #
 # Program-level (cross-composite) rejections                                  #
 # --------------------------------------------------------------------------- #
@@ -305,8 +406,8 @@ class TestProgramRejections:
             validate_program(_program(node, cvar_types={"theta": "string"}))
         assert _code(e) == "invalid_threshold_type"
 
-    def test_invalid_cardinality_type(self):
-        node = CompositeNode(
+    def _ensemble_cardinality(self) -> CompositeNode:
+        return CompositeNode(
             name="ens",
             kind=CompositeKind.ENSEMBLE,
             body=EnsembleBody(
@@ -315,10 +416,13 @@ class TestProgramRejections:
                 cardinality="k",
             ),
         )
+
+    def test_invalid_cardinality_type_cvar_float(self):
+        # §3.2 item 7: a CALIBRATED (CVAR) cardinality declared float, not int.
         with pytest.raises(ValueError) as e:
             validate_program(
                 _program(
-                    node,
+                    self._ensemble_cardinality(),
                     cvars=frozenset({"k"}),
                     cvar_types={"k": "float"},  # not int
                     cvar_signals={},
@@ -326,6 +430,38 @@ class TestProgramRejections:
                 )
             )
         assert _code(e) == "invalid_cardinality_type"
+
+    def test_invalid_cardinality_type_tvar_float(self):
+        # F2 (§3.2 item 7): a TUNED (TVAR) cardinality must ALSO be int-typed;
+        # a float TVAR cardinality rejects invalid_cardinality_type (previously
+        # any name in program.tvars was accepted unchecked).
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                _program(
+                    self._ensemble_cardinality(),
+                    tvars=frozenset({"k"}),
+                    tvar_types={"k": "float"},  # not int
+                    cvars=frozenset(),
+                    cvar_types={},
+                    cvar_signals={},
+                    cvar_depends_on={},
+                )
+            )
+        assert _code(e) == "invalid_cardinality_type"
+
+    def test_int_typed_tvar_cardinality_passes(self):
+        # An int-typed TVAR cardinality is well-formed (the happy path).
+        validate_program(
+            _program(
+                self._ensemble_cardinality(),
+                tvars=frozenset({"k"}),
+                tvar_types={"k": "int"},
+                cvars=frozenset(),
+                cvar_types={},
+                cvar_signals={},
+                cvar_depends_on={},
+            )
+        )
 
     def test_missing_calibration_signal(self):
         node = _post_cascade()
@@ -449,11 +585,11 @@ class TestProgramRejections:
 
 class TestDerivedFunctions:
     def test_leaf_tvars_of_stage(self):
-        registry: dict[str, CompositeNode] = {}
-        assert leaf_tvars(StageArm("a", ("m", "t")), registry) == frozenset({"m", "t"})
+        prog = CompositeProgram(composites={}, tvars=frozenset({"m", "t"}))
+        assert leaf_tvars(prog, StageArm("a", ("m", "t"))) == frozenset({"m", "t"})
 
     def test_leaf_tvars_folds_nested_sampling_cardinality(self):
-        # §3.5: a sampling ensemble whose tuned cardinality is k folds k into
+        # §3.5: a sampling ensemble whose TUNED cardinality is k folds k into
         # leafT, recursively through nesting.
         inner = CompositeNode(
             name="ens",
@@ -464,9 +600,33 @@ class TestDerivedFunctions:
                 cardinality="k",
             ),
         )
-        registry = {"ens": inner}
-        leaves = leaf_tvars(CompositeArm("ens"), registry)
+        prog = CompositeProgram(composites={"ens": inner}, tvars=frozenset({"m", "k"}))
+        leaves = leaf_tvars(prog, CompositeArm("ens"))
         assert leaves == frozenset({"m", "k"})
+
+    def test_leaf_tvars_public_never_returns_a_calibrated_cardinality(self):
+        # F1 (§3.5 / C6 / P5 boundary): when a sampling ensemble's cardinality
+        # is bound CALIBRATED (a CVAR, not a TVAR), the PUBLIC leaf_tvars must
+        # NOT fold it in — it is a Cal member, never a TVAR leaf. The stage's
+        # own tuned param stays.
+        inner = CompositeNode(
+            name="ens",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a", ("m",)),),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+                cardinality="kc",  # a CALIBRATED cardinality (in N_C, not N_T)
+            ),
+        )
+        prog = CompositeProgram(
+            composites={"ens": inner},
+            tvars=frozenset({"m"}),  # kc is NOT a TVAR
+            cvars=frozenset({"kc"}),
+        )
+        # The calibrated cardinality kc is intersected out of the leaf set ...
+        assert leaf_tvars(prog, CompositeArm("ens")) == frozenset({"m"})
+        # ... but it IS a Cal-fold member (still certificate-covered, §3.6).
+        assert "kc" in cal_fold(prog)
 
     def test_required_parents_post_cascade_prefix_union(self):
         node = CompositeNode(

--- a/tests/unit/knobs/test_composites_model.py
+++ b/tests/unit/knobs/test_composites_model.py
@@ -1,0 +1,558 @@
+"""Composite IR model tests (RFC 0002 P5, §3.2/§3.5/§3.6/§3.11).
+
+Red-first: every structural rejection is asserted by its EXACT §3.11
+error-code message prefix (``code: detail``), so the test pins the diagnostic
+contract, never just "some ValueError". The derived functions ``leaf_tvars``,
+``required_parents``, ``cal_fold``, and ``roots`` are pinned against the §3.5 /
+§3.6 definitions including the sampling-ensemble tuned-cardinality term.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.knobs.composites import (
+    AggregateDecl,
+    AggregateKind,
+    CascadeBody,
+    CompositeArm,
+    CompositeKind,
+    CompositeNode,
+    CompositeProgram,
+    EnsembleBody,
+    GateDecl,
+    GateKind,
+    LoopBody,
+    Placement,
+    SignalUse,
+    StageArm,
+    StopDecl,
+    StopKind,
+    cal_fold,
+    leaf_tvars,
+    required_parents,
+    roots,
+    validate_program,
+)
+
+
+def _code(excinfo: pytest.ExceptionInfo[ValueError]) -> str:
+    """The §3.11 code prefix of a rejection message (text before the colon)."""
+    return str(excinfo.value).split(":", 1)[0]
+
+
+def _post_cascade(threshold: str = "theta") -> CompositeNode:
+    return CompositeNode(
+        name="casc",
+        kind=CompositeKind.CASCADE,
+        body=CascadeBody(
+            arms=(StageArm("a"), StageArm("b")),
+            gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold=threshold),),
+            placement=Placement.POST,
+        ),
+    )
+
+
+def _program(node: CompositeNode, **ns) -> CompositeProgram:
+    base = {
+        "composites": {node.name: node},
+        "tvars": frozenset(),
+        "cvars": frozenset({"theta"}),
+        "cvar_types": {"theta": "float"},
+        "cvar_signals": {"theta": "vote_margin"},
+        "cvar_depends_on": {"theta": frozenset()},
+        "cvar_signal_inputs": {},
+    }
+    base.update(ns)
+    return CompositeProgram(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Node-local rejections (checked on construction)                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestNodeLocalRejections:
+    def test_unknown_composite_kind(self):
+        with pytest.raises(ValueError) as e:
+            CompositeNode(name="x", kind="quantum", body=CascadeBody(arms=(StageArm("a"),)))  # type: ignore[arg-type]
+        assert _code(e) == "unknown_composite_kind"
+
+    def test_unknown_composite_field_kind_body_mismatch(self):
+        with pytest.raises(ValueError) as e:
+            CompositeNode(
+                name="x",
+                kind=CompositeKind.LOOP,
+                body=CascadeBody(arms=(StageArm("a"),)),
+            )
+        assert _code(e) == "unknown_composite_field"
+
+    def test_cascade_arity(self):
+        with pytest.raises(ValueError) as e:
+            CascadeBody(arms=(StageArm("a"), StageArm("b")), gates=())
+        assert _code(e) == "cascade_arity"
+
+    def test_empty_arms(self):
+        with pytest.raises(ValueError) as e:
+            CascadeBody(arms=())
+        assert _code(e) == "empty_arms"
+
+    def test_empty_arms_ensemble(self):
+        with pytest.raises(ValueError) as e:
+            EnsembleBody(
+                arms=(), aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE)
+            )
+        assert _code(e) == "empty_arms"
+
+    def test_duplicate_stage(self):
+        with pytest.raises(ValueError) as e:
+            CascadeBody(
+                arms=(StageArm("a"), StageArm("a")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+            )
+        assert _code(e) == "duplicate_stage"
+
+    def test_unknown_gate_kind(self):
+        with pytest.raises(ValueError) as e:
+            GateDecl(kind="signal_above", threshold="theta")  # type: ignore[arg-type]
+        assert _code(e) == "unknown_gate_kind"
+
+    def test_missing_gate_signal(self):
+        with pytest.raises(ValueError) as e:
+            GateDecl(kind=GateKind.SIGNAL_BELOW, threshold="theta")
+        assert _code(e) == "missing_gate_signal"
+
+    def test_gate_kind_placement_mismatch_margin_in_pre(self):
+        with pytest.raises(ValueError) as e:
+            CascadeBody(
+                arms=(StageArm("a"), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+                placement=Placement.PRE,
+            )
+        assert _code(e) == "gate_kind_placement_mismatch"
+
+    def test_gate_kind_placement_mismatch_signal_in_post(self):
+        with pytest.raises(ValueError) as e:
+            CascadeBody(
+                arms=(StageArm("a"), StageArm("b")),
+                gates=(
+                    GateDecl(
+                        kind=GateKind.SIGNAL_BELOW,
+                        threshold="theta",
+                        signal=SignalUse(signal="router_sig"),
+                    ),
+                ),
+                placement=Placement.POST,
+            )
+        assert _code(e) == "gate_kind_placement_mismatch"
+
+    def test_cardinality_arity_mismatch_missing_on_single_arm(self):
+        with pytest.raises(ValueError) as e:
+            EnsembleBody(
+                arms=(StageArm("a"),),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+            )
+        assert _code(e) == "cardinality_arity_mismatch"
+
+    def test_cardinality_arity_mismatch_present_on_committee(self):
+        with pytest.raises(ValueError) as e:
+            EnsembleBody(
+                arms=(StageArm("a"), StageArm("b")),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+                cardinality="k",
+            )
+        assert _code(e) == "cardinality_arity_mismatch"
+
+    def test_invalid_max_iters(self):
+        with pytest.raises(ValueError) as e:
+            LoopBody(
+                body=StageArm("a"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                max_iters=0,
+            )
+        assert _code(e) == "invalid_max_iters"
+
+    def test_stop_signal_outside_state(self):
+        with pytest.raises(ValueError) as e:
+            LoopBody(
+                body=StageArm("a"),
+                stop=StopDecl(
+                    kind=StopKind.SIGNAL_ACCEPT,
+                    threshold="theta",
+                    signal=SignalUse(signal="q", inputs=("not_a_state_key",)),
+                ),
+                state_keys=("draft",),
+                max_iters=2,
+            )
+        assert _code(e) == "stop_signal_outside_state"
+
+    def test_missing_stop_threshold(self):
+        with pytest.raises(ValueError) as e:
+            StopDecl(kind=StopKind.SIGNAL_ACCEPT, signal=SignalUse(signal="q"))
+        assert _code(e) == "missing_stop_threshold"
+
+    def test_missing_stop_signal(self):
+        with pytest.raises(ValueError) as e:
+            StopDecl(kind=StopKind.SIGNAL_ACCEPT, threshold="theta")
+        assert _code(e) == "missing_stop_signal"
+
+    def test_missing_stop_predicate(self):
+        with pytest.raises(ValueError) as e:
+            StopDecl(kind=StopKind.EXTERNAL_ACCEPT)
+        assert _code(e) == "missing_stop_predicate"
+
+    def test_unknown_stop_kind(self):
+        with pytest.raises(ValueError) as e:
+            StopDecl(kind="give_up")  # type: ignore[arg-type]
+        assert _code(e) == "unknown_stop_kind"
+
+    def test_missing_judge(self):
+        with pytest.raises(ValueError) as e:
+            AggregateDecl(kind=AggregateKind.JUDGE_MAX)
+        assert _code(e) == "missing_judge"
+
+    def test_unknown_aggregate_kind(self):
+        with pytest.raises(ValueError) as e:
+            AggregateDecl(kind="weighted_mean")  # type: ignore[arg-type]
+        assert _code(e) == "unknown_aggregate_kind"
+
+    def test_invalid_signal_use_missing_signal(self):
+        with pytest.raises(ValueError) as e:
+            SignalUse(signal="")
+        assert _code(e) == "invalid_signal_use"
+
+    def test_invalid_signal_use_non_tuple_inputs(self):
+        with pytest.raises(ValueError) as e:
+            SignalUse(signal="q", inputs=["a"])  # type: ignore[arg-type]
+        assert _code(e) == "invalid_signal_use"
+
+    def test_invalid_arm_shape_bad_tuned_params(self):
+        with pytest.raises(ValueError) as e:
+            StageArm("a", tuned_params=("ok", ""))
+        assert _code(e) == "invalid_arm_shape"
+
+    def test_gate_arm_incompatible_stage_case_is_accepted(self):
+        # A stage arm IS margin-bearing — post + margin_below over a stage is OK.
+        node = _post_cascade()
+        assert node.kind is CompositeKind.CASCADE
+
+
+# --------------------------------------------------------------------------- #
+# Program-level (cross-composite) rejections                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestProgramRejections:
+    def test_missing_composite_ref(self):
+        loop = CompositeNode(
+            name="L",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=CompositeArm("ghost"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                max_iters=2,
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(CompositeProgram(composites={"L": loop}))
+        assert _code(e) == "missing_composite_ref"
+
+    def test_composite_cycle(self):
+        a = CompositeNode(
+            name="A",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=CompositeArm("B"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                max_iters=2,
+            ),
+        )
+        b = CompositeNode(
+            name="B",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=CompositeArm("A"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                max_iters=2,
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(CompositeProgram(composites={"A": a, "B": b}))
+        assert _code(e) == "composite_cycle"
+
+    def test_invalid_tuned_param(self):
+        node = CompositeNode(
+            name="casc",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a", ("ghost_tvar",)), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(node))  # tvars is empty -> ghost_tvar unknown
+        assert _code(e) == "invalid_tuned_param"
+
+    def test_missing_ref_threshold_not_a_cvar(self):
+        node = _post_cascade(threshold="not_declared")
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(node))
+        assert _code(e) == "missing_ref"
+
+    def test_invalid_threshold_type(self):
+        node = _post_cascade()
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(node, cvar_types={"theta": "string"}))
+        assert _code(e) == "invalid_threshold_type"
+
+    def test_invalid_cardinality_type(self):
+        node = CompositeNode(
+            name="ens",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a"),),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+                cardinality="k",
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                _program(
+                    node,
+                    cvars=frozenset({"k"}),
+                    cvar_types={"k": "float"},  # not int
+                    cvar_signals={},
+                    cvar_depends_on={},
+                )
+            )
+        assert _code(e) == "invalid_cardinality_type"
+
+    def test_missing_calibration_signal(self):
+        node = _post_cascade()
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(node, cvar_signals={"theta": None}))
+        assert _code(e) == "missing_calibration_signal"
+
+    def test_signal_mismatch(self):
+        node = _post_cascade()
+        with pytest.raises(ValueError) as e:
+            # margin_below determines sig=vote_margin; declaring a different one rejects.
+            validate_program(_program(node, cvar_signals={"theta": "other_signal"}))
+        assert _code(e) == "signal_mismatch"
+
+    def test_unbound_signal_inputs(self):
+        node = CompositeNode(
+            name="L",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=StageArm("a"),
+                stop=StopDecl(
+                    kind=StopKind.SIGNAL_ACCEPT,
+                    threshold="theta",
+                    signal=SignalUse(signal="q", inputs=("draft",)),
+                ),
+                state_keys=("draft",),
+                max_iters=2,
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                _program(
+                    node,
+                    cvar_signals={"theta": "q"},
+                    cvar_signal_inputs={},  # inputs not covered
+                )
+            )
+        assert _code(e) == "unbound_signal_inputs"
+
+    def test_gate_arm_incompatible_nested_pre_cascade(self):
+        # A margin_below gate gating a nested PRE-cascade composite (yields a
+        # route, not a vote margin) is incompatible (item 5).
+        inner = CompositeNode(
+            name="inner",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("p"), StageArm("q")),
+                gates=(
+                    GateDecl(
+                        kind=GateKind.SIGNAL_BELOW,
+                        threshold="route_t",
+                        signal=SignalUse(signal="route_sig"),
+                    ),
+                ),
+                placement=Placement.PRE,
+            ),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(CompositeArm("inner"), StageArm("z")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+                placement=Placement.POST,
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                CompositeProgram(
+                    composites={"inner": inner, "outer": outer},
+                    cvars=frozenset({"theta", "route_t"}),
+                    cvar_types={"theta": "float", "route_t": "float"},
+                    cvar_signals={"theta": "vote_margin", "route_t": "route_sig"},
+                    cvar_depends_on={"theta": frozenset(), "route_t": frozenset()},
+                )
+            )
+        assert _code(e) == "gate_arm_incompatible"
+
+    def test_missing_composite_parent(self):
+        # A stage declares tuned_params [m]; the gate over it must depend_on m.
+        node = CompositeNode(
+            name="casc",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a", ("m",)), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+            ),
+        )
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                _program(
+                    node,
+                    tvars=frozenset({"m"}),
+                    cvar_depends_on={"theta": frozenset()},  # missing m
+                )
+            )
+        assert _code(e) == "missing_composite_parent"
+
+    def test_parent_coverage_satisfied_passes(self):
+        node = CompositeNode(
+            name="casc",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a", ("m",)), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="theta"),),
+            ),
+        )
+        validate_program(
+            _program(
+                node,
+                tvars=frozenset({"m"}),
+                cvar_depends_on={"theta": frozenset({"m"})},
+            )
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Derived functions (§3.5 leafT / required_parents, §3.6 Cal/roots)           #
+# --------------------------------------------------------------------------- #
+
+
+class TestDerivedFunctions:
+    def test_leaf_tvars_of_stage(self):
+        registry: dict[str, CompositeNode] = {}
+        assert leaf_tvars(StageArm("a", ("m", "t")), registry) == frozenset({"m", "t"})
+
+    def test_leaf_tvars_folds_nested_sampling_cardinality(self):
+        # §3.5: a sampling ensemble whose tuned cardinality is k folds k into
+        # leafT, recursively through nesting.
+        inner = CompositeNode(
+            name="ens",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a", ("m",)),),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+                cardinality="k",
+            ),
+        )
+        registry = {"ens": inner}
+        leaves = leaf_tvars(CompositeArm("ens"), registry)
+        assert leaves == frozenset({"m", "k"})
+
+    def test_required_parents_post_cascade_prefix_union(self):
+        node = CompositeNode(
+            name="casc",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a", ("m1",)), StageArm("b", ("m2",)), StageArm("c")),
+                gates=(
+                    GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t1"),
+                    GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t2"),
+                ),
+            ),
+        )
+        prog = CompositeProgram(
+            composites={"casc": node}, tvars=frozenset({"m1", "m2"})
+        )
+        rp = required_parents(prog, node)
+        # θ_1 covers leafT(a_1); θ_2 covers leafT(a_1) ∪ leafT(a_2).
+        assert rp["t1"] == frozenset({"m1"})
+        assert rp["t2"] == frozenset({"m1", "m2"})
+
+    def test_cal_fold_collects_gate_thresholds_over_roots(self):
+        casc = _post_cascade()
+        prog = _program(casc)
+        assert cal_fold(prog) == frozenset({"theta"})
+
+    def test_cal_fold_descends_into_nested_judge_and_accept(self):
+        inner = CompositeNode(
+            name="best",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a"),),
+                aggregate=AggregateDecl(
+                    kind=AggregateKind.JUDGE_MAX, judge=StageArm("judge")
+                ),
+                cardinality="kc",  # a CALIBRATED cardinality -> a Cal member
+            ),
+        )
+        outer = CompositeNode(
+            name="loop",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=CompositeArm("best"),
+                stop=StopDecl(
+                    kind=StopKind.SIGNAL_ACCEPT,
+                    threshold="stop_t",
+                    signal=SignalUse(signal="q"),
+                ),
+                max_iters=2,
+            ),
+        )
+        prog = CompositeProgram(
+            composites={"best": inner, "loop": outer},
+            cvars=frozenset({"kc", "stop_t"}),
+        )
+        # roots = {loop} (best is nested); Cal folds the loop stop threshold +
+        # the nested ensemble's calibrated cardinality.
+        assert roots(prog) == frozenset({"loop"})
+        assert cal_fold(prog) == frozenset({"kc", "stop_t"})
+
+    def test_roots_excludes_nested_composites(self):
+        inner = CompositeNode(
+            name="inner",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=StageArm("a"), stop=StopDecl(kind=StopKind.EXHAUSTED), max_iters=1
+            ),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=CompositeArm("inner"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                max_iters=1,
+            ),
+        )
+        prog = CompositeProgram(composites={"inner": inner, "outer": outer})
+        assert roots(prog) == frozenset({"outer"})
+
+    def test_m1_degenerate_cascade_no_gates(self):
+        node = CompositeNode(
+            name="solo",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("only"),), gates=()),
+        )
+        prog = CompositeProgram(composites={"solo": node})
+        validate_program(prog)
+        assert cal_fold(prog) == frozenset()

--- a/tests/unit/knobs/test_pattern_factories.py
+++ b/tests/unit/knobs/test_pattern_factories.py
@@ -1,0 +1,469 @@
+"""Pattern catalog v1 tests (RFC 0002 P5, §3.7/§3.8/§3.10).
+
+Four admission-contract obligations are exercised here:
+
+(a) GOLDEN EXPANSION — a byte-stable canonical serialization (``_node_to_dict``
+    + ``canonical_hash``) of each factory's expansion, pinned as a known-answer
+    constant; the same hash must reproduce across runs (determinism, §3.7
+    admission item 5);
+(b) the P8 CANARY — a sentinel string passed as a pattern param must NEVER
+    appear in the serialized provenance/IR (only ``param_hash`` rides; §3.7,
+    §7);
+(c) FAIL-CLOSED coverage — a composite whose gate-threshold CVAR lacks a
+    CERTIFIED certificate yields a non-empty coverage gap from a ``cal_fold``
+    walk; issuing a real certificate (the resolver-test fixture style) closes
+    it (§3.6 fold, admission item 6);
+(d) UNROLL — ``self_refine.unroll(3)`` golden K-chain; ``self_debug.unroll``
+    raises (§3.8).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from traigent.api.parameter_ranges import Choices
+from traigent.knobs import (
+    Calibrated,
+    CertificateDecision,
+    Fixed,
+    FreshnessContext,
+    Knob,
+    Ref,
+    SignalSpec,
+    TargetProperty,
+    Tuned,
+    canonical_hash,
+    issue_certificate,
+)
+from traigent.knobs.composites import (
+    CascadeBody,
+    CompositeArm,
+    CompositeProgram,
+    EnsembleBody,
+    LoopBody,
+    StageArm,
+    cal_fold,
+)
+from traigent.knobs.patterns import (
+    best_of_n,
+    binary_cascade,
+    n_cascade,
+    self_consistency,
+    self_debug,
+    self_refine,
+)
+
+# --------------------------------------------------------------------------- #
+# Byte-stable serializer (the golden-expansion oracle)                        #
+# --------------------------------------------------------------------------- #
+
+
+def _arm_to_dict(arm):
+    if isinstance(arm, StageArm):
+        return {
+            "tag": "stage",
+            "name": arm.name,
+            "tuned_params": list(arm.tuned_params),
+        }
+    if isinstance(arm, CompositeArm):
+        return {"tag": "composite", "ref": arm.ref}
+    raise TypeError(f"unknown arm type: {type(arm).__name__}")
+
+
+def _sig_to_dict(sig):
+    if sig is None:
+        return None
+    return {"signal": sig.signal, "inputs": list(sig.inputs)}
+
+
+def _prov_to_dict(prov):
+    if prov is None:
+        return None
+    return {
+        "pattern": prov.pattern,
+        "pattern_version": prov.pattern_version,
+        "param_hash": prov.param_hash,
+        "node_path": prov.node_path,
+    }
+
+
+def _body_to_dict(body):
+    if isinstance(body, CascadeBody):
+        return {
+            "type": "cascade",
+            "placement": body.placement.value,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "gates": [
+                {
+                    "kind": g.kind.value,
+                    "threshold": g.threshold,
+                    "signal": _sig_to_dict(g.signal),
+                }
+                for g in body.gates
+            ],
+        }
+    if isinstance(body, EnsembleBody):
+        agg = body.aggregate
+        return {
+            "type": "ensemble",
+            "cardinality": body.cardinality,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "aggregate": {
+                "kind": agg.kind.value,
+                "judge": _arm_to_dict(agg.judge) if agg.judge is not None else None,
+                "accept": (
+                    {
+                        "kind": agg.accept.kind,
+                        "stat": agg.accept.stat.value,
+                        "threshold": agg.accept.threshold,
+                    }
+                    if agg.accept is not None
+                    else None
+                ),
+            },
+        }
+    if isinstance(body, LoopBody):
+        return {
+            "type": "loop",
+            "body": _arm_to_dict(body.body),
+            "state_keys": list(body.state_keys),
+            "max_iters": body.max_iters,
+            "stop": {
+                "kind": body.stop.kind.value,
+                "threshold": body.stop.threshold,
+                "signal": _sig_to_dict(body.stop.signal),
+                "predicate": body.stop.predicate,
+            },
+        }
+    raise TypeError(f"unknown body type: {type(body).__name__}")
+
+
+def _node_to_dict(node):
+    return {
+        "name": node.name,
+        "kind": node.kind.value,
+        "body": _body_to_dict(node.body),
+        "provenance": _prov_to_dict(node.provenance),
+    }
+
+
+def _golden_hash(node) -> str:
+    return canonical_hash(_node_to_dict(node))
+
+
+# Canonical factory invocations used by the golden tests below.
+def _bc():
+    return binary_cascade(
+        "answerer",
+        base_stage="cheap",
+        expert_stage="strong",
+        threshold="router.margin",
+        base_tuned_params=("cheap_model", "temperature"),
+        expert_tuned_params=("strong_model",),
+    )
+
+
+def _nc():
+    return n_cascade(
+        "chain",
+        stages=("a", "b", "c"),
+        thresholds=("t1", "t2"),
+        tuned_params=(("m1",), ("m2",), ()),
+    )
+
+
+def _sc():
+    return self_consistency(
+        "sc",
+        stage="gen",
+        cardinality="k",
+        accept_threshold="acc_t",
+        stage_tuned_params=("m",),
+    )
+
+
+def _bon():
+    return best_of_n("bon", stage="gen", judge_stage="judge", cardinality="k")
+
+
+def _sd():
+    return self_debug("coder", stage="gen", predicate="run_tests", max_iters=3)
+
+
+def _sr():
+    return self_refine(
+        "refiner",
+        stage="gen",
+        signal="quality",
+        threshold="stop_t",
+        max_iters=4,
+        state_keys=("draft",),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# (a) Golden expansion known-answers                                          #
+# --------------------------------------------------------------------------- #
+
+# NOTE: these are deterministic SHA-256 known-answer fixtures over the IR
+# expansion (the §3.7 golden tests), NOT secrets — detect-secrets flags them as
+# high-entropy hex, so each carries an allowlist pragma.
+GOLDEN = {
+    "binary_cascade": "353abb8c42b5fab1f32738ec4f0fca76215f4fc7122e6dd9363e11d1389cd055",  # pragma: allowlist secret
+    "n_cascade": "52c8ace634c47ad28768e67ddb4b05d7a054d7febd82f0c3c678b1b766e42849",  # pragma: allowlist secret
+    "self_consistency": "18f0c814758112bed8ad3a9817c864420aa5a0d6d4f2d474a5529ae18f7b513d",  # pragma: allowlist secret
+    "best_of_n": "a0e959620ca6c58099f2fa53762530f565446348ba3045edf23cdbf9b8b7fbae",  # pragma: allowlist secret
+    "self_debug": "c816be0383cdf46b81aa6ca4bdea27070503d062580cf46c7832685e0c94e979",  # pragma: allowlist secret
+    "self_refine": "00e7ef9438a34f6347b7d894d900a147e5cd0ff95e45ae1779bf60c754512fa4",  # pragma: allowlist secret
+}
+
+
+class TestGoldenExpansion:
+    @pytest.mark.parametrize(
+        "name,factory",
+        [
+            ("binary_cascade", _bc),
+            ("n_cascade", _nc),
+            ("self_consistency", _sc),
+            ("best_of_n", _bon),
+            ("self_debug", _sd),
+            ("self_refine", _sr),
+        ],
+    )
+    def test_golden_hash_pinned(self, name, factory):
+        assert _golden_hash(factory().structure) == GOLDEN[name]
+
+    def test_expansion_is_deterministic_across_two_builds(self):
+        # §3.7 admission item 5: expand is a pure, total function of validated
+        # params — two builds yield byte-identical expansions.
+        assert _golden_hash(_bc().structure) == _golden_hash(_bc().structure)
+        assert _golden_hash(_sr().structure) == _golden_hash(_sr().structure)
+
+    def test_telemetry_names_per_kind(self):
+        assert _bc().telemetry_names == (
+            "escalation_rate",
+            "stage_selected",
+            "gate_margin_pass_rate",
+        )
+        assert _bon().telemetry_names == (
+            "vote_agreement",
+            "vote_margin",
+            "candidates_evaluated",
+            "candidates_excluded",
+        )
+        assert _sr().telemetry_names == ("iterations_used", "stop_reason")
+
+    def test_provenance_pattern_name_stamped(self):
+        assert _bc().structure.provenance.pattern == "binary_cascade"
+        assert _sr().structure.provenance.pattern == "self_refine"
+
+
+# --------------------------------------------------------------------------- #
+# (b) The P8 canary                                                           #
+# --------------------------------------------------------------------------- #
+
+_SENTINEL = "SECRET-CANARY-d4f1c0de-leak-detector"
+
+
+class TestP8Canary:
+    def test_sentinel_param_never_appears_in_serialized_provenance(self):
+        # The sentinel rides in a pattern param (a stage name + a tuned param);
+        # only its canonical HASH may appear in provenance, never the raw value.
+        ck = binary_cascade(
+            "answerer",
+            base_stage=_SENTINEL,
+            expert_stage="strong",
+            threshold=_SENTINEL + "_cvar",
+            base_tuned_params=(_SENTINEL + "_tvar",),
+        )
+        # The serialized PROVENANCE blob must not contain the sentinel string;
+        # the closed shape carries only identifiers + the param hash.
+        prov_blob = json.dumps(_prov_to_dict(ck.structure.provenance), sort_keys=True)
+        assert _SENTINEL not in prov_blob
+        # The full IR node serialization is allowed to carry structural
+        # identifiers (stage names are content-free ids); but PROVENANCE never
+        # carries the raw param — param_hash is present and is a hash.
+        assert ck.structure.provenance.param_hash is not None
+        assert _SENTINEL not in ck.structure.provenance.param_hash
+        # canonical_hash of the provenance succeeds (closed, hashable shape).
+        assert canonical_hash(_prov_to_dict(ck.structure.provenance))
+
+    def test_param_hash_changes_with_params_but_stays_content_free(self):
+        a = binary_cascade(
+            "x", base_stage="cheap", expert_stage="strong", threshold="t"
+        ).structure.provenance.param_hash
+        b = binary_cascade(
+            "x", base_stage="OTHER", expert_stage="strong", threshold="t"
+        ).structure.provenance.param_hash
+        assert a != b  # the hash is sensitive to params
+        assert "cheap" not in a and "OTHER" not in b  # but never reveals them
+
+
+# --------------------------------------------------------------------------- #
+# (c) Fail-closed coverage under the §3.6 fold                                #
+# --------------------------------------------------------------------------- #
+
+
+def _signal_spec() -> SignalSpec:
+    return SignalSpec(
+        name="vote_margin",
+        version="1",
+        score_function="exact_match",
+        score_function_version="1",
+        comparator="key_eq",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="margin_floor", mode="require_calibration")
+
+
+def _ctx(cvar: str) -> FreshnessContext:
+    return FreshnessContext(
+        cvar_name=cvar,
+        tuned_parent_values=(),
+        calibration_source_id="pool_a",
+        signal_spec_hash=_signal_spec().spec_hash(),
+        calibrator_id="budget_threshold",
+        calibrator_version="1",
+        calibrator_params_hash=canonical_hash({}),
+        dataset_hash="ds_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target=_target(),
+    )
+
+
+def _coverage_gap(
+    program: CompositeProgram, certified: dict[str, object]
+) -> frozenset[str]:
+    """The §3.6 fold made operational: the member CVARs whose certificate is
+    absent or not CERTIFIED. A non-empty result is a fail-closed gap (no
+    certified selection)."""
+    needed = cal_fold(program)
+    covered = {
+        cvar
+        for cvar, cert in certified.items()
+        if cert is not None and cert.valid_for(cvar, "float", 0.5, _ctx(cvar))
+    }
+    return frozenset(needed - covered)
+
+
+class TestFailClosedCoverage:
+    def test_uncertified_gate_threshold_yields_coverage_gap(self):
+        ck = binary_cascade(
+            "answerer", base_stage="cheap", expert_stage="strong", threshold="theta"
+        )
+        program = CompositeProgram(
+            composites={"answerer": ck.structure},
+            cvars=frozenset({"theta"}),
+            cvar_types={"theta": "float"},
+            cvar_signals={"theta": "vote_margin"},
+            cvar_depends_on={"theta": frozenset()},
+        )
+        # No certificate issued -> the fold reports theta as an uncertified gap.
+        gap = _coverage_gap(program, certified={"theta": None})
+        assert gap == frozenset({"theta"})  # fail-closed: non-empty gap
+
+    def test_certified_gate_threshold_closes_the_gap(self):
+        ck = binary_cascade(
+            "answerer", base_stage="cheap", expert_stage="strong", threshold="theta"
+        )
+        program = CompositeProgram(
+            composites={"answerer": ck.structure},
+            cvars=frozenset({"theta"}),
+            cvar_types={"theta": "float"},
+            cvar_signals={"theta": "vote_margin"},
+            cvar_depends_on={"theta": frozenset()},
+        )
+        # Issue a REAL certificate for theta (resolver-test fixture style).
+        cert = issue_certificate("theta", "float", 0.5, _ctx("theta"))
+        assert cert.decision is CertificateDecision.CERTIFIED
+        gap = _coverage_gap(program, certified={"theta": cert})
+        assert gap == frozenset()  # positive case: fully covered
+
+    def test_members_dict_carries_real_bindings_not_composites(self):
+        # The catalog returns DECLARATIONS: members are Tuned/Calibrated/Fixed
+        # Knobs the caller spreads in — a composite never binds a value.
+        theta = Knob(
+            name="theta",
+            binding=Calibrated(
+                signal=_signal_spec(),
+                target=_target(),
+                depends_on=(Ref(knob="cheap_model"),),
+            ),
+        )
+        cheap_model = Knob(name="cheap_model", binding=Tuned(range=Choices(["a", "b"])))
+        seed = Knob(name="seed", binding=Fixed(value=7))
+        ck = binary_cascade(
+            "answerer",
+            base_stage="cheap",
+            expert_stage="strong",
+            threshold="theta",
+            base_tuned_params=("cheap_model",),
+            members={"theta": theta, "cheap_model": cheap_model, "seed": seed},
+        )
+        assert ck.members["theta"].is_calibrated()
+        assert ck.members["cheap_model"].is_tuned()
+        assert ck.members["seed"].is_fixed()
+
+
+# --------------------------------------------------------------------------- #
+# (d) Unroll (§3.8)                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class TestUnroll:
+    def test_self_refine_unroll_golden(self):
+        chain = _sr().unroll(3)
+        assert chain.signal == "quality"
+        assert chain.threshold == "stop_t"
+        assert chain.state_keys == ("draft",)
+        assert len(chain.stages) == 3
+        # Each stage escalates on the acceptance-direction complement σ < θ.
+        assert [s.index for s in chain.stages] == [1, 2, 3]
+        assert chain.stages[0].escalate_when == "quality(state_1) < stop_t"
+        assert chain.stages[2].escalate_when == "quality(state_3) < stop_t"
+        # Byte-stable golden over the chain stage descriptors (known-answer).
+        chain_blob = canonical_hash(
+            [
+                {
+                    "index": s.index,
+                    "escalate_when": s.escalate_when,
+                    "body": s.body.name,
+                }
+                for s in chain.stages
+            ]
+        )
+        # Deterministic known-answer over the K-chain stage descriptors.
+        assert (
+            chain_blob
+            == "be1d95f953848df99bbd6972a5ab85b08f13b306782f67732f9d4ae8bbc16908"  # pragma: allowlist secret
+        )
+
+    def test_self_refine_unroll_is_deterministic(self):
+        def blob():
+            return canonical_hash(
+                [
+                    {"index": s.index, "escalate_when": s.escalate_when}
+                    for s in _sr().unroll(3).stages
+                ]
+            )
+
+        assert blob() == blob()
+
+    def test_self_debug_unroll_raises(self):
+        with pytest.raises(ValueError, match="signal_accept"):
+            _sd().unroll(3)
+
+    def test_non_loop_unroll_raises(self):
+        with pytest.raises(ValueError, match="loop composites"):
+            _bc().unroll(2)
+
+    def test_unroll_k_must_be_positive(self):
+        with pytest.raises(ValueError, match="K must be >= 1"):
+            _sr().unroll(0)

--- a/tests/unit/knobs/test_pattern_factories.py
+++ b/tests/unit/knobs/test_pattern_factories.py
@@ -89,6 +89,12 @@ def _prov_to_dict(prov):
     }
 
 
+def _scope_to_dict(scope):
+    if scope is None:
+        return None
+    return {"node": scope.node, "agent": scope.agent, "workflow": scope.workflow}
+
+
 def _body_to_dict(body):
     if isinstance(body, CascadeBody):
         return {
@@ -145,6 +151,7 @@ def _node_to_dict(node):
         "name": node.name,
         "kind": node.kind.value,
         "body": _body_to_dict(node.body),
+        "scope": _scope_to_dict(node.scope),
         "provenance": _prov_to_dict(node.provenance),
     }
 
@@ -211,12 +218,12 @@ def _sr():
 # expansion (the §3.7 golden tests), NOT secrets — detect-secrets flags them as
 # high-entropy hex, so each carries an allowlist pragma.
 GOLDEN = {
-    "binary_cascade": "353abb8c42b5fab1f32738ec4f0fca76215f4fc7122e6dd9363e11d1389cd055",  # pragma: allowlist secret
-    "n_cascade": "52c8ace634c47ad28768e67ddb4b05d7a054d7febd82f0c3c678b1b766e42849",  # pragma: allowlist secret
-    "self_consistency": "18f0c814758112bed8ad3a9817c864420aa5a0d6d4f2d474a5529ae18f7b513d",  # pragma: allowlist secret
-    "best_of_n": "a0e959620ca6c58099f2fa53762530f565446348ba3045edf23cdbf9b8b7fbae",  # pragma: allowlist secret
-    "self_debug": "c816be0383cdf46b81aa6ca4bdea27070503d062580cf46c7832685e0c94e979",  # pragma: allowlist secret
-    "self_refine": "00e7ef9438a34f6347b7d894d900a147e5cd0ff95e45ae1779bf60c754512fa4",  # pragma: allowlist secret
+    "binary_cascade": "72c2db9bcd480a272b6ca0bfcd66e1b55750c45379f150f606d0756ab7b7007f",  # pragma: allowlist secret
+    "n_cascade": "f338422ffb1a59fa76fda5cfa550635ee481987f75f51615932e2787d26357c8",  # pragma: allowlist secret
+    "self_consistency": "f9059062a08cf7db17b7252896b7845657ec1ab764ec22ec628faf9bbc2f9ef9",  # pragma: allowlist secret
+    "best_of_n": "4b04d9e8825236470c1cbe7aef0a9c77fbf5b13aaf32b3888db8a5412465003a",  # pragma: allowlist secret
+    "self_debug": "07aa2c8cc3bea171a5395d704f2e9b80886dd0d3ab4cefa69f4bdcdb341fbf10",  # pragma: allowlist secret
+    "self_refine": "7f4ee735559d93674e55550f5fe7a16c9ec4ecf36397609884937c56d634fc42",  # pragma: allowlist secret
 }
 
 
@@ -415,6 +422,46 @@ class TestFailClosedCoverage:
 # --------------------------------------------------------------------------- #
 # (d) Unroll (§3.8)                                                           #
 # --------------------------------------------------------------------------- #
+
+
+class TestNCascadeTunedParamsLength:
+    """F4a (§3.5): n_cascade does not silently backfill partial per-stage
+    tuned_params — a provided list must have exactly one tuple per stage."""
+
+    def test_partial_tuned_params_rejects(self):
+        with pytest.raises(ValueError, match="invalid_tuned_param"):
+            n_cascade(
+                "chain",
+                stages=("a", "b", "c"),
+                thresholds=("t1", "t2"),
+                tuned_params=(("m1",), ("m2",)),  # 2 tuples for 3 stages
+            )
+
+    def test_too_many_tuned_params_rejects(self):
+        with pytest.raises(ValueError, match="invalid_tuned_param"):
+            n_cascade(
+                "chain",
+                stages=("a", "b"),
+                thresholds=("t1",),
+                tuned_params=(("m1",), ("m2",), ("m3",)),  # 3 tuples for 2 stages
+            )
+
+    def test_exact_per_stage_tuned_params_accepted(self):
+        ck = n_cascade(
+            "chain",
+            stages=("a", "b", "c"),
+            thresholds=("t1", "t2"),
+            tuned_params=(("m1",), ("m2",), ()),
+        )
+        arms = ck.structure.body.arms
+        assert arms[0].tuned_params == ("m1",)
+        assert arms[1].tuned_params == ("m2",)
+        assert arms[2].tuned_params == ()
+
+    def test_omitting_tuned_params_leaves_all_empty(self):
+        # The documented all-empty policy-migration ratchet stays allowed.
+        ck = n_cascade("chain", stages=("a", "b"), thresholds=("t1",))
+        assert all(arm.tuned_params == () for arm in ck.structure.body.arms)
 
 
 class TestUnroll:

--- a/traigent/knobs/composites.py
+++ b/traigent/knobs/composites.py
@@ -1112,6 +1112,8 @@ def cal_fold(program: CompositeProgram) -> frozenset[str]:
     members: frozenset[str] = frozenset()
     for root in roots(program):
         members |= _cal_of_node(program.composites[root], program.composites)
-    if program.cvars:
-        return members & program.cvars
-    return members
+    # ALWAYS intersect — an empty cvar namespace means an empty Cal set, never
+    # a raw fall-through (codex delta round: the falsy-empty check leaked a
+    # TUNED cardinality into the Cal set — the §3.5/§3.6 boundary dual of the
+    # leafT cut).
+    return members & program.cvars

--- a/traigent/knobs/composites.py
+++ b/traigent/knobs/composites.py
@@ -1,0 +1,1037 @@
+"""The composite-knob internal IR: a sealed control-flow algebra (RFC 0002).
+
+A ``CompositeKnob`` is NOT a binding kind (RFC 0001's one-Knob model is
+untouched): it is a namespace/expansion/provenance unit that *groups* member
+knobs and gate declarations under a declared control-flow shape. Nothing in
+this module binds, carries, or defaults a value — value binding stays on
+``Tuned | Fixed | Calibrated`` knobs exclusively.
+
+This module is the machine-facing layer: three disjoint structural
+constructors (:class:`CompositeKind` ``∈ {cascade, ensemble, loop}``), closed
+under nesting, that the optimizer projection, the certificate coverage fold,
+the freshness dependency compilation, the cost models, and the model checker
+consume. The frozen dataclasses below mirror the §3.2 algebra exactly:
+
+- tagged arms — :class:`StageArm` (opaque, with declared ``tuned_params``) and
+  :class:`CompositeArm` (a nesting reference into ``N_X``);
+- bodies — :class:`CascadeBody`, :class:`EnsembleBody`, :class:`LoopBody`,
+  discriminated by :class:`CompositeKind`;
+- declarations — :class:`GateDecl`, :class:`AcceptDecl`, :class:`StopDecl`,
+  :class:`AggregateDecl`, :class:`SignalUse`;
+- :class:`Provenance`, a CLOSED shape (identifiers + one canonical hash; no
+  raw-params field exists, §3.7).
+
+Structural well-formedness (§3.2 items 1–11, §3.5, §3.11) is checked here and
+raises :class:`ValueError` whose message is PREFIXED with the exact §3.11
+error code. Node-local rules check on construction; cross-composite rules
+(cycle detection, ``ambiguous_arm``, ``missing_composite_ref``) need the whole
+``N_X`` and a TVAR/CVAR namespace view, so they run in
+:func:`validate_program` over a :class:`CompositeProgram`.
+
+The derived functions :func:`leaf_tvars`, :func:`required_parents`,
+:func:`cal_fold`, and :func:`roots` are the §3.5/§3.6 compilations onto leaf
+TVARs and calibratable members. No value binding appears anywhere.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+__all__ = [
+    "AcceptDecl",
+    "AggregateDecl",
+    "AggregateKind",
+    "Arm",
+    "CascadeBody",
+    "CompositeArm",
+    "CompositeKind",
+    "CompositeNode",
+    "CompositeProgram",
+    "EnsembleBody",
+    "GateDecl",
+    "GateKind",
+    "LoopBody",
+    "Placement",
+    "Provenance",
+    "SignalUse",
+    "StageArm",
+    "StatKind",
+    "StopDecl",
+    "StopKind",
+    "cal_fold",
+    "leaf_tvars",
+    "required_parents",
+    "roots",
+    "validate_program",
+]
+
+
+def _reject(code: str, detail: str) -> ValueError:
+    """A §3.11 rejection: a ``ValueError`` whose message is PREFIXED with the
+    exact error code so callers can assert on the code, never on prose."""
+    return ValueError(f"{code}: {detail}")
+
+
+# --------------------------------------------------------------------------- #
+# Sealed registries (§3.2)                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class CompositeKind(StrEnum):
+    """The SEALED structural-constructor registry (§3.2).
+
+    A fourth kind is a new RFC, not a registry entry — DAG-shaped
+    configurations are the closure of nesting, not a fourth "DAG kind".
+    """
+
+    CASCADE = "cascade"
+    ENSEMBLE = "ensemble"
+    LOOP = "loop"
+
+
+class Placement(StrEnum):
+    """Cascade placement (§3.2); ``post`` is the default."""
+
+    PRE = "pre"
+    POST = "post"
+
+
+class GateKind(StrEnum):
+    """v1 gate registry (§3.2 ``GateDecl``).
+
+    ``margin_below`` is POST-only and consumes the just-executed arm's vote
+    statistics; ``signal_below`` is PRE-only and scores the input before any
+    arm runs (strict placement symmetry, item 5).
+    """
+
+    MARGIN_BELOW = "margin_below"
+    SIGNAL_BELOW = "signal_below"
+
+
+class StatKind(StrEnum):
+    """Content-free vote statistics for an :class:`AcceptDecl` (§3.2)."""
+
+    VOTE_MARGIN = "vote_margin"
+    VOTE_AGREEMENT = "vote_agreement"
+
+
+class AggregateKind(StrEnum):
+    """v1 ensemble aggregate registry (§3.2 ``AggregateDecl``)."""
+
+    MAJORITY_VOTE = "majority_vote"
+    JUDGE_MAX = "judge_max"
+
+
+class StopKind(StrEnum):
+    """v1 loop-stop registry (§3.2 ``StopDecl``)."""
+
+    SIGNAL_ACCEPT = "signal_accept"
+    EXTERNAL_ACCEPT = "external_accept"
+    EXHAUSTED = "exhausted"
+
+
+# --------------------------------------------------------------------------- #
+# Provenance (closed shape, §3.7)                                             #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class Provenance:
+    """Closed-shape expansion-output metadata stamped on every emitted node.
+
+    Identifiers and one canonical hash only — there is NO raw-params field and
+    NO content-typed field, so provenance can ride operational metadata
+    without widening the P8 surface (§3.7, §7). ``param_hash`` is
+    ``H_c(canonical validated params)``; raw pattern params NEVER serialize.
+    """
+
+    pattern: str
+    pattern_version: str | None = None
+    param_hash: str | None = None
+    node_path: str | None = None
+
+
+# --------------------------------------------------------------------------- #
+# Signal use (§3.2 SignalUse / §3.9 SignalSurface)                            #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class SignalUse:
+    """A named signal reference plus its declared input keys (§3.2).
+
+    ``signal`` names a registry signal exactly as RFC 0001's module-facing
+    ``calibration.signal`` does (operationally resolved; one signal model
+    across the language). ``inputs`` are the declared input keys the signal
+    reads; for loop stops they MUST be a subset of the loop's ``state_keys``
+    (checked by the enclosing :class:`LoopBody`). A malformed object — missing
+    ``signal`` or a non-tuple ``inputs`` — rejects ``invalid_signal_use``.
+    """
+
+    signal: str
+    inputs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.signal, str) or not self.signal:
+            raise _reject(
+                "invalid_signal_use", "SignalUse.signal must be a non-empty identifier"
+            )
+        if not isinstance(self.inputs, tuple):
+            raise _reject(
+                "invalid_signal_use", "SignalUse.inputs must be a tuple of identifiers"
+            )
+        for key in self.inputs:
+            if not isinstance(key, str) or not key:
+                raise _reject(
+                    "invalid_signal_use",
+                    f"SignalUse.inputs entry not an identifier: {key!r}",
+                )
+
+
+# --------------------------------------------------------------------------- #
+# Arms (tagged; §3.2 Arm / §3.9 ArmSurface)                                   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class StageArm:
+    """An opaque stage arm with DECLARED tuned parentage (§3.2, §3.5).
+
+    ``tuned_params`` declares the TVARs parameterizing this opaque stage
+    (possibly empty — the author's declaration). Stages never consult the
+    namespace; TVAR-only resolution of these entries is checked at program
+    level (item 9, ``invalid_tuned_param``).
+    """
+
+    name: str
+    tuned_params: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise _reject(
+                "invalid_arm_shape", "StageArm.name must be a non-empty identifier"
+            )
+        if not isinstance(self.tuned_params, tuple):
+            raise _reject(
+                "invalid_arm_shape",
+                "StageArm.tuned_params must be a tuple of identifiers",
+            )
+        for tvar in self.tuned_params:
+            if not isinstance(tvar, str) or not tvar:
+                raise _reject(
+                    "invalid_arm_shape",
+                    f"tuned_params entry not an identifier: {tvar!r}",
+                )
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeArm:
+    """A tagged nesting reference; exact-match into ``N_X`` (§3.2 item 3).
+
+    Resolution is checked at program level (``missing_composite_ref``); the
+    bare/ambiguous-identifier case (``ambiguous_arm``) is a SURFACE concern and
+    cannot arise in this tagged IR (it is parsed there), so it is N/A here.
+    """
+
+    ref: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.ref, str) or not self.ref:
+            raise _reject(
+                "invalid_arm_shape", "CompositeArm.ref must be a non-empty identifier"
+            )
+
+
+#: The tagged arm union — isinstance-discriminated, mirroring the bindings
+#: module's discriminator-free style.
+Arm = StageArm | CompositeArm
+
+
+# --------------------------------------------------------------------------- #
+# Declarations (§3.2)                                                         #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class GateDecl:
+    """A cascade gate (§3.2 ``GateDecl``).
+
+    ``threshold`` MUST resolve to a numeric CVAR (program-level kind/type
+    checks). ``signal`` is REQUIRED iff ``kind = signal_below``
+    (``missing_gate_signal``) and FORBIDDEN otherwise.
+    """
+
+    kind: GateKind
+    threshold: str
+    signal: SignalUse | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, GateKind):
+            raise _reject(
+                "unknown_gate_kind", f"gate kind outside the v1 registry: {self.kind!r}"
+            )
+        if not isinstance(self.threshold, str) or not self.threshold:
+            raise _reject(
+                "invalid_arm_shape", "GateDecl.threshold must be a non-empty identifier"
+            )
+        if self.kind is GateKind.SIGNAL_BELOW and self.signal is None:
+            raise _reject(
+                "missing_gate_signal", "signal_below gate requires a declared signal"
+            )
+        if self.kind is GateKind.MARGIN_BELOW and self.signal is not None:
+            raise _reject(
+                "unknown_composite_field", "margin_below gate carries no signal field"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptDecl:
+    """An ensemble acceptance decl (§3.2 ``AcceptDecl``).
+
+    The acceptance inequality is ``stat ≥ θ`` — deliberately the OPPOSITE
+    direction of cascade escalation (``margin < θ``), a distinct registry so
+    the two cannot drift. ``threshold`` MUST resolve to a numeric CVAR.
+    """
+
+    stat: StatKind
+    threshold: str
+    kind: str = "stat_at_least"
+
+    def __post_init__(self) -> None:
+        if self.kind != "stat_at_least":
+            raise _reject(
+                "unknown_aggregate_kind", f"unknown accept kind: {self.kind!r}"
+            )
+        if not isinstance(self.stat, StatKind):
+            raise _reject(
+                "unknown_aggregate_kind", f"unknown accept stat: {self.stat!r}"
+            )
+        if not isinstance(self.threshold, str) or not self.threshold:
+            raise _reject(
+                "invalid_arm_shape",
+                "AcceptDecl.threshold must be a non-empty identifier",
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AggregateDecl:
+    """An ensemble aggregate (§3.2 ``AggregateDecl``).
+
+    ``judge`` is REQUIRED iff ``kind = judge_max`` (``missing_judge``) and is
+    stage- or composite-tagged. ``accept`` is optional for either kind.
+    """
+
+    kind: AggregateKind
+    judge: Arm | None = None
+    accept: AcceptDecl | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, AggregateKind):
+            raise _reject(
+                "unknown_aggregate_kind",
+                f"aggregate kind outside the v1 registry: {self.kind!r}",
+            )
+        if self.kind is AggregateKind.JUDGE_MAX and self.judge is None:
+            raise _reject("missing_judge", "judge_max aggregate requires a judge arm")
+        if self.kind is AggregateKind.MAJORITY_VOTE and self.judge is not None:
+            raise _reject(
+                "unknown_composite_field",
+                "majority_vote aggregate carries no judge field",
+            )
+        if self.judge is not None and not isinstance(
+            self.judge, (StageArm, CompositeArm)
+        ):
+            raise _reject(
+                "invalid_arm_shape", "AggregateDecl.judge must be a tagged Arm"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class StopDecl:
+    """A loop stop rule (§3.2 ``StopDecl``).
+
+    - ``signal_accept`` REQUIRES ``threshold`` (``missing_stop_threshold``)
+      AND ``signal`` (``missing_stop_signal``); ``signal.inputs`` MUST ⊆ the
+      loop's ``state_keys`` (checked by :class:`LoopBody`).
+    - ``external_accept`` REQUIRES ``predicate`` (``missing_stop_predicate``);
+      the predicate is an OPAQUE runtime id, outside the P8 surface.
+    - ``exhausted`` carries none of the above.
+    """
+
+    kind: StopKind
+    threshold: str | None = None
+    signal: SignalUse | None = None
+    predicate: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, StopKind):
+            raise _reject(
+                "unknown_stop_kind", f"stop kind outside the v1 registry: {self.kind!r}"
+            )
+        if self.kind is StopKind.SIGNAL_ACCEPT:
+            if self.threshold is None:
+                raise _reject(
+                    "missing_stop_threshold", "signal_accept stop requires a threshold"
+                )
+            if self.signal is None:
+                raise _reject(
+                    "missing_stop_signal", "signal_accept stop requires a signal"
+                )
+            if self.predicate is not None:
+                raise _reject(
+                    "unknown_composite_field",
+                    "signal_accept stop carries no predicate field",
+                )
+        elif self.kind is StopKind.EXTERNAL_ACCEPT:
+            if self.predicate is None:
+                raise _reject(
+                    "missing_stop_predicate",
+                    "external_accept stop requires a predicate",
+                )
+            if self.threshold is not None or self.signal is not None:
+                raise _reject(
+                    "unknown_composite_field",
+                    "external_accept stop carries no threshold/signal field",
+                )
+        else:  # EXHAUSTED
+            if (
+                self.threshold is not None
+                or self.signal is not None
+                or self.predicate is not None
+            ):
+                raise _reject(
+                    "unknown_composite_field",
+                    "exhausted stop carries no threshold/signal/predicate field",
+                )
+
+
+# --------------------------------------------------------------------------- #
+# Bodies (§3.2)                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _check_arms_nonempty(arms: tuple[Arm, ...]) -> None:
+    if not isinstance(arms, tuple):
+        raise _reject("invalid_arm_shape", "arms must be a tuple of tagged Arms")
+    if not arms:
+        raise _reject("empty_arms", "arms must be non-empty for every constructor")
+    for arm in arms:
+        if not isinstance(arm, (StageArm, CompositeArm)):
+            raise _reject("invalid_arm_shape", f"arm is not a tagged Arm: {arm!r}")
+
+
+def _check_duplicate_stages(arms: Iterable[Arm]) -> None:
+    seen: set[str] = set()
+    for arm in arms:
+        if isinstance(arm, StageArm):
+            if arm.name in seen:
+                raise _reject(
+                    "duplicate_stage",
+                    f"duplicate stage {arm.name!r} within one composite",
+                )
+            seen.add(arm.name)
+
+
+def _arm_is_margin_bearing(
+    arm: Arm, registry: Mapping[str, CompositeNode] | None
+) -> bool:
+    """Item 5: a margin-bearing arm is a stage (RFC 0001 vote semantics) or an
+    ensemble whose ``aggregate.kind = majority_vote`` (committee votes).
+
+    With no registry the nested-composite case is conservatively rejected as
+    non-margin-bearing — node-local construction only sees stages as
+    definitively margin-bearing. Program-level validation passes the registry.
+    """
+    if isinstance(arm, StageArm):
+        return True
+    if registry is None:
+        return False
+    node = registry.get(arm.ref)
+    if node is None:
+        return False
+    body = node.body
+    return (
+        isinstance(body, EnsembleBody)
+        and body.aggregate.kind is AggregateKind.MAJORITY_VOTE
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CascadeBody:
+    """A cascade body (§3.2 ``Cascade``).
+
+    ``|gates| = |arms| − 1`` (``cascade_arity``); the degenerate ``m = 1``
+    cascade has no gates and always returns its arm. ``placement`` defaults
+    POST. Gate kind/placement symmetry (item 5) is enforced here for the
+    placement axis and for the margin-bearing-arm rule in the stage case; the
+    nested-composite margin-bearing case is finalized at program level.
+    """
+
+    arms: tuple[Arm, ...]
+    gates: tuple[GateDecl, ...] = ()
+    placement: Placement = Placement.POST
+
+    def __post_init__(self) -> None:
+        _check_arms_nonempty(self.arms)
+        if not isinstance(self.placement, Placement):
+            raise _reject(
+                "unknown_composite_field", f"unknown placement: {self.placement!r}"
+            )
+        if not isinstance(self.gates, tuple):
+            raise _reject("invalid_arm_shape", "gates must be a tuple of GateDecl")
+        if len(self.gates) != len(self.arms) - 1:
+            raise _reject(
+                "cascade_arity",
+                f"|gates|={len(self.gates)} must equal |arms|-1={len(self.arms) - 1}",
+            )
+        _check_duplicate_stages(self.arms)
+        self._check_gate_placement(registry=None)
+
+    def _check_gate_placement(
+        self, registry: Mapping[str, CompositeNode] | None
+    ) -> None:
+        for index, gate in enumerate(self.gates):
+            if self.placement is Placement.PRE and gate.kind is GateKind.MARGIN_BELOW:
+                raise _reject(
+                    "gate_kind_placement_mismatch", "margin_below gate is POST-only"
+                )
+            if self.placement is Placement.POST and gate.kind is GateKind.SIGNAL_BELOW:
+                raise _reject(
+                    "gate_kind_placement_mismatch", "signal_below gate is PRE-only"
+                )
+            if (
+                self.placement is Placement.POST
+                and gate.kind is GateKind.MARGIN_BELOW
+                and not _arm_is_margin_bearing(self.arms[index], registry)
+            ):
+                # Defer the nested-composite verdict to program level: only
+                # raise here when a registry is present (final verdict) or when
+                # the gated arm is a CompositeArm we cannot yet resolve.
+                if registry is not None or isinstance(self.arms[index], StageArm):
+                    raise _reject(
+                        "gate_arm_incompatible",
+                        f"margin_below gate {index} gates a non-margin-bearing arm",
+                    )
+
+
+@dataclass(frozen=True, slots=True)
+class EnsembleBody:
+    """An ensemble body (§3.2 ``Ensemble``).
+
+    ``cardinality`` is REQUIRED iff ``|arms| = 1`` (sampling form) and
+    FORBIDDEN if ``|arms| > 1`` (committee form) — ``cardinality_arity_mismatch``.
+    It is a namespace ref to a TVAR or CVAR of TVL type ``int`` (kind/type
+    checked at program level; resolution-time ``k < 1`` is rejection R9).
+    """
+
+    arms: tuple[Arm, ...]
+    aggregate: AggregateDecl
+    cardinality: str | None = None
+
+    def __post_init__(self) -> None:
+        _check_arms_nonempty(self.arms)
+        if not isinstance(self.aggregate, AggregateDecl):
+            raise _reject(
+                "unknown_aggregate_kind", "ensemble requires an AggregateDecl"
+            )
+        is_sampling = len(self.arms) == 1
+        if is_sampling and self.cardinality is None:
+            raise _reject(
+                "cardinality_arity_mismatch",
+                "single-arm (sampling) ensemble requires cardinality",
+            )
+        if not is_sampling and self.cardinality is not None:
+            raise _reject(
+                "cardinality_arity_mismatch",
+                "multi-arm (committee) ensemble forbids cardinality",
+            )
+        if self.cardinality is not None and (
+            not isinstance(self.cardinality, str) or not self.cardinality
+        ):
+            raise _reject(
+                "invalid_arm_shape", "cardinality must be a non-empty identifier"
+            )
+        _check_duplicate_stages(self.arms)
+
+
+@dataclass(frozen=True, slots=True)
+class LoopBody:
+    """A loop body (§3.2 ``Loop``).
+
+    ``state_keys`` are content-free identifiers (``[]`` ⟺ body treated pure).
+    ``stop.signal.inputs`` (when present) MUST ⊆ ``state_keys``
+    (``stop_signal_outside_state``). ``max_iters`` is the REQUIRED totality
+    bound (``invalid_max_iters`` when ``< 1``).
+    """
+
+    body: Arm
+    stop: StopDecl
+    state_keys: tuple[str, ...] = ()
+    max_iters: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.body, (StageArm, CompositeArm)):
+            raise _reject("invalid_arm_shape", "Loop.body must be a tagged Arm")
+        if not isinstance(self.stop, StopDecl):
+            raise _reject("unknown_stop_kind", "Loop requires a StopDecl")
+        if not isinstance(self.state_keys, tuple):
+            raise _reject(
+                "invalid_arm_shape", "state_keys must be a tuple of identifiers"
+            )
+        for key in self.state_keys:
+            if not isinstance(key, str) or not key:
+                raise _reject(
+                    "invalid_arm_shape", f"state_key not an identifier: {key!r}"
+                )
+        if not isinstance(self.max_iters, int) or isinstance(self.max_iters, bool):
+            raise _reject("invalid_max_iters", "max_iters must be an integer")
+        if self.max_iters < 1:
+            raise _reject(
+                "invalid_max_iters", f"max_iters must be >= 1, got {self.max_iters}"
+            )
+        if (
+            self.stop.kind is StopKind.SIGNAL_ACCEPT
+            and self.stop.signal is not None
+            and not set(self.stop.signal.inputs) <= set(self.state_keys)
+        ):
+            raise _reject(
+                "stop_signal_outside_state",
+                "signal_accept stop inputs must be a subset of state_keys",
+            )
+
+
+Body = CascadeBody | EnsembleBody | LoopBody
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeNode:
+    """One composite declaration: a member of ``N_X`` (§3.2 ``Composite``).
+
+    ``kind`` discriminates ``body``; a kind/body mismatch rejects
+    (``unknown_composite_field``). ``provenance`` rides as expansion-output
+    metadata. ``parameters`` is an opaque operational map OUTSIDE the P8
+    surface, exactly as ``PolicyDecl.parameters`` (kept as an opaque mapping;
+    never serialized through the typed wire).
+    """
+
+    name: str
+    kind: CompositeKind
+    body: Body
+    provenance: Provenance | None = None
+    parameters: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise _reject(
+                "invalid_arm_shape", "CompositeNode.name must be a non-empty identifier"
+            )
+        if not isinstance(self.kind, CompositeKind):
+            raise _reject(
+                "unknown_composite_kind",
+                f"kind outside the closed registry: {self.kind!r}",
+            )
+        expected = {
+            CompositeKind.CASCADE: CascadeBody,
+            CompositeKind.ENSEMBLE: EnsembleBody,
+            CompositeKind.LOOP: LoopBody,
+        }[self.kind]
+        if not isinstance(self.body, expected):
+            raise _reject(
+                "unknown_composite_field",
+                f"kind {self.kind.value!r} requires {expected.__name__}, "
+                f"got {type(self.body).__name__}",
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Program (the N_X registry + namespace view) and cross-composite validation  #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeProgram:
+    """A module's composite registry plus the TVAR/CVAR namespace view.
+
+    ``composites`` is ``N_X`` (keyed by name). ``tvars`` and ``cvars`` are the
+    declared identifier names of the surrounding module's tuned/calibrated
+    knobs (a namespace VIEW only — no bindings, no values). ``cvar_types``
+    maps each CVAR name to its declared TVL type (for the int/float threshold
+    and int-cardinality checks). ``cvar_signals`` maps each CVAR to its
+    declared ``calibration.signal`` id (``None`` when absent) for the §3.2
+    item-11 binding lint, and ``cvar_depends_on`` to its declared TVAR parents
+    for the §3.5 ``missing_composite_parent`` lint. ``cvar_signal_inputs``
+    maps each CVAR to the input list covered under the ``signal_inputs``
+    freshness-context extension (``None`` when uncovered).
+    """
+
+    composites: Mapping[str, CompositeNode]
+    tvars: frozenset[str] = frozenset()
+    cvars: frozenset[str] = frozenset()
+    cvar_types: Mapping[str, str] = field(default_factory=dict)
+    cvar_signals: Mapping[str, str | None] = field(default_factory=dict)
+    cvar_depends_on: Mapping[str, frozenset[str]] = field(default_factory=dict)
+    cvar_signal_inputs: Mapping[str, tuple[str, ...] | None] = field(
+        default_factory=dict
+    )
+
+
+def _all_arms(body: Body) -> tuple[Arm, ...]:
+    """Every arm/body/judge an expansion node directly contains."""
+    if isinstance(body, CascadeBody):
+        return body.arms
+    if isinstance(body, EnsembleBody):
+        if body.aggregate.judge is not None:
+            return (*body.arms, body.aggregate.judge)
+        return body.arms
+    return (body.body,)  # LoopBody
+
+
+def _detect_cycle(program: CompositeProgram) -> None:
+    """Item 4: the ``composite(·)`` reference graph over ``N_X`` is acyclic.
+
+    DFS with a recursion stack; a back-edge is ``composite_cycle``. A
+    reference to an undeclared composite is ``missing_composite_ref`` (item 3).
+    """
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = dict.fromkeys(program.composites, WHITE)
+
+    def visit(name: str) -> None:
+        color[name] = GRAY
+        node = program.composites[name]
+        for arm in _all_arms(node.body):
+            if isinstance(arm, CompositeArm):
+                if arm.ref not in program.composites:
+                    raise _reject(
+                        "missing_composite_ref",
+                        f"composite({arm.ref!r}) resolves to no N_X member",
+                    )
+                if color[arm.ref] == GRAY:
+                    raise _reject(
+                        "composite_cycle", f"cycle through composite({arm.ref!r})"
+                    )
+                if color[arm.ref] == WHITE:
+                    visit(arm.ref)
+        color[name] = BLACK
+
+    for name in program.composites:
+        if color[name] == WHITE:
+            visit(name)
+
+
+def _check_tuned_params(program: CompositeProgram) -> None:
+    """Item 9: every ``tuned_params`` entry resolves to a declared TVAR."""
+    for node in program.composites.values():
+        for arm in _all_arms(node.body):
+            if isinstance(arm, StageArm):
+                for tvar in arm.tuned_params:
+                    if tvar not in program.tvars:
+                        raise _reject(
+                            "invalid_tuned_param",
+                            f"tuned_param {tvar!r} does not resolve to a TVAR",
+                        )
+
+
+def _check_threshold(program: CompositeProgram, threshold: str) -> None:
+    """Item 6 + item 10: a gate/accept/stop threshold resolves to a numeric
+    (int/float) CVAR."""
+    if threshold not in program.cvars:
+        raise _reject(
+            "missing_ref", f"threshold {threshold!r} does not resolve to a CVAR"
+        )
+    declared = program.cvar_types.get(threshold)
+    if declared not in ("int", "float"):
+        raise _reject(
+            "invalid_threshold_type",
+            f"threshold CVAR {threshold!r} has non-numeric type {declared!r}",
+        )
+
+
+def _check_cardinality(program: CompositeProgram, cardinality: str) -> None:
+    """Item 7: cardinality references a TVAR or CVAR of declared type ``int``."""
+    if cardinality in program.tvars:
+        return  # tuned cardinality; resolution-time k<1 is R9 (runtime)
+    if cardinality not in program.cvars:
+        raise _reject(
+            "missing_ref",
+            f"cardinality {cardinality!r} does not resolve to a TVAR/CVAR",
+        )
+    if program.cvar_types.get(cardinality) != "int":
+        raise _reject(
+            "invalid_cardinality_type", f"cardinality {cardinality!r} is not int-typed"
+        )
+
+
+def _sig_of_construct(
+    *,
+    gate: GateDecl | None = None,
+    accept: AcceptDecl | None = None,
+    stop: StopDecl | None = None,
+) -> str:
+    """§3.2 item 11: the canonical signal id a thresholded construct
+    determines."""
+    if gate is not None:
+        if gate.kind is GateKind.SIGNAL_BELOW:
+            if gate.signal is None:  # guaranteed by GateDecl.__post_init__
+                raise _reject("missing_gate_signal", "signal_below gate has no signal")
+            return gate.signal.signal
+        return StatKind.VOTE_MARGIN.value  # margin_below -> vote_margin
+    if accept is not None:
+        return accept.stat.value
+    if stop is None or stop.signal is None:  # guaranteed by StopDecl.__post_init__
+        raise _reject("missing_stop_signal", "signal_accept stop has no signal")
+    return stop.signal.signal
+
+
+def _check_signal_binding(
+    program: CompositeProgram,
+    threshold: str,
+    expected_signal: str,
+    inputs: tuple[str, ...],
+) -> None:
+    """§3.2 item 11 (composite USE-SITE): the referenced threshold CVAR must
+    declare ``calibration.signal = sig(construct)``, and when the governing
+    ``SignalUse.inputs ≠ []`` must cover ``signal_inputs`` with that exact
+    ordered list."""
+    declared = program.cvar_signals.get(threshold)
+    if declared is None:
+        raise _reject(
+            "missing_calibration_signal",
+            f"composite-referenced threshold {threshold!r} declares no calibration.signal",
+        )
+    if declared != expected_signal:
+        raise _reject(
+            "signal_mismatch",
+            f"threshold {threshold!r} calibration.signal {declared!r} != sig {expected_signal!r}",
+        )
+    if inputs:
+        covered = program.cvar_signal_inputs.get(threshold)
+        if covered is None or tuple(covered) != inputs:
+            raise _reject(
+                "unbound_signal_inputs",
+                f"threshold {threshold!r} does not cover signal_inputs {inputs!r}",
+            )
+
+
+def _check_node_semantics(program: CompositeProgram, node: CompositeNode) -> None:
+    """Per-node threshold/signal/placement checks with the registry present."""
+    body = node.body
+    if isinstance(body, CascadeBody):
+        body._check_gate_placement(
+            registry=program.composites
+        )  # final margin-bearing verdict
+        for gate in body.gates:
+            _check_threshold(program, gate.threshold)
+            inputs = gate.signal.inputs if gate.signal is not None else ()
+            _check_signal_binding(
+                program, gate.threshold, _sig_of_construct(gate=gate), inputs
+            )
+    elif isinstance(body, EnsembleBody):
+        if body.cardinality is not None:
+            _check_cardinality(program, body.cardinality)
+        accept = body.aggregate.accept
+        if accept is not None:
+            _check_threshold(program, accept.threshold)
+            _check_signal_binding(
+                program, accept.threshold, _sig_of_construct(accept=accept), ()
+            )
+    else:  # LoopBody
+        stop = body.stop
+        if stop.kind is StopKind.SIGNAL_ACCEPT and stop.threshold is not None:
+            _check_threshold(program, stop.threshold)
+            inputs = stop.signal.inputs if stop.signal is not None else ()
+            _check_signal_binding(
+                program, stop.threshold, _sig_of_construct(stop=stop), inputs
+            )
+
+
+def validate_program(program: CompositeProgram) -> None:
+    """Run every cross-composite well-formedness check (§3.2, §3.5, §3.11).
+
+    Node-local rules already ran on construction. This adds the rules that
+    need the whole ``N_X`` and the namespace view: acyclicity
+    (``composite_cycle``) + reference resolution (``missing_composite_ref``),
+    TVAR-only ``tuned_params`` (``invalid_tuned_param``), numeric/typed
+    thresholds and cardinality, the §3.2 item-11 signal binding, the final
+    margin-bearing-arm verdict (``gate_arm_incompatible``), and the §3.5
+    parent-coverage obligation (``missing_composite_parent``).
+    """
+    _detect_cycle(program)
+    _check_tuned_params(program)
+    for node in program.composites.values():
+        _check_node_semantics(program, node)
+    _check_parent_coverage(program)
+
+
+# --------------------------------------------------------------------------- #
+# §3.5 leafT / required_parents                                               #
+# --------------------------------------------------------------------------- #
+
+
+def leaf_tvars(
+    arm: Arm, registry: Mapping[str, CompositeNode], _seen: frozenset[str] | None = None
+) -> frozenset[str]:
+    """``leafT`` (§3.5): the tuned-TVAR leaf set an arm parameterizes.
+
+    ``leafT(stage(s, ps)) = ps``; ``leafT(composite(x))`` unions ``leafT`` over
+    all arms/body/judge of ``x`` PLUS its sampling-ensemble's tuned cardinality
+    (``{cardinality} ∩ N_T``), folding in recursively through nesting. The
+    codomain is TVAR-only (C6).
+    """
+    seen = _seen or frozenset()
+    if isinstance(arm, StageArm):
+        return frozenset(arm.tuned_params)
+    # CompositeArm
+    if arm.ref in seen:  # acyclic by validation; guard anyway
+        return frozenset()
+    node = registry[arm.ref]
+    return _leaf_of_node(node, registry, seen | {arm.ref})
+
+
+def _leaf_of_node(
+    node: CompositeNode, registry: Mapping[str, CompositeNode], seen: frozenset[str]
+) -> frozenset[str]:
+    body = node.body
+    leaves: frozenset[str] = frozenset()
+    for member in _all_arms(body):
+        leaves |= leaf_tvars(member, registry, seen)
+    if isinstance(body, EnsembleBody) and body.cardinality is not None:
+        # {cardinality} ∩ N_T — a Calibrated/absent cardinality contributes
+        # nothing to leafT (it is a Cal member instead, §3.6). The N_T test is
+        # against the registry's owning program, but leaf_tvars takes only the
+        # registry; cardinality TVAR-membership is resolved by the caller via
+        # leaf_tvars_in_program when the program is available. Here we include
+        # it optimistically and let required_parents (program-scoped) intersect.
+        leaves |= {body.cardinality}
+    return leaves
+
+
+def _leaf_tvars_program(arm: Arm, program: CompositeProgram) -> frozenset[str]:
+    """``leafT`` intersected with ``N_T`` using the program's TVAR namespace —
+    keeps the cardinality term TVAR-only (C6)."""
+    raw = leaf_tvars(arm, program.composites)
+    return raw & program.tvars
+
+
+def required_parents(
+    program: CompositeProgram, node: CompositeNode
+) -> dict[str, frozenset[str]]:
+    """``required_parents`` (§3.5): per-threshold coverage obligations.
+
+    Returns a map from each threshold CVAR in ``node`` to the TVAR set its
+    certificate must depend on. TVAR-only (C6) — the cardinality term is
+    intersected with ``N_T``.
+    """
+    out: dict[str, frozenset[str]] = {}
+    body = node.body
+    if isinstance(body, CascadeBody):
+        if body.placement is Placement.POST:
+            # θ_i covers leafT(a_1) ∪ … ∪ leafT(a_i)
+            prefix: frozenset[str] = frozenset()
+            for index, gate in enumerate(body.gates):
+                prefix |= _leaf_tvars_program(body.arms[index], program)
+                out[gate.threshold] = out.get(gate.threshold, frozenset()) | prefix
+        else:  # PRE: θ_i covers leafT(a_i)
+            for index, gate in enumerate(body.gates):
+                out[gate.threshold] = out.get(
+                    gate.threshold, frozenset()
+                ) | _leaf_tvars_program(body.arms[index], program)
+    elif isinstance(body, EnsembleBody):
+        accept = body.aggregate.accept
+        if accept is not None:
+            leaves: frozenset[str] = frozenset()
+            for member in _all_arms(body):
+                leaves |= _leaf_tvars_program(member, program)
+            if body.cardinality is not None and body.cardinality in program.tvars:
+                leaves |= {body.cardinality}
+            out[accept.threshold] = out.get(accept.threshold, frozenset()) | leaves
+    else:  # LoopBody
+        stop = body.stop
+        if stop.kind is StopKind.SIGNAL_ACCEPT and stop.threshold is not None:
+            out[stop.threshold] = out.get(
+                stop.threshold, frozenset()
+            ) | _leaf_tvars_program(body.body, program)
+    return out
+
+
+def _check_parent_coverage(program: CompositeProgram) -> None:
+    """§3.5 ``missing_composite_parent``: ``required_parents(θ) ⊆ depends_on(θ)``."""
+    for node in program.composites.values():
+        for threshold, needed in required_parents(program, node).items():
+            declared = program.cvar_depends_on.get(threshold, frozenset())
+            if not needed <= declared:
+                missing = needed - declared
+                raise _reject(
+                    "missing_composite_parent",
+                    f"threshold {threshold!r} depends_on missing TVAR parents {sorted(missing)!r}",
+                )
+
+
+# --------------------------------------------------------------------------- #
+# §3.6 Cal fold + roots                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _cal_of_arm(arm: Arm, registry: Mapping[str, CompositeNode]) -> frozenset[str]:
+    """``Cal(stage) = ∅``; ``Cal(composite(x)) = Cal(body(x))``."""
+    if isinstance(arm, StageArm):
+        return frozenset()
+    node = registry.get(arm.ref)
+    if node is None:
+        return frozenset()
+    return _cal_of_node(node, registry)
+
+
+def _cal_of_node(
+    node: CompositeNode, registry: Mapping[str, CompositeNode]
+) -> frozenset[str]:
+    body = node.body
+    members: frozenset[str] = frozenset()
+    if isinstance(body, CascadeBody):
+        for arm in body.arms:
+            members |= _cal_of_arm(arm, registry)
+        members |= {gate.threshold for gate in body.gates}
+    elif isinstance(body, EnsembleBody):
+        for arm in body.arms:
+            members |= _cal_of_arm(arm, registry)
+        if body.aggregate.judge is not None:
+            members |= _cal_of_arm(body.aggregate.judge, registry)
+        if body.aggregate.accept is not None:
+            members |= {body.aggregate.accept.threshold}
+        # ({k} ∩ N_C) — a Calibrated cardinality is a Cal member. The N_C test
+        # needs the program; cal_fold(program, ...) intersects below.
+        if body.cardinality is not None:
+            members |= {body.cardinality}
+    else:  # LoopBody
+        members |= _cal_of_arm(body.body, registry)
+        if body.stop.kind is StopKind.SIGNAL_ACCEPT and body.stop.threshold is not None:
+            members |= {body.stop.threshold}
+    return members
+
+
+def roots(program: CompositeProgram) -> frozenset[str]:
+    """§3.6 root consumption (v1, conservative): the roots of the ``N_X``
+    reference DAG — every declared composite NOT referenced as a nested arm of
+    another. v1 consumes all roots by every candidate (fail-closed)."""
+    referenced: set[str] = set()
+    for node in program.composites.values():
+        for arm in _all_arms(node.body):
+            if isinstance(arm, CompositeArm):
+                referenced.add(arm.ref)
+    return frozenset(name for name in program.composites if name not in referenced)
+
+
+def cal_fold(program: CompositeProgram) -> frozenset[str]:
+    """§3.6 certificate coverage fold: ``⋃_{r ∈ roots} Cal(r)`` — the set of
+    calibratable member CVAR names whose certificates strict selection
+    requires. Intersected with ``N_C`` so a tuned cardinality is excluded
+    (it is a ``leafT`` member instead, §3.5). Fail-closed: the caller checks
+    each member has a valid fresh certificate; any gap ⇒ no certified
+    selection."""
+    members: frozenset[str] = frozenset()
+    for root in roots(program):
+        members |= _cal_of_node(program.composites[root], program.composites)
+    if program.cvars:
+        return members & program.cvars
+    return members

--- a/traigent/knobs/composites.py
+++ b/traigent/knobs/composites.py
@@ -55,6 +55,7 @@ __all__ = [
     "LoopBody",
     "Placement",
     "Provenance",
+    "Scope",
     "SignalUse",
     "StageArm",
     "StatKind",
@@ -130,6 +131,40 @@ class StopKind(StrEnum):
     SIGNAL_ACCEPT = "signal_accept"
     EXTERNAL_ACCEPT = "external_accept"
     EXHAUSTED = "exhausted"
+
+
+# --------------------------------------------------------------------------- #
+# Scope (RFC 0001 §3.7 scope_spec — carried verbatim onto a composite, §3.2)  #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class Scope:
+    """RFC 0001 §3.7 ``scope_spec`` — ``⟨ node?, agent?, workflow? ⟩``.
+
+    Carried VERBATIM onto a composite with the SAME semantics as
+    ``PolicyDecl.scope`` (§3.2, §4 subsumption): each field is an optional
+    ``Ident`` recording node/agent/workflow ownership. v1 semantics are
+    informational (RFC 0001 metadata) — a composite still binds no value. The
+    closed shape (three optional identifiers, no content-typed field) keeps it
+    OUTSIDE the P8 surface, exactly as the policy form's scope.
+    """
+
+    node: str | None = None
+    agent: str | None = None
+    workflow: str | None = None
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("node", self.node),
+            ("agent", self.agent),
+            ("workflow", self.workflow),
+        ):
+            if value is not None and (not isinstance(value, str) or not value):
+                raise _reject(
+                    "invalid_arm_shape",
+                    f"Scope.{label} must be a non-empty identifier or None",
+                )
 
 
 # --------------------------------------------------------------------------- #
@@ -371,7 +406,7 @@ class StopDecl:
                 "unknown_stop_kind", f"stop kind outside the v1 registry: {self.kind!r}"
             )
         if self.kind is StopKind.SIGNAL_ACCEPT:
-            if self.threshold is None:
+            if not isinstance(self.threshold, str) or not self.threshold:
                 raise _reject(
                     "missing_stop_threshold", "signal_accept stop requires a threshold"
                 )
@@ -385,10 +420,10 @@ class StopDecl:
                     "signal_accept stop carries no predicate field",
                 )
         elif self.kind is StopKind.EXTERNAL_ACCEPT:
-            if self.predicate is None:
+            if not isinstance(self.predicate, str) or not self.predicate:
                 raise _reject(
                     "missing_stop_predicate",
-                    "external_accept stop requires a predicate",
+                    "external_accept stop requires a non-empty predicate identifier",
                 )
             if self.threshold is not None or self.signal is not None:
                 raise _reject(
@@ -553,7 +588,11 @@ class EnsembleBody:
             raise _reject(
                 "invalid_arm_shape", "cardinality must be a non-empty identifier"
             )
-        _check_duplicate_stages(self.arms)
+        # §3.2 item 6: duplicates within ONE composite — the judge arm is part
+        # of this composite's stage scope, so it is checked alongside arms.
+        judge = self.aggregate.judge
+        scope = self.arms if judge is None else (*self.arms, judge)
+        _check_duplicate_stages(scope)
 
 
 @dataclass(frozen=True, slots=True)
@@ -610,7 +649,9 @@ class CompositeNode:
     """One composite declaration: a member of ``N_X`` (§3.2 ``Composite``).
 
     ``kind`` discriminates ``body``; a kind/body mismatch rejects
-    (``unknown_composite_field``). ``provenance`` rides as expansion-output
+    (``unknown_composite_field``). ``scope`` is the RFC 0001 §3.7 ``scope_spec``
+    carried VERBATIM with PolicyDecl semantics (§3.2, §4 subsumption — optional,
+    frozen, OUTSIDE the P8 surface). ``provenance`` rides as expansion-output
     metadata. ``parameters`` is an opaque operational map OUTSIDE the P8
     surface, exactly as ``PolicyDecl.parameters`` (kept as an opaque mapping;
     never serialized through the typed wire).
@@ -619,6 +660,7 @@ class CompositeNode:
     name: str
     kind: CompositeKind
     body: Body
+    scope: Scope | None = None
     provenance: Provenance | None = None
     parameters: Mapping[str, object] | None = None
 
@@ -631,6 +673,11 @@ class CompositeNode:
             raise _reject(
                 "unknown_composite_kind",
                 f"kind outside the closed registry: {self.kind!r}",
+            )
+        if self.scope is not None and not isinstance(self.scope, Scope):
+            raise _reject(
+                "unknown_composite_field",
+                f"scope must be a Scope, got {type(self.scope).__name__}",
             )
         expected = {
             CompositeKind.CASCADE: CascadeBody,
@@ -658,11 +705,14 @@ class CompositeProgram:
     declared identifier names of the surrounding module's tuned/calibrated
     knobs (a namespace VIEW only — no bindings, no values). ``cvar_types``
     maps each CVAR name to its declared TVL type (for the int/float threshold
-    and int-cardinality checks). ``cvar_signals`` maps each CVAR to its
-    declared ``calibration.signal`` id (``None`` when absent) for the §3.2
-    item-11 binding lint, and ``cvar_depends_on`` to its declared TVAR parents
-    for the §3.5 ``missing_composite_parent`` lint. ``cvar_signal_inputs``
-    maps each CVAR to the input list covered under the ``signal_inputs``
+    and int-cardinality checks); ``tvar_types`` is the PARALLEL mapping for
+    TVARs (a TVAR-bound cardinality must also be int-typed — §3.2 item 7). A
+    name absent from its type map is treated as untyped/unknown and rejected by
+    the type checks. ``cvar_signals`` maps each CVAR to its declared
+    ``calibration.signal`` id (``None`` when absent) for the §3.2 item-11
+    binding lint, and ``cvar_depends_on`` to its declared TVAR parents for the
+    §3.5 ``missing_composite_parent`` lint. ``cvar_signal_inputs`` maps each
+    CVAR to the input list covered under the ``signal_inputs``
     freshness-context extension (``None`` when uncovered).
     """
 
@@ -670,6 +720,7 @@ class CompositeProgram:
     tvars: frozenset[str] = frozenset()
     cvars: frozenset[str] = frozenset()
     cvar_types: Mapping[str, str] = field(default_factory=dict)
+    tvar_types: Mapping[str, str] = field(default_factory=dict)
     cvar_signals: Mapping[str, str | None] = field(default_factory=dict)
     cvar_depends_on: Mapping[str, frozenset[str]] = field(default_factory=dict)
     cvar_signal_inputs: Mapping[str, tuple[str, ...] | None] = field(
@@ -749,9 +800,19 @@ def _check_threshold(program: CompositeProgram, threshold: str) -> None:
 
 
 def _check_cardinality(program: CompositeProgram, cardinality: str) -> None:
-    """Item 7: cardinality references a TVAR or CVAR of declared type ``int``."""
+    """Item 7: cardinality references a TVAR or CVAR of declared TVL type
+    ``int``. The int-type obligation applies to BOTH a tuned and a calibrated
+    cardinality — a non-int cardinality (e.g. a float TVAR) rejects
+    ``invalid_cardinality_type`` regardless of binding kind. Resolution-time
+    ``k < 1`` is the separate runtime rejection R9 (``invalid_cardinality_value``).
+    """
     if cardinality in program.tvars:
-        return  # tuned cardinality; resolution-time k<1 is R9 (runtime)
+        if program.tvar_types.get(cardinality) != "int":
+            raise _reject(
+                "invalid_cardinality_type",
+                f"cardinality TVAR {cardinality!r} is not int-typed",
+            )
+        return  # int-typed tuned cardinality; k<1 is R9 (runtime)
     if cardinality not in program.cvars:
         raise _reject(
             "missing_ref",
@@ -759,7 +820,8 @@ def _check_cardinality(program: CompositeProgram, cardinality: str) -> None:
         )
     if program.cvar_types.get(cardinality) != "int":
         raise _reject(
-            "invalid_cardinality_type", f"cardinality {cardinality!r} is not int-typed"
+            "invalid_cardinality_type",
+            f"cardinality CVAR {cardinality!r} is not int-typed",
         )
 
 
@@ -869,15 +931,18 @@ def validate_program(program: CompositeProgram) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def leaf_tvars(
+def _leaf_names_raw(
     arm: Arm, registry: Mapping[str, CompositeNode], _seen: frozenset[str] | None = None
 ) -> frozenset[str]:
-    """``leafT`` (§3.5): the tuned-TVAR leaf set an arm parameterizes.
+    """NAMESPACE-BLIND leaf walk over the §3.5 ``leafT`` structure.
 
-    ``leafT(stage(s, ps)) = ps``; ``leafT(composite(x))`` unions ``leafT`` over
-    all arms/body/judge of ``x`` PLUS its sampling-ensemble's tuned cardinality
-    (``{cardinality} ∩ N_T``), folding in recursively through nesting. The
-    codomain is TVAR-only (C6).
+    Collects every ``tuned_params`` entry plus every sampling-ensemble
+    ``cardinality`` name, recursively through nesting — WITHOUT consulting the
+    ``N_T`` partition. The cardinality term it folds in may therefore be a CVAR
+    or a TVAR; this raw set is INTERNAL only and must be intersected with
+    ``N_T`` before it is exposed (the public :func:`leaf_tvars` does so). Using
+    this set directly on the public surface would violate the TVAR-only / P5
+    boundary (§3.5, C6) by returning calibrated names as leaves.
     """
     seen = _seen or frozenset()
     if isinstance(arm, StageArm):
@@ -885,33 +950,48 @@ def leaf_tvars(
     # CompositeArm
     if arm.ref in seen:  # acyclic by validation; guard anyway
         return frozenset()
-    node = registry[arm.ref]
-    return _leaf_of_node(node, registry, seen | {arm.ref})
+    node = registry.get(arm.ref)
+    if node is None:  # unresolved ref (caught elsewhere as missing_composite_ref)
+        return frozenset()
+    return _leaf_names_of_node(node, registry, seen | {arm.ref})
 
 
-def _leaf_of_node(
+def _leaf_names_of_node(
     node: CompositeNode, registry: Mapping[str, CompositeNode], seen: frozenset[str]
 ) -> frozenset[str]:
     body = node.body
     leaves: frozenset[str] = frozenset()
     for member in _all_arms(body):
-        leaves |= leaf_tvars(member, registry, seen)
+        leaves |= _leaf_names_raw(member, registry, seen)
     if isinstance(body, EnsembleBody) and body.cardinality is not None:
-        # {cardinality} ∩ N_T — a Calibrated/absent cardinality contributes
-        # nothing to leafT (it is a Cal member instead, §3.6). The N_T test is
-        # against the registry's owning program, but leaf_tvars takes only the
-        # registry; cardinality TVAR-membership is resolved by the caller via
-        # leaf_tvars_in_program when the program is available. Here we include
-        # it optimistically and let required_parents (program-scoped) intersect.
+        # Raw fold: include the cardinality name WHATEVER its binding. A
+        # Calibrated/absent cardinality contributes nothing to the final
+        # ``leafT`` (it is a Cal member instead, §3.6), but that ∩ N_T cut is
+        # the PUBLIC layer's job — never this namespace-blind walk's.
         leaves |= {body.cardinality}
     return leaves
 
 
+def leaf_tvars(program: CompositeProgram, arm: Arm) -> frozenset[str]:
+    """``leafT`` (§3.5): the tuned-TVAR leaf set an arm parameterizes.
+
+    PUBLIC surface, TVAR-only (C6 / the P5 boundary). ``leafT(stage(s, ps)) =
+    ps``; ``leafT(composite(x))`` unions ``leafT`` over all arms/body/judge of
+    ``x`` PLUS its sampling-ensemble's tuned cardinality (``{cardinality} ∩
+    N_T``), folding in recursively through nesting.
+
+    The cardinality fold is intersected with ``N_T`` at EVERY layer (via the
+    final ``& program.tvars`` cut over the namespace-blind walk), so a composite
+    whose ensemble cardinality is bound Calibrated NEVER leaks a CVAR onto this
+    helper — that CVAR is a :func:`cal_fold` member instead (§3.6). Requiring
+    the ``program`` namespace is what makes this guarantee total.
+    """
+    return _leaf_names_raw(arm, program.composites) & program.tvars
+
+
 def _leaf_tvars_program(arm: Arm, program: CompositeProgram) -> frozenset[str]:
-    """``leafT`` intersected with ``N_T`` using the program's TVAR namespace —
-    keeps the cardinality term TVAR-only (C6)."""
-    raw = leaf_tvars(arm, program.composites)
-    return raw & program.tvars
+    """Internal alias kept for the §3.5 ``required_parents`` call sites."""
+    return leaf_tvars(program, arm)
 
 
 def required_parents(

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -1,0 +1,487 @@
+"""The pattern catalog v1: named macros over the composite algebra (RFC 0002).
+
+Patterns are the human-facing layer. Each catalog factory is a pure function
+of validated params that expands DETERMINISTICALLY into the sealed algebra of
+:mod:`traigent.knobs.composites`, stamping every emitted node with a closed
+:class:`~traigent.knobs.composites.Provenance` value (``pattern = <name>``,
+``param_hash = H_c(canonical validated params)``). Raw pattern params are
+NEVER stored — only their canonical hash rides provenance (§3.7, the P8
+admission-contract canary).
+
+A factory returns a :class:`CompositeKnob`: a declaration bundle the caller
+spreads into a ``ConfigSpace``. It exposes ``.structure`` (the IR root node),
+``.members`` (the member ``Knob`` declarations — bindings stay
+``Tuned | Calibrated | Fixed``; a composite never binds a value), ``.provenance``,
+and ``.telemetry_names`` (the §3.10 per-kind standard measure names). Adding a
+pattern is an SDK release, not a language or schema change; the algebra never
+grows because a pattern was added.
+
+INTEGRATION BOUNDARY (deliberate, captain decision): factories return
+DECLARATIONS only. Deep orchestrator/resolver wiring is a follow-up packet —
+nothing here touches ``traigent.core`` or ``traigent.cloud``.
+
+Unroll (§3.8): ``self_refine`` (a ``signal_accept`` loop) is unroll-eligible
+and exposes :meth:`CompositeKnob.unroll` returning the internal K-chain IR.
+``self_debug`` (an ``external_accept`` loop) offers no unroll and raises.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .bindings import Knob
+from .canonical import canonical_hash
+from .composites import (
+    AcceptDecl,
+    AggregateDecl,
+    AggregateKind,
+    CascadeBody,
+    CompositeKind,
+    CompositeNode,
+    EnsembleBody,
+    GateDecl,
+    GateKind,
+    LoopBody,
+    Placement,
+    Provenance,
+    SignalUse,
+    StageArm,
+    StatKind,
+    StopDecl,
+    StopKind,
+)
+
+__all__ = [
+    "CompositeKnob",
+    "KChain",
+    "KChainStage",
+    "best_of_n",
+    "binary_cascade",
+    "n_cascade",
+    "self_consistency",
+    "self_debug",
+    "self_refine",
+]
+
+#: §3.10 standard telemetry measure names, per constructor kind. Content-free:
+#: counts, rates, enums, finite numbers only (P8 discipline).
+_TELEMETRY: dict[CompositeKind, tuple[str, ...]] = {
+    CompositeKind.CASCADE: (
+        "escalation_rate",
+        "stage_selected",
+        "gate_margin_pass_rate",
+    ),
+    CompositeKind.ENSEMBLE: (
+        "vote_agreement",
+        "vote_margin",
+        "candidates_evaluated",
+        "candidates_excluded",
+    ),
+    CompositeKind.LOOP: ("iterations_used", "stop_reason"),
+}
+
+
+# --------------------------------------------------------------------------- #
+# K-chain IR (§3.8 Loop -> K-chain semantic compilation)                      #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class KChainStage:
+    """One stage of an unrolled ``signal_accept`` loop (§3.8).
+
+    ``body`` is the loop body specialized to iteration ``index``'s threaded
+    state; ``escalate_when`` carries the acceptance-direction complement
+    ``σ(state_i) < θ`` (the chain escalates to stage ``i+1`` exactly when the
+    ``signal_accept`` stop has NOT fired).
+    """
+
+    index: int
+    body: StageArm
+    escalate_when: str  # human-readable record of the escalation predicate
+
+
+@dataclass(frozen=True, slots=True)
+class KChain:
+    """The internal K-chain execution form of a ``signal_accept`` loop (§3.8).
+
+    This is an SDK intermediate representation, NOT a surface ``Cascade_post``
+    (the v1 gate registry has no state-predicate gate). ``signal``/``threshold``
+    are the loop stop's ``SignalUse.signal`` and threshold CVAR; ``state_keys``
+    are the declared threaded-state keys.
+    """
+
+    signal: str
+    threshold: str
+    state_keys: tuple[str, ...]
+    stages: tuple[KChainStage, ...]
+    provenance: Provenance | None = None
+
+
+# --------------------------------------------------------------------------- #
+# CompositeKnob: the factory return type                                      #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeKnob:
+    """A named composite declaration bundle (the pattern-factory return type).
+
+    ``structure`` is the IR root :class:`CompositeNode`; ``members`` are the
+    member ``Knob`` declarations the caller spreads into their ``ConfigSpace``
+    (bindings stay ``Tuned | Calibrated | Fixed`` — a composite NEVER binds a
+    value); ``provenance`` is stamped by the expander (``pattern = <name>``,
+    ``param_hash`` only — raw params never stored); ``telemetry_names`` is the
+    §3.10 per-kind standard measure tuple.
+    """
+
+    name: str
+    structure: CompositeNode
+    members: dict[str, Knob[Any]] = field(default_factory=dict)
+    provenance: Provenance | None = None
+    telemetry_names: tuple[str, ...] = ()
+
+    @property
+    def kind(self) -> CompositeKind:
+        return self.structure.kind
+
+    def unroll(self, k: int) -> KChain:
+        """Return the §3.8 K-chain IR (``signal_accept`` loops only).
+
+        Raises ``ValueError`` for any non-``signal_accept`` loop (an
+        ``external_accept``/``exhausted`` loop offers no unroll) or any
+        non-loop composite.
+        """
+        body = self.structure.body
+        if not isinstance(body, LoopBody):
+            raise ValueError(
+                f"unroll is only defined for loop composites; "
+                f"{self.name!r} is a {self.structure.kind.value}"
+            )
+        if body.stop.kind is not StopKind.SIGNAL_ACCEPT:
+            raise ValueError(
+                f"unroll is only defined for signal_accept loops; "
+                f"{self.name!r} stop kind is {body.stop.kind.value}"
+            )
+        if k < 1:
+            raise ValueError(f"unroll K must be >= 1, got {k}")
+        if not isinstance(body.body, StageArm):
+            raise ValueError("unroll v1 supports a stage-bodied loop only")
+        # A signal_accept stop always carries signal + threshold (guaranteed by
+        # StopDecl.__post_init__); guard explicitly so this holds under -O too.
+        if body.stop.signal is None or body.stop.threshold is None:
+            raise ValueError("signal_accept stop is missing its signal/threshold")
+        signal = body.stop.signal.signal
+        threshold = body.stop.threshold
+        stages = tuple(
+            KChainStage(
+                index=i,
+                body=body.body,
+                escalate_when=f"{signal}(state_{i}) < {threshold}",
+            )
+            for i in range(1, k + 1)
+        )
+        return KChain(
+            signal=signal,
+            threshold=threshold,
+            state_keys=body.state_keys,
+            stages=stages,
+            provenance=self.provenance,
+        )
+
+
+def _provenance(name: str, params: dict[str, Any]) -> Provenance:
+    """Stamp closed-shape provenance: ``pattern`` + ``param_hash`` only.
+
+    ``param_hash`` is ``H_c`` of the CANONICAL validated params; the raw
+    ``params`` dict is hashed and discarded — it never enters the returned
+    object (the P8 canary asserts a sentinel param value never serializes).
+    """
+    return Provenance(pattern=name, param_hash=canonical_hash(params))
+
+
+# --------------------------------------------------------------------------- #
+# Catalog v1 (§3.7)                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def binary_cascade(
+    name: str,
+    *,
+    base_stage: str,
+    expert_stage: str,
+    threshold: str,
+    base_tuned_params: tuple[str, ...] = (),
+    expert_tuned_params: tuple[str, ...] = (),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Cascade(arms=[stage(base), stage(expert)], gates=[margin_below θ], post)``.
+
+    The RFC 0001 cascade policy's exact shape — the migration target (§4).
+    """
+    params = {
+        "name": name,
+        "base_stage": base_stage,
+        "expert_stage": expert_stage,
+        "threshold": threshold,
+        "base_tuned_params": list(base_tuned_params),
+        "expert_tuned_params": list(expert_tuned_params),
+    }
+    prov = _provenance("binary_cascade", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.CASCADE,
+        body=CascadeBody(
+            arms=(
+                StageArm(base_stage, base_tuned_params),
+                StageArm(expert_stage, expert_tuned_params),
+            ),
+            gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold=threshold),),
+            placement=Placement.POST,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.CASCADE],
+    )
+
+
+def n_cascade(
+    name: str,
+    *,
+    stages: tuple[str, ...],
+    thresholds: tuple[str, ...],
+    tuned_params: tuple[tuple[str, ...], ...] | None = None,
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Cascade(arms=[stage(a_1)..stage(a_m)], gates=[θ_1..θ_{m-1}], post)``.
+
+    Ordered escalation. ``|thresholds|`` must equal ``|stages| - 1`` (the IR
+    enforces ``cascade_arity``). ``tuned_params``, when given, is one tuple per
+    stage.
+    """
+    if tuned_params is None:
+        tuned_params = tuple(() for _ in stages)
+    params = {
+        "name": name,
+        "stages": list(stages),
+        "thresholds": list(thresholds),
+        "tuned_params": [list(tp) for tp in tuned_params],
+    }
+    prov = _provenance("n_cascade", params)
+    arms = tuple(
+        StageArm(stage, tuned_params[i] if i < len(tuned_params) else ())
+        for i, stage in enumerate(stages)
+    )
+    gates = tuple(
+        GateDecl(kind=GateKind.MARGIN_BELOW, threshold=theta) for theta in thresholds
+    )
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.CASCADE,
+        body=CascadeBody(arms=arms, gates=gates, placement=Placement.POST),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.CASCADE],
+    )
+
+
+def self_consistency(
+    name: str,
+    *,
+    stage: str,
+    cardinality: str,
+    accept_threshold: str | None = None,
+    stage_tuned_params: tuple[str, ...] = (),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Ensemble(arms=[stage(a)], cardinality=k, majority_vote, accept?)``.
+
+    ``k`` may be tuned or calibrated. An optional ``accept_threshold`` adds a
+    ``stat_at_least(vote_margin, θ)`` acceptance decl (§3.7 note).
+    """
+    params = {
+        "name": name,
+        "stage": stage,
+        "cardinality": cardinality,
+        "accept_threshold": accept_threshold,
+        "stage_tuned_params": list(stage_tuned_params),
+    }
+    prov = _provenance("self_consistency", params)
+    accept = (
+        AcceptDecl(stat=StatKind.VOTE_MARGIN, threshold=accept_threshold)
+        if accept_threshold is not None
+        else None
+    )
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.ENSEMBLE,
+        body=EnsembleBody(
+            arms=(StageArm(stage, stage_tuned_params),),
+            aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE, accept=accept),
+            cardinality=cardinality,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.ENSEMBLE],
+    )
+
+
+def best_of_n(
+    name: str,
+    *,
+    stage: str,
+    judge_stage: str,
+    cardinality: str,
+    stage_tuned_params: tuple[str, ...] = (),
+    judge_tuned_params: tuple[str, ...] = (),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Ensemble(arms=[stage(a)], cardinality=k, judge_max(stage(judge)))``.
+
+    The judge output contract (finite numeric score) is §3.2 execution
+    semantics — runtime-enforced, not part of this declaration.
+    """
+    params = {
+        "name": name,
+        "stage": stage,
+        "judge_stage": judge_stage,
+        "cardinality": cardinality,
+        "stage_tuned_params": list(stage_tuned_params),
+        "judge_tuned_params": list(judge_tuned_params),
+    }
+    prov = _provenance("best_of_n", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.ENSEMBLE,
+        body=EnsembleBody(
+            arms=(StageArm(stage, stage_tuned_params),),
+            aggregate=AggregateDecl(
+                kind=AggregateKind.JUDGE_MAX,
+                judge=StageArm(judge_stage, judge_tuned_params),
+            ),
+            cardinality=cardinality,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.ENSEMBLE],
+    )
+
+
+def self_debug(
+    name: str,
+    *,
+    stage: str,
+    predicate: str,
+    max_iters: int,
+    state_keys: tuple[str, ...] = ("attempt", "critique"),
+    stage_tuned_params: tuple[str, ...] = (),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Loop(body=stage(a), state_keys, stop=external_accept(tests), max_iters=K)``.
+
+    The "2-step knob" at ``max_iters = 1``. The ``external_accept`` stop is an
+    opaque runtime predicate — NO unroll (§3.8); :meth:`CompositeKnob.unroll`
+    raises.
+    """
+    params = {
+        "name": name,
+        "stage": stage,
+        "predicate": predicate,
+        "max_iters": max_iters,
+        "state_keys": list(state_keys),
+        "stage_tuned_params": list(stage_tuned_params),
+    }
+    prov = _provenance("self_debug", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.LOOP,
+        body=LoopBody(
+            body=StageArm(stage, stage_tuned_params),
+            stop=StopDecl(kind=StopKind.EXTERNAL_ACCEPT, predicate=predicate),
+            state_keys=state_keys,
+            max_iters=max_iters,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.LOOP],
+    )
+
+
+def self_refine(
+    name: str,
+    *,
+    stage: str,
+    signal: str,
+    threshold: str,
+    max_iters: int,
+    state_keys: tuple[str, ...] = ("draft",),
+    signal_inputs: tuple[str, ...] = (),
+    stage_tuned_params: tuple[str, ...] = (),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Loop(body=stage(a), state_keys, stop=signal_accept(σ, θ), max_iters=K)``.
+
+    The calibrated ``signal_accept`` stop is unroll-eligible (§3.8):
+    :meth:`CompositeKnob.unroll` returns the K-chain IR. ``signal_inputs``, when
+    non-empty, must be a subset of ``state_keys`` (the IR enforces
+    ``stop_signal_outside_state``).
+    """
+    params = {
+        "name": name,
+        "stage": stage,
+        "signal": signal,
+        "threshold": threshold,
+        "max_iters": max_iters,
+        "state_keys": list(state_keys),
+        "signal_inputs": list(signal_inputs),
+        "stage_tuned_params": list(stage_tuned_params),
+    }
+    prov = _provenance("self_refine", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.LOOP,
+        body=LoopBody(
+            body=StageArm(stage, stage_tuned_params),
+            stop=StopDecl(
+                kind=StopKind.SIGNAL_ACCEPT,
+                threshold=threshold,
+                signal=SignalUse(signal=signal, inputs=signal_inputs),
+            ),
+            state_keys=state_keys,
+            max_iters=max_iters,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.LOOP],
+    )

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -262,11 +262,25 @@ def n_cascade(
     """``Cascade(arms=[stage(a_1)..stage(a_m)], gates=[θ_1..θ_{m-1}], post)``.
 
     Ordered escalation. ``|thresholds|`` must equal ``|stages| - 1`` (the IR
-    enforces ``cascade_arity``). ``tuned_params``, when given, is one tuple per
-    stage.
+    enforces ``cascade_arity``).
+
+    ``tuned_params``, WHEN PROVIDED, declares the per-stage parentage and MUST
+    have EXACTLY one tuple per stage (``len(tuned_params) == len(stages)``) — a
+    short list is NOT silently backfilled with ``()``, because that would
+    under-declare an arm's parent coverage (§3.5). Omitting the argument
+    entirely keeps every stage's ``tuned_params`` empty (the documented
+    policy-migration ratchet, §4); a PARTIAL declaration rejects with
+    ``invalid_tuned_param``.
     """
     if tuned_params is None:
         tuned_params = tuple(() for _ in stages)
+    elif len(tuned_params) != len(stages):
+        raise ValueError(
+            "invalid_tuned_param: tuned_params must declare exactly one tuple "
+            f"per stage (got {len(tuned_params)} for {len(stages)} stage(s)); "
+            "omit tuned_params entirely to leave all stages undeclared, but "
+            "partial per-stage declarations are not silently backfilled"
+        )
     params = {
         "name": name,
         "stages": list(stages),
@@ -274,10 +288,7 @@ def n_cascade(
         "tuned_params": [list(tp) for tp in tuned_params],
     }
     prov = _provenance("n_cascade", params)
-    arms = tuple(
-        StageArm(stage, tuned_params[i] if i < len(tuned_params) else ())
-        for i, stage in enumerate(stages)
-    )
+    arms = tuple(StageArm(stage, tuned_params[i]) for i, stage in enumerate(stages))
     gates = tuple(
         GateDecl(kind=GateKind.MARGIN_BELOW, threshold=theta) for theta in thresholds
     )


### PR DESCRIPTION
## What

Implements the SDK packet of **RFC 0002 — Composite Knobs** (owner-ACCEPTED 2026-06-06; `tvl/formalization/rfc-0002-composite-knobs.md`). Two-layer design: a **sealed internal IR** (`CompositeKind ∈ {cascade, ensemble, loop}`, frozen algebra nodes, closed Provenance) + an **open pattern catalog v1** (`binary_cascade`, `n_cascade`, `self_consistency`, `best_of_n`, `self_debug`, `self_refine`) expanding as provenance-carrying macros.

**Deliberate packet boundary**: declarations only — `traigent/core` and `traigent/cloud` untouched; orchestrator/resolver wiring is a follow-up packet. 4 new files, zero existing files modified.

## Governance & review
- ChangeSession `cs_aef1b9d2edfa5200`, packet `pkt_11c56d120487dbd9`.
- codex gpt-5.5 xhigh review: round 1 REJECT (5 blockers: leafT TVAR-boundary, cardinality typing, scope carry-over, judge duplicate-stage, empty-ident holes) → all fixed red-first + 1 self-found hole; delta round found the `cal_fold` boundary dual (tuned cardinality leaking into the Cal set) → fixed red-first; **final VERDICT: ACCEPT**.
- Honest note: one intermediate commit briefly pushed a malformed regression test (failed at construction); corrected in `4f4b545c` with provenance in the commit message.

## Verification
- `tests/unit/knobs`: **184 passed** (62→79 packet tests), captain re-ran twice; golden expansion hashes byte-stable across independent runs.
- P8 canary: sentinel pattern-param never serializes (param_hash only).
- Fail-closed: uncertified gate threshold ⇒ non-empty coverage gap (real issued certificate closes it).
- pre-commit (black/isort/ruff/mypy/bandit/detect-secrets) clean.

## PR checklist (policy-surface items)
1. **Worst-case prod path**: IR/factories are declaration-time only — no runtime/policy path executes; the coverage fold is fail-closed by construction (any gap ⇒ no certified selection).
2. **Production-branch test**: `test_pattern_factories.py` fail-closed coverage test; `test_composites_model.py::TestCalFoldBoundary`.
3. **Contract regeneration**: none — no wire/schema crossing this program (contract-decision v1, FR-TVL-COMPOSITE-KNOBS-V1).
4. **Public surface delta**: new submodules `traigent.knobs.composites` / `.patterns`; `knobs/__init__.py` deliberately unchanged this packet.
5. **Review threads**: will be resolved per Rule 8 before merge.
6. **Quality gates**: none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)