### PR TITLE
docs: 0.12.0 freshness refresh (all 149 docs reviewed)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,15 @@
 
 ## 🚀 Quick Start
 
+Current release: Traigent SDK 0.12.0. Install with
+`pip install "traigent[recommended]"`, then run `traigent onboard`,
+`traigent auth device-login`, `traigent quickstart`,
+`traigent first-prompt --agent claude|cursor|codex`, `traigent mcp serve`, or
+`traigent recommend` as needed.
+
+License: Traigent SDK is dual-licensed under
+`AGPL-3.0-only OR LicenseRef-Traigent-Commercial`.
+
 ```python
 import litellm
 import traigent
@@ -82,11 +91,8 @@ Traigent is a **zero-code optimization platform** that automatically finds the b
 
 ## 🌐 Examples Navigator
 
-- Open: `examples/index.html` (repo copy)
-- Serve locally (avoids file:// fetch restrictions):
-  - `python -m http.server 8000`
-  - Visit `http://localhost:8000/examples/`
-- Run icon: Each code block has a play button that copies a ready-to-run mock-mode command.
+Use [Examples Guide](examples/README.md), [Start Here](examples/START_HERE.md),
+and [Quick Reference](examples/QUICK_REFERENCE.md) for runnable examples.
 
 ## 🧪 Example Guides
 
@@ -100,7 +106,7 @@ Traigent is a **zero-code optimization platform** that automatically finds the b
 
 1. **[Install Traigent](getting-started/installation.md)** - Get set up in minutes
 2. **[Follow the Getting Started Guide](getting-started/GETTING_STARTED.md)** - Your first optimization
-3. **Open the Examples** – `examples/index.html` and browse the gallery
+3. **Use the Example Guides** - Start with [Examples Guide](examples/README.md)
 4. **[Explore User Guides](user-guide/)** - Learn advanced features
 5. **[Check API Reference](api-reference/)** - Detailed technical documentation
 

--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -1,6 +1,6 @@
 # Traigent SDK API Reference
 
-Authoritative reference for Traigent SDK **v0.10.0 (Beta)**.
+Authoritative reference for Traigent SDK **0.12.0**.
 
 ## Quick Navigation
 
@@ -22,7 +22,8 @@ def optimize(
     objectives: list[str] | ObjectiveSchema | None = None,
     configuration_space: dict[str, Any] | ConfigSpace | None = None,
     default_config: dict[str, Any] | None = None,
-    constraints: list[Constraint | Callable[..., Any]] | None = None,
+    constraints: list[Constraint | BoolExpr | Callable[..., Any]] | None = None,
+    safety_constraints: list[SafetyConstraint | CompoundSafetyConstraint] | None = None,
     # TVL integration
     tvl_spec: str | Path | None = None,
     tvl_environment: str | None = None,
@@ -30,8 +31,29 @@ def optimize(
     # Grouped options (preferred)
     evaluation: EvaluationOptions | dict[str, Any] | None = None,
     injection: InjectionOptions | dict[str, Any] | None = None,
+    effectuation: bool = False,
     execution: ExecutionOptions | dict[str, Any] | None = None,
     mock: MockModeOptions | dict[str, Any] | None = None,
+    strategy: str | None = None,
+    strategy_params: Mapping[str, Any] | None = None,
+    # Multi-agent configuration
+    agents: dict[str, AgentDefinition] | None = None,
+    agent_prefixes: list[str] | None = None,
+    agent_measures: dict[str, list[str]] | None = None,
+    global_measures: list[str] | None = None,
+    # Config persistence
+    auto_load_best: bool = False,
+    load_from: str | None = None,
+    config_id: str | None = None,
+    best_config_source: str = "off",
+    best_config_strict: bool = False,
+    best_config_cache_dir: str | None = None,
+    best_config_cache_ttl_seconds: int = 24 * 60 * 60,
+    best_config_stale_ok_ttl_seconds: int | None = None,
+    enable_auto_load_dev_logs: bool | None = None,
+    # Guided generation
+    prompt_rewrite: dict[str, Any] | None = None,
+    grow_dataset: dict[str, Any] | None = None,
     # Legacy compatibility
     legacy: LegacyOptimizeArgs | dict[str, Any] | None = None,
     **runtime_overrides: Any,
@@ -48,6 +70,13 @@ def optimize(
 | `configuration_space` | `dict[str, Any] \| ConfigSpace \| None` | `None` | Search space describing tunable parameters. Lists denote discrete choices; `(min, max)` tuples denote ranges. `Range`, `IntRange`, `LogRange`, `Choices`, and `ConfigSpace` are supported directly. Required for optimization. |
 | `default_config` | `dict[str, Any] \| None` | `None` | Baseline configuration applied before the first trial. Missing keys remain unset unless you provide defaults via `default_config` or parameter defaults (for example `Range(..., default=...)`). |
 | `constraints` | `list[Constraint \| Callable[..., Any]] \| None` | `None` | Hard constraints evaluated before running a trial. Accepts SE-friendly `Constraint` objects and/or callables that take `(config, metrics=None)` and return `True/False`. |
+| `safety_constraints` | `list[SafetyConstraint \| CompoundSafetyConstraint] \| None` | `None` | Safety metric gates evaluated as part of optimization. |
+| `strategy` | `str \| None` | `None` | Optional strategy preset name. 0.12.0 presets are advisory selection rules over completed trials. |
+| `strategy_params` | `Mapping[str, Any] \| None` | `None` | Parameters for the selected strategy preset. |
+| `effectuation` | `bool` | `False` | Enables effectuation tracking for tuned-variable observations. |
+| `agents`, `agent_prefixes`, `agent_measures`, `global_measures` | See signature | `None` | Multi-agent measurement configuration. |
+| Config persistence fields | See signature | See signature | `auto_load_best`, `load_from`, `config_id`, `best_config_*`, and cache TTL controls for persisted best configurations. |
+| Guided-generation fields | `dict[str, Any] \| None` | `None` | `prompt_rewrite` and `grow_dataset` configure guided generation; run it with `.optimize_with_guidance(provider)`. |
 
 **SE-friendly tuned variables (first-class)**
 
@@ -98,6 +127,20 @@ def my_agent(question: str) -> str:
 | `privacy_enabled` | `bool \| None` | `None` | Redacts prompts/responses from telemetry and logs. |
 | `max_total_examples` | `int \| None` | `None` | Global sample budget across all trials (budget guardrail). |
 | `samples_include_pruned` | `bool` | `True` | Whether pruned trials count toward the sample budget. |
+| `reps_per_trial` | `int` | `1` | Number of repetitions per configuration. OSS SDK accepts only `1`; other values raise `pydantic.ValidationError` and require Traigent Enterprise. |
+| `reps_aggregation` | `str` | `"mean"` | Repetition aggregation method. OSS SDK accepts only `"mean"`; other values raise `pydantic.ValidationError` and require Traigent Enterprise. |
+| `hybrid_api_endpoint` | `str \| None` | `None` | External-agent Hybrid API base endpoint. |
+| `tunable_id` | `str \| None` | `None` | Optional Hybrid API tunable identifier. |
+| `hybrid_api_transport` | `Any \| None` | `None` | Custom Hybrid API transport object. |
+| `hybrid_api_transport_type` | `str` | `"auto"` | Hybrid API transport type selector. |
+| `hybrid_api_batch_size` | `int` | `1` | Number of examples per Hybrid API execute request. |
+| `hybrid_api_batch_parallelism` | `int` | `1` | Concurrent Hybrid API batch execution limit. |
+| `hybrid_api_keep_alive` | `bool` | `True` | Reuse Hybrid API HTTP connections. |
+| `hybrid_api_heartbeat_interval` | `float` | `30.0` | Heartbeat interval for Hybrid API transports. |
+| `hybrid_api_timeout` | `float \| None` | `None` | Hybrid API request timeout override. |
+| `hybrid_api_auth_header` | `str \| None` | `None` | Auth token/header value sent as both `Authorization` and `x-api-key`. |
+| `hybrid_api_auto_discover_tvars` | `bool` | `False` | Auto-discover Hybrid API tuned variables when supported. |
+| `cloud_fallback_policy` | `str \| None` | `None` | Legacy/future cloud fallback policy. It does not enable `execution_mode="cloud"` in 0.12.0. |
 
 **Legacy Compatibility**
 
@@ -171,6 +214,9 @@ async def optimize(
     tvl_spec: str | Path | None = None,
     tvl_environment: str | None = None,
     tvl: TVLOptions | dict[str, Any] | None = None,
+    strategy: str | None = None,
+    strategy_params: Mapping[str, Any] | None = None,
+    progress_bar: bool | None = None,
     **algorithm_kwargs: Any,
 ) -> OptimizationResult
 ```
@@ -190,6 +236,9 @@ async def optimize(
 | `tvl_spec` | `str \| Path \| None` | `None` | Load TVL spec at runtime. |
 | `tvl_environment` | `str \| None` | `None` | Environment overlay from the TVL spec. |
 | `tvl` | `TVLOptions \| dict \| None` | `None` | Structured TVL options for runtime overrides. |
+| `strategy` | `str \| None` | `None` | Runtime strategy preset override. Preset selections are advisory only. |
+| `strategy_params` | `Mapping[str, Any] \| None` | `None` | Runtime parameters for the strategy preset. |
+| `progress_bar` | `bool \| None` | `None` | Runtime progress-bar override. |
 | `**algorithm_kwargs` | `Any` | – | Extra tuning knobs. See recognised keys below. |
 
 **Recognised `algorithm_kwargs`**
@@ -379,6 +428,64 @@ def override_config(
 ```python
 def get_available_strategies() -> dict[str, Any]
 ```
+
+### Recommendation Catalog and Strategy Presets
+
+0.12.0 exposes local catalog helpers and advisory selection presets through
+`traigent.api`.
+
+```python
+def list_recommendation_agent_types() -> tuple[str, ...]
+
+def recommend_configuration_space(
+    agent_type: str,
+    *,
+    min_impact: str | None = None,
+    min_confidence: str | None = None,
+) -> dict[str, Any]
+```
+
+`recommend_configuration_space()` returns catalog metadata for supported
+agent/task types: knob names, suggested ranges, impact estimates, evidence
+notes, effectuation status, and apply guidance. It does not call a remote
+service.
+
+```python
+VALID_PRESET_NAMES: tuple[str, ...] = (
+    "max_accuracy_then_cheapest_within_epsilon",
+    "quality_floor_min_cost",
+    "pareto_frontier",
+)
+
+def normalize_strategy_preset(
+    preset_name: str | None,
+    params: Mapping[str, Any] | None = None,
+) -> NormalizedStrategyPreset
+
+def select_strategy_preset(
+    preset: NormalizedStrategyPreset,
+    trials: Iterable[TrialResult],
+) -> PresetSelection
+```
+
+Strategy presets are advisory selection rules over completed trials. They are
+task-local heuristics and do not provide a statistical certificate.
+
+### CLI surfaces in 0.12.0
+
+The local CLI includes these onboarding and recommendation entry points:
+
+- `traigent onboard`
+- `traigent auth device-login`
+- `traigent first-prompt --agent claude|cursor|codex`
+- `traigent quickstart`
+- `traigent mcp serve`
+- `traigent recommend`
+
+The local MCP server in this worktree exposes these tools: `auth_status`,
+`list_recommendation_agent_types`, `recommend_configuration_space`,
+`detect_tvars`, `scaffold_eval`, `validate_dataset`, `estimate_cost`,
+`run_optimization`, `get_results`, and `export_evidence`.
 
 ### `traigent.get_optimization_insights()`
 
@@ -592,4 +699,4 @@ def my_function(input_text: str) -> str:
 
 ---
 
-This documentation reflects Traigent SDK v0.10.0.
+This documentation reflects Traigent SDK 0.12.0.

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -36,6 +36,7 @@ def optimize(
     configuration_space: dict[str, Any] | ConfigSpace | None = None,
     default_config: dict[str, Any] | None = None,
     constraints: list[Constraint | BoolExpr | Callable[..., Any]] | None = None,
+    safety_constraints: list[SafetyConstraint | CompoundSafetyConstraint] | None = None,
 
     # TVL integration
     tvl_spec: str | Path | None = None,
@@ -45,8 +46,32 @@ def optimize(
     # Grouped option bundles (preferred)
     evaluation: EvaluationOptions | dict[str, Any] | None = None,
     injection: InjectionOptions | dict[str, Any] | None = None,
+    effectuation: bool = False,
     execution: ExecutionOptions | dict[str, Any] | None = None,
     mock: MockModeOptions | dict[str, Any] | None = None,
+    strategy: str | None = None,
+    strategy_params: Mapping[str, Any] | None = None,
+
+    # Multi-agent configuration
+    agents: dict[str, AgentDefinition] | None = None,
+    agent_prefixes: list[str] | None = None,
+    agent_measures: dict[str, list[str]] | None = None,
+    global_measures: list[str] | None = None,
+
+    # Config persistence
+    auto_load_best: bool = False,
+    load_from: str | None = None,
+    config_id: str | None = None,
+    best_config_source: str = "off",
+    best_config_strict: bool = False,
+    best_config_cache_dir: str | None = None,
+    best_config_cache_ttl_seconds: int = 24 * 60 * 60,
+    best_config_stale_ok_ttl_seconds: int | None = None,
+    enable_auto_load_dev_logs: bool | None = None,
+
+    # Guided generation
+    prompt_rewrite: dict[str, Any] | None = None,
+    grow_dataset: dict[str, Any] | None = None,
 
     # Legacy compatibility
     legacy: LegacyOptimizeArgs | dict[str, Any] | None = None,
@@ -424,7 +449,8 @@ def my_function(prompt: str) -> str:
     ...
 ```
 
-Complete Example: See [06_custom_evaluator.py](../../walkthrough/real/06_custom_evaluator.py) for a full LLM-as-Judge implementation.
+Complete example: see the repository's custom evaluator walkthrough for a full
+LLM-as-Judge implementation.
 
 #### `injection`
 
@@ -470,6 +496,8 @@ from traigent.config.parallel import ParallelConfig
         privacy_enabled=False,
         max_total_examples=1000,
         samples_include_pruned=True,
+        reps_per_trial=1,
+        reps_aggregation="mean",
     ),
     ...
 )
@@ -484,6 +512,10 @@ from traigent.config.parallel import ParallelConfig
 - `privacy_enabled`: Redact sensitive data
 - `max_total_examples`: Global sample budget
 - `samples_include_pruned`: Count pruned trials in budget
+- `reps_per_trial`: Repetitions per configuration. OSS SDK accepts only `1`; non-default values raise `pydantic.ValidationError` and require Traigent Enterprise.
+- `reps_aggregation`: Repetition aggregation method. OSS SDK accepts only `"mean"`; non-default values raise `pydantic.ValidationError` and require Traigent Enterprise.
+- `hybrid_api_endpoint`, `tunable_id`, `hybrid_api_transport`, `hybrid_api_transport_type`, `hybrid_api_batch_size`, `hybrid_api_batch_parallelism`, `hybrid_api_keep_alive`, `hybrid_api_heartbeat_interval`, `hybrid_api_timeout`, `hybrid_api_auth_header`, `hybrid_api_auto_discover_tvars`: Hybrid API execution controls.
+- `cloud_fallback_policy`: Legacy/future cloud fallback behavior. It does not enable `execution_mode="cloud"` in 0.12.0.
 
 #### `mock`
 
@@ -665,4 +697,4 @@ def my_agent(query: str) -> str:
 - [Execution Modes Guide](../guides/execution-modes.md) - Execution mode details
 - [Thread Pool Examples](./thread-pool-examples.md) - Context propagation with threads
 - [Telemetry Documentation](./telemetry.md) - Data collection and privacy
-- [Custom Evaluator Example](../../walkthrough/real/06_custom_evaluator.py) - LLM-as-Judge implementation
+- Custom evaluator walkthrough in the repository examples - LLM-as-Judge implementation

--- a/docs/api-reference/telemetry.md
+++ b/docs/api-reference/telemetry.md
@@ -80,6 +80,35 @@ The older plural spelling `TRAIGENT_TRACES_ENABLED` remains as a deprecated
 alias when the canonical flag is unset; if both are set,
 `TRAIGENT_TRACE_ENABLED` takes precedence.
 
+### Agent Workflow Spans
+
+0.12.0 exposes a public helper for adding sanitized agent/node spans to the
+active optimization workflow trace:
+
+```python
+from collections.abc import Mapping
+from typing import Any
+
+from traigent.observability import add_agent_span
+
+def add_agent_span(
+    node_id: str,
+    *,
+    span_type: str = "agent",
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_usd: float | None = None,
+    latency_ms: float | None = None,
+    model: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None
+```
+
+The helper is safe to call from user code. If no active optimization trial or
+workflow trace manager exists, it logs at debug level and returns. Metadata is
+limited to safe numeric values, sensitive keys such as prompt/response/output
+are dropped, and model identifiers are validated before emission.
+
 ## How Telemetry is Used
 
 Telemetry data is used for:

--- a/docs/api-reference/thread-pool-examples.md
+++ b/docs/api-reference/thread-pool-examples.md
@@ -458,4 +458,4 @@ async def process_items_async(items):
 - [API Reference](./complete-function-specification.md) - Full API documentation
 - [Parallel Configuration Guide](../guides/parallel-configuration.md) - Concurrency tuning and precedence
 - [Evaluation Guide](../guides/evaluation.md) - Parallel evaluation and concurrency tips
-- [Context Management Source](../../traigent/config/context.py) - Implementation details
+- Context management implementation: see `traigent/config/context.py` in the repository source.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -413,4 +413,4 @@ print(f"Accuracy: {result.best_metrics['accuracy']:.2%}")
 
 ## Learn More
 
-- [Examples](../../examples/)
+- Examples in the repository source (`examples/`)

--- a/docs/architecture/cost-architecture-validation.md
+++ b/docs/architecture/cost-architecture-validation.md
@@ -26,6 +26,11 @@ The following items from this validation were implemented on
   - `claude-haiku`, `claude-sonnet`, `claude-opus`.
 - Hybrid aggregated metrics now emit both `cost` and `total_cost`, and orchestrator
   extraction uses `total_cost` with `cost` fallback.
+- 0.12.0 adds pre-trial model price coverage checks before any cloud or local
+  trial dispatch: unpriced models warn in normal mode and fail before a trial
+  when `TRAIGENT_STRICT_COST_ACCOUNTING=true`. Custom pricing can be supplied
+  with `TRAIGENT_CUSTOM_MODEL_PRICING_JSON` or
+  `TRAIGENT_CUSTOM_MODEL_PRICING_FILE`.
 - CI/pre-commit guardrail added to prevent reintroducing
   `cost_from_tokens(..., strict=False)` in runtime post-call paths
   (allowlisted only for query pricing helper usage).

--- a/docs/architecture/integrations-inventory.md
+++ b/docs/architecture/integrations-inventory.md
@@ -3,8 +3,8 @@
 ## Overview
 The `traigent/integrations/` directory contains the framework integration system that enables zero-code optimization across multiple LLM providers and frameworks. This system uses a hybrid plugin + framework override architecture.
 
-**Total Files**: 27 Python files (~8,241 lines)
-**Total Integrations**: 7+ major providers with 20+ framework variants
+**Total Files**: 66 Python files, regenerated from the current `traigent/integrations/` tree.
+**Total Integrations**: Built-in coverage spans OpenAI, Anthropic, LangChain, Bedrock, Azure OpenAI, Cohere, Gemini, HuggingFace, LiteLLM, LlamaIndex, Mistral, PydanticAI, vector stores, and observability integrations.
 
 ---
 
@@ -622,7 +622,7 @@ log_override_details: bool = False
 **Features**:
 - Sync and streaming interfaces
 - boto3 optional import
-- Mock mode support (BEDROCK_MOCK=true)
+- Mock mode support through `TRAIGENT_MOCK_LLM=true` or the in-code quickstart helper. Provider-specific `*_MOCK` environment variables are ignored.
 - Anthropic Messages API format
 
 ---
@@ -682,12 +682,13 @@ langchain_nvidia
 
 ---
 
-## Vector Stores (Placeholder for Future)
+## Vector Stores
 
 ### 20. **vector_stores/__init__.py** (5 lines)
-**Purpose**: Future vector store integrations
+**Purpose**: Vector store integration package
 
-**Status**: Framework in place, implementations pending
+**Status**: Implementations are present for ChromaDB, Pinecone, and Weaviate,
+with a shared base plugin.
 
 ---
 
@@ -814,43 +815,34 @@ OpenAI SDK (optional):
 
 ## Known Gaps & TODOs
 
-### Missing Implementations
-1. **Vector Store Integrations** - Placeholder exists, no implementations
-   - Pinecone, Weaviate, Milvus, etc.
-
-2. **Cohere Plugin** - Referenced in framework_override.py but no dedicated plugin
-   - Parameter mappings exist in hardcoded form
-   - Needs dedicated CoherPlugin class
-
-3. **HuggingFace Plugin** - Referenced but no dedicated plugin
-   - Parameter mappings exist in hardcoded form
-   - Needs dedicated HuggingFacePlugin class
+### Implemented Plugin Families
+The current integrations tree includes dedicated plugins for Cohere and
+HuggingFace, plus vector-store plugins for ChromaDB, Pinecone, and Weaviate.
+Do not treat those families as missing when planning integration work.
 
 ### Partial Implementations
-4. **Bedrock Async Support** - Limited async/await integration
-5. **Azure OpenAI Streaming** - Streaming support incomplete
-6. **Gemini Streaming** - Streaming support incomplete
+1. **Bedrock Async Support** - Limited async/await integration
+2. **Azure OpenAI Streaming** - Streaming support incomplete
+3. **Gemini Streaming** - Streaming support incomplete
 
 ### Feature Gaps
-7. **Batch Endpoints** - Limited batch processing support for some providers
-8. **Vision/Multimodal** - No vision parameter handling (OpenAI vision, Claude vision)
-9. **Structured Output** - No JSON mode / structured output support
-10. **Custom Endpoints** - Limited custom endpoint override support
+4. **Batch Endpoints** - Limited batch processing support for some providers
+5. **Vision/Multimodal** - No vision parameter handling (OpenAI vision, Claude vision)
+6. **Structured Output** - No JSON mode / structured output support
+7. **Custom Endpoints** - Limited custom endpoint override support
 
 ### Documentation Gaps
-11. No TODO/FIXME comments found in integration code (clean!)
-12. Some complex logic lacks inline documentation
-13. Plugin contribution guide missing
+8. No TODO/FIXME comments found in integration code (clean!)
+9. Some complex logic lacks inline documentation
+10. Plugin contribution guide missing
 
 ---
 
 ## Enhancement Opportunities
 
 ### High Priority
-1. Create `CoherPlugin` for Cohere SDK integration
-2. Create `HuggingFacePlugin` for HuggingFace integration
-3. Implement vector store integration framework
-4. Add streaming support documentation
+1. Keep provider-specific plugin docs synchronized with `traigent/integrations/llms/`.
+2. Add streaming support documentation.
 
 ### Medium Priority
 5. Add vision/multimodal parameter support

--- a/docs/architecture/plugin_architecture.md
+++ b/docs/architecture/plugin_architecture.md
@@ -172,23 +172,14 @@ response = client.chat.completions.create(
 
 ## Built-in Plugins
 
-### OpenAI Plugin (`openai_plugin.py`)
+The built-in plugin surface is regenerated from the current
+`traigent/integrations/` tree. It includes:
 
-- **Packages**: `openai`
-- **Models**: GPT-4, GPT-3.5, Davinci, etc.
-- **Special Features**: Function calling, streaming, vision
-
-### LangChain Plugin (`langchain_plugin.py`)
-
-- **Packages**: `langchain`, `langchain-*` sub-packages
-- **Special Features**: Dynamic discovery, RAG parameters, chain configuration
-- **Auto-Discovery**: Scans for installed LangChain packages
-
-### Anthropic Plugin (`anthropic_plugin.py`)
-
-- **Packages**: `anthropic`
-- **Models**: Claude 3, Claude 2, Claude Instant
-- **Special Features**: System prompts, tool use
+- **LLM providers and frameworks**: OpenAI, Anthropic, LangChain, Bedrock, Azure OpenAI, Cohere, Gemini, HuggingFace, LiteLLM, LlamaIndex, and Mistral.
+- **PydanticAI**: PydanticAI handler and plugin support under `integrations/pydantic_ai/`.
+- **Vector stores**: ChromaDB, Pinecone, Weaviate, and the shared vector-store base plugin.
+- **Observability integrations**: MLflow, Weights & Biases, and workflow trace integration files under `integrations/observability/`.
+- **Supporting surfaces**: model discovery, provider registries, mock adapter, response wrapping, validation, and parameter normalization utilities.
 
 ## Advanced Features
 

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -13,7 +13,6 @@ Traigent/
 ├── traigent/                  # Core SDK source code
 ├── tests/                     # Test suite
 ├── examples/                  # Usage examples and demo runners
-├── walkthrough/               # Interactive tutorials with datasets
 ├── docs/                      # Documentation (this folder)
 ├── tools/                     # Architecture analysis and dev utilities
 ├── scripts/                   # Utility and automation scripts
@@ -38,8 +37,8 @@ Core SDK source code, including:
 - `core/` orchestration and optimized function
 - `optimizers/` algorithms (grid/random/optuna/interactive)
 - `evaluators/` dataset and evaluation
-- `integrations/` framework adapters (LangChain/OpenAI/Anthropic)
-- `cloud/` cloud client models (experimental)
+- `integrations/` framework adapters (OpenAI, Anthropic, LangChain, Bedrock, Azure, Gemini, Cohere, HuggingFace, LiteLLM, LlamaIndex, Mistral, PydanticAI, vector stores, and observability)
+- `cloud/` hybrid/backend auth and sync clients; remote cloud execution remains reserved for future service-backed runs
 - `storage/`, `utils/`, `visualization/`, `tvl/`, etc.
 
 ### `/tests/`
@@ -58,9 +57,6 @@ Documentation content:
 ### `/examples/`
 Usage examples, datasets, and the browser gallery assets (`examples/gallery/`).
 
-### `/walkthrough/`
-Interactive step-by-step tutorials with datasets.
-
 ### `/tools/`
 Architecture analysis (`tools/architecture/`) and environment utilities.
 CI workflow dependency via `.github/workflows/architecture-analysis.yml`.
@@ -72,7 +68,8 @@ Helper scripts (e.g., launchers, verification, utilities).
 Optional plugin packages: analytics, tracing, OPAL, tuned-variables, UI.
 
 ### `/requirements/`
-Dependency sets by feature. See `requirements/README.md` for install guidance.
+Legacy dependency mirrors and supporting guides. `pyproject.toml` extras are
+the canonical install surface for current package builds.
 
 ## File Organization Principles
 

--- a/docs/contributing/ADDING_NEW_INTEGRATIONS.md
+++ b/docs/contributing/ADDING_NEW_INTEGRATIONS.md
@@ -528,5 +528,4 @@ For reference, study these existing implementations:
 ## License
 
 By contributing, you agree to follow Traigent's Contributor License Agreement
-(CLA) policy. See
-[`../../CONTRIBUTOR-LICENSING.md`](../../CONTRIBUTOR-LICENSING.md).
+(CLA) policy. See `CONTRIBUTOR-LICENSING.md` in the repository root.

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -205,8 +205,8 @@ Traigent/
 Traigent accepts external contributions only after a signed Contributor License
 Agreement (CLA). Contributions are merged into a project whose open-source
 releases are licensed under AGPLv3, and Traigent may also offer the project
-under separate commercial terms. See
-[`../../CONTRIBUTOR-LICENSING.md`](../../CONTRIBUTOR-LICENSING.md).
+under separate commercial terms. See `CONTRIBUTOR-LICENSING.md` in the
+repository root.
 
 ## Thank You
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -14,6 +14,11 @@ Guidelines and policies for contributing to Traigent SDK.
 2. **Review [Code of Conduct](CODE_OF_CONDUCT.md)** - Community expectations
 3. **Check [Security Policy](SECURITY.md)** - If reporting security issues
 
+For SDK development, use `make install-dev` or
+`python -m pip install -e ".[all,dev,dspy,docs]"`. For end-user onboarding
+surfaces in 0.12.0, see `traigent onboard`, `traigent quickstart`, and
+`traigent auth device-login`.
+
 ## Additional Resources
 
 - **[Architecture Documentation](../architecture/)** - Understand the codebase structure

--- a/docs/contributing/aikido_triage.md
+++ b/docs/contributing/aikido_triage.md
@@ -9,15 +9,15 @@ cannot be safely fixed by code changes alone.
 - Aikido issue group: `27772214`
 - Type: `license`
 - Severity: `critical`
-- Affected package: `traigent@0.11.4`
+- Affected package: `traigent@0.12.0`
 - Affected file: `uv.lock`
-- Related license: `AGPL-3.0-only`
+- Related license: `AGPL-3.0-only OR LicenseRef-Traigent-Commercial`
 - Disposition: intentional project license, requires Aikido issue ignore
 
 The finding is for the SDK root package's declared license, not for a
 third-party dependency license drift. The repository consistently declares
-`AGPL-3.0-only` in `pyproject.toml`, includes the AGPL license text in
-`LICENSE`, and documents separate commercial licensing in
+`AGPL-3.0-only OR LicenseRef-Traigent-Commercial` in `pyproject.toml`,
+includes the AGPL license text in `LICENSE`, and documents separate commercial licensing in
 `COMMERCIAL-LICENSING.md` and `CONTRIBUTOR-LICENSING.md`.
 
 Do not resolve this by excluding `uv.lock` from Aikido scanning. That would
@@ -27,5 +27,5 @@ Do not change the SDK license as a scanner remediation without explicit legal
 and business approval. If Aikido comments on a PR for this finding, reply:
 
 ```text
-@AikidoSec ignore: Intentional SDK project license. Traigent open-source releases are AGPL-3.0-only and separate commercial licenses are documented in COMMERCIAL-LICENSING.md and CONTRIBUTOR-LICENSING.md. This is the root package license, not a third-party dependency license drift.
+@AikidoSec ignore: Intentional SDK project license. Traigent SDK is dual-licensed under AGPL-3.0-only OR LicenseRef-Traigent-Commercial, with commercial licensing documented in COMMERCIAL-LICENSING.md and CONTRIBUTOR-LICENSING.md. This is the root package license, not a third-party dependency license drift.
 ```

--- a/docs/examples/LEARNING_ROADMAP.md
+++ b/docs/examples/LEARNING_ROADMAP.md
@@ -34,8 +34,8 @@ Outcome: you can experiment with new metrics, evaluate RAG systems, and integrat
 
 ## Running and debugging
 ```bash
-pip install -e ".[examples]"
-export TRAIGENT_MOCK_LLM=true
+pip install "traigent[recommended]"
+# In local tutorial code, call enable_mock_mode_for_quickstart() before running LLM examples.
 ls examples/datasets/<example-name>
 rg "optimize(" examples
 ```

--- a/docs/examples/QUICK_REFERENCE.md
+++ b/docs/examples/QUICK_REFERENCE.md
@@ -5,7 +5,7 @@ Everything you need to run and adapt examples quickly.
 ## Common commands
 ```bash
 # Install from repo root (includes example deps)
-pip install -e ".[examples]"
+pip install "traigent[recommended]"
 
 # Auto-mocks when ANTHROPIC_API_KEY is unset
 python examples/core/simple-prompt/run.py
@@ -34,7 +34,7 @@ def summarize(text: str) -> str:
 - `edge_analytics` (default and supported) - local execution with analytics.
 - `hybrid` (supported) - local trial execution with backend/portal session and metric tracking.
 - `cloud` (reserved) - future remote execution; currently fails closed with guidance to use `hybrid`.
-- Mock: `TRAIGENT_MOCK_LLM=true` works in OSS/local mode.
+- Mock: call `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial code.
 
 ## Quick knobs
 - Constrain cost: smaller `max_trials`, cheaper models, `constraints={"cost_per_call": "<0.01"}`.
@@ -52,8 +52,8 @@ examples/
 ```
 
 ## Troubleshooting highlights
-- `ModuleNotFoundError: traigent` -> `pip install -e ".[examples]"` from repo root.
-- `API key not found` -> `TRAIGENT_MOCK_LLM=true` or export keys.
+- `ModuleNotFoundError: traigent` -> `pip install "traigent[recommended]"`.
+- `API key not found` -> call `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial code or export keys.
 - Slow runs -> lower `max_trials` or narrow the configuration space.
 - Empty results -> verify dataset paths in `eval_dataset`.
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -52,7 +52,7 @@ examples/
 ## How to run
 ```bash
 # Install from repo root (includes example deps)
-pip install -e ".[examples]"
+pip install "traigent[recommended]"
 
 # Optional: browse the gallery in a browser
 python -m http.server 8000

--- a/docs/examples/START_HERE.md
+++ b/docs/examples/START_HERE.md
@@ -63,7 +63,7 @@ examples/
 ## Run instructions
 ```bash
 cd /path/to/Traigent
-pip install -e ".[examples]"
+pip install "traigent[recommended]"
 python examples/core/simple-prompt/run.py
 ```
 

--- a/docs/examples/TROUBLESHOOTING.md
+++ b/docs/examples/TROUBLESHOOTING.md
@@ -3,8 +3,8 @@
 Fast fixes for the most common issues. Start here, then dive deeper if needed.
 
 ## One-minute fixes
-- Missing API keys: set `TRAIGENT_MOCK_LLM=true`.
-- Import errors: run `pip install -e ".[examples]"` from repo root.
+- Missing API keys: call `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial code.
+- Import errors: run `pip install "traigent[recommended]"`.
 - High cost or latency: lower `max_trials` and pick cheaper models.
 - Slow runs: shrink the configuration space; enable caching; reduce concurrency.
 - Empty/poor results: verify dataset paths and that objectives match your goal.
@@ -12,10 +12,11 @@ Fast fixes for the most common issues. Start here, then dive deeper if needed.
 ## Setup and keys
 ```bash
 # Install
-pip install -e ".[examples]"
+pip install "traigent[recommended]"
 
-# Mock mode (no keys)
-export TRAIGENT_MOCK_LLM=true
+# Mock mode in local tutorial code
+# from traigent.testing import enable_mock_mode_for_quickstart
+# enable_mock_mode_for_quickstart()
 
 # Real keys
 export OPENAI_API_KEY="sk-..." # pragma: allowlist secret
@@ -39,7 +40,7 @@ export ANTHROPIC_API_KEY="sk-ant-..." # pragma: allowlist secret
 - Reproduce issues: run a single trial with a tiny dataset to isolate bad configs.
 
 ## Integration hiccups
-- LangChain/OpenAI/Anthropic: install integrations via `pip install -e ".[integrations]"` (or include with `.[examples]`/`.[all]`).
+- LangChain/OpenAI/Anthropic: install integrations via `pip install "traigent[integrations]"` (or include them with `traigent[recommended]`).
 - Network: increase `request_timeout`, set proxies if required.
 
 ## Prevention checklist

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -4,11 +4,19 @@ Documentation for Traigent SDK features and configuration options.
 
 ## Available Features
 
-- **[Authentication](authentication.md)** - Authentication and credential management system
-- **[Prompt Management](prompt_management.md)** - Prompt registry, analytics, and playground usage
-- **[Seamless Injection](seamless_injection.md)** - Automatic parameter injection for zero-code optimization
-- **[Strict Metrics Nulls](strict_metrics_nulls.md)** - Null handling for missing metrics (feature flag)
-- **[Framework Override Enhancements](framework_override_enhanced_features.md)** - Dynamic framework parameter discovery and validation
+- **[Authentication](authentication.md)** - Authentication and credential management, including CLI login and status flows.
+- **[Prompt Management](prompt_management.md)** - Prompt registry, analytics, and playground usage.
+- **[Seamless Injection](seamless_injection.md)** - Automatic parameter injection for zero-code optimization.
+- **[Strict Metrics Nulls](strict_metrics_nulls.md)** - Null handling for missing metrics through the strict metrics flag.
+- **[Framework Override](framework_override_enhanced_features.md)** - Dynamic framework parameter discovery and validation.
+- **[Constraint DSL](constraint-dsl.md)** - Python constraint helpers and TVL expression generation.
+- **[Data-Flow Detection](dataflow-detection.md)** - Static detection of tuned-variable candidates in Python code.
+- **[Onboarding & CLI](onboarding.md)** - Guided setup, browser device login, first-prompt generation, and the mock quickstart.
+- **[Local MCP Server](mcp-server.md)** - Local stdio MCP tools for coding agents, recommendations, datasets, cost estimates, and dry-run-first optimization.
+- **[Configuration Recommendations](recommendations.md)** - Catalog-backed configuration-space recommendations through the public API and CLI.
+- **[Strategy Presets](strategy-presets.md)** - Advisory selection helpers for choosing completed trials by accuracy and cost rules.
+- **[Safety Gates](safety-gates.md)** - Cost coverage, CI approval, dataset containment, backend validation, and content logging controls.
+- **[Agent Observability Spans](observability-spans.md)** - Public workflow-span API plus Bedrock token, cost, and mock capture paths.
 
 ## Overview
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -1,0 +1,68 @@
+# Local MCP Server
+
+Traigent 0.12.0 includes a local stdio MCP server for coding agents.
+
+```bash
+python3 -m pip install "traigent[mcp]"
+traigent mcp serve
+```
+
+The server runs locally over stdio and is created with the name `traigent`. Its
+instructions describe a local-first SDK server where tools run against local
+code and local auth storage.
+
+## Tools
+
+The current server source registers these tools:
+
+- `auth_status`
+- `list_recommendation_agent_types`
+- `recommend_configuration_space`
+- `detect_tvars`
+- `scaffold_eval`
+- `validate_dataset`
+- `estimate_cost`
+- `run_optimization`
+- `get_results`
+- `export_evidence`
+
+## Security Boundary
+
+`auth_status` returns local auth state and masked key metadata only. The agent
+never receives the raw API key. A live backend validation call is made only when
+the tool is called with `check=true`.
+
+Path-taking tools constrain paths to the MCP server's current working directory,
+or to `TRAIGENT_DATASET_ROOT` for dataset validation and cost estimation.
+
+## Dry-Run-First Optimization
+
+`run_optimization` defaults to mock mode:
+
+```text
+mode = "mock"
+```
+
+Mock mode sets local safe defaults for the run:
+
+```bash
+TRAIGENT_MOCK_LLM=true
+TRAIGENT_OFFLINE_MODE=true
+```
+
+Real mode is refused unless `confirm=true` and `cost_limit` is set. Real mode
+also refuses local draft evaluation manifests until a human reviews or replaces
+the dataset and sets the manifest approval status to `user_approved` or
+`approved`.
+
+## Copy-Paste Example
+
+```bash
+python3 -m pip install "traigent[mcp]"
+traigent mcp serve
+```
+
+Then configure your coding agent to launch that command as a stdio MCP server.
+
+Honesty note: the server is a local single-client v1 surface. A running
+optimization blocks the MCP stdio loop until it returns.

--- a/docs/features/observability-spans.md
+++ b/docs/features/observability-spans.md
@@ -1,0 +1,90 @@
+# Agent Observability Spans
+
+Traigent 0.12.0 exposes `add_agent_span(...)` as a public API for recording
+agent workflow spans inside active optimization trials.
+
+## Public API
+
+```python
+from traigent.observability import add_agent_span
+
+add_agent_span(
+    "retriever",
+    span_type="agent",
+    input_tokens=120,
+    output_tokens=35,
+    cost_usd=0.00042,
+    latency_ms=180.5,
+    model="anthropic.claude-3-5-sonnet",
+    metadata={"documents": 4},
+)
+```
+
+Signature:
+
+```python
+add_agent_span(
+    node_id: str,
+    *,
+    span_type: str = "agent",
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_usd: float | None = None,
+    latency_ms: float | None = None,
+    model: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None
+```
+
+The helper is safe to call from user code. If no optimization trial or workflow
+trace transport is active, it logs at debug level and returns.
+
+## Sanitization
+
+`add_agent_span` keeps numeric metadata only. Sensitive content-like metadata
+keys are dropped. Unsafe model identifiers, negative numbers, and non-finite
+numbers are ignored.
+
+## Bedrock Capture
+
+Traigent captures usage and latency from:
+
+- `langchain_aws.ChatBedrock`
+- `langchain_aws.ChatBedrockConverse`
+- the SDK `BedrockChatClient` wrapper for `bedrock-runtime`
+
+Captured responses are normalized into token and cost tracking paths when usage
+metadata is present. Bedrock mock mode uses the same response-capture path, so
+tests can exercise token and span behavior without live AWS calls.
+
+## Mock Interception
+
+For local development, mock mode can be enabled in code:
+
+```python
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
+```
+
+## Copy-Paste Example
+
+```python
+from traigent.observability import add_agent_span
+
+def run_node(query: str) -> str:
+    output = "mock answer"
+    add_agent_span(
+        "answer_node",
+        input_tokens=20,
+        output_tokens=8,
+        cost_usd=0.0,
+        latency_ms=12.0,
+        metadata={"candidate_count": 2},
+    )
+    return output
+```
+
+Honesty note: spans are collected only when an active optimization trial has
+workflow trace collection enabled. Calling `add_agent_span` outside that context
+is intentionally a no-op.

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -1,0 +1,84 @@
+# Onboarding & CLI
+
+Traigent 0.12.0 adds guided CLI surfaces for getting a Python project from
+install to a safe first run.
+
+## Commands
+
+```bash
+traigent onboard
+traigent auth device-login
+traigent first-prompt --agent codex
+traigent quickstart
+```
+
+`traigent onboard` detects common Python project markers, supported coding
+agents, current authentication state, MCP availability, and then prints or runs
+the next setup steps.
+
+In a terminal, onboarding can offer to:
+
+- add `traigent[integrations]` to the project
+- start device login unless `--no-login` is set
+- install Traigent agent skills through `npx skills add Traigent/agents-skills`
+- register MCP for detected agents when `traigent mcp --help` succeeds
+- run the packaged mock quickstart
+- print the first prompt for the detected coding agent
+
+In non-interactive mode, onboarding prints a plan and JSON block instead of
+starting login by default. Use `--login` to run device login after the plan.
+
+## Device Login
+
+```bash
+traigent auth device-login
+traigent auth device-login --write-env
+traigent auth device-login --backend-url https://portal.traigent.ai
+```
+
+The command starts an RFC 8628-style browser device-code flow against the
+resolved API base, which defaults to the cloud portal at
+`https://portal.traigent.ai`. It prints a verification URL and one-time code,
+then polls until the backend returns a project-scoped API key or the request
+expires.
+
+By default, credentials are stored in the secure local credential store. With
+`--write-env`, the command also writes project credentials to a local `.env`
+file in the current directory.
+
+## First Prompt
+
+```bash
+traigent first-prompt --agent claude
+traigent first-prompt --agent cursor
+traigent first-prompt --agent codex
+```
+
+The first prompt is a paste block for coding agents. It tells the agent to read
+the Traigent agent guide, inspect the project, run dry-run/mock mode first, avoid
+real provider spend without approval, and finish with evidence and changed
+files.
+
+## Quickstart
+
+```bash
+traigent quickstart
+```
+
+`quickstart` runs the bundled mock-mode demo. It does not require provider API
+keys and does not make LLM provider calls. LiteLLM may still try an import-time
+model-cost-map fetch and fall back to bundled pricing data when offline; the
+guarantee is no provider spend, not zero outbound packets.
+
+## Copy-Paste Example
+
+```bash
+python3 -m pip install "traigent[integrations]"
+traigent auth device-login --write-env
+traigent quickstart
+traigent first-prompt --agent codex
+```
+
+Honesty note: `traigent onboard` is a guided setup helper, not an installer that
+silently changes every project. Interactive dependency, skill, MCP, and `.env`
+steps ask for consent; non-interactive mode prints a plan for a caller to run.

--- a/docs/features/recommendations.md
+++ b/docs/features/recommendations.md
@@ -1,0 +1,69 @@
+# Configuration Recommendations
+
+Traigent 0.12.0 exposes catalog-backed recommendations for configuration spaces.
+Use them to bootstrap candidate knobs for an agent or task type before validating
+the choices on your own evaluation dataset.
+
+## Public API
+
+```python
+from traigent.api.functions import (
+    list_recommendation_agent_types,
+    recommend_configuration_space,
+)
+
+print(list_recommendation_agent_types())
+
+recommendations = recommend_configuration_space(
+    "rag",
+    min_impact="medium",
+    min_confidence="medium",
+)
+```
+
+`list_recommendation_agent_types()` returns the valid catalog task types.
+
+`recommend_configuration_space(agent_type, *, min_impact=None,
+min_confidence=None)` returns a JSON-serializable response with version metadata,
+a caveat, a `configuration_space`, and recommendation rows.
+
+The optional filters accept:
+
+- `low`
+- `medium`
+- `high`
+
+## CLI
+
+```bash
+traigent recommend --list-types
+traigent recommend rag
+traigent recommend code_gen --min-impact medium
+traigent recommend rag --min-confidence high --json
+```
+
+The CLI uses the same public API. Use `--json` when another tool needs to parse
+the response.
+
+## What The Response Contains
+
+Recommendation rows are public catalog metadata. They include knob names,
+suggested ranges, impact estimates, evidence labels, effectuation status, and
+apply guidance.
+
+## Copy-Paste Example
+
+```python
+import traigent as tg
+from traigent.api.functions import recommend_configuration_space
+
+space = recommend_configuration_space("rag", min_impact="medium")
+
+@tg.optimize(configuration_space=space["configuration_space"])
+def answer_question(query: str, **config: object) -> str:
+    return query
+```
+
+Honesty note: recommendations are catalog-backed starter guidance. The public
+response intentionally does not expose private signal-taxonomy details, and the
+result is not proof that a knob will improve your task.

--- a/docs/features/safety-gates.md
+++ b/docs/features/safety-gates.md
@@ -1,0 +1,82 @@
+# Safety Gates
+
+Traigent 0.12.0 adds several fail-closed or explicit-opt-in gates around real
+optimization, CI runs, dataset paths, backend validation, and persisted example
+content.
+
+## Cost Coverage Preflight
+
+Real runs check model cost coverage before trials start. Unknown or unpriced
+models are detected from the configuration space or current/default config.
+
+By default, missing pricing emits a warning and the affected results report
+`$0`. To fail before any trial starts, enable strict cost accounting:
+
+```bash
+export TRAIGENT_STRICT_COST_ACCOUNTING=true
+```
+
+Provide explicit pricing for private or unsupported models with:
+
+```bash
+export TRAIGENT_CUSTOM_MODEL_PRICING_JSON='{"my-model":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}'
+export TRAIGENT_CUSTOM_MODEL_PRICING_FILE=.traigent/model-pricing.json
+```
+
+## CI Run Approval
+
+Edge analytics optimization in CI requires explicit approval. The recommended
+environment approval is:
+
+```bash
+export TRAIGENT_RUN_APPROVED=1
+export TRAIGENT_APPROVED_BY="your_name"
+```
+
+`TRAIGENT_MOCK_LLM` does not bypass this CI approval gate.
+
+## Dataset Path Containment
+
+Evaluation datasets must resolve under the trusted dataset root. Set the root
+explicitly when a process should only read datasets from one directory:
+
+```bash
+export TRAIGENT_DATASET_ROOT="$PWD/evals"
+```
+
+When `TRAIGENT_DATASET_ROOT` is not set, the current working directory is the
+trusted root.
+
+## Backend Validation Loopback Gate
+
+Loopback backend validation is default-closed. For local backend development,
+use an explicit non-production environment and opt in:
+
+```bash
+export ENVIRONMENT=development
+export TRAIGENT_ALLOW_INSECURE_BACKEND=true
+```
+
+Do not use this override for production.
+
+## Content Logging Opt-Out
+
+Per-example prompt, response, and expected-output content is persisted by
+default for local developer experience. To keep IDs and metrics while omitting
+content-bearing fields from disk:
+
+```bash
+export TRAIGENT_LOG_EXAMPLE_CONTENT=false
+```
+
+## Copy-Paste Example
+
+```bash
+export TRAIGENT_STRICT_COST_ACCOUNTING=true
+export TRAIGENT_DATASET_ROOT="$PWD/evals"
+export TRAIGENT_LOG_EXAMPLE_CONTENT=false
+```
+
+Honesty note: Traigent cost limits and estimates are local guardrails, not
+provider billing caps. Set provider-side billing limits in your LLM or cloud
+account for hard spend protection.

--- a/docs/features/strategy-presets.md
+++ b/docs/features/strategy-presets.md
@@ -1,0 +1,74 @@
+# Strategy Presets
+
+Strategy presets select completed trials using advisory accuracy and cost rules.
+They are helpers for choosing from existing results, not optimizers themselves.
+
+## Public API
+
+```python
+from traigent.api.strategy_presets import (
+    VALID_PRESET_NAMES,
+    normalize_strategy_preset,
+    select_strategy_preset,
+)
+
+print(VALID_PRESET_NAMES)
+
+preset = normalize_strategy_preset(
+    "max_accuracy_then_cheapest_within_epsilon",
+    {"epsilon": 0.02},
+)
+selection = select_strategy_preset(preset, trials)
+```
+
+## Valid Presets
+
+`VALID_PRESET_NAMES` contains:
+
+- `max_accuracy_then_cheapest_within_epsilon`
+- `quality_floor_min_cost`
+- `pareto_frontier`
+
+`max_accuracy_then_cheapest_within_epsilon` requires:
+
+```python
+{"epsilon": 0.02}
+```
+
+It selects the lowest-cost completed trial within the preset accuracy band.
+
+`quality_floor_min_cost` requires:
+
+```python
+{"floor": 0.85}
+```
+
+It selects the lowest-cost completed trial satisfying the quality floor.
+
+`pareto_frontier` accepts no params and returns completed trials on the advisory
+accuracy-cost Pareto frontier.
+
+## Copy-Paste Example
+
+```python
+from traigent.api.strategy_presets import (
+    normalize_strategy_preset,
+    select_strategy_preset,
+)
+
+preset = normalize_strategy_preset(
+    "quality_floor_min_cost",
+    {"floor": 0.90},
+)
+
+selection = select_strategy_preset(preset, result.trials)
+print(selection.selected_config)
+print(selection.selection_grade)
+```
+
+## Honesty Note
+
+These presets are advisory and selection-only over completed trials. They are
+not a statistical certificate, do not prove significance, and do not certify
+that the selected configuration will generalize beyond the task-local trials and
+metrics you already ran.

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -7,17 +7,25 @@ The fastest path to optimize an LLM workflow with **zero code changes**.
 1) Install and run - no API keys needed:
 
 ```bash
-pip install "traigent[integrations]"
-python -m traigent.examples.quickstart
+pip install "traigent[recommended]"
+traigent quickstart
 ```
 
-Or from a source checkout:
+For guided setup after the quickstart:
+
+```bash
+traigent onboard
+traigent auth device-login
+traigent first-prompt --agent codex
+```
+
+From a source checkout for development:
 
 Pip:
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[recommended]"
+pip install "traigent[recommended]"
 python hello_world.py
 ```
 
@@ -26,7 +34,7 @@ Uv:
 ```bash
 uv venv --python 3.11
 source .venv/bin/activate
-uv pip install -e ".[recommended]"
+uv pip install "traigent[recommended]"
 python hello_world.py
 ```
 
@@ -101,6 +109,12 @@ def classify(text: str) -> str:
 ```bash
 traigent info                                   # Version/features
 traigent algorithms                             # Available strategies
+traigent quickstart                             # Packaged mock-mode demo
+traigent onboard                                # Guided project setup
+traigent auth device-login                      # Browser device login
+traigent first-prompt --agent codex             # Coding-agent prompt
+traigent recommend rag                          # Configuration recommendations
+traigent mcp serve                              # Local stdio MCP server
 traigent optimize examples/core/rag-optimization/run.py -a grid -n 5
 traigent validate examples/datasets/rag-optimization/evaluation_set.jsonl
 traigent plot my_run -p progress
@@ -144,4 +158,4 @@ To run fully local (no Traigent backend communication), set `TRAIGENT_OFFLINE_MO
 
 ---
 
-Ready for more? Dive into the [examples](../../examples/) and the [API reference](../api-reference/complete-function-specification.md).
+Ready for more? Dive into the [examples](../examples/) and the [API reference](../api-reference/complete-function-specification.md).

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -15,3 +15,11 @@ Quick start guides to get you up and running with Traigent SDK.
 2. [Follow the getting started tutorial](GETTING_STARTED.md)
 3. [Use minimum integration checklist](minimal-integration.md) to validate readiness
 4. [Explore user guides](../user-guide/) for advanced features
+
+## New in 0.12.0
+
+- Onboarding CLI: `traigent onboard`, `traigent auth device-login`, `traigent quickstart`, and `traigent first-prompt --agent claude|cursor|codex`.
+- Local agent tooling: `traigent mcp serve` exposes the stdio MCP server for coding agents.
+- Configuration recommendations: `traigent recommend`, `recommend_configuration_space()`, and `list_recommendation_agent_types()`; see [configuration spaces](../user-guide/configuration-spaces.md).
+- Advisory strategy presets: `max_accuracy_then_cheapest_within_epsilon`, `quality_floor_min_cost`, and `pareto_frontier`; see [decorator reference](../api-reference/decorator-reference.md).
+- Workflow observability: `add_agent_span()` records user-defined agent spans; see [telemetry](../api-reference/telemetry.md).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -7,35 +7,33 @@ Release-ready, minimal install steps for the SDK and examples.
 ### Fast path (pip)
 
 ```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
 python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[recommended]"           # Recommended bundle: integrations, analytics, bayesian, visualization, hybrid, pydanticai
+pip install "traigent[recommended]"       # Recommended bundle: integrations, analytics, bayesian, visualization, hybrid, pydanticai
 ```
 
 ### Fast path (uv)
 
 Use this path if your environment already uses `uv`. It installs the same
-source checkout and extras; `pip` remains fully supported. Replace `3.11` with
+published package and extras; `pip` remains fully supported. Replace `3.11` with
 any supported Python 3.11-3.13 interpreter available in your environment.
 
 ```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
 uv venv --python 3.11
 source .venv/bin/activate
-uv pip install -e ".[recommended]"        # Same recommended bundle as the pip path
+uv pip install "traigent[recommended]"    # Same recommended bundle as the pip path
 ```
 
 ### PyPI vs source installs
 
-`0.10.0` release validation uses the source install from this repository. Use a published package only if your team separately validates that artifact for your environment.
+For Traigent SDK 0.12.0, prefer the published PyPI package: `pip install "traigent[recommended]"`. Use a source checkout only for development or when validating unreleased changes.
+
+License: Traigent SDK is dual-licensed under AGPL-3.0-only OR LicenseRef-Traigent-Commercial.
 
 ## Extras (from `pyproject.toml`)
 
 | Extra | What's included | Install example |
 | --- | --- | --- |
-| **`recommended`** | **All user-facing features (integrations + analytics + bayesian + visualization + hybrid + pydanticai)** | **`pip install -e ".[recommended]"`** |
+| **`recommended`** | **All user-facing features (integrations + analytics + bayesian + visualization + hybrid + pydanticai)** | **`pip install "traigent[recommended]"`** |
 | `integrations` | LangChain, OpenAI, Anthropic, MLflow, W&B | `pip install -e ".[integrations]"` |
 | `analytics` | numpy, pandas, matplotlib | `pip install -e ".[analytics]"` |
 | `bayesian` | Optuna + sklearn/scipy | `pip install -e ".[bayesian]"` |
@@ -51,20 +49,18 @@ uv pip install -e ".[recommended]"        # Same recommended bundle as the pip p
 
 ## Common Scenarios
 
-- **Run examples from a pip-managed source checkout (no API keys):**
+- **Run the packaged quickstart with pip (no API keys):**
 
   ```bash
-  pip install -e ".[recommended]"
-  export TRAIGENT_MOCK_LLM=true
-  python hello_world.py
+  pip install "traigent[recommended]"
+  traigent quickstart
   ```
 
-- **Run examples from a uv-managed source checkout (no API keys):**
+- **Run the packaged quickstart with uv (no API keys):**
 
   ```bash
-  uv pip install -e ".[recommended]"
-  export TRAIGENT_MOCK_LLM=true
-  python hello_world.py
+  uv pip install "traigent[recommended]"
+  traigent quickstart
   ```
 
 - **Develop/contribute:**
@@ -95,9 +91,9 @@ PY
 
 ## Troubleshooting (quick fixes)
 
-- **`ModuleNotFoundError: langchain`** — install recommended extras: `pip install -e ".[recommended]"`.
-- **Missing API keys** — copy `.env.example` to `.env` and set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` (skip if using `TRAIGENT_MOCK_LLM=true`). On Ubuntu desktop, you can also store keys in GNOME Keyring and export them with `secret-tool lookup ...` before running examples (see `docs/guides/secrets_management.md`).
-- **Virtualenv confusion** — recreate: `deactivate; rm -rf .venv; python -m venv .venv; source .venv/bin/activate; pip install -e ".[recommended]"`.
+- **`ModuleNotFoundError: langchain`** — install recommended extras: `pip install "traigent[recommended]"`.
+- **Missing API keys** — copy `.env.example` to `.env` and set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`, or call `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial code. On Ubuntu desktop, you can also store keys in GNOME Keyring and export them with `secret-tool lookup ...` before running examples (see `docs/guides/secrets_management.md`).
+- **Virtualenv confusion** — recreate: `deactivate; rm -rf .venv; python -m venv .venv; source .venv/bin/activate; pip install "traigent[recommended]"`.
 
 ---
 

--- a/docs/getting-started/minimal-integration.md
+++ b/docs/getting-started/minimal-integration.md
@@ -43,7 +43,7 @@ Minimal checklist:
 
 ## Environment Minimum
 
-1. `TRAIGENT_API_KEY` configured.
+1. Authentication configured with `traigent auth device-login`, `traigent onboard`, or `TRAIGENT_API_KEY` for CI/non-interactive environments.
 2. `TRAIGENT_API_URL` configured (if not using default backend URL).
 3. For hybrid mode scripts using `requests`, set `User-Agent: Traigent-SDK/1.0`.
 

--- a/docs/getting-started/testing.md
+++ b/docs/getting-started/testing.md
@@ -35,7 +35,7 @@ TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true pytest -k "test_optimization" 
 
 The `[test]` extra includes:
 
-- **pytest>=7.0.0** - Testing framework
+- **pytest>=9.0.3** - Testing framework
 - **pytest-asyncio>=0.21.0** - Async test support
 - **pytest-cov>=4.0.0** - Coverage reporting
 - **pytest-mock>=3.10.0** - Mocking utilities
@@ -220,8 +220,8 @@ async def test_optimization_basic():
 ### Import Errors
 
 ```bash
-# Make sure package is installed in editable mode
-pip install -e ".[recommended]"
+# Make sure the recommended bundle is installed
+pip install "traigent[recommended]"
 
 # Check installation
 python -c "import traigent; print(traigent.__version__)"
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -498,7 +498,7 @@ Best accuracy: 0.00
 - [Execution Modes](execution-modes.md)
 - [Parallel Configuration](parallel-configuration.md)
 - [API Reference](../api-reference/)
-- [Examples](../../examples/)
+- [Examples](../examples/)
 
 ---
 

--- a/docs/hybrid-mode-api-contract.md
+++ b/docs/hybrid-mode-api-contract.md
@@ -67,7 +67,9 @@ Example: `http://your-service:8080/traigent/v1/capabilities`
 
 ## Authentication (Optional)
 
-If your service requires authentication, accept an `Authorization` header (for example, bearer token).
+If your service requires authentication, accept the configured token in both
+`Authorization` and `x-api-key` headers. The SDK sets both headers from
+`hybrid_api_auth_header` for compatibility.
 
 Configure the Traigent SDK client with:
 - `hybrid_api_auth_header="Bearer <token>"`
@@ -818,4 +820,4 @@ Optional extension:
 ## Related Documentation
 
 - [Client Integration Guide](./hybrid-mode-client-guide.md) - Implementation patterns and examples
-- [TraigentService Wrapper](../traigent/wrapper/) - Decorator-based SDK for building services
+- TraigentService wrapper: see the inline wrapper example in the Client Integration Guide.

--- a/docs/hybrid-mode-client-guide.md
+++ b/docs/hybrid-mode-client-guide.md
@@ -25,7 +25,7 @@ Before running optimization, verify:
 3. `POST /traigent/v1/execute` enforces capability matching and returns `operational_metrics.total_cost_usd`.
 4. `POST /traigent/v1/evaluate` is implemented when `supports_evaluate=true`.
 5. Optional fields (`constraints`, `objectives`, `exploration`, `promotion_policy`, `defaults`, `measures`) are omitted unless intentionally used.
-6. Auth behavior is consistent across all endpoints if `Authorization` is required.
+6. Auth behavior is consistent across all endpoints if authentication is required; accept both `Authorization` and `x-api-key` because the SDK sends both from `hybrid_api_auth_header`.
 7. Timeout/error behavior is explicit for `400/401/404/408/429/500/503` and client retry logic is implemented.
 
 ## Privacy-Preserving Mode (Default)
@@ -433,6 +433,7 @@ class ExecuteRequest(BaseModel):
     tunable_id: str
     config: dict
     examples: list[dict]
+    session_id: str | None = None
 
 @app.get("/traigent/v1/capabilities")
 async def capabilities():
@@ -896,4 +897,4 @@ Backend tracking unavailable ... Results will be saved locally
 
 - [API Contract](./hybrid-mode-api-contract.md) - Detailed endpoint specifications
 - See inline Flask and FastAPI examples in this guide
-- [TraigentService Wrapper](../traigent/wrapper/) - Decorator-based SDK
+- TraigentService wrapper: see the wrapper example above.

--- a/docs/operations/azure_openai.md
+++ b/docs/operations/azure_openai.md
@@ -11,8 +11,9 @@ export AZURE_OPENAI_API_KEY="<key>"
 # Optional: API version override (default: 2024-02-15-preview)
 # export AZURE_OPENAI_API_VERSION=2024-10-21
 
-# Mock mode (dry-run, no SDK needed)
-# export AZURE_OPENAI_MOCK=true
+# Local mock mode: export TRAIGENT_MOCK_LLM=true, or call
+# traigent.testing.enable_mock_mode_for_quickstart() in tutorial code.
+# Provider-specific *_MOCK env vars are ignored.
 
 # Note: use `--provider azure` in the experiment scripts below.
 ```

--- a/docs/operations/bedrock.md
+++ b/docs/operations/bedrock.md
@@ -25,8 +25,9 @@ export AWS_PROFILE=traigent-bedrock
 # Optional explicit model override
 # export BEDROCK_MODEL_ID=anthropic.claude-3-sonnet-20240229-v1:0
 
-# Optional: Mock Bedrock to dry-run without AWS credentials
-# export BEDROCK_MOCK=true
+# Local mock mode: export TRAIGENT_MOCK_LLM=true, or call
+# traigent.testing.enable_mock_mode_for_quickstart() in tutorial code.
+# Provider-specific *_MOCK env vars are ignored.
 ```
 
 ## Credential Boundary
@@ -64,7 +65,10 @@ With AWS credentials configured, you can exercise the shipped Bedrock example:
 python examples/integrations/bedrock/bedrock_hello.py
 ```
 
-If the Bedrock path is selected, the pipeline will route through `traigent.integrations.bedrock_client.BedrockChatClient`.
+Bedrock coverage includes the native `BedrockChatClient` plus LangChain
+`ChatBedrock` and `ChatBedrockConverse` interception. In mock mode,
+`TRAIGENT_MOCK_LLM` routes Bedrock calls through `MockAdapter`; in real mode,
+responses are captured for token/cost/latency extraction.
 
 ## Troubleshooting
 - `AccessDeniedException`: Verify model access is granted in Bedrock console and IAM policy includes `InvokeModel*`.

--- a/docs/operations/google_gemini.md
+++ b/docs/operations/google_gemini.md
@@ -8,8 +8,9 @@ discovery surfaces shipped in this repository.
 # Required for real runs
 export GOOGLE_API_KEY="<key>"   # or GEMINI_API_KEY
 
-# Mock mode (dry-run, no SDK needed)
-# export GEMINI_MOCK=true
+# Local mock mode: export TRAIGENT_MOCK_LLM=true, or call
+# traigent.testing.enable_mock_mode_for_quickstart() in tutorial code.
+# Provider-specific *_MOCK env vars are ignored.
 ```
 
 ## Dependencies

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -24,3 +24,11 @@ Comprehensive guides for using Traigent SDK features and capabilities.
 **Advanced Users**: Explore [Agent Optimization](agent_optimization.md), [Interactive Optimization](interactive_optimization.md), and [Optuna Integration](optuna_integration.md)
 
 **Evaluation**: Use [Evaluation Guide](evaluation_guide.md) to measure success
+
+## New in 0.12.0
+
+- Onboarding: `traigent onboard`, browser `traigent auth device-login`, `traigent quickstart`, and `traigent first-prompt --agent claude|cursor|codex`.
+- Local MCP: `traigent mcp serve` provides the stdio MCP server for coding agents.
+- Recommendation catalog: `traigent recommend`, `recommend_configuration_space()`, and `list_recommendation_agent_types()`; see [Tuned Variables](tuned_variables.md).
+- Advisory strategy presets: `max_accuracy_then_cheapest_within_epsilon`, `quality_floor_min_cost`, and `pareto_frontier`; see [Choosing Models](choosing_optimization_model.md).
+- Observability: `add_agent_span()` adds user-defined agent workflow spans; see [telemetry](../api-reference/telemetry.md).

--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -554,6 +554,6 @@ logger.setLevel(logging.DEBUG)
 
 ## Next Steps
 
-- See the [examples catalog](../examples/START_HERE.md) for runnable examples
+- Start with `traigent quickstart`, then use `traigent recommend rag` for configuration-space suggestions.
 - Review [Execution Modes](../guides/execution-modes.md) for local/cloud/hybrid context
 - Read [Architecture Overview](../architecture/ARCHITECTURE.md) for system design details

--- a/docs/user-guide/choosing_optimization_model.md
+++ b/docs/user-guide/choosing_optimization_model.md
@@ -231,7 +231,7 @@ Use `execution_mode="hybrid"` when you want the supported portal-tracked path:
 ### From Local-Only to Portal-Tracked:
 
 1. Keep the optimized function and dataset unchanged.
-2. Authenticate with `traigent auth login` or set `TRAIGENT_API_KEY`.
+2. Authenticate with `traigent auth device-login`, run `traigent onboard` for guided setup, or set `TRAIGENT_API_KEY` in CI/non-interactive environments.
 3. Set `execution_mode="hybrid"`.
 4. Confirm the run appears in Traigent Portal.
 

--- a/docs/user-guide/evaluation_guide.md
+++ b/docs/user-guide/evaluation_guide.md
@@ -162,9 +162,10 @@ def classifier(text):
 
 For testing without real API calls:
 
-```bash
-export TRAIGENT_MOCK_LLM=true
-python your_script.py
+```python
+from traigent.testing import enable_mock_mode_for_quickstart
+
+enable_mock_mode_for_quickstart()
 ```
 
 Mock mode provides:
@@ -330,8 +331,10 @@ def summarizer(text):
    ERROR log.
 
 5. **Use Mock Mode for Testing**
-   ```bash
-   export TRAIGENT_MOCK_LLM=true
+   ```python
+   from traigent.testing import enable_mock_mode_for_quickstart
+
+   enable_mock_mode_for_quickstart()
    ```
 
 ### Issue: Inconsistent Results
@@ -461,5 +464,5 @@ def qa_system(question, temperature=0.5, max_tokens=100):
 ## Next Steps
 
 - [Custom Evaluator Patterns](../examples/API_PATTERNS.md)
-- [Dataset Creation Tools](../../examples/datasets/)
+- Dataset creation tools are available in the repository examples.
 - [Troubleshooting Guide](../README.md#troubleshooting)

--- a/docs/user-guide/interactive_optimization.md
+++ b/docs/user-guide/interactive_optimization.md
@@ -395,7 +395,7 @@ await asyncio.sleep(1.0)  # Add delay between trials if needed
 
 ## Next Steps
 
-1. Explore the [examples catalog](../examples/START_HERE.md)
+1. Run `traigent quickstart`, then use `traigent recommend rag` for configuration-space suggestions
 2. Learn about [agent-based optimization](./agent_optimization.md)
 3. Read the [API reference](../api-reference/interactive_optimizer.md)
 4. Join our [community forum](https://community.traigent.ai) for support

--- a/docs/user-guide/tuned_variables.md
+++ b/docs/user-guide/tuned_variables.md
@@ -7,19 +7,12 @@ This guide covers Traigent's tuned variables system, which provides domain-aware
 Tuned variables in Traigent consist of two components:
 
 1. **Core SDK** (`traigent.tuned_variables`): Callable auto-discovery from source code
-2. **Plugin** (`traigent-tuned-variables`): Domain presets, variable analysis, and TunedCallable pattern
+2. **Recommendation catalog**: `traigent recommend` plus `recommend_configuration_space()` and `list_recommendation_agent_types()` for evidence-backed configuration-space suggestions
 
 ## Installation
 
 ```bash
-# Core tuned variables (included with the SDK; run from the Traigent repo root)
-pip install -e ".[recommended]"
-
-# Plugin with domain presets and analysis
-pip install traigent-tuned-variables
-
-# With DSPy integration
-pip install traigent-tuned-variables[dspy]
+pip install "traigent[recommended]"
 ```
 
 ---
@@ -162,320 +155,42 @@ compatible = filter_by_signature(all_funcs, target_sig, strict=False)
 
 ---
 
-## Part 2: Domain Presets (Plugin)
+## Part 2: Recommendation Catalog
 
-The `traigent-tuned-variables` plugin provides pre-configured parameter ranges that encode domain knowledge.
+Traigent 0.12.0 exposes configuration-space recommendations through the core SDK and CLI. There is no separate `traigent-tuned-variables` package to install for this path.
 
-### LLM Presets
-
-```python
-from traigent_tuned_variables import LLMPresets
-import traigent
-
-@traigent.optimize(
-    temperature=LLMPresets.temperature(creative=True),  # Range(0.7, 1.5)
-    top_p=LLMPresets.top_p(),                          # Range(0.1, 1.0)
-    max_tokens=LLMPresets.max_tokens(task="medium"),   # IntRange(256, 1024)
-    model=LLMPresets.model(provider="openai", tier="balanced"),
-    objectives=["accuracy", "cost"],
-)
-def my_agent(query: str) -> str:
-    ...
-```
-
-**Available LLM Presets:**
-
-| Method | Description | Default Range |
-| ------ | ----------- | ------------- |
-| `temperature(conservative=False, creative=False)` | Temperature control | 0.0-1.0 (default), 0.0-0.5 (conservative), 0.7-1.5 (creative) |
-| `top_p()` | Nucleus sampling | 0.1-1.0 |
-| `frequency_penalty()` | Frequency penalty | 0.0-2.0 |
-| `presence_penalty()` | Presence penalty | 0.0-2.0 |
-| `max_tokens(task="short"\|"medium"\|"long")` | Token limit | short: 50-256, medium: 256-1024, long: 1024-4096 |
-| `model(provider=None, tier="fast"\|"balanced"\|"quality")` | Model selection | Provider/tier dependent |
-
-### RAG Presets
-
-```python
-from traigent_tuned_variables import RAGPresets
-
-@traigent.optimize(
-    k=RAGPresets.k_retrieval(max_k=10),      # IntRange(1, 10)
-    chunk_size=RAGPresets.chunk_size(),       # IntRange(100, 1000, step=100)
-    objectives=["accuracy"],
-)
-def rag_agent(query: str) -> str:
-    ...
-```
-
-### Prompting Presets
-
-```python
-from traigent_tuned_variables import PromptingPresets
-
-@traigent.optimize(
-    strategy=PromptingPresets.strategy(),       # CoT, few-shot, etc.
-    context_format=PromptingPresets.context_format(),
-    objectives=["accuracy"],
-)
-def prompt_agent(query: str) -> str:
-    ...
-```
-
-### Environment-Based Model Configuration
-
-Model presets use environment variables for flexibility:
+### CLI
 
 ```bash
-# Override model lists via environment
-export TRAIGENT_MODELS_OPENAI_FAST="gpt-4o-mini"
-export TRAIGENT_MODELS_OPENAI_BALANCED="gpt-4o-mini,gpt-4o"
-export TRAIGENT_MODELS_ANTHROPIC_QUALITY="claude-3-opus-20240229"
+traigent recommend --list-types
+traigent recommend rag
+traigent recommend code_gen --min-impact medium
 ```
+
+The recommendations are advisory catalog entries. They include task-local evidence notes and suggested ranges, but they are not a statistical certificate for your dataset. Validate returned knobs on your own evaluation dataset.
+
+### Python API
+
+```python
+from traigent import (
+    list_recommendation_agent_types,
+    recommend_configuration_space,
+)
+
+agent_types = list_recommendation_agent_types()
+recommendations = recommend_configuration_space("rag", min_impact="medium")
+configuration_space = recommendations["configuration_space"]
+```
+
+You can pass the returned `configuration_space` into `@traigent.optimize(...)` after reviewing it for your task and provider constraints.
+
+### Provider Override Variables
+
+SDK provider override variables such as `TRAIGENT_MODELS_OPENAI_FAST`, `TRAIGENT_MODELS_OPENAI_BALANCED`, and `TRAIGENT_MODELS_ANTHROPIC_QUALITY` are available when using integration/provider presets. They are not tied to a separate tuned-variables plugin.
 
 ---
 
-## Part 3: TunedCallable Pattern (Plugin)
-
-`TunedCallable` is a composition pattern for function-valued variables with per-callable parameters.
-
-### Basic Usage
-
-```python
-from traigent_tuned_variables import TunedCallable
-from traigent.api.parameter_ranges import Range
-import traigent
-
-# Define callables with per-callable parameters
-retrievers = TunedCallable(
-    name="retriever",
-    callables={
-        "similarity": similarity_search,
-        "mmr": mmr_search,
-        "bm25": bm25_search,
-    },
-    parameters={
-        "mmr": {"lambda_mult": Range(0.0, 1.0)},
-        "bm25": {"b": Range(0.0, 1.0), "k1": Range(0.5, 2.0)},
-    },
-)
-
-@traigent.optimize(
-    retriever=retrievers.as_choices(),  # Converts to Choices
-    objectives=["accuracy"],
-)
-def my_agent(query: str) -> str:
-    config = traigent.get_config()
-
-    # Invoke the selected callable
-    docs = retrievers.invoke(config["retriever"], query=query)
-    return generate_answer(query, docs)
-```
-
-### Full Configuration Space
-
-For per-callable parameters, use `get_full_space()`:
-
-```python
-# Get full config space including per-callable params
-space = retrievers.get_full_space()
-# Returns: {
-#     "retriever": Choices(["similarity", "mmr", "bm25"]),
-#     "retriever.mmr.lambda_mult": Range(0.0, 1.0),
-#     "retriever.bm25.b": Range(0.0, 1.0),
-#     "retriever.bm25.k1": Range(0.5, 2.0),
-# }
-
-@traigent.optimize(**space, objectives=["accuracy"])
-def my_agent(query: str) -> str:
-    config = traigent.get_config()
-
-    # Extract only params for selected callable
-    params = retrievers.extract_callable_params(config)
-    # If retriever="mmr", returns: {"lambda_mult": 0.7}
-
-    fn = retrievers.get_callable(config["retriever"])
-    docs = fn(query=query, **params)
-    return generate_answer(query, docs)
-```
-
-### Pre-built Callables
-
-The plugin includes pre-built `Retrievers` and `ContextFormatters`:
-
-```python
-from traigent_tuned_variables import Retrievers, ContextFormatters
-
-@traigent.optimize(
-    retriever=Retrievers.as_choices(),
-    context_format=ContextFormatters.as_choices(),
-    objectives=["accuracy"],
-)
-def rag_agent(query: str) -> str:
-    config = traigent.get_config()
-
-    docs = Retrievers.invoke(config["retriever"], vector_store, query)
-    formatted = ContextFormatters.invoke(config["context_format"], docs)
-
-    return llm(f"{formatted}\n\nQuestion: {query}")
-```
-
----
-
-## Part 4: Variable Analysis (Plugin)
-
-After optimization, use `VariableAnalyzer` to understand which variables matter and which values to prune.
-
-### Basic Analysis
-
-```python
-from traigent_tuned_variables import VariableAnalyzer
-
-# After optimization completes
-result = my_agent.optimize()
-
-# Analyze for a specific objective
-analyzer = VariableAnalyzer(result)
-analysis = analyzer.analyze("accuracy")
-
-# View elimination suggestions
-for suggestion in analysis.elimination_suggestions:
-    print(f"{suggestion.variable}: {suggestion.action.value}")
-    print(f"  Reason: {suggestion.reason}")
-    print(f"  Importance: {suggestion.importance_score:.3f}")
-```
-
-### Multi-Objective Analysis
-
-```python
-# Analyze across multiple objectives
-analysis = analyzer.analyze_multi_objective(
-    objectives=["accuracy", "cost", "latency"],
-    aggregation="mean",  # or "max", "min"
-)
-
-# Get Pareto-dominated values
-for var_name, frontier_values in analysis.pareto_frontier_values.items():
-    print(f"{var_name}: Keep {frontier_values}")
-```
-
-### Refined Configuration Space
-
-Get a pruned configuration space for the next optimization round:
-
-```python
-# Get refined space with dominated values removed
-refined_space = analyzer.get_refined_space(
-    objectives=["accuracy", "cost"],
-    prune_low_importance=True,    # Remove low-importance variables
-    prune_dominated_values=True,  # Remove dominated categorical values
-    narrow_ranges=True,           # Narrow numeric ranges
-)
-
-# Use refined space for next optimization
-@traigent.optimize(**refined_space, objectives=["accuracy", "cost"])
-def my_agent_v2(query: str) -> str:
-    ...
-```
-
-### Variable Importance
-
-```python
-# Get importance scores
-importance = analyzer.get_variable_importance("accuracy")
-for var, score in sorted(importance.items(), key=lambda x: -x[1]):
-    print(f"{var}: {score:.3f}")
-```
-
-### Value Rankings
-
-```python
-# Rank categorical values by performance
-rankings = analyzer.get_value_rankings("model", "accuracy")
-for ranking in rankings:
-    status = " (dominated)" if ranking.is_dominated else ""
-    print(f"{ranking.value}: {ranking.mean_score:.3f}{status}")
-```
-
-### Objective Direction Support
-
-The analyzer respects optimization direction for each objective:
-
-```python
-analyzer = VariableAnalyzer(
-    result,
-    directions={
-        "accuracy": "maximize",
-        "cost": "minimize",
-        "latency": "minimize",
-    }
-)
-```
-
----
-
-## Complete Example
-
-```python
-import traigent
-from traigent.tuned_variables import discover_callables
-from traigent_tuned_variables import (
-    LLMPresets,
-    RAGPresets,
-    VariableAnalyzer,
-    TunedCallable,
-)
-from traigent.api.parameter_ranges import Range
-import my_retrievers
-
-# 1. Discover callables from module
-discovered = discover_callables(
-    my_retrievers,
-    pattern=r"^search_",
-    required_params=["query"],
-)
-
-# 2. Create TunedCallable with per-callable params
-retrievers = TunedCallable(
-    name="retriever",
-    callables={name: info.callable for name, info in discovered.items()},
-    parameters={
-        "search_mmr": {"lambda_mult": Range(0.0, 1.0)},
-    },
-)
-
-# 3. Define optimization with domain presets
-@traigent.optimize(
-    retriever=retrievers.as_choices(),
-    k=RAGPresets.k_retrieval(),
-    temperature=LLMPresets.temperature(),
-    model=LLMPresets.model(tier="balanced"),
-    objectives=["accuracy", "cost"],
-)
-def optimized_rag(query: str) -> str:
-    config = traigent.get_config()
-
-    docs = retrievers.invoke(config["retriever"], query=query, k=config["k"])
-    return generate_with_llm(query, docs, config["temperature"], config["model"])
-
-# 4. Run optimization
-result = optimized_rag.optimize()
-
-# 5. Analyze results
-analyzer = VariableAnalyzer(
-    result,
-    directions={"accuracy": "maximize", "cost": "minimize"},
-)
-analysis = analyzer.analyze_multi_objective(["accuracy", "cost"])
-
-# 6. Get refined space for next iteration
-refined = analyzer.get_refined_space(["accuracy", "cost"])
-print(f"Refined space has {len(refined)} variables (down from original)")
-```
-
----
-
-## Part 5: Tuned Variable Detection (SDK)
+## Part 3: Tuned Variable Detection (SDK)
 
 The SDK includes a static analysis engine that automatically detects likely tunable variables in your existing Python functions — before you write any optimization code. It combines AST-based name matching, data-flow analysis, and optional LLM heuristics.
 
@@ -750,17 +465,13 @@ class TunedVariableCandidate:
 | `SourceLocation` | Frozen dataclass: line/col position in source |
 | `SuggestedRange` | Frozen dataclass with `range_type` and `kwargs`; `.to_parameter_range_code()` |
 
-### traigent_tuned_variables
+### Recommendation APIs
 
-| Class | Description |
-| ----- | ----------- |
-| `LLMPresets` | Pre-configured LLM parameter ranges |
-| `RAGPresets` | Pre-configured RAG parameter ranges |
-| `PromptingPresets` | Pre-configured prompting parameter ranges |
-| `TunedCallable` | Composition pattern for function-valued variables |
-| `VariableAnalyzer` | Post-optimization variable analysis |
-| `Retrievers` | Pre-built retriever callables |
-| `ContextFormatters` | Pre-built context formatting callables |
+| Symbol | Description |
+| ------ | ----------- |
+| `traigent recommend` | CLI for listing agent types and showing recommendation catalog entries |
+| `list_recommendation_agent_types()` | Return valid agent/task types for recommendation queries |
+| `recommend_configuration_space(agent_type, *, min_impact=None, min_confidence=None)` | Return advisory configuration-space recommendations for an agent/task type |
 
 ---
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -58,4 +58,4 @@ These are not part of the core 8-step path, but they complement it:
 
 ## Browse source
 
-[walkthrough/mock/](../walkthrough/mock/)
+Browse source in the repository: `walkthrough/mock/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,12 @@ nav:
       - Prompt Management: features/prompt_management.md
       - Seamless Injection: features/seamless_injection.md
       - Strict Metrics Nulls: features/strict_metrics_nulls.md
+      - Onboarding & CLI: features/onboarding.md
+      - Local MCP Server: features/mcp-server.md
+      - Configuration Recommendations: features/recommendations.md
+      - Strategy Presets: features/strategy-presets.md
+      - Safety Gates: features/safety-gates.md
+      - Agent Observability Spans: features/observability-spans.md
       - Hybrid Mode API Contract: hybrid-mode-api-contract.md
       - Hybrid Mode Client Guide: hybrid-mode-client-guide.md
       - Walkthrough: walkthrough.md


### PR DESCRIPTION
Captain-orchestrated docs review (6 codex review packets + 3 fix workers, all verified against code) to make docs.traigent.ai match the released 0.12.0. Directly fixes the Features page that listed only 5 pre-0.12 features.

### Features index + 6 NEW pages (the screenshot fix)
`docs/features/README.md` now lists all current features; new code-accurate pages: **onboarding**, **mcp-server**, **recommendations**, **strategy-presets** (with the mandatory advisory/selection-only honesty note), **safety-gates**, **observability-spans** — wired into nav.

### Stale → current (verified against source, not the doc text)
- Install: `pip install -e ".[recommended]"` → `pip install "traigent[recommended]"`; removed instructions for the **nonexistent** `traigent-tuned-variables` package → point to `traigent recommend` / `recommend_configuration_space()`.
- Mock mode in **tutorials**: raw `TRAIGENT_MOCK_LLM=true` → `from traigent.testing import enable_mock_mode_for_quickstart` (test-shell usages left as-is).
- Version strings: `v0.10.0`/`traigent@0.11.4` → `0.12.0`; license → `AGPL-3.0-only OR LicenseRef-Traigent-Commercial`.
- API reference: added `recommend_configuration_space`/`list_recommendation_agent_types`/strategy presets/`add_agent_span`/CLI+MCP surfaces; refreshed `optimize()`/`ExecutionOptions`/`.optimize()` signatures.
- Architecture: real plugin list + integrations inventory; removed dead `walkthrough/`; cost-coverage preflight note.
- Hybrid docs: both-headers auth (`Authorization` + `x-api-key`), optional `session_id`.
- ~6 relative links that pointed **outside** `docs/` (broke on the site) repointed in-docs.

### Captain verifications (worker self-corrections kept)
- **MCP = 10 tools, not 8** (my brief said 8; worker counted code).
- **Cost gate = `TRAIGENT_STRICT_COST_ACCOUNTING`** + custom-pricing envs; `TRAIGENT_ALLOW_UNPRICED_MODELS` **doesn't exist** (a phantom from a PR description) — confirmed 0 refs in code; not written anywhere.
- 3 fix branches touched **disjoint files** (A=18, B=19, C=8, zero overlap); `mkdocs build` clean (0 errors; warnings 10→4, all pre-existing out-of-docs links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)