### PR TITLE
feat(cost): unpriced models block and require confirmation (no more warn-and-continue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **Unpriced models now block instead of warn-and-continue.** When a real run includes
+  models with no known pricing, the SDK now requires explicit confirmation: interactive
+  terminals get a blocking prompt; non-interactive runs fail closed before any trial.
+  Pre-approve with `cost_approved=True` (must be a real boolean) or
+  `TRAIGENT_COST_APPROVED=true` (exact value), or supply custom pricing via
+  `TRAIGENT_CUSTOM_MODEL_PRICING_JSON`/`_FILE`. `TRAIGENT_STRICT_COST_ACCOUNTING=true`
+  still hard-fails without prompting; mock runs are unaffected.
+
 ## [0.12.0] - 2026-06-06
 
 ### Added

--- a/tests/unit/core/test_cost_coverage_preflight.py
+++ b/tests/unit/core/test_cost_coverage_preflight.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import sys
 import warnings
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -27,10 +30,12 @@ class CountedFunction:
 
 
 @pytest.fixture(autouse=True)
-def reset_cost_preflight_state(monkeypatch: pytest.MonkeyPatch):
+def reset_cost_preflight_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.delenv("TRAIGENT_STRICT_COST_ACCOUNTING", raising=False)
     monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_JSON", raising=False)
     monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
+    monkeypatch.delenv("TRAIGENT_COST_APPROVED", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     monkeypatch.setattr("traigent.core.optimized_function._COST_WARNING_EMITTED", True)
     cost_calculator._CUSTOM_PRICING_CACHE = None
     cost_calculator._CUSTOM_PRICING_CACHE_KEY = None
@@ -64,19 +69,50 @@ def _completed_result() -> OptimizationResult:
 
 async def _run_with_mocked_orchestrator(
     opt_func: OptimizedFunction,
+    *,
+    cost_approved: Any | None = None,
 ) -> OptimizationResult:
     with patch(
         "traigent.core.optimized_function.OptimizationOrchestrator"
     ) as mock_orchestrator_cls:
         mock_orchestrator = mock_orchestrator_cls.return_value
         mock_orchestrator.optimize = AsyncMock(return_value=_completed_result())
-        result = await opt_func.optimize(progress_bar=False)
+        optimize_kwargs: dict[str, Any] = {}
+        if cost_approved is not None:
+            optimize_kwargs["cost_approved"] = cost_approved
+        result = await opt_func.optimize(progress_bar=False, **optimize_kwargs)
         mock_orchestrator.optimize.assert_awaited_once()
         return result
 
 
 @pytest.mark.asyncio
-async def test_cost_preflight_warns_once_with_exact_unpriced_models(
+async def test_cost_preflight_blocks_unpriced_models_non_interactive_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    counted = CountedFunction()
+    opt_func = OptimizedFunction(
+        func=counted,
+        configuration_space={"model": ["gpt-4o", FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
+        with patch(
+            "traigent.core.optimized_function.OptimizationOrchestrator"
+        ) as mock_orchestrator_cls:
+            with pytest.raises(UnknownModelError, match="non-interactive shell"):
+                await opt_func.optimize(progress_bar=False)
+
+    assert counted.call_count == 0
+    mock_orchestrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_env_approved_warns_with_exact_unpriced_models(
+    monkeypatch: pytest.MonkeyPatch,
     one_example_dataset: Dataset,
 ) -> None:
     opt_func = OptimizedFunction(
@@ -85,6 +121,12 @@ async def test_cost_preflight_warns_once_with_exact_unpriced_models(
         eval_dataset=one_example_dataset,
         max_trials=1,
     )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": pytest.fail("approval prompt should be skipped"),
+    )
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
 
     with (
         patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
@@ -107,6 +149,228 @@ async def test_cost_preflight_warns_once_with_exact_unpriced_models(
 
 
 @pytest.mark.asyncio
+async def test_cost_preflight_cost_approved_param_skips_prompt_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": pytest.fail("approval prompt should be skipped"),
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func, cost_approved=True)
+
+    assert [
+        warning
+        for warning in captured
+        if FAKE_MODEL in str(warning.message)
+        and "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cost_approved", ["false", "true"])
+async def test_cost_preflight_string_cost_approved_param_blocks_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    one_example_dataset: Dataset,
+    cost_approved: str,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": pytest.fail("non-interactive preflight should not prompt"),
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        patch(
+            "traigent.core.optimized_function.OptimizationOrchestrator"
+        ) as mock_orchestrator_cls,
+        caplog.at_level("WARNING", logger="traigent.core.cost_enforcement"),
+    ):
+        with pytest.raises(UnknownModelError, match="non-interactive shell"):
+            await opt_func.optimize(progress_bar=False, cost_approved=cost_approved)
+
+    assert (
+        f"Ignoring non-boolean cost_approved='{cost_approved}' (type: str)"
+        in caplog.text
+    )
+    mock_orchestrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_token_approval_skips_prompt_non_interactive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    one_example_dataset: Dataset,
+) -> None:
+    token_path = tmp_path / "traigent" / "cost_approval.token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("approved")
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": pytest.fail("approval prompt should be skipped"),
+    )
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert [
+        warning
+        for warning in captured
+        if FAKE_MODEL in str(warning.message)
+        and "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("choice", ["n", ""])
+async def test_cost_preflight_interactive_decline_blocks_before_any_trial(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+    choice: str,
+) -> None:
+    counted = CountedFunction()
+    opt_func = OptimizedFunction(
+        func=counted,
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": choice)
+
+    with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
+        with patch(
+            "traigent.core.optimized_function.OptimizationOrchestrator"
+        ) as mock_orchestrator_cls:
+            with pytest.raises(UnknownModelError, match="declined"):
+                await opt_func.optimize(progress_bar=False)
+
+    assert counted.call_count == 0
+    mock_orchestrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_interactive_eof_blocks_before_any_trial(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    counted = CountedFunction()
+    opt_func = OptimizedFunction(
+        func=counted,
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    def raise_eof(_prompt: str = "") -> str:
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
+        with patch(
+            "traigent.core.optimized_function.OptimizationOrchestrator"
+        ) as mock_orchestrator_cls:
+            with pytest.raises(UnknownModelError, match="interrupted"):
+                await opt_func.optimize(progress_bar=False)
+
+    assert counted.call_count == 0
+    mock_orchestrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_interactive_keyboard_interrupt_blocks_before_any_trial(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    counted = CountedFunction()
+    opt_func = OptimizedFunction(
+        func=counted,
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    def raise_keyboard_interrupt() -> str:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", raise_keyboard_interrupt)
+
+    with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
+        with patch(
+            "traigent.core.optimized_function.OptimizationOrchestrator"
+        ) as mock_orchestrator_cls:
+            with pytest.raises(UnknownModelError, match="interrupted"):
+                await opt_func.optimize(progress_bar=False)
+
+    assert counted.call_count == 0
+    mock_orchestrator_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cost_preflight_interactive_yes_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+    one_example_dataset: Dataset,
+) -> None:
+    opt_func = OptimizedFunction(
+        func=CountedFunction(),
+        configuration_space={"model": [FAKE_MODEL]},
+        eval_dataset=one_example_dataset,
+        max_trials=1,
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+
+    with (
+        patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
+        warnings.catch_warnings(record=True) as captured,
+    ):
+        warnings.simplefilter("always")
+        await _run_with_mocked_orchestrator(opt_func)
+
+    assert [
+        warning
+        for warning in captured
+        if FAKE_MODEL in str(warning.message)
+        and "results will report $0" in str(warning.message)
+    ]
+
+
+@pytest.mark.asyncio
 async def test_cost_preflight_strict_blocks_before_any_trial(
     monkeypatch: pytest.MonkeyPatch,
     one_example_dataset: Dataset,
@@ -119,6 +383,11 @@ async def test_cost_preflight_strict_blocks_before_any_trial(
         max_trials=1,
     )
     monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": pytest.fail("strict mode should not prompt"),
+    )
 
     with patch("traigent.core.optimized_function.is_mock_llm", return_value=False):
         with pytest.raises(UnknownModelError, match=FAKE_MODEL):
@@ -176,6 +445,11 @@ async def test_cost_preflight_custom_pricing_json_counts_as_covered(
         eval_dataset=one_example_dataset,
         max_trials=1,
     )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": pytest.fail("covered model should not prompt"),
+    )
 
     with (
         patch("traigent.core.optimized_function.is_mock_llm", return_value=False),
@@ -197,6 +471,7 @@ async def test_cost_preflight_mock_mode_skips_warning_and_strict_block(
     one_example_dataset: Dataset,
 ) -> None:
     monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     opt_func = OptimizedFunction(
         func=CountedFunction(),
         configuration_space={"model": [FAKE_MODEL]},
@@ -220,8 +495,10 @@ async def test_cost_preflight_mock_mode_skips_warning_and_strict_block(
 
 @pytest.mark.asyncio
 async def test_cost_preflight_checks_default_model_when_model_is_fixed(
+    monkeypatch: pytest.MonkeyPatch,
     one_example_dataset: Dataset,
 ) -> None:
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")
     opt_func = OptimizedFunction(
         func=CountedFunction(),
         configuration_space={"temperature": [0.0, 0.5]},

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -11,6 +11,7 @@ import threading
 from collections.abc import Generator
 from datetime import UTC
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -27,6 +28,7 @@ from traigent.core.cost_enforcement import (
     CostTrackingRequiredError,
     OptimizationAborted,
     Permit,
+    normalize_cost_approved,
 )
 from traigent.core.stop_conditions import CostLimitStopCondition
 
@@ -64,6 +66,35 @@ UNKNOWN_COST_PAIRWISE_CASES = [
 ]
 
 
+class _CostEnforcerSink:
+    def __init__(self) -> None:
+        self.cost_enforcer: CostEnforcer | None = None
+
+    def set_cost_enforcer(self, cost_enforcer: CostEnforcer) -> None:
+        self.cost_enforcer = cost_enforcer
+
+
+class _StopConditionSink:
+    def __init__(self) -> None:
+        self.cost_enforcer: CostEnforcer | None = None
+
+    def register_cost_limit_condition(self, cost_enforcer: CostEnforcer) -> None:
+        self.cost_enforcer = cost_enforcer
+
+
+def _setup_orchestrator_cost_enforcer(cost_approved: object) -> CostEnforcer:
+    from traigent.core.orchestrator import OptimizationOrchestrator
+
+    orchestrator = cast(
+        Any, OptimizationOrchestrator.__new__(OptimizationOrchestrator)
+    )
+    orchestrator.config = {"cost_limit": 1.0, "cost_approved": cost_approved}
+    orchestrator.parallel_execution_manager = _CostEnforcerSink()
+    orchestrator._stop_condition_manager = _StopConditionSink()
+    orchestrator._setup_cost_enforcer()
+    return cast(CostEnforcer, orchestrator.cost_enforcer)
+
+
 class TestCostEnforcerConfig:
     """Tests for CostEnforcerConfig defaults and validation."""
 
@@ -87,6 +118,39 @@ class TestCostEnforcerConfig:
         assert config.approved is True
         assert config.warning_threshold == 0.8
         assert config.fallback_trial_limit == 20
+
+
+class TestCostApprovalNormalization:
+    """Tests for fail-closed runtime approval parameter parsing."""
+
+    def test_normalize_cost_approved_accepts_only_real_true(self) -> None:
+        assert normalize_cost_approved(True) is True
+        assert normalize_cost_approved(False) is False
+        assert normalize_cost_approved(None) is False
+
+    @pytest.mark.parametrize("value", ["true", "false", 1])
+    def test_normalize_cost_approved_rejects_non_bool_values(
+        self, caplog: pytest.LogCaptureFixture, value: object
+    ) -> None:
+        with caplog.at_level("WARNING", logger="traigent.core.cost_enforcement"):
+            assert normalize_cost_approved(value) is False
+
+        assert repr(value) in caplog.text
+        assert f"type: {type(value).__name__}" in caplog.text
+
+    def test_orchestrator_string_cost_approved_does_not_approve_cost_enforcer(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level("WARNING", logger="traigent.core.cost_enforcement"):
+            enforcer = _setup_orchestrator_cost_enforcer("true")
+
+        assert enforcer.config.approved is False
+        assert "Ignoring non-boolean cost_approved='true' (type: str)" in caplog.text
+
+    def test_orchestrator_bool_cost_approved_approves_cost_enforcer(self) -> None:
+        enforcer = _setup_orchestrator_cost_enforcer(True)
+
+        assert enforcer.config.approved is True
 
 
 class TestCostEnforcerBasic:
@@ -703,6 +767,24 @@ class TestCostEnforcerEnvironmentVariables:
         with patch.dict(os.environ, {"TRAIGENT_COST_APPROVED": "true"}):
             enforcer = CostEnforcer()
             assert enforcer.config.approved is True
+
+    def test_cost_approved_env_one_does_not_approve(self, tmp_path: Path) -> None:
+        """TRAIGENT_COST_APPROVED=1 is not an approval token."""
+        with patch.dict(os.environ, {"TRAIGENT_COST_APPROVED": "1"}):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=1.0))
+            enforcer._approval_token_path = tmp_path / "missing-cost-approval.token"
+            assert enforcer.config.approved is False
+            with patch.object(enforcer, "_request_user_approval", return_value=False):
+                assert enforcer.check_and_approve(2.0) is False
+
+    def test_cost_approved_env_true_approves(self) -> None:
+        """TRAIGENT_COST_APPROVED=true approves cost-sensitive execution."""
+        with patch.dict(os.environ, {"TRAIGENT_COST_APPROVED": "true"}):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=1.0))
+            with patch.object(enforcer, "_request_user_approval") as request_approval:
+                assert enforcer.check_and_approve(2.0) is True
+
+        request_approval.assert_not_called()
 
     def test_invalid_env_uses_default(self) -> None:
         """Invalid environment values fall back to defaults."""

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -52,6 +52,21 @@ DEFAULT_COST_LIMIT_USD = 2.0
 EMA_COLD_START_WARNING_TRIALS = 5
 
 
+def normalize_cost_approved(value: object) -> bool:
+    """Return True only for the runtime parameter value ``True``."""
+    if value is True:
+        return True
+    if value is False or value is None:
+        return False
+    logger.warning(
+        "Ignoring non-boolean cost_approved=%r (type: %s); cost approval "
+        "requires bool True.",
+        value,
+        type(value).__name__,
+    )
+    return False
+
+
 class CostTrackingRequiredError(Exception):
     """Raised when cost tracking fails but strict mode is enabled."""
 
@@ -121,6 +136,70 @@ class CostEnforcerConfig:
     warning_threshold: float = 0.5
     fallback_trial_limit: int = 10
     estimated_cost_per_trial: float = 0.05  # $0.05 default estimate
+
+
+def _get_approval_token_path() -> Path:
+    """Get XDG-compliant token path."""
+    xdg_config = os.getenv("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+    return Path(xdg_config) / "traigent" / "cost_approval.token"
+
+
+def _check_approval_token_path(
+    token_path: Path,
+    *,
+    config: CostEnforcerConfig | None = None,
+) -> bool:
+    """Check for a valid XDG approval token file.
+
+    Token format:
+        - "approved" - approve with default limit
+        - "approved:10.0" - approve with custom limit
+
+    Args:
+        token_path: Approval token path to check.
+        config: Optional cost config to update when the token raises the limit.
+
+    Returns:
+        True if valid approval token found.
+    """
+    if not token_path.exists():
+        return False
+
+    try:
+        content = token_path.read_text().strip()
+        if content.startswith("approved"):
+            if ":" in content and config is not None:
+                try:
+                    token_limit = float(content.split(":")[1])
+                    if token_limit > 0:
+                        config.limit = max(config.limit, token_limit)
+                        logger.debug(f"Token limit: ${token_limit:.2f}")
+                except (ValueError, IndexError):
+                    logger.warning(f"Invalid token format: {content}")
+            return True
+    except OSError as e:
+        logger.warning(f"Failed to read approval token: {e}")
+
+    return False
+
+
+def is_cost_preapproved(
+    config_approved: bool = False,
+    *,
+    token_path: Path | None = None,
+    config: CostEnforcerConfig | None = None,
+) -> bool:
+    """Return whether the user has pre-approved cost-sensitive execution."""
+    if config_approved:
+        return True
+
+    if os.getenv("TRAIGENT_COST_APPROVED", "false").lower() == "true":
+        return True
+
+    return _check_approval_token_path(
+        token_path if token_path is not None else _get_approval_token_path(),
+        config=config,
+    )
 
 
 @dataclass
@@ -344,8 +423,7 @@ class CostEnforcer:
 
     def _get_approval_token_path(self) -> Path:
         """Get XDG-compliant token path."""
-        xdg_config = os.getenv("XDG_CONFIG_HOME", str(Path.home() / ".config"))
-        return Path(xdg_config) / "traigent" / "cost_approval.token"
+        return _get_approval_token_path()
 
     @property
     def accumulated_cost(self) -> float:
@@ -382,17 +460,12 @@ class CostEnforcer:
         Returns:
             True if approved to proceed, False if user declined or non-interactive abort.
         """
-        if self.config.approved:
-            logger.info(
-                f"Cost pre-approved via TRAIGENT_COST_APPROVED "
-                f"(limit: ${self.config.limit:.2f})"
-            )
-            return True
-
-        if self._check_approval_token():
-            logger.info(
-                f"Cost approved via token file (limit: ${self.config.limit:.2f})"
-            )
+        if is_cost_preapproved(
+            self.config.approved,
+            token_path=self._approval_token_path,
+            config=self.config,
+        ):
+            logger.info("Cost pre-approved (limit: $%.2f)", self.config.limit)
             return True
 
         if estimated_cost <= self.config.limit:
@@ -413,25 +486,7 @@ class CostEnforcer:
         Returns:
             True if valid approval token found.
         """
-        if not self._approval_token_path.exists():
-            return False
-
-        try:
-            content = self._approval_token_path.read_text().strip()
-            if content.startswith("approved"):
-                if ":" in content:
-                    try:
-                        token_limit = float(content.split(":")[1])
-                        if token_limit > 0:
-                            self.config.limit = max(self.config.limit, token_limit)
-                            logger.debug(f"Token limit: ${token_limit:.2f}")
-                    except (ValueError, IndexError):
-                        logger.warning(f"Invalid token format: {content}")
-                return True
-        except OSError as e:
-            logger.warning(f"Failed to read approval token: {e}")
-
-        return False
+        return _check_approval_token_path(self._approval_token_path, config=self.config)
 
     def _request_user_approval(self, estimated: float) -> bool:
         """Interactive approval prompt. Fail-safe: abort if non-interactive.
@@ -482,7 +537,8 @@ Options:
         )
 
         try:
-            choice = input("Enter choice [y/n/r]: ").strip().lower()
+            print("Enter choice [y/n/r]: ", end="", file=sys.stderr, flush=True)
+            choice = input().strip().lower()
         except (EOFError, KeyboardInterrupt):
             print("\nAborted.", file=sys.stderr)
             logger.info("User aborted via EOF/interrupt")
@@ -1212,6 +1268,8 @@ __all__ = [
     "CostLimitExceeded",
     "CostStatus",
     "CostTrackingRequiredError",
+    "is_cost_preapproved",
+    "normalize_cost_approved",
     "OptimizationAborted",
     "Permit",
 ]

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -55,6 +55,7 @@ from traigent.config.types import (
 )
 from traigent.core.ci_approval import check_ci_approval
 from traigent.core.config_state_manager import ConfigStateManager, OptimizationState
+from traigent.core.cost_enforcement import is_cost_preapproved, normalize_cost_approved
 from traigent.core.objectives import (
     ObjectiveSchema,
     create_default_objectives,
@@ -218,6 +219,21 @@ def _extract_config_model_ids(config: Mapping[str, Any]) -> list[str]:
 
 def _format_model_id_list(model_ids: Sequence[str]) -> str:
     return ", ".join(f"`{model_id}`" for model_id in model_ids)
+
+
+def _format_unpriced_model_warning(model_ids: Sequence[str]) -> str:
+    formatted = _format_model_id_list(model_ids)
+    if len(model_ids) == 1:
+        return (
+            f"Cost for {formatted} is unavailable — results will report $0 "
+            "for it. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+            "Traigent to add coverage."
+        )
+    return (
+        f"Costs for {formatted} are unavailable — results will report $0 "
+        "for them. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
+        "Traigent to add coverage."
+    )
 
 
 def _emit_cost_warning_once() -> None:
@@ -1935,7 +1951,10 @@ class OptimizedFunction:
         return algorithm
 
     def _preflight_model_cost_coverage(
-        self, effective_config_space: Mapping[str, Any]
+        self,
+        effective_config_space: Mapping[str, Any],
+        *,
+        cost_approved: bool = False,
     ) -> None:
         """Warn or fail before trials when a real run includes unpriced models."""
         if is_mock_llm():
@@ -1964,19 +1983,80 @@ class OptimizedFunction:
                 "pricing, or contact Traigent to add coverage."
             )
 
-        if len(missing) == 1:
-            message = (
-                f"Cost for {formatted} is unavailable — results will report $0 "
-                "for it. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
-                "Traigent to add coverage."
+        message = _format_unpriced_model_warning(missing)
+
+        if is_cost_preapproved(cost_approved):
+            warnings.warn(message, UserWarning, stacklevel=3)
+            logger.info(
+                "Proceeding with unpriced models because cost execution was "
+                "pre-approved: %s",
+                ", ".join(missing),
             )
-        else:
-            message = (
-                f"Costs for {formatted} are unavailable — results will report $0 "
-                "for them. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON, or contact "
-                "Traigent to add coverage."
+            return
+
+        if not sys.stdin.isatty():
+            raise UnknownModelError(
+                "Cost coverage preflight failed before any optimization trial "
+                "started: pricing is unavailable for "
+                f"{formatted}. Cannot prompt for confirmation in a "
+                "non-interactive shell. Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON "
+                "or TRAIGENT_CUSTOM_MODEL_PRICING_FILE with explicit per-token "
+                "pricing, set TRAIGENT_COST_APPROVED=true to acknowledge this "
+                "cost concern, or run interactively."
             )
+
+        plural = "model has" if len(missing) == 1 else "models have"
+        print(
+            f"""
+================================================================================
+Traigent Unpriced Model Warning
+================================================================================
+
+The following {len(missing)} {plural} NO known pricing:
+  {formatted}
+
+Their optimization results will report $0 cost for those calls, but your LLM
+provider may still bill you.
+
+Remediation:
+  - Set TRAIGENT_CUSTOM_MODEL_PRICING_JSON with explicit per-token pricing
+  - Contact Traigent to add model pricing coverage
+  - Set TRAIGENT_COST_APPROVED=true to skip this prompt after acknowledging
+    this cost concern
+
+================================================================================
+""",
+            file=sys.stderr,
+        )
+
+        try:
+            print(
+                "Proceed despite unpriced models? [y/N]: ",
+                end="",
+                file=sys.stderr,
+                flush=True,
+            )
+            choice = input().strip().lower()
+        except (EOFError, KeyboardInterrupt) as exc:
+            raise UnknownModelError(
+                "Cost coverage preflight failed before any optimization trial "
+                "started: user confirmation was interrupted for unpriced "
+                f"models {formatted}."
+            ) from exc
+
+        if choice not in {"y", "yes"}:
+            raise UnknownModelError(
+                "Cost coverage preflight failed before any optimization trial "
+                "started: user declined to proceed with unpriced models "
+                f"{formatted}."
+            )
+
         warnings.warn(message, UserWarning, stacklevel=3)
+        logger.info(
+            "Proceeding with unpriced models after interactive user "
+            "confirmation: %s",
+            ", ".join(missing),
+        )
 
     async def _execute_optimization(
         self,
@@ -2075,7 +2155,12 @@ class OptimizedFunction:
             self.max_total_examples = max_total_examples_value
 
         # Phase 3.5: cost coverage preflight before any cloud or local trial dispatch.
-        self._preflight_model_cost_coverage(effective_config_space)
+        self._preflight_model_cost_coverage(
+            effective_config_space,
+            cost_approved=normalize_cost_approved(
+                algorithm_kwargs.get("cost_approved", False)
+            ),
+        )
 
         # Phase 4: Try cloud execution if applicable
         cloud_result = await self._try_cloud_execution(
@@ -2675,7 +2760,7 @@ class OptimizedFunction:
 
     def publish_best_config(self, *, target: str = "cloud") -> dict[str, Any]:
         """Publish the best config to a durable remote target when supported."""
-        return self._csm.publish_best_config(target=target)
+        return self._csm.publish_best_config(target=target)  # type: ignore[no-any-return]
 
     def _load_config_from_path(self, path: str) -> dict[str, Any] | None:
         """Load config from a file path. Delegates to ConfigStateManager."""

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -50,6 +50,7 @@ from traigent.core.cost_enforcement import (
     CostEnforcer,
     CostEnforcerConfig,
     Permit,
+    normalize_cost_approved,
 )
 from traigent.core.cost_estimator import CostEstimator
 from traigent.core.exception_handler import VendorErrorCategory
@@ -434,7 +435,7 @@ class OptimizationOrchestrator:
         """Map public agent types to workflow graph node types."""
 
         if agent.agent_type in {"llm", "retriever", "router", "tool"}:
-            return agent.agent_type
+            return cast(str, agent.agent_type)
         return "agent"
 
     def _register_declared_workflow_trace_nodes(self) -> None:
@@ -602,12 +603,12 @@ class OptimizationOrchestrator:
     def _setup_cost_enforcer(self) -> None:
         """Initialize cost enforcer for cost limit enforcement."""
         cost_limit = self.config.get("cost_limit")
-        cost_approved = self.config.get("cost_approved", False)
+        cost_approved = normalize_cost_approved(self.config.get("cost_approved", False))
         cost_config = None
         if cost_limit is not None or cost_approved:
             cost_config = CostEnforcerConfig(
                 limit=float(cost_limit) if cost_limit else DEFAULT_COST_LIMIT_USD,
-                approved=bool(cost_approved),
+                approved=cost_approved,
             )
         self.cost_enforcer = CostEnforcer(config=cost_config)
         self.parallel_execution_manager.set_cost_enforcer(self.cost_enforcer)
@@ -974,7 +975,10 @@ class OptimizationOrchestrator:
 
         from traigent.cloud.governance import build_certified_selection
 
-        return build_certified_selection(incumbent.trial_id, certificates)
+        return cast(
+            dict[str, Any] | None,
+            build_certified_selection(incumbent.trial_id, certificates),
+        )
 
     def _withhold_promotion(self, reason: str) -> bool:
         """Fail closed: record + log a strict-mode withheld promotion."""
@@ -1112,9 +1116,11 @@ class OptimizationOrchestrator:
             return True
 
         minimization = is_minimization_objective(primary_objective)
+        new_score_value = cast(float, new_score)
+        current_score_value = cast(float, current_score)
         if minimization:
-            return new_score < current_score
-        return new_score > current_score
+            return new_score_value < current_score_value
+        return new_score_value > current_score_value
 
     def _update_best_trial_cache(self, trial_result: TrialResult) -> None:
         if not self.optimizer.objectives:
@@ -2138,7 +2144,7 @@ class OptimizationOrchestrator:
                     raw_result
                 )
             )
-            return session_id
+            return cast(str, session_id)
         else:
             # Return a mock session ID if no backend client
             mock_session_id = f"mock-session-{self._optimization_id[:8]}"


### PR DESCRIPTION
Closes the gap the owner identified after #1146: unpriced models produced a pass-through warning and the run continued. Now they require explicit user feedback, reusing the existing CostEnforcer approval idiom (no new env):

- **Interactive TTY** → blocking prompt on stderr (lists unpriced models verbatim, warns results report \$0 while the provider may still bill) — `y` proceeds, anything else/EOF/interrupt aborts before any trial.
- **Non-interactive** → fails closed (`UnknownModelError` before trial 1) with remediation.
- **Pre-approved** (`cost_approved=True` param, `TRAIGENT_COST_APPROVED=true`, or approval token) → proceeds with the warning. Mock skips; strict hard-fails (both unchanged).

### Adversarial review (captain-dispatched) caught and fixed 2 blockers
1. `bool("false") is True` coercion meant a **string** `cost_approved="false"` approved → new fail-closed `normalize_cost_approved`: only literal `True` approves; any non-bool logs a warning and fails closed. Applied at both call sites (preflight + orchestrator→CostEnforcer).
2. Env approval had been silently broadened to `1/yes/y/on` → restored to exact `"true"`.
Plus: all prompt text to stderr; KeyboardInterrupt-during-prompt test.

**Verification**: 133 tests (preflight + enforcement) green; captain ran independent probes (string params block, env=1 blocks, env=true approves, non-TTY default raises with zero trials). ruff/mypy clean. Policy surface fail-closed per workspace Rule 1; production path = the non-TTY fail-closed test. CHANGELOG entry under [Unreleased].

🤖 Generated with [Claude Code](https://claude.com/claude-code)