### PR TITLE
docs(skills): shipped skill docs — post-#1166 cost gate, dataset= sweep, LICENSE METADATA fix

### DIFF
--- a/traigent/skills/traigent-analyze-results/SKILL.md
+++ b/traigent/skills/traigent-analyze-results/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-analyze-results
 description: "Analyze Traigent optimization results: best config, trial comparison, convergence, cost, and applying results to production. Use when reading results.best_config, comparing trials, checking stop_reason, calling apply_best_config(), accessing total_cost or total_tokens, or understanding why optimization stopped."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"
@@ -30,6 +30,7 @@ import traigent
 @traigent.optimize(
     configuration_space={"model": ["gpt-4o-mini", "gpt-4o"], "temperature": [0.0, 0.5, 1.0]},
     objectives=["accuracy"],
+    eval_dataset="eval_data.jsonl",
     max_trials=10,
 )
 def classify(text):
@@ -37,7 +38,7 @@ def classify(text):
     # ... LLM call using config ...
     return result
 
-results = classify.optimize(dataset="eval_data.jsonl")
+results = classify.optimize()
 
 # Top-level results
 print(results.best_config)      # {"model": "gpt-4o", "temperature": 0.0}
@@ -195,7 +196,7 @@ After optimization, apply the winning configuration so your function uses it in 
 
 ```python
 # Run optimization
-results = classify.optimize(dataset="eval_data.jsonl")
+results = classify.optimize()
 
 # Apply the best configuration
 classify.apply_best_config(results)
@@ -212,7 +213,7 @@ response = classify("What category is this email?")
 Verify results before applying:
 
 ```python
-results = classify.optimize(dataset="eval_data.jsonl")
+results = classify.optimize()
 
 if results.best_score is not None and results.best_score >= 0.85:
     classify.apply_best_config(results)
@@ -266,6 +267,7 @@ import traigent
         "max_tokens": [256, 512, 1024],
     },
     objectives=["accuracy"],
+    eval_dataset="summarization_eval.jsonl",
     max_trials=15,
 )
 def summarize(text):
@@ -274,7 +276,7 @@ def summarize(text):
     return summary
 
 # 1. Run optimization
-results = summarize.optimize(dataset="summarization_eval.jsonl")
+results = summarize.optimize()
 
 # 2. Quick summary
 print(f"Best config: {results.best_config}")

--- a/traigent/skills/traigent-analyze-results/references/convergence-patterns.md
+++ b/traigent/skills/traigent-analyze-results/references/convergence-patterns.md
@@ -5,7 +5,7 @@
 The `results.convergence_info` field is a dictionary containing statistics about how the optimization progressed over trials. Use it to understand whether the optimizer found a good solution or whether more trials might help.
 
 ```python
-results = func.optimize(dataset="data.jsonl")
+results = func.optimize()
 info = results.convergence_info
 ```
 
@@ -130,7 +130,7 @@ def should_run_more_trials(results) -> bool:
     return False
 
 
-results = func.optimize(dataset="data.jsonl")
+results = func.optimize()
 if should_run_more_trials(results):
     print("Consider re-running with higher max_trials")
 ```

--- a/traigent/skills/traigent-analyze-results/references/optimization-result-api.md
+++ b/traigent/skills/traigent-analyze-results/references/optimization-result-api.md
@@ -37,7 +37,7 @@ The `OptimizationResult` dataclass is returned by `func.optimize()` and contains
 ### Usage
 
 ```python
-results = func.optimize(dataset="data.jsonl")
+results = func.optimize()
 
 # Direct field access
 print(results.best_config)       # {"model": "gpt-4o", "temperature": 0.0}

--- a/traigent/skills/traigent-configuration-space/SKILL.md
+++ b/traigent/skills/traigent-configuration-space/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-configuration-space
 description: "Define tuned variables and configuration spaces for Traigent optimization. Use when setting up parameter search spaces, choosing models/temperatures/prompts to optimize, using Range/IntRange/Choices/LogRange types, adding constraints between parameters, or using factory presets like Range.temperature()."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"

--- a/traigent/skills/traigent-debugging/SKILL.md
+++ b/traigent/skills/traigent-debugging/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-debugging
 description: "Debug and troubleshoot Traigent optimization issues. Use when encountering CostLimitExceeded, ConfigurationError, OptimizationStateError, ModuleNotFoundError, or when optimization produces unexpected results. Covers mock mode, logging configuration, and common error resolution."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"
@@ -112,7 +112,7 @@ traigent.utils.exceptions.CostLimitExceeded: Cost limit exceeded: $0.52 >= $0.50
 from traigent.utils.exceptions import CostLimitExceeded
 
 try:
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
 except CostLimitExceeded as e:
     print(f"Budget exceeded: spent ${e.accumulated:.2f} of ${e.limit:.2f} limit")
     # Check if partial results are available
@@ -139,7 +139,7 @@ def my_func(text):
 my_func("hello")  # OptimizationStateError!
 
 # CORRECT: run optimization first, then apply
-results = my_func.optimize(dataset="data.jsonl")
+results = my_func.optimize()
 my_func.apply_best_config(results)
 my_func("hello")  # Works - get_config() returns applied config
 ```
@@ -190,7 +190,7 @@ Has `config`, `input_data`, and `original_error` attributes. Check the original 
 from traigent.utils.exceptions import InvocationError
 
 try:
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
 except InvocationError as e:
     print(f"Config that caused failure: {e.config}")
     print(f"Original error: {e.original_error}")
@@ -256,6 +256,7 @@ import traigent
 @traigent.optimize(
     configuration_space={"model": ["gpt-4o-mini", "gpt-4o"], "temperature": [0.0, 0.5]},
     objectives=["accuracy"],
+    eval_dataset="test_data.jsonl",
     max_trials=5,
 )
 def my_func(text):
@@ -264,7 +265,7 @@ def my_func(text):
     return "mock response"
 
 # Runs without API keys or backend
-results = my_func.optimize(dataset="test_data.jsonl")
+results = my_func.optimize()
 ```
 
 Mock mode is essential for:
@@ -364,6 +365,7 @@ DEFAULT_CONFIG = {"model": "gpt-4o-mini", "temperature": 0.0}
         "temperature": [0.0, 0.3, 0.7],
     },
     objectives=["accuracy"],
+    eval_dataset="eval_data.jsonl",
     max_trials=10,
 )
 def classify(text):
@@ -373,7 +375,7 @@ def classify(text):
 
 # Attempt optimization with fallback
 try:
-    results = classify.optimize(dataset="eval_data.jsonl")
+    results = classify.optimize()
 
     if results.best_score is not None and results.best_score >= 0.7:
         classify.apply_best_config(results)

--- a/traigent/skills/traigent-debugging/references/error-reference.md
+++ b/traigent/skills/traigent-debugging/references/error-reference.md
@@ -66,7 +66,7 @@ Exception
 from traigent.utils.exceptions import TraigentError
 
 try:
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
 except TraigentError as e:
     print(f"Error: {e.message}")
     print(f"Details: {e.details}")
@@ -121,7 +121,7 @@ Raised before optimization starts when provider API keys are invalid or missing.
 from traigent.utils.exceptions import CostLimitExceeded
 
 try:
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
 except CostLimitExceeded as e:
     print(f"Spent ${e.accumulated:.2f} of ${e.limit:.2f} budget")
 ```
@@ -233,7 +233,7 @@ Traigent handles retries automatically for retryable errors. This surfaces when 
 from traigent.utils.exceptions import TraigentError
 
 try:
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
 except TraigentError as e:
     print(f"Traigent error: {e.message}")
 ```
@@ -249,7 +249,7 @@ from traigent.utils.exceptions import (
 )
 
 try:
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
 except CostLimitExceeded as e:
     print(f"Over budget: ${e.accumulated:.2f}")
 except ProviderValidationError as e:

--- a/traigent/skills/traigent-debugging/references/logging-config.md
+++ b/traigent/skills/traigent-debugging/references/logging-config.md
@@ -109,7 +109,7 @@ Full Python traceback is shown:
 ```
 Traceback (most recent call last):
   File "my_script.py", line 15, in <module>
-    results = func.optimize(dataset="data.jsonl")
+    results = func.optimize()
   File "/path/to/traigent/core/optimized_function.py", line 234, in optimize
     self._validate_config_space(config_space)
   File "/path/to/traigent/core/optimized_function.py", line 178, in _validate_config_space

--- a/traigent/skills/traigent-debugging/references/mock-mode.md
+++ b/traigent/skills/traigent-debugging/references/mock-mode.md
@@ -165,6 +165,7 @@ import traigent
         "temperature": [0.0, 0.5, 1.0],
     },
     objectives=["accuracy"],
+    eval_dataset="data.jsonl",
     max_trials=3,
 )
 def my_func(text):
@@ -172,7 +173,7 @@ def my_func(text):
     return f"Response using {config['model']}"
 
 # Quick validation run
-results = my_func.optimize(dataset="data.jsonl")
+results = my_func.optimize()
 
 print(f"Ran {len(results.trials)} trials")
 print(f"Stop reason: {results.stop_reason}")

--- a/traigent/skills/traigent-decorator-setup/SKILL.md
+++ b/traigent/skills/traigent-decorator-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-decorator-setup
 description: "Configure the @traigent.optimize() decorator with evaluation, injection, and execution options. Use when setting up eval_dataset, choosing injection_mode, configuring execution_mode, defining objectives, using EvaluationOptions/InjectionOptions/ExecutionOptions, or integrating custom evaluators."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"

--- a/traigent/skills/traigent-integrations/SKILL.md
+++ b/traigent/skills/traigent-integrations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-integrations
 description: "Integrate Traigent with LangChain, LiteLLM, DSPy, and other AI frameworks. Use when importing langchain/litellm/dspy alongside traigent, setting up multi-provider model testing, using auto_override_frameworks, or asking about framework-specific adapter patterns."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"
@@ -50,6 +50,7 @@ from langchain_core.prompts import ChatPromptTemplate
         "temperature": [0.0, 0.3, 0.7, 1.0],
     },
     objectives=["accuracy"],
+    eval_dataset="questions.jsonl",
     max_trials=10,
 )
 def answer_question(question):
@@ -68,7 +69,7 @@ def answer_question(question):
     response = chain.invoke({"question": question})
     return response.content
 
-results = answer_question.optimize(dataset="questions.jsonl")
+results = answer_question.optimize()
 ```
 
 ### Auto Override Frameworks
@@ -132,6 +133,7 @@ import litellm
         "max_tokens": [256, 512, 1024],
     },
     objectives=["accuracy"],
+    eval_dataset="classification_eval.jsonl",
     max_trials=15,
 )
 def classify_text(text):
@@ -145,7 +147,7 @@ def classify_text(text):
     )
     return response.choices[0].message.content
 
-results = classify_text.optimize(dataset="classification_eval.jsonl")
+results = classify_text.optimize()
 
 # Check cost across providers
 for trial in results.successful_trials:
@@ -221,7 +223,7 @@ Log Traigent optimization results to MLflow for experiment tracking:
 ```python
 import mlflow
 
-results = func.optimize(dataset="data.jsonl")
+results = func.optimize()
 
 with mlflow.start_run():
     mlflow.log_param("algorithm", results.algorithm)
@@ -242,7 +244,7 @@ with mlflow.start_run():
 ```python
 import wandb
 
-results = func.optimize(dataset="data.jsonl")
+results = func.optimize()
 
 wandb.init(project="traigent-optimization")
 for trial in results.trials:

--- a/traigent/skills/traigent-integrations/references/dspy.md
+++ b/traigent/skills/traigent-integrations/references/dspy.md
@@ -139,6 +139,7 @@ import dspy
         "temperature": [0.0, 0.3, 0.7],
     },
     objectives=["accuracy"],
+    eval_dataset="qa_eval.jsonl",
     max_trials=9,
 )
 def optimized_qa(question):
@@ -154,14 +155,14 @@ def optimized_qa(question):
     return result.answer
 
 # Traigent finds the best model + temperature
-results = optimized_qa.optimize(dataset="qa_eval.jsonl")
+results = optimized_qa.optimize()
 ```
 
 For a two-stage approach (Traigent model optimization, then DSPy prompt optimization):
 
 ```python
 # Stage 1: Find the best model with Traigent
-model_results = optimized_qa.optimize(dataset="qa_eval.jsonl")
+model_results = optimized_qa.optimize()
 best_model = model_results.best_config["model"]
 best_temp = model_results.best_config["temperature"]
 

--- a/traigent/skills/traigent-integrations/references/langchain.md
+++ b/traigent/skills/traigent-integrations/references/langchain.md
@@ -141,6 +141,7 @@ from langchain_core.runnables import RunnablePassthrough
         ],
     },
     objectives=["accuracy"],
+    eval_dataset="rag_eval.jsonl",
     max_trials=12,
 )
 def rag_answer(question):
@@ -169,7 +170,7 @@ def rag_answer(question):
     )
     return chain.invoke(question)
 
-results = rag_answer.optimize(dataset="rag_eval.jsonl")
+results = rag_answer.optimize()
 ```
 
 ## Programmatic Framework Override API

--- a/traigent/skills/traigent-integrations/references/litellm.md
+++ b/traigent/skills/traigent-integrations/references/litellm.md
@@ -57,6 +57,7 @@ import litellm
         "max_tokens": [256, 512],
     },
     objectives=["accuracy"],
+    eval_dataset="qa_eval.jsonl",
     max_trials=15,
 )
 def answer(question):
@@ -70,7 +71,7 @@ def answer(question):
     )
     return response.choices[0].message.content
 
-results = answer.optimize(dataset="qa_eval.jsonl")
+results = answer.optimize()
 ```
 
 ## Cost Tracking
@@ -78,7 +79,7 @@ results = answer.optimize(dataset="qa_eval.jsonl")
 LiteLLM tracks cost per completion call. You can access this through Traigent's results:
 
 ```python
-results = answer.optimize(dataset="qa_eval.jsonl")
+results = answer.optimize()
 
 # Traigent aggregates cost across all trials
 if results.total_cost is not None:
@@ -98,7 +99,7 @@ print(f"Cost per config: ${stats.cost_per_configuration:.4f}")
 ### Cost-Accuracy Tradeoff Analysis
 
 ```python
-results = answer.optimize(dataset="qa_eval.jsonl")
+results = answer.optimize()
 
 # Group trials by provider
 from collections import defaultdict
@@ -142,6 +143,7 @@ import litellm
         "max_tokens": [256, 512, 1024],
     },
     objectives=["accuracy"],
+    eval_dataset="eval_prompts.jsonl",
     max_trials=20,
 )
 def generate_response(prompt):
@@ -160,7 +162,7 @@ def generate_response(prompt):
 
 
 # Run optimization
-results = generate_response.optimize(dataset="eval_prompts.jsonl")
+results = generate_response.optimize()
 
 # Analyze results
 print(f"Best model: {results.best_config['model']}")

--- a/traigent/skills/traigent-quickstart/SKILL.md
+++ b/traigent/skills/traigent-quickstart/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-quickstart
 description: "Install and set up the Traigent SDK for LLM optimization. Use when the user wants to install traigent, set up their first optimization, create an eval dataset, or get started with @traigent.optimize. Covers pip install, environment variables, mock mode, and running a first optimization."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"
@@ -22,15 +22,18 @@ Use this skill when:
 
 ## Installation
 
-### Basic Install
+### Recommended Install
 
 ```bash
-pip install traigent
+pip install "traigent[recommended]"
 ```
 
 ### With Optional Extras
 
 ```bash
+# Minimal base package
+pip install traigent
+
 # Framework integrations (LangChain, OpenAI, Anthropic, MLflow, W&B)
 pip install 'traigent[integrations]'
 
@@ -39,9 +42,6 @@ pip install 'traigent[analytics]'
 
 # All optional features
 pip install 'traigent[all]'
-
-# Enterprise bundle (all production features)
-pip install 'traigent[enterprise]'
 ```
 
 See `references/installation-extras.md` for the full table of extras and their contents.

--- a/traigent/skills/traigent-quickstart/references/environment-variables.md
+++ b/traigent/skills/traigent-quickstart/references/environment-variables.md
@@ -9,10 +9,10 @@ Complete reference of environment variables recognized by the Traigent SDK.
 | `TRAIGENT_MOCK_LLM`               | `false`         | When `true`, mocks all LLM API calls. No provider API keys needed. Use for development and testing. |
 | `TRAIGENT_OFFLINE_MODE`            | `false`         | When `true`, skips all backend communication. Use for local-only development.                       |
 | `TRAIGENT_RUN_COST_LIMIT`         | `2.0`           | Maximum cost budget (in USD) per optimization run. Optimization stops when this limit is reached.    |
-| `TRAIGENT_COST_APPROVED`          | `false`         | When `true`, skips the interactive cost confirmation prompt before starting optimization.            |
+| `TRAIGENT_COST_APPROVED`          | `false`         | Exact value `true` pre-approves both the cost-limit prompt and unpriced-model preflight. `1`, `yes`, and `on` do not approve. |
 | `TRAIGENT_SKIP_PROVIDER_VALIDATION`| `false`        | When `true`, skips API key validation at decoration time. Useful in CI environments.                |
 | `TRAIGENT_VALIDATION_TIMEOUT`     | `5.0`           | Timeout in seconds for provider API key validation checks.                                          |
-| `TRAIGENT_STRICT_COST_ACCOUNTING` | `false`         | When `true`, enables strict cost tracking. Cost overruns raise errors instead of warnings.          |
+| `TRAIGENT_STRICT_COST_ACCOUNTING` | `false`         | Exact value `true` fails fast before trial 1 on unpriced models and when runtime cost extraction is missing or unknown. |
 | `TRAIGENT_LOG_LEVEL`              | `INFO`          | Logging verbosity. Options: `DEBUG`, `INFO`, `WARNING`, `ERROR`.                                    |
 | `TRAIGENT_DEBUG`                  | (unset)         | When set to `1`, shows full tracebacks for `ConfigurationError` instead of user-friendly messages.  |
 | `TRAIGENT_STRICT_VALIDATION`      | `true`          | When `true`, DTO schema validation raises exceptions. When `false`, logs warnings only.             |
@@ -54,6 +54,11 @@ export TRAIGENT_SKIP_PROVIDER_VALIDATION=true
 pytest tests/
 ```
 
+`TRAIGENT_COST_APPROVED=true` must be the exact value `true`. It acknowledges
+cost-sensitive execution for both cost-limit confirmation and unpriced-model
+coverage warnings; it does not supply pricing. Runtime `cost_approved=True` must
+be a real boolean, because string values are ignored and logged as warnings.
+
 ### Production with Cost Controls
 
 ```bash
@@ -64,6 +69,13 @@ export TRAIGENT_COST_APPROVED=true
 export TRAIGENT_LOG_LEVEL=WARNING
 python optimize_production.py
 ```
+
+Unpriced models block before trial 1 unless cost-sensitive execution is
+pre-approved: an interactive terminal prompts `y/N`, and non-interactive runs
+fail closed. Mock LLM mode skips the optimized-function pricing preflight, but
+it does not disable cost permits or accounting globally. Budget overruns are
+controlled by `TRAIGENT_RUN_COST_LIMIT` / `CostLimitExceeded`, not strict cost
+accounting.
 
 ### Portal-Tracked Hybrid Runs
 

--- a/traigent/skills/traigent-quickstart/references/installation-extras.md
+++ b/traigent/skills/traigent-quickstart/references/installation-extras.md
@@ -2,6 +2,12 @@
 
 Full reference of optional dependency groups available via `pip install 'traigent[extra_name]'`.
 
+For most users, start with:
+
+```bash
+pip install "traigent[recommended]"
+```
+
 ## Extras Table
 
 | Extra           | Description                                        | Key Packages                                                                 |
@@ -10,24 +16,27 @@ Full reference of optional dependency groups available via `pip install 'traigen
 | `bayesian`      | Bayesian optimization algorithms                   | scikit-learn, scipy                                                          |
 | `integrations`  | Framework integrations                             | LangChain (+ community/anthropic/openai/google), OpenAI, Anthropic, Groq, Google GenAI, MLflow, W&B, python-dotenv, boto3, faiss-cpu |
 | `dspy`          | DSPy prompt optimization                           | dspy-ai                                                                      |
-| `pydanticai`    | PydanticAI agent framework                         | pydantic-ai                                                                  |
-| `security`      | Enterprise security features                       | PyJWT, passlib, FastAPI, Starlette, uvicorn, redis, defusedxml, pyotp        |
+| `pydanticai`    | PydanticAI agent framework                         | pydantic-ai-slim                                                             |
+| `security`      | Enterprise security features                       | passlib, FastAPI, Starlette, uvicorn, redis, defusedxml, pyotp               |
 | `visualization` | Visualization and plotting                         | matplotlib, plotly                                                           |
-| `hybrid`        | Portal-tracked local execution and external hybrid API integrations | httpx with HTTP/2                                                            |
+| `hybrid`        | Portal-tracked local execution and external hybrid API integrations | httpx with HTTP/2, claude-code-sdk, mcp                                      |
 | `tracing`       | OpenTelemetry tracing                              | opentelemetry-api, opentelemetry-sdk, opentelemetry-exporter-otlp            |
 | `test`          | Testing dependencies                               | pytest, pytest-asyncio, pytest-cov, pytest-mock, pytest-timeout, pytest-xdist, coverage, ragas, rapidfuzz, hypothesis |
 | `dev`           | Development tools (linting + testing)              | pytest suite, black, isort, flake8, mypy, pre-commit, ruff, bandit           |
 | `docs`          | Documentation generation                           | mkdocs, mkdocs-material, mkdocstrings                                        |
 | `ml`            | Machine learning bundle                            | bayesian + analytics + numpy + scipy                                         |
 | `cloud`         | Reserved dependencies for future remote execution; not needed for portal-tracked `hybrid` runs | security + boto3                                                             |
+| `recommended`   | Recommended end-user bundle for running optimizations | integrations, analytics, bayesian, visualization, hybrid, pydanticai         |
 | `all`           | All optional features combined                     | analytics, bayesian, integrations, pydanticai, security, visualization, test, tracing, hybrid |
-| `enterprise`    | Enterprise bundle with all production features     | analytics, bayesian, integrations, security, visualization, test, tracing, ml, cloud, hybrid  |
 
 ## Install Commands
 
 ### pip
 
 ```bash
+# Recommended install
+pip install "traigent[recommended]"
+
 # Individual extras
 pip install 'traigent[analytics]'
 pip install 'traigent[bayesian]'
@@ -45,8 +54,8 @@ pip install 'traigent[ml]'
 pip install 'traigent[cloud]'
 
 # Combined bundles
+pip install 'traigent[recommended]'
 pip install 'traigent[all]'
-pip install 'traigent[enterprise]'
 
 # Multiple extras at once
 pip install 'traigent[integrations,analytics,visualization]'
@@ -62,8 +71,7 @@ These packages are installed with the base `pip install traigent`:
 - requests (sync HTTP fallback)
 - jsonschema (schema validation)
 - cryptography (encryption)
-- claude-code-sdk (Claude Code integration)
-- mcp (Model Context Protocol)
+- PyJWT[crypto] (JWT signing and verification)
 - backoff (retry with backoff)
 - litellm (LLM provider abstraction)
 - rank-bm25 (BM25 retrieval)
@@ -74,4 +82,5 @@ These packages are installed with the base `pip install traigent`:
 
 - Requires Python >= 3.11.
 - `faiss-cpu` (in `integrations`) is not available on Windows.
-- The `all` and `enterprise` bundles include most extras. The difference is that `enterprise` also includes `ml` and `cloud` bundles.
+- The `recommended` bundle installs `integrations`, `analytics`, `bayesian`, `visualization`, `hybrid`, and `pydanticai`.
+- The `all` bundle includes most extras for broad local development and testing.

--- a/traigent/skills/traigent-run-optimization/SKILL.md
+++ b/traigent/skills/traigent-run-optimization/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: traigent-run-optimization
 description: "Run Traigent optimization: async/sync execution, algorithm selection, cost limits, stop conditions, and parallel trials. Use when calling func.optimize() or optimize_sync(), choosing algorithms (grid/random/bayesian/optuna), setting max_trials or cost_limit, configuring parallel execution, or handling CostLimitExceeded."
-license: Apache-2.0
+license: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
 metadata:
   author: Traigent
   version: "1.0"
@@ -169,13 +169,31 @@ Skip the interactive cost approval handshake:
 export TRAIGENT_COST_APPROVED=true
 ```
 
+`TRAIGENT_COST_APPROVED=true` must be the exact environment value `true`; values
+such as `1`, `yes`, or `on` do not approve cost-sensitive execution. The runtime
+`cost_approved=True` option must be a real boolean; strings are ignored and
+logged as warnings.
+
+Pre-approval covers both the cost-limit prompt and the unpriced-model preflight
+gate. It proceeds with a warning for unpriced models; it does not add pricing
+coverage. Without pre-approval, unpriced models block before trial 1: interactive
+shells show a `y/N` prompt, and non-interactive shells fail closed.
+
+Mock LLM mode skips the optimized-function pricing preflight because no provider
+spend occurs, but it is not a global `CostEnforcer` bypass.
+
 ### Strict Cost Accounting
 
-Fail fast if cost tracking cannot extract costs from LLM responses:
+Fail fast before trial 1 on unpriced models, and fail if runtime cost tracking
+cannot extract costs from LLM responses:
 
 ```bash
 export TRAIGENT_STRICT_COST_ACCOUNTING=true
 ```
+
+`TRAIGENT_STRICT_COST_ACCOUNTING=true` must be the exact value `true`. Budget
+overruns are separate: they are controlled by `TRAIGENT_RUN_COST_LIMIT` and raise
+`CostLimitExceeded`.
 
 ## Stop Conditions
 

--- a/traigent/skills/traigent-run-optimization/references/cost-management.md
+++ b/traigent/skills/traigent-run-optimization/references/cost-management.md
@@ -7,12 +7,12 @@ Traigent provides real-time cost tracking and enforcement to prevent runaway LLM
 | Variable | Default | Description |
 |---|---|---|
 | `TRAIGENT_RUN_COST_LIMIT` | `2.0` | Maximum USD spending per optimization run. |
-| `TRAIGENT_COST_APPROVED` | `false` | Set to `"true"` to skip the interactive cost approval handshake. |
-| `TRAIGENT_STRICT_COST_ACCOUNTING` | `false` | Fail fast if cost extraction from LLM responses fails. |
+| `TRAIGENT_COST_APPROVED` | `false` | Exact value `true` pre-approves both the cost-limit prompt and unpriced-model preflight. `1`, `yes`, and `on` do not approve. |
+| `TRAIGENT_STRICT_COST_ACCOUNTING` | `false` | Exact value `true` fails fast before trial 1 on unpriced models and when runtime cost extraction is missing or unknown. |
 | `TRAIGENT_REQUIRE_COST_TRACKING` | `false` | Raise exception if cost tracking cannot extract costs. |
 | `TRAIGENT_COST_WARNING_THRESHOLD` | `0.5` | Warn when this fraction of the limit is consumed (0.0-1.0). |
 | `TRAIGENT_COST_DIVERGENCE_THRESHOLD` | `2.0` | Log warning if actual/estimated cost ratio exceeds this. |
-| `TRAIGENT_MOCK_LLM` | `false` | Bypass all cost tracking (no real LLM costs in mock mode). |
+| `TRAIGENT_MOCK_LLM` | `false` | Mock provider calls and skip optimized-function pricing preflight; not a global `CostEnforcer` bypass. |
 
 ## Setting a Cost Limit
 
@@ -89,25 +89,38 @@ This means the enforcer gets better at predicting costs as the optimization prog
 
 ## Pre-Approving Costs
 
-By default, Traigent may prompt for cost approval before running optimization (especially for expensive configurations). To skip this:
+By default, Traigent may prompt for cost approval before running optimization
+(especially for expensive or unpriced configurations). To pre-approve
+cost-sensitive execution:
 
 ```bash
 export TRAIGENT_COST_APPROVED=true
 ```
 
-This is useful in CI/CD pipelines, automated scripts, or when you have already verified the budget is acceptable.
+The environment value must be exactly `true`; values such as `1`, `yes`, and
+`on` do not approve. In code, runtime `cost_approved=True` must be a real
+boolean; string values are ignored and logged as warnings.
+
+Pre-approval covers both the cost-limit prompt and the unpriced-model preflight
+gate. It proceeds with a warning for unpriced models; it does not add pricing
+coverage. Without pre-approval, unpriced models block before trial 1: interactive
+terminals prompt `y/N`, and non-interactive shells fail closed.
 
 ## Strict Cost Accounting
 
-Enable strict mode to fail fast when cost information is unavailable:
+Enable strict mode to fail fast before trial 1 on unpriced models, and fail if
+runtime cost information is missing or unknown:
 
 ```bash
 export TRAIGENT_STRICT_COST_ACCOUNTING=true
 ```
 
-In strict mode, if Traigent cannot extract the cost from an LLM response (e.g., the provider does not report usage), it raises `CostTrackingRequiredError` instead of logging a warning and continuing.
+The environment value must be exactly `true`. In strict mode, unpriced models
+fail fast before trial 1, and missing or unknown runtime cost extraction raises
+`CostTrackingRequiredError` instead of logging a warning and continuing.
 
-This is recommended for production environments where accurate cost tracking is critical.
+Budget overruns are separate: `TRAIGENT_RUN_COST_LIMIT` controls the run budget
+and raises `CostLimitExceeded` when exceeded.
 
 ## Cost Warning Threshold
 
@@ -136,7 +149,10 @@ Trial 2: acquire_permit() -> execute -> track_cost(permit, $0.05)
 
 ## Mock Mode
 
-When `TRAIGENT_MOCK_LLM=true`, all cost tracking is bypassed. No permits are issued, no costs are recorded, and `CostLimitExceeded` is never raised. Use this for local development and testing.
+When `TRAIGENT_MOCK_LLM=true`, provider calls are mocked and the
+optimized-function pricing preflight is skipped because no provider spend
+occurs. Mock mode does not globally bypass `CostEnforcer` permits or accounting,
+so do not rely on it to disable budget checks in production.
 
 ```bash
 export TRAIGENT_MOCK_LLM=true


### PR DESCRIPTION
xhigh review of the SHIPPED traigent/skills/** docs (never previously reviewed). P1s: every example passing `dataset=` to `.optimize()` (API rejects it — ~25 spots, now decorator `eval_dataset`); **all 7 SKILL.md declared `license: Apache-2.0`** vs the dual license (wrong metadata shipped in 0.12.0 — this fix should ride 0.12.1); cost docs described the pre-#1166 warn-and-continue gate. Captain verified: 7/7 licenses corrected, 0 dataset= remnants, blocking-gate semantics accurate vs code. 🤖 Generated with [Claude Code](https://claude.com/claude-code)