### PR TITLE
docs: xhigh freshness pass — blocking cost gate, fictional-API rewrite, signature drift, npm honesty

### DIFF
--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -57,10 +57,13 @@ def optimize(
     # Legacy compatibility
     legacy: LegacyOptimizeArgs | dict[str, Any] | None = None,
     **runtime_overrides: Any,
-) -> OptimizedFunction
+) -> Callable[[Callable[..., Any]], Any]
 ```
 
 > **New in 0.8.0** – The decorator now uses keyword-only arguments with grouped option bundles. Legacy arguments are supported via the `legacy` parameter or directly in `**runtime_overrides`. Conflicting values between a bundle and a direct keyword raise `TypeError`.
+
+`optimize(...)` is a decorator factory. Applying the returned decorator to a
+function returns Traigent's optimized wrapper.
 
 **Core Parameters**
 
@@ -116,11 +119,11 @@ def my_agent(question: str) -> str:
 | `execution` | `ExecutionOptions \| dict \| None` | Bundle for execution settings including `execution_mode`, `local_storage_path`, `parallel_config`, `privacy_enabled`, and `max_total_examples`. |
 | `mock` | `MockModeOptions \| dict \| None` | **Deprecated — all fields inert.** Retained on the schema for backwards compatibility (config round-trip). Mock mode is enabled by calling `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial or test code, not via this object. The legacy `TRAIGENT_MOCK_LLM=true` env var remains available outside production for shell fixtures and backwards compatibility but emits `DeprecationWarning` when users set it directly. See issue #874. |
 
-**ExecutionOptions Fields** (open-source builds run in `edge_analytics` only; other modes are roadmap-compatible but not currently provisioned)
+**ExecutionOptions Fields**
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `execution_mode` | `str` | `"edge_analytics"` | `"edge_analytics"` runs locally. `"hybrid"` runs trials locally and submits sessions/trial metrics to the backend for portal tracking. `"cloud"` is reserved for future remote execution and fails closed with guidance to use `"hybrid"`. `"privacy"` is accepted as a legacy alias for `"hybrid"` and sets `privacy_enabled=True`. |
+| `execution_mode` | `str` | `"edge_analytics"` | `"edge_analytics"` runs locally. `"hybrid"` runs trials locally and submits sessions/trial metrics to the backend for portal tracking. `"hybrid_api"` delegates trial execution to an external service implementing the Traigent Hybrid API contract. `"privacy"` is accepted as a legacy alias for `"hybrid"` and sets `privacy_enabled=True`. `"cloud"` is reserved for future remote execution and fails closed with guidance to use `"hybrid"`. |
 | `local_storage_path` | `str \| None` | `None` | Custom directory for persisted results. Falls back to `TRAIGENT_RESULTS_FOLDER` or `~/.traigent/`. |
 | `minimal_logging` | `bool` | `True` | Suppresses verbose logs in privacy-sensitive modes. |
 | `parallel_config` | `ParallelConfig \| dict \| None` | `None` | Unified concurrency configuration. |
@@ -250,7 +253,7 @@ async def optimize(
 | `max_total_examples` | Global sample budget across all trials. |
 | `cache_policy` | One of `"allow_repeats"` (default) or other cache policies. |
 | `cost_limit` | Maximum USD spending for this run. |
-| `cost_approved` | Skip cost approval prompt. |
+| `cost_approved` | Skip cost approval prompt only when passed as real Python `True`; strings such as `"true"` are ignored. Env approval requires exact `TRAIGENT_COST_APPROVED=true`; `1`/`yes` do not approve. |
 | `metric_limit` / `metric_name` / `metric_include_pruned` | Configure soft cumulative-metric early stopping. |
 | `budget_limit` / `budget_metric` / `budget_include_pruned` | Deprecated aliases for metric-limit controls. Use `cost_limit` for hard USD spend control. |
 | `plateau_window` / `plateau_epsilon` | Configure plateau detection stop conditions. |
@@ -278,12 +281,14 @@ def get_best_config() -> dict[str, Any] | None
 ```
 
 #### `.current_config`
-**Get/set current configuration**
+**Get current configuration**
 
 ```python
 @property
 def current_config() -> dict[str, Any]
 ```
+
+`current_config` is read-only. Change the active override with `.set_config()`.
 
 #### `.set_config()`
 **Set current configuration**
@@ -505,7 +510,7 @@ def get_optimization_insights(
 class OptimizationResult:
     trials: list[TrialResult]
     best_config: dict[str, Any]
-    best_score: float
+    best_score: float | None
     optimization_id: str
     duration: float
     convergence_info: dict[str, Any]
@@ -518,11 +523,16 @@ class OptimizationResult:
     total_cost: float | None = None
     total_tokens: int | None = None
     metrics: dict[str, Any] = field(default_factory=dict)
+    preset_selection: PresetSelection | None = None
+    stop_reason: StopReason | None = None
+    experiment_id: str | None = None
+    cloud_url: str | None = None
+    run_label: str | None = None
 ```
 
 **Properties:**
 - `total_trials`: Total number of trials executed
-- `successful_trials`: Number of trials that completed successfully
+- `successful_trials`: List of trials that completed successfully
 - `success_rate`: Ratio of successful trials to total trials
 
 ### TrialResult
@@ -538,6 +548,7 @@ class TrialResult:
     timestamp: datetime
     error_message: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    error: TrialError | None = None
 ```
 
 **Properties:**
@@ -550,10 +561,12 @@ class TrialResult:
 
 ```python
 class TrialStatus(Enum):
+    NOT_STARTED = "not_started"
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
     PRUNED = "pruned"
 ```
 
@@ -561,6 +574,7 @@ class TrialStatus(Enum):
 
 ```python
 class OptimizationStatus(Enum):
+    NOT_STARTED = "not_started"
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -462,7 +462,7 @@ from traigent.api.decorators import InjectionOptions
 
 @traigent.optimize(
     injection=InjectionOptions(
-        injection_mode="context",  # or "parameter", "attribute", "seamless"
+        injection_mode="context",  # or "parameter", "seamless"
         config_param="config",  # required when injection_mode="parameter"
         auto_override_frameworks=True,
         framework_targets=["OpenAI", "Anthropic"],
@@ -473,7 +473,7 @@ from traigent.api.decorators import InjectionOptions
 
 **InjectionOptions Fields**:
 
-- `injection_mode`: How to inject config ("context", "parameter", "attribute", "seamless")
+- `injection_mode`: How to inject config ("context", "parameter", "seamless")
 - `config_param`: Parameter name when using "parameter" mode
 - `auto_override_frameworks`: Auto-detect framework classes
 - `framework_targets`: Explicit list of framework classes
@@ -505,7 +505,7 @@ from traigent.config.parallel import ParallelConfig
 
 **ExecutionOptions Fields**:
 
-- `execution_mode`: "edge_analytics" for local-only runs; "hybrid" for local execution with backend/portal tracking; "cloud" is reserved for future remote execution.
+- `execution_mode`: "edge_analytics" for local-only runs; "hybrid" for local execution with backend/portal tracking; "hybrid_api" for external API-backed trial execution; "privacy" as a legacy alias for "hybrid" with privacy enabled; "cloud" is reserved for future remote execution and fails closed.
 - `local_storage_path`: Custom storage directory
 - `minimal_logging`: Reduce log verbosity
 - `parallel_config`: Concurrency configuration
@@ -561,21 +561,27 @@ The `**runtime_overrides` parameter accepts additional settings:
 ```python
 @traigent.optimize(
     algorithm="optuna",  # "grid", "random", "bayesian", "optuna"
-    max_trials=50,
-    timeout=3600,  # seconds
     ...
 )
+```
+
+Run controls such as `max_trials` and `timeout` are passed to `.optimize()`:
+
+```python
+result = await my_agent.optimize(max_trials=50, timeout=3600)
 ```
 
 **Cost Controls**:
 
 ```python
-@traigent.optimize(
+result = await my_agent.optimize(
     cost_limit=5.00,  # USD
-    cost_approved=False,  # Prompt for approval
-    ...
+    cost_approved=False,  # Real bool only; strings do not approve
 )
 ```
+
+Env approval requires exact `TRAIGENT_COST_APPROVED=true`; `1`/`yes` do not
+approve.
 
 **Metric-Limit Controls**:
 

--- a/docs/api-reference/telemetry.md
+++ b/docs/api-reference/telemetry.md
@@ -24,7 +24,8 @@ During optimization runs, Traigent collects:
 - Algorithm used (grid, random, bayesian, optuna)
 - Number of trials executed
 - Total optimization duration
-- Execution mode (edge_analytics, cloud, etc.)
+- Execution mode (`edge_analytics`, `hybrid`, `hybrid_api`; `privacy` is a
+  legacy alias for `hybrid`, and `cloud` is reserved/fails closed)
 - Stop conditions triggered
 - Content-free tuned-variable observations can include knob names, enum/scalar values, numeric metrics, and aggregate effectuation events for backend optimization. Set `TRAIGENT_TVAR_OBSERVATION=off` to disable them, or use `TRAIGENT_TVAR_OBSERVATION=hashed` (default) to hash free-form string values. Only `off` and `hashed` are supported; unsupported values fall back to `hashed`.
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -9,7 +9,10 @@ Traigent is a zero-code LLM optimization SDK that automatically finds the best c
 - **Parameter Optimization**: Automatically tune model selection, temperature, prompts, and other parameters
 - **Multi-Objective Optimization**: Balance accuracy, cost, latency, and other metrics simultaneously
 - **Framework Integration**: Native support for LangChain, DSPy, OpenAI, Anthropic, and more
-- **Flexible Execution**: Run locally (edge analytics) or in the cloud
+- **Flexible Execution**: Run locally (`edge_analytics`), with backend tracking
+  (`hybrid`), or through an external Hybrid API service (`hybrid_api`).
+  `privacy` is a legacy alias for `hybrid` with privacy enabled; `cloud` is
+  reserved and fails closed.
 - **TVL Specifications**: Define optimization specs in YAML for version control and collaboration
 
 ---
@@ -395,16 +398,15 @@ from traigent import Range, Choices
     # Configure evaluation
     evaluation={"eval_dataset": "test_cases.jsonl"},
 
-    # Set budget
-    exploration={"budget": 50}
+    # Runtime limits are passed to .optimize()
 )
 def my_agent(query: str) -> str:
     config = traigent.get_config()
     # Your LLM logic here
     return response
 
-# Run optimization
-result = my_agent.optimize()
+# Run optimization from synchronous code
+result = my_agent.optimize_sync(max_trials=50, cost_limit=50.0)
 print(f"Best config: {result.best_config}")
 print(f"Accuracy: {result.best_metrics['accuracy']:.2%}")
 ```

--- a/docs/architecture/cost-architecture-validation.md
+++ b/docs/architecture/cost-architecture-validation.md
@@ -26,11 +26,25 @@ The following items from this validation were implemented on
   - `claude-haiku`, `claude-sonnet`, `claude-opus`.
 - Hybrid aggregated metrics now emit both `cost` and `total_cost`, and orchestrator
   extraction uses `total_cost` with `cost` fallback.
-- 0.12.0 adds pre-trial model price coverage checks before any cloud or local
-  trial dispatch: unpriced models warn in normal mode and fail before a trial
-  when `TRAIGENT_STRICT_COST_ACCOUNTING=true`. Custom pricing can be supplied
-  with `TRAIGENT_CUSTOM_MODEL_PRICING_JSON` or
-  `TRAIGENT_CUSTOM_MODEL_PRICING_FILE`.
+- 0.12.0 + #1166 adds pre-trial model price coverage checks before any cloud,
+  hybrid_api, or local trial dispatch. The preflight scans model IDs from
+  `configuration_space` and, when no model key is tunable, from the
+  current/default config. Mock mode skips the check. Priced models and models
+  covered by `TRAIGENT_CUSTOM_MODEL_PRICING_JSON` or
+  `TRAIGENT_CUSTOM_MODEL_PRICING_FILE` proceed.
+  - If `TRAIGENT_STRICT_COST_ACCOUNTING=true`, any unpriced model raises
+    `UnknownModelError` before trial 1.
+  - Otherwise, Traigent proceeds with a warning only when cost-sensitive
+    execution is pre-approved: `cost_approved=True` as a real Python bool,
+    `TRAIGENT_COST_APPROVED=true` as the exact env value, or a valid XDG
+    approval token. String runtime values such as `"true"` and env values such
+    as `1`/`yes` do not approve.
+  - In an interactive TTY with no pre-approval, Traigent prints a blocking
+    stderr `y/N` prompt; only `y`/`yes` proceeds with a warning. Decline, empty
+    input, EOF, or interrupt raises `UnknownModelError` before trial 1.
+  - In a non-interactive shell with no pre-approval, Traigent fail-closes with
+    `UnknownModelError` before trial 1 and tells the user to add custom pricing,
+    set exact `TRAIGENT_COST_APPROVED=true`, or rerun interactively.
 - CI/pre-commit guardrail added to prevent reintroducing
   `cost_from_tokens(..., strict=False)` in runtime post-call paths
   (allowlisted only for query pricing helper usage).

--- a/docs/examples/API_PATTERNS.md
+++ b/docs/examples/API_PATTERNS.md
@@ -1,454 +1,208 @@
-# 🔌 Traigent API Patterns - Common Usage Examples
+# Traigent API Patterns
 
-## Core Patterns
+This page shows current Traigent SDK patterns for decorating a function, reading
+tuned values, running optimization, and inspecting results.
 
-### 1. Basic Decorator Pattern
-The simplest way to optimize a function.
-
-```python
-import traigent
-
-@traigent.optimize(
-    config_space={
-        "model": ["gpt-3.5-turbo", "gpt-4"],
-        "temperature": [0.0, 0.3, 0.7],
-        "max_tokens": [100, 200, 500]
-    },
-    objectives=["accuracy", "cost"],
-    num_trials=10
-)
-def my_llm_function(input_text: str) -> str:
-    # Your LLM logic here
-    return response
-```
-
-### 2. Dataset-Based Evaluation
-For systematic evaluation across multiple examples.
-
-```python
-from traigent import Dataset, EvaluationExample
-
-# Create dataset
-dataset = Dataset(
-    examples=[
-        EvaluationExample(input_data={"question": "What is 2+2?"}, expected_output="4"),
-        EvaluationExample(input_data={"question": "Capital of France?"}, expected_output="Paris"),
-    ]
-)
-
-# Optimize with dataset
-results = my_llm_function.optimize(
-    dataset=dataset,
-    algorithm="bayesian",
-    metrics=["accuracy", "f1_score"]
-)
-```
-
-### 3. Custom Evaluator Pattern
-Define custom evaluation logic for specific needs.
-
-```python
-def custom_evaluator(output: str, expected: str) -> dict:
-    """Custom evaluation function."""
-    # Your evaluation logic
-    score = calculate_similarity(output, expected)
-    return {
-        "accuracy": score,
-        "custom_metric": custom_calculation(output)
-    }
-
-results = my_function.optimize(
-    evaluator=custom_evaluator,
-    num_trials=20
-)
-```
-
-### 4. Multi-Objective Optimization
-Balance multiple goals simultaneously.
-
-```python
-@traigent.optimize(
-    objectives=[
-        ("accuracy", "maximize"),
-        ("cost", "minimize"),
-        ("latency", "minimize")
-    ],
-    constraints={
-        "cost": {"max": 0.05},  # Max $0.05 per call
-        "latency": {"max": 2.0}  # Max 2 seconds
-    }
-)
-def optimized_function(text: str) -> str:
-    # Implementation
-    pass
-```
-
-### 5. Async Pattern
-For concurrent optimization and execution.
+## Canonical Pattern
 
 ```python
 import asyncio
+import traigent
 
-@traigent.optimize(
-    config_space={"model": ["gpt-3.5", "gpt-4"]},
-    async_mode=True
-)
-async def async_llm_function(text: str) -> str:
-    # Async implementation
-    response = await llm_client.generate(text)
-    return response
 
-# Run async optimization
-results = await async_llm_function.optimize_async(
-    dataset=dataset,
-    num_workers=5
-)
-```
+def my_score(output: str, expected: str) -> float:
+    return 1.0 if output.strip().lower() == expected.strip().lower() else 0.0
 
-### 6. Batch Processing Pattern
-Optimize batch operations efficiently.
 
-```python
-from traigent.config.parallel import ParallelConfig
+def call_model(prompt: str, *, temperature: float) -> str:
+    # Replace with your provider call.
+    return prompt
 
 
 @traigent.optimize(
-    parallel_config=ParallelConfig(
-        mode="parallel",
-        example_concurrency=10,
-    ),
-    config_space={"model": ["gpt-3.5", "claude-3"]},
+    configuration_space={"temperature": [0.0, 0.3, 0.7]},
+    eval_dataset="data/eval.jsonl",
+    scoring_function=my_score,
+    objectives=["accuracy", "cost"],
 )
-def batch_process(texts: List[str]) -> List[str]:
-    # Process multiple inputs
-    return [process(text) for text in texts]
+def fn(prompt: str) -> str:
+    cfg = traigent.get_config()
+    return call_model(prompt, temperature=cfg["temperature"])
 
-# Optimize with batches
-results = batch_process.optimize(
-    dataset=large_dataset,
-    batch_mode=True
-)
-```
 
-### 7. Caching Pattern
-Avoid redundant API calls during optimization.
-
-```python
-from traigent.cache import OptimizationCache
-
-@traigent.optimize(
-    config_space={"temperature": [0.0, 0.5, 1.0]},
-    cache=OptimizationCache("./cache")
-)
-def cached_function(text: str) -> str:
-    # Expensive operation
-    return expensive_llm_call(text)
-```
-
-### 8. Progressive Optimization
-Start simple and progressively increase complexity.
-
-```python
-# Stage 1: Quick exploration
-results_1 = function.optimize(
-    config_space={"model": ["gpt-3.5", "gpt-4"]},
-    num_trials=5,
-    algorithm="random"
-)
-
-# Stage 2: Refined search
-best_model = results_1.best_config["model"]
-results_2 = function.optimize(
-    config_space={
-        "model": [best_model],
-        "temperature": np.linspace(0, 1, 10),
-        "top_p": np.linspace(0.5, 1, 5)
-    },
-    num_trials=20,
-    algorithm="bayesian"
-)
-```
-
-### 9. A/B Testing Pattern
-Compare different approaches systematically.
-
-```python
-@traigent.optimize(
-    variants={
-        "approach_a": {"prompt": "Be concise", "model": "gpt-3.5"},
-        "approach_b": {"prompt": "Be detailed", "model": "gpt-4"}
-    },
-    split_test=True
-)
-def ab_test_function(text: str, variant: str) -> str:
-    config = get_variant_config(variant)
-    return process_with_config(text, config)
-```
-
-### 10. Constraint-Based Optimization
-Optimize within specific boundaries.
-
-```python
-@traigent.optimize(
-    config_space={
-        "model": ["gpt-3.5", "gpt-4", "claude-3"],
-        "max_tokens": range(50, 500, 50)
-    },
-    constraints={
-        "token_usage": lambda config: config["max_tokens"] * 2 < 1000,
-        "cost_per_call": lambda config: estimate_cost(config) < 0.10
-    }
-)
-def constrained_function(text: str) -> str:
-    # Implementation
-    pass
-```
-
-## Configuration Space Patterns
-
-### Discrete Choices
-```python
-config_space = {
-    "model": ["gpt-3.5", "gpt-4", "claude-3"],
-    "prompt_style": ["formal", "casual", "technical"]
-}
-```
-
-### Continuous Ranges
-```python
-config_space = {
-    "temperature": np.linspace(0, 1, 11),  # 0.0, 0.1, ..., 1.0
-    "top_p": np.arange(0.5, 1.0, 0.1)      # 0.5, 0.6, ..., 0.9
-}
-```
-
-### Mixed Types
-```python
-config_space = {
-    "model": ["gpt-3.5", "gpt-4"],
-    "temperature": [0.0, 0.3, 0.7, 1.0],
-    "use_cot": [True, False],
-    "max_retries": range(1, 4)
-}
-```
-
-### Conditional Spaces
-```python
-def get_config_space(task_type):
-    base = {"model": ["gpt-3.5", "gpt-4"]}
-
-    if task_type == "creative":
-        base["temperature"] = [0.7, 0.9, 1.0]
-    else:
-        base["temperature"] = [0.0, 0.3, 0.5]
-
-    return base
-```
-
-## Evaluation Patterns
-
-### Simple Accuracy
-```python
-def accuracy_evaluator(output: str, expected: str) -> float:
-    return 1.0 if output.strip() == expected.strip() else 0.0
-```
-
-### Fuzzy Matching
-```python
-from difflib import SequenceMatcher
-
-def fuzzy_evaluator(output: str, expected: str) -> float:
-    return SequenceMatcher(None, output, expected).ratio()
-```
-
-### Multi-Metric Evaluation
-```python
-def comprehensive_evaluator(output: str, expected: str) -> dict:
-    return {
-        "exact_match": output == expected,
-        "contains": expected in output,
-        "length_ratio": len(output) / len(expected),
-        "word_overlap": calculate_word_overlap(output, expected)
-    }
-```
-
-### LLM-as-Judge
-```python
-def llm_judge_evaluator(output: str, expected: str) -> float:
-    prompt = f"Rate similarity (0-1): Output: {output}, Expected: {expected}"
-    score = llm_client.evaluate(prompt)
-    return float(score)
-```
-
-## Algorithm Selection
-
-### Grid Search
-Best for small search spaces with discrete parameters.
-```python
-results = await function.optimize(
-    algorithm="grid",
-    max_trials=50,
-    parameter_order={"model": 0, "temperature": 1},
-)
-```
-
-### Random Search
-Efficient for large search spaces.
-```python
-results = await function.optimize(
-    algorithm="random",
-    max_trials=50,
-    random_seed=42,
-)
-```
-
-### Bayesian Optimization
-Smart exploration for expensive evaluations.
-```python
-results = await function.optimize(
-    algorithm="bayesian",
-    acquisition_function="expected_improvement",
-    initial_random_samples=10,
-)
-```
-
-### Custom Algorithm
-```python
-from traigent.optimizers import register_optimizer
-from my_project.optimizers import CustomOptimizer
-
-register_optimizer("genetic", CustomOptimizer)
-
-results = await function.optimize(
-    algorithm="genetic",
-    population_size=20,
-    generations=10,
-)
-```
-
-## Result Analysis Patterns
-
-### Best Configuration
-```python
-best_config = results.best_config
-best_score = results.best_score
-print(f"Best: {best_config} with score {best_score}")
-```
-
-### Performance Visualization
-```python
-import matplotlib.pyplot as plt
-
-results.plot_convergence()  # Show optimization progress
-results.plot_pareto_front()  # For multi-objective
-results.plot_parameter_importance()  # Feature importance
-```
-
-### Export Results
-```python
-# Save to JSON
-results.to_json("optimization_results.json")
-
-# Save to CSV
-results.to_csv("optimization_results.csv")
-
-# Get DataFrame
+results = asyncio.run(fn.optimize(max_trials=20))
 df = results.to_dataframe()
 ```
 
-### Statistical Analysis
+Key points:
+
+- Use `configuration_space`, not `config_space`.
+- Put datasets and scoring on the decorator through `eval_dataset`,
+  `scoring_function`, `metric_functions`, or the `evaluation={...}` bundle.
+- Read tuned values with `traigent.get_config()` in default context mode.
+- Run optimization with `await fn.optimize(...)` or `asyncio.run(fn.optimize(...))`.
+- Use `fn.optimize_sync(...)` only from synchronous code that is not already
+  inside an event loop.
+
+## Custom Scoring
+
 ```python
-# Summary statistics
-print(results.summary())
+def contains_expected(output: str, expected: str) -> float:
+    return 1.0 if str(expected).lower() in str(output).lower() else 0.0
 
-# Confidence intervals
-ci = results.confidence_interval(metric="accuracy", confidence=0.95)
 
-# Parameter sensitivity
-sensitivity = results.parameter_sensitivity()
+@traigent.optimize(
+    configuration_space={"style": ["short", "detailed"]},
+    eval_dataset="data/qa.jsonl",
+    scoring_function=contains_expected,
+    objectives=["accuracy"],
+)
+def answer(question: str) -> str:
+    cfg = traigent.get_config()
+    return render_answer(question, style=cfg["style"])
 ```
 
-## Error Handling Patterns
+## Runtime Controls
 
-### Retry Logic
+Runtime controls belong on `.optimize()`, not on the decorator.
+
+```python
+results = await answer.optimize(
+    algorithm="grid",
+    max_trials=50,
+    timeout=3600,
+    cost_limit=5.00,
+    cost_approved=True,
+)
+```
+
+`cost_approved=True` must be a real Python boolean. String values such as
+`"true"` are ignored.
+
+## Configuration Spaces
+
+```python
+space = {
+    "model": ["gpt-4o-mini", "gpt-4o"],
+    "temperature": [0.0, 0.3, 0.7],
+    "max_tokens": [128, 256, 512],
+}
+```
+
+You can also use structured tuned-variable objects:
+
+```python
+from traigent import Choices, Range
+
+space = {
+    "model": Choices(["gpt-4o-mini", "gpt-4o"]),
+    "temperature": Range(0.0, 1.0),
+}
+```
+
+## Parameter Injection
+
+Context injection is the default and works with `traigent.get_config()`:
+
+```python
+@traigent.optimize(configuration_space={"temperature": [0.0, 0.5]})
+def summarize(text: str) -> str:
+    cfg = traigent.get_config()
+    return call_model(text, temperature=cfg["temperature"])
+```
+
+If you prefer explicit config arguments, opt into parameter injection:
+
 ```python
 @traigent.optimize(
-    retry_failed_trials=True,
-    max_retries=3,
-    retry_delay=1.0
+    configuration_space={"temperature": [0.0, 0.5]},
+    injection={"injection_mode": "parameter", "config_param": "config"},
 )
-def robust_function(text: str) -> str:
-    # May fail occasionally
-    pass
+def summarize(text: str, config: dict[str, object]) -> str:
+    return call_model(text, temperature=float(config["temperature"]))
 ```
 
-### Fallback Strategy
+Valid injection modes are `context`, `parameter`, and `seamless`.
+
+## Async Functions
+
 ```python
 @traigent.optimize(
-    fallback_config={"model": "gpt-3.5", "temperature": 0.3}
+    configuration_space={"temperature": [0.0, 0.3]},
+    eval_dataset="data/eval.jsonl",
+    scoring_function=my_score,
 )
-def function_with_fallback(text: str) -> str:
-    # Falls back to safe config on error
-    pass
+async def async_answer(question: str) -> str:
+    cfg = traigent.get_config()
+    return await async_call_model(question, temperature=cfg["temperature"])
+
+
+results = await async_answer.optimize(max_trials=10)
 ```
 
-### Error Recovery
+## Results
+
+```python
+print(results.best_config)
+print(results.best_score)
+print(results.status)
+
+successful = results.successful_trials
+df = results.to_dataframe()
+```
+
+`successful_trials` is a list of successful `TrialResult` objects. Use
+`len(results.successful_trials)` when you need a count.
+
+## Progressive Runs
+
+```python
+quick = await answer.optimize(algorithm="random", max_trials=5)
+
+refined_space = {
+    "model": [quick.best_config["model"]],
+    "temperature": [0.0, 0.2, 0.4, 0.6],
+}
+
+refined = await answer.optimize(
+    configuration_space=refined_space,
+    algorithm="grid",
+    max_trials=20,
+)
+```
+
+## Hybrid API
+
+Use `execution_mode="hybrid_api"` when trials are delegated to an external
+service that implements the Traigent Hybrid API contract.
+
 ```python
 @traigent.optimize(
-    on_error="continue",  # or "stop", "retry"
-    error_score=0.0      # Score for failed trials
+    execution={
+        "execution_mode": "hybrid_api",
+        "hybrid_api_endpoint": "http://localhost:8080",
+    },
+    configuration_space={"temperature": [0.0, 0.3]},
+    eval_dataset="data/eval.jsonl",
+    scoring_function=my_score,
 )
-def error_tolerant_function(text: str) -> str:
-    # Continues optimization despite errors
-    pass
+def external_agent(_query: str) -> str:
+    return ""
+
+
+results = await external_agent.optimize(max_trials=10)
 ```
 
-## Performance Tips
+## Mock Smoke Tests
 
-1. **Start Small**: Begin with few trials and expand
-2. **Use Caching**: Enable caching for expensive operations
-3. **Parallelize**: Use async mode or batch processing
-4. **Progressive Refinement**: Start broad, then narrow search
-5. **Mock Mode**: Test with mock mode before using real APIs
-6. **Monitor Resources**: Track token usage and costs
-7. **Early Stopping**: Stop when convergence is reached
+For tutorials and CI smoke tests, call mock mode explicitly near the top of the
+file:
 
-## Common Integration Patterns
-
-### With LangChain
 ```python
-from langchain import LLMChain
-import traigent
+from traigent.testing import enable_mock_mode_for_quickstart
 
-@traigent.optimize(config_space={...})
-def optimized_chain(prompt: str) -> str:
-    chain = LLMChain(llm=llm, prompt=prompt_template)
-    return chain.run(prompt)
+enable_mock_mode_for_quickstart()
 ```
 
-### With OpenAI
-```python
-import openai
-import traigent
-
-@traigent.optimize(config_space={...})
-def optimized_openai(text: str) -> str:
-    response = openai.ChatCompletion.create(
-        model=config["model"],
-        messages=[{"role": "user", "content": text}],
-        temperature=config["temperature"]
-    )
-    return str(response.choices[0].message.content)
-```
-
-### With Custom Frameworks
-```python
-@traigent.optimize(config_space={...})
-def optimized_custom(text: str) -> str:
-    # Your custom framework integration
-    return custom_framework.process(text, **config)
-```
-
----
-
-**Remember**: These patterns are composable - combine them as needed for your specific use case!
+Mock mode avoids provider spend and skips model-pricing preflight, but it is not
+a production billing bypass.

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -224,9 +224,9 @@ import traigent
     evaluation={"eval_dataset": "data.jsonl"},
     configuration_space={"model": ["gpt-4", "gpt-3.5-turbo"]}
 )
-def my_function(input_text: str, **config):
-    # Your function here
-    return result
+def my_function(input_text: str) -> str:
+    config = traigent.get_config()
+    return f"{config['model']}: {input_text}"
 
 # Optimization automatically uses authenticated backend
 results = asyncio.run(my_function.optimize())

--- a/docs/features/constraint-dsl.md
+++ b/docs/features/constraint-dsl.md
@@ -607,7 +607,7 @@ constraints = [
 ### In Decorator
 
 ```python
-from traigent import optimize, Range, Choices
+from traigent import optimize, Range, Choices, get_config
 
 temperature = Range(0.0, 2.0)
 model = Choices(["gpt-4", "gpt-3.5-turbo"])
@@ -621,8 +621,9 @@ model = Choices(["gpt-4", "gpt-3.5-turbo"])
         model.equals("gpt-4") >> temperature.lte(0.7),
     ],
 )
-def my_llm_call(temperature: float, model: str):
-    ...
+def my_llm_call(prompt: str):
+    cfg = get_config()
+    return call_model(prompt, temperature=cfg["temperature"], model=cfg["model"])
 ```
 
 ---
@@ -814,5 +815,5 @@ print(msg)
 
 ## See Also
 
-- [TVL Tutorials](../../examples/tvl/tutorials/README.md) - TVL usage examples and tutorials
+- [Tuned Variables](../user-guide/tuned_variables.md) - Tuned variable usage examples and concepts
 - [Configuration Spaces](../user-guide/configuration-spaces.md) - Defining parameter ranges

--- a/docs/features/recommendations.md
+++ b/docs/features/recommendations.md
@@ -60,10 +60,11 @@ from traigent.api.functions import recommend_configuration_space
 space = recommend_configuration_space("rag", min_impact="medium")
 
 @tg.optimize(configuration_space=space["configuration_space"])
-def answer_question(query: str, **config: object) -> str:
+def answer_question(query: str) -> str:
+    cfg = tg.get_config()
     return query
 ```
 
-Honesty note: recommendations are catalog-backed starter guidance. The public
-response intentionally does not expose private signal-taxonomy details, and the
-result is not proof that a knob will improve your task.
+Honesty note: recommendations are catalog-backed starter guidance. They are not
+proof that a knob will improve your task; validate them on your own evaluation
+dataset before treating them as winners.

--- a/docs/features/safety-gates.md
+++ b/docs/features/safety-gates.md
@@ -9,8 +9,21 @@ content.
 Real runs check model cost coverage before trials start. Unknown or unpriced
 models are detected from the configuration space or current/default config.
 
-By default, missing pricing emits a warning and the affected results report
-`$0`. To fail before any trial starts, enable strict cost accounting:
+With `TRAIGENT_STRICT_COST_ACCOUNTING=true`, unpriced models always raise
+`UnknownModelError` before any trial and no prompt is shown.
+
+To proceed after acknowledging that affected results will report `$0` cost while
+your provider may still bill you, use one explicit approval:
+
+- pass `cost_approved=True` as a real Python boolean; strings such as `"true"` are ignored,
+- set `TRAIGENT_COST_APPROVED=true`; `1`, `yes`, and `on` do not approve this gate,
+- or create the XDG cost approval token (`approved` or `approved:<limit>`).
+
+Approved runs still emit the unpriced-model warning. Mock LLM quickstart mode
+skips this model-pricing preflight, but it is a test/demo mode, not a production
+billing bypass.
+
+To fail before any trial starts, enable strict cost accounting:
 
 ```bash
 export TRAIGENT_STRICT_COST_ACCOUNTING=true

--- a/docs/getting-started/portal-dev-laptop-agent.md
+++ b/docs/getting-started/portal-dev-laptop-agent.md
@@ -9,7 +9,6 @@ Use the API host, not the portal host:
 ```bash
 export TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai
 export TRAIGENT_API_URL=https://api-dev.traigent.ai
-export TRAIGENT_CLOUD_API_URL=https://api-dev.traigent.ai
 ```
 
 `portal-dev.traigent.ai` is the browser application. SDK and agent code should call

--- a/docs/guides/evaluation.md
+++ b/docs/guides/evaluation.md
@@ -209,29 +209,22 @@ For shell-only fixtures, `TRAIGENT_MOCK_LLM=true` remains available outside prod
 ### Pattern 1: RAG Quality Evaluator
 
 ```python
-from traigent.metrics.rag import (
-    calculate_relevance,
-    calculate_faithfulness,
-    calculate_context_precision
-)
+def token_overlap(output: str, expected: str) -> float:
+    output_tokens = {token.lower() for token in str(output).split()}
+    expected_tokens = {token.lower() for token in str(expected).split()}
+    if not expected_tokens:
+        return 0.0
+    return len(output_tokens & expected_tokens) / len(expected_tokens)
 
-def rag_evaluator(output: str, expected: str, context: Dict[str, Any]) -> float:
-    """Evaluate RAG system quality"""
+
+def rag_evaluator(output: str, expected: str, context: dict[str, object]) -> float:
     retrieved_docs = context.get("retrieved_docs", [])
+    context_text = " ".join(str(doc) for doc in retrieved_docs)
 
-    # Calculate RAG-specific metrics
-    relevance = calculate_relevance(output, retrieved_docs)
-    faithfulness = calculate_faithfulness(output, retrieved_docs)
-    answer_similarity = semantic_similarity(output, expected)
+    answer_similarity = token_overlap(output, expected)
+    context_support = token_overlap(output, context_text)
 
-    # Weighted combination
-    score = (
-        0.4 * answer_similarity +
-        0.3 * relevance +
-        0.3 * faithfulness
-    )
-
-    return score
+    return 0.7 * answer_similarity + 0.3 * context_support
 ```
 
 ### Pattern 2: Classification Evaluator

--- a/docs/guides/js-bridge.md
+++ b/docs/guides/js-bridge.md
@@ -2,11 +2,12 @@
 
 Python SDK <= 0.11.x supported Python-orchestrated JavaScript optimization through `execution={"runtime": "node"}` as a temporary bridge. Python SDK 0.12.0 removes that bridge.
 
-Use the native JavaScript SDK instead:
+The Python JS bridge was removed. The native JS SDK publish is pending; do not
+document `npm install @traigent/sdk` as available yet. Use the JS SDK source
+checkout instructions when available.
 
-- install `@traigent/sdk`
-- define optimization metadata with `optimize(spec)(agentFn)`
-- run optimization with `await wrapped.optimize(...)`
+The current native TypeScript SDK support exists in the internal `traigent-js`
+repo; npm publication for `@traigent/sdk` is pending.
 
 Migration reference:
 

--- a/docs/hybrid-mode-client-guide.md
+++ b/docs/hybrid-mode-client-guide.md
@@ -616,7 +616,7 @@ import traigent
 def my_agent(_query: str):
     return ""  # Execution is delegated to the external hybrid API
 
-result = my_agent.optimize()
+result = await my_agent.optimize()
 print(f"Best config: {result.best_config}")
 print(f"Best metrics: {result.best_metrics}")
 ```

--- a/docs/testing/RELEASE_READINESS_TESTING.md
+++ b/docs/testing/RELEASE_READINESS_TESTING.md
@@ -62,7 +62,7 @@ python -c "import traigent; print(traigent.__version__)"
 ```
 
 **Checklist:**
-- [ ] All three show version `0.10.0`
+- [ ] All three show version `0.12.0`
 - [ ] `traigent info` shows expected features and integrations
 - [ ] No import warnings when loading traigent module
 

--- a/docs/traceability/concepts/composite-knob-ir.md
+++ b/docs/traceability/concepts/composite-knob-ir.md
@@ -1,0 +1,43 @@
+# Composite-Knob IR
+
+Traigent 0.12.0 includes the RFC 0002 P5 composite-knob intermediate
+representation in `traigent.knobs.composites` and catalog factories in
+`traigent.knobs.patterns`.
+
+This is internal declaration-only IR — not wired to optimizer/cloud effectuation.
+It lets the SDK declare grouped control-flow shapes without changing the RFC
+0001 one-knob binding model.
+
+## What It Represents
+
+`traigent.knobs.composites` defines a sealed algebra for composite declarations:
+
+- `cascade`
+- `ensemble`
+- `loop`
+
+The module models declarations such as `CompositeNode`, `CompositeProgram`,
+`StageArm`, `CompositeArm`, gates, stop rules, aggregate declarations, and signal
+uses. Validation checks structural well-formedness, including missing composite
+references, cycles, ambiguous arms, and parent coverage.
+
+## Pattern Catalog
+
+`traigent.knobs.patterns` provides named factories over the composite algebra,
+including:
+
+- `binary_cascade`
+- `n_cascade`
+- `best_of_n`
+- `self_consistency`
+- `self_refine`
+- `self_debug`
+
+Each factory returns a `CompositeKnob` declaration bundle with a structure,
+member knob declarations, provenance, and standard telemetry names.
+
+## Boundary
+
+Composite knobs do not bind values. Value binding remains on regular `Tuned`,
+`Fixed`, and `Calibrated` knobs. The pattern factories return declarations only;
+they do not change orchestrator behavior and do not trigger cloud effectuation.

--- a/docs/traceability/concepts/guided-generation.md
+++ b/docs/traceability/concepts/guided-generation.md
@@ -87,9 +87,8 @@ env keys.
 
 ## Using it (TypeScript SDK)
 
-`@traigent/sdk` exposes the parity surface — `GuidancePlan*` Zod DTOs, the
-`PromptRewriter` / `ExampleSynthesizer` / `GuidanceLoop` / `BackendGuidanceProvider`
-engines, and `promptRewrite?` / `growDataset?` fields on `OptimizationSpec`.
+Native TypeScript SDK support exists in the internal `traigent-js` repo; npm
+publication for `@traigent/sdk` is pending.
 
 ## Required-by-design
 
@@ -99,5 +98,5 @@ compass is essential, and that keeps the signals protected.
 
 ## See also
 
-- Runnable offline example: [`examples/core/guided-generation/`](../../examples/core/guided-generation/README.md)
+- Runnable offline example: `examples/core/guided-generation/` in the source repository
 - Contract: `TraigentSchema/traigent_schema/schemas/guidance/`

--- a/docs/user-guide/evaluation_guide.md
+++ b/docs/user-guide/evaluation_guide.md
@@ -392,7 +392,10 @@ def sentiment_score(output, expected, llm_metrics=None):
     objectives=["accuracy"],
     max_trials=10
 )
-def sentiment_classifier(text, temperature=0.3, model="gpt-3.5-turbo"):
+def sentiment_classifier(text):
+    cfg = traigent.get_config()
+    temperature = cfg["temperature"]
+    model = cfg["model"]
     # Your LLM logic here
     # This is simplified for example
     if "amazing" in text.lower() or "great" in text.lower():
@@ -439,11 +442,12 @@ def semantic_accuracy(output: str, expected: str) -> float:
     objectives=["accuracy", "cost"],
     max_trials=15,
 )
-def qa_system(question, temperature=0.5, max_tokens=100):
+def qa_system(question: str) -> str:
+    cfg = traigent.get_config()
     response = litellm.completion(
         model="gpt-4o-mini",
-        temperature=temperature,
-        max_tokens=max_tokens,
+        temperature=cfg["temperature"],
+        max_tokens=cfg["max_tokens"],
         messages=[{"role": "user", "content": f"Answer concisely: {question}"}],
     )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Portal Dev Laptop Agent: getting-started/portal-dev-laptop-agent.md
   - Concepts:
       - Guided Generation: concepts/guided-generation.md
+      - Composite-Knob IR: concepts/composite-knob-ir.md
       - Configuration Spaces: user-guide/configuration-spaces.md
       - Constraint Expressions: tvl/CONSTRAINT_EXPRESSIONS.md
       - Dataflow Detection: features/dataflow-detection.md


### PR DESCRIPTION
Consolidated fixes from 3 codex-xhigh review packets over docs/** (captain-adjudicated, every finding code-cited). Highlights: safety-gates + cost-architecture now describe the #1166 blocking unpriced gate (bool-only cost_approved, exact-match env); docs/examples/API_PATTERNS.md rewritten — it documented entirely nonexistent APIs (config_space, num_trials, optimize_async, batch_mode, traigent.cache.*); injection_mode='attribute' removed; OptimizationResult/status drift fixed (successful_trials is a list; best_score nullable); timeout/exploration kwargs corrected; @traigent/sdk references honest (npm publish pending); signal-taxonomy wording scrubbed (lockdown rule); NEW composite-knob IR concept page (declaration-only caveat); 0.10.0 strings → 0.12.0. mkdocs build: 0 errors, warnings 4→1. 🤖 Generated with [Claude Code](https://claude.com/claude-code)