### PR TITLE
docs: JavaScript SDK nav cross-link + /js/-preserving deploys (temp unified site)

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -33,6 +33,17 @@ jobs:
       - name: Build
         run: mkdocs build
 
+      # The JS SDK docs are served as a /js/ subsite (built from the traigent-js
+      # repo). gh-deploy replaces the whole branch, so preserve /js/ across
+      # Python-docs deploys until traigent-js publishes its own site.
+      - name: Preserve /js/ subsite
+        run: |
+          git fetch origin gh-pages --depth 1 || exit 0
+          git show origin/gh-pages:js/index.html >/dev/null 2>&1 || exit 0
+          git worktree add /tmp/ghp origin/gh-pages
+          cp -r /tmp/ghp/js site/js
+          git worktree remove /tmp/ghp --force
+
       - name: Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ markdown_extensions:
 
 nav:
   - Home: README.md
+  - JavaScript SDK: https://traigent.github.io/Traigent/js/
   - Getting Started:
       - Overview: getting-started/README.md
       - Quickstart: getting-started/GETTING_STARTED.md


### PR DESCRIPTION
traigent-js goes public this week; until then its docs are served as a /js/ subsite on this public site (already live: https://traigent.github.io/Traigent/js/ — content swept for secrets/IP before publishing). This PR adds the nav tab and makes the deploy workflow preserve /js/ so a Python-docs redeploy can't wipe it. When the JS repo is public + on npm, we either flip /js/ to its own Pages or keep the unified site (and ask Profisea for the docs CNAME either way). 🤖 Generated with [Claude Code](https://claude.com/claude-code)