### PR TITLE
feat(knobs): composite telemetry rides the measures channel + catalog docs/example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Composite telemetry rides the measures channel.** `composite_measures(run)`
+  (`traigent.knobs.telemetry`, re-exported from `traigent.knobs`) flattens a composite
+  run's RFC 0002 §3.10 content-free telemetry — `escalation_rate`, `stage_selected`, and
+  the per-gate `gate_margin_pass_rate` map — into flat, identifier-safe, numeric-only keys
+  (e.g. `composite_escalation_rate`, `composite_stage_selected`,
+  `composite_gate_0_margin_pass_rate`). Merge it into the metrics your decorated function
+  returns and the `composite_*` keys ride the existing per-trial measures wire channel as
+  ordinary numeric metrics — no new wire surface. Keys are capped with headroom below the
+  backend `MeasuresDict` 50-key ceiling (truncated deterministically with a logged warning,
+  never raised mid-trial), and the output is content-free by construction (the adapter reads
+  `run.measures` only, never `run.output`). New docs page
+  `docs/concepts/composite-knobs.md` covers the pattern catalog, executing a composite,
+  certified selection with a `binary_cascade`, and telemetry-to-measures; runnable offline
+  example at `examples/advanced/composite-knobs/composite_telemetry.py`.
+
 ### Changed
 - **Unpriced models now block instead of warn-and-continue.** When a real run includes
   models with no known pricing, the SDK now requires explicit confirmation: interactive

--- a/docs/traceability/concepts/composite-knobs.md
+++ b/docs/traceability/concepts/composite-knobs.md
@@ -154,7 +154,7 @@ backend cap of 50 keys per trial (`traigent.cloud.dtos.MeasuresDict`).
 It flattens the run's measures into identifier-safe, numeric-only keys:
 
 ```python
-from traigent.knobs.telemetry import composite_measures
+from traigent.knobs.telemetry import composite_measures, merge_composite_measures
 
 composite_measures(run)
 # {
@@ -189,7 +189,7 @@ channel as ordinary numeric metrics:
 ```python
 import traigent
 from traigent.knobs.runtime import execute_composite
-from traigent.knobs.telemetry import composite_measures
+from traigent.knobs.telemetry import composite_measures, merge_composite_measures
 
 
 @traigent.optimize(
@@ -209,7 +209,7 @@ def answer(text: str) -> tuple[str, dict[str, float]]:
         calibrated_values={"router_margin_threshold": params["router_margin_threshold"]},
     )
     metrics = {"accuracy": 1.0 if str(run.output) == "STRONG" else 0.0}
-    metrics.update(composite_measures(run))  # composite_* keys ride the wire
+    merge_composite_measures(metrics, run)  # composite_* keys ride the wire
     return str(run.output), metrics
 ```
 

--- a/docs/traceability/concepts/composite-knobs.md
+++ b/docs/traceability/concepts/composite-knobs.md
@@ -1,0 +1,227 @@
+# Composite Knobs: Patterns, Execution, and Telemetry
+
+Composite knobs let you declare grouped control-flow shapes — cascades,
+ensembles, and refinement loops — over the RFC 0001 one-knob binding model
+(`Tuned | Fixed | Calibrated`). The declaration layer (the
+[Composite-Knob IR](composite-knob-ir.md)) is the algebra; this page covers the
+**runnable** surface the SDK ships today:
+
+- the **pattern catalog** (the six named factories and what each expands to);
+- **executing a composite** in-trial with `execute_composite` + `StageRunner`;
+- **certified selection** with a composite (the `binary_cascade` strict recipe);
+- **telemetry → the measures channel** (`composite_measures`).
+
+A runnable, offline example accompanies this page:
+`examples/advanced/composite-knobs/composite_telemetry.py`.
+
+> Scope note: this page documents what the SDK *does* procedurally. It does not
+> make guarantees about model behavior or future inputs. Where a "certified"
+> decision is mentioned, it is a procedural decision over the evidence and
+> policy you supply.
+
+## Pattern catalog
+
+`traigent.knobs.patterns` provides six named factories over the composite
+algebra. Each returns a `CompositeKnob` declaration bundle (`.structure` is the
+IR root, `.members` are member knob declarations, `.provenance` stamps the
+pattern name + a hash of its validated params, `.telemetry_names` are the
+§3.10 standard measure names). Factories return **declarations only**; they do
+not bind values and do not trigger cloud effectuation.
+
+| Pattern | Kind | Expands to |
+|---|---|---|
+| `binary_cascade` | cascade | `Cascade(arms=[stage(base), stage(expert)], gates=[margin_below θ], post)` — the two-arm escalate-or-stop policy. |
+| `n_cascade` | cascade | `Cascade(arms=[stage(a₁)..stage(a_m)], gates=[θ₁..θ_{m-1}], post)` — ordered escalation; `|thresholds| == |stages| - 1`. |
+| `self_consistency` | ensemble | `Ensemble(arms=[stage(a)], cardinality=k, majority_vote, accept?)` — sample `k` times, majority-vote; optional `vote_margin` acceptance. |
+| `best_of_n` | ensemble | `Ensemble(arms=[stage(a)], cardinality=k, judge_max(stage(judge)))` — sample `k`, pick the judge's highest-scoring candidate. |
+| `self_refine` | loop | `Loop(body=stage(a), state_keys, stop=signal_accept(σ, θ), max_iters=K)` — refine until a calibrated signal accepts (unroll-eligible). |
+| `self_debug` | loop | `Loop(body=stage(a), state_keys, stop=external_accept(tests), max_iters=K)` — retry until an opaque predicate (e.g. tests) passes. |
+
+```python
+from traigent.knobs.patterns import binary_cascade
+
+answerer = binary_cascade(
+    "answerer",
+    base_stage="cheap",
+    expert_stage="strong",
+    threshold="router_margin_threshold",  # a calibrated CVAR name
+)
+```
+
+## Executing a composite
+
+The SDK ships execution for the **post-cascade** kind today (ensemble and loop
+execution are deferred and raise an explicit `NotImplementedError` naming the
+gap — they are never silently skipped).
+
+You execute a composite for one item with `execute_composite`, supplying a
+`StageRunner` (or a bare callable) for each stage name and the live calibrated
+gate thresholds:
+
+```python
+from traigent.knobs.runtime import StageRunner, execute_composite
+
+
+def stage(outputs):
+    # A voting stage: returns its sample multiset; key_fn maps an output to a
+    # content-free equivalence key (required for a stage that feeds a gate).
+    return StageRunner(run=lambda _item: list(outputs), key_fn=lambda x: x,
+                       samples=len(outputs))
+
+
+run = execute_composite(
+    answerer.structure,
+    stages={"cheap": stage(["A", "A", "B"]), "strong": stage(["STRONG"])},
+    config={"variant": "strong"},
+    calibrated_values={"router_margin_threshold": 0.9},
+)
+print(run.result_kind)  # output | no_accept | error
+print(run.output)       # the selected arm's output (when result_kind is output)
+print(run.measures)     # the §3.10 content-free telemetry dict
+```
+
+`execute_composite` returns a frozen `CompositeRunResult`:
+
+- `result_kind` is the result-algebra tag: `output`, `no_accept` (ran but
+  nothing met acceptance — an honest no-output outcome, not an error), or
+  `error`;
+- `output` carries the selected arm's output only when `result_kind` is
+  `output`;
+- `measures` is the §3.10 telemetry dict (see below);
+- `error` carries a fail-closed diagnostic string when `result_kind` is `error`.
+
+Execution **fails closed**: a stage exception, a missing stage callable, or a
+missing / non-finite calibrated threshold yields an `error` result — never a
+silent fallback to some stage's output.
+
+## Certified selection with a composite
+
+A composite's gate threshold is a **calibrated variable** (a CVAR), so a
+`binary_cascade` slots into the strict certified-selection path. The shape
+(mirrored by the offline example and the integration suite):
+
+1. declare the cascade with a calibrated gate threshold;
+2. build a `ConfigSpace` from `binary_cascade(...).members` with the gate bound
+   `Calibrated` (the searched space is the tuned variant; the calibrated
+   threshold stays client-side);
+3. execute the composite in-trial so the gate creates real, observable
+   dominance between candidate configs;
+4. let the promotion gate decide over the collected metrics.
+
+```python
+from traigent.tvl.models import PromotionPolicy
+from traigent.tvl.promotion_gate import ObjectiveSpec, PromotionGate
+
+gate = PromotionGate(
+    PromotionPolicy(alpha=0.05, min_effect={"accuracy": 0.0}),
+    [ObjectiveSpec("accuracy", "maximize")],
+)
+decision = gate.evaluate(
+    incumbent_metrics={"accuracy": incumbent_accuracy_samples},
+    candidate_metrics={"accuracy": candidate_accuracy_samples},
+)
+# decision.decision is "promote", "reject", or "no_decision".
+```
+
+`decision.decision` is one of `promote`, `reject`, or `no_decision`. A
+`no_decision` is the honest outcome when the evidence does not establish
+dominance under the policy — it is not a failure and is never reported as a
+winner. The offline example prints a CERTIFIED WINNER or an honest "no winner
+yet" depending on the samples it collects.
+
+In a hybrid or cloud run you do not call the promotion gate yourself; the
+orchestrator runs it over the per-trial metrics your decorated function
+submits.
+
+## Telemetry → the measures channel
+
+Every composite run produces the RFC 0002 §3.10 **content-free** telemetry dict
+(counts, rates, enums, finite numbers only — never anything output-derived).
+For a cascade:
+
+- `escalation_rate` — the per-run 0/1 escalated indicator;
+- `stage_selected` — the selected arm index;
+- `gate_margin_pass_rate` — a per-gate map (keyed by gate index) over the gates
+  actually evaluated: `1.0` where the gate did not escalate (the margin
+  passed), `0.0` where it did.
+
+`run.measures` is structured (it nests the per-gate map). The Traigent
+**measures wire channel** — the per-trial numeric metrics that ride a trial
+submission — is flat: numeric values only, with Python-identifier keys, and a
+backend cap of 50 keys per trial (`traigent.cloud.dtos.MeasuresDict`).
+
+`traigent.knobs.telemetry.composite_measures` is the adapter between the two.
+It flattens the run's measures into identifier-safe, numeric-only keys:
+
+```python
+from traigent.knobs.telemetry import composite_measures
+
+composite_measures(run)
+# {
+#   "composite_escalation_rate": 1.0,
+#   "composite_stage_selected": 1,
+#   "composite_gate_0_margin_pass_rate": 0.0,
+# }
+```
+
+Flattening rules:
+
+- a scalar measure `m` becomes `{prefix}_{m}` (default prefix `composite`);
+- the per-gate map is flattened per gate into
+  `{prefix}_gate_{index}_margin_pass_rate`;
+- non-finite or non-numeric values are dropped (the channel carries finite
+  numbers only);
+- the total key count is capped with headroom below the 50-key ceiling so your
+  own metrics co-exist; over the cap the lowest-priority keys are truncated
+  deterministically and a warning is logged — `composite_measures` never raises
+  mid-trial.
+
+The output is content-free by construction: the adapter reads `run.measures`
+only (never `run.output`) and emits finite numbers and integer gate indices.
+
+### Integration recipe (riding the existing channel)
+
+To make composite telemetry visible on the wire, merge `composite_measures(run)`
+into the metrics your decorated function returns. No new wire surface is
+introduced — the `composite_*` keys ride the existing per-trial measures
+channel as ordinary numeric metrics:
+
+```python
+import traigent
+from traigent.knobs.runtime import execute_composite
+from traigent.knobs.telemetry import composite_measures
+
+
+@traigent.optimize(
+    eval_dataset=...,
+    objectives=["accuracy"],
+    configuration_space={"variant": ["cheap", "strong"]},
+    default_config={"variant": "cheap"},
+    execution_mode="hybrid",
+)
+def answer(text: str) -> tuple[str, dict[str, float]]:
+    cfg = traigent.get_config()
+    params = dict(cfg)
+    run = execute_composite(
+        answerer.structure,
+        stages={"cheap": stage([...]), "strong": stage(["STRONG"])},
+        config=params,
+        calibrated_values={"router_margin_threshold": params["router_margin_threshold"]},
+    )
+    metrics = {"accuracy": 1.0 if str(run.output) == "STRONG" else 0.0}
+    metrics.update(composite_measures(run))  # composite_* keys ride the wire
+    return str(run.output), metrics
+```
+
+On submission, the SDK splits off the reserved `measures` / `summary_stats`
+keys and validates the remaining numeric metrics (your `accuracy` plus the
+`composite_*` keys) through `MeasuresDict` before posting them in the trial
+result body. The integration test
+`tests/unit/cloud/test_composite_measures_submission.py` asserts the
+`composite_*` keys appear in the posted body.
+
+## See also
+
+- [Composite-Knob IR](composite-knob-ir.md) — the declaration algebra.
+- `examples/advanced/composite-knobs/composite_telemetry.py` — the runnable,
+  offline example mirrored from this page.

--- a/examples/advanced/composite-knobs/composite_telemetry.py
+++ b/examples/advanced/composite-knobs/composite_telemetry.py
@@ -45,7 +45,7 @@ os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
 from traigent.knobs.patterns import binary_cascade
 from traigent.knobs.runtime import StageRunner, execute_composite
-from traigent.knobs.telemetry import composite_measures
+from traigent.knobs.telemetry import composite_measures, merge_composite_measures
 from traigent.tvl.models import PromotionPolicy
 from traigent.tvl.promotion_gate import ObjectiveSpec, PromotionGate
 
@@ -118,7 +118,7 @@ def _evaluate_config(
         # Merge the composite's §3.10 telemetry into the per-item metrics. In a
         # hybrid/cloud run, this exact dict is what rides the measures channel.
         item_metrics: dict[str, float] = {"accuracy": accuracy_samples[-1]}
-        item_metrics.update(composite_measures(run))
+        merge_composite_measures(item_metrics, run)
         last_measures = item_metrics
 
     return accuracy_samples, last_measures
@@ -186,7 +186,7 @@ def main() -> None:
 #         )
 #         # The composite_* keys become per-trial measures on the wire.
 #         metrics = {"accuracy": 1.0 if str(run.output) == _EXPECTED else 0.0}
-#         metrics.update(composite_measures(run))
+#         merge_composite_measures(metrics, run)
 #         return str(run.output), metrics
 #
 # Requires a reachable backend and credentials (TRAIGENT_API_KEY,

--- a/examples/advanced/composite-knobs/composite_telemetry.py
+++ b/examples/advanced/composite-knobs/composite_telemetry.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Composite knobs: execute a cascade, ride its telemetry on the measures channel.
+
+This example is OFFLINE-BY-DEFAULT and deterministic — it makes NO LLM calls and
+talks to NO backend. It demonstrates, end to end:
+
+1. declaring an RFC 0002 ``binary_cascade`` pattern;
+2. executing it in-trial over deterministic stub stages with ``execute_composite``
+   + ``StageRunner`` (a cheap arm that escalates to an expert arm below a
+   calibrated margin threshold);
+3. flattening the run's §3.10 content-free telemetry with ``composite_measures``
+   and merging it into the per-example metrics — the SAME numeric metrics that
+   ride the Traigent *measures* wire channel in hybrid/cloud mode;
+4. running the certified-selection promotion gate over the collected metrics to
+   produce a CERTIFIED winner or an honest "no winner yet" — no fabricated
+   success.
+
+Run it::
+
+    python examples/advanced/composite-knobs/composite_telemetry.py
+
+Environment (all optional; offline by default):
+
+- ``TRAIGENT_OFFLINE_MODE=true`` — already the default for this example; no
+  network is touched regardless.
+
+The "Hybrid / cloud wire" section near the bottom is COMMENTED and documented:
+it shows where ``composite_measures(run)`` is merged into the metrics a
+``@traigent.optimize``-decorated function returns so the composite telemetry
+rides the existing trial-submission channel. It is intentionally not executed
+here (it needs a live backend + credentials).
+
+NOTE on claim scope: the promotion gate reports a *procedural* decision over the
+provided samples (promote / reject / no decision). It does not assert any
+guarantee about future inputs; treat its output as "this evidence, this policy".
+"""
+
+from __future__ import annotations
+
+import os
+
+# Offline by default: this example never needs a backend.
+os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
+
+from traigent.knobs.patterns import binary_cascade
+from traigent.knobs.runtime import StageRunner, execute_composite
+from traigent.knobs.telemetry import composite_measures
+from traigent.tvl.models import PromotionPolicy
+from traigent.tvl.promotion_gate import ObjectiveSpec, PromotionGate
+
+# The calibrated gate threshold (a CVAR name). In a governed run this is
+# certificate-backed; here we pass a plain calibrated value for the example.
+GATE = "router_margin_threshold"
+
+# The composite under test: a cheap arm that escalates to an expert arm when the
+# cheap arm's vote margin falls below the calibrated threshold (§3.2 post-cascade).
+COMPOSITE = binary_cascade(
+    "answerer",
+    base_stage="cheap",
+    expert_stage="strong",
+    threshold=GATE,
+)
+
+
+def _stage(outputs: list[str]) -> StageRunner:
+    """A deterministic voting stage over a fixed output multiset (identity keys).
+
+    Real stages would call a model; here we return fixed samples so the example
+    is fully reproducible offline.
+    """
+    return StageRunner(
+        run=lambda _item: list(outputs),
+        key_fn=lambda x: x,
+        samples=len(outputs),
+    )
+
+
+# Three evaluation items; the "correct" answer is STRONG for each.
+_ITEMS = ["q0", "q1", "q2"]
+_EXPECTED = "STRONG"
+
+
+def _evaluate_config(
+    variant: str, theta: float
+) -> tuple[list[float], dict[str, float]]:
+    """Evaluate one candidate config over the dataset (offline, deterministic).
+
+    Returns the per-item accuracy samples and the LAST item's flattened composite
+    telemetry (representative for printing). The dominance comparison uses the
+    accuracy samples; the composite measures are content-free observability that
+    rides the measures channel alongside accuracy.
+
+    Stage behavior, by variant:
+
+    - ``cheap``: unanimous WRONG cheap votes (margin 1.0 >= theta) => ACCEPTED at
+      the cheap arm => wrong answer => accuracy 0.
+    - ``strong``: split cheap votes (margin 1/3 < theta) => ESCALATES to the
+      expert arm => correct answer => accuracy 1.
+
+    The gate therefore creates real, observable dominance for the promotion gate.
+    """
+    cheap_outputs = (
+        ["nope", "nope", "nope"] if variant == "cheap" else ["STRONG", "x", "y"]
+    )
+    accuracy_samples: list[float] = []
+    last_measures: dict[str, float] = {}
+    for _item in _ITEMS:
+        run = execute_composite(
+            COMPOSITE.structure,
+            {"cheap": _stage(cheap_outputs), "strong": _stage([_EXPECTED])},
+            config={"variant": variant},
+            calibrated_values={GATE: theta},
+        )
+        accuracy_samples.append(1.0 if str(run.output) == _EXPECTED else 0.0)
+
+        # --- The integration recipe (offline form) -----------------------------
+        # Merge the composite's §3.10 telemetry into the per-item metrics. In a
+        # hybrid/cloud run, this exact dict is what rides the measures channel.
+        item_metrics: dict[str, float] = {"accuracy": accuracy_samples[-1]}
+        item_metrics.update(composite_measures(run))
+        last_measures = item_metrics
+
+    return accuracy_samples, last_measures
+
+
+def main() -> None:
+    theta = 0.7  # calibrated margin threshold
+
+    incumbent_acc, incumbent_measures = _evaluate_config("cheap", theta)
+    candidate_acc, candidate_measures = _evaluate_config("strong", theta)
+
+    print("Composite telemetry example (offline, deterministic)\n")
+    print(f"  gate threshold (calibrated): {theta}")
+    print(f"  incumbent (variant=cheap)  accuracy samples: {incumbent_acc}")
+    print(f"    measures: {incumbent_measures}")
+    print(f"  candidate (variant=strong) accuracy samples: {candidate_acc}")
+    print(f"    measures: {candidate_measures}\n")
+
+    # Certified selection over the collected metrics (a real statistical test —
+    # no fabricated winner). With a small deterministic sample the gate may
+    # honestly return "no decision"; that is a correct, non-faked outcome.
+    gate = PromotionGate(
+        PromotionPolicy(alpha=0.05, min_effect={"accuracy": 0.0}),
+        [ObjectiveSpec("accuracy", "maximize")],
+    )
+    decision = gate.evaluate(
+        incumbent_metrics={"accuracy": incumbent_acc},
+        candidate_metrics={"accuracy": candidate_acc},
+    )
+
+    if decision.decision == "promote":
+        print(f"CERTIFIED WINNER: variant=strong promoted — {decision.reason}")
+    elif decision.decision == "reject":
+        print(f"NO PROMOTION: candidate rejected — {decision.reason}")
+    else:
+        print(f"NO WINNER YET (honest): {decision.reason}")
+
+
+# --------------------------------------------------------------------------- #
+# Hybrid / cloud wire (documented, NOT executed here)                         #
+# --------------------------------------------------------------------------- #
+#
+# In a hybrid or cloud run, you do not call the promotion gate yourself — the
+# orchestrator does. Your decorated function executes the composite in-trial and
+# merges the composite telemetry into the metrics it returns; those numeric
+# metrics ride the existing measures channel to the backend:
+#
+#     import traigent
+#
+#     @traigent.optimize(
+#         eval_dataset=...,
+#         objectives=["accuracy"],
+#         configuration_space={"variant": ["cheap", "strong"]},
+#         default_config={"variant": "cheap"},
+#         execution_mode="hybrid",
+#     )
+#     def answer(text: str) -> tuple[str, dict[str, float]]:
+#         cfg = traigent.get_config()
+#         params = dict(cfg)
+#         run = execute_composite(
+#             COMPOSITE.structure,
+#             {"cheap": _stage([...]), "strong": _stage([_EXPECTED])},
+#             config=params,
+#             calibrated_values={GATE: params[GATE]},
+#         )
+#         # The composite_* keys become per-trial measures on the wire.
+#         metrics = {"accuracy": 1.0 if str(run.output) == _EXPECTED else 0.0}
+#         metrics.update(composite_measures(run))
+#         return str(run.output), metrics
+#
+# Requires a reachable backend and credentials (TRAIGENT_API_KEY,
+# TRAIGENT_BACKEND_URL) plus TRAIGENT_OFFLINE_MODE=false. See
+# docs/concepts/composite-knobs.md for the strict certified-selection recipe.
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
   - Concepts:
       - Guided Generation: concepts/guided-generation.md
       - Composite-Knob IR: concepts/composite-knob-ir.md
+      - Composite Knobs (Execution & Telemetry): concepts/composite-knobs.md
       - Configuration Spaces: user-guide/configuration-spaces.md
       - Constraint Expressions: tvl/CONSTRAINT_EXPRESSIONS.md
       - Dataflow Detection: features/dataflow-detection.md

--- a/tests/unit/cloud/test_composite_measures_submission.py
+++ b/tests/unit/cloud/test_composite_measures_submission.py
@@ -1,0 +1,217 @@
+"""Composite telemetry rides the measures wire channel end-to-end.
+
+This is the INTEGRATION test for the composite telemetry feature: it proves the
+full path from a composite run's §3.10 measures to the trial-submission HTTP
+body, exercising the SAME mechanism every user follows.
+
+The user-facing mechanism (traced in
+``traigent/cloud/trial_operations.py``):
+
+1. A trial's numeric metrics flow into
+   ``TrialOperations.submit_trial_result_via_session(metrics=...)``.
+2. There, ``_extract_measures_from_metrics`` splits off the reserved
+   ``measures``/``summary_stats`` keys; the remaining numeric metrics
+   (``clean_metrics``) are validated through ``MeasuresDict`` (≤ 50
+   Python-identifier keys, numeric values only) and become the trial's
+   per-trial measures in the posted body's ``metrics``.
+
+So a user merges ``composite_measures(run)`` into the metrics their evaluated
+function returns; those ``composite_*`` keys then ride the existing channel.
+This test mocks the HTTP layer (mirroring
+``tests/unit/cloud/test_trial_operations.py``) and asserts the posted body's
+``metrics`` carries the flattened ``composite_*`` keys.
+
+No new wire surface is introduced — the composite keys are ordinary numeric
+metrics on a path that already exists.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from traigent.cloud.trial_operations import TrialOperations
+from traigent.knobs.patterns import binary_cascade
+from traigent.knobs.runtime import StageRunner, execute_composite
+from traigent.knobs.telemetry import composite_measures
+
+GATE = "router_margin_threshold"
+
+
+def _stage(outputs: list[str]) -> StageRunner:
+    return StageRunner(
+        run=lambda _item: list(outputs),
+        key_fn=lambda x: x,
+        samples=len(outputs),
+    )
+
+
+def _evaluate_one_item_metrics() -> dict[str, float]:
+    """Mirror what a decorated function's evaluation produces for one trial.
+
+    A composite is executed in-trial (deterministic stub stages, no LLM calls),
+    the user's own score is recorded, and the composite telemetry is merged into
+    the SAME metrics dict — exactly the documented integration recipe.
+    """
+    composite = binary_cascade(
+        "answerer", base_stage="cheap", expert_stage="strong", threshold=GATE
+    )
+    # cheap split 2/3 -> margin 0.666 < theta 0.9 -> escalate to the expert arm.
+    run = execute_composite(
+        composite.structure,
+        {"cheap": _stage(["A", "A", "B"]), "strong": _stage(["STRONG"])},
+        config={"variant": "strong"},
+        calibrated_values={GATE: 0.9},
+    )
+    metrics: dict[str, float] = {"accuracy": 1.0}
+    metrics.update(composite_measures(run))
+    return metrics
+
+
+def _build_post_mock() -> tuple[Mock, Mock]:
+    """Return (mock_session, mock_aiohttp_ClientSession) capturing post()."""
+    mock_response = Mock()
+    mock_response.status = 201
+
+    mock_post_ctx = AsyncMock()
+    mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.post = Mock(return_value=mock_post_ctx)
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_session, mock_session_ctx
+
+
+@pytest.mark.asyncio
+async def test_composite_measures_appear_in_posted_trial_metrics() -> None:
+    """The flattened composite_* keys ride the posted trial-result body."""
+    mock_client = Mock()
+    mock_client.backend_config = Mock()
+    mock_client.backend_config.backend_base_url = "https://api.example.com"
+    mock_client.backend_config.api_base_url = "https://api.example.com/api/v1"
+    mock_client.auth_manager = AsyncMock()
+    mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+    mock_client._map_to_backend_status = Mock(return_value="COMPLETED")
+    mock_client._normalize_execution_mode = Mock(return_value="hybrid")
+    mock_client._sanitize_error_message = Mock(return_value="")
+
+    ops = TrialOperations(mock_client)
+    ops._handle_trial_success_response = AsyncMock(return_value=True)
+
+    # The user's evaluation produces metrics WITH the composite telemetry merged.
+    metrics = _evaluate_one_item_metrics()
+    # Pre-condition: the recipe actually produced composite keys to transport.
+    assert metrics["composite_escalation_rate"] == 1.0
+    assert metrics["composite_stage_selected"] == 1
+    assert metrics["composite_gate_0_margin_pass_rate"] == 0.0
+
+    mock_session, mock_session_ctx = _build_post_mock()
+
+    with (
+        patch(
+            "traigent.cloud.trial_operations.is_backend_offline",
+            return_value=False,
+        ),
+        patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+        # Real schema validation would require a full result envelope; the
+        # measures-channel transport is the unit under test, so neutralize it
+        # exactly as the sibling test in test_trial_operations.py does.
+        patch("traigent.cloud.trial_operations.validate_configuration_run_submission"),
+        patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+    ):
+        mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+        mock_aiohttp.ClientTimeout = Mock()
+
+        result = await ops.submit_trial_result_via_session(
+            session_id="session_123",
+            trial_id="trial_001",
+            config={"variant": "strong"},
+            metrics=metrics,
+            status="completed",
+            execution_mode="hybrid",
+        )
+
+    assert result is True
+
+    # The posted body is the json= kwarg of session.post(...).
+    posted_body = mock_session.post.call_args.kwargs["json"]
+    posted_metrics = posted_body["metrics"]
+
+    # The composite_* keys rode the channel as ordinary numeric metrics,
+    # alongside the user's own metric.
+    assert posted_metrics["accuracy"] == 1.0
+    assert posted_metrics["composite_escalation_rate"] == 1.0
+    assert posted_metrics["composite_stage_selected"] == 1
+    assert posted_metrics["composite_gate_0_margin_pass_rate"] == 0.0
+
+    # Content-free: no produced output value leaked onto the wire; every
+    # transported metric value is a plain number.
+    assert all(
+        isinstance(v, (int, float)) and not isinstance(v, bool)
+        for v in posted_metrics.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_composite_metrics_pass_measuresdict_on_the_submission_path() -> None:
+    """The clean_metrics MeasuresDict validation accepts composite_* keys.
+
+    ``submit_trial_result_via_session`` constructs ``MeasuresDict(clean_metrics)``
+    before posting; a composite key that violated the identifier/numeric
+    contract would trip a validation warning and submit unvalidated. This test
+    asserts the composite keys validate cleanly (no warning path), proving the
+    flattener's MeasuresDict-compliance holds on the REAL submission code.
+    """
+    mock_client = Mock()
+    mock_client.backend_config = Mock()
+    mock_client.backend_config.backend_base_url = "https://api.example.com"
+    mock_client.backend_config.api_base_url = "https://api.example.com/api/v1"
+    mock_client.auth_manager = AsyncMock()
+    mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+    mock_client._map_to_backend_status = Mock(return_value="COMPLETED")
+    mock_client._normalize_execution_mode = Mock(return_value="hybrid")
+    mock_client._sanitize_error_message = Mock(return_value="")
+
+    ops = TrialOperations(mock_client)
+    ops._handle_trial_success_response = AsyncMock(return_value=True)
+
+    metrics = _evaluate_one_item_metrics()
+    mock_session, mock_session_ctx = _build_post_mock()
+
+    with (
+        patch(
+            "traigent.cloud.trial_operations.is_backend_offline",
+            return_value=False,
+        ),
+        patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+        patch("traigent.cloud.trial_operations.validate_configuration_run_submission"),
+        patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+        patch("traigent.cloud.trial_operations.logger") as mock_logger,
+    ):
+        mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+        mock_aiohttp.ClientTimeout = Mock()
+
+        await ops.submit_trial_result_via_session(
+            session_id="session_123",
+            trial_id="trial_001",
+            config={"variant": "strong"},
+            metrics=metrics,
+            status="completed",
+            execution_mode="hybrid",
+        )
+
+    # No "Metrics validation warning" was emitted — composite keys validated.
+    warning_msgs = [
+        call.args[0]
+        for call in mock_logger.warning.call_args_list
+        if call.args and isinstance(call.args[0], str)
+    ]
+    assert not any(
+        "Metrics validation warning" in msg for msg in warning_msgs
+    ), f"composite metrics tripped MeasuresDict validation: {warning_msgs}"

--- a/tests/unit/cloud/test_composite_measures_submission.py
+++ b/tests/unit/cloud/test_composite_measures_submission.py
@@ -34,7 +34,7 @@ import pytest
 from traigent.cloud.trial_operations import TrialOperations
 from traigent.knobs.patterns import binary_cascade
 from traigent.knobs.runtime import StageRunner, execute_composite
-from traigent.knobs.telemetry import composite_measures
+from traigent.knobs.telemetry import composite_measures, merge_composite_measures
 
 GATE = "router_margin_threshold"
 
@@ -65,7 +65,7 @@ def _evaluate_one_item_metrics() -> dict[str, float]:
         calibrated_values={GATE: 0.9},
     )
     metrics: dict[str, float] = {"accuracy": 1.0}
-    metrics.update(composite_measures(run))
+    merge_composite_measures(metrics, run)
     return metrics
 
 

--- a/tests/unit/knobs/test_composite_telemetry.py
+++ b/tests/unit/knobs/test_composite_telemetry.py
@@ -310,3 +310,25 @@ class TestCodexRoundBlockers:
         assert merged["accuracy"] == 0.9
         assert merged["composite_escalation_rate"] == 1.0
         assert merged["composite_stage_selected"] == 1
+
+
+class TestCodexConfirmResiduals:
+    def test_any_prefixed_user_key_is_rejected(self):
+        """The composite_* namespace is reserved WHOLESALE — not merely the
+        keys this run happens to flatten."""
+        from traigent.knobs.telemetry import merge_composite_measures
+
+        run = _run_with_measures({"escalation_rate": 1.0})
+        with pytest.raises(ValueError, match="reserved"):
+            merge_composite_measures({"composite_user": 9.0}, run)
+
+    def test_user_dict_already_over_ceiling_raises(self):
+        """A user dict ALREADY beyond the 50-key ceiling cannot be made valid
+        by truncating composite keys (user keys are never dropped) — fail
+        LOUD instead of returning a contract-violating dict."""
+        from traigent.knobs.telemetry import merge_composite_measures
+
+        run = _run_with_measures({"escalation_rate": 1.0})
+        over = {f"user_metric_{i}": float(i) for i in range(51)}
+        with pytest.raises(ValueError, match="ceiling|50"):
+            merge_composite_measures(over, run)

--- a/tests/unit/knobs/test_composite_telemetry.py
+++ b/tests/unit/knobs/test_composite_telemetry.py
@@ -256,3 +256,57 @@ class TestEdgeCases:
 
     def test_reexported_from_knobs_package(self) -> None:
         assert composite_measures_reexport is composite_measures
+
+
+def _run_with_measures(measures):
+    return CompositeRunResult(
+        output=None, result_kind=ResultKind.OUTPUT, measures=measures
+    )
+
+
+class TestCodexRoundBlockers:
+    def test_flatten_collision_raises(self):
+        """Blocker 3: a scalar named gate_0_margin_pass_rate and the standard
+        per-gate map both flatten to the same key — duplicates must RAISE,
+        never silently last-write-win."""
+        run = _run_with_measures(
+            {
+                "gate_0_margin_pass_rate": 0.5,
+                "gate_margin_pass_rate": {0: 1.0},
+            }
+        )
+        with pytest.raises(ValueError, match="collid|duplicate"):
+            composite_measures(run)
+
+    def test_merge_rejects_user_key_collisions(self):
+        """Blocker 1: merging into a user metrics dict that already carries a
+        composite_* key must fail LOUD (reserved namespace), never overwrite."""
+        from traigent.knobs.telemetry import merge_composite_measures
+
+        run = _run_with_measures({"escalation_rate": 1.0})
+        user_metrics = {"accuracy": 0.9, "composite_escalation_rate": 123.0}
+        with pytest.raises(ValueError, match="collid|reserved"):
+            merge_composite_measures(user_metrics, run)
+
+    def test_merge_enforces_the_total_measures_ceiling(self):
+        """Blocker 2: the 50-key MeasuresDict cap applies to the WHOLE
+        submitted metrics dict — the merge truncates composite keys
+        deterministically (logged) so the TOTAL never exceeds 50."""
+        from traigent.knobs.telemetry import merge_composite_measures
+
+        run = _run_with_measures({"gate_margin_pass_rate": {i: 1.0 for i in range(30)}})
+        user_metrics = {f"user_metric_{i}": float(i) for i in range(45)}
+        merged = merge_composite_measures(dict(user_metrics), run)
+        assert len(merged) <= 50
+        # user metrics are NEVER dropped — only composite keys yield
+        for k in user_metrics:
+            assert k in merged
+
+    def test_merge_happy_path(self):
+        from traigent.knobs.telemetry import merge_composite_measures
+
+        run = _run_with_measures({"escalation_rate": 1.0, "stage_selected": 1})
+        merged = merge_composite_measures({"accuracy": 0.9}, run)
+        assert merged["accuracy"] == 0.9
+        assert merged["composite_escalation_rate"] == 1.0
+        assert merged["composite_stage_selected"] == 1

--- a/tests/unit/knobs/test_composite_telemetry.py
+++ b/tests/unit/knobs/test_composite_telemetry.py
@@ -1,0 +1,258 @@
+"""Composite telemetry → measures channel adapter tests (RFC 0002 §3.10).
+
+:func:`traigent.knobs.telemetry.composite_measures` flattens a composite run's
+content-free §3.10 measures into a flat, identifier-safe, numeric-only dict
+that satisfies the backend ``MeasuresDict`` contract (≤ 50 Python-identifier
+keys, numeric values only). These tests pin:
+
+- the flattening rules (scalars prefixed; the per-gate map flattened by index);
+- ``MeasuresDict`` round-trip compliance of every emitted key/value;
+- content-freedom: nothing output-derived can enter the output — the adapter
+  reads ``run.measures`` only, never ``run.output``;
+- the deterministic key cap (truncate + warn, NEVER raise mid-trial).
+
+Stub stages are deterministic — NO LLM calls.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from traigent.cloud.dtos import MeasuresDict
+from traigent.knobs import composite_measures as composite_measures_reexport
+from traigent.knobs.patterns import binary_cascade
+from traigent.knobs.runtime import (
+    CompositeRunResult,
+    ResultKind,
+    StageRunner,
+    execute_composite,
+)
+from traigent.knobs.telemetry import MAX_COMPOSITE_MEASURES, composite_measures
+
+GATE = "router_margin_threshold"
+
+
+def _stage(outputs: list[str]) -> StageRunner:
+    return StageRunner(
+        run=lambda _item: list(outputs),
+        key_fn=lambda x: x,
+        samples=len(outputs),
+    )
+
+
+def _binary() -> object:
+    return binary_cascade(
+        "answerer", base_stage="cheap", expert_stage="strong", threshold=GATE
+    ).structure
+
+
+# --------------------------------------------------------------------------- #
+# Flattening rules over a REAL composite run                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestFlattenRealRun:
+    def test_kept_at_cheap_arm_flattens_scalars_and_one_gate(self) -> None:
+        # cheap unanimous: margin 1.0 >= theta 0.6 -> kept at arm 0.
+        run = execute_composite(
+            _binary(),
+            {"cheap": _stage(["A", "A", "A"]), "strong": _stage(["STRONG"])},
+            config={},
+            calibrated_values={GATE: 0.6},
+        )
+        assert run.result_kind is ResultKind.OUTPUT
+
+        flat = composite_measures(run)
+        assert flat == {
+            "composite_escalation_rate": 0.0,
+            "composite_stage_selected": 0,
+            "composite_gate_0_margin_pass_rate": 1.0,
+        }
+
+    def test_escalated_run_flattens_failing_gate(self) -> None:
+        # cheap split 2/3 -> margin 0.666 < theta 0.9 -> escalate to arm 1.
+        run = execute_composite(
+            _binary(),
+            {"cheap": _stage(["A", "A", "B"]), "strong": _stage(["STRONG"])},
+            config={},
+            calibrated_values={GATE: 0.9},
+        )
+        flat = composite_measures(run)
+        assert flat["composite_escalation_rate"] == 1.0
+        assert flat["composite_stage_selected"] == 1
+        assert flat["composite_gate_0_margin_pass_rate"] == 0.0
+
+    def test_custom_prefix_is_applied_to_every_key(self) -> None:
+        run = execute_composite(
+            _binary(),
+            {"cheap": _stage(["A", "A", "A"]), "strong": _stage(["STRONG"])},
+            config={},
+            calibrated_values={GATE: 0.6},
+        )
+        flat = composite_measures(run, prefix="answerer")
+        assert set(flat) == {
+            "answerer_escalation_rate",
+            "answerer_stage_selected",
+            "answerer_gate_0_margin_pass_rate",
+        }
+
+    def test_multi_gate_map_flattens_by_ascending_index(self) -> None:
+        # Synthetic measures mirroring a 3-arm cascade that escalated twice.
+        run = CompositeRunResult(
+            output=None,
+            result_kind=ResultKind.OUTPUT,
+            measures={
+                "escalation_rate": 1.0,
+                "stage_selected": 2,
+                "gate_margin_pass_rate": {0: 0.0, 1: 0.0},
+            },
+        )
+        flat = composite_measures(run)
+        assert flat == {
+            "composite_escalation_rate": 1.0,
+            "composite_stage_selected": 2,
+            "composite_gate_0_margin_pass_rate": 0.0,
+            "composite_gate_1_margin_pass_rate": 0.0,
+        }
+        # Deterministic ordering: gate entries trail scalars, by index.
+        keys = list(flat)
+        assert keys.index("composite_gate_0_margin_pass_rate") < keys.index(
+            "composite_gate_1_margin_pass_rate"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# MeasuresDict contract compliance (the wire channel's gate)                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestMeasuresDictCompliance:
+    def test_every_emitted_key_satisfies_measuresdict(self) -> None:
+        run = execute_composite(
+            _binary(),
+            {"cheap": _stage(["A", "A", "B"]), "strong": _stage(["STRONG"])},
+            config={},
+            calibrated_values={GATE: 0.9},
+        )
+        flat = composite_measures(run)
+        # The backend validates the trial's numeric metrics through MeasuresDict;
+        # constructing one must NOT raise for any composite key/value.
+        validated = MeasuresDict(flat)
+        assert dict(validated) == flat
+
+    def test_keys_are_python_identifiers(self) -> None:
+        run = CompositeRunResult(
+            output=None,
+            result_kind=ResultKind.OUTPUT,
+            measures={
+                "escalation_rate": 0.0,
+                "stage_selected": 0,
+                "gate_margin_pass_rate": {0: 1.0},
+            },
+        )
+        for key in composite_measures(run):
+            assert key.isidentifier(), key
+
+
+# --------------------------------------------------------------------------- #
+# Content-freedom: nothing output-derived can enter the output                #
+# --------------------------------------------------------------------------- #
+
+
+class TestContentFree:
+    def test_output_value_never_appears_in_measures(self) -> None:
+        sentinel = "SECRET_MODEL_OUTPUT_DO_NOT_LEAK"
+        run = execute_composite(
+            _binary(),
+            {"cheap": _stage([sentinel, sentinel, sentinel]), "strong": _stage(["x"])},
+            config={},
+            calibrated_values={GATE: 0.6},
+        )
+        assert run.output == sentinel  # the run really produced the sentinel
+        flat = composite_measures(run)
+        # No key OR value carries the produced content (§3.10 content-free).
+        assert sentinel not in flat
+        assert all(isinstance(v, (int, float)) for v in flat.values())
+        assert sentinel not in {str(v) for v in flat.values()}
+
+    def test_non_numeric_or_non_finite_values_are_dropped(self) -> None:
+        run = CompositeRunResult(
+            output=None,
+            result_kind=ResultKind.OUTPUT,
+            measures={
+                "escalation_rate": float("nan"),  # non-finite -> dropped
+                "stage_selected": 1,
+                "leaked_text": "should never ride the channel",  # non-numeric
+                "flag": True,  # bool is not a measure (MeasuresDict parity)
+                "gate_margin_pass_rate": {0: float("inf"), 1: 0.0},
+            },
+        )
+        flat = composite_measures(run)
+        assert flat == {
+            "composite_stage_selected": 1,
+            "composite_gate_1_margin_pass_rate": 0.0,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic cap: truncate + warn, never raise                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestKeyCap:
+    def test_overflow_truncates_deterministically_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A pathological per-gate map larger than the cap.
+        big = dict.fromkeys(range(MAX_COMPOSITE_MEASURES + 10), 1.0)
+        run = CompositeRunResult(
+            output=None,
+            result_kind=ResultKind.OUTPUT,
+            measures={"stage_selected": 0, "gate_margin_pass_rate": big},
+        )
+        with caplog.at_level(logging.WARNING):
+            flat = composite_measures(run)
+
+        assert len(flat) == MAX_COMPOSITE_MEASURES  # capped, never raised
+        assert "stage_selected" in {k.removeprefix("composite_") for k in flat} or any(
+            k == "composite_stage_selected" for k in flat
+        )
+        # Deterministic: the scalar (priority 1) survives; lowest indices win.
+        assert "composite_stage_selected" in flat
+        assert "composite_gate_0_margin_pass_rate" in flat
+        assert any("exceed the" in rec.message for rec in caplog.records)
+
+    def test_repeated_calls_are_stable(self) -> None:
+        big = dict.fromkeys(range(MAX_COMPOSITE_MEASURES + 5), 1.0)
+        run = CompositeRunResult(
+            output=None,
+            result_kind=ResultKind.OUTPUT,
+            measures={"escalation_rate": 1.0, "gate_margin_pass_rate": big},
+        )
+        assert composite_measures(run) == composite_measures(run)
+
+
+# --------------------------------------------------------------------------- #
+# Edge cases                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestEdgeCases:
+    def test_error_run_has_empty_measures_and_yields_empty_dict(self) -> None:
+        # A fail-closed error run carries no measures (runtime contract).
+        run = CompositeRunResult(
+            output=None, result_kind=ResultKind.ERROR, measures={}, error="boom"
+        )
+        assert composite_measures(run) == {}
+
+    def test_non_identifier_prefix_raises_value_error(self) -> None:
+        run = CompositeRunResult(
+            output=None, result_kind=ResultKind.OUTPUT, measures={"stage_selected": 0}
+        )
+        with pytest.raises(ValueError, match="identifier"):
+            composite_measures(run, prefix="bad-prefix")
+
+    def test_reexported_from_knobs_package(self) -> None:
+        assert composite_measures_reexport is composite_measures

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -46,7 +46,7 @@ from .kinds import KnobKind
 from .resolution import ResolutionError, ResolutionNode, ResolutionRejection
 from .resolver import CalibratedInput, KnobResolver, ResolvedConfiguration
 from .signals import SignalObservation, SignalSpec
-from .telemetry import composite_measures
+from .telemetry import composite_measures, merge_composite_measures
 
 __all__ = [
     "CTX_EXT_KEYS",
@@ -81,6 +81,7 @@ __all__ = [
     "VoteStats",
     "canonical_hash",
     "composite_measures",
+    "merge_composite_measures",
     "conformal_evidence_floor",
     "issue_certificate",
     "knob_to_parameter_range",

--- a/traigent/knobs/__init__.py
+++ b/traigent/knobs/__init__.py
@@ -46,6 +46,7 @@ from .kinds import KnobKind
 from .resolution import ResolutionError, ResolutionNode, ResolutionRejection
 from .resolver import CalibratedInput, KnobResolver, ResolvedConfiguration
 from .signals import SignalObservation, SignalSpec
+from .telemetry import composite_measures
 
 __all__ = [
     "CTX_EXT_KEYS",
@@ -79,6 +80,7 @@ __all__ = [
     "Tuned",
     "VoteStats",
     "canonical_hash",
+    "composite_measures",
     "conformal_evidence_floor",
     "issue_certificate",
     "knob_to_parameter_range",

--- a/traigent/knobs/telemetry.py
+++ b/traigent/knobs/telemetry.py
@@ -199,14 +199,27 @@ def merge_composite_measures(
     """
     flattened = composite_measures(run, prefix=prefix)
 
-    collisions = sorted(set(metrics) & set(flattened))
+    # The namespace is reserved WHOLESALE (codex confirm round): ANY user key
+    # under '{prefix}_' is rejected, not merely the keys this run flattens —
+    # otherwise composite_user would merge beside composite_escalation_rate.
+    reserved_prefix = f"{prefix}_"
+    collisions = sorted(k for k in metrics if str(k).startswith(reserved_prefix))
     if collisions:
         raise ValueError(
-            f"metrics dict already carries reserved {prefix}_* key(s) "
-            f"{collisions[:5]} — the composite telemetry namespace is "
-            "reserved; rename the user metric(s) or choose another prefix"
+            f"metrics dict carries key(s) in the reserved '{reserved_prefix}*' "
+            f"namespace {collisions[:5]} — rename the user metric(s) or choose "
+            "another prefix"
         )
 
+    if len(metrics) > TOTAL_MEASURES_CEILING:
+        # User keys are never dropped, so an already-over-ceiling dict cannot
+        # be made submission-valid here — fail LOUD instead of returning a
+        # contract-violating dict (codex confirm round).
+        raise ValueError(
+            f"metrics dict already has {len(metrics)} keys — beyond the "
+            f"{TOTAL_MEASURES_CEILING}-key MeasuresDict ceiling; reduce your "
+            "own metrics before merging composite telemetry"
+        )
     budget = TOTAL_MEASURES_CEILING - len(metrics)
     if budget <= 0:
         logger.warning(

--- a/traigent/knobs/telemetry.py
+++ b/traigent/knobs/telemetry.py
@@ -1,0 +1,157 @@
+"""Composite telemetry → the measures wire channel (RFC 0002 §3.10).
+
+The composite execution runtime (:mod:`traigent.knobs.runtime`) hands back a
+:class:`~traigent.knobs.runtime.CompositeRunResult` whose ``measures`` is the
+§3.10 *content-free* telemetry dict (counts, rates, enums, finite numbers only
+— never anything output-derived). That dict is **structured**: it nests a
+per-gate ``gate_margin_pass_rate`` map keyed by gate index.
+
+The Traigent measures wire channel (the per-trial numeric metrics that ride a
+trial submission — see :class:`traigent.cloud.dtos.MeasuresDict`) is **flat**:
+≤ 50 entries, each key a Python identifier (``^[a-zA-Z_]\\w*$``), each value a
+plain number. This module is the small, pure adapter between the two:
+
+    >>> from traigent.knobs.runtime import execute_composite
+    >>> from traigent.knobs.telemetry import composite_measures
+    >>> run = execute_composite(knob, stages, config=cfg, calibrated_values=cv)
+    >>> metrics = {"accuracy": score}
+    >>> metrics.update(composite_measures(run))   # rides the same channel
+
+:func:`composite_measures` flattens the run's measures into identifier-safe,
+numeric-only keys so a user can merge them straight into the ``metrics`` dict
+their evaluated function already returns. The per-gate map is flattened by
+index (``composite_gate_0_margin_pass_rate``, ``composite_gate_1_...``). The
+output is **content-free by construction**: the input is already content-free
+per §3.10, and this adapter only ever copies finite numbers and emits integer
+gate indices — it never reads ``run.output`` or any stage value.
+
+This module adds NO new wire surface: it produces an ordinary numeric metrics
+dict that the existing channel already validates and transports.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from traigent.utils.logging import get_logger
+
+if TYPE_CHECKING:  # avoid importing the runtime module at import time
+    from traigent.knobs.runtime import CompositeRunResult
+
+__all__ = [
+    "MAX_COMPOSITE_MEASURES",
+    "composite_measures",
+]
+
+logger = get_logger(__name__)
+
+#: Cap on the number of flattened composite keys, with headroom below the
+#: backend ``MeasuresDict`` 50-key ceiling so a user's own metrics (accuracy,
+#: cost, latency, ...) co-exist on the same trial without tripping the
+#: cardinality guard. Truncation is deterministic and logged — never raised
+#: mid-trial (a telemetry overflow must not fail the user's optimization).
+MAX_COMPOSITE_MEASURES = 40
+
+
+def _is_finite_number(value: object) -> bool:
+    """True for a real, finite int/float (bool and non-finite excluded).
+
+    ``bool`` is rejected for parity with the backend ``MeasuresDict`` contract
+    (a bool is not a measure); NaN/±inf are dropped because the wire channel
+    carries finite numbers only (§3.10).
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return True
+    if isinstance(value, float):
+        return math.isfinite(value)
+    return False
+
+
+def composite_measures(
+    run: CompositeRunResult, *, prefix: str = "composite"
+) -> dict[str, float | int]:
+    """Flatten a composite run's §3.10 measures into MeasuresDict-safe keys.
+
+    The result is a flat dict of identifier-safe keys → finite numbers, ready
+    to merge into the ``metrics`` dict a decorated function returns (the keys
+    then ride the existing measures wire channel; see the module docstring).
+
+    Flattening rules:
+
+    - a scalar measure ``m`` (e.g. ``escalation_rate``, ``stage_selected``)
+      becomes ``{prefix}_{m}`` carrying the same finite number;
+    - the per-gate ``gate_margin_pass_rate`` map (keyed by gate INDEX) is
+      flattened per gate into ``{prefix}_gate_{index}_margin_pass_rate``;
+    - any non-finite or non-numeric value is DROPPED (never coerced) — the
+      channel carries finite numbers only (§3.10);
+    - keys are emitted in a deterministic order (scalars in input order, then
+      gate entries by ascending index) and the total is capped at
+      :data:`MAX_COMPOSITE_MEASURES`. Over the cap, the lowest-priority keys
+      are truncated deterministically and a warning is logged — this function
+      NEVER raises (a telemetry overflow must not fail a trial).
+
+    Args:
+        run: the frozen :class:`~traigent.knobs.runtime.CompositeRunResult`.
+            Only its ``measures`` is read — never ``output`` (content-free).
+        prefix: the identifier-safe namespace for every emitted key (default
+            ``"composite"``). A non-identifier prefix raises ``ValueError`` —
+            this is a programming error at call time, not a per-trial fault.
+
+    Returns:
+        A flat ``dict[str, float | int]`` of content-free composite measures.
+    """
+    if not prefix.isidentifier():
+        raise ValueError(
+            f"composite_measures prefix {prefix!r} must be a Python identifier "
+            r"(^[a-zA-Z_]\w*$) so emitted keys satisfy the MeasuresDict contract"
+        )
+
+    measures: Mapping[str, object] = run.measures or {}
+
+    # Build (key, value) pairs in a deterministic, priority order:
+    #   1. scalar measures in input order (these are the per-run summaries);
+    #   2. per-gate entries by ascending gate index.
+    ordered: list[tuple[str, float | int]] = []
+    gate_entries: list[tuple[int, str, float | int]] = []
+
+    for name, value in measures.items():
+        if isinstance(value, Mapping):
+            # The §3.10 per-gate map (gate_margin_pass_rate): index -> rate.
+            # The map's own name already carries the `gate_` prefix; strip it so
+            # the flattened key reads `..._gate_{index}_margin_pass_rate`, not a
+            # doubled `..._gate_{index}_gate_margin_pass_rate`.
+            suffix = name.removeprefix("gate_")
+            for raw_index, rate in value.items():
+                try:
+                    index = int(raw_index)
+                except (TypeError, ValueError):
+                    # An index that is not integer-coercible is not a §3.10
+                    # gate key; drop it rather than emit a bogus name.
+                    continue
+                if index < 0 or not _is_finite_number(rate):
+                    continue
+                key = f"{prefix}_gate_{index}_{suffix}"
+                gate_entries.append((index, key, rate))  # type: ignore[arg-type]
+            continue
+        if _is_finite_number(value):
+            ordered.append((f"{prefix}_{name}", value))  # type: ignore[arg-type]
+
+    gate_entries.sort(key=lambda item: item[0])
+    ordered.extend((key, rate) for _index, key, rate in gate_entries)
+
+    if len(ordered) > MAX_COMPOSITE_MEASURES:
+        dropped = [key for key, _ in ordered[MAX_COMPOSITE_MEASURES:]]
+        logger.warning(
+            "composite_measures: %d composite measure key(s) exceed the "
+            "%d-key cap; truncating deterministically. Dropped: %s",
+            len(ordered),
+            MAX_COMPOSITE_MEASURES,
+            sorted(dropped),
+        )
+        ordered = ordered[:MAX_COMPOSITE_MEASURES]
+
+    return dict(ordered)

--- a/traigent/knobs/telemetry.py
+++ b/traigent/knobs/telemetry.py
@@ -42,7 +42,9 @@ if TYPE_CHECKING:  # avoid importing the runtime module at import time
 
 __all__ = [
     "MAX_COMPOSITE_MEASURES",
+    "TOTAL_MEASURES_CEILING",
     "composite_measures",
+    "merge_composite_measures",
 ]
 
 logger = get_logger(__name__)
@@ -53,6 +55,12 @@ logger = get_logger(__name__)
 #: cardinality guard. Truncation is deterministic and logged — never raised
 #: mid-trial (a telemetry overflow must not fail the user's optimization).
 MAX_COMPOSITE_MEASURES = 40
+
+#: The backend ``MeasuresDict`` cardinality cap applies to the WHOLE submitted
+#: metrics dict (user metrics + composite telemetry together) — not to the
+#: composite keys alone. ``merge_composite_measures`` enforces it at the merge
+#: boundary (codex round: the per-flattener cap alone over-claimed 'headroom').
+TOTAL_MEASURES_CEILING = 50
 
 
 def _is_finite_number(value: object) -> bool:
@@ -143,6 +151,18 @@ def composite_measures(
     gate_entries.sort(key=lambda item: item[0])
     ordered.extend((key, rate) for _index, key, rate in gate_entries)
 
+    # Injectivity guard (codex round): a scalar literally named
+    # 'gate_0_margin_pass_rate' and the standard per-gate map both flatten to
+    # the same key — duplicates RAISE rather than silently last-write-win.
+    seen: set[str] = set()
+    for key, _value in ordered:
+        if key in seen:
+            raise ValueError(
+                f"composite_measures: flattened key {key!r} collides with "
+                "another measure — §3.10 names must flatten injectively"
+            )
+        seen.add(key)
+
     if len(ordered) > MAX_COMPOSITE_MEASURES:
         dropped = [key for key, _ in ordered[MAX_COMPOSITE_MEASURES:]]
         logger.warning(
@@ -155,3 +175,58 @@ def composite_measures(
         ordered = ordered[:MAX_COMPOSITE_MEASURES]
 
     return dict(ordered)
+
+
+def merge_composite_measures(
+    metrics: dict[str, float | int],
+    run: CompositeRunResult,
+    *,
+    prefix: str = "composite",
+) -> dict[str, float | int]:
+    """Merge a composite run's flattened telemetry into a user metrics dict,
+    fail-closed at both merge hazards (codex round):
+
+    * the ``{prefix}_*`` namespace is RESERVED — a user metric already named
+      e.g. ``composite_escalation_rate`` raises ``ValueError`` (never a silent
+      overwrite);
+    * the backend ``MeasuresDict`` ceiling (:data:`TOTAL_MEASURES_CEILING`)
+      applies to the WHOLE dict — composite keys are truncated
+      deterministically (and the drop logged) so the total never exceeds it;
+      user metrics are never dropped.
+
+    Returns the SAME dict instance, mutated, for ergonomic
+    ``return merge_composite_measures(metrics, run)`` use.
+    """
+    flattened = composite_measures(run, prefix=prefix)
+
+    collisions = sorted(set(metrics) & set(flattened))
+    if collisions:
+        raise ValueError(
+            f"metrics dict already carries reserved {prefix}_* key(s) "
+            f"{collisions[:5]} — the composite telemetry namespace is "
+            "reserved; rename the user metric(s) or choose another prefix"
+        )
+
+    budget = TOTAL_MEASURES_CEILING - len(metrics)
+    if budget <= 0:
+        logger.warning(
+            "merge_composite_measures: user metrics already at the %d-key "
+            "ceiling; ALL %d composite measure(s) dropped",
+            TOTAL_MEASURES_CEILING,
+            len(flattened),
+        )
+        return metrics
+    if len(flattened) > budget:
+        keep = dict(list(flattened.items())[:budget])
+        dropped = [k for k in flattened if k not in keep]
+        logger.warning(
+            "merge_composite_measures: total measures would exceed the "
+            "%d-key ceiling; %d composite key(s) dropped deterministically: %s",
+            TOTAL_MEASURES_CEILING,
+            len(dropped),
+            sorted(dropped),
+        )
+        flattened = keep
+
+    metrics.update(flattened)
+    return metrics


### PR DESCRIPTION
## What

Makes composites **visible**: `composite_measures()` flattens the RFC 0002 §3.10 telemetry into MeasuresDict-safe keys, and `merge_composite_measures()` is the fail-closed merge boundary — the `composite_*` namespace is reserved **wholesale** (any prefixed user key raises), the **50-key ceiling applies to the whole metrics dict** (user keys never dropped; composite keys truncated deterministically + logged; an already-over-ceiling user dict raises loud), and flattening is **injectivity-guarded**. Submission-boundary integration test drives the real `submit_trial_result_via_session` path and asserts the `composite_*` keys in the posted body.

Plus the adoption surface: a user docs page (pattern catalog, executing composites, the certified `binary_cascade` recipe, telemetry — procedural claim-scope language) and a runnable **offline example** that prints a certified winner with merged measures.

## Review chain
codex gpt-5.5 xhigh: REJECT (silent user-key collisions; false 50-key claim at the boundary; non-injective flatten) → fixes → REJECT (prefix-wide reservation; >50-user-keys contradiction) → **ACCEPT**. All fixes red-first. Captain re-ran: **1586 tests green**, example verified offline.
Provenance note: initial draft authored by a worker that crashed (529) pre-verification; verified, hardened, and shipped by the captain.

No changes to runtime.py/composites.py/patterns.py (concurrent sibling branch owns them). Quality gates: none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)