### PR TITLE
feat(knobs): ensemble + loop execution — the full RFC 0002 composite algebra runs

### DIFF
--- a/tests/unit/knobs/test_composites_runtime.py
+++ b/tests/unit/knobs/test_composites_runtime.py
@@ -1056,6 +1056,405 @@ class TestNestedCompositeArms:
 
 
 # --------------------------------------------------------------------------- #
+# F1: nested composite arms in GATED cascade positions (§3.2.1)               #
+# --------------------------------------------------------------------------- #
+
+
+def _mv_ensemble(name, *, stage_name, accept_threshold=None):
+    """A nested majority_vote ensemble (the ONLY legal gated nested arm, §3.2)."""
+    accept = (
+        AcceptDecl(stat=StatKind.VOTE_MARGIN, threshold=accept_threshold)
+        if accept_threshold is not None
+        else None
+    )
+    return CompositeNode(
+        name=name,
+        kind=CompositeKind.ENSEMBLE,
+        body=EnsembleBody(
+            arms=(StageArm(stage_name),),
+            aggregate=AggregateDecl(
+                kind=AggregateKind.MAJORITY_VOTE, accept=accept
+            ),
+            cardinality="k",
+        ),
+    )
+
+
+class TestGatedNestedCompositeArm:
+    """F1: a nested majority_vote ensemble sitting in a GATED cascade position.
+
+    (a) Its OWN vote stats must feed the cascade gate (margin surfaced), so it
+        no longer errors with 'feeds a gate but has no key_fn'.
+    (b) A gated arm's no_accept ESCALATES (i < m); only the terminal arm's
+        no_accept becomes the cascade's no_accept (§3.2.1).
+    """
+
+    def _outer(self):
+        return CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(CompositeArm("inner"), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+
+    def test_gated_nested_ensemble_high_margin_stops_and_returns_its_output(self):
+        # inner unanimous: vote margin 1.0 >= gate t 0.5 -> NO escalate; the
+        # cascade selects the nested ensemble arm and returns ITS output.
+        inner = _mv_ensemble("inner", stage_name="i")
+        outer = self._outer()
+        stages = {"i": _stage(["A", "A", "A"]), "b": _stage(["B"])}
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 3},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A"  # the nested ensemble's selected output
+        assert result.measures["stage_selected"] == 0
+        assert result.measures["escalation_rate"] == 0.0
+
+    def test_gated_nested_ensemble_low_margin_escalates(self):
+        # inner split 1/3: vote margin ~0.33 < gate t 0.9 -> ESCALATE to b.
+        inner = _mv_ensemble("inner", stage_name="i")
+        outer = self._outer()
+        stages = {"i": _stage(["x", "y", "z"]), "b": _stage(["B"])}
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 3},
+            calibrated_values={"t": 0.9},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "B"  # escalated to the expert stage arm
+        assert result.measures["stage_selected"] == 1
+        assert result.measures["escalation_rate"] == 1.0
+
+    def test_gated_nested_no_accept_escalates_to_next_stage(self):
+        # F1(b) PROBE: inner has an accept gate that FAILS (margin 0.5 < acc 0.9)
+        # -> nested no_accept. At a GATED position (i < m) that no_accept MUST
+        # escalate to the next stage, NOT become the cascade's no_accept.
+        inner = _mv_ensemble("inner", stage_name="i", accept_threshold="acc")
+        outer = self._outer()
+        stages = {"i": _stage(["p", "q"]), "b": _stage(["B"])}
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 2},
+            calibrated_values={"t": 0.5, "acc": 0.9},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "B"  # escalated past the no_accept gated arm
+        assert result.measures["stage_selected"] == 1
+        assert result.measures["escalation_rate"] == 1.0
+
+    def test_terminal_nested_no_accept_still_yields_cascade_no_accept(self):
+        # Contrast: a no_accept at the TERMINAL arm DOES become cascade
+        # no_accept (the existing §3.2.1 propagation must be preserved).
+        inner = _mv_ensemble("inner", stage_name="i", accept_threshold="acc")
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        stages = {"a": _stage(["x", "y"]), "i": _stage(["p", "q"])}
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 2},
+            calibrated_values={"t": 0.9, "acc": 0.9},  # a escalates; inner no_accept
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+
+    def test_gated_nested_error_propagates_as_error(self):
+        # A nested ERROR is absorbing even at a gated position.
+        inner = _mv_ensemble("inner", stage_name="i")
+        outer = self._outer()
+
+        def boom(_i):
+            raise RuntimeError("nested ensemble stage exploded")
+
+        stages = {
+            "i": StageRunner(run=boom, key_fn=lambda x: x, samples=1),
+            "b": _stage(["B"]),
+        }
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 1},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.ERROR
+
+
+# --------------------------------------------------------------------------- #
+# F2: single-arm SAMPLING ensemble over a CompositeArm body                   #
+# --------------------------------------------------------------------------- #
+
+
+class TestSamplingEnsembleNestedComposite:
+    def test_sampling_runs_nested_composite_k_times_keyed_by_output(self):
+        # F2 PROBE: a single-arm (sampling) ensemble whose ONE arm is a
+        # CompositeArm must run the nested composite k times (each run = one
+        # candidate, keyed by its output) — NOT KeyError on stages[ref].
+        leaf = CompositeNode(
+            name="leaf",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("s"),), gates=()),
+        )
+        samp = CompositeNode(
+            name="samp",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(CompositeArm("leaf"),),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+                cardinality="k",
+            ),
+        )
+        # leaf produces a value that depends on a per-call counter so the k runs
+        # are observable as k distinct candidate evaluations.
+        calls = {"n": 0}
+
+        def s(_item):
+            calls["n"] += 1
+            # first two runs -> 'A', third -> 'B' (majority A, margin 2/3).
+            return "A" if calls["n"] <= 2 else "B"
+
+        result = execute_composite(
+            samp,
+            {"s": s},
+            config={"k": 3},
+            calibrated_values={},
+            registry={"samp": samp, "leaf": leaf},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A"  # 2/3 majority over the nested runs
+        assert result.measures["candidates_evaluated"] == 3
+        assert result.measures["vote_margin"] == pytest.approx(2 / 3)
+        assert calls["n"] == 3  # the nested composite ran EXACTLY k times
+
+
+# --------------------------------------------------------------------------- #
+# F3: committee arms contribute EXACTLY ONE candidate (the selected output)   #
+# --------------------------------------------------------------------------- #
+
+
+class TestCommitteeOneCandidatePerArm:
+    def test_multisample_committee_stage_arm_contributes_one_candidate(self):
+        # F3 PROBE: a samples=3 member must NOT get triple vote weight. With
+        # a=[A,A,A] and b=[B] the committee has EXACTLY 2 candidates (A, B),
+        # vote_margin 0.5 — NOT 4 candidates / 0.75 (which could falsely pass a
+        # stat_at_least accept gate).
+        comm = CompositeNode(
+            name="comm",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a"), StageArm("b")),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+            ),
+        )
+        stages = {"a": _stage(["A", "A", "A"]), "b": _stage(["B"])}
+        result = execute_composite(
+            comm, stages, config={}, calibrated_values={}, registry={"comm": comm}
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.measures["candidates_evaluated"] == 2  # one per arm
+        assert result.measures["vote_margin"] == pytest.approx(0.5)
+
+    def test_committee_arm_selected_output_is_its_majority_winner(self):
+        # Each multisample committee arm contributes its OWN majority winner.
+        # a=[A,A,B] -> winner A; b=[C,C,D] -> winner C; committee = {A, C},
+        # a 2-way tie at margin 0.5 (deterministic representative).
+        comm = CompositeNode(
+            name="comm",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a"), StageArm("b")),
+                aggregate=AggregateDecl(kind=AggregateKind.MAJORITY_VOTE),
+            ),
+        )
+        stages = {"a": _stage(["A", "A", "B"]), "b": _stage(["C", "C", "D"])}
+        result = execute_composite(
+            comm, stages, config={}, calibrated_values={}, registry={"comm": comm}
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.measures["candidates_evaluated"] == 2
+        assert result.measures["vote_margin"] == pytest.approx(0.5)
+        assert result.output in {"A", "C"}  # one arm's selected winner
+
+    def test_inflated_weight_does_not_falsely_pass_accept_gate(self):
+        # The bug's HARM: with the old 4-candidate / 0.75 margin a 0.7 accept
+        # threshold would FALSELY pass. The correct 0.5 margin must FAIL it.
+        comm = CompositeNode(
+            name="comm",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(StageArm("a"), StageArm("b")),
+                aggregate=AggregateDecl(
+                    kind=AggregateKind.MAJORITY_VOTE,
+                    accept=AcceptDecl(stat=StatKind.VOTE_MARGIN, threshold="acc"),
+                ),
+            ),
+        )
+        stages = {"a": _stage(["A", "A", "A"]), "b": _stage(["B"])}
+        result = execute_composite(
+            comm,
+            stages,
+            config={},
+            calibrated_values={"acc": 0.7},
+            registry={"comm": comm},
+        )
+        # correct margin 0.5 < 0.7 -> honest no_accept (NOT a false OUTPUT)
+        assert result.result_kind is ResultKind.NO_ACCEPT
+
+
+# --------------------------------------------------------------------------- #
+# F5: deep fail-closed preflight over ALL reachable composites                #
+# --------------------------------------------------------------------------- #
+
+
+class TestDeepPreflight:
+    def test_missing_stage_in_unselected_nested_arm_is_error_upfront(self):
+        # F5 PROBE: 'a' is unanimous so the gate STOPS at it and the nested
+        # 'inner' arm is never selected — yet 'inner' references stage 'z' which
+        # is not provided. The deep preflight must fail closed BEFORE any arm
+        # runs, never return the root's silent output.
+        inner = CompositeNode(
+            name="inner",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("z"),), gates=()),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        result = execute_composite(
+            outer,
+            {"a": _stage(["A", "A", "A"])},  # 'z' (inside inner) absent
+            config={},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "missing stage callable" in (result.error or "")
+        assert "z" in (result.error or "")
+
+    def test_missing_signal_in_unreached_nested_loop_is_error_upfront(self):
+        # A nested signal_accept loop arm whose signal is not provided fails
+        # closed upfront even if the loop arm is never selected.
+        innerloop = CompositeNode(
+            name="innerloop",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=StageArm("lb"),
+                stop=StopDecl(
+                    kind=StopKind.SIGNAL_ACCEPT,
+                    threshold="lt",
+                    signal=SignalUse(signal="needed_sig", inputs=()),
+                ),
+                state_keys=(),
+                max_iters=2,
+            ),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("innerloop")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        result = execute_composite(
+            outer,
+            {"a": _stage(["A", "A", "A"]), "lb": lambda _i: "x"},
+            config={},
+            calibrated_values={"t": 0.5, "lt": 0.5},
+            registry={"outer": outer, "innerloop": innerloop},
+            signals={},  # 'needed_sig' absent
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "not provided" in (result.error or "")
+        assert "needed_sig" in (result.error or "")
+
+    def test_missing_predicate_in_unreached_nested_loop_is_error_upfront(self):
+        innerloop = CompositeNode(
+            name="innerloop",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=StageArm("lb"),
+                stop=StopDecl(kind=StopKind.EXTERNAL_ACCEPT, predicate="needed_pred"),
+                state_keys=(),
+                max_iters=2,
+            ),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("innerloop")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        result = execute_composite(
+            outer,
+            {"a": _stage(["A", "A", "A"]), "lb": lambda _i: "x"},
+            config={},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer, "innerloop": innerloop},
+            predicates={},  # 'needed_pred' absent
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "not provided" in (result.error or "")
+        assert "needed_pred" in (result.error or "")
+
+    def test_all_present_deep_chain_executes_normally(self):
+        # Sanity: when every reachable leaf/signal/predicate IS provided the
+        # preflight is transparent (no spurious error).
+        inner = CompositeNode(
+            name="inner",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("z"),), gates=()),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        result = execute_composite(
+            outer,
+            {"a": _stage(["A", "A", "A"]), "z": lambda _i: "Z"},
+            config={},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A"  # gate stops at the unanimous first arm
+
+
+# --------------------------------------------------------------------------- #
 # K-chain unroll execution (§3.8) + trace-equality property + teeth twin      #
 # --------------------------------------------------------------------------- #
 
@@ -1133,6 +1532,42 @@ class TestKChainExecutionBasics:
         )
         assert result.result_kind is ResultKind.ERROR
 
+    def test_kchain_body_error_is_error_parity_with_live_loop(self):
+        # F4 PROBE: a body that reports an ERROR result-kind must ABSORB to an
+        # error in BOTH executors. The live loop already does; the K-chain used
+        # to treat the ERROR cell's .output as a produced output ('output bad')
+        # — fail-closed parity broken. After the fix both yield ERROR.
+        knob = _refine_knob(max_iters=4)
+
+        def err_body():
+            def run(_item, _state):
+                # ERROR result whose state WOULD cross theta if (wrongly) read
+                # as an output — exposing the K-chain's 'output bad' divergence.
+                return LoopBodyResult(
+                    output="bad", state={"draft": 1.0}, result_kind=ResultKind.ERROR
+                )
+
+            return LoopBodyRunner(run=run)
+
+        signal = lambda s: s["draft"]
+        loop = execute_composite(
+            knob.structure,
+            {"body": err_body()},
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"quality": signal},
+        )
+        chain = execute_kchain(
+            knob.unroll(4),
+            err_body(),
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"quality": signal},
+        )
+        assert loop.result_kind is ResultKind.ERROR
+        assert chain.result_kind is ResultKind.ERROR
+        assert chain.output is None  # never a produced 'output bad'
+
 
 @settings(max_examples=120, deadline=None)
 @given(
@@ -1169,6 +1604,75 @@ def test_kchain_trace_equals_live_loop_under_conditions_1_3(k, values, theta):
     chain_result = execute_kchain(
         chain,
         _seq_body(values),  # fresh body with the SAME deterministic sequence
+        config={},
+        calibrated_values={"theta": theta},
+        signals={"quality": signal},
+    )
+
+    assert loop.result_kind is chain_result.result_kind
+    assert loop.output == chain_result.output
+    assert loop.measures.get("iterations_used") == chain_result.measures.get(
+        "iterations_used"
+    )
+    assert loop.measures.get("stop_reason") == chain_result.measures.get("stop_reason")
+
+
+def _seq_body_with_error(values, error_at):
+    """A deterministic body that reports an ERROR result-kind at iteration
+    ``error_at`` (1-based), otherwise behaving like :func:`_seq_body`.
+
+    The ERROR cell is the §3.2.1 absorbing error a body honestly reports — the
+    live loop and the K-chain MUST absorb it identically (F4 parity). ``None``
+    error_at means no error cell (a pure value body)."""
+    counter = {"i": 0}
+
+    def run(_item, _state):
+        counter["i"] += 1
+        i = counter["i"]  # 1-based iteration index
+        v = values[min(i - 1, len(values) - 1)]
+        if error_at is not None and i == error_at:
+            return LoopBodyResult(
+                output=v, state={"draft": v}, result_kind=ResultKind.ERROR
+            )
+        return LoopBodyResult(output=v, state={"draft": v})
+
+    return LoopBodyRunner(run=run)
+
+
+@settings(max_examples=120, deadline=None)
+@given(
+    k=st.integers(min_value=1, max_value=4),
+    values=st.lists(
+        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+        min_size=4,
+        max_size=4,
+    ),
+    theta=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+    error_at=st.integers(min_value=1, max_value=4),
+)
+def test_kchain_trace_equals_live_loop_with_error_result_kind_bodies(
+    k, values, theta, error_at
+):
+    """§3.8 claim C5 EXTENDED (reviewer non-blocker, F4): the trace-equality
+    holds even when the body reports an ERROR result-kind (the §3.2.1 absorbing
+    error). Whether the error cell is reached before acceptance or not, BOTH
+    executors produce the SAME trace — proving fail-closed parity over the full
+    result-kind codomain, not just OUTPUT/no_accept."""
+    knob = _refine_knob(max_iters=k)
+    node = knob.structure
+    chain = knob.unroll(k)
+    signal = lambda s: s["draft"]
+
+    loop = execute_composite(
+        node,
+        {"body": _seq_body_with_error(values, error_at)},
+        config={},
+        calibrated_values={"theta": theta},
+        signals={"quality": signal},
+    )
+    chain_result = execute_kchain(
+        chain,
+        _seq_body_with_error(values, error_at),
         config={},
         calibrated_values={"theta": theta},
         signals={"quality": signal},

--- a/tests/unit/knobs/test_composites_runtime.py
+++ b/tests/unit/knobs/test_composites_runtime.py
@@ -1199,6 +1199,68 @@ class TestGatedNestedCompositeArm:
         assert result.result_kind is ResultKind.ERROR
 
 
+class TestDriverSampleCardinalityParity:
+    """Codex round-2 blocker: the manual driver must keep the engine's
+
+    ``StageSpec.samples >= 1`` validation. A ``samples=0`` stage arm behind the
+    new gated-nested driver path must fail CLOSED (§3.2.1 error), never return
+    ``OUTPUT None``.
+    """
+
+    def _outer(self):
+        return CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(CompositeArm("inner"), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+
+    def test_zero_sample_terminal_stage_arm_fails_closed(self):
+        # RED PROBE (pre-fix: OUTPUT None): split inner escalates to a
+        # samples=0 terminal arm -> must be an ERROR, not a silent None output.
+        inner = _mv_ensemble("inner", stage_name="i")
+        empty = StageRunner(run=lambda _i: [], key_fn=lambda x: x, samples=0)
+        outer = self._outer()
+        result = execute_composite(
+            outer,
+            {"i": _stage(["x", "y", "z"]), "b": empty},
+            config={"k": 3},
+            calibrated_values={"t": 0.9},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "samples" in (result.error or "")
+
+    def test_zero_sample_gated_stage_arm_fails_closed(self):
+        # Twin at the GATED position: stage arm 'g' (samples=0) feeds a gate.
+        inner = _mv_ensemble("inner", stage_name="i")
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("g"), CompositeArm("inner"), StageArm("b")),
+                gates=(
+                    GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),
+                    GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),
+                ),
+                placement=Placement.POST,
+            ),
+        )
+        empty = StageRunner(run=lambda _i: [], key_fn=lambda x: x, samples=0)
+        result = execute_composite(
+            outer,
+            {"g": empty, "i": _stage(["A", "A", "A"]), "b": _stage(["B"])},
+            config={"k": 3},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "samples" in (result.error or "")
+
+
 # --------------------------------------------------------------------------- #
 # F2: single-arm SAMPLING ensemble over a CompositeArm body                   #
 # --------------------------------------------------------------------------- #

--- a/tests/unit/knobs/test_composites_runtime.py
+++ b/tests/unit/knobs/test_composites_runtime.py
@@ -41,22 +41,41 @@ from traigent.knobs import (
     issue_certificate,
 )
 from traigent.knobs.composites import (
+    AcceptDecl,
+    AggregateDecl,
+    AggregateKind,
     CascadeBody,
     CompositeArm,
     CompositeKind,
     CompositeNode,
+    EnsembleBody,
     GateDecl,
     GateKind,
+    LoopBody,
     Placement,
     SignalUse,
     StageArm,
+    StatKind,
+    StopDecl,
+    StopKind,
 )
-from traigent.knobs.patterns import binary_cascade, self_consistency, self_debug
+from traigent.knobs.patterns import (
+    best_of_n,
+    binary_cascade,
+    n_cascade,
+    self_consistency,
+    self_debug,
+    self_refine,
+)
 from traigent.knobs.runtime import (
     CompositeRunResult,
+    LoopBodyResult,
+    LoopBodyRunner,
     ResultKind,
     StageRunner,
+    StopReason,
     execute_composite,
+    execute_kchain,
 )
 
 GATE = "router_margin_threshold"
@@ -156,40 +175,18 @@ class TestBinaryCascadeExecution:
 
 
 # --------------------------------------------------------------------------- #
-# Deferred kinds raise loudly (honest, never faked)                           #
+# Surviving deferrals raise loudly (honest, never faked)                      #
 # --------------------------------------------------------------------------- #
 
 
-class TestDeferredKinds:
-    def test_nested_composite_arm_raises_not_implemented(self):
-        node = CompositeNode(
-            name="outer",
-            kind=CompositeKind.CASCADE,
-            body=CascadeBody(
-                arms=(StageArm("a"), CompositeArm("inner")),
-                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
-                placement=Placement.POST,
-            ),
-        )
-        with pytest.raises(NotImplementedError, match="nested-composite"):
-            execute_composite(
-                node,
-                {"a": _stage(["x"])},
-                config={},
-                calibrated_values={"t": 0.5},
-            )
+class TestSurvivingDeferrals:
+    """The two genuinely-deferred surfaces (pre-cascade dispatch + a
+    nested-composite LOOP body) raise NotImplementedError naming the gap.
 
-    def test_ensemble_root_raises_not_implemented(self):
-        node = self_consistency(
-            "sc", stage="a", cardinality="k", accept_threshold="acc"
-        ).structure
-        with pytest.raises(NotImplementedError, match="ensemble"):
-            execute_composite(node, {}, config={}, calibrated_values={})
-
-    def test_loop_root_raises_not_implemented(self):
-        node = self_debug("sd", stage="a", predicate="tests", max_iters=2).structure
-        with pytest.raises(NotImplementedError, match="loop"):
-            execute_composite(node, {}, config={}, calibrated_values={})
+    Every OTHER former deferral (ensemble/loop roots, nested-composite cascade
+    AND ensemble arms, the K-chain unroll) is now executed end-to-end — proven
+    by the execution test classes below.
+    """
 
     def test_pre_cascade_dispatch_raises_not_implemented(self):
         node = CompositeNode(
@@ -213,6 +210,33 @@ class TestDeferredKinds:
                 {"a": _stage(["x"]), "b": _stage(["y"])},
                 config={},
                 calibrated_values={"t": 0.5},
+            )
+
+    def test_nested_composite_loop_body_raises_not_implemented(self):
+        # A loop whose BODY is a nested composite has no v1 state-producing
+        # convention -> deferred (stage-bodied loops execute fully).
+        inner = CompositeNode(
+            name="inner",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("a"),), gates=(), placement=Placement.POST),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=CompositeArm("inner"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                state_keys=(),
+                max_iters=2,
+            ),
+        )
+        with pytest.raises(NotImplementedError, match="nested-composite loop"):
+            execute_composite(
+                outer,
+                {"a": lambda _i: "x"},
+                config={},
+                calibrated_values={},
+                registry={"inner": inner, "outer": outer},
             )
 
 
@@ -415,3 +439,824 @@ class TestPerGateTelemetryIndexed:
         assert result.result_kind is ResultKind.OUTPUT
         per_gate = result.measures["gate_margin_pass_rate"]
         assert per_gate == {0: 0.0, 1: 1.0}  # BOTH gates preserved by INDEX
+
+
+# --------------------------------------------------------------------------- #
+# Ensemble execution (§3.2 sampling/committee; majority_vote/judge_max)       #
+# --------------------------------------------------------------------------- #
+
+
+class TestEnsembleSamplingMajorityVote:
+    """Sampling form: one arm runs k times, majority_vote over keys (§3.2).
+
+    Reuses the shipped cascade.vote_over (RFC 0001 tie/abstain rules) — never a
+    reimplementation; telemetry is the §3.10 ensemble dict.
+    """
+
+    def _sc(self, accept_threshold=None):
+        return self_consistency(
+            "sc", stage="a", cardinality="k", accept_threshold=accept_threshold
+        ).structure
+
+    def test_majority_winner_and_telemetry(self):
+        # k=3: A,A,B -> winner A, margin 2/3, agreement 3/3
+        node = self._sc()
+        stages = {"a": _stage(["A", "A", "B"])}
+        result = execute_composite(node, stages, config={"k": 3}, calibrated_values={})
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A"
+        assert result.measures["candidates_evaluated"] == 3
+        assert result.measures["candidates_excluded"] == 0
+        assert result.measures["vote_margin"] == pytest.approx(2 / 3)
+        assert result.measures["vote_agreement"] == pytest.approx(1.0)
+
+    def test_accept_gate_passes_when_margin_at_or_above_theta(self):
+        node = self._sc(accept_threshold="acc")
+        stages = {"a": _stage(["A", "A", "A"])}  # unanimous -> margin 1.0
+        result = execute_composite(
+            node, stages, config={"k": 3}, calibrated_values={"acc": 0.6}
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A"
+
+    def test_accept_gate_failure_is_no_accept_not_error(self):
+        # margin 2/3 < theta 0.9 -> HONEST no_accept (§3.2.1), telemetry kept.
+        node = self._sc(accept_threshold="acc")
+        stages = {"a": _stage(["A", "A", "B"])}
+        result = execute_composite(
+            node, stages, config={"k": 3}, calibrated_values={"acc": 0.9}
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert result.output is None
+        assert result.measures["vote_margin"] == pytest.approx(2 / 3)
+
+    def test_cardinality_resolves_from_calibrated_when_absent_in_config(self):
+        node = self._sc()
+        stages = {"a": _stage(["A", "A"])}
+        result = execute_composite(node, stages, config={}, calibrated_values={"k": 2})
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.measures["candidates_evaluated"] == 2
+
+    def test_cardinality_below_one_is_error_r9(self):
+        node = self._sc()
+        result = execute_composite(
+            node, {"a": _stage([])}, config={"k": 0}, calibrated_values={}
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "R9" in (result.error or "")
+
+    def test_missing_cardinality_value_is_error(self):
+        node = self._sc()
+        result = execute_composite(
+            node, {"a": _stage(["A"])}, config={}, calibrated_values={}
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "unresolved" in (result.error or "")
+
+    def test_sample_count_mismatch_is_error(self):
+        # arm declared k=3 but produced 2 -> the effectuation did not happen.
+        node = self._sc()
+        result = execute_composite(
+            node, {"a": _stage(["A", "B"])}, config={"k": 3}, calibrated_values={}
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "k=3" in (result.error or "")
+
+
+class TestEnsembleJudgeMax:
+    """judge_max: judge scores each candidate; max wins; the judge output
+    contract (finite numeric score) gates exclusion vs. all-excluded failure."""
+
+    def _bon(self):
+        return best_of_n("bon", stage="a", judge_stage="j", cardinality="k").structure
+
+    def test_judge_max_selects_highest_score(self):
+        node = self._bon()
+        scores = {"x": 0.2, "y": 0.9, "z": 0.5}
+        stages = {
+            "a": _stage(["x", "y", "z"]),
+            "j": StageRunner(run=lambda cand: [scores[cand]], samples=1),
+        }
+        result = execute_composite(node, stages, config={"k": 3}, calibrated_values={})
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "y"  # the max-scored candidate
+        assert result.measures["candidates_evaluated"] == 3
+        assert result.measures["candidates_excluded"] == 0
+
+    def test_nan_score_candidate_is_excluded(self):
+        node = self._bon()
+        scores = {"x": float("nan"), "y": 0.4}
+        stages = {
+            "a": _stage(["x", "y"]),
+            "j": StageRunner(run=lambda cand: [scores[cand]], samples=1),
+        }
+        result = execute_composite(node, stages, config={"k": 2}, calibrated_values={})
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "y"  # x excluded by NaN
+        assert result.measures["candidates_excluded"] == 1
+
+    def test_judge_exception_excludes_candidate(self):
+        node = self._bon()
+
+        def judge(cand):
+            if cand == "x":
+                raise RuntimeError("judge blew up on x")
+            return [0.7]
+
+        stages = {
+            "a": _stage(["x", "y"]),
+            "j": StageRunner(run=judge, samples=1),
+        }
+        result = execute_composite(node, stages, config={"k": 2}, calibrated_values={})
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "y"
+        assert result.measures["candidates_excluded"] == 1
+
+    def test_all_excluded_by_error_fails(self):
+        # ALL candidates excluded by judge-contract violation -> error (§3.2.1),
+        # DISTINCT from a committee all-excluded-by-no_accept.
+        node = self._bon()
+        stages = {
+            "a": _stage(["x", "y"]),
+            "j": StageRunner(run=lambda _c: [float("inf")], samples=1),
+        }
+        result = execute_composite(node, stages, config={"k": 2}, calibrated_values={})
+        assert result.result_kind is ResultKind.ERROR
+        assert "all candidates excluded" in (result.error or "")
+
+    def test_score_tie_breaks_by_deterministic_serialized_key_order(self):
+        # x and y tie at 0.5; the SMALLEST serialized key ('x') wins (§3.2).
+        node = self._bon()
+        stages = {
+            "a": _stage(["y", "x"]),  # note order: y first
+            "j": StageRunner(run=lambda _c: [0.5], samples=1),
+        }
+        result = execute_composite(node, stages, config={"k": 2}, calibrated_values={})
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "x"  # deterministic, order-independent
+
+
+class TestEnsembleCommittee:
+    """Committee form (|arms| > 1): each arm runs once; a committee arm
+    yielding no_accept is excluded; ALL-excluded-by-no_accept -> no_accept."""
+
+    def _committee(self, accept_threshold=None):
+        accept = (
+            AcceptDecl(stat=StatKind.VOTE_MARGIN, threshold=accept_threshold)
+            if accept_threshold is not None
+            else None
+        )
+        return CompositeNode(
+            name="committee",
+            kind=CompositeKind.ENSEMBLE,
+            body=EnsembleBody(
+                arms=(CompositeArm("m1"), CompositeArm("m2"), CompositeArm("m3")),
+                aggregate=AggregateDecl(
+                    kind=AggregateKind.MAJORITY_VOTE, accept=accept
+                ),
+            ),
+        )
+
+    def _member(self, name, outputs):
+        return CompositeNode(
+            name=name,
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("s"),), gates=(), placement=Placement.POST),
+        )
+
+    def test_committee_majority_over_member_outputs(self):
+        committee = self._committee()
+        # Three single-stage cascade members, each producing one output.
+        registry = {
+            "committee": committee,
+            "m1": CompositeNode(
+                name="m1",
+                kind=CompositeKind.CASCADE,
+                body=CascadeBody(arms=(StageArm("s1"),), gates=()),
+            ),
+            "m2": CompositeNode(
+                name="m2",
+                kind=CompositeKind.CASCADE,
+                body=CascadeBody(arms=(StageArm("s2"),), gates=()),
+            ),
+            "m3": CompositeNode(
+                name="m3",
+                kind=CompositeKind.CASCADE,
+                body=CascadeBody(arms=(StageArm("s3"),), gates=()),
+            ),
+        }
+        stages = {
+            "s1": lambda _i: "P",
+            "s2": lambda _i: "P",
+            "s3": lambda _i: "Q",
+        }
+        result = execute_composite(
+            committee, stages, config={}, calibrated_values={}, registry=registry
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "P"  # 2/3 majority
+        assert result.measures["candidates_evaluated"] == 3
+
+    def test_all_committee_arms_no_accept_yields_no_accept(self):
+        # Each member is a self_consistency with an accept gate that ALL fail,
+        # so every committee candidate is excluded by no_accept -> no_accept.
+        committee = self._committee()
+
+        def member(name):
+            return CompositeNode(
+                name=name,
+                kind=CompositeKind.ENSEMBLE,
+                body=EnsembleBody(
+                    arms=(StageArm(f"{name}_s"),),
+                    aggregate=AggregateDecl(
+                        kind=AggregateKind.MAJORITY_VOTE,
+                        accept=AcceptDecl(stat=StatKind.VOTE_MARGIN, threshold="acc"),
+                    ),
+                    cardinality="k",
+                ),
+            )
+
+        registry = {
+            "committee": committee,
+            "m1": member("m1"),
+            "m2": member("m2"),
+            "m3": member("m3"),
+        }
+        stages = {
+            "m1_s": _stage(["a", "b"]),  # margin 0.5 < acc 0.9 -> no_accept
+            "m2_s": _stage(["a", "b"]),
+            "m3_s": _stage(["a", "b"]),
+        }
+        result = execute_composite(
+            committee,
+            stages,
+            config={"k": 2},
+            calibrated_values={"acc": 0.9},
+            registry=registry,
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert result.measures["candidates_excluded"] == 3
+
+
+# --------------------------------------------------------------------------- #
+# Loop execution (§3.2 signal_accept / external_accept / exhausted)           #
+# --------------------------------------------------------------------------- #
+
+
+def _stateful_body(seq, signal_key="draft"):
+    """A loop body whose successive outputs are `seq`, threading them on
+    `signal_key`. Iteration i returns LoopBodyResult(output=seq[i],
+    state={signal_key: seq[i]})."""
+    counter = {"i": 0}
+
+    def run(_item, _state):
+        i = counter["i"]
+        counter["i"] += 1
+        value = seq[min(i, len(seq) - 1)]
+        return LoopBodyResult(output=value, state={signal_key: value})
+
+    return LoopBodyRunner(run=run)
+
+
+class TestLoopSignalAccept:
+    """signal_accept loop: σ(state) >= θ accepts; stop_reason/iterations_used."""
+
+    def _sr(self, max_iters):
+        return self_refine(
+            "sr",
+            stage="body",
+            signal="quality",
+            threshold="theta",
+            max_iters=max_iters,
+        ).structure
+
+    def test_accepts_when_signal_reaches_theta(self):
+        node = self._sr(max_iters=4)
+        # quality rises 0.2, 0.5, 0.95; theta 0.9 -> accepts on iteration 3.
+        body = _stateful_body([0.2, 0.5, 0.95])
+        quality = lambda state: state["draft"]
+        result = execute_composite(
+            node,
+            {"body": body},
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"quality": quality},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == 0.95
+        assert result.measures["iterations_used"] == 3
+        assert result.measures["stop_reason"] == StopReason.SIGNAL_ACCEPT.value
+
+    def test_exhausts_without_acceptance_yields_no_accept(self):
+        node = self._sr(max_iters=2)
+        body = _stateful_body([0.1, 0.2])
+        quality = lambda state: state["draft"]
+        result = execute_composite(
+            node,
+            {"body": body},
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"quality": quality},
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert result.measures["iterations_used"] == 2
+        assert result.measures["stop_reason"] == StopReason.EXHAUSTED.value
+
+    def test_missing_signal_is_error_fail_closed(self):
+        node = self._sr(max_iters=2)
+        result = execute_composite(
+            node,
+            {"body": _stateful_body([0.5])},
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={},  # signal absent -> fail closed
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "not provided" in (result.error or "")
+
+    def test_missing_threshold_is_error_fail_closed(self):
+        node = self._sr(max_iters=2)
+        result = execute_composite(
+            node,
+            {"body": _stateful_body([0.5])},
+            config={},
+            calibrated_values={},  # threshold absent
+            signals={"quality": lambda s: s["draft"]},
+        )
+        assert result.result_kind is ResultKind.ERROR
+
+    def test_body_exception_is_error(self):
+        node = self._sr(max_iters=2)
+
+        def boom(_item, _state):
+            raise RuntimeError("body blew up")
+
+        result = execute_composite(
+            node,
+            {"body": LoopBodyRunner(run=boom)},
+            config={},
+            calibrated_values={"theta": 0.5},
+            signals={"quality": lambda s: 1.0},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "RuntimeError" in (result.error or "")
+
+
+class TestLoopExternalAccept:
+    """external_accept loop: opaque predicate over state decides acceptance."""
+
+    def _sd(self, max_iters):
+        return self_debug(
+            "sd", stage="body", predicate="tests_pass", max_iters=max_iters
+        ).structure
+
+    def test_predicate_accepts(self):
+        node = self._sd(max_iters=3)
+        calls = {"n": 0}
+
+        def body(_item, _state):
+            calls["n"] += 1
+            return LoopBodyResult(output=f"attempt{calls['n']}", state={})
+
+        def predicate(_state):
+            return calls["n"] >= 2  # accepts on the 2nd attempt
+
+        result = execute_composite(
+            node,
+            {"body": LoopBodyRunner(run=body)},
+            config={},
+            calibrated_values={},
+            predicates={"tests_pass": predicate},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "attempt2"
+        assert result.measures["iterations_used"] == 2
+        assert result.measures["stop_reason"] == StopReason.EXTERNAL_ACCEPT.value
+
+    def test_missing_predicate_is_error_fail_closed(self):
+        node = self._sd(max_iters=2)
+        result = execute_composite(
+            node,
+            {"body": lambda _i: "x"},
+            config={},
+            calibrated_values={},
+            predicates={},  # predicate absent -> fail closed
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "not provided" in (result.error or "")
+
+    def test_never_accepts_yields_no_accept(self):
+        node = self._sd(max_iters=2)
+        result = execute_composite(
+            node,
+            {"body": lambda _i: "x"},
+            config={},
+            calibrated_values={},
+            predicates={"tests_pass": lambda _s: False},
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert result.measures["stop_reason"] == StopReason.EXHAUSTED.value
+
+
+class TestLoopExhausted:
+    """exhausted loop: always runs max_iters; final produced output is the
+    result (no acceptance predicate)."""
+
+    def _exhausted_loop(self, max_iters):
+        return CompositeNode(
+            name="ex",
+            kind=CompositeKind.LOOP,
+            body=LoopBody(
+                body=StageArm("body"),
+                stop=StopDecl(kind=StopKind.EXHAUSTED),
+                state_keys=(),
+                max_iters=max_iters,
+            ),
+        )
+
+    def test_runs_all_iters_and_returns_final_output(self):
+        node = self._exhausted_loop(max_iters=3)
+        seq = ["r1", "r2", "r3"]
+        counter = {"i": 0}
+
+        def body(_item, _state):
+            v = seq[counter["i"]]
+            counter["i"] += 1
+            return LoopBodyResult(output=v, state={})
+
+        result = execute_composite(
+            node,
+            {"body": LoopBodyRunner(run=body)},
+            config={},
+            calibrated_values={},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "r3"  # final produced output
+        assert result.measures["iterations_used"] == 3
+        assert result.measures["stop_reason"] == StopReason.EXHAUSTED.value
+
+
+class TestLoopStateThreading:
+    """State threads over declared state_keys; undeclared keys are dropped."""
+
+    def test_undeclared_state_keys_invisible_to_stop(self):
+        # state_keys=[draft]; the body also produces 'scratch' -> dropped, so
+        # the signal (reading 'draft') only ever sees 'draft'.
+        node = self_refine(
+            "sr",
+            stage="body",
+            signal="q",
+            threshold="theta",
+            max_iters=2,
+            state_keys=("draft",),
+        ).structure
+        seen_keys = []
+
+        def body(_item, state):
+            seen_keys.append(set(state.keys()))
+            return LoopBodyResult(
+                output="x", state={"draft": 1.0, "scratch": "INVISIBLE"}
+            )
+
+        def signal(state):
+            # 'scratch' must NOT be present (dropped: not in state_keys).
+            assert "scratch" not in state
+            return state.get("draft", 0.0)
+
+        result = execute_composite(
+            node,
+            {"body": LoopBodyRunner(run=body)},
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"q": signal},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        # iteration 1 sees empty state; the body's 'scratch' never threads.
+        assert seen_keys[0] == set()
+
+
+# --------------------------------------------------------------------------- #
+# Nested-composite arm execution (§3.2.1 propagation through nesting)          #
+# --------------------------------------------------------------------------- #
+
+
+class TestNestedCompositeArms:
+    def test_nested_cascade_arm_output_lifts_onto_escalation_line(self):
+        # outer cascade: [stage(a), composite(inner)] — a escalates (margin
+        # below theta) to the nested inner composite, whose output is the result.
+        inner = self_consistency("inner", stage="i", cardinality="k").structure
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        registry = {"outer": outer, "inner": inner}
+        stages = {
+            "a": _stage(["x", "y"]),  # margin 0.5 < t 0.9 -> escalate
+            "i": _stage(["W", "W"]),  # nested unanimous -> output W
+        }
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 2},
+            calibrated_values={"t": 0.9},
+            registry=registry,
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "W"  # nested composite's output
+        assert result.measures["stage_selected"] == 1
+
+    def test_nested_error_propagates_to_parent_error(self):
+        # The nested inner stage raises -> parent yields error (absorbing).
+        inner = CompositeNode(
+            name="inner",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(arms=(StageArm("i"),), gates=()),
+        )
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+
+        def boom(_i):
+            raise RuntimeError("nested stage exploded")
+
+        stages = {
+            "a": _stage(["x", "y"]),  # escalate
+            "i": StageRunner(run=boom, samples=1),
+        }
+        result = execute_composite(
+            outer,
+            stages,
+            config={},
+            calibrated_values={"t": 0.9},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "nested composite 'inner' failed" in (result.error or "")
+
+    def test_nested_no_accept_at_last_arm_yields_cascade_no_accept(self):
+        # outer = [stage(a), composite(inner)]; a escalates; inner is a
+        # self_consistency whose accept gate fails -> nested no_accept; at the
+        # LAST arm a no_accept yields cascade no_accept (§3.2.1).
+        inner = self_consistency(
+            "inner", stage="i", cardinality="k", accept_threshold="acc"
+        ).structure
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        stages = {
+            "a": _stage(["x", "y"]),  # escalate
+            "i": _stage(["p", "q"]),  # margin 0.5 < acc 0.9 -> inner no_accept
+        }
+        result = execute_composite(
+            outer,
+            stages,
+            config={"k": 2},
+            calibrated_values={"t": 0.9, "acc": 0.9},
+            registry={"outer": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+
+    def test_missing_nested_ref_is_error_fail_closed(self):
+        outer = CompositeNode(
+            name="outer",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("ghost")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        result = execute_composite(
+            outer,
+            {"a": _stage(["x"])},
+            config={},
+            calibrated_values={"t": 0.5},
+            registry={"outer": outer},  # 'ghost' absent
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "missing composite ref" in (result.error or "")
+        assert "ghost" in (result.error or "")
+
+
+# --------------------------------------------------------------------------- #
+# K-chain unroll execution (§3.8) + trace-equality property + teeth twin      #
+# --------------------------------------------------------------------------- #
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from traigent.knobs.patterns import self_refine as _self_refine  # noqa: E402
+
+
+def _refine_knob(max_iters):
+    return _self_refine(
+        "sr",
+        stage="body",
+        signal="quality",
+        threshold="theta",
+        max_iters=max_iters,
+        state_keys=("draft",),
+    )
+
+
+def _seq_body(values):
+    """A deterministic loop/chain body whose i-th invocation outputs values[i]
+    and threads it on 'draft'. SAME body object convention for both the live
+    loop and the K-chain so traces are comparable."""
+    counter = {"i": 0}
+
+    def run(_item, _state):
+        i = counter["i"]
+        counter["i"] += 1
+        v = values[min(i, len(values) - 1)]
+        return LoopBodyResult(output=v, state={"draft": v})
+
+    return LoopBodyRunner(run=run)
+
+
+class TestKChainExecutionBasics:
+    def test_kchain_accepts_at_first_stage_meeting_theta(self):
+        knob = _refine_knob(max_iters=4)
+        chain = knob.unroll(4)
+        body = _seq_body([0.2, 0.6, 0.95])
+        result = execute_kchain(
+            chain,
+            body,
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"quality": lambda s: s["draft"]},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == 0.95
+        assert result.measures["iterations_used"] == 3
+        assert result.measures["stop_reason"] == StopReason.SIGNAL_ACCEPT.value
+
+    def test_kchain_exhausts_to_no_accept(self):
+        knob = _refine_knob(max_iters=2)
+        chain = knob.unroll(2)
+        body = _seq_body([0.1, 0.2])
+        result = execute_kchain(
+            chain,
+            body,
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={"quality": lambda s: s["draft"]},
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert result.measures["stop_reason"] == StopReason.EXHAUSTED.value
+
+    def test_kchain_missing_signal_fail_closed(self):
+        chain = _refine_knob(max_iters=2).unroll(2)
+        result = execute_kchain(
+            chain,
+            _seq_body([0.5]),
+            config={},
+            calibrated_values={"theta": 0.9},
+            signals={},
+        )
+        assert result.result_kind is ResultKind.ERROR
+
+
+@settings(max_examples=120, deadline=None)
+@given(
+    k=st.integers(min_value=1, max_value=4),
+    values=st.lists(
+        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+        min_size=4,
+        max_size=4,
+    ),
+    theta=st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+)
+def test_kchain_trace_equals_live_loop_under_conditions_1_3(k, values, theta):
+    """§3.8 claim C5 (SDK property level): under conditions 1–3 (state flows
+    exclusively through declared state_keys; the stop is a deterministic
+    function of that state — structural for signal_accept; bounded by
+    max_iters), the K-chain execution TRACE equals the live loop's: SAME
+    result_kind, SAME selected output, SAME iterations_used, SAME stop_reason.
+
+    The signal is a PURE deterministic function of the threaded 'draft' state
+    (condition 2), the body threads state ONLY through 'draft' (condition 1),
+    and both are bounded by K = max_iters (condition 3)."""
+    knob = _refine_knob(max_iters=k)
+    node = knob.structure
+    chain = knob.unroll(k)
+    signal = lambda s: s["draft"]
+
+    loop = execute_composite(
+        node,
+        {"body": _seq_body(values)},
+        config={},
+        calibrated_values={"theta": theta},
+        signals={"quality": signal},
+    )
+    chain_result = execute_kchain(
+        chain,
+        _seq_body(values),  # fresh body with the SAME deterministic sequence
+        config={},
+        calibrated_values={"theta": theta},
+        signals={"quality": signal},
+    )
+
+    assert loop.result_kind is chain_result.result_kind
+    assert loop.output == chain_result.output
+    assert loop.measures.get("iterations_used") == chain_result.measures.get(
+        "iterations_used"
+    )
+    assert loop.measures.get("stop_reason") == chain_result.measures.get("stop_reason")
+
+
+def _trace_of(result):
+    """The observable trace tuple the §3.8 C5 property compares (result kind,
+    selected output, iterations_used, stop_reason)."""
+    return (
+        result.result_kind,
+        result.output,
+        result.measures.get("iterations_used"),
+        result.measures.get("stop_reason"),
+    )
+
+
+def test_kchain_teeth_condition1_violation_diverges_detectably():
+    """TEETH twin (model-checking discipline at runtime level).
+
+    The trace-equality property above could be vacuous — passing because the two
+    executors are SO aligned that NO body could ever make them differ. This twin
+    proves it has teeth by constructing a body that VIOLATES §3.8 condition 1
+    (state flows ONLY through declared state_keys) and showing the very same
+    trace comparator the property uses DETECTS the divergence.
+
+    The violation: the body's acceptance behavior depends on AMBIENT mutable
+    state (a hidden counter) NOT threaded through state_keys, and — critically —
+    each executor walks the body a different number of effective times before the
+    ambient counter trips the signal, because the live loop and the chain
+    initialize the ambient state at different points. A correct contract
+    (conditions 1–3) forbids exactly this; under it the property holds. Here we
+    force the violation deterministically and ASSERT the comparator fires —
+    mirroring the model checker's 'add a violating transition and require it be
+    SAT' discipline (the UNSAT-only proof is not enough)."""
+    theta = 0.5
+
+    # Two bodies that share ONE ambient counter (ambient mutation — the cond-1
+    # violation). The signal reads the ambient counter, NOT the threaded draft.
+    # Because the live loop's body and the chain's body increment the SAME shared
+    # ambient across BOTH runs (no reset between them), the chain — run SECOND —
+    # starts from a higher ambient value and accepts at an earlier stage, so the
+    # traces diverge. This is precisely the non-determinism cond-1 rules out.
+    ambient = {"hidden": 0}
+
+    def shared_body():
+        def run(_item, _state):
+            ambient["hidden"] += 1
+            return LoopBodyResult(output=ambient["hidden"], state={"draft": 0})
+
+        return LoopBodyRunner(run=run)
+
+    def ambient_signal(_restricted_state):
+        # Reads ambient (undeclared) state — a cond-1 violation. >= 3 -> accept.
+        return float(ambient["hidden"]) / 1.0 - 2.5  # crosses theta=0.5 at hidden=3
+
+    knob = _refine_knob(max_iters=4)
+
+    # NOTE: NO reset of `ambient` between the two runs — the shared ambient
+    # mutation is the contract violation under test.
+    loop = execute_composite(
+        knob.structure,
+        {"body": shared_body()},
+        config={},
+        calibrated_values={"theta": theta},
+        signals={"quality": ambient_signal},
+    )
+    chain = execute_kchain(
+        knob.unroll(4),
+        shared_body(),
+        config={},
+        calibrated_values={"theta": theta},
+        signals={"quality": ambient_signal},
+    )
+
+    # The comparator the C5 property relies on MUST detect the divergence. If
+    # the traces were equal here, the property would be vacuous.
+    assert _trace_of(loop) != _trace_of(chain), (
+        "teeth twin saw NO divergence under a condition-1 violation; the "
+        "trace-equality property may be vacuous — investigate before trusting C5"
+    )
+    # Concretely: the live loop accepts later (lower ambient start) than the
+    # chain (which begins after the loop already advanced the shared counter).
+    assert loop.measures["iterations_used"] != chain.measures["iterations_used"]

--- a/traigent/knobs/runtime.py
+++ b/traigent/knobs/runtime.py
@@ -561,6 +561,15 @@ def _evaluate_stage_arm(
     error the engine raises ("feeds a gate but has no key_fn").
     """
     runner = _coerce_stage_runner(stages[arm.name])
+    if runner.samples < 1:
+        # Parity with the engine path: ``StageSpec.samples must be >= 1``
+        # (cascade.py). Without this, a samples=0 stage self-consistently
+        # produces zero outputs and the driver would emit a silent
+        # ``OUTPUT None`` — fail closed instead.
+        raise ValueError(
+            f"stage {arm.name!r} declared samples={runner.samples}; "
+            "StageSpec.samples must be >= 1"
+        )
     samples = list(runner.run(config))
     if len(samples) != runner.samples:
         raise ValueError(

--- a/traigent/knobs/runtime.py
+++ b/traigent/knobs/runtime.py
@@ -440,6 +440,290 @@ def _nested_cascade_stage(
     return StageSpec(name=arm.ref, run=_run, key_fn=None, samples=1)
 
 
+@dataclass(frozen=True, slots=True)
+class _ArmOutcome:
+    """One cascade arm's evaluated outcome for the manual driver (F1).
+
+    ``vote`` is the margin-bearing producer's :class:`VoteStats` (a stage's vote
+    over its samples, OR a nested majority_vote ensemble's OWN vote surfaced to
+    the gate); ``None`` for a non-voting terminal arm. ``kind`` is the §3.2.1
+    outcome of THIS arm (``output`` / ``no_accept`` / ``error``).
+    """
+
+    output: Any
+    vote: VoteStats | None
+    kind: ResultKind
+    error: str | None = None
+
+
+def _has_gated_nested_arm(body: CascadeBody) -> bool:
+    """A cascade has a GATED nested-composite arm iff a :class:`CompositeArm`
+    sits at a NON-terminal index (i < m-1, i.e. a position followed by a gate).
+
+    Only this case needs the manual driver (the gate must read the nested arm's
+    OWN vote stats, and a gated arm's no_accept must ESCALATE — neither of which
+    the shipped ``CascadePolicy.decide`` supports for a synthetic stage). The
+    stage-only and terminal-nested cases keep the engine fast path verbatim.
+    """
+    last = len(body.arms) - 1
+    return any(isinstance(arm, CompositeArm) for arm in body.arms[:last])
+
+
+def _run_nested_majority_vote(
+    node: CompositeNode,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> _ArmOutcome:
+    """Run a nested majority_vote ensemble and SURFACE its VoteStats (F1a).
+
+    The ONLY legal gated nested arm is a ``majority_vote`` ensemble (the §3.2
+    margin-bearing-arm rule, ``gate_arm_incompatible``), whose own vote feeds the
+    cascade gate. This collects the nested candidates, runs the SHIPPED
+    ``vote_over`` (never a reimplementation), applies the nested ensemble's OWN
+    accept gate, and returns the representative output + the surfaced vote:
+    ``no_accept`` (accept-gate failure / all-excluded-by-no_accept) and ``error``
+    (absorbing) are reported via :class:`_ArmOutcome.kind` so the cascade driver
+    can ESCALATE (gated) or propagate (§3.2.1).
+    """
+    body = node.body
+    if not (
+        isinstance(body, EnsembleBody)
+        and body.aggregate.kind is AggregateKind.MAJORITY_VOTE
+    ):
+        # Defensive: the IR forbids a non-margin-bearing gated nested arm; if one
+        # reaches here it is a fail-closed error (never a silent gate read).
+        return _ArmOutcome(
+            output=None,
+            vote=None,
+            kind=ResultKind.ERROR,
+            error=(
+                f"composite-runtime: gated nested arm {node.name!r} is not a "
+                "majority_vote ensemble (no margin to feed the gate)"
+            ),
+        )
+    try:
+        candidates, excluded_no_accept = _collect_candidates(
+            body, stages, registry, config, calibrated_values, signals, predicates
+        )
+    except Exception as exc:  # noqa: BLE001 - error is absorbing (§3.2.1)
+        return _ArmOutcome(
+            output=None,
+            vote=None,
+            kind=ResultKind.ERROR,
+            error=f"composite-runtime: {type(exc).__name__}: {exc}",
+        )
+
+    if not candidates:
+        # All-excluded-by-no_accept -> no_accept; truly-no-candidates -> error.
+        if excluded_no_accept > 0:
+            return _ArmOutcome(output=None, vote=None, kind=ResultKind.NO_ACCEPT)
+        return _ArmOutcome(
+            output=None,
+            vote=None,
+            kind=ResultKind.ERROR,
+            error="composite-runtime: nested ensemble produced no candidates",
+        )
+
+    output, vote = _majority_vote(candidates)
+    accept = body.aggregate.accept
+    if accept is not None:
+        try:
+            if not _accept_passes(accept, vote, calibrated_values):
+                # The nested ensemble's accept gate failed -> nested no_accept;
+                # the surfaced vote is still carried for the gate's margin read.
+                return _ArmOutcome(output=None, vote=vote, kind=ResultKind.NO_ACCEPT)
+        except Exception as exc:  # noqa: BLE001 - non-finite threshold -> error
+            return _ArmOutcome(
+                output=None,
+                vote=None,
+                kind=ResultKind.ERROR,
+                error=f"composite-runtime: {type(exc).__name__}: {exc}",
+            )
+    return _ArmOutcome(output=output, vote=vote, kind=ResultKind.OUTPUT)
+
+
+def _evaluate_stage_arm(
+    arm: StageArm,
+    stages: Mapping[str, StageEntry],
+    *,
+    gated: bool,
+    config: Mapping[str, Any],
+) -> _ArmOutcome:
+    """Evaluate a leaf stage arm for the manual driver, mirroring the engine.
+
+    Reproduces ``CascadePolicy.decide``'s per-stage semantics verbatim (sample
+    cardinality enforcement, ``vote_over`` over the keys, deterministic
+    representative). A gated stage with no ``key_fn`` is the SAME fail-closed
+    error the engine raises ("feeds a gate but has no key_fn").
+    """
+    runner = _coerce_stage_runner(stages[arm.name])
+    samples = list(runner.run(config))
+    if len(samples) != runner.samples:
+        raise ValueError(
+            f"stage {arm.name!r} declared samples={runner.samples} "
+            f"but produced {len(samples)}"
+        )
+    if runner.key_fn is None:
+        if gated:
+            raise ValueError(
+                f"stage {arm.name!r} feeds a gate but has no key_fn comparator; "
+                "voting stages require one"
+            )
+        representative = samples[0] if samples else None
+        return _ArmOutcome(output=representative, vote=None, kind=ResultKind.OUTPUT)
+    keys = [runner.key_fn(sample) for sample in samples]
+    vote = vote_over(keys, len(samples))
+    representative = next(
+        (
+            sample
+            for sample, key in zip(samples, keys, strict=False)
+            if key == vote.top_key
+        ),
+        samples[0] if samples else None,
+    )
+    return _ArmOutcome(output=representative, vote=vote, kind=ResultKind.OUTPUT)
+
+
+def _drive_cascade(
+    body: CascadeBody,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult:
+    """The manual post-cascade driver for the GATED-nested-arm case (F1).
+
+    Reuses the SHIPPED gate math (:meth:`Gate.should_escalate`) and ``vote_over``
+    — never a reimplementation. Semantics (§3.2.1):
+
+    - a gated arm's ``no_accept`` ESCALATES (i < m); only the TERMINAL arm's
+      ``no_accept`` becomes the cascade's ``no_accept`` (F1b);
+    - a gated nested majority_vote ensemble's OWN vote feeds the gate (F1a);
+    - an ``error`` is absorbing (propagates to the cascade error).
+    """
+    gates: list[Gate] = []
+    for gate in body.gates:
+        if gate.kind is not IRGateKind.MARGIN_BELOW:  # pragma: no cover - IR-guarded
+            return _error(
+                f"composite-runtime: post-cascade gate kind {gate.kind.value!r} "
+                "is not executable (margin_below only)"
+            )
+        gates.append(
+            Gate(
+                kind=GateKind.MARGIN_BELOW,
+                threshold_ref=_build_threshold_ref(gate.threshold, calibrated_values),
+            )
+        )
+
+    escalations = 0
+    last = len(body.arms) - 1
+    for index, arm in enumerate(body.arms):
+        is_last = index == last
+        try:
+            if isinstance(arm, StageArm):
+                outcome = _evaluate_stage_arm(
+                    arm, stages, gated=not is_last, config=config
+                )
+            elif is_last:
+                # A terminal nested arm: any composite kind; no vote needed.
+                inner = _execute_node(
+                    registry[arm.ref],
+                    stages,
+                    registry,
+                    config,
+                    calibrated_values,
+                    signals,
+                    predicates,
+                )
+                outcome = _ArmOutcome(
+                    output=inner.output,
+                    vote=None,
+                    kind=inner.result_kind,
+                    error=inner.error,
+                )
+            else:
+                # A GATED nested arm MUST be a majority_vote ensemble (F1a).
+                outcome = _run_nested_majority_vote(
+                    registry[arm.ref],
+                    stages,
+                    registry,
+                    config,
+                    calibrated_values,
+                    signals,
+                    predicates,
+                )
+        except Exception as exc:  # noqa: BLE001 - error is absorbing (§3.2.1)
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+        if outcome.kind is ResultKind.ERROR:
+            return _error(
+                outcome.error
+                or f"composite-runtime: cascade arm {index} failed (no detail)"
+            )
+
+        if is_last:
+            step = CascadeStep(
+                stage_index=index,
+                stage_name="",
+                output=outcome.output,
+                representative=outcome.output,
+                vote=outcome.vote,
+                escalations=escalations,
+            )
+            if outcome.kind is ResultKind.NO_ACCEPT:
+                # Only the terminal arm's no_accept becomes the cascade's (F1b).
+                return _no_accept(_cascade_measures(step, body))
+            return CompositeRunResult(
+                output=outcome.output,
+                result_kind=ResultKind.OUTPUT,
+                measures=_cascade_measures(step, body),
+                error=None,
+            )
+
+        # A non-terminal (gated) arm.
+        if outcome.kind is ResultKind.NO_ACCEPT:
+            # F1b: a gated arm's no_accept ESCALATES to the next stage.
+            escalations += 1
+            continue
+        runtime_gate = gates[index]
+        if outcome.vote is None:  # pragma: no cover - guarded above for stages
+            return _error(
+                f"composite-runtime: gated cascade arm {index} has no vote to "
+                "feed the gate (margin-bearing arm required)"
+            )
+        try:
+            escalate = runtime_gate.should_escalate(outcome.vote)
+        except Exception as exc:  # noqa: BLE001 - non-finite/unset threshold
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+        if escalate:
+            escalations += 1
+            continue
+        step = CascadeStep(
+            stage_index=index,
+            stage_name="",
+            output=outcome.output,
+            representative=outcome.output,
+            vote=outcome.vote,
+            escalations=escalations,
+        )
+        return CompositeRunResult(
+            output=outcome.output,
+            result_kind=ResultKind.OUTPUT,
+            measures=_cascade_measures(step, body),
+            error=None,
+        )
+
+    return _error(  # pragma: no cover - the loop always returns at the last arm
+        "composite-runtime: cascade driver reached an unreachable terminal state"
+    )
+
+
 def _cascade_measures(step: CascadeStep, body: CascadeBody) -> dict[str, Any]:
     """The §3.10 cascade telemetry for one decided cascade — content-free.
 
@@ -479,6 +763,14 @@ def _execute_cascade(
             f"composite-runtime: pre-cascade (dispatch) execution is deferred to "
             f"a follow-up packet (composite {node.name!r}); this packet executes "
             "the post-cascade kind only"
+        )
+
+    # F1: a GATED nested-composite arm needs the manual driver (the gate must
+    # read the nested arm's OWN vote, and a gated arm's no_accept ESCALATES).
+    # Every other shape keeps the shipped CascadePolicy.decide fast path.
+    if _has_gated_nested_arm(body):
+        return _drive_cascade(
+            body, stages, registry, config, calibrated_values, signals, predicates
         )
 
     policy = _adapt_cascade(
@@ -536,28 +828,64 @@ def _collect_candidates(
     if body.cardinality is not None:  # sampling form
         k = _resolve_cardinality(body.cardinality, config, calibrated_values)
         arm = body.arms[0]
-        runner = _coerce_stage_runner(stages[_stage_name(arm)])
-        samples = list(runner.run(config))
-        key_fn = runner.key_fn or (lambda x: x)
-        candidates = [_Candidate(output=s, key=key_fn(s)) for s in samples]
-        # Sampling over a stage produces k outputs; cap the declared vote
-        # denominator at k so margins never exceed 1 (the vote_over contract).
-        if len(candidates) != k:
-            raise ValueError(
-                f"sampling ensemble arm {_stage_name(arm)!r} declared k={k} "
-                f"but produced {len(candidates)} samples"
+        if isinstance(arm, StageArm):
+            runner = _coerce_stage_runner(stages[arm.name])
+            samples = list(runner.run(config))
+            key_fn = runner.key_fn or (lambda x: x)
+            candidates = [_Candidate(output=s, key=key_fn(s)) for s in samples]
+            # Sampling over a stage produces k outputs; cap the declared vote
+            # denominator at k so margins never exceed 1 (the vote_over contract).
+            if len(candidates) != k:
+                raise ValueError(
+                    f"sampling ensemble arm {arm.name!r} declared k={k} "
+                    f"but produced {len(candidates)} samples"
+                )
+            return candidates, excluded_no_accept
+        # F2: a single-arm SAMPLING ensemble over a nested COMPOSITE runs that
+        # composite k times — each run is ONE candidate (keyed by its output via
+        # the nested run's own selection semantics). A nested error is absorbing;
+        # a nested no_accept excludes that draw (§3.2.1).
+        node = registry[arm.ref]
+        sampled: list[_Candidate] = []
+        for _draw in range(k):
+            inner = _execute_node(
+                node, stages, registry, config, calibrated_values, signals, predicates
             )
-        return candidates, excluded_no_accept
+            if inner.result_kind is ResultKind.ERROR:
+                raise RuntimeError(
+                    f"sampling ensemble arm {arm.ref!r} failed: {inner.error}"
+                )
+            if inner.result_kind is ResultKind.NO_ACCEPT:
+                excluded_no_accept += 1
+                continue
+            sampled.append(_Candidate(output=inner.output, key=inner.output))
+        return sampled, excluded_no_accept
 
     candidates = []  # committee form
     for arm in body.arms:
         if isinstance(arm, StageArm):
             runner = _coerce_stage_runner(stages[arm.name])
             samples = list(runner.run(config))
+            if not samples:
+                continue  # an arm that produced nothing contributes no candidate
+            # F3: a committee arm contributes EXACTLY ONE candidate — its
+            # SELECTED output (the majority winner over its OWN samples per the
+            # RFC 0001 vote semantics), NOT one candidate per raw sample (which
+            # would give a multi-sample member inflated vote weight).
             key_fn = runner.key_fn or (lambda x: x)
-            # A committee arm contributes its (single) representative output.
-            for sample in samples:
-                candidates.append(_Candidate(output=sample, key=key_fn(sample)))
+            arm_keys = [key_fn(sample) for sample in samples]
+            arm_vote = vote_over(arm_keys, len(arm_keys))
+            representative = next(
+                (
+                    sample
+                    for sample, key in zip(samples, arm_keys, strict=False)
+                    if key == arm_vote.top_key
+                ),
+                samples[0],
+            )
+            candidates.append(
+                _Candidate(output=representative, key=key_fn(representative))
+            )
         else:  # nested-composite committee arm
             inner = _execute_node(
                 registry[arm.ref],
@@ -1099,6 +1427,14 @@ def execute_kchain(
             result = raw if isinstance(raw, LoopBodyResult) else LoopBodyResult(raw)
         except Exception as exc:  # noqa: BLE001 - body exception is absorbing
             return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+        if result.result_kind is ResultKind.ERROR:
+            # F4 parity: a body ERROR result-kind is the §3.2.1 absorbing error
+            # — the SAME outcome the live loop produces. The chain must NOT
+            # treat the error cell's .output as a produced output (fail closed).
+            return _error(
+                f"composite-runtime: K-chain body of {chain.signal!r} failed: "
+                f"{result.error if isinstance(result, CompositeRunResult) else 'error'}"
+            )
         if result.result_kind is ResultKind.NO_ACCEPT:
             # a no_accept body iteration: escalate (no accepted state to test).
             state = _restrict_state(result.state, state_keys)
@@ -1192,6 +1528,90 @@ def _missing_composite_refs(
     elif isinstance(body, LoopBody) and isinstance(body.body, CompositeArm):
         refs = [body.body.ref]
     return [ref for ref in refs if ref not in registry]
+
+
+def _preflight_reachable(
+    root: CompositeNode,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult | None:
+    """F5: a deep fail-closed preflight over ALL composites reachable from the
+    root through the registry (§3.2.1).
+
+    The per-node check in :func:`_execute_node` only sees the CURRENT node, so a
+    missing leaf stage/signal/predicate inside an UNSELECTED nested arm would
+    slip through and the root would return a silent output. This walks the whole
+    reachable sub-DAG up front: ANY reachable missing composite ref, leaf stage
+    callable, ``signal_accept`` signal, or ``external_accept`` predicate is a
+    fail-closed ``error`` BEFORE any arm runs. Returns the error result, or
+    ``None`` when every reachable obligation is satisfied.
+    """
+    visited: set[str] = set()
+    stack: list[CompositeNode] = [root]
+    while stack:
+        node = stack.pop()
+        if node.name in visited:
+            continue
+        visited.add(node.name)
+
+        missing_stages = _missing_stage_names(node, stages)
+        if missing_stages:
+            return _error(
+                "composite-runtime: missing stage callable(s) "
+                f"{sorted(missing_stages)!r} for composite {node.name!r} "
+                "(fail-closed: a missing stage fails the item's evaluation)"
+            )
+        missing_refs = _missing_composite_refs(node, registry)
+        if missing_refs:
+            return _error(
+                "composite-runtime: missing composite ref(s) "
+                f"{sorted(missing_refs)!r} for composite {node.name!r} "
+                "(fail-closed: an unresolved nested arm fails the item's evaluation)"
+            )
+
+        body = node.body
+        if isinstance(body, LoopBody):
+            stop = body.stop
+            if stop.kind is StopKind.SIGNAL_ACCEPT and stop.signal is not None:
+                if stop.signal.signal not in signals:
+                    return _error(
+                        f"composite-runtime: signal {stop.signal.signal!r} is not "
+                        f"provided for composite {node.name!r} (fail-closed: a "
+                        "missing signal fails the item's evaluation)"
+                    )
+            elif stop.kind is StopKind.EXTERNAL_ACCEPT and stop.predicate is not None:
+                if stop.predicate not in predicates:
+                    return _error(
+                        f"composite-runtime: predicate {stop.predicate!r} is not "
+                        f"provided for composite {node.name!r} (fail-closed: a "
+                        "missing predicate fails the item's evaluation)"
+                    )
+
+        # Recurse into every present nested composite ref (missing refs already
+        # short-circuited above, so every ref here resolves).
+        for arm in _reachable_refs(node):
+            child = registry.get(arm)
+            if child is not None and child.name not in visited:
+                stack.append(child)
+    return None
+
+
+def _reachable_refs(node: CompositeNode) -> list[str]:
+    """The nested-composite refs a node directly references (arms + judge +
+    loop body) — the edges of the §3.2 reference sub-DAG the preflight walks."""
+    body = node.body
+    refs: list[str] = []
+    if isinstance(body, (CascadeBody, EnsembleBody)):
+        refs = [arm.ref for arm in body.arms if isinstance(arm, CompositeArm)]
+        if isinstance(body, EnsembleBody) and isinstance(
+            body.aggregate.judge, CompositeArm
+        ):
+            refs.append(body.aggregate.judge.ref)
+    elif isinstance(body, LoopBody) and isinstance(body.body, CompositeArm):
+        refs = [body.body.ref]
+    return refs
 
 
 def _execute_node(
@@ -1306,4 +1726,10 @@ def execute_composite(
     # and the single-node default both work).
     if knob.name not in reg:
         reg = {**reg, knob.name: knob}
+    # F5: deep fail-closed preflight over EVERY reachable composite — a missing
+    # leaf stage/signal/predicate inside an unselected nested arm fails closed
+    # up front, before any arm runs (never a silent root output).
+    preflight = _preflight_reachable(knob, stages, reg, sigs, preds)
+    if preflight is not None:
+        return preflight
     return _execute_node(knob, stages, reg, config, calibrated_values, sigs, preds)

--- a/traigent/knobs/runtime.py
+++ b/traigent/knobs/runtime.py
@@ -1,65 +1,85 @@
-"""The composite EXECUTION runtime — post-cascade only (RFC 0002 §3.2).
+"""The composite EXECUTION runtime — the full §3.2 algebra (RFC 0002).
 
-This packet executes the ``placement: post`` cascade kind end-to-end and
-**only** that kind. Per the §3.2 cross-reference, a post-cascade is EXACTLY
-RFC 0001 §3.8 cascade execution, so this module does NOT reimplement gate math:
-it ADAPTS the §3.2 ``CascadeBody`` IR into the shipped
-:class:`~traigent.knobs.cascade.CascadePolicy` (the cascade execution engine —
-vote/margin/escalation, the fail-closed exception rule, totality/determinism)
-and reads the LIVE calibrated gate thresholds through ``threshold_ref``
-closures over ``calibrated_values``.
+This module executes EVERY ``placement: post`` composite kind end-to-end:
+the post-cascade (cross-referenced as RFC 0001 §3.8), the ensemble (sampling
+and committee forms, ``majority_vote`` / ``judge_max``), and the loop
+(``signal_accept`` / ``external_accept`` / ``exhausted`` stops), closed under
+nested-composite arms, plus the §3.8 K-chain unroll executor.
 
-Ensemble and loop execution are **deferred to a follow-up packet** (captain
-decision). They are NOT silently skipped: :func:`execute_composite` raises
-:class:`NotImplementedError` naming the deferral when handed an ``ensemble`` or
-``loop`` root. Nested-composite arms are likewise deferred and raise loudly —
-post-cascade-over-stages is the bounded surface this packet ships.
+It does NOT reimplement vote/margin math: cascade and ensemble ``majority_vote``
+both route through the shipped :func:`~traigent.knobs.cascade.vote_over`
+(content-free majority vote over equivalence keys, RFC 0001 tie/abstain rules,
+deterministic total order over serialized keys). The cascade kind ADAPTS the
+§3.2 ``CascadeBody`` IR into the shipped
+:class:`~traigent.knobs.cascade.CascadePolicy` and reads LIVE calibrated gate
+thresholds through ``threshold_ref`` closures over ``calibrated_values``.
 
-The result codomain is the §3.2.1 algebra, named once:
+The result codomain is the §3.2.1 algebra (closed, total, disjoint), named once:
 
-- ``output`` — a produced output (the selected arm's output);
+- ``output`` — a produced output (the selected arm/aggregate/accepted state);
 - ``no_accept`` — ran, but nothing met the construct's acceptance condition (an
-  HONEST no-output outcome, NOT an error). In a v1 post-cascade over opaque
-  stage runners there is no arm-level acceptance predicate, so a post-cascade
-  always lands in ``output`` or ``error``; ``no_accept`` is part of the named
-  codomain (the result mirrors the full algebra) and becomes reachable when the
-  deferred ensemble ``accept`` decls / loop exhaustion land. It is declared
-  here, never faked into firing.
-- ``error`` — evaluation failed (a stage exception, a missing stage callable,
-  a missing/non-finite gate threshold). Fail CLOSED: a stage exception fails
-  the item's evaluation, never a silent degradation (RFC 0001 §3.8 / §3.2.1
-  "error is absorbing").
+  HONEST no-output outcome, NOT an error). Reachable in THIS packet:
+  ensemble accept-gate failure (``stat < θ``); a loop exhausting ``max_iters``
+  without ``signal_accept`` firing (or an ``exhausted`` loop whose final body
+  result is ``no_accept``); a committee whose candidates are ALL excluded by
+  ``no_accept`` (§3.2.1). A ``no_accept`` reaching the root is honest no-output.
+- ``error`` — evaluation failed (a stage/body/judge/stop exception, a missing
+  stage/signal/predicate, a missing/non-finite gate threshold, a judge
+  contract violation with NO survivor, a committee ALL-excluded-by-error, an
+  out-of-range cardinality). Fail CLOSED: ``error`` is absorbing (§3.2.1) —
+  it propagates outward to the root, never a silent degradation.
 
-Telemetry (:attr:`CompositeRunResult.measures`) is the §3.10 content-free dict:
-``escalation_rate`` (the per-run 0/1 escalated indicator), ``stage_selected``
-(the selected arm index), and per-gate ``gate_margin_pass_rate`` (1.0 when the
-gate did NOT escalate — the margin passed — 0.0 when it did, for every gate
-actually evaluated). Counts/rates/enums/finite numbers only — never content.
+Telemetry (:attr:`CompositeRunResult.measures`) is the §3.10 content-free dict,
+per kind:
+
+- cascade: ``escalation_rate``, ``stage_selected``, per-gate (INDEX-keyed)
+  ``gate_margin_pass_rate``;
+- ensemble: ``vote_agreement``, ``vote_margin``, ``candidates_evaluated``,
+  ``candidates_excluded``;
+- loop: ``iterations_used``, ``stop_reason`` (enum over StopDecl kinds).
+
+Counts/rates/enums/finite numbers only — never content.
 """
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
-from .cascade import CascadePolicy, CascadeStep, Gate, GateKind, StageSpec, VoteKey
+from .cascade import (
+    CascadePolicy,
+    CascadeStep,
+    Gate,
+    GateKind,
+    StageSpec,
+    VoteKey,
+    VoteStats,
+    vote_over,
+)
 from .composites import (
+    AcceptDecl,
+    AggregateKind,
+    Arm,
     CascadeBody,
     CompositeArm,
-    CompositeKind,
     CompositeNode,
     EnsembleBody,
 )
 from .composites import GateKind as IRGateKind
-from .composites import LoopBody, Placement, StageArm
+from .composites import LoopBody, Placement, StageArm, StatKind, StopKind
 
 __all__ = [
     "CompositeRunResult",
+    "LoopBodyResult",
+    "LoopBodyRunner",
     "ResultKind",
     "StageRunner",
+    "StopReason",
     "execute_composite",
+    "execute_kchain",
 ]
 
 
@@ -71,20 +91,42 @@ class ResultKind(StrEnum):
     ERROR = "error"
 
 
+class StopReason(StrEnum):
+    """The §3.10 loop ``stop_reason`` enum over the StopDecl kinds.
+
+    A loop that runs until a ``signal_accept`` stop fires reports
+    ``signal_accept``; an ``external_accept`` predicate firing reports
+    ``external_accept``; a loop reaching ``max_iters`` without acceptance (the
+    ``exhausted`` stop kind, OR a ``signal_accept`` loop that never accepts)
+    reports ``exhausted``.
+    """
+
+    SIGNAL_ACCEPT = "signal_accept"
+    EXTERNAL_ACCEPT = "external_accept"
+    EXHAUSTED = "exhausted"
+
+
+# --------------------------------------------------------------------------- #
+# Runtime execution units (calling conventions)                               #
+# --------------------------------------------------------------------------- #
+
+
 @dataclass(frozen=True, slots=True)
 class StageRunner:
     """A runtime execution unit for one opaque stage (§3.2 StageRef).
 
     ``run`` returns the stage's sample sequence for an item; ``key_fn`` maps an
     output to its content-free equivalence key (REQUIRED for a voting stage —
-    one that feeds a margin gate); ``samples`` is the declared per-stage
-    cardinality (the §3.4 ``k`` knob — the engine rejects a run that produces a
-    different count, mirroring :class:`~traigent.knobs.cascade.StageSpec`).
+    one that feeds a margin gate, OR an ensemble ``majority_vote`` candidate
+    stage); ``samples`` is the declared per-stage cardinality (the §3.4 ``k``
+    knob — the engine rejects a run that produces a different count, mirroring
+    :class:`~traigent.knobs.cascade.StageSpec`).
 
     A bare ``Callable`` may be supplied directly in the ``stages`` mapping; it
     is wrapped as a NON-VOTING single-sample runner (``key_fn=None`` — a leaf
-    stage that feeds no gate; supplying one to a gated position fails closed). A stage that DOES feed a margin gate must be supplied as a
-    :class:`StageRunner` carrying a ``key_fn``.
+    stage that feeds no gate; supplying one to a gated position fails closed). A
+    stage that DOES feed a margin gate (or votes in an ensemble) MUST be
+    supplied as a :class:`StageRunner` carrying a ``key_fn``.
     """
 
     run: Callable[[Any], Sequence[Any]]
@@ -93,11 +135,56 @@ class StageRunner:
 
 
 @dataclass(frozen=True, slots=True)
+class LoopBodyResult:
+    """The frozen outcome of ONE loop-body invocation (§3.2 loop semantics).
+
+    ``output`` is the body's produced output for this iteration; ``state`` is
+    the threaded state the body produced — iteration ``i+1`` observes EXACTLY
+    these keys (restricted to the loop's declared ``state_keys`` by the runtime;
+    undeclared keys are dropped, invisible to ``stop``). ``result_kind`` lets a
+    body honestly report a ``no_accept`` (the iteration completes unaccepted;
+    the loop CONTINUES, §3.2.1) — defaulting to ``OUTPUT`` keeps the common
+    "produced something" case terse. A body that raises is the §3.2.1
+    absorbing ``error`` (caught by the runtime, never reaches here).
+    """
+
+    output: Any
+    state: Mapping[str, Any] = field(default_factory=dict)
+    result_kind: ResultKind = ResultKind.OUTPUT
+
+
+@dataclass(frozen=True, slots=True)
+class LoopBodyRunner:
+    """A runtime execution unit for a loop body (§3.2 loop calling convention).
+
+    ``run`` is called once per iteration as ``run(item, state)`` where ``state``
+    is the threaded-state mapping RESTRICTED to the loop's declared
+    ``state_keys`` (iteration 1 receives ``{}``; iteration ``i+1`` receives the
+    keys iteration ``i`` produced, ∩ ``state_keys``). It returns a
+    :class:`LoopBodyResult` (or a bare value, wrapped as
+    ``LoopBodyResult(output=value)`` with empty produced state — a pure body).
+    Undeclared produced keys are dropped by the runtime (documented: invisible
+    to ``stop``).
+
+    A bare ``Callable`` may be supplied in the ``stages`` mapping for a loop
+    body; it is wrapped as ``run(item, _state) -> LoopBodyResult(output=call(item))``
+    (a pure, state-free body — the ``state_keys = []`` case).
+    """
+
+    run: Callable[[Any, Mapping[str, Any]], LoopBodyResult | Any]
+
+
+# --------------------------------------------------------------------------- #
+# Result type                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
 class CompositeRunResult:
     """The frozen outcome of one composite execution (§3.2.1 + §3.10).
 
-    ``output`` is the selected arm's output when ``result_kind`` is
-    ``OUTPUT`` (``None`` otherwise — ``no_accept``/``error`` carry no output).
+    ``output`` is the selected output when ``result_kind`` is ``OUTPUT``
+    (``None`` otherwise — ``no_accept``/``error`` carry no output).
     ``result_kind`` is the §3.2.1 algebra tag. ``measures`` is the §3.10
     content-free telemetry dict; ``error`` carries a fail-closed diagnostic
     string when ``result_kind`` is ``ERROR`` (never a partial output).
@@ -109,22 +196,96 @@ class CompositeRunResult:
     error: str | None = None
 
 
-def _coerce_runner(stage: StageRunner | Callable[[Any], Any]) -> StageRunner:
-    """Normalize a ``stages`` entry into a :class:`StageRunner`.
+def _error(message: str) -> CompositeRunResult:
+    """A fail-closed ``error`` result (no output, no measures, §3.2.1)."""
+    return CompositeRunResult(
+        output=None, result_kind=ResultKind.ERROR, measures={}, error=message
+    )
 
-    A bare callable becomes a single-sample, identity-keyed runner. A missing
-    callable is the caller's problem (caught up-front by
-    :func:`execute_composite` as a fail-closed ``error`` — never reached here).
+
+def _no_accept(measures: dict[str, Any]) -> CompositeRunResult:
+    """An honest ``no_accept`` result carrying its telemetry (§3.2.1)."""
+    return CompositeRunResult(
+        output=None, result_kind=ResultKind.NO_ACCEPT, measures=measures, error=None
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Shared resolution helpers                                                   #
+# --------------------------------------------------------------------------- #
+
+#: A ``stages`` mapping entry: a voting/sampling runner, a loop-body runner, or
+#: a bare callable normalized to whichever convention its position demands.
+StageEntry = StageRunner | LoopBodyRunner | Callable[..., Any]
+
+
+def _coerce_stage_runner(stage: StageEntry) -> StageRunner:
+    """Normalize a ``stages`` entry into a :class:`StageRunner` (vote position).
+
+    A bare callable becomes a single-sample, identity-keyed runner. A
+    :class:`LoopBodyRunner` is NOT a stage runner — handing one to a vote
+    position is the caller's error (it has no ``run(item)`` arity), surfaced as
+    a fail-closed ``error`` by the enclosing executor's exception guard.
     """
     if isinstance(stage, StageRunner):
         return stage
-
+    if isinstance(stage, LoopBodyRunner):
+        raise TypeError(
+            "a LoopBodyRunner was supplied to a voting/sampling stage position "
+            "(it has no run(item) arity); supply a StageRunner or a bare callable"
+        )
     call: Callable[[Any], Any] = stage
 
     def _run(item: Any) -> Sequence[Any]:
         return [call(item)]
 
     return StageRunner(run=_run, key_fn=None, samples=1)
+
+
+def _coerce_loop_runner(stage: StageEntry) -> LoopBodyRunner:
+    """Normalize a ``stages`` entry into a :class:`LoopBodyRunner` (loop body).
+
+    A bare callable becomes a pure, state-free body (``run(item, _state)``
+    returning ``LoopBodyResult(output=call(item))``).
+    """
+    if isinstance(stage, LoopBodyRunner):
+        return stage
+    if isinstance(stage, StageRunner):
+        raise TypeError(
+            "a StageRunner was supplied to a loop-body position (it has no "
+            "run(item, state) arity); supply a LoopBodyRunner or a bare callable"
+        )
+    call: Callable[[Any], Any] = stage
+
+    def _run(item: Any, _state: Mapping[str, Any]) -> LoopBodyResult:
+        return LoopBodyResult(output=call(item))
+
+    return LoopBodyRunner(run=_run)
+
+
+def _resolve_cardinality(
+    name: str,
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+) -> int:
+    """Resolve an ensemble cardinality ``k`` (§3.2; R9 ``k < 1``).
+
+    ``k`` is a TVAR (tuned, in ``config``) or CVAR (calibrated, in
+    ``calibrated_values``) ref; we look in ``config`` first, then
+    ``calibrated_values``. A missing or non-integer or ``< 1`` value raises —
+    caught as a fail-closed ``error`` by the caller (R9
+    ``invalid_cardinality_value``).
+    """
+    raw: Any = config.get(name, calibrated_values.get(name))
+    if raw is None:
+        raise ValueError(f"ensemble cardinality {name!r} is unresolved (no value)")
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(
+            f"ensemble cardinality {name!r} must resolve to an int, got {raw!r}"
+        )
+    if raw < 1:
+        raise ValueError(f"ensemble cardinality {name!r} resolved to {raw} < 1 (R9)")
+    return int(raw)
 
 
 def _build_threshold_ref(
@@ -134,9 +295,8 @@ def _build_threshold_ref(
 
     Reads ``calibrated_values[threshold]`` at decide time so a re-calibration
     is observed, never snapshotted. A missing threshold returns ``None`` — the
-    :class:`~traigent.knobs.cascade.Gate` then fails CLOSED ("calibrate the
-    CVAR before routing"), which this runtime maps to an ``error`` result
-    (§3.2.1: a non-finite/absent threshold fails the item's evaluation).
+    :class:`~traigent.knobs.cascade.Gate` then fails CLOSED, which this runtime
+    maps to an ``error`` result (§3.2.1).
     """
 
     def _ref() -> float | None:
@@ -146,44 +306,82 @@ def _build_threshold_ref(
     return _ref
 
 
+def _resolve_threshold(
+    threshold: str, calibrated_values: Mapping[str, float | int]
+) -> float:
+    """Resolve a finite acceptance/stop threshold or fail closed.
+
+    A missing threshold ("calibrate the CVAR before routing") or a non-finite
+    value (a NaN would make ``stat >= θ`` silently True/False) is a calibration
+    defect — raise, mapping to an ``error`` (§3.2.1 non-finite threshold).
+    """
+    value = calibrated_values.get(threshold)
+    if value is None:
+        raise ValueError(
+            f"threshold {threshold!r} is unset; calibrate the CVAR before routing"
+        )
+    fvalue = float(value)
+    if not math.isfinite(fvalue):
+        raise ValueError(
+            f"threshold {threshold!r} is non-finite ({fvalue!r}); re-calibrate"
+        )
+    return fvalue
+
+
+# --------------------------------------------------------------------------- #
+# Cascade execution (§3.2 post-cascade; ADAPTS the shipped CascadePolicy)     #
+# --------------------------------------------------------------------------- #
+
+
 def _adapt_cascade(
     body: CascadeBody,
-    stages: Mapping[str, StageRunner | Callable[[Any], Any]],
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
     calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
 ) -> CascadePolicy:
     """Adapt a §3.2 post-cascade ``CascadeBody`` into a ``CascadePolicy``.
 
-    Every arm MUST be a stage arm (nested-composite arms are deferred, raised
-    by the caller). Each gate is a ``margin_below`` gate (the only v1 post
-    gate) whose ``threshold_ref`` reads ``calibrated_values`` live. This does
-    NOT reimplement gate math — it constructs the engine that owns it.
+    A stage arm becomes a leaf :class:`StageSpec`; a nested-composite arm
+    becomes a synthetic single-sample stage whose ``run`` recursively executes
+    the nested composite and lifts its result into the cascade's escalation
+    line (§3.2.1 propagation). Each gate is a ``margin_below`` gate whose
+    ``threshold_ref`` reads ``calibrated_values`` live. This does NOT
+    reimplement gate math — it constructs the engine that owns it.
     """
     stage_specs: list[StageSpec] = []
     for arm in body.arms:
-        # Guaranteed StageArm by the caller's deferral guard; assert for -O.
-        if not isinstance(arm, StageArm):  # pragma: no cover - guarded upstream
-            raise NotImplementedError(
-                "composite-runtime: nested-composite cascade arms are deferred "
-                f"(arm {arm!r}); this packet executes post-cascade over stages only"
+        if isinstance(arm, StageArm):
+            runner = _coerce_stage_runner(stages[arm.name])
+            stage_specs.append(
+                StageSpec(
+                    name=arm.name,
+                    run=runner.run,
+                    key_fn=runner.key_fn,
+                    samples=runner.samples,
+                )
             )
-        runner = _coerce_runner(stages[arm.name])
-        stage_specs.append(
-            StageSpec(
-                name=arm.name,
-                run=runner.run,
-                key_fn=runner.key_fn,
-                samples=runner.samples,
+        else:  # CompositeArm — nested execution lifted onto the escalation line
+            stage_specs.append(
+                _nested_cascade_stage(
+                    arm,
+                    stages,
+                    registry,
+                    config,
+                    calibrated_values,
+                    signals,
+                    predicates,
+                )
             )
-        )
 
     gates: list[Gate] = []
     for gate in body.gates:
-        # margin_below is the only v1 post gate (IR-enforced); map it onto the
-        # cascade engine's single gate kind with a LIVE threshold_ref.
         if gate.kind is not IRGateKind.MARGIN_BELOW:  # pragma: no cover - IR-guarded
-            raise NotImplementedError(
-                f"composite-runtime: post-cascade gate kind {gate.kind.value!r} "
-                "is not executable in this packet (margin_below only)"
+            raise ValueError(
+                f"post-cascade gate kind {gate.kind.value!r} is not executable "
+                "(margin_below only)"
             )
         gates.append(
             Gate(
@@ -195,33 +393,69 @@ def _adapt_cascade(
     return CascadePolicy(stages=tuple(stage_specs), gates=tuple(gates))
 
 
+class _NestedNoAccept(Exception):
+    """Signals a nested-composite arm returned ``no_accept`` (NOT an error).
+
+    Carries the nested composite name for diagnostics. The cascade driver maps
+    this back into §3.2.1 post-cascade ``no_accept`` propagation (escalate, or
+    yield ``no_accept`` at the last arm); never an ``error``.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"nested composite {name!r} yielded no_accept")
+        self.name = name
+
+
+def _nested_cascade_stage(
+    arm: CompositeArm,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> StageSpec:
+    """A synthetic non-voting stage that executes a nested composite arm.
+
+    A nested ``error`` raises (absorbing — fails the parent item via the
+    cascade engine's exception propagation). A nested ``no_accept`` raises
+    :class:`_NestedNoAccept` (the parent cascade then escalates / yields
+    ``no_accept`` per §3.2.1). Only a nested ``output`` produces a sample. Such
+    a stage is NON-VOTING (``key_fn=None``); the IR forbids a margin gate over a
+    non-margin-bearing nested arm (``gate_arm_incompatible``), so a nested arm
+    only sits in a NON-gated cascade position.
+    """
+    node = registry[arm.ref]  # presence guaranteed by the caller's pre-flight
+
+    def _run(item: Any) -> Sequence[Any]:
+        inner = _execute_node(
+            node, stages, registry, config, calibrated_values, signals, predicates
+        )
+        if inner.result_kind is ResultKind.ERROR:
+            raise RuntimeError(f"nested composite {arm.ref!r} failed: {inner.error}")
+        if inner.result_kind is ResultKind.NO_ACCEPT:
+            raise _NestedNoAccept(arm.ref)
+        return [inner.output]
+
+    return StageSpec(name=arm.ref, run=_run, key_fn=None, samples=1)
+
+
 def _cascade_measures(step: CascadeStep, body: CascadeBody) -> dict[str, Any]:
     """The §3.10 cascade telemetry for one decided cascade — content-free.
 
-    ``escalation_rate`` is the per-run 0/1 escalated indicator (1 iff any
-    escalation happened); ``stage_selected`` is the selected arm index;
-    ``gate_margin_pass_rate`` is a per-gate map (keyed by gate INDEX —
-    threshold names may repeat across gates) over the gates actually
-    EVALUATED: 1.0 where the gate did not escalate (the margin passed) and 0.0
-    where it did. A gate is evaluated for arm ``i`` iff stage ``i`` ran and was
-    not the selected terminal stage (i.e. ``i < stage_selected``: those
-    escalated; the gate at ``stage_selected`` itself only fires if a non-last
-    stage was kept, which never escalates).
+    Keyed by GATE INDEX (duplicate threshold refs across gates are legal —
+    ``n_cascade`` may reuse one CVAR — and name-keying would collapse per-gate
+    values, the duplicate-ref lesson). ``escalation_rate`` is the per-run 0/1
+    escalated indicator; ``stage_selected`` is the selected arm index.
     """
     selected = step.stage_index
     escalated = 1 if step.escalations > 0 else 0
-    # Keyed by GATE INDEX, not threshold name: duplicate threshold refs across
-    # gates are legal (n_cascade may reuse one CVAR) and name-keying collapsed
-    # per-gate values (codex runtime-round blocker). §3.10: per-gate.
     per_gate: dict[int, float] = {}
     for index, _gate in enumerate(body.gates):
         if index < selected:
-            # stage index < selected ran a gate that escalated.
             per_gate[index] = 0.0
         elif index == selected and index < len(body.arms) - 1:
-            # the selected non-terminal stage's gate evaluated and STOPPED.
             per_gate[index] = 1.0
-        # gates beyond the selected stage never evaluated — omitted (honest).
     return {
         "escalation_rate": float(escalated),
         "stage_selected": selected,
@@ -229,106 +463,36 @@ def _cascade_measures(step: CascadeStep, body: CascadeBody) -> dict[str, Any]:
     }
 
 
-def _has_nested_arm(body: CascadeBody) -> bool:
-    return any(isinstance(arm, CompositeArm) for arm in body.arms)
-
-
-def execute_composite(
-    knob: CompositeNode,
-    stages: Mapping[str, StageRunner | Callable[[Any], Any]],
-    *,
+def _execute_cascade(
+    node: CompositeNode,
+    body: CascadeBody,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
     config: Mapping[str, Any],
     calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
 ) -> CompositeRunResult:
-    """Execute a composite for one item — POST-CASCADE ONLY (RFC 0002 §3.2).
-
-    Args:
-        knob: the composite IR root (:class:`CompositeNode`). Only a
-            ``placement: post`` cascade over stage arms executes in this packet.
-        stages: ``StageRef`` name -> a :class:`StageRunner` (or a bare callable
-            wrapped as a single-sample, identity-keyed runner). A voting stage
-            (one that feeds a margin gate) MUST be a ``StageRunner`` carrying a
-            ``key_fn``.
-        config: the current trial's tuned assignment (Mapping) — carried for
-            symmetry with the resolver chokepoint and future per-stage
-            parameterization; this packet does not read individual entries.
-        calibrated_values: resolved CVAR values (gate thresholds), read LIVE
-            via ``threshold_ref``. A missing threshold fails CLOSED.
-
-    Returns:
-        A frozen :class:`CompositeRunResult` whose ``result_kind`` is the
-        §3.2.1 algebra tag and whose ``measures`` is the §3.10 telemetry.
-
-    Raises:
-        NotImplementedError: for an ``ensemble`` or ``loop`` root, a
-            ``placement: pre`` cascade, or a nested-composite cascade arm —
-            each named explicitly (deferred, never faked).
-    """
-    body = knob.body
-
-    # --- deferrals: loud, never silent (NotImplementedError naming the gap) --
-    if isinstance(body, EnsembleBody) or knob.kind is CompositeKind.ENSEMBLE:
-        raise NotImplementedError(
-            f"composite-runtime: ensemble execution is deferred to a follow-up "
-            f"packet (composite {knob.name!r}); this packet executes the "
-            "post-cascade kind only"
-        )
-    if isinstance(body, LoopBody) or knob.kind is CompositeKind.LOOP:
-        raise NotImplementedError(
-            f"composite-runtime: loop execution is deferred to a follow-up "
-            f"packet (composite {knob.name!r}); this packet executes the "
-            "post-cascade kind only"
-        )
-    if not isinstance(body, CascadeBody):  # pragma: no cover - kind/body checked in IR
-        raise NotImplementedError(
-            f"composite-runtime: unsupported composite body {type(body).__name__} "
-            f"(composite {knob.name!r})"
-        )
+    """Execute one post-cascade body for one item (§3.2 / §3.2.1)."""
     if body.placement is not Placement.POST:
         raise NotImplementedError(
             f"composite-runtime: pre-cascade (dispatch) execution is deferred to "
-            f"a follow-up packet (composite {knob.name!r}); this packet executes "
+            f"a follow-up packet (composite {node.name!r}); this packet executes "
             "the post-cascade kind only"
         )
-    if _has_nested_arm(body):
-        raise NotImplementedError(
-            f"composite-runtime: nested-composite arms are deferred to a follow-up "
-            f"packet (composite {knob.name!r}); this packet executes post-cascade "
-            "over stage arms only"
-        )
 
-    # --- fail-closed pre-flight: every stage callable must be present --------
-    missing = [
-        arm.name
-        for arm in body.arms
-        if isinstance(arm, StageArm) and arm.name not in stages
-    ]
-    if missing:
-        return CompositeRunResult(
-            output=None,
-            result_kind=ResultKind.ERROR,
-            measures={},
-            error=(
-                "composite-runtime: missing stage callable(s) "
-                f"{sorted(missing)!r} for composite {knob.name!r} "
-                "(fail-closed: a missing stage fails the item's evaluation)"
-            ),
-        )
-
-    policy = _adapt_cascade(body, stages, calibrated_values)
-
-    # --- decide; a stage/gate exception (incl. missing/non-finite threshold)
-    #     is the §3.2.1 absorbing `error` — fail CLOSED, never degrade. --------
-    item = config
+    policy = _adapt_cascade(
+        body, stages, registry, config, calibrated_values, signals, predicates
+    )
     try:
-        step = policy.decide(item)
+        step = policy.decide(config)
+    except _NestedNoAccept:
+        # §3.2.1: the cascade engine escalated past every gate (a nested arm's
+        # no_accept never stops the cascade); reaching here means the LAST arm
+        # was a nested composite that yielded no_accept -> cascade no_accept.
+        return _no_accept({})
     except Exception as exc:  # noqa: BLE001 - error is absorbing (§3.2.1)
-        return CompositeRunResult(
-            output=None,
-            result_kind=ResultKind.ERROR,
-            measures={},
-            error=f"composite-runtime: {type(exc).__name__}: {exc}",
-        )
+        return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
 
     return CompositeRunResult(
         output=step.output,
@@ -336,3 +500,810 @@ def execute_composite(
         measures=_cascade_measures(step, body),
         error=None,
     )
+
+
+# --------------------------------------------------------------------------- #
+# Ensemble execution (§3.2 sampling / committee; majority_vote / judge_max)   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    """One ensemble candidate output plus its content-free equivalence key."""
+
+    output: Any
+    key: VoteKey
+
+
+def _collect_candidates(
+    body: EnsembleBody,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> tuple[list[_Candidate], int]:
+    """Run the ensemble arms and collect candidate outputs (§3.2).
+
+    Sampling form (``|arms| = 1``): the single arm runs ``k`` times (``k`` the
+    resolved cardinality). Committee form (``|arms| > 1``): each arm runs once;
+    a committee arm yielding ``no_accept`` is EXCLUDED from the vote (§3.2.1),
+    an arm error propagates (absorbing). Returns the surviving candidates and
+    the count excluded BY ``no_accept`` (NOT by error — error already raised).
+    """
+    excluded_no_accept = 0
+    if body.cardinality is not None:  # sampling form
+        k = _resolve_cardinality(body.cardinality, config, calibrated_values)
+        arm = body.arms[0]
+        runner = _coerce_stage_runner(stages[_stage_name(arm)])
+        samples = list(runner.run(config))
+        key_fn = runner.key_fn or (lambda x: x)
+        candidates = [_Candidate(output=s, key=key_fn(s)) for s in samples]
+        # Sampling over a stage produces k outputs; cap the declared vote
+        # denominator at k so margins never exceed 1 (the vote_over contract).
+        if len(candidates) != k:
+            raise ValueError(
+                f"sampling ensemble arm {_stage_name(arm)!r} declared k={k} "
+                f"but produced {len(candidates)} samples"
+            )
+        return candidates, excluded_no_accept
+
+    candidates = []  # committee form
+    for arm in body.arms:
+        if isinstance(arm, StageArm):
+            runner = _coerce_stage_runner(stages[arm.name])
+            samples = list(runner.run(config))
+            key_fn = runner.key_fn or (lambda x: x)
+            # A committee arm contributes its (single) representative output.
+            for sample in samples:
+                candidates.append(_Candidate(output=sample, key=key_fn(sample)))
+        else:  # nested-composite committee arm
+            inner = _execute_node(
+                registry[arm.ref],
+                stages,
+                registry,
+                config,
+                calibrated_values,
+                signals,
+                predicates,
+            )
+            if inner.result_kind is ResultKind.ERROR:
+                raise RuntimeError(f"committee arm {arm.ref!r} failed: {inner.error}")
+            if inner.result_kind is ResultKind.NO_ACCEPT:
+                excluded_no_accept += 1
+                continue
+            candidates.append(_Candidate(output=inner.output, key=inner.output))
+    return candidates, excluded_no_accept
+
+
+def _majority_vote(candidates: Sequence[_Candidate]) -> tuple[Any, VoteStats]:
+    """Aggregate candidates by ``majority_vote`` via the shipped ``vote_over``.
+
+    Reuses :func:`~traigent.knobs.cascade.vote_over` verbatim (RFC 0001
+    tie/abstain, deterministic total order over serialized keys) — never a
+    reimplementation. Returns the winning representative output and the vote
+    stats (the margin-bearing producer's ``vote_stats``, §3.2.1).
+    """
+    keys = [c.key for c in candidates]
+    vote = vote_over(keys, len(keys))
+    representative = next(
+        (c.output for c in candidates if c.key == vote.top_key),
+        candidates[0].output if candidates else None,
+    )
+    return representative, vote
+
+
+def _judge_max(
+    candidates: Sequence[_Candidate],
+    judge: Arm,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> tuple[Any, int]:
+    """Aggregate candidates by ``judge_max`` (§3.2 judge output contract).
+
+    The judge arm is invoked once per candidate and MUST yield a FINITE numeric
+    score. A candidate whose judging raises or yields NaN/±∞/non-numeric is
+    EXCLUDED (judge-contract exclusion). If ALL candidates are excluded the
+    ensemble FAILS (raise — §3.2.1 all-excluded-by-error). Selection is the max
+    score; ties break by the deterministic total order over serialized keys
+    (the §3.2 tie-break). Returns the winning output and the
+    ``candidates_excluded`` count (judge-contract violations).
+    """
+    judge_run = _judge_callable(
+        judge, stages, registry, config, calibrated_values, signals, predicates
+    )
+    scored: list[tuple[float, str, Any]] = []
+    excluded = 0
+    for candidate in candidates:
+        try:
+            raw = judge_run(candidate.output)
+        except Exception:  # noqa: BLE001 - judge-contract exclusion (§3.2)
+            excluded += 1
+            continue
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            excluded += 1
+            continue
+        score = float(raw)
+        if not math.isfinite(score):
+            excluded += 1
+            continue
+        scored.append((score, str(candidate.key), candidate.output))
+    if not scored:
+        # ALL excluded BY ERROR (judge contract) -> the ensemble FAILS (§3.2.1).
+        raise RuntimeError(
+            "judge_max: all candidates excluded by judge-contract violation "
+            "(no finite numeric score) — the ensemble evaluation fails (§3.2.1)"
+        )
+    # max score; deterministic tie-break by the serialized-key total order.
+    best = max(scored, key=lambda t: (t[0], _neg_key(t[1])))
+    return best[2], excluded
+
+
+def _neg_key(serialized: str) -> Any:
+    """A tie-break helper: among equal max scores, the SMALLEST serialized key
+    wins (the §3.2 deterministic total order over serialized keys). ``max``
+    selects the LARGEST tuple, so we invert the key ordering with a wrapper that
+    reverses string comparison."""
+    return _ReverseStr(serialized)
+
+
+@dataclass(frozen=True, slots=True)
+class _ReverseStr:
+    """A string wrapper whose ordering is REVERSED, so that under ``max`` the
+    lexicographically SMALLEST serialized key is chosen on a score tie (§3.2
+    deterministic total order)."""
+
+    value: str
+
+    def __lt__(self, other: _ReverseStr) -> bool:
+        return self.value > other.value
+
+
+def _judge_callable(
+    judge: Arm,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> Callable[[Any], Any]:
+    """Build the per-candidate judge invocation.
+
+    A stage judge runs once per candidate (the candidate output is the judge's
+    item). A nested-composite judge executes the nested composite per candidate;
+    its ``output`` is the score (an error/no_accept from the judge composite is
+    a judge-contract exclusion at the ``_judge_max`` call site via the raise).
+    """
+    if isinstance(judge, StageArm):
+        runner = _coerce_stage_runner(stages[judge.name])
+
+        def _stage_judge(candidate_output: Any) -> Any:
+            produced = list(runner.run(candidate_output))
+            if not produced:
+                raise ValueError("judge stage produced no output")
+            return produced[0]
+
+        return _stage_judge
+
+    node = registry[judge.ref]
+
+    def _composite_judge(candidate_output: Any) -> Any:
+        inner = _execute_node(
+            node,
+            stages,
+            registry,
+            candidate_output,
+            calibrated_values,
+            signals,
+            predicates,
+        )
+        if inner.result_kind is not ResultKind.OUTPUT:
+            raise RuntimeError(
+                f"nested judge composite {judge.ref!r} did not produce an output"
+            )
+        return inner.output
+
+    return _composite_judge
+
+
+def _stage_name(arm: Arm) -> str:
+    """The lookup key for an arm in ``stages`` (stage name or composite ref)."""
+    if isinstance(arm, StageArm):
+        return str(arm.name)
+    return str(arm.ref)
+
+
+def _ensemble_measures(
+    vote: VoteStats | None, evaluated: int, excluded: int
+) -> dict[str, Any]:
+    """The §3.10 ensemble telemetry — content-free.
+
+    ``vote_agreement``/``vote_margin`` come from the vote stats (0.0 when there
+    is no vote, e.g. a ``judge_max`` aggregate — no majority vote ran);
+    ``candidates_evaluated`` is the count fed to aggregation;
+    ``candidates_excluded`` is the judge-contract / no_accept exclusion count.
+    """
+    return {
+        "vote_agreement": float(vote.valid_rate) if vote is not None else 0.0,
+        "vote_margin": float(vote.margin) if vote is not None else 0.0,
+        "candidates_evaluated": int(evaluated),
+        "candidates_excluded": int(excluded),
+    }
+
+
+def _execute_ensemble(
+    body: EnsembleBody,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult:
+    """Execute one ensemble body for one item (§3.2 / §3.2.1)."""
+    try:
+        candidates, excluded_no_accept = _collect_candidates(
+            body, stages, registry, config, calibrated_values, signals, predicates
+        )
+    except Exception as exc:  # noqa: BLE001 - error is absorbing (§3.2.1)
+        return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+    aggregate = body.aggregate
+    evaluated = len(candidates)
+
+    # A committee whose candidates are ALL excluded by no_accept -> the ensemble
+    # yields no_accept (§3.2.1, DISTINCT from all-excluded-by-error).
+    if not candidates:
+        if excluded_no_accept > 0:
+            return _no_accept(
+                _ensemble_measures(None, evaluated=0, excluded=excluded_no_accept)
+            )
+        return _error(
+            "composite-runtime: ensemble produced no candidates (no arms ran)"
+        )
+
+    vote: VoteStats | None = None
+    judge_excluded = 0
+    try:
+        if aggregate.kind is AggregateKind.MAJORITY_VOTE:
+            output, vote = _majority_vote(candidates)
+        else:  # JUDGE_MAX
+            if aggregate.judge is None:  # pragma: no cover - IR-guarded
+                raise ValueError("judge_max aggregate requires a judge arm")
+            output, judge_excluded = _judge_max(
+                candidates,
+                aggregate.judge,
+                stages,
+                registry,
+                config,
+                calibrated_values,
+                signals,
+                predicates,
+            )
+    except Exception as exc:  # noqa: BLE001 - error is absorbing (§3.2.1)
+        return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+    total_excluded = excluded_no_accept + judge_excluded
+    measures = _ensemble_measures(vote, evaluated=evaluated, excluded=total_excluded)
+
+    # The §3.2.1 accept gate: stat >= θ, the OPPOSITE direction of cascade
+    # escalation. Failing it is an HONEST no_accept (NOT an error).
+    accept = aggregate.accept
+    if accept is not None:
+        try:
+            decision = _accept_passes(accept, vote, calibrated_values)
+        except Exception as exc:  # noqa: BLE001 - non-finite threshold -> error
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+        if not decision:
+            return _no_accept(measures)
+
+    return CompositeRunResult(
+        output=output, result_kind=ResultKind.OUTPUT, measures=measures, error=None
+    )
+
+
+def _accept_passes(
+    accept: AcceptDecl,
+    vote: VoteStats | None,
+    calibrated_values: Mapping[str, float | int],
+) -> bool:
+    """Evaluate the §3.2 acceptance inequality ``stat >= θ``.
+
+    The named content-free statistic (``vote_margin`` / ``vote_agreement``) is
+    read from the vote stats. A ``judge_max`` aggregate has no vote, so an
+    accept decl over it has no statistic to read — that is an IR-level
+    misconfiguration (accept stats are vote stats), surfaced as an error here.
+    """
+    theta = _resolve_threshold(accept.threshold, calibrated_values)
+    if vote is None:
+        raise ValueError(
+            f"accept stat {accept.stat.value!r} has no vote statistic to read "
+            "(an accept decl over a non-voting aggregate is misconfigured)"
+        )
+    if accept.stat is StatKind.VOTE_MARGIN:
+        stat = float(vote.margin)
+    else:  # VOTE_AGREEMENT
+        stat = float(vote.valid_rate)
+    return bool(stat >= theta)
+
+
+# --------------------------------------------------------------------------- #
+# Loop execution (§3.2 signal_accept / external_accept / exhausted)           #
+# --------------------------------------------------------------------------- #
+
+
+def _restrict_state(
+    state: Mapping[str, Any], state_keys: tuple[str, ...]
+) -> dict[str, Any]:
+    """Project ``state`` onto the declared ``state_keys`` (§3.2).
+
+    Undeclared keys are DROPPED (documented: invisible to ``stop``). Declared
+    keys the body did not produce are simply absent.
+    """
+    allowed = set(state_keys)
+    return {k: v for k, v in state.items() if k in allowed}
+
+
+def _execute_loop(
+    node: CompositeNode,
+    body: LoopBody,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult:
+    """Execute one loop body up to ``max_iters`` (§3.2 / §3.2.1 / §3.10).
+
+    State threads over the declared ``state_keys`` (iteration ``i+1`` observes
+    exactly the keys iteration ``i`` produced, ∩ ``state_keys``). Stop kinds:
+    ``signal_accept`` (σ(state) ≥ θ accepts), ``external_accept`` (opaque
+    predicate), ``exhausted`` (runs all ``max_iters``). A body/stop exception
+    fails the item (absorbing error). A loop exhausting without acceptance, or
+    whose final body result is ``no_accept``, yields ``no_accept``.
+    """
+    stop = body.stop
+    try:
+        runner = _loop_body_runner(body.body, stages, registry)
+    except Exception as exc:  # noqa: BLE001 - missing body callable -> error
+        return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+    state: dict[str, Any] = {}
+    last_output: Any = None
+    last_kind: ResultKind = ResultKind.NO_ACCEPT
+    iterations_used = 0
+
+    for _iteration in range(body.max_iters):
+        iterations_used += 1
+        try:
+            result = _invoke_loop_body(runner, config, state, body.state_keys)
+        except Exception as exc:  # noqa: BLE001 - body exception is absorbing
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+        if result.result_kind is ResultKind.ERROR:  # a nested body error
+            return _error(
+                f"composite-runtime: loop body of {node.name!r} failed: "
+                f"{result.error if isinstance(result, CompositeRunResult) else 'error'}"
+            )
+
+        last_output = result.output
+        last_kind = result.result_kind
+        state = _restrict_state(result.state, body.state_keys)
+
+        # §3.2.1: a no_accept body result completes the iteration unaccepted;
+        # the loop CONTINUES (no stop is evaluated on a non-output iteration —
+        # there is no accepted state to test).
+        if result.result_kind is ResultKind.NO_ACCEPT:
+            continue
+
+        # An output iteration: evaluate the stop on the produced state.
+        try:
+            accepted = _stop_accepts(
+                stop, state, calibrated_values, signals, predicates
+            )
+        except Exception as exc:  # noqa: BLE001 - stop exception is absorbing
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+        if accepted:
+            measures = _loop_measures(iterations_used, _accept_reason(stop.kind))
+            return CompositeRunResult(
+                output=last_output,
+                result_kind=ResultKind.OUTPUT,
+                measures=measures,
+                error=None,
+            )
+
+    # max_iters reached without acceptance, OR an exhausted loop whose final
+    # body result is no_accept -> the loop yields no_accept (§3.2.1).
+    measures = _loop_measures(iterations_used, StopReason.EXHAUSTED)
+    if stop.kind is StopKind.EXHAUSTED and last_kind is ResultKind.OUTPUT:
+        # An exhausted loop with a produced final output: that output IS the
+        # loop's output (the exhausted stop has no acceptance predicate, so the
+        # final produced output is the result, NOT no_accept) — §3.2 exhausted
+        # "always runs max_iters iterations" and yields its final body output.
+        return CompositeRunResult(
+            output=last_output,
+            result_kind=ResultKind.OUTPUT,
+            measures=measures,
+            error=None,
+        )
+    return _no_accept(measures)
+
+
+def _loop_body_runner(
+    body_arm: Arm,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+) -> LoopBodyRunner | CompositeNode:
+    """Resolve the loop body to a :class:`LoopBodyRunner` or a nested node.
+
+    A stage body resolves through ``stages``; a nested-composite body resolves
+    through the registry (executed per iteration with the threaded state passed
+    as ``config`` overlay — see :func:`_invoke_loop_body`).
+    """
+    if isinstance(body_arm, StageArm):
+        return _coerce_loop_runner(stages[body_arm.name])
+    return registry[body_arm.ref]
+
+
+def _invoke_loop_body(
+    runner: LoopBodyRunner | CompositeNode,
+    config: Mapping[str, Any],
+    state: Mapping[str, Any],
+    state_keys: tuple[str, ...],
+) -> LoopBodyResult:
+    """Invoke the loop body for one iteration with the restricted state.
+
+    A :class:`LoopBodyRunner` is called ``run(item, restricted_state)``; a bare
+    value return is wrapped as an output with empty produced state. A nested
+    composite is NOT executed here (it has no state-producing convention in v1)
+    — a nested-composite loop body is rejected upstream as a deferral.
+    """
+    if isinstance(runner, CompositeNode):  # pragma: no cover - rejected upstream
+        raise NotImplementedError(
+            "composite-runtime: nested-composite loop bodies are deferred "
+            "(no v1 state-producing convention for a composite body)"
+        )
+    restricted = _restrict_state(state, state_keys)
+    raw = runner.run(config, restricted)
+    if isinstance(raw, LoopBodyResult):
+        return raw
+    return LoopBodyResult(output=raw)
+
+
+def _stop_accepts(
+    stop: Any,
+    state: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> bool:
+    """Evaluate the loop stop on the produced state (§3.2).
+
+    - ``signal_accept``: σ(threaded state) ≥ θ accepts. ``state`` is ALREADY
+      restricted to the loop's declared ``state_keys`` by the caller (undeclared
+      keys dropped, §3.2). The signal receives that FULL threaded view — the
+      SAME view the K-chain's σ receives (§3.8 trace-equality). The declared
+      ``signal.inputs ⊆ state_keys`` is a calibration/freshness COVERAGE
+      declaration (§3.2 item 11 / `signal_inputs`), NOT a runtime input filter,
+      so it never narrows what σ observes. A missing signal callable or a
+      non-finite/absent threshold fails closed (raise -> error); σ MUST return a
+      finite number.
+    - ``external_accept``: the opaque predicate over the state decides; a
+      missing predicate fails closed.
+    - ``exhausted``: never accepts mid-loop (runs all iterations).
+    """
+    if stop.kind is StopKind.SIGNAL_ACCEPT:
+        if stop.signal is None or stop.threshold is None:  # pragma: no cover - IR
+            raise ValueError("signal_accept stop missing signal/threshold")
+        signal_id = stop.signal.signal
+        if signal_id not in signals:
+            raise ValueError(
+                f"signal {signal_id!r} is not provided (fail-closed: a missing "
+                "signal fails the item's evaluation)"
+            )
+        theta = _resolve_threshold(stop.threshold, calibrated_values)
+        raw = signals[signal_id](dict(state))
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            raise ValueError(
+                f"signal {signal_id!r} must return a finite number, got {raw!r}"
+            )
+        sigma = float(raw)
+        if not math.isfinite(sigma):
+            raise ValueError(f"signal {signal_id!r} returned non-finite {sigma!r}")
+        return sigma >= theta
+
+    if stop.kind is StopKind.EXTERNAL_ACCEPT:
+        predicate_id = stop.predicate
+        if predicate_id not in predicates:
+            raise ValueError(
+                f"predicate {predicate_id!r} is not provided (fail-closed: a "
+                "missing predicate fails the item's evaluation)"
+            )
+        return bool(predicates[predicate_id](dict(state)))
+
+    return False  # EXHAUSTED never accepts mid-loop
+
+
+def _accept_reason(stop_kind: StopKind) -> StopReason:
+    """Map an accepting stop kind to its §3.10 ``stop_reason`` enum value."""
+    if stop_kind is StopKind.SIGNAL_ACCEPT:
+        return StopReason.SIGNAL_ACCEPT
+    return StopReason.EXTERNAL_ACCEPT
+
+
+def _loop_measures(iterations_used: int, stop_reason: StopReason) -> dict[str, Any]:
+    """The §3.10 loop telemetry — content-free (count + enum)."""
+    return {
+        "iterations_used": int(iterations_used),
+        "stop_reason": stop_reason.value,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# K-chain unroll execution (§3.8 — signal_accept loops only)                  #
+# --------------------------------------------------------------------------- #
+
+
+def execute_kchain(
+    chain: Any,
+    body_runner: LoopBodyRunner | Callable[..., Any],
+    *,
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult:
+    """Execute a §3.8 K-chain IR object (the ``self_refine.unroll(K)`` return).
+
+    A K-chain is the SDK intermediate-representation compilation of a
+    ``signal_accept`` loop: ``stages = [b₁ .. b_K]`` escalating to stage ``i+1``
+    exactly when ``σ(state_i) < θ`` (the acceptance-direction complement). This
+    executor walks the chain stages, threading the body's state over
+    ``chain.state_keys`` and reading the live ``chain.threshold`` and
+    ``chain.signal`` — so its execution TRACE (selected stage index, accept
+    decision, output) matches the live :func:`_execute_loop` under the §3.8
+    conditions 1–3 (the property test asserts trace-equality).
+
+    Args:
+        chain: a :class:`~traigent.knobs.patterns.KChain` (duck-typed:
+            ``signal``, ``threshold``, ``state_keys``, ``stages``).
+        body_runner: the loop body, SAME convention as the loop's body — a
+            :class:`LoopBodyRunner` (or a bare callable wrapped pure).
+        config: the trial assignment passed as the body item.
+        calibrated_values: holds ``chain.threshold`` (read via the live ref).
+        signals: holds ``chain.signal`` (fail-closed if absent).
+
+    Returns:
+        ``OUTPUT`` at the first chain stage whose ``σ(state_i) ≥ θ`` accepts;
+        ``no_accept`` when the whole chain escalates without accepting (the
+        exhausted-equivalent of the live loop); ``error`` (absorbing) for a
+        body/signal exception, a missing signal, or a non-finite threshold.
+    """
+    runner = _coerce_loop_runner(body_runner)
+    state_keys = tuple(chain.state_keys)
+    state: dict[str, Any] = {}
+    last_output: Any = None
+    stages = list(chain.stages)
+
+    for index, _stage in enumerate(stages):
+        iterations_used = index + 1
+        try:
+            raw = runner.run(config, _restrict_state(state, state_keys))
+            result = raw if isinstance(raw, LoopBodyResult) else LoopBodyResult(raw)
+        except Exception as exc:  # noqa: BLE001 - body exception is absorbing
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+        if result.result_kind is ResultKind.NO_ACCEPT:
+            # a no_accept body iteration: escalate (no accepted state to test).
+            state = _restrict_state(result.state, state_keys)
+            continue
+        last_output = result.output
+        state = _restrict_state(result.state, state_keys)
+        try:
+            sigma = _kchain_sigma(chain, state, signals)
+            theta = _resolve_threshold(chain.threshold, calibrated_values)
+        except Exception as exc:  # noqa: BLE001 - signal/threshold absorbing
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+        if sigma >= theta:  # ¬escalate: the signal_accept stop fired
+            return CompositeRunResult(
+                output=last_output,
+                result_kind=ResultKind.OUTPUT,
+                measures=_loop_measures(iterations_used, StopReason.SIGNAL_ACCEPT),
+                error=None,
+            )
+        # σ < θ: escalate to the next chain stage (acceptance-direction
+        # complement, §3.8).
+
+    return _no_accept(_loop_measures(len(stages), StopReason.EXHAUSTED))
+
+
+def _kchain_sigma(
+    chain: Any, state: Mapping[str, Any], signals: Mapping[str, Callable[..., Any]]
+) -> float:
+    """Evaluate the chain's ``signal_accept`` signal σ over the threaded state.
+
+    Identical signal contract to the live loop's ``signal_accept`` (§3.8
+    condition 1/2): a missing signal fails closed; σ must return a finite
+    number. The signal reads the state restricted to the chain's declared
+    state_keys (the chain carries no separate ``inputs`` — the loop's
+    ``signal.inputs ⊆ state_keys`` is structurally enforced, §3.8 condition 2).
+    """
+    signal_id = chain.signal
+    if signal_id not in signals:
+        raise ValueError(
+            f"signal {signal_id!r} is not provided (fail-closed: a missing "
+            "signal fails the item's evaluation)"
+        )
+    raw = signals[signal_id](dict(state))
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ValueError(f"signal {signal_id!r} must return a finite number")
+    sigma = float(raw)
+    if not math.isfinite(sigma):
+        raise ValueError(f"signal {signal_id!r} returned non-finite {sigma!r}")
+    return sigma
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch + the public surface                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _missing_stage_names(
+    node: CompositeNode, stages: Mapping[str, StageEntry]
+) -> list[str]:
+    """The stage-arm names a node references but ``stages`` does not provide.
+
+    Composite-arm refs are validated against the registry (a separate
+    fail-closed pre-flight); this only checks the LEAF stage callables.
+    """
+    body = node.body
+    needed: list[str] = []
+    if isinstance(body, CascadeBody):
+        needed = [arm.name for arm in body.arms if isinstance(arm, StageArm)]
+    elif isinstance(body, EnsembleBody):
+        needed = [arm.name for arm in body.arms if isinstance(arm, StageArm)]
+        judge = body.aggregate.judge
+        if isinstance(judge, StageArm):
+            needed.append(judge.name)
+    else:  # LoopBody
+        if isinstance(body.body, StageArm):
+            needed = [body.body.name]
+    return [name for name in needed if name not in stages]
+
+
+def _missing_composite_refs(
+    node: CompositeNode, registry: Mapping[str, CompositeNode]
+) -> list[str]:
+    """The composite-arm refs a node references but the registry lacks."""
+    body = node.body
+    refs: list[str] = []
+    if isinstance(body, (CascadeBody, EnsembleBody)):
+        refs = [arm.ref for arm in body.arms if isinstance(arm, CompositeArm)]
+        if isinstance(body, EnsembleBody) and isinstance(
+            body.aggregate.judge, CompositeArm
+        ):
+            refs.append(body.aggregate.judge.ref)
+    elif isinstance(body, LoopBody) and isinstance(body.body, CompositeArm):
+        refs = [body.body.ref]
+    return [ref for ref in refs if ref not in registry]
+
+
+def _execute_node(
+    node: CompositeNode,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult:
+    """Execute ONE composite node (the recursive dispatch over §3.2 kinds).
+
+    Fail-closed pre-flight on EVERY node (incl. nested): a missing leaf stage
+    callable or a missing composite ref is an ``error`` (§3.2.1) — never a
+    silent pick. A nested-composite loop body is the one v1 deferral and raises
+    NotImplementedError (no state-producing convention for a composite body).
+    """
+    missing_stages = _missing_stage_names(node, stages)
+    if missing_stages:
+        return _error(
+            "composite-runtime: missing stage callable(s) "
+            f"{sorted(missing_stages)!r} for composite {node.name!r} "
+            "(fail-closed: a missing stage fails the item's evaluation)"
+        )
+    missing_refs = _missing_composite_refs(node, registry)
+    if missing_refs:
+        return _error(
+            "composite-runtime: missing composite ref(s) "
+            f"{sorted(missing_refs)!r} for composite {node.name!r} "
+            "(fail-closed: an unresolved nested arm fails the item's evaluation)"
+        )
+
+    body = node.body
+    if isinstance(body, CascadeBody):
+        return _execute_cascade(
+            node, body, stages, registry, config, calibrated_values, signals, predicates
+        )
+    if isinstance(body, EnsembleBody):
+        return _execute_ensemble(
+            body, stages, registry, config, calibrated_values, signals, predicates
+        )
+    if isinstance(body, LoopBody):
+        if isinstance(body.body, CompositeArm):
+            raise NotImplementedError(
+                f"composite-runtime: nested-composite loop bodies are deferred "
+                f"(composite {node.name!r}); a composite loop body has no v1 "
+                "state-producing convention. Stage-bodied loops execute fully."
+            )
+        return _execute_loop(
+            node, body, stages, registry, config, calibrated_values, signals, predicates
+        )
+    raise NotImplementedError(  # pragma: no cover - kind/body checked in IR
+        f"composite-runtime: unsupported composite body {type(body).__name__} "
+        f"(composite {node.name!r})"
+    )
+
+
+def execute_composite(
+    knob: CompositeNode,
+    stages: Mapping[str, StageEntry],
+    *,
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]] | None = None,
+    predicates: Mapping[str, Callable[..., Any]] | None = None,
+    registry: Mapping[str, CompositeNode] | None = None,
+) -> CompositeRunResult:
+    """Execute a composite for one item — the FULL §3.2 algebra (RFC 0002).
+
+    Args:
+        knob: the composite IR root (:class:`CompositeNode`). Cascade
+            (post), ensemble (sampling/committee, ``majority_vote`` /
+            ``judge_max``), and loop (``signal_accept`` / ``external_accept`` /
+            ``exhausted``) kinds all execute, closed under nested-composite arms.
+        stages: ``StageRef`` name -> a :class:`StageRunner` (voting/sampling),
+            a :class:`LoopBodyRunner` (a loop body), or a bare callable wrapped
+            to whichever convention its position demands. A voting stage MUST
+            carry a ``key_fn``.
+        config: the current trial's tuned assignment (Mapping). It is the item
+            passed to stage/body runners; tuned ensemble cardinalities resolve
+            from it.
+        calibrated_values: resolved CVAR values (gate/accept/stop thresholds,
+            calibrated cardinalities), read LIVE. A missing/non-finite
+            threshold fails CLOSED.
+        signals: signal id -> callable over the (restricted) state, for
+            ``signal_accept`` loop stops. A referenced-but-missing signal fails
+            CLOSED (an ``error``), same as a missing stage.
+        predicates: external-accept id -> callable over the state, for
+            ``external_accept`` loop stops. A referenced-but-missing predicate
+            fails CLOSED.
+        registry: the ``N_X`` composites map (name -> :class:`CompositeNode`)
+            for nested-composite arm resolution. Defaults to ``{knob.name: knob}``
+            (a single-node program); a nested arm whose ref is absent fails
+            CLOSED (``missing composite ref``).
+
+    Returns:
+        A frozen :class:`CompositeRunResult` whose ``result_kind`` is the
+        §3.2.1 algebra tag and whose ``measures`` is the §3.10 telemetry.
+
+    Raises:
+        NotImplementedError: for a ``placement: pre`` cascade or a
+            nested-composite LOOP body — each named explicitly (deferred, never
+            faked). Every other deferral has been replaced by tested behavior.
+    """
+    sigs: Mapping[str, Callable[..., Any]] = signals or {}
+    preds: Mapping[str, Callable[..., Any]] = predicates or {}
+    reg: Mapping[str, CompositeNode] = (
+        dict(registry) if registry is not None else {knob.name: knob}
+    )
+    # The root must be resolvable in its own registry (so nested self-reference
+    # and the single-node default both work).
+    if knob.name not in reg:
+        reg = {**reg, knob.name: knob}
+    return _execute_node(knob, stages, reg, config, calibrated_values, sigs, preds)


### PR DESCRIPTION
## What

Completes the composite-knob EXECUTION surface (RFC 0002, TVL 1.2): the `ensemble` and `loop` kinds now run, joining the cascade runtime shipped in #1167. The full sealed algebra `{cascade, ensemble, loop}` — including nesting closure — executes in-trial.

- **Ensemble**: sampling form (single arm × k, k resolved from config per R9) and committee form (one candidate per arm = the arm's own majority winner); `majority_vote` via the shipped `vote_over` machinery; `judge_max` contract; `stat_at_least` accept → honest `no_accept` reachable.
- **Loop**: `signal_accept` / `external_accept` / `exhausted` stop reasons, `state_keys` threading, `max_iters` bound; `execute_kchain` (the §3.9 Loop→K-chain compilation relation) with full ERROR parity to the live loop — equality proven by a Hypothesis trace-equality property incl. ERROR-result bodies.
- **Nested composite arms**: gated nested majority-vote ensembles feed the cascade gate with their OWN vote stats; a gated arm's `no_accept` ESCALATES, only the terminal arm's `no_accept` is the cascade's (§3.2.1); deep fail-closed preflight over ALL reachable composites (missing stage/signal/predicate/ref errors BEFORE any arm runs).
- Principled `NotImplementedError` survivors (pre-dispatch only): pre-cascade dispatch execution and composite-bodied loops — loud, documented, recorded follow-ups; never silent.

## Review chain

- codex gpt-5.5 xhigh round 1: REJECT, 5 blockers (gated-nested gating + escalation, sampling CompositeArm KeyError, committee per-sample vote-weight inflation, K-chain ERROR parity, shallow preflight) → all fixed red-first @6622d984.
- codex round 2 (delta): REJECT, 1 new blocker — the manual driver lost the engine's `StageSpec.samples >= 1` validation (`samples=0` ⇒ silent `OUTPUT None`) → fixed red-first @a512e917 (fail-closed §3.2.1 error at both terminal and gated positions; ensemble paths verified already fail-closed).
- codex round 3 (confirmation): running; merge gated on ACCEPT.
- Captain verification: knobs suite re-run personally (249 passed); independent depth-2 nesting probe (gate fed by nested committee stats, deep preflight names depth-2 missing stages); full unit tree failure-diffed vs develop — identical pre-existing set, zero introduced.

## PR checklist

1. **Worst-case prod path**: composite runtime mis-selecting an arm or faking success. All abnormal paths are fail-closed `ResultKind.ERROR` / honest `no_accept` (incl. the round-2 `samples=0` hole); errors are absorbing per §3.2.1.
2. **Production-branch test**: fail-closed coverage — `TestDriverSampleCardinalityParity` (tests/unit/knobs/test_composites_runtime.py), kchain missing-signal/ERROR-parity tests, deep-preflight tests; no production-gated fixture paths touched.
3. **Contract regeneration**: none — no wire/schema surface (RFC 0002 §0 freeze: composites do NOT ride the wire this program). JS parity for execution is a recorded follow-up; parse-parity already shipped (traigent-js#92).
4. **Public surface delta**: no `__all__`/exports change; extends the existing `traigent.knobs.runtime` module shipped in #1167. NotImplementedError survivors are pre-dispatch, documented, and not in any public-surface registry.
5. **Review threads resolved**: will be confirmed before merge (Rule 8).
6. **Quality gates**: none relaxed; hook-mypy (strict) green.