### PR TITLE
feat(evaluators): tuple-return user-metrics channel — make the documented hybrid recipe real (CV-C)

### DIFF
--- a/docs/traceability/concepts/composite-knobs.md
+++ b/docs/traceability/concepts/composite-knobs.md
@@ -126,7 +126,7 @@ decision = gate.evaluate(
 `decision.decision` is one of `promote`, `reject`, or `no_decision`. A
 `no_decision` is the honest outcome when the evidence does not establish
 dominance under the policy — it is not a failure and is never reported as a
-winner. The offline example prints a CERTIFIED WINNER or an honest "no winner
+winner. The offline example prints a CALIBRATION-BACKED WINNER (client-attested) or an honest "no winner
 yet" depending on the samples it collects.
 
 In a hybrid or cloud run you do not call the promotion gate yourself; the

--- a/docs/traceability/concepts/composite-knobs.md
+++ b/docs/traceability/concepts/composite-knobs.md
@@ -213,12 +213,22 @@ def answer(text: str) -> tuple[str, dict[str, float]]:
     return str(run.output), metrics
 ```
 
+The evaluator unpacks a return that is EXACTLY a length-2 tuple
+`(output, metrics)` whose `metrics` is a `Mapping` with all-string keys and
+all-numeric (non-`bool`) values: `output` (element `[0]`) is used for accuracy,
+`actual_output`, and scoring, while `metrics` (element `[1]`) mean-aggregates
+across examples onto the trial — every other return shape is left untouched, so
+existing string/dict returns are unaffected. A user metric never overrides an
+evaluator-computed key (e.g. a user-supplied `accuracy` is skipped and the
+computed accuracy is kept).
+
 On submission, the SDK splits off the reserved `measures` / `summary_stats`
 keys and validates the remaining numeric metrics (your `accuracy` plus the
 `composite_*` keys) through `MeasuresDict` before posting them in the trial
-result body. The integration test
-`tests/unit/cloud/test_composite_measures_submission.py` asserts the
-`composite_*` keys appear in the posted body.
+result body. The integration tests in
+`tests/unit/cloud/test_composite_measures_submission.py` assert the
+`composite_*` keys appear in the posted body — both from a pre-merged metrics
+dict and end-to-end from a tuple-returning function through the real evaluator.
 
 ## See also
 

--- a/docs/traceability/concepts/composite-knobs.md
+++ b/docs/traceability/concepts/composite-knobs.md
@@ -214,13 +214,21 @@ def answer(text: str) -> tuple[str, dict[str, float]]:
 ```
 
 The evaluator unpacks a return that is EXACTLY a length-2 tuple
-`(output, metrics)` whose `metrics` is a `Mapping` with all-string keys and
-all-numeric (non-`bool`) values: `output` (element `[0]`) is used for accuracy,
-`actual_output`, and scoring, while `metrics` (element `[1]`) mean-aggregates
-across examples onto the trial — every other return shape is left untouched, so
-existing string/dict returns are unaffected. A user metric never overrides an
-evaluator-computed key (e.g. a user-supplied `accuracy` is skipped and the
-computed accuracy is kept).
+`(output, metrics)` whose `metrics` is a `Mapping` with all-identifier keys
+(every key is a string satisfying `str.isidentifier()`, matching the
+`MeasuresDict` wire contract — a key like `"bad-key"` makes the shape NOT match,
+so the raw tuple rides through untouched) and all-numeric (non-`bool`) values:
+`output` (element `[0]`) is used for accuracy, `actual_output`, and scoring,
+while `metrics` (element `[1]`) mean-aggregates across examples onto the trial —
+every other return shape is left untouched, so existing string/dict returns are
+unaffected. A user metric never overrides a reserved evaluator-computed key
+(`accuracy`, `success_rate`, `error_rate`, `avg_output_length`, `latency`,
+`cost`, `examples_attempted`, the token/cost aggregates, …): such keys are
+skipped (warning-logged) at every merge and aggregation site, regardless of
+ordering. The aggregated trial metrics are capped at the same
+`TOTAL_MEASURES_CEILING` (50) total keys as `merge_composite_measures` — only
+user keys are truncated (deterministically, warning-logged); evaluator keys are
+never dropped.
 
 On submission, the SDK splits off the reserved `measures` / `summary_stats`
 keys and validates the remaining numeric metrics (your `accuracy` plus the

--- a/examples/advanced/composite-knobs/composite_telemetry.py
+++ b/examples/advanced/composite-knobs/composite_telemetry.py
@@ -150,7 +150,7 @@ def main() -> None:
     )
 
     if decision.decision == "promote":
-        print(f"CERTIFIED WINNER: variant=strong promoted — {decision.reason}")
+        print(f"CALIBRATION-BACKED WINNER (client-attested): variant=strong promoted — {decision.reason}")
     elif decision.decision == "reject":
         print(f"NO PROMOTION: candidate rejected — {decision.reason}")
     else:

--- a/examples/advanced/composite-knobs/composite_telemetry.py
+++ b/examples/advanced/composite-knobs/composite_telemetry.py
@@ -45,7 +45,7 @@ os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 
 from traigent.knobs.patterns import binary_cascade
 from traigent.knobs.runtime import StageRunner, execute_composite
-from traigent.knobs.telemetry import composite_measures, merge_composite_measures
+from traigent.knobs.telemetry import merge_composite_measures
 from traigent.tvl.models import PromotionPolicy
 from traigent.tvl.promotion_gate import ObjectiveSpec, PromotionGate
 
@@ -164,7 +164,13 @@ def main() -> None:
 # In a hybrid or cloud run, you do not call the promotion gate yourself — the
 # orchestrator does. Your decorated function executes the composite in-trial and
 # merges the composite telemetry into the metrics it returns; those numeric
-# metrics ride the existing measures channel to the backend:
+# metrics ride the existing measures channel to the backend.
+#
+# The evaluator unpacks a return that is EXACTLY a 2-tuple ``(output, metrics)``
+# whose ``metrics`` is a dict of str keys to numeric values: ``output`` is used
+# for accuracy/scoring and ``metrics`` mean-aggregates onto the trial (any other
+# return shape is left untouched). A user metric never overrides an
+# evaluator-computed key (e.g. ``accuracy`` stays the computed value):
 #
 #     import traigent
 #

--- a/tests/unit/cloud/test_composite_measures_submission.py
+++ b/tests/unit/cloud/test_composite_measures_submission.py
@@ -32,9 +32,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from traigent.cloud.trial_operations import TrialOperations
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
 from traigent.knobs.patterns import binary_cascade
 from traigent.knobs.runtime import StageRunner, execute_composite
-from traigent.knobs.telemetry import composite_measures, merge_composite_measures
+from traigent.knobs.telemetry import merge_composite_measures
 
 GATE = "router_margin_threshold"
 
@@ -215,3 +217,105 @@ async def test_composite_metrics_pass_measuresdict_on_the_submission_path() -> N
     assert not any(
         "Metrics validation warning" in msg for msg in warning_msgs
     ), f"composite metrics tripped MeasuresDict validation: {warning_msgs}"
+
+
+# ---------------------------------------------------------------------------
+# Upstream hop: a TUPLE-RETURNING decorated function drives the REAL evaluator,
+# and the composite_* keys reach the posted trial-result body.
+#
+# The existing tests above start from ``submit_trial_result_via_session`` with a
+# pre-merged metrics dict — they proved only the DOWNSTREAM half. The smoke that
+# motivated this packet showed the UPSTREAM half was broken: the decorated
+# function returned ``(output, metrics_dict)``, but tuple[1] was never extracted
+# into the evaluator's trial metrics, so the composite_* keys never reached the
+# wire (and the raw tuple poisoned the accuracy comparison). This test exercises
+# the real LocalEvaluator lane end-to-end.
+# ---------------------------------------------------------------------------
+
+
+async def _trial_metrics_from_tuple_returning_function() -> dict[str, float]:
+    """Run the REAL evaluator over a tuple-returning function (offline)."""
+    dataset = Dataset(
+        examples=[
+            EvaluationExample(input_data={"text": "q1"}, expected_output="STRONG"),
+            EvaluationExample(input_data={"text": "q2"}, expected_output="STRONG"),
+        ],
+        name="composite_upstream_hop",
+    )
+
+    async def answer(text: str) -> tuple[str, dict[str, float]]:
+        composite = binary_cascade(
+            "answerer", base_stage="cheap", expert_stage="strong", threshold=GATE
+        )
+        run = execute_composite(
+            composite.structure,
+            {"cheap": _stage(["A", "A", "B"]), "strong": _stage(["STRONG"])},
+            config={"variant": "strong"},
+            calibrated_values={GATE: 0.9},
+        )
+        metrics: dict[str, float] = {}
+        merge_composite_measures(metrics, run)
+        return str(run.output), metrics
+
+    evaluator = LocalEvaluator(
+        metrics=["accuracy"], detailed=True, execution_mode="edge_analytics"
+    )
+    result = await evaluator.evaluate(answer, {}, dataset)
+    return result.metrics
+
+
+@pytest.mark.asyncio
+async def test_tuple_returning_function_metrics_reach_posted_body() -> None:
+    """The composite_* keys produced upstream reach the posted trial body."""
+    trial_metrics = await _trial_metrics_from_tuple_returning_function()
+
+    # Pre-condition: the REAL evaluator surfaced the composite keys AND derived
+    # accuracy from tuple[0] (== "STRONG" == expected) rather than the raw tuple.
+    assert trial_metrics["accuracy"] == 1.0
+    assert trial_metrics["composite_escalation_rate"] == 1.0
+    assert trial_metrics["composite_stage_selected"] == 1
+    assert trial_metrics["composite_gate_0_margin_pass_rate"] == 0.0
+
+    mock_client = Mock()
+    mock_client.backend_config = Mock()
+    mock_client.backend_config.backend_base_url = "https://api.example.com"
+    mock_client.backend_config.api_base_url = "https://api.example.com/api/v1"
+    mock_client.auth_manager = AsyncMock()
+    mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+    mock_client._map_to_backend_status = Mock(return_value="COMPLETED")
+    mock_client._normalize_execution_mode = Mock(return_value="hybrid")
+    mock_client._sanitize_error_message = Mock(return_value="")
+
+    ops = TrialOperations(mock_client)
+    ops._handle_trial_success_response = AsyncMock(return_value=True)
+
+    mock_session, mock_session_ctx = _build_post_mock()
+
+    with (
+        patch(
+            "traigent.cloud.trial_operations.is_backend_offline",
+            return_value=False,
+        ),
+        patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+        patch("traigent.cloud.trial_operations.validate_configuration_run_submission"),
+        patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+    ):
+        mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+        mock_aiohttp.ClientTimeout = Mock()
+
+        result = await ops.submit_trial_result_via_session(
+            session_id="session_123",
+            trial_id="trial_001",
+            config={"variant": "strong"},
+            metrics=trial_metrics,
+            status="completed",
+            execution_mode="hybrid",
+        )
+
+    assert result is True
+
+    posted_metrics = mock_session.post.call_args.kwargs["json"]["metrics"]
+    assert posted_metrics["accuracy"] == 1.0
+    assert posted_metrics["composite_escalation_rate"] == 1.0
+    assert posted_metrics["composite_stage_selected"] == 1
+    assert posted_metrics["composite_gate_0_margin_pass_rate"] == 0.0

--- a/tests/unit/evaluators/test_tuple_metrics_channel.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel.py
@@ -1,0 +1,140 @@
+"""The 2-tuple ``(output, metrics_dict)`` return rides the measures channel.
+
+These tests exercise the REAL local/hybrid evaluation lane (no mocking of the
+unpack itself): a decorated-style function returns ``(output, user_metrics)``
+and we assert (a) accuracy is computed from ``output`` (tuple[0]), not the raw
+tuple, and (b) the numeric ``user_metrics`` keys mean-aggregate into the trial
+metrics so they ride the measures wire channel.
+
+Strict unpack rule (see ``BaseEvaluator._unpack_user_metrics``): ONLY a length-2
+tuple whose [1] is a Mapping with all-str keys and all-numeric (non-bool)
+values is unpacked. Every other shape is left untouched (absolute back-compat).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
+
+
+def _two_example_dataset() -> Dataset:
+    return Dataset(
+        examples=[
+            EvaluationExample(input_data={"text": "q1"}, expected_output="YES"),
+            EvaluationExample(input_data={"text": "q2"}, expected_output="YES"),
+        ],
+        name="tuple_metrics_channel",
+    )
+
+
+def _evaluator() -> LocalEvaluator:
+    # edge_analytics keeps everything offline (no backend / no LLM).
+    return LocalEvaluator(
+        metrics=["accuracy"],
+        detailed=True,
+        execution_mode="edge_analytics",
+    )
+
+
+@pytest.mark.asyncio
+async def test_tuple_return_rides_composite_metrics_and_accuracy_from_output() -> None:
+    """5a: composite_* keys mean-aggregate AND accuracy comes from tuple[0]."""
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        # Both examples return ("YES", {...}) so accuracy is 1.0 from tuple[0].
+        # vote_margin differs per example so the MEAN is asserted (not a sum).
+        margin = 1.0 if text == "q1" else 0.5
+        return "YES", {
+            "composite_vote_margin": margin,
+            "composite_candidates_evaluated": 3,
+        }
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+
+    # Accuracy is computed from tuple[0] == "YES" == expected "YES" -> 1.0.
+    # (The RED here: today the raw tuple is compared to "YES" -> 0.0.)
+    assert result.metrics["accuracy"] == 1.0
+
+    # The composite_* keys rode the channel, mean-aggregated across the 2
+    # examples: vote_margin mean = (1.0 + 0.5) / 2 = 0.75; candidates = 3.
+    assert result.metrics["composite_vote_margin"] == pytest.approx(0.75)
+    assert result.metrics["composite_candidates_evaluated"] == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_plain_str_return_unchanged() -> None:
+    """5c: a plain str return is unaffected (no composite keys, accuracy ok)."""
+
+    async def func(text: str) -> str:
+        return "YES"
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+    assert result.metrics["accuracy"] == 1.0
+    assert not any(k.startswith("composite_") for k in result.metrics)
+
+
+@pytest.mark.asyncio
+async def test_dict_with_text_return_unchanged() -> None:
+    """5c: a dict-with-'text' return keeps its existing accuracy behavior."""
+
+    async def func(text: str) -> dict[str, str]:
+        return {"text": "YES", "other": "ignored"}
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+    # accuracy still derived from output["text"] == "YES".
+    assert result.metrics["accuracy"] == 1.0
+    assert not any(k.startswith("composite_") for k in result.metrics)
+
+
+@pytest.mark.asyncio
+async def test_three_tuple_not_unpacked() -> None:
+    """5c: a length-3 tuple is NOT unpacked (left as raw output)."""
+
+    async def func(text: str) -> tuple:
+        return ("YES", {"composite_x": 1.0}, "extra")
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+    # Raw 3-tuple != "YES" so accuracy is 0.0, and no composite key leaks.
+    assert result.metrics["accuracy"] == 0.0
+    assert not any(k.startswith("composite_") for k in result.metrics)
+
+
+@pytest.mark.asyncio
+async def test_tuple_with_non_numeric_dict_values_not_unpacked() -> None:
+    """5c: a 2-tuple whose [1] has a non-numeric value is NOT unpacked."""
+
+    async def func(text: str) -> tuple[str, dict[str, object]]:
+        return ("YES", {"composite_x": "not-a-number"})
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+    assert result.metrics["accuracy"] == 0.0
+    assert not any(k.startswith("composite_") for k in result.metrics)
+
+
+@pytest.mark.asyncio
+async def test_tuple_with_list_second_element_not_unpacked() -> None:
+    """5c: a 2-tuple whose [1] is a list (not a Mapping) is NOT unpacked."""
+
+    async def func(text: str) -> tuple[str, list[int]]:
+        return ("YES", [1, 2, 3])
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+    assert result.metrics["accuracy"] == 0.0
+    assert not any(k.startswith("composite_") for k in result.metrics)
+
+
+@pytest.mark.asyncio
+async def test_user_metric_named_accuracy_does_not_override_evaluator() -> None:
+    """5d: a user 'accuracy' key never overrides the evaluator's computed one."""
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        # User tries to inject accuracy=0.0; evaluator computes 1.0 from "YES".
+        return "YES", {"accuracy": 0.0, "composite_ok": 1.0}
+
+    result = await _evaluator().evaluate(func, {}, _two_example_dataset())
+    # Evaluator's computed accuracy (1.0) wins; the user value is ignored.
+    assert result.metrics["accuracy"] == 1.0
+    # The non-colliding composite key still rides.
+    assert result.metrics["composite_ok"] == pytest.approx(1.0)

--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening.py
@@ -1,0 +1,214 @@
+"""Hardening probes for the tuple-return metrics channel (codex review round).
+
+These pin the four codex-verified findings on the ``(output, metrics_dict)``
+return channel:
+
+* F1 — SimpleScoringEvaluator's trial aggregation surfaces user keys on the
+  result.metrics (it previously aggregated only ``self.metrics``).
+* F2a — ``_unpack_user_metrics`` requires EVERY key to be a Python identifier;
+  a non-identifier key (e.g. ``"bad-key"``) means the shape does not match and
+  the raw tuple rides through untouched.
+* F2b — user keys cannot push the aggregated trial metrics past the
+  ``TOTAL_MEASURES_CEILING`` (50) total; user keys are truncated
+  deterministically (evaluator keys never dropped) with a warning.
+* F3 — user keys can never overwrite a reserved evaluator/tracker key
+  (``success_rate``, ``latency``, ``examples_attempted``, …) at ANY merge or
+  aggregation site, regardless of ordering or setdefault.
+* F4 — a nested matching tuple is unpacked exactly once: the carrier already
+  attached upstream is preferred, so ``_process_single_output`` does not
+  re-unpack an already-unpacked output.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from traigent.evaluators.base import Dataset, EvaluationExample, SimpleScoringEvaluator
+from traigent.evaluators.local import LocalEvaluator
+from traigent.knobs.telemetry import TOTAL_MEASURES_CEILING
+
+
+def _two_example_dataset() -> Dataset:
+    return Dataset(
+        examples=[
+            EvaluationExample(input_data={"text": "q1"}, expected_output="YES"),
+            EvaluationExample(input_data={"text": "q2"}, expected_output="YES"),
+        ],
+        name="tuple_metrics_hardening",
+    )
+
+
+def _local_evaluator() -> LocalEvaluator:
+    return LocalEvaluator(
+        metrics=["accuracy"],
+        detailed=True,
+        execution_mode="edge_analytics",
+    )
+
+
+# ---------------------------------------------------------------------------
+# F1: SimpleScoringEvaluator surfaces tuple-supplied user keys on result.metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_simple_scoring_tuple_user_keys_reach_result_metrics() -> None:
+    """F1: the public SimpleScoringEvaluator path mean-aggregates user keys."""
+
+    def score(output: object, expected: object) -> float:
+        return 1.0 if output == expected else 0.0
+
+    def func(text: str) -> tuple[str, dict[str, float]]:
+        margin = 1.0 if text == "q1" else 0.5
+        return "YES", {"composite_vote_margin": margin}
+
+    evaluator = SimpleScoringEvaluator(
+        scoring_function=score,
+        metrics=["accuracy"],
+        capture_llm_metrics=False,
+    )
+    result = await evaluator.evaluate(func, {}, _two_example_dataset())
+
+    # RED before F1: composite_vote_margin reaches example_results[*].metrics but
+    # never result.metrics, so the channel dies on this evaluator.
+    assert result.metrics["composite_vote_margin"] == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# F2a: non-identifier keys make the shape NOT match -> raw passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_identifier_key_is_not_unpacked() -> None:
+    """F2a: a metrics dict with a non-identifier key is left as the raw tuple."""
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "ok", {"bad-key": 1.0}
+
+    result = await _local_evaluator().evaluate(func, {}, _two_example_dataset())
+
+    # RED before F2a: "bad-key" is unpacked and rides; the tuple is split.
+    assert "bad-key" not in result.metrics
+    # The raw tuple poisons accuracy (output != "YES"), proving no unpack.
+    assert result.metrics["accuracy"] == 0.0
+
+
+def test_unpack_helper_rejects_non_identifier_keys_directly() -> None:
+    """F2a (unit): _unpack_user_metrics passes through on any non-identifier."""
+    raw = ("ok", {"bad-key": 1.0, "fine_key": 2.0})
+    output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+    assert output is raw
+    assert user_metrics is None
+
+
+# ---------------------------------------------------------------------------
+# F2b: user keys cannot push aggregated trial metrics past the ceiling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_keys_truncated_to_ceiling(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """F2b: >50 distinct user keys are truncated to the total ceiling."""
+    # 60 distinct identifier user keys; the evaluator also contributes its own
+    # keys (accuracy, etc.), so the total must be clamped to the ceiling.
+    user_keys = {f"composite_metric_{i}": float(i) for i in range(60)}
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", dict(user_keys)
+
+    with caplog.at_level(logging.WARNING):
+        result = await _local_evaluator().evaluate(func, {}, _two_example_dataset())
+
+    # RED before F2b: nothing clamps the total, so it exceeds the ceiling.
+    assert len(result.metrics) <= TOTAL_MEASURES_CEILING
+    # Evaluator keys are never dropped.
+    assert "accuracy" in result.metrics
+    # A truncation warning was logged.
+    assert any("ceiling" in record.getMessage().lower() for record in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# F3: user keys never overwrite reserved evaluator/tracker keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_keys_never_overwrite_reserved_builtins(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """F3: success_rate / latency / examples_attempted stay evaluator-computed."""
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", {
+            "success_rate": 0.01,
+            "latency": 0.0,
+            "examples_attempted": 999.0,
+            "composite_ok": 1.0,
+        }
+
+    evaluator = LocalEvaluator(
+        metrics=["accuracy", "success_rate", "latency"],
+        detailed=True,
+        execution_mode="edge_analytics",
+    )
+    with caplog.at_level(logging.WARNING):
+        result = await evaluator.evaluate(func, {}, _two_example_dataset())
+
+    # examples_attempted is the count (2), never the user's 999.0.
+    assert result.metrics["examples_attempted"] == 2
+    # success_rate is the evaluator's computed value (both succeeded -> 1.0),
+    # never the user's 0.01.
+    assert result.metrics["success_rate"] != pytest.approx(0.01)
+    # latency is evaluator-computed, never forced to the user's 0.0-by-injection;
+    # the key exists and is the computed one (it is allowed to equal 0.0 if the
+    # evaluator computed 0.0, but it must not be sourced from the user dict).
+    assert "latency" in result.metrics
+    # The non-reserved composite key still rides.
+    assert result.metrics["composite_ok"] == pytest.approx(1.0)
+    # Reserved-key skips are warning-logged (upgraded from debug).
+    assert any(
+        "reserved" in record.getMessage().lower() and record.levelno >= logging.WARNING
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# F4: nested matching tuple is unpacked exactly once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nested_tuple_unpacked_once() -> None:
+    """F4: ((inner, {x}), {outer}) keeps output == (inner, {x}); rides {outer}."""
+
+    captured_outputs: list[object] = []
+
+    def _capture(index: int, payload: dict[str, object]) -> None:
+        if "output" in payload:
+            captured_outputs.append(payload["output"])
+
+    async def func(text: str) -> tuple[tuple[str, dict[str, float]], dict[str, float]]:
+        return (("inner", {"x": 1.0}), {"outer": 2.0})
+
+    evaluator = _local_evaluator()
+    result = await evaluator.evaluate(
+        func, {}, _two_example_dataset(), progress_callback=_capture
+    )
+
+    # Only the OUTER user metric rides; the inner mapping is part of the output
+    # and is NOT re-unpacked into trial metrics.
+    assert result.metrics["outer"] == pytest.approx(2.0)
+    assert "x" not in result.metrics
+    # The resolved per-example actual_output is the inner tuple, unpacked once.
+    assert result.example_results[0].actual_output == ("inner", {"x": 1.0})
+    # RED before F4: _process_single_output re-unpacks the already-unpacked
+    # output, so the resolved per-example output becomes "inner" (the inner
+    # tuple[0]) instead of the inner tuple. The local-lane progress payload
+    # carries that resolved output, so it must stay the inner tuple.
+    assert captured_outputs, "expected per-example progress payloads"
+    assert all(out == ("inner", {"x": 1.0}) for out in captured_outputs)

--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round2.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round2.py
@@ -1,0 +1,257 @@
+"""Round-2 hardening probes for the tuple-return metrics channel (codex review).
+
+These pin the four codex-verified round-2 findings on the
+``(output, metrics_dict)`` return channel. They are written RED-first: each
+asserts the *fixed* behavior so it fails against the pre-fix code.
+
+* G1 — ``SimpleScoringEvaluator`` caps user keys, then inserts
+  ``examples_attempted`` AFTER the cap with no final-union ceiling, so >50 flat
+  trial metrics can escape. The fix applies the SAME ``enforce_user_metric_ceiling``
+  helper as the local lane as the LAST step before returning trial metrics.
+* G2 — ``_unpack_user_metrics`` gated on ``str.isidentifier()``, which accepts
+  Unicode identifiers (e.g. ``"π_metric"``) that the ``MeasuresDict`` wire
+  contract (``^[a-zA-Z_]\\w*$`` with ``re.ASCII``) rejects. The fix swaps the
+  gate to the EXACT ASCII pattern, pinned to ``dtos.py``'s ``KEY_PATTERN`` by a
+  consistency test.
+* G3 — reserved-key protection missed evaluator-computable names not in the
+  static frozenset (RAGAS metrics such as ``context_precision``). The fix
+  consults ``RESERVED_METRIC_KEYS`` UNION the evaluator's own metric-registry +
+  RAGAS names at every merge site.
+* G4 — SDK-internal cost/token keys (``input_cost`` etc.) injected by the local
+  lane flow through the shared user-aggregation pass and were skipped with a
+  WARNING that *lies* (they are evaluator-internal, not user metrics). The fix
+  logs reserved-key skips in the shared aggregator at DEBUG; the per-example
+  ``_merge_user_metrics`` (genuinely user dicts) KEEPS the WARNING.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from traigent.cloud.dtos import MeasuresDict
+from traigent.evaluators.base import Dataset, EvaluationExample, SimpleScoringEvaluator
+from traigent.evaluators.local import LocalEvaluator
+from traigent.evaluators.metrics_tracker import (
+    USER_METRIC_KEY_PATTERN,
+    aggregate_user_custom_metrics,
+)
+from traigent.knobs.telemetry import TOTAL_MEASURES_CEILING
+
+
+def _two_example_dataset() -> Dataset:
+    return Dataset(
+        examples=[
+            EvaluationExample(input_data={"text": "q1"}, expected_output="YES"),
+            EvaluationExample(input_data={"text": "q2"}, expected_output="YES"),
+        ],
+        name="tuple_metrics_hardening_round2",
+    )
+
+
+def _local_evaluator(metrics: list[str] | None = None) -> LocalEvaluator:
+    return LocalEvaluator(
+        metrics=metrics or ["accuracy"],
+        detailed=True,
+        execution_mode="edge_analytics",
+    )
+
+
+# ---------------------------------------------------------------------------
+# G1: SimpleScoringEvaluator final-union ceiling (examples_attempted added last)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_simple_scoring_final_union_capped_after_examples_attempted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """G1 (codex repro): metrics=["accuracy"] + 60 tuple user keys -> <= ceiling.
+
+    Pre-fix: user keys are capped, then ``examples_attempted`` is added AFTER
+    with no final-union cap, so ``len(result.metrics) == 51``.
+    """
+
+    def score(output: object, expected: object) -> float:
+        return 1.0 if output == expected else 0.0
+
+    user_keys = {f"composite_metric_{i}": float(i) for i in range(60)}
+
+    def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", dict(user_keys)
+
+    evaluator = SimpleScoringEvaluator(
+        scoring_function=score,
+        metrics=["accuracy"],
+        capture_llm_metrics=False,
+    )
+    with caplog.at_level(logging.WARNING):
+        result = await evaluator.evaluate(func, {}, _two_example_dataset())
+
+    # RED before G1: examples_attempted slips past the user-key cap -> 51 keys.
+    assert len(result.metrics) <= TOTAL_MEASURES_CEILING
+    # examples_attempted is a reserved evaluator key and must survive the cap.
+    assert "examples_attempted" in result.metrics
+    assert result.metrics["examples_attempted"] == 2
+    # The result is wire-valid against the MeasuresDict ceiling.
+    assert len(MeasuresDict(dict(result.metrics))) <= MeasuresDict.MAX_KEYS
+
+
+# ---------------------------------------------------------------------------
+# G2: Unicode-identifier bypass closed; ASCII pattern matches MeasuresDict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unicode_identifier_key_is_not_unpacked() -> None:
+    """G2 (codex repro): "π_metric".isidentifier() is True but the wire rejects it.
+
+    Pre-fix: the tuple is unpacked, ``π_metric`` rides into result.metrics, and
+    MeasuresDict rejects it at submission (the compat catch then submits
+    unvalidated). Fixed: the shape does NOT match, so the raw tuple rides
+    through and accuracy is poisoned (output != "YES").
+    """
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "ok", {"π_metric": 1.0}
+
+    result = await _local_evaluator().evaluate(func, {}, _two_example_dataset())
+
+    assert "π_metric" not in result.metrics
+    # No unpack -> the raw tuple stays the output -> accuracy is 0.0.
+    assert result.metrics["accuracy"] == 0.0
+
+
+def test_unpack_helper_rejects_unicode_identifier_directly() -> None:
+    """G2 (unit): _unpack_user_metrics passes through on a Unicode-identifier key."""
+    assert "π_metric".isidentifier() is True  # the bypass premise
+    raw = ("ok", {"π_metric": 1.0, "fine_key": 2.0})
+    output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+    assert output is raw
+    assert user_metrics is None
+
+
+def test_user_metric_pattern_matches_measuresdict_pattern() -> None:
+    """G2 (consistency): the evaluator gate and the wire contract agree.
+
+    Imports BOTH the evaluator-side ``USER_METRIC_KEY_PATTERN`` and the cloud
+    ``MeasuresDict.KEY_PATTERN`` and asserts they accept/reject the SAME key
+    corpus. If the wire pattern drifts, THIS test fails rather than the bypass
+    silently reopening.
+    """
+    accept = ["_x", "ok_key", "metric_123", "abc", "A1_b2"]
+    reject = ["π_metric", "a-b", "9a", "", "has space", "éclair"]
+
+    wire = MeasuresDict.KEY_PATTERN
+    # The wire contract is ASCII-identifier syntax; the evaluator gate must be
+    # at least as strict (it must reject everything the wire rejects). Both must
+    # use re.ASCII semantics so \\w does not leak Unicode word chars.
+    assert wire.flags & re.ASCII, "MeasuresDict.KEY_PATTERN must be compiled re.ASCII"
+    assert USER_METRIC_KEY_PATTERN.flags & re.ASCII
+
+    for key in accept:
+        assert USER_METRIC_KEY_PATTERN.match(key), key
+        assert wire.match(key), key
+    for key in reject:
+        assert not USER_METRIC_KEY_PATTERN.match(key), key
+        assert not wire.match(key), key
+
+
+# ---------------------------------------------------------------------------
+# G3: reserved-key protection covers evaluator-computable (RAGAS) names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_cannot_overwrite_evaluator_computable_ragas_name() -> None:
+    """G3 (codex repro): metrics=["context_precision"] + tuple {context_precision}.
+
+    Pre-fix: ``context_precision`` is absent from RESERVED_METRIC_KEYS and the
+    local merge overwrites it with the user's 0.9, so the user value wins.
+    Fixed: the evaluator's metric-registry/RAGAS name is reserved, so the user
+    value is skipped and the evaluator-computed value wins.
+    """
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", {"context_precision": 0.9}
+
+    evaluator = _local_evaluator(metrics=["accuracy", "context_precision"])
+    result = await evaluator.evaluate(func, {}, _two_example_dataset())
+
+    # The user's 0.9 must NOT win: context_precision is evaluator-computable.
+    # RAGAS is unavailable in unit tests, so the evaluator computes 0.0 (the
+    # fail-closed default); the key must exist and must not be the user's 0.9.
+    assert "context_precision" in result.metrics
+    assert result.metrics["context_precision"] != pytest.approx(0.9)
+
+
+def test_shared_aggregator_honors_extra_reserved_keys() -> None:
+    """G3 (unit): aggregate_user_custom_metrics skips extra_reserved names."""
+    target: dict[str, float] = {}
+    aggregate_user_custom_metrics(
+        target,
+        [{"context_precision": 0.9, "composite_ok": 1.0}],
+        context="g3 unit",
+        extra_reserved=frozenset({"context_precision"}),
+    )
+    assert "context_precision" not in target
+    assert target["composite_ok"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# G4: reserved-key skips in the shared aggregator log at DEBUG (not WARNING)
+# ---------------------------------------------------------------------------
+
+
+def test_shared_aggregator_reserved_skip_logs_debug_not_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """G4: SDK-internal cost keys skipped in the shared pass log at DEBUG.
+
+    The shared aggregator receives evaluator-internal keys (input_cost,
+    total_cost, ...) injected by the local lane. Skipping them is correct, but
+    the WARNING lied ("user metric"). Fixed: reserved skips in the shared
+    aggregator log at DEBUG.
+    """
+    target: dict[str, float] = {}
+    with caplog.at_level(logging.DEBUG, logger="traigent.evaluators.metrics_tracker"):
+        aggregate_user_custom_metrics(
+            target,
+            [{"input_cost": 0.01, "total_cost": 0.02, "composite_ok": 1.0}],
+            context="g4 unit",
+        )
+
+    # The non-reserved key still rides.
+    assert target["composite_ok"] == pytest.approx(1.0)
+    reserved_records = [
+        r for r in caplog.records if "reserved" in r.getMessage().lower()
+    ]
+    assert reserved_records, "expected a reserved-skip log line"
+    # RED before G4: these are WARNINGs. Fixed: DEBUG.
+    assert all(r.levelno == logging.DEBUG for r in reserved_records)
+    assert not any(
+        r.levelno >= logging.WARNING and "reserved" in r.getMessage().lower()
+        for r in caplog.records
+    )
+
+
+def test_per_example_user_merge_reserved_skip_keeps_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """G4: the per-example _merge_user_metrics KEEPS the WARNING (real user dict)."""
+    evaluator = _local_evaluator(metrics=["accuracy", "success_rate"])
+    target: dict[str, float] = {}
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.base"):
+        evaluator._merge_user_metrics(
+            target,
+            {"success_rate": 0.01, "composite_ok": 1.0},
+            context="local lane",
+        )
+    assert target["composite_ok"] == pytest.approx(1.0)
+    assert "success_rate" not in target
+    assert any(
+        "reserved" in r.getMessage().lower() and r.levelno >= logging.WARNING
+        for r in caplog.records
+    )

--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round3.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round3.py
@@ -1,0 +1,293 @@
+"""Round-3 hardening probes for the tuple-return metrics channel (captain review).
+
+These pin the two captain-found residuals that survived the G1-G4 round. Written
+RED-first: each asserts the *fixed* behavior so it fails against the pre-fix code.
+
+* R1 — the G1 class survives in the LOCAL lane. The local-lane
+  ``enforce_user_metric_ceiling`` (``local.py``) and the ``format_for_backend``
+  user-metric cap BOTH run, bounding ``eval_result.metrics`` to 50 keys. But
+  ``build_success_result`` (``core/trial_result_factory.py``) writes ONE more
+  reserved key — ``total_cost`` — into the trial metrics AFTER both caps, so the
+  final ``result.metrics`` has 51 keys. The fix re-applies
+  ``enforce_user_metric_ceiling`` as the LAST step of ``build_success_result``,
+  the SINGLE authoritative final-union cap covering EVERY lane that produces a
+  successful trial; only user keys are dropped, the reserved keys all survive.
+* R2 — a 2-tuple whose ``[1]`` IS a Mapping but FAILS the strict wire rule (bad
+  key syntax, or a bool / non-numeric value) is left as raw output per design
+  (absolute back-compat). Pre-fix this is SILENT: the user's accuracy is poisoned
+  (the raw tuple becomes the output) with zero signal. The fix logs ONE WARNING
+  naming the first offending key/value and stating the tuple was NOT unpacked and
+  why — with NO behavior change (raw passthrough stays). Shapes that are silent
+  by design (plain return, 3-tuple, tuple whose ``[1]`` is a list) stay silent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from traigent.cloud.dtos import MeasuresDict
+from traigent.core.trial_result_factory import build_success_result
+from traigent.evaluators.base import Dataset, EvaluationExample, SimpleScoringEvaluator
+from traigent.evaluators.local import LocalEvaluator
+from traigent.knobs.telemetry import TOTAL_MEASURES_CEILING
+
+#: The reserved (non-user) keys the captain's 60-key local-lane repro produces on
+#: the final trial metrics. Every one must SURVIVE the final-union cap — only the
+#: user keys may shrink.
+EXPECTED_NON_USER_KEYS = {
+    "accuracy",
+    "cost",
+    "duration",
+    "examples_attempted",
+    "input_tokens",
+    "output_tokens",
+    "response_time_ms",
+    "score",
+    "successful_examples",
+    "total_cost",
+    "total_examples",
+    "total_tokens",
+}
+
+
+def _two_example_dataset() -> Dataset:
+    return Dataset(
+        examples=[
+            EvaluationExample(input_data={"text": "q1"}, expected_output="YES"),
+            EvaluationExample(input_data={"text": "q2"}, expected_output="YES"),
+        ],
+        name="tuple_metrics_hardening_round3",
+    )
+
+
+def _local_evaluator(metrics: list[str] | None = None) -> LocalEvaluator:
+    return LocalEvaluator(
+        metrics=metrics or ["accuracy"],
+        detailed=True,
+        execution_mode="edge_analytics",
+    )
+
+
+# ---------------------------------------------------------------------------
+# R1: build_success_result is the authoritative final-union cap (local lane)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_lane_final_trial_metrics_capped_after_total_cost(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """R1 (captain repro): 60 tuple user keys -> final result.metrics <= ceiling.
+
+    Pre-fix: the local-lane caps bound ``eval_result.metrics`` to 50, then
+    ``build_success_result`` writes ``total_cost`` AFTER them -> 51 keys.
+    Fixed: ``build_success_result`` re-applies the ceiling as the LAST step, so
+    only user keys shrink and ALL reserved keys survive.
+    """
+
+    user_keys = {f"composite_metric_{i}": float(i) for i in range(60)}
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", dict(user_keys)
+
+    with caplog.at_level(logging.WARNING):
+        eval_result = await _local_evaluator().evaluate(
+            func, {}, _two_example_dataset()
+        )
+
+    # Build the trial result exactly as the orchestrator does: the lane's
+    # reserved keys (examples_attempted, total_cost) are written here, AFTER the
+    # local-lane caps already ran on eval_result.metrics.
+    trial_result = build_success_result(
+        trial_id="r1-local",
+        evaluation_config={},
+        eval_result=eval_result,
+        duration=0.1,
+        examples_attempted=2,
+        total_cost=0.0,
+        optuna_trial_id=None,
+    )
+
+    metrics = trial_result.metrics
+    # RED before R1: total_cost slips past the local-lane caps -> 51 keys.
+    assert len(metrics) <= TOTAL_MEASURES_CEILING
+    # ALL 12 non-user (reserved) keys must survive the cap; only user keys shrink.
+    present_non_user = {k for k in metrics if not k.startswith("composite_metric_")}
+    assert EXPECTED_NON_USER_KEYS <= present_non_user, (
+        f"reserved keys dropped: {EXPECTED_NON_USER_KEYS - present_non_user}"
+    )
+    # total_cost (the post-cap writer) is present and is a reserved key, not a
+    # casualty of the ceiling.
+    assert "total_cost" in metrics
+    # The final union is wire-valid against the MeasuresDict ceiling.
+    assert len(MeasuresDict(dict(metrics))) <= MeasuresDict.MAX_KEYS
+
+
+@pytest.mark.asyncio
+async def test_simple_scoring_60_key_probe_still_holds_after_refactor(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """R1 (regression): the G1 SimpleScoring 60-key probe still holds.
+
+    The authoritative final-union cap must not regress the SimpleScoring lane:
+    its own evaluate() still returns <= ceiling and examples_attempted survives.
+    """
+
+    def score(output: object, expected: object) -> float:
+        return 1.0 if output == expected else 0.0
+
+    user_keys = {f"composite_metric_{i}": float(i) for i in range(60)}
+
+    def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", dict(user_keys)
+
+    evaluator = SimpleScoringEvaluator(
+        scoring_function=score,
+        metrics=["accuracy"],
+        capture_llm_metrics=False,
+    )
+    with caplog.at_level(logging.WARNING):
+        result = await evaluator.evaluate(func, {}, _two_example_dataset())
+
+    assert len(result.metrics) <= TOTAL_MEASURES_CEILING
+    assert "examples_attempted" in result.metrics
+    assert result.metrics["examples_attempted"] == 2
+
+    # And the same result, assembled through build_success_result, stays capped.
+    trial_result = build_success_result(
+        trial_id="r1-simple",
+        evaluation_config={},
+        eval_result=result,
+        duration=0.1,
+        examples_attempted=2,
+        total_cost=0.0,
+        optuna_trial_id=None,
+    )
+    assert len(trial_result.metrics) <= TOTAL_MEASURES_CEILING
+    assert "examples_attempted" in trial_result.metrics
+
+
+def test_build_success_result_caps_reserved_writes_added_after_eval() -> None:
+    """R1 (unit): a 50-key eval_result + total_cost write -> capped to ceiling.
+
+    Direct unit on the authoritative site: feed a 50-key metrics dict (49 user +
+    accuracy) and let build_success_result add examples_attempted + total_cost.
+    The final union must clamp back to the ceiling, dropping only user keys.
+    """
+
+    class _EvalResult:
+        def __init__(self) -> None:
+            self.metrics: dict[str, float] = {"accuracy": 1.0}
+            self.metrics.update({f"composite_metric_{i}": float(i) for i in range(49)})
+            self.summary_stats = None
+            self.comparability = None
+
+    eval_result = _EvalResult()
+    assert len(eval_result.metrics) == TOTAL_MEASURES_CEILING
+
+    trial_result = build_success_result(
+        trial_id="r1-unit",
+        evaluation_config={},
+        eval_result=eval_result,
+        duration=0.1,
+        examples_attempted=2,
+        total_cost=0.5,
+        optuna_trial_id=None,
+    )
+
+    metrics = trial_result.metrics
+    assert len(metrics) <= TOTAL_MEASURES_CEILING
+    # The reserved keys written by build_success_result survive.
+    assert metrics["accuracy"] == 1.0
+    assert "examples_attempted" in metrics
+    assert "total_cost" in metrics
+
+
+# ---------------------------------------------------------------------------
+# R2: silent near-miss unpack now logs ONE warning (no behavior change)
+# ---------------------------------------------------------------------------
+
+
+def test_near_miss_bad_key_logs_warning_no_unpack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """R2: ("YES", {"π_metric": 1.0}) -> WARNING + raw passthrough (no unpack)."""
+    raw = ("YES", {"π_metric": 1.0})
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.base"):
+        output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+
+    # Behavior unchanged: raw passthrough.
+    assert output is raw
+    assert user_metrics is None
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "not treated as" in r.getMessage().lower()
+    ]
+    assert len(warnings) == 1, [r.getMessage() for r in caplog.records]
+    msg = warnings[0].getMessage()
+    assert "π_metric" in msg
+
+
+def test_near_miss_bad_value_logs_warning_no_unpack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """R2: non-numeric / bool value also warns once and passes through raw."""
+    raw = ("YES", {"good_key": True})
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.base"):
+        output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+
+    assert output is raw
+    assert user_metrics is None
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "not treated as" in r.getMessage().lower()
+    ]
+    assert len(warnings) == 1
+    assert "good_key" in warnings[0].getMessage()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "plain string return",
+        ("a", "b", "c"),  # 3-tuple
+        ("YES", [1, 2, 3]),  # [1] is a list, not a Mapping
+        ("YES",),  # 1-tuple
+        42,  # non-tuple scalar
+    ],
+)
+def test_by_design_silent_shapes_emit_no_warning(
+    raw: object, caplog: pytest.LogCaptureFixture
+) -> None:
+    """R2: shapes silent by design stay silent — only the NEAR-MISS shape warns.
+
+    A near-miss is a 2-tuple whose [1] IS a Mapping but fails the strict rule. A
+    plain return, a 3-tuple, or a tuple whose [1] is a list are NOT a near-miss:
+    the user never signaled intent to ship metrics, so warning would be noise.
+    """
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.base"):
+        output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+
+    assert output is raw
+    assert user_metrics is None
+    assert not any(
+        "not treated as" in r.getMessage().lower() for r in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+
+def test_valid_tuple_still_unpacks_and_emits_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """R2: a legitimate (output, metrics) tuple unpacks silently (no warning)."""
+    raw = ("YES", {"composite_ok": 1.0, "another": 2})
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.base"):
+        output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+
+    assert output == "YES"
+    assert user_metrics == {"composite_ok": 1.0, "another": 2.0}
+    assert not any("not treated as" in r.getMessage().lower() for r in caplog.records)

--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round4.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round4.py
@@ -1,0 +1,228 @@
+"""Round-4 hardening probes for the tuple-return metrics channel (captain repro).
+
+These pin the two captain-verified BLOCKERS that survived rounds G1-G4 + R1-R2.
+Written RED-first: each asserts the *fixed* behavior so it fails against the
+pre-fix code.
+
+* H1 — ``_evaluator_computable_metric_names()`` returned ``_metric_registry`` ∪
+  ``_ragas_metric_names`` but NOT ``self.metric_functions`` keys (user-passed
+  custom metric functions, never registered into ``_metric_registry``). So a
+  user tuple key named e.g. ``"f1"`` (matching a custom metric function) passed
+  the merge filter and could overwrite the evaluator-computed value. The fix
+  also folds ``metric_functions`` keys into the computable set, which threads
+  through every merge site and lane cap that already takes ``extra_reserved``.
+* H2 — ``RESERVED_METRIC_KEYS`` omitted the TRANSPORT-reserved keys ``"measures"``
+  and ``"summary_stats"``. ``_unpack_user_metrics`` accepted them (valid
+  identifier + numeric value), they rode into trial metrics, and then the
+  submission path broke: ``_extract_measures_from_metrics`` extracts them by name
+  as top-level payload fields and ``_validate_metrics_no_misplaced_fields``
+  hard-raises ``ValueError`` for either key in a metrics dict. The fix reserves
+  both names so user tuple keys with these names are skipped at merge.
+* H3 — the final factory cap (``build_success_result`` →
+  ``enforce_user_metric_ceiling``) passed NO ``extra_reserved``, so under ceiling
+  pressure evaluator-computed runtime names (``"f1"``, ``"context_precision"``,
+  …) were treated as droppable user keys and the primary objective could be
+  dropped from ``TrialResult.metrics``. The fix threads the evaluator's runtime
+  computable names into the final cap.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from traigent.cloud.validators import (
+    _validate_metrics_no_misplaced_fields,
+    validate_configuration_run_submission,
+)
+from traigent.core.trial_result_factory import build_success_result
+from traigent.evaluators.base import SimpleScoringEvaluator
+from traigent.evaluators.local import LocalEvaluator
+from traigent.evaluators.metrics_tracker import RESERVED_METRIC_KEYS
+
+
+def _custom_f1(output: object, expected: object) -> float:
+    return 1.0
+
+
+# ---------------------------------------------------------------------------
+# H1: metric_functions names are evaluator-computable (reserved)
+# ---------------------------------------------------------------------------
+
+
+def test_computable_names_include_metric_functions_simple_scoring() -> None:
+    """H1: SimpleScoringEvaluator folds metric_functions keys into computable set.
+
+    Pre-fix: ``_evaluator_computable_metric_names()`` is registry ∪ RAGAS only,
+    so a custom metric function named ``f1`` is absent and a user tuple key
+    ``f1`` would overwrite the evaluator's computed value.
+    """
+    evaluator = SimpleScoringEvaluator(metric_functions={"f1": _custom_f1})
+    assert "f1" in evaluator._evaluator_computable_metric_names()
+
+
+def test_computable_names_include_metric_functions_local_evaluator() -> None:
+    """H1: LocalEvaluator (inherits the base method) folds metric_functions keys."""
+    evaluator = LocalEvaluator(
+        metric_functions={"f1": _custom_f1},
+        detailed=True,
+        execution_mode="edge_analytics",
+    )
+    assert "f1" in evaluator._evaluator_computable_metric_names()
+
+
+# ---------------------------------------------------------------------------
+# H1/H2: merge site skips metric_functions name and transport-reserved names
+# ---------------------------------------------------------------------------
+
+
+def test_merge_skips_user_key_colliding_with_metric_functions_name() -> None:
+    """H1: a user tuple key colliding with a metric_functions name is SKIPPED.
+
+    ``extra_reserved`` is derived from the evaluator's computable names — pre-fix
+    that set excludes ``f1`` (a metric_functions key never registered into
+    ``_metric_registry``), so the user's value would merge into an EMPTY target
+    and overwrite the slot the evaluator will later fill. With ``target`` empty,
+    the only thing that can keep ``f1`` out is the reserved-name skip, so this is
+    a true probe of the computable-names fix (not the "already present" guard).
+    """
+    evaluator = SimpleScoringEvaluator(metric_functions={"f1": _custom_f1})
+    target: dict[str, float] = {}
+    evaluator._merge_user_metrics(
+        target,
+        {"f1": 0.99, "composite_ok": 1.0},
+        context="h1 merge",
+        extra_reserved=evaluator._evaluator_computable_metric_names(),
+    )
+    # f1 is evaluator-computable → user value skipped (never lands in target).
+    assert "f1" not in target
+    # A genuine user key still merges.
+    assert target["composite_ok"] == pytest.approx(1.0)
+
+
+def test_merge_skips_transport_reserved_keys_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """H2: ``_merge_user_metrics`` skips ``measures``/``summary_stats`` (reserved).
+
+    Pre-fix: these names are not in RESERVED_METRIC_KEYS and ride into metrics,
+    later breaking the submission path. Fixed: they are skipped at merge with a
+    WARNING (the per-example merge surfaces genuine user collisions).
+    """
+    evaluator = SimpleScoringEvaluator()
+    target: dict[str, float] = {}
+    with caplog.at_level(logging.WARNING):
+        evaluator._merge_user_metrics(
+            target,
+            {"measures": 1.0, "summary_stats": 2.0, "composite_ok": 3.0},
+            context="h2 merge",
+        )
+    assert "measures" not in target
+    assert "summary_stats" not in target
+    assert target["composite_ok"] == pytest.approx(3.0)
+    warnings = " ".join(rec.message for rec in caplog.records)
+    assert "measures" in warnings
+    assert "summary_stats" in warnings
+
+
+def test_transport_reserved_merge_keeps_submission_valid() -> None:
+    """H2 end-to-end shape: post-merge metrics carry no transport key, so the
+    submission validator that hard-rejects ``measures`` in a metrics dict passes.
+    """
+    evaluator = SimpleScoringEvaluator()
+    metrics: dict[str, float] = {"accuracy": 0.9}
+    evaluator._merge_user_metrics(
+        metrics,
+        {"measures": 1.0, "summary_stats": 2.0},
+        context="h2 e2e",
+    )
+    assert "measures" not in metrics
+    assert "summary_stats" not in metrics
+    # Validation that previously raised ValueError("metrics dict should not
+    # contain 'measures'") now passes because the transport keys never landed.
+    assert (
+        validate_configuration_run_submission(
+            {"configuration_id": "cfg-1", "metrics": metrics}
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# H3: final factory cap protects evaluator-computed runtime names
+# ---------------------------------------------------------------------------
+
+
+def _eval_result_with_metrics(metrics: dict[str, float]) -> Mock:
+    result = Mock()
+    result.metrics = dict(metrics)
+    result.success_rate = 1.0
+    result.has_errors = False
+    result.outputs = []
+    result.example_results = None
+    result.successful_examples = 0
+    result.summary_stats = None
+    return result
+
+
+def test_final_cap_keeps_evaluator_computed_name_drops_user_key() -> None:
+    """H3 (captain repro): 49 composite_metric_* user keys + ``f1`` at the
+    ceiling. With ``extra_reserved={"f1"}`` the cap must KEEP ``f1`` (the primary
+    objective) and drop a composite user key instead.
+
+    Pre-fix: ``build_success_result`` passes no ``extra_reserved``, so ``f1`` is
+    seen as a droppable user key and (being last in sorted order after the
+    composites) the cap removes it — the objective vanishes.
+    """
+    metrics = {f"composite_metric_{i:03d}": 1.0 for i in range(49)}
+    metrics["f1"] = 0.93
+    eval_result = _eval_result_with_metrics(metrics)
+
+    result = build_success_result(
+        trial_id="trial_h3",
+        evaluation_config={"model": "gpt-4"},
+        eval_result=eval_result,
+        duration=1.0,
+        examples_attempted=None,
+        total_cost=None,
+        optuna_trial_id=None,
+        extra_reserved=frozenset({"f1"}),
+    )
+
+    assert "f1" in result.metrics
+    assert result.metrics["f1"] == pytest.approx(0.93)
+    # Exactly one composite user key was dropped to make room.
+    composite_kept = [k for k in result.metrics if k.startswith("composite_metric_")]
+    assert len(composite_kept) == 49 - (len(metrics) - 50)
+
+
+# ---------------------------------------------------------------------------
+# H2 consistency: every misplaced-field name is reserved
+# ---------------------------------------------------------------------------
+
+
+def test_misplaced_submission_fields_are_reserved() -> None:
+    """H2 (consistency): every field rejected by
+    ``_validate_metrics_no_misplaced_fields`` (``measures``, ``summary_stats``)
+    is in RESERVED_METRIC_KEYS, so the merge filter skips them before they can
+    ever reach a metrics dict the submission validator rejects.
+
+    Mirrors ``test_user_metric_pattern_matches_measuresdict_pattern``: if the
+    transport contract grows a new misplaced field, THIS test fails rather than
+    the bypass silently reopening.
+    """
+    import inspect
+
+    # The validator enumerates the misplaced fields in a literal tuple; pull the
+    # names straight from its source so this stays pinned to the validator.
+    src = inspect.getsource(_validate_metrics_no_misplaced_fields)
+    for field in ("measures", "summary_stats"):
+        assert f'"{field}"' in src, (
+            f"{field!r} no longer rejected by validator — update this test"
+        )
+        assert field in RESERVED_METRIC_KEYS, (
+            f"{field!r} is rejected in a metrics dict by the submission "
+            f"validator but is NOT in RESERVED_METRIC_KEYS"
+        )

--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round4.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round4.py
@@ -168,13 +168,18 @@ def _eval_result_with_metrics(metrics: dict[str, float]) -> Mock:
 
 
 def test_final_cap_keeps_evaluator_computed_name_drops_user_key() -> None:
-    """H3 (captain repro): 49 composite_metric_* user keys + ``f1`` at the
-    ceiling. With ``extra_reserved={"f1"}`` the cap must KEEP ``f1`` (the primary
-    objective) and drop a composite user key instead.
+    """H3 (captain repro): 49 composite_metric_* user keys + ``f1`` arrive at the
+    ceiling from the lane, then assembly writes ``examples_attempted`` and
+    ``total_cost`` AFTER the lane caps ran — pushing the final union to 52. The
+    cap must fire, KEEP ``f1`` (the primary objective, via ``extra_reserved``)
+    and drop composite user keys instead.
 
-    Pre-fix: ``build_success_result`` passes no ``extra_reserved``, so ``f1`` is
-    seen as a droppable user key and (being last in sorted order after the
-    composites) the cap removes it — the objective vanishes.
+    Pre-fix: ``build_success_result`` passed no ``extra_reserved``, so ``f1`` was
+    seen as a droppable user key and (sorting after the composites) the cap
+    removed it — the objective vanished from ``TrialResult.metrics``. The
+    non-``None`` ``examples_attempted``/``total_cost`` are essential: with both
+    ``None`` the union is exactly 50 and the cap returns early without testing
+    anything (codex round-4 MINOR).
     """
     metrics = {f"composite_metric_{i:03d}": 1.0 for i in range(49)}
     metrics["f1"] = 0.93
@@ -185,17 +190,46 @@ def test_final_cap_keeps_evaluator_computed_name_drops_user_key() -> None:
         evaluation_config={"model": "gpt-4"},
         eval_result=eval_result,
         duration=1.0,
-        examples_attempted=None,
-        total_cost=None,
+        examples_attempted=2,
+        total_cost=0.01,
         optuna_trial_id=None,
         extra_reserved=frozenset({"f1"}),
     )
 
-    assert "f1" in result.metrics
+    # The cap actually fired: 52-key union clamped back to the ceiling.
+    assert len(result.metrics) == 50
+    # The evaluator-computed objective survived...
     assert result.metrics["f1"] == pytest.approx(0.93)
-    # Exactly one composite user key was dropped to make room.
+    # ...as did the reserved assembly keys written after the lane caps...
+    assert "examples_attempted" in result.metrics
+    assert "total_cost" in result.metrics
+    # ...and exactly TWO composite user keys were dropped to make room.
     composite_kept = [k for k in result.metrics if k.startswith("composite_metric_")]
-    assert len(composite_kept) == 49 - (len(metrics) - 50)
+    assert len(composite_kept) == 47
+
+
+def test_final_cap_without_extra_reserved_would_drop_objective() -> None:
+    """H3 counterfactual guard: the same 52-key union WITHOUT ``extra_reserved``
+    drops ``f1`` — proving the threaded set is what protects the objective (if a
+    refactor silently stops threading it, the positive test above could go
+    vacuous; this pins the mechanism).
+    """
+    metrics = {f"composite_metric_{i:03d}": 1.0 for i in range(49)}
+    metrics["f1"] = 0.93
+    eval_result = _eval_result_with_metrics(metrics)
+
+    result = build_success_result(
+        trial_id="trial_h3_cf",
+        evaluation_config={"model": "gpt-4"},
+        eval_result=eval_result,
+        duration=1.0,
+        examples_attempted=2,
+        total_cost=0.01,
+        optuna_trial_id=None,
+    )
+
+    assert len(result.metrics) == 50
+    assert "f1" not in result.metrics
 
 
 # ---------------------------------------------------------------------------

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -530,6 +530,13 @@ class ExampleResult:
     success: bool
     error_message: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    #: Per-example numeric metrics unpacked from a decorated function that
+    #: returned ``(output, metrics_dict)``. Populated by the evaluator's strict
+    #: 2-tuple unpack rule (``BaseEvaluator._unpack_user_metrics``); ``None`` for
+    #: every other return shape. NOT persisted via ``to_dict`` — these merge
+    #: into the per-example custom metrics (and then mean-aggregate onto the
+    #: trial) through the normal metrics path, not the example record.
+    user_metrics: dict[str, float] | None = None
 
     @property
     def is_successful(self) -> bool:

--- a/traigent/cloud/dtos.py
+++ b/traigent/cloud/dtos.py
@@ -247,7 +247,14 @@ class MeasuresDict(UserDict):
     """
 
     MAX_KEYS = 50
-    KEY_PATTERN = re.compile(r"^[a-zA-Z_]\w*$")
+    # ``re.ASCII`` pins ``\w`` to ``[A-Za-z0-9_]`` so the regex matches the
+    # documented ``^[a-zA-Z_][a-zA-Z0-9_]*$`` contract exactly. Without it,
+    # ``\w`` would also accept Unicode word characters (e.g. ``"a_πmetric"``),
+    # which the SDK evaluators' identifier gate rejects — that divergence is the
+    # Unicode-identifier bypass closed in the composite-knobs metrics channel.
+    # ``traigent.evaluators.metrics_tracker.USER_METRIC_KEY_PATTERN`` mirrors this
+    # exactly; the consistency test pins the two together.
+    KEY_PATTERN = re.compile(r"^[a-zA-Z_]\w*$", re.ASCII)
 
     def __init__(self, data: dict[str, Any] | None = None) -> None:
         """Initialize with optional data dictionary.

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -390,6 +390,16 @@ class TrialLifecycle:
                 examples_attempted=examples_attempted,
                 total_cost=total_cost,
                 optuna_trial_id=optuna_trial_id,
+                # Thread the evaluator's runtime-only computable names (registry +
+                # RAGAS + user metric functions) into the final-union cap so an
+                # evaluator-computed objective like ``f1`` is never dropped as a
+                # user key. Guard with getattr: custom evaluators may not subclass
+                # BaseEvaluator and so may lack this method.
+                extra_reserved=getattr(
+                    orchestrator.evaluator,
+                    "_evaluator_computable_metric_names",
+                    lambda: frozenset(),
+                )(),
             )
             self._apply_budget_metadata(result, closure, budget_exhausted)
             self._apply_effectuation_metadata(result, func)

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -341,8 +341,17 @@ def build_success_result(
     examples_attempted: int | None,
     total_cost: float | None,
     optuna_trial_id: int | None,
+    extra_reserved: frozenset[str] = frozenset(),
 ) -> TrialResult:
-    """Create a successful :class:`TrialResult` instance."""
+    """Create a successful :class:`TrialResult` instance.
+
+    ``extra_reserved`` carries the evaluator's runtime-only computable metric
+    names (registered custom metrics, RAGAS metrics, user-passed metric
+    functions) that the static :data:`RESERVED_METRIC_KEYS` cannot enumerate.
+    The final-union ceiling below uses it so an evaluator-computed runtime name
+    (e.g. ``f1``, ``context_precision``) is never mistaken for a droppable user
+    key under ceiling pressure.
+    """
     trial_metadata = _build_success_trial_metadata(
         eval_result,
         examples_attempted,
@@ -389,13 +398,17 @@ def build_success_result(
     # the final union — a 50-key eval_result + total_cost would ship 51. Re-apply
     # the ceiling here as the last metric mutation: only NON-reserved user keys
     # are dropped (deterministically, warning-logged); the evaluator/assembly
-    # reserved keys are never sacrificed. The static RESERVED_METRIC_KEYS already
-    # covers every key written here and by the evaluator lanes (accuracy, score,
-    # duration, the token/cost family, examples_attempted, total_cost, ...), so no
-    # extra_reserved is needed at this site.
+    # reserved keys are never sacrificed. The static RESERVED_METRIC_KEYS covers
+    # the keys written here and the standard evaluator-lane keys (accuracy, score,
+    # duration, the token/cost family, examples_attempted, total_cost, ...), but
+    # NOT the evaluator's runtime-only computable names (registered custom metrics,
+    # RAGAS metrics, user metric functions such as ``f1``). Those arrive via
+    # ``extra_reserved`` so the cap never sacrifices an evaluator-computed runtime
+    # objective (e.g. ``f1``) to fit a flood of user keys.
     enforce_user_metric_ceiling(
         trial_result.metrics,
         context=f"trial {trial_id} final assembly",
+        extra_reserved=extra_reserved,
     )
 
     if getattr(eval_result, "summary_stats", None):

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -16,6 +16,7 @@ from traigent.api.types import (
     TrialResult,
     TrialStatus,
 )
+from traigent.evaluators.metrics_tracker import enforce_user_metric_ceiling
 from traigent.security.redaction import redact_sensitive_data, redact_sensitive_text
 from traigent.utils.exceptions import TrialPrunedError
 from traigent.utils.logging import get_logger
@@ -378,6 +379,24 @@ def build_success_result(
             float,
             trial_id,
         )
+
+    # Authoritative final-union ceiling — the SINGLE cap that bounds what every
+    # lane actually ships on a successful trial. Both evaluator lanes already cap
+    # ``eval_result.metrics`` (the local lane's enforce_user_metric_ceiling /
+    # format_for_backend pre-trims, the SimpleScoring lane's own ceiling), but
+    # this assembly site writes reserved keys (``examples_attempted``,
+    # ``total_cost``) AFTER those caps ran, so the per-lane cap alone cannot bound
+    # the final union — a 50-key eval_result + total_cost would ship 51. Re-apply
+    # the ceiling here as the last metric mutation: only NON-reserved user keys
+    # are dropped (deterministically, warning-logged); the evaluator/assembly
+    # reserved keys are never sacrificed. The static RESERVED_METRIC_KEYS already
+    # covers every key written here and by the evaluator lanes (accuracy, score,
+    # duration, the token/cost family, examples_attempted, total_cost, ...), so no
+    # extra_reserved is needed at this site.
+    enforce_user_metric_ceiling(
+        trial_result.metrics,
+        context=f"trial {trial_id} final assembly",
+    )
 
     if getattr(eval_result, "summary_stats", None):
         trial_result.summary_stats = redact_sensitive_data(  # type: ignore[attr-defined]

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -1096,6 +1096,16 @@ class BaseEvaluator(ABC):
         ``[0]`` is not itself such a 2-tuple) is a no-op, so calling this at more
         than one boundary is safe.
 
+        NEAR-MISS warning (no behavior change): when ``raw`` IS a 2-tuple whose
+        ``[1]`` is a Mapping but a key or value fails the strict rule (e.g.
+        ``("YES", {"bad-key": 1.0})`` or a ``bool`` / non-numeric value), the
+        user almost certainly meant ``(output, metrics)`` — leaving it raw
+        silently poisons their accuracy. Exactly ONE ``WARNING`` is logged naming
+        the FIRST offending key/value and stating the tuple was NOT treated as
+        ``(output, metrics)`` and why. Shapes that are silent by design (a plain
+        return, a 3-tuple, a tuple whose ``[1]`` is a list) carry no intent to
+        ship metrics and are NOT warned — warning there would be noise.
+
         The numeric values are coerced to ``float`` so they aggregate by mean and
         satisfy the ``MeasuresDict`` numeric contract downstream.
 
@@ -1111,10 +1121,35 @@ class BaseEvaluator(ABC):
         output, candidate = raw
         if not isinstance(candidate, Mapping):
             return raw, None
+        # The shape is a NEAR-MISS: a 2-tuple whose [1] is a Mapping, i.e. the
+        # user almost certainly intended (output, metrics). If any key/value
+        # fails the strict wire rule the tuple is left as RAW output for absolute
+        # back-compat — but that silently poisons the user's accuracy (the raw
+        # tuple becomes the output) with zero signal. Surface exactly ONE warning
+        # naming the FIRST offender and stating why; behavior is unchanged.
         for key, value in candidate.items():
             if not isinstance(key, str) or not USER_METRIC_KEY_PATTERN.match(key):
+                logger.warning(
+                    "Return value %r looks like an (output, metrics) tuple but "
+                    "key %r is not a wire-valid metric name (must match "
+                    "%s, ASCII); the tuple was NOT treated as (output, metrics) "
+                    "and is passed through as raw output.",
+                    raw,
+                    key,
+                    USER_METRIC_KEY_PATTERN.pattern,
+                )
                 return raw, None
             if isinstance(value, bool) or not isinstance(value, (int, float)):
+                logger.warning(
+                    "Return value %r looks like an (output, metrics) tuple but "
+                    "value %r for key %r is not a finite number (got %s); the "
+                    "tuple was NOT treated as (output, metrics) and is passed "
+                    "through as raw output.",
+                    raw,
+                    value,
+                    key,
+                    type(value).__name__,
+                )
                 return raw, None
         user_metrics = {key: float(value) for key, value in candidate.items()}
         return output, user_metrics

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -1048,6 +1048,75 @@ class BaseEvaluator(ABC):
 
     # Common evaluation methods to reduce duplication in subclasses
 
+    @staticmethod
+    def _unpack_user_metrics(raw: Any) -> tuple[Any, dict[str, float] | None]:
+        """Split a decorated function's return into (output, per-example metrics).
+
+        Strict, conservative unpack rule (back-compat is absolute): the return
+        is unpacked ONLY when ``raw`` is EXACTLY a length-2 ``tuple`` whose
+        second element is a ``Mapping`` with all-``str`` keys and all-numeric
+        (``int``/``float``, excluding ``bool``) values. In that case element
+        ``[0]`` becomes the output used for ALL downstream purposes (accuracy
+        comparison, ``actual_output`` storage, scoring functions) and element
+        ``[1]`` becomes the per-example user metrics dict.
+
+        EVERY other shape is left untouched and returned as raw output with no
+        user metrics — longer/shorter tuples, a non-tuple, a ``[1]`` that is not
+        a Mapping (e.g. a list), a Mapping with any non-``str`` key, or a Mapping
+        with any non-numeric / ``bool`` value. This makes the rule idempotent: an
+        already-unpacked output (whose ``[0]`` is not itself such a 2-tuple) is a
+        no-op, so calling this at more than one boundary is safe.
+
+        The numeric values are coerced to ``float`` so they aggregate by mean and
+        satisfy the ``MeasuresDict`` numeric contract downstream.
+
+        Args:
+            raw: The raw value returned by the user's decorated function.
+
+        Returns:
+            ``(output, user_metrics)`` where ``user_metrics`` is ``None`` unless
+            the strict 2-tuple shape matched.
+        """
+        if not (type(raw) is tuple and len(raw) == 2):
+            return raw, None
+        output, candidate = raw
+        if not isinstance(candidate, Mapping):
+            return raw, None
+        for key, value in candidate.items():
+            if not isinstance(key, str):
+                return raw, None
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return raw, None
+        user_metrics = {key: float(value) for key, value in candidate.items()}
+        return output, user_metrics
+
+    def _merge_user_metrics(
+        self,
+        target: dict[str, Any],
+        user_metrics: dict[str, float] | None,
+        *,
+        context: str,
+    ) -> None:
+        """Merge per-example user metrics into ``target`` without overriding.
+
+        User keys are first-class but NEVER override an evaluator-computed key:
+        a user key already present in ``target`` is skipped (the evaluator's own
+        value wins) and a debug line records the skip. This protects computed
+        keys such as ``accuracy`` from being shadowed by a user-supplied metric.
+        """
+        if not user_metrics:
+            return
+        for key, value in user_metrics.items():
+            if key in target:
+                logger.debug(
+                    "Skipping user metric %r (%s): evaluator already set it to %r",
+                    key,
+                    context,
+                    target[key],
+                )
+                continue
+            target[key] = value
+
     def _prepare_call_arguments(
         self,
         func: Callable[..., Any],
@@ -2102,10 +2171,16 @@ class BaseEvaluator(ABC):
             # Default evaluation with correlation key
             capture_key = self._get_capture_key_context()
             with capture_key(example_id):
-                output, error = await self._execute_function(
+                raw_output, error = await self._execute_function(
                     func, config, example.input_data, executor
                 )
             execution_time = time.time() - start_time
+
+            # Strict 2-tuple unpack: a (output, numeric-metrics) return becomes
+            # output[0] for ALL downstream purposes (actual_output, accuracy,
+            # scoring); the metrics ride to per-example custom metrics. Any other
+            # shape is left untouched (back-compat).
+            output, user_metrics = self._unpack_user_metrics(raw_output)
 
             result = ExampleResult(
                 example_id=example_id,
@@ -2117,6 +2192,7 @@ class BaseEvaluator(ABC):
                 success=(error is None),
                 error_message=error,
                 metadata=example.metadata.copy() if example.metadata else {},
+                user_metrics=user_metrics,
             )
 
             # Record to tracing span
@@ -2713,9 +2789,15 @@ class SimpleScoringEvaluator(BaseEvaluator):
                 with _maybe_restore_trial_context(trial_ctx):
                     with ConfigurationContext(config):
                         if asyncio.iscoroutinefunction(func):
-                            output = await func(**example.input_data)
+                            raw_output = await func(**example.input_data)
                         else:
-                            output = func(**example.input_data)
+                            raw_output = func(**example.input_data)
+
+                # Strict 2-tuple unpack: a (output, numeric-metrics) return
+                # becomes output[0] for ALL downstream purposes; the metrics
+                # merge into this example's metrics (no-override). Any other
+                # shape is left untouched (back-compat).
+                output, user_metrics = self._unpack_user_metrics(raw_output)
 
                 per_example_duration = time.time() - example_start_time
 
@@ -2730,6 +2812,11 @@ class SimpleScoringEvaluator(BaseEvaluator):
                 # Add LLM metrics if captured
                 if llm_metrics:
                     self._add_llm_metrics_to_example(example_metrics, llm_metrics)
+
+                # Merge per-example user metrics (never overriding computed keys).
+                self._merge_user_metrics(
+                    example_metrics, user_metrics, context="simple-scoring lane"
+                )
 
                 # Calculate execution time
                 execution_time = per_example_duration

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -26,7 +26,9 @@ from traigent.evaluators.dataset_registry import (
     resolve_dataset_reference,
 )
 from traigent.evaluators.metrics_tracker import (
+    USER_METRIC_KEY_PATTERN,
     aggregate_user_custom_metrics,
+    enforce_user_metric_ceiling,
     extract_llm_metrics,
     is_reserved_metric_key,
 )
@@ -768,6 +770,22 @@ class BaseEvaluator(ABC):
             logger.debug(f"Overriding metric: {name}")
         self._metric_registry[name] = func
 
+    def _evaluator_computable_metric_names(self) -> frozenset[str]:
+        """Names this evaluator can compute itself, beyond the static reserved set.
+
+        The static :data:`RESERVED_METRIC_KEYS` cannot enumerate metrics that are
+        only known at runtime — registered custom metrics and RAGAS metrics
+        (``context_precision`` etc.) that the evaluator computes and writes into
+        the trial metrics. A user-supplied tuple key with one of these names must
+        NOT overwrite the evaluator's computed value, so this set is threaded into
+        every user-metric merge site as ``extra_reserved``. The registry IS the
+        evaluator-computable set, so we derive it at runtime rather than hand-copy
+        RAGAS names into the frozenset (which would drift).
+        """
+        names: set[str] = set(self._metric_registry)
+        names.update(getattr(self, "_ragas_metric_names", set()))
+        return frozenset(names)
+
     def compute_metrics(
         self,
         outputs: list[Any],
@@ -1058,9 +1076,11 @@ class BaseEvaluator(ABC):
 
         Strict, conservative unpack rule (back-compat is absolute): the return
         is unpacked ONLY when ``raw`` is EXACTLY a length-2 ``tuple`` whose
-        second element is a ``Mapping`` with all-identifier keys (every key is a
-        ``str`` satisfying ``str.isidentifier()``, matching the MeasuresDict wire
-        contract) and all-numeric (``int``/``float``, excluding ``bool``)
+        second element is a ``Mapping`` with all-wire-valid keys (every key is a
+        ``str`` matching :data:`USER_METRIC_KEY_PATTERN`, the ASCII identifier
+        pattern that exactly mirrors the ``MeasuresDict`` wire contract — NOT
+        ``str.isidentifier()``, which accepts Unicode identifiers the wire
+        rejects) and all-numeric (``int``/``float``, excluding ``bool``)
         values. In that case element ``[0]`` becomes the output used for ALL
         downstream purposes (accuracy comparison, ``actual_output`` storage,
         scoring functions) and element ``[1]`` becomes the per-example user
@@ -1068,8 +1088,10 @@ class BaseEvaluator(ABC):
 
         EVERY other shape is left untouched and returned as raw output with no
         user metrics — longer/shorter tuples, a non-tuple, a ``[1]`` that is not
-        a Mapping (e.g. a list), a Mapping with any non-``str`` / non-identifier
-        key (e.g. ``"bad-key"``), or a Mapping with any non-numeric / ``bool``
+        a Mapping (e.g. a list), a Mapping with any non-``str`` key or any key
+        rejected by :data:`USER_METRIC_KEY_PATTERN` (e.g. ``"bad-key"`` or the
+        Unicode identifier ``"π_metric"``), or a Mapping with any non-numeric /
+        ``bool``
         value. This makes the rule idempotent: an already-unpacked output (whose
         ``[0]`` is not itself such a 2-tuple) is a no-op, so calling this at more
         than one boundary is safe.
@@ -1090,7 +1112,7 @@ class BaseEvaluator(ABC):
         if not isinstance(candidate, Mapping):
             return raw, None
         for key, value in candidate.items():
-            if not isinstance(key, str) or not key.isidentifier():
+            if not isinstance(key, str) or not USER_METRIC_KEY_PATTERN.match(key):
                 return raw, None
             if isinstance(value, bool) or not isinstance(value, (int, float)):
                 return raw, None
@@ -1103,24 +1125,37 @@ class BaseEvaluator(ABC):
         user_metrics: dict[str, float] | None,
         *,
         context: str,
+        extra_reserved: frozenset[str] | None = None,
     ) -> None:
         """Merge per-example user metrics into ``target`` without overriding.
 
         User keys are first-class but NEVER override an evaluator-computed key.
-        Two guards, applied regardless of merge ordering or ``setdefault``
-        timing (so a reserved key is protected even when the evaluator writes it
-        AFTER this merge):
+        Guards, applied regardless of merge ordering or ``setdefault`` timing (so
+        a reserved key is protected even when the evaluator writes it AFTER this
+        merge):
 
-        * a key in :data:`RESERVED_METRIC_KEYS` is skipped and warning-logged —
-          the user asked for a key they cannot have (e.g. ``success_rate``,
-          ``latency``, ``examples_attempted``);
+        * a key in :data:`RESERVED_METRIC_KEYS` OR in ``extra_reserved`` is
+          skipped and warning-logged — the user asked for a key they cannot have
+          (e.g. ``success_rate``, ``latency``, ``examples_attempted``, or a
+          runtime-only evaluator-computable name such as the RAGAS metric
+          ``context_precision``). ``extra_reserved`` defaults to this evaluator's
+          own metric-registry + RAGAS names;
         * a key already present in ``target`` is skipped (the evaluator's own
           value wins).
+
+        Unlike the shared aggregator's DEBUG split, the reserved-key skip here
+        WARNS: this method receives the GENUINELY user-supplied tuple dict, so a
+        collision is a real user mistake worth surfacing.
         """
         if not user_metrics:
             return
+        reserved_extra = (
+            extra_reserved
+            if extra_reserved is not None
+            else self._evaluator_computable_metric_names()
+        )
         for key, value in user_metrics.items():
-            if is_reserved_metric_key(key):
+            if is_reserved_metric_key(key) or key in reserved_extra:
                 logger.warning(
                     "Skipping user metric %r (%s): %r is a reserved "
                     "evaluator-computed key and cannot be overwritten",
@@ -2933,9 +2968,24 @@ class SimpleScoringEvaluator(BaseEvaluator):
             aggregated_metrics,
             successful_example_metrics,
             context="simple-scoring trial aggregation",
+            extra_reserved=self._evaluator_computable_metric_names(),
         )
 
         aggregated_metrics.setdefault("examples_attempted", len(example_results))
+
+        # Authoritative final-union cap. ``aggregate_user_custom_metrics`` above
+        # caps the union as it MERGES user keys, but reserved evaluator keys are
+        # added to ``aggregated_metrics`` AFTER that (the custom/LLM/RAGAS
+        # aggregations and ``examples_attempted`` here), so the per-merge cap
+        # alone cannot bound the FINAL union. Re-apply the ceiling as the LAST
+        # step before returning trial metrics so >50 flat metrics can never
+        # escape; only user keys are dropped (evaluator keys are never
+        # sacrificed), matching the local lane's enforce-ceiling call.
+        enforce_user_metric_ceiling(
+            aggregated_metrics,
+            context="simple-scoring trial aggregation",
+            extra_reserved=self._evaluator_computable_metric_names(),
+        )
 
         # Log results
         success_count = sum(1 for result in example_results if result.is_successful)

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -774,16 +774,29 @@ class BaseEvaluator(ABC):
         """Names this evaluator can compute itself, beyond the static reserved set.
 
         The static :data:`RESERVED_METRIC_KEYS` cannot enumerate metrics that are
-        only known at runtime — registered custom metrics and RAGAS metrics
-        (``context_precision`` etc.) that the evaluator computes and writes into
-        the trial metrics. A user-supplied tuple key with one of these names must
-        NOT overwrite the evaluator's computed value, so this set is threaded into
-        every user-metric merge site as ``extra_reserved``. The registry IS the
-        evaluator-computable set, so we derive it at runtime rather than hand-copy
-        RAGAS names into the frozenset (which would drift).
+        only known at runtime — three runtime sources the evaluator computes and
+        writes into the trial metrics:
+
+        * registered custom metrics (``_metric_registry``);
+        * RAGAS metrics (``context_precision`` etc., tracked in
+          ``_ragas_metric_names``);
+        * user-passed custom metric functions (``self.metric_functions``, set on
+          ``SimpleScoringEvaluator`` / ``LocalEvaluator``). These are NEVER
+          registered into ``_metric_registry`` — they are invoked directly — so
+          a name like ``f1`` would otherwise be invisible here. Omitting them let
+          a user tuple key named ``f1`` overwrite the evaluator-computed ``f1``,
+          and let the final-union cap treat the evaluator's own ``f1`` as a
+          droppable user key under ceiling pressure.
+
+        A user-supplied tuple key with one of these names must NOT overwrite the
+        evaluator's computed value, so this set is threaded into every
+        user-metric merge site (and the final factory cap) as ``extra_reserved``.
+        We derive it at runtime rather than hand-copy names into a frozenset
+        (which would drift).
         """
         names: set[str] = set(self._metric_registry)
         names.update(getattr(self, "_ragas_metric_names", set()))
+        names.update(getattr(self, "metric_functions", None) or {})
         return frozenset(names)
 
     def compute_metrics(

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -25,7 +25,11 @@ from traigent.evaluators.dataset_registry import (
     DatasetRegistryEntry,
     resolve_dataset_reference,
 )
-from traigent.evaluators.metrics_tracker import extract_llm_metrics
+from traigent.evaluators.metrics_tracker import (
+    aggregate_user_custom_metrics,
+    extract_llm_metrics,
+    is_reserved_metric_key,
+)
 from traigent.utils.error_handler import APIKeyError
 from traigent.utils.error_handler import TraigentError as FriendlyTraigentError
 from traigent.utils.exceptions import ConfigurationError, EvaluationError
@@ -1054,18 +1058,21 @@ class BaseEvaluator(ABC):
 
         Strict, conservative unpack rule (back-compat is absolute): the return
         is unpacked ONLY when ``raw`` is EXACTLY a length-2 ``tuple`` whose
-        second element is a ``Mapping`` with all-``str`` keys and all-numeric
-        (``int``/``float``, excluding ``bool``) values. In that case element
-        ``[0]`` becomes the output used for ALL downstream purposes (accuracy
-        comparison, ``actual_output`` storage, scoring functions) and element
-        ``[1]`` becomes the per-example user metrics dict.
+        second element is a ``Mapping`` with all-identifier keys (every key is a
+        ``str`` satisfying ``str.isidentifier()``, matching the MeasuresDict wire
+        contract) and all-numeric (``int``/``float``, excluding ``bool``)
+        values. In that case element ``[0]`` becomes the output used for ALL
+        downstream purposes (accuracy comparison, ``actual_output`` storage,
+        scoring functions) and element ``[1]`` becomes the per-example user
+        metrics dict.
 
         EVERY other shape is left untouched and returned as raw output with no
         user metrics — longer/shorter tuples, a non-tuple, a ``[1]`` that is not
-        a Mapping (e.g. a list), a Mapping with any non-``str`` key, or a Mapping
-        with any non-numeric / ``bool`` value. This makes the rule idempotent: an
-        already-unpacked output (whose ``[0]`` is not itself such a 2-tuple) is a
-        no-op, so calling this at more than one boundary is safe.
+        a Mapping (e.g. a list), a Mapping with any non-``str`` / non-identifier
+        key (e.g. ``"bad-key"``), or a Mapping with any non-numeric / ``bool``
+        value. This makes the rule idempotent: an already-unpacked output (whose
+        ``[0]`` is not itself such a 2-tuple) is a no-op, so calling this at more
+        than one boundary is safe.
 
         The numeric values are coerced to ``float`` so they aggregate by mean and
         satisfy the ``MeasuresDict`` numeric contract downstream.
@@ -1083,7 +1090,7 @@ class BaseEvaluator(ABC):
         if not isinstance(candidate, Mapping):
             return raw, None
         for key, value in candidate.items():
-            if not isinstance(key, str):
+            if not isinstance(key, str) or not key.isidentifier():
                 return raw, None
             if isinstance(value, bool) or not isinstance(value, (int, float)):
                 return raw, None
@@ -1099,14 +1106,29 @@ class BaseEvaluator(ABC):
     ) -> None:
         """Merge per-example user metrics into ``target`` without overriding.
 
-        User keys are first-class but NEVER override an evaluator-computed key:
-        a user key already present in ``target`` is skipped (the evaluator's own
-        value wins) and a debug line records the skip. This protects computed
-        keys such as ``accuracy`` from being shadowed by a user-supplied metric.
+        User keys are first-class but NEVER override an evaluator-computed key.
+        Two guards, applied regardless of merge ordering or ``setdefault``
+        timing (so a reserved key is protected even when the evaluator writes it
+        AFTER this merge):
+
+        * a key in :data:`RESERVED_METRIC_KEYS` is skipped and warning-logged —
+          the user asked for a key they cannot have (e.g. ``success_rate``,
+          ``latency``, ``examples_attempted``);
+        * a key already present in ``target`` is skipped (the evaluator's own
+          value wins).
         """
         if not user_metrics:
             return
         for key, value in user_metrics.items():
+            if is_reserved_metric_key(key):
+                logger.warning(
+                    "Skipping user metric %r (%s): %r is a reserved "
+                    "evaluator-computed key and cannot be overwritten",
+                    key,
+                    context,
+                    key,
+                )
+                continue
             if key in target:
                 logger.debug(
                     "Skipping user metric %r (%s): evaluator already set it to %r",
@@ -2893,6 +2915,25 @@ class SimpleScoringEvaluator(BaseEvaluator):
 
         # Aggregate RAGAS metrics if applicable
         self._aggregate_ragas_metrics(example_results, aggregated_metrics)
+
+        # Surface tuple-supplied user metrics on the trial result. The custom-,
+        # LLM-, and RAGAS-aggregations above only cover keys the evaluator knows
+        # about (``self.metrics`` / token / cost), so user keys reach
+        # ``example_results[*].metrics`` but never ``result.metrics`` without
+        # this. Uses the SAME shared helper as the local/tracker path: reserved
+        # evaluator keys are skipped (warning-logged), already-present keys are
+        # never clobbered, and the total is capped at the MeasuresDict ceiling
+        # by truncating user keys only.
+        successful_example_metrics = [
+            metric
+            for metric, ex_result in zip(all_metrics, example_results, strict=False)
+            if metric and ex_result is not None and ex_result.is_successful
+        ]
+        aggregate_user_custom_metrics(
+            aggregated_metrics,
+            successful_example_metrics,
+            context="simple-scoring trial aggregation",
+        )
 
         aggregated_metrics.setdefault("examples_attempted", len(example_results))
 

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -1354,8 +1354,13 @@ class LocalEvaluator(BaseEvaluator):
             custom_aggregated = self._compute_aggregated_custom_metrics(example_results)
             aggregated_metrics.update(custom_aggregated)
 
-        # Add comprehensive metrics from tracker using helper
-        comprehensive_metrics = metrics_tracker.format_for_backend()
+        # Add comprehensive metrics from tracker using helper. Thread the
+        # evaluator's runtime-only computable names (registry + RAGAS) so a
+        # user tuple key cannot overwrite an evaluator-computed value during the
+        # tracker's user-metric aggregation pass.
+        comprehensive_metrics = metrics_tracker.format_for_backend(
+            extra_reserved=self._evaluator_computable_metric_names()
+        )
         self._merge_comprehensive_metrics(aggregated_metrics, comprehensive_metrics)
 
         aggregated_metrics.setdefault("examples_attempted", len(outputs))
@@ -1365,7 +1370,9 @@ class LocalEvaluator(BaseEvaluator):
         # must not push the union past the MeasuresDict ceiling. Only user keys
         # are dropped; reserved evaluator keys are never sacrificed.
         enforce_user_metric_ceiling(
-            aggregated_metrics, context="local trial aggregation"
+            aggregated_metrics,
+            context="local trial aggregation",
+            extra_reserved=self._evaluator_computable_metric_names(),
         )
 
         # Generate summary_stats for all modes except CLOUD (needed for insights)

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -20,6 +20,7 @@ from traigent.evaluators.metrics_tracker import (
     ExampleMetrics,
     MetricsCalculator,
     MetricsTracker,
+    enforce_user_metric_ceiling,
     extract_llm_metrics,
 )
 from traigent.utils.exceptions import EvaluationError
@@ -966,25 +967,27 @@ class LocalEvaluator(BaseEvaluator):
         Returns:
             ExampleMetrics for this output
         """
-        # Strict 2-tuple unpack: a (output, numeric-metrics) return becomes
-        # output[0] for ALL downstream purposes (LLM/meta extraction, accuracy,
-        # scoring). This is idempotent: in detailed mode the boundary already
-        # unpacked actual_output, so this is a no-op there; in non-detailed mode
-        # the raw tuple still rides ``outputs`` and is unpacked here. Any other
-        # shape is left untouched (back-compat).
-        output, unpacked_user_metrics = self._unpack_user_metrics(output)
-
         # Per-example user metrics: prefer the carrier the boundary already
-        # attached to the ExampleResult (detailed mode); fall back to the
-        # value unpacked here (non-detailed mode).
-        user_metrics = unpacked_user_metrics
+        # attached to the ExampleResult (detailed mode). When the carrier is
+        # present the output was ALREADY unpacked upstream, so re-unpacking here
+        # would double-unpack a nested matching tuple — e.g. an output of
+        # ``("inner", {"x": 1.0})`` would be split again into ``"inner"`` and a
+        # spurious ``{"x": 1.0}``. We therefore unpack HERE only when the
+        # carrier is absent (the genuinely non-detailed lane, where ``outputs``
+        # still holds the raw tuple). Any non-matching shape is left untouched.
+        carrier = None
         if (
             example_results
             and index < len(example_results)
             and example_results[index] is not None
             and getattr(example_results[index], "user_metrics", None) is not None
         ):
-            user_metrics = example_results[index].user_metrics
+            carrier = example_results[index]
+
+        if carrier is not None:
+            user_metrics = carrier.user_metrics
+        else:
+            output, user_metrics = self._unpack_user_metrics(output)
 
         # Extract LLM metrics
         example_metric = self._extract_llm_metrics_for_output(
@@ -1356,6 +1359,14 @@ class LocalEvaluator(BaseEvaluator):
         self._merge_comprehensive_metrics(aggregated_metrics, comprehensive_metrics)
 
         aggregated_metrics.setdefault("examples_attempted", len(outputs))
+
+        # Authoritative cap on the FINAL trial metrics: user keys (arriving via
+        # the per-example custom_metrics -> comprehensive_metrics merge above)
+        # must not push the union past the MeasuresDict ceiling. Only user keys
+        # are dropped; reserved evaluator keys are never sacrificed.
+        enforce_user_metric_ceiling(
+            aggregated_metrics, context="local trial aggregation"
+        )
 
         # Generate summary_stats for all modes except CLOUD (needed for insights)
         summary_stats = None

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -966,6 +966,26 @@ class LocalEvaluator(BaseEvaluator):
         Returns:
             ExampleMetrics for this output
         """
+        # Strict 2-tuple unpack: a (output, numeric-metrics) return becomes
+        # output[0] for ALL downstream purposes (LLM/meta extraction, accuracy,
+        # scoring). This is idempotent: in detailed mode the boundary already
+        # unpacked actual_output, so this is a no-op there; in non-detailed mode
+        # the raw tuple still rides ``outputs`` and is unpacked here. Any other
+        # shape is left untouched (back-compat).
+        output, unpacked_user_metrics = self._unpack_user_metrics(output)
+
+        # Per-example user metrics: prefer the carrier the boundary already
+        # attached to the ExampleResult (detailed mode); fall back to the
+        # value unpacked here (non-detailed mode).
+        user_metrics = unpacked_user_metrics
+        if (
+            example_results
+            and index < len(example_results)
+            and example_results[index] is not None
+            and getattr(example_results[index], "user_metrics", None) is not None
+        ):
+            user_metrics = example_results[index].user_metrics
+
         # Extract LLM metrics
         example_metric = self._extract_llm_metrics_for_output(
             output, index, config, dataset, all_captured_responses
@@ -989,6 +1009,12 @@ class LocalEvaluator(BaseEvaluator):
         accuracy_value = self._calculate_example_accuracy(actual_value, expected_output)
         if accuracy_value is not None:
             example_metric.custom_metrics.setdefault("accuracy", accuracy_value)
+
+        # Merge per-example user metrics into custom_metrics, never overriding
+        # an evaluator-computed key (e.g. accuracy stays the computed value).
+        self._merge_user_metrics(
+            example_metric.custom_metrics, user_metrics, context="local lane"
+        )
 
         # Transfer metrics from example_results if available
         if example_results and index < len(example_results):

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -2,6 +2,7 @@
 
 # Traceability: CONC-Layer-Core CONC-Quality-Reliability CONC-Quality-Observability FUNC-EVAL-METRICS REQ-EVAL-005 SYNC-OptimizationFlow
 
+import math
 import os
 import statistics
 import time
@@ -321,7 +322,74 @@ class MetricsTracker:
                 aggregated, "tokens_per_second", "mean"
             )
 
+        # Mean-aggregate user-supplied per-example custom metrics (e.g. the
+        # composite_* telemetry keys from a (output, metrics_dict) return) the
+        # same way accuracy aggregates above. These are rates/means/counts, so
+        # mean across examples is the correct trial-level value. Standard keys
+        # already produced above are excluded so we never double-count or
+        # clobber the canonical aggregation.
+        self._aggregate_user_custom_metrics(formatted)
+
         return formatted
+
+    #: Keys ``format_for_backend`` already produces via dedicated, non-mean
+    #: aggregation (accuracy/score by mean elsewhere; tokens/cost as the
+    #: tracker's own statistics). User custom keys outside this set are
+    #: mean-aggregated as-is.
+    _RESERVED_BACKEND_METRIC_KEYS = frozenset(
+        {
+            "score",
+            "accuracy",
+            "success",
+            "duration",
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "response_time_ms",
+            "cost",
+            "input_cost",
+            "output_cost",
+            "total_cost",
+            "tokens_per_second",
+            "total_examples",
+            "successful_examples",
+        }
+    )
+
+    def _aggregate_user_custom_metrics(self, formatted: dict[str, Any]) -> None:
+        """Mean-aggregate non-reserved custom metrics into ``formatted``.
+
+        Mirrors the accuracy mean-aggregation in ``format_for_backend``: for
+        every custom-metric key that is NOT a reserved/standard key, average
+        its finite numeric values across the successful examples and write the
+        mean into ``formatted``. Non-numeric or non-finite values are skipped
+        (the wire channel carries finite numbers only). Reserved keys already
+        present in ``formatted`` are never overwritten.
+        """
+        if not self.example_metrics:
+            return
+
+        values_by_key: dict[str, list[float]] = {}
+        for metric in self.example_metrics:
+            if not metric.success:
+                continue
+            for key, value in metric.custom_metrics.items():
+                if key in self._RESERVED_BACKEND_METRIC_KEYS:
+                    continue
+                if isinstance(value, bool) or value is None:
+                    continue
+                try:
+                    numeric = float(value)
+                except (TypeError, ValueError):
+                    continue
+                if not math.isfinite(numeric):
+                    continue
+                values_by_key.setdefault(key, []).append(numeric)
+
+        for key, values in values_by_key.items():
+            if not values or key in formatted:
+                continue
+            formatted[key] = sum(values) / len(values)
 
     def _empty_backend_format(self) -> dict[str, Any]:
         """Return empty backend format structure when error occurs."""

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -4,6 +4,7 @@
 
 import math
 import os
+import re
 import statistics
 import time
 import warnings
@@ -25,6 +26,19 @@ from traigent.utils.logging import get_logger
 
 # Initialize logger first
 logger = get_logger(__name__)
+
+#: Wire contract for user-supplied metric KEY names. This MUST stay byte-for-byte
+#: identical to ``traigent.cloud.dtos.MeasuresDict.KEY_PATTERN`` (dtos.py:250):
+#: a user key that the evaluator unpacks but the ``MeasuresDict`` wire contract
+#: later rejects is the exact Unicode-identifier bypass we are closing — the key
+#: would ride into ``result.metrics`` and then either be dropped at submission or
+#: smuggled through the backward-compat catch unvalidated. We deliberately do NOT
+#: import ``MeasuresDict`` here (the cloud layer must not be a dependency of the
+#: evaluators layer); the duplication is pinned by
+#: ``test_user_metric_pattern_matches_measuresdict_pattern`` so any drift fails a
+#: test rather than silently reopening the bypass. ``re.ASCII`` keeps ``\w`` to
+#: ``[A-Za-z0-9_]`` so Unicode identifiers (e.g. ``"π_metric"``) are rejected.
+USER_METRIC_KEY_PATTERN: re.Pattern[str] = re.compile(r"^[a-zA-Z_]\w*$", re.ASCII)
 
 # Expose TOKENCOST availability and backward compatibility functions for tests
 try:
@@ -110,6 +124,7 @@ def aggregate_user_custom_metrics(
     example_metric_dicts: Sequence[dict[str, Any]],
     *,
     context: str,
+    extra_reserved: frozenset[str] = frozenset(),
 ) -> None:
     """Mean-aggregate non-reserved user keys across examples into ``target``.
 
@@ -119,9 +134,12 @@ def aggregate_user_custom_metrics(
 
     Semantics (fail-closed):
 
-    * a key in :data:`RESERVED_METRIC_KEYS` is skipped (the evaluator's own
-      computed value wins) and the skip is warning-logged — the user asked for
-      a key they cannot have;
+    * a key in :data:`RESERVED_METRIC_KEYS` OR in ``extra_reserved`` is skipped
+      (the evaluator's own computed value wins). ``extra_reserved`` carries the
+      runtime-only evaluator-computable names (registered custom metrics and
+      RAGAS metrics such as ``context_precision``) that the static frozenset
+      cannot enumerate, so a user tuple key with one of those names cannot
+      overwrite the evaluator's value;
     * a key already present in ``target`` is left untouched (never clobbered);
     * non-numeric / non-finite / ``bool`` values are skipped (the wire channel
       carries finite numbers only);
@@ -129,6 +147,14 @@ def aggregate_user_custom_metrics(
       TOTAL keys — only USER keys are truncated, deterministically in sorted
       order, with the drop warning-logged; evaluator keys are never dropped,
       mirroring ``merge_composite_measures``.
+
+    Logging split: reserved-key SKIPS here log at ``DEBUG``. This shared pass is
+    fed evaluator-INTERNAL dicts (e.g. the local lane's per-example
+    ``custom_metrics``, which carry injected ``input_cost`` / ``total_cost`` /
+    token keys), so a reserved-key collision here is dominated by the evaluator's
+    own keys, not a user mistake — warning on it would lie. The per-example
+    ``BaseEvaluator._merge_user_metrics`` (which sees the GENUINELY user-supplied
+    tuple dict) keeps the ``WARNING`` for the same condition.
     """
     values_by_key: dict[str, list[float]] = {}
     for metric in example_metric_dicts:
@@ -137,13 +163,12 @@ def aggregate_user_custom_metrics(
         for key, value in metric.items():
             if key in target:
                 continue
-            if is_reserved_metric_key(key):
-                logger.warning(
-                    "Skipping user metric %r (%s): %r is a reserved "
-                    "evaluator-computed key and cannot be overwritten",
+            if is_reserved_metric_key(key) or key in extra_reserved:
+                logger.debug(
+                    "Skipping reserved metric %r (%s): evaluator-computed key, "
+                    "cannot be overwritten",
                     key,
                     context,
-                    key,
                 )
                 continue
             if isinstance(value, bool) or value is None:
@@ -205,19 +230,30 @@ def _merge_capped_user_means(
         target[key] = user_means[key]
 
 
-def enforce_user_metric_ceiling(target: dict[str, Any], *, context: str) -> None:
+def enforce_user_metric_ceiling(
+    target: dict[str, Any],
+    *,
+    context: str,
+    extra_reserved: frozenset[str] = frozenset(),
+) -> None:
     """Clamp ``target`` to :data:`TOTAL_MEASURES_CEILING` TOTAL keys in place.
 
     The cap mirrors ``merge_composite_measures``: only NON-reserved (user) keys
     are dropped — deterministically, in sorted order, warning-logged — so the
     reserved evaluator-computed keys are never sacrificed to fit the ceiling.
-    This is the authoritative cap for a lane whose user keys arrive via an
-    intermediate dict (e.g. the local lane's ``comprehensive_metrics``), where
-    capping the intermediate dict alone cannot bound the final union.
+    ``extra_reserved`` extends the static :data:`RESERVED_METRIC_KEYS` with the
+    evaluator's runtime-only computable names (registry + RAGAS), so an
+    evaluator-computed key like ``context_precision`` is never mistaken for a
+    droppable user key. This is the authoritative cap for a lane whose user keys
+    arrive via an intermediate dict (e.g. the local lane's
+    ``comprehensive_metrics``), where capping the intermediate dict alone cannot
+    bound the final union.
     """
     if len(target) <= TOTAL_MEASURES_CEILING:
         return
-    user_keys = sorted(k for k in target if not is_reserved_metric_key(k))
+    user_keys = sorted(
+        k for k in target if not is_reserved_metric_key(k) and k not in extra_reserved
+    )
     overflow = len(target) - TOTAL_MEASURES_CEILING
     if overflow <= 0:
         return
@@ -460,8 +496,16 @@ class MetricsTracker:
             "duration": missing_default,
         }
 
-    def format_for_backend(self) -> dict[str, Any]:
-        """Format aggregated metrics for backend submission."""
+    def format_for_backend(
+        self, extra_reserved: frozenset[str] = frozenset()
+    ) -> dict[str, Any]:
+        """Format aggregated metrics for backend submission.
+
+        ``extra_reserved`` carries the owning evaluator's runtime-only
+        computable metric names (registered custom metrics + RAGAS names) so
+        user-supplied tuple keys cannot overwrite an evaluator-computed value
+        during the user-metric aggregation pass below.
+        """
         try:
             aggregated = self.aggregate_metrics()
         except Exception as e:
@@ -541,19 +585,25 @@ class MetricsTracker:
         # mean across examples is the correct trial-level value. Standard keys
         # already produced above are excluded so we never double-count or
         # clobber the canonical aggregation.
-        self._aggregate_user_custom_metrics(formatted)
+        self._aggregate_user_custom_metrics(formatted, extra_reserved)
 
         return formatted
 
-    def _aggregate_user_custom_metrics(self, formatted: dict[str, Any]) -> None:
+    def _aggregate_user_custom_metrics(
+        self, formatted: dict[str, Any], extra_reserved: frozenset[str] = frozenset()
+    ) -> None:
         """Mean-aggregate non-reserved custom metrics into ``formatted``.
 
         Delegates to the shared :func:`aggregate_user_custom_metrics` helper so
         the tuple-return metrics channel behaves identically on every public
-        evaluator path: reserved evaluator-computed keys are skipped (never
-        overwritten), already-present keys are left untouched, non-finite values
-        are dropped, and the total key count is capped at
-        :data:`TOTAL_MEASURES_CEILING` by truncating user keys only.
+        evaluator path: reserved evaluator-computed keys (the static
+        :data:`RESERVED_METRIC_KEYS` plus the evaluator's runtime-only
+        ``extra_reserved`` names) are skipped (never overwritten), already-present
+        keys are left untouched, non-finite values are dropped, and the total key
+        count is capped at :data:`TOTAL_MEASURES_CEILING` by truncating user keys
+        only. Reserved-key skips here log at ``DEBUG``: this pass is fed the
+        evaluator's own per-example ``custom_metrics`` (incl. injected cost/token
+        keys), so a collision is evaluator-internal, not a user error.
         """
         if not self.example_metrics:
             return
@@ -561,6 +611,7 @@ class MetricsTracker:
             formatted,
             [m.custom_metrics for m in self.example_metrics if m.success],
             context="format_for_backend user metrics",
+            extra_reserved=extra_reserved,
         )
 
     def _empty_backend_format(self) -> dict[str, Any]:

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -106,6 +106,17 @@ RESERVED_METRIC_KEYS: frozenset[str] = frozenset(
         "examples_attempted",
         "examples_consumed",
         "execution_time_ms",
+        # TRANSPORT-reserved: the submission lane passes the measures array and
+        # summary_stats object THROUGH the metrics dict and extracts them BY NAME
+        # in ``trial_operations._extract_measures_from_metrics``; the submission
+        # validator ``validators._validate_metrics_no_misplaced_fields`` HARD-
+        # rejects either name inside a metrics dict. A user tuple key with one of
+        # these names is wire-valid (identifier + numeric) and would otherwise
+        # ride into metrics and break submission — and the caps must never drop
+        # the system's own transport entries. Reserving them skips user keys with
+        # these names (WARNING) at merge.
+        "measures",
+        "summary_stats",
     }
 )
 

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -13,6 +13,14 @@ from dataclasses import dataclass, field
 from typing import Any, Optional, cast
 
 from traigent._version import get_version
+
+# The backend ``MeasuresDict`` ceiling (≤ 50 total keys) is the single source of
+# truth for the per-trial metric cardinality cap. It lives in
+# ``traigent.knobs.telemetry`` (which has no evaluators dependency, so importing
+# it here is cycle-free) and is reused by ``merge_composite_measures`` for the
+# pre-merge path; this aggregation path mirrors the SAME semantics — user keys
+# are truncated, evaluator keys are never dropped.
+from traigent.knobs.telemetry import TOTAL_MEASURES_CEILING
 from traigent.utils.logging import get_logger
 
 # Initialize logger first
@@ -33,6 +41,211 @@ except Exception:
     calculate_completion_cost = None  # type: ignore[assignment]
 
 TOKENCOST_AVAILABLE = _TOKENCOST_AVAILABLE
+
+#: Evaluator/tracker-computed metric keys that user-supplied per-example metrics
+#: (e.g. the ``(output, metrics_dict)`` tuple channel) MUST NEVER overwrite,
+#: at ANY merge or aggregation site, regardless of merge ordering or
+#: ``setdefault`` timing. Derived from what actually lands in a trial's metrics:
+#:
+#: * the metric registry built-ins (``BaseEvaluator._metric_registry``):
+#:   ``accuracy``, ``success_rate``, ``error_rate``, ``avg_output_length``,
+#:   ``cost``, ``latency`` (plus the per-example ``success`` flag);
+#: * ``MetricsTracker.format_for_backend`` outputs: ``score``, ``accuracy``,
+#:   ``duration``, ``input_tokens``, ``output_tokens``, ``total_tokens``,
+#:   ``response_time_ms``, ``cost``, ``total_examples``, ``successful_examples``,
+#:   ``tokens_per_second``;
+#: * the LLM aggregation (``_aggregate_llm_metrics``): ``prompt_tokens``,
+#:   ``completion_tokens``, ``total_tokens``, ``input_cost``, ``output_cost``,
+#:   ``total_cost``, ``avg_response_time``, ``avg_response_time_ms``;
+#: * standard/LLM per-example keys and lifecycle counters: ``input_cost``,
+#:   ``output_cost``, ``total_cost``, ``examples_attempted``,
+#:   ``examples_consumed``, ``execution_time_ms``.
+RESERVED_METRIC_KEYS: frozenset[str] = frozenset(
+    {
+        # Metric-registry built-ins + per-example success flag.
+        "accuracy",
+        "success",
+        "success_rate",
+        "error_rate",
+        "avg_output_length",
+        "cost",
+        "latency",
+        "score",
+        # format_for_backend / summary outputs.
+        "duration",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "response_time_ms",
+        "total_examples",
+        "successful_examples",
+        "tokens_per_second",
+        # LLM aggregation + per-example cost/token detail.
+        "prompt_tokens",
+        "completion_tokens",
+        "input_cost",
+        "output_cost",
+        "total_cost",
+        "avg_response_time",
+        "avg_response_time_ms",
+        # Lifecycle counters / timing.
+        "examples_attempted",
+        "examples_consumed",
+        "execution_time_ms",
+    }
+)
+
+
+def is_reserved_metric_key(key: str) -> bool:
+    """Return ``True`` if ``key`` is an evaluator/tracker-computed metric.
+
+    User-supplied per-example metrics must never overwrite a reserved key; see
+    :data:`RESERVED_METRIC_KEYS`.
+    """
+    return key in RESERVED_METRIC_KEYS
+
+
+def aggregate_user_custom_metrics(
+    target: dict[str, Any],
+    example_metric_dicts: Sequence[dict[str, Any]],
+    *,
+    context: str,
+) -> None:
+    """Mean-aggregate non-reserved user keys across examples into ``target``.
+
+    Shared by both the ``SimpleScoringEvaluator`` trial-aggregation path and
+    ``MetricsTracker._aggregate_user_custom_metrics`` so the tuple-return
+    metrics channel surfaces user keys identically on every public evaluator.
+
+    Semantics (fail-closed):
+
+    * a key in :data:`RESERVED_METRIC_KEYS` is skipped (the evaluator's own
+      computed value wins) and the skip is warning-logged — the user asked for
+      a key they cannot have;
+    * a key already present in ``target`` is left untouched (never clobbered);
+    * non-numeric / non-finite / ``bool`` values are skipped (the wire channel
+      carries finite numbers only);
+    * the resulting ``target`` is capped at :data:`TOTAL_MEASURES_CEILING`
+      TOTAL keys — only USER keys are truncated, deterministically in sorted
+      order, with the drop warning-logged; evaluator keys are never dropped,
+      mirroring ``merge_composite_measures``.
+    """
+    values_by_key: dict[str, list[float]] = {}
+    for metric in example_metric_dicts:
+        if not metric:
+            continue
+        for key, value in metric.items():
+            if key in target:
+                continue
+            if is_reserved_metric_key(key):
+                logger.warning(
+                    "Skipping user metric %r (%s): %r is a reserved "
+                    "evaluator-computed key and cannot be overwritten",
+                    key,
+                    context,
+                    key,
+                )
+                continue
+            if isinstance(value, bool) or value is None:
+                continue
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                continue
+            if not math.isfinite(numeric):
+                continue
+            values_by_key.setdefault(key, []).append(numeric)
+
+    means = {
+        key: sum(values) / len(values)
+        for key, values in values_by_key.items()
+        if values
+    }
+    _merge_capped_user_means(target, means, context=context)
+
+
+def _merge_capped_user_means(
+    target: dict[str, Any],
+    user_means: dict[str, float],
+    *,
+    context: str,
+) -> None:
+    """Merge ``user_means`` into ``target`` under the total-key ceiling.
+
+    Only user keys are truncated (deterministic sorted order, warning-logged);
+    evaluator keys already in ``target`` are never dropped.
+    """
+    if not user_means:
+        return
+    budget = TOTAL_MEASURES_CEILING - len(target)
+    ordered_keys = sorted(user_means)
+    if budget <= 0:
+        logger.warning(
+            "%s: trial metrics already at the %d-key ceiling; ALL %d "
+            "user metric(s) dropped: %s",
+            context,
+            TOTAL_MEASURES_CEILING,
+            len(ordered_keys),
+            ordered_keys[:10],
+        )
+        return
+    if len(ordered_keys) > budget:
+        kept = ordered_keys[:budget]
+        dropped = ordered_keys[budget:]
+        logger.warning(
+            "%s: user metrics would exceed the %d-key ceiling; %d user key(s) "
+            "dropped deterministically: %s",
+            context,
+            TOTAL_MEASURES_CEILING,
+            len(dropped),
+            dropped[:10],
+        )
+        ordered_keys = kept
+    for key in ordered_keys:
+        target[key] = user_means[key]
+
+
+def enforce_user_metric_ceiling(target: dict[str, Any], *, context: str) -> None:
+    """Clamp ``target`` to :data:`TOTAL_MEASURES_CEILING` TOTAL keys in place.
+
+    The cap mirrors ``merge_composite_measures``: only NON-reserved (user) keys
+    are dropped — deterministically, in sorted order, warning-logged — so the
+    reserved evaluator-computed keys are never sacrificed to fit the ceiling.
+    This is the authoritative cap for a lane whose user keys arrive via an
+    intermediate dict (e.g. the local lane's ``comprehensive_metrics``), where
+    capping the intermediate dict alone cannot bound the final union.
+    """
+    if len(target) <= TOTAL_MEASURES_CEILING:
+        return
+    user_keys = sorted(k for k in target if not is_reserved_metric_key(k))
+    overflow = len(target) - TOTAL_MEASURES_CEILING
+    if overflow <= 0:
+        return
+    # Drop the LAST `overflow` user keys (deterministic sorted order); reserved
+    # keys are never eligible for dropping.
+    droppable = user_keys[len(user_keys) - min(overflow, len(user_keys)) :]
+    for key in droppable:
+        del target[key]
+    if droppable:
+        logger.warning(
+            "%s: trial metrics exceeded the %d-key ceiling; %d user key(s) "
+            "dropped deterministically: %s",
+            context,
+            TOTAL_MEASURES_CEILING,
+            len(droppable),
+            droppable[:10],
+        )
+    if len(target) > TOTAL_MEASURES_CEILING:
+        # All remaining overflow is reserved keys (never dropped): the evaluator
+        # itself produced more than the ceiling. Surface loudly; do not silently
+        # exceed the contract by dropping computed keys.
+        logger.warning(
+            "%s: %d reserved evaluator key(s) leave the trial metrics above the "
+            "%d-key ceiling; reserved keys are never dropped",
+            context,
+            len(target) - TOTAL_MEASURES_CEILING,
+            TOTAL_MEASURES_CEILING,
+        )
 
 
 @dataclass
@@ -332,64 +545,23 @@ class MetricsTracker:
 
         return formatted
 
-    #: Keys ``format_for_backend`` already produces via dedicated, non-mean
-    #: aggregation (accuracy/score by mean elsewhere; tokens/cost as the
-    #: tracker's own statistics). User custom keys outside this set are
-    #: mean-aggregated as-is.
-    _RESERVED_BACKEND_METRIC_KEYS = frozenset(
-        {
-            "score",
-            "accuracy",
-            "success",
-            "duration",
-            "input_tokens",
-            "output_tokens",
-            "total_tokens",
-            "response_time_ms",
-            "cost",
-            "input_cost",
-            "output_cost",
-            "total_cost",
-            "tokens_per_second",
-            "total_examples",
-            "successful_examples",
-        }
-    )
-
     def _aggregate_user_custom_metrics(self, formatted: dict[str, Any]) -> None:
         """Mean-aggregate non-reserved custom metrics into ``formatted``.
 
-        Mirrors the accuracy mean-aggregation in ``format_for_backend``: for
-        every custom-metric key that is NOT a reserved/standard key, average
-        its finite numeric values across the successful examples and write the
-        mean into ``formatted``. Non-numeric or non-finite values are skipped
-        (the wire channel carries finite numbers only). Reserved keys already
-        present in ``formatted`` are never overwritten.
+        Delegates to the shared :func:`aggregate_user_custom_metrics` helper so
+        the tuple-return metrics channel behaves identically on every public
+        evaluator path: reserved evaluator-computed keys are skipped (never
+        overwritten), already-present keys are left untouched, non-finite values
+        are dropped, and the total key count is capped at
+        :data:`TOTAL_MEASURES_CEILING` by truncating user keys only.
         """
         if not self.example_metrics:
             return
-
-        values_by_key: dict[str, list[float]] = {}
-        for metric in self.example_metrics:
-            if not metric.success:
-                continue
-            for key, value in metric.custom_metrics.items():
-                if key in self._RESERVED_BACKEND_METRIC_KEYS:
-                    continue
-                if isinstance(value, bool) or value is None:
-                    continue
-                try:
-                    numeric = float(value)
-                except (TypeError, ValueError):
-                    continue
-                if not math.isfinite(numeric):
-                    continue
-                values_by_key.setdefault(key, []).append(numeric)
-
-        for key, values in values_by_key.items():
-            if not values or key in formatted:
-                continue
-            formatted[key] = sum(values) / len(values)
+        aggregate_user_custom_metrics(
+            formatted,
+            [m.custom_metrics for m in self.example_metrics if m.success],
+            context="format_for_backend user metrics",
+        )
 
     def _empty_backend_format(self) -> dict[str, Any]:
         """Return empty backend format structure when error occurs."""
@@ -1079,7 +1251,7 @@ def _calculate_cost_for_metrics(
             )
     except Exception as e:
         logger.error(
-            "Cost calculation failed for model %s: %s " "(tokens: in=%d, out=%d)",
+            "Cost calculation failed for model %s: %s (tokens: in=%d, out=%d)",
             model_name,
             e,
             metrics.tokens.input_tokens,


### PR DESCRIPTION
## CV-C — tuple-return user-metrics channel: make the documented hybrid recipe real

The composite-knobs docs and `examples/advanced/composite-knobs/composite_telemetry.py` documented a hybrid recipe — *"return `(output, metrics)` and the metrics ride the wire"* — that **did not exist** (fake completion, Rule 2): the raw tuple poisoned accuracy scoring (`tuple != "YES"` → accuracy 0.0) and no user metric ever reached the backend. Caught by the program-closing live smoke for #1171/#1172.

### What this PR adds

A strict, conservative tuple-unpack channel in the evaluators:

- **Unpack rule** (`_unpack_user_metrics`, `evaluators/base.py`): unpacks **exactly** `type(raw) is tuple and len(raw)==2` with `raw[1]` a Mapping whose keys all match `^[a-zA-Z_]\w*$` (ASCII, pinned by test to `MeasuresDict.KEY_PATTERN`) and whose values are all numeric non-bool. **Any** other shape passes through untouched — absolute back-compat. Near-miss shapes log one WARNING.
- **No-override**: user keys colliding with `RESERVED_METRIC_KEYS` (28 builtin + transport keys) ∪ the evaluator's runtime-computable names (metric registry, RAGAS, **user `metric_functions`**) are skipped at every merge site — the evaluator's computed value always wins.
- **50-key ceiling**: `enforce_user_metric_ceiling` is the single authoritative final-union cap at `build_success_result` (the true final assembly point — `total_cost` is written after every lane cap), threaded with the evaluator's runtime reserved names; only user keys are dropped, deterministically (sorted), warning-logged. Lane-end caps retained as pre-trims because `eval_result.metrics` is read by `enforce_constraints` and tracing before assembly.
- **Aggregation**: per-example user metrics ride `ExampleResult.user_metrics` (not serialized) and are mean-aggregated by the shared `aggregate_user_custom_metrics` in both the MetricsTracker and SimpleScoring lanes.

### Review chain (codex gpt-5.5 xhigh, anchored rounds; captain probes interleaved)

| Round | Verdict | Findings → fix commit |
|---|---|---|
| 1 | REJECT (3 MAJOR + 1 MINOR) | F1–F4 @f63ca4cb |
| 2 | REJECT (3 MAJOR + 1 MINOR, reproduced) | G1–G4 @62e524eb |
| captain probe | 51st-key residual in the **local** lane codex's SimpleScoring-only probe missed (`total_cost` written post-cap) | R1–R2 @cefade25 |
| 3 | REJECT (2 BLOCKER: `metric_functions` names unprotected; transport-reserved `measures`/`summary_stats` broke hybrid submission) — both captain-reproduced | H1–H3 @4ccde01c |
| 4 | **ACCEPT** + 1 MINOR (H3 test was vacuous: 50-key union → cap returned early; only went red pre-fix via the kwarg TypeError) | de-vacuized + counterfactual companion @825ecae0 |

Commit `4b37025f` (docs wording: "CALIBRATION-BACKED WINNER (client-attested)", per the claim-scope audit) was added after the round-3 reviewed range and is covered by round 4.

### Verification

- `tests/unit/evaluators/ tests/unit/core/ tests/unit/cloud/test_composite_measures_submission.py tests/unit/knobs/` → **2589 passed, 2 skipped** (all red-first; round-1..4 hardening files).
- **Live smoke** (`hybrid` against local dev backend): self_consistency ensemble executes in-trial (CV-B runtime), §3.10 telemetry rides this channel — backend persisted `composite_candidates_evaluated`, `composite_candidates_excluded`, `composite_vote_agreement`, `composite_vote_margin` with accuracy intact on every trial.

### PR checklist

1. **Worst-case prod path** — a malformed/abusive tuple from user code: any non-conforming shape is passed through (back-compat), conforming user keys can never override evaluator-computed metrics or transport fields, and the total key count is hard-capped at 50 with reserved keys never sacrificed. Fail-closed at every decision point.
2. **Production-branch test** — no production-gated branches added; no-override + ceiling + transport-reservation proven by `tests/unit/evaluators/test_tuple_metrics_channel*.py` (rounds 1–4), e.g. `test_final_cap_keeps_evaluator_computed_name_drops_user_key`, `test_transport_reserved_merge_keeps_submission_valid`.
3. **Contract regeneration** — none: user metrics ride the existing measures channel; `MeasuresDict.KEY_PATTERN` tightened to compiled `re.ASCII` (wire-compatible narrowing, consistency-tested). No TraigentSchema change; JS parity not required this program (channel is Python-evaluator-internal).
4. **Public surface delta** — no `__all__`/route/optimizer changes; the documented recipe in `docs/traceability/concepts/composite-knobs.md` + the example now matches runtime behavior (it previously didn't — that was the bug).
5. **Review threads resolved** — to be confirmed before merge (Rule 8 sweep).
6. **Quality gates not relaxed** — none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
