### PR TITLE
feat(knobs): composite catalog v2 — pre-cascade dispatch + router/fallback/moe/react_tool_loop/verification_gate + knob packs

### DIFF
--- a/examples/advanced/composite-knobs/composite_telemetry.py
+++ b/examples/advanced/composite-knobs/composite_telemetry.py
@@ -17,7 +17,7 @@ talks to NO backend. It demonstrates, end to end:
 
 Run it::
 
-    python examples/advanced/composite-knobs/composite_telemetry.py
+    uv run python examples/advanced/composite-knobs/composite_telemetry.py
 
 Environment (all optional; offline by default):
 

--- a/examples/advanced/composite-knobs/moe_example.py
+++ b/examples/advanced/composite-knobs/moe_example.py
@@ -7,7 +7,7 @@ reproducible.
 
 Run it::
 
-    python examples/advanced/composite-knobs/moe_example.py
+    uv run python examples/advanced/composite-knobs/moe_example.py
 """
 
 from __future__ import annotations

--- a/examples/advanced/composite-knobs/moe_example.py
+++ b/examples/advanced/composite-knobs/moe_example.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Composite knobs: a deterministic mixture-of-experts committee example.
+
+This example is offline by default. It makes no model calls and talks to no
+backend; the expert and judge stages are deterministic stubs so the output is
+reproducible.
+
+Run it::
+
+    python examples/advanced/composite-knobs/moe_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
+
+from traigent.knobs.patterns import moe
+from traigent.knobs.runtime import StageRunner, execute_composite
+from traigent.knobs.telemetry import merge_composite_measures
+
+VOTE_MARGIN_MIN = "patch_moe.vote_margin_min"
+
+VOTE_MOE = moe(
+    "patch_moe",
+    experts=("fast_patch", "semantic_patch", "test_driven_patch"),
+    aggregate="vote",
+    accept_threshold=VOTE_MARGIN_MIN,
+    expert_tuned_params=(
+        ("repo_context_strategy", "edit_granularity"),
+        ("repo_context_strategy",),
+        ("test_selection_strategy", "patch_review_mode"),
+    ),
+)
+
+JUDGE_MOE = moe(
+    "review_moe",
+    experts=("draft_a", "draft_b"),
+    aggregate="judge",
+    judge_stage="rubric_judge",
+    expert_tuned_params=(("summary_style",), ("citation_policy",)),
+    judge_tuned_params=("judge_rubric",),
+)
+
+
+def _stage(outputs: list[str]) -> StageRunner:
+    return StageRunner(
+        run=lambda _item: list(outputs),
+        key_fn=lambda x: x,
+        samples=len(outputs),
+    )
+
+
+def _judge() -> StageRunner:
+    scores = {"brief_patch": 0.4, "tested_patch": 0.9}
+    return StageRunner(run=lambda candidate: [scores[str(candidate)]], samples=1)
+
+
+def main() -> None:
+    vote_run = execute_composite(
+        VOTE_MOE.structure,
+        {
+            "fast_patch": _stage(["tested_patch"]),
+            "semantic_patch": _stage(["tested_patch"]),
+            "test_driven_patch": _stage(["brief_patch"]),
+        },
+        config={},
+        calibrated_values={VOTE_MARGIN_MIN: 0.5},
+    )
+    vote_metrics = {"accepted": 1.0 if vote_run.output == "tested_patch" else 0.0}
+    merge_composite_measures(vote_metrics, vote_run, prefix="vote_moe")
+
+    judge_run = execute_composite(
+        JUDGE_MOE.structure,
+        {
+            "draft_a": _stage(["brief_patch"]),
+            "draft_b": _stage(["tested_patch"]),
+            "rubric_judge": _judge(),
+        },
+        config={},
+        calibrated_values={},
+    )
+    judge_metrics = {"accepted": 1.0 if judge_run.output == "tested_patch" else 0.0}
+    merge_composite_measures(judge_metrics, judge_run, prefix="judge_moe")
+
+    print("Mixture-of-experts example (offline, deterministic)\n")
+    print(f"  vote aggregate output:  {vote_run.output!r}")
+    print(f"    metrics: {vote_metrics}")
+    print(f"  judge aggregate output: {judge_run.output!r}")
+    print(f"    metrics: {judge_metrics}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/composite-knobs/react_tool_loop_example.py
+++ b/examples/advanced/composite-knobs/react_tool_loop_example.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Composite knobs: run a ReAct-style tool loop offline and merge telemetry.
+
+This example is deterministic and makes NO LLM calls and NO network calls. It
+declares the ``react_tool_loop`` catalog pattern, executes it with a stubbed
+tool-step loop body, evaluates a confidence signal over the threaded state, and
+merges the composite telemetry into an ordinary metrics dict.
+
+Run it::
+
+    python examples/advanced/composite-knobs/react_tool_loop_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+# Offline by default: this example never needs a backend.
+os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
+
+from traigent.knobs.patterns import react_tool_loop
+from traigent.knobs.runtime import (
+    LoopBodyResult,
+    LoopBodyRunner,
+    ResultKind,
+    execute_composite,
+)
+from traigent.knobs.telemetry import merge_composite_measures
+
+CONFIDENCE_MIN = "tool_confidence_min"
+
+COMPOSITE = react_tool_loop(
+    "qa_react",
+    stage="react_tool_step",
+    signal="tool_confidence",
+    tool_confidence_min=CONFIDENCE_MIN,
+    max_tool_calls=4,
+)
+
+
+def _tool_step(confidences: list[float]) -> LoopBodyRunner:
+    """A deterministic one-tool-step body over a fixed confidence sequence."""
+    counter = {"i": 0}
+
+    def run(_item, state):
+        i = counter["i"]
+        counter["i"] += 1
+        confidence = confidences[min(i, len(confidences) - 1)]
+        tool_calls = [*state.get("tool_calls", ()), f"lookup-{i + 1}"]
+        observations = [*state.get("observations", ()), f"observation-{i + 1}"]
+        return LoopBodyResult(
+            output=f"offline answer after {i + 1} step(s)",
+            state={
+                "scratchpad": f"thought-{i + 1}",
+                "tool_calls": tool_calls,
+                "observations": observations,
+                "confidence": confidence,
+                "last_error": None,
+            },
+        )
+
+    return LoopBodyRunner(run=run)
+
+
+def _confidence_signal(state) -> float:
+    return float(state["confidence"])
+
+
+def main() -> None:
+    run = execute_composite(
+        COMPOSITE.structure,
+        {"react_tool_step": _tool_step([0.35, 0.66, 0.92])},
+        config={"question": "offline demo"},
+        calibrated_values={CONFIDENCE_MIN: 0.9},
+        signals={"tool_confidence": _confidence_signal},
+    )
+
+    metrics: dict[str, float | int] = {
+        "accepted": 1 if run.result_kind is ResultKind.OUTPUT else 0
+    }
+    merge_composite_measures(metrics, run)
+
+    print("react_tool_loop example (offline, deterministic)\n")
+    print(f"  result: {run.result_kind.value}")
+    print(f"  output: {run.output}")
+    print(f"  raw composite telemetry: {run.measures}")
+    print(f"  merged metrics: {metrics}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/composite-knobs/react_tool_loop_example.py
+++ b/examples/advanced/composite-knobs/react_tool_loop_example.py
@@ -8,7 +8,7 @@ merges the composite telemetry into an ordinary metrics dict.
 
 Run it::
 
-    python examples/advanced/composite-knobs/react_tool_loop_example.py
+    uv run python examples/advanced/composite-knobs/react_tool_loop_example.py
 """
 
 from __future__ import annotations

--- a/examples/advanced/composite-knobs/router_example.py
+++ b/examples/advanced/composite-knobs/router_example.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Composite knobs: adaptive-RAG-style router dispatch, offline.
+
+This example makes no LLM calls and no network calls. It declares a pre-cascade
+``router`` pattern, routes deterministic question payloads through stub RAG
+stages, and merges the emitted composite telemetry into ordinary metrics.
+
+Run it::
+
+    python examples/advanced/composite-knobs/router_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
+
+from traigent.knobs.patterns import router
+from traigent.knobs.runtime import ResultKind, StageRunner, execute_composite
+from traigent.knobs.telemetry import merge_composite_measures
+
+COMPLEXITY_THRESHOLD = "complexity_threshold"
+
+# Adaptive-RAG recipe:
+# - Route on an adequacy/inverted complexity signal, not raw "hardness":
+#   P(light_rag adequate | query_light_adequacy(question) >= threshold) >= p.
+# - Keep ``signal_inputs=("question",)`` freshness-covered for the threshold
+#   CVAR so the gate is calibrated against the same input surface it declares.
+# - ``retrieval_confidence_min`` is a heavy-arm CVAR owned by ``rag_heavy``; it
+#   is not consumed by this outer router unless the heavy arm is modeled as a
+#   nested composite.
+# - The terminal heavy arm handles abstention/fall-through when the light-arm
+#   adequacy signal is below threshold or unavailable.
+ADAPTIVE_RAG_GATE = router(
+    "adaptive_rag_gate",
+    arms=("rag_light", "rag_heavy"),
+    signals=("query_light_adequacy",),
+    thresholds=(COMPLEXITY_THRESHOLD,),
+    signal_inputs=(("question",),),
+    tuned_params=(
+        ("retrieval_mode", "query_complexity_strategy", "retrieval_k"),
+        (
+            "retrieval_mode",
+            "query_complexity_strategy",
+            "retrieval_k",
+            "reranker",
+            "web_fallback",
+            "decompose_query",
+        ),
+    ),
+)
+
+
+def _rag_stage(label: str) -> StageRunner:
+    def run(payload):
+        question = str(payload["question"])
+        return [f"{label} answer for: {question}"]
+
+    return StageRunner(run=run, key_fn=lambda x: x, samples=1)
+
+
+def _query_light_adequacy(payload) -> float:
+    question = str(payload["question"]).lower()
+    tokens = question.split()
+    hard_terms = {"compare", "derive", "audit", "multi-hop", "counterfactual"}
+    penalty = 0.2 * sum(1 for term in hard_terms if term in question)
+    length_penalty = max(0.0, (len(tokens) - 8) * 0.06)
+    return max(0.0, min(1.0, 0.95 - penalty - length_penalty))
+
+
+def main() -> None:
+    stages = {
+        "rag_light": _rag_stage("light RAG"),
+        "rag_heavy": _rag_stage("heavy RAG"),
+    }
+    questions = (
+        "What is the refund policy?",
+        "Compare the audit findings and derive a multi-hop remediation plan.",
+    )
+
+    print("router example (offline, deterministic)\n")
+    for question in questions:
+        run = execute_composite(
+            ADAPTIVE_RAG_GATE.structure,
+            stages,
+            config={"question": question},
+            calibrated_values={COMPLEXITY_THRESHOLD: 0.6},
+            signals={"query_light_adequacy": _query_light_adequacy},
+        )
+        metrics: dict[str, float | int] = {
+            "accepted": 1 if run.result_kind is ResultKind.OUTPUT else 0
+        }
+        merge_composite_measures(metrics, run)
+
+        print(f"  question: {question}")
+        print(f"    result: {run.result_kind.value}")
+        print(f"    output: {run.output}")
+        print(f"    raw composite telemetry: {run.measures}")
+        print(f"    merged metrics: {metrics}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/composite-knobs/router_example.py
+++ b/examples/advanced/composite-knobs/router_example.py
@@ -7,7 +7,7 @@ stages, and merges the emitted composite telemetry into ordinary metrics.
 
 Run it::
 
-    python examples/advanced/composite-knobs/router_example.py
+    uv run python examples/advanced/composite-knobs/router_example.py
 """
 
 from __future__ import annotations

--- a/examples/advanced/composite-knobs/verification_gate_example.py
+++ b/examples/advanced/composite-knobs/verification_gate_example.py
@@ -11,7 +11,7 @@ backend. It demonstrates:
 
 Run it::
 
-    python examples/advanced/composite-knobs/verification_gate_example.py
+    uv run python examples/advanced/composite-knobs/verification_gate_example.py
 """
 
 from __future__ import annotations

--- a/examples/advanced/composite-knobs/verification_gate_example.py
+++ b/examples/advanced/composite-knobs/verification_gate_example.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Composite knobs: execute a verifier gate loop with offline stub stages.
+
+This example is deterministic and offline. It makes no LLM calls and talks to no
+backend. It demonstrates:
+
+1. declaring the ``verification_gate`` pattern;
+2. executing a generate-verify-revise loop with ``execute_composite``;
+3. using a verifier score signal to accept a draft; and
+4. merging the content-free loop telemetry into ordinary numeric measures.
+
+Run it::
+
+    python examples/advanced/composite-knobs/verification_gate_example.py
+"""
+
+from __future__ import annotations
+
+import os
+
+# Offline by default: this example never needs a backend.
+os.environ.setdefault("TRAIGENT_OFFLINE_MODE", "true")
+os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
+
+from traigent.knobs.patterns import self_refine, verification_gate
+from traigent.knobs.runtime import LoopBodyResult, LoopBodyRunner, execute_composite
+from traigent.knobs.telemetry import merge_composite_measures
+
+PASS_THRESHOLD = "verifier_pass_threshold"
+VERIFIER_SIGNAL = "verifier_pass_score"
+
+
+VERIFIER_GATE = verification_gate(
+    "qa_verified",
+    stage="generate_verify_revise",
+    verifier_signal=VERIFIER_SIGNAL,
+    verifier_pass_threshold=PASS_THRESHOLD,
+    verification_style="verification_style",
+    verification_question_count="verification_question_count",
+    verifier_model="verifier_model",
+    independent_context="independent_context",
+    revision_policy="revision_policy",
+    max_iters=2,
+)
+
+
+# bounded_refine_loop RECIPE, not a new factory:
+# - use self_refine() with a literal max_iters envelope;
+# - thread previous_score and improvement_delta through the loop body state;
+# - expose only one acceptance-direction signal threshold to the IR.
+# Not expressible in v1: a simultaneous raw improvement_min_delta stop or a
+# tuned max_repair_rounds structural loop bound.
+BOUNDED_REFINE_RECIPE = self_refine(
+    name="bounded_refine_loop",
+    stage="critique_repair",
+    signal="refine_accept_score",
+    threshold="acceptance_threshold",
+    max_iters=3,
+    state_keys=(
+        "draft",
+        "critique",
+        "score",
+        "previous_score",
+        "improvement_delta",
+        "round",
+    ),
+    signal_inputs=("draft", "score", "previous_score", "improvement_delta"),
+    stage_tuned_params=(
+        "critic_model",
+        "feedback_rubric",
+        "repair_prompt",
+        "max_repair_rounds",
+        "stop_condition",
+    ),
+)
+
+
+def _generate_verify_revise(
+    scores: list[float],
+) -> tuple[LoopBodyRunner, dict[str, float]]:
+    """Return a deterministic loop body for generate -> verify -> revise."""
+    cursor = {"i": 0}
+    last = {"score": 0.0, "contradiction_score": 0.0}
+
+    def run(config, state):
+        i = cursor["i"]
+        cursor["i"] += 1
+        score = scores[min(i, len(scores) - 1)]
+        revised = bool(state)
+        draft = (
+            f"{config['question']} -> concise answer"
+            if not revised
+            else f"{state['draft']} [revised against reference]"
+        )
+        contradiction_score = max(0.0, 1.0 - score)
+        last["score"] = score
+        last["contradiction_score"] = contradiction_score
+        return LoopBodyResult(
+            output=draft,
+            state={
+                "draft": draft,
+                "verification_questions": 3,
+                "verification_answers": "all required checks completed",
+                "verifier_pass_score": score,
+                "contradiction_score": contradiction_score,
+                "revision": "tightened" if revised else "none",
+                "independent_context": config["reference"],
+            },
+        )
+
+    return LoopBodyRunner(run=run), last
+
+
+def _verifier_pass_score(state: dict[str, object]) -> float:
+    return float(state["verifier_pass_score"])
+
+
+def main() -> None:
+    body, last = _generate_verify_revise([0.52, 0.93])
+    run = execute_composite(
+        VERIFIER_GATE.structure,
+        {"generate_verify_revise": body},
+        config={
+            "question": "What does the verifier gate demonstrate?",
+            "reference": "Use only offline stub evidence.",
+        },
+        calibrated_values={PASS_THRESHOLD: 0.9},
+        signals={VERIFIER_SIGNAL: _verifier_pass_score},
+    )
+
+    metrics = {
+        "verifier_pass_score": last["score"],
+        "contradiction_score": last["contradiction_score"],
+        "verification_questions_evaluated": 3,
+    }
+    merge_composite_measures(metrics, run)
+
+    print("Verification gate example (offline, deterministic)\n")
+    print(f"  result kind: {run.result_kind.value}")
+    print(f"  output: {run.output}")
+    print(f"  measures: {metrics}")
+    print(f"  recipe pattern: {BOUNDED_REFINE_RECIPE.provenance.pattern}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/config_generator/test_knob_pack_rows.py
+++ b/tests/unit/config_generator/test_knob_pack_rows.py
@@ -1,0 +1,118 @@
+"""Catalog tests for ACI and context-budget knob-pack TVar rows."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from jsonschema import Draft7Validator
+
+from traigent.api.functions import (
+    list_recommendation_agent_types,
+    recommend_configuration_space,
+)
+from traigent.config_generator.catalog import _load_catalog_entry_schema, load_catalog
+
+ACI_NAMES = {
+    "repo_context_strategy",
+    "file_view_window",
+    "edit_granularity",
+    "test_selection_strategy",
+    "patch_review_mode",
+}
+CONTEXT_BUDGET_NAMES = {
+    "context_selection_policy",
+    "context_order",
+    "summary_style",
+    "compression_ratio",
+    "citation_policy",
+}
+NEW_NAMES = ACI_NAMES | CONTEXT_BUDGET_NAMES
+CVAR_VOCABULARY = {
+    "confidence_to_edit",
+    "min_test_signal",
+    "evidence_coverage_min",
+    "max_context_tokens",
+}
+
+
+def _new_entries() -> list[dict[str, object]]:
+    entries = [
+        entry
+        for entry in load_catalog()
+        if str(entry.get("name")) in NEW_NAMES
+    ]
+    assert {str(entry["name"]) for entry in entries} == NEW_NAMES
+    return entries
+
+
+def test_new_knob_pack_rows_validate_against_existing_schema() -> None:
+    schema = _load_catalog_entry_schema()
+    validator = Draft7Validator(schema)
+
+    for entry in _new_entries():
+        errors = sorted(validator.iter_errors(entry), key=lambda err: err.path)
+        assert errors == []
+
+
+def test_recommendations_include_aci_rows_for_code_gen_at_low_confidence() -> None:
+    payload = recommend_configuration_space("code_gen", min_confidence="low")
+    names = {row["name"] for row in payload["recommendations"]}
+
+    assert ACI_NAMES <= names
+    assert ACI_NAMES <= set(payload["configuration_space"])
+    for row in payload["recommendations"]:
+        if row["name"] in ACI_NAMES:
+            assert row["confidence"] == "low"
+            assert row["category"] == "agent_computer_interface"
+            assert row["catalog_entry_id"].startswith("code_gen.")
+            assert "software_engineering_agent" in row["apply_guidance"]
+
+
+def test_recommendations_include_context_budget_rows_for_rag_at_low_confidence() -> None:
+    payload = recommend_configuration_space("rag", min_confidence="low")
+    names = {row["name"] for row in payload["recommendations"]}
+
+    assert CONTEXT_BUDGET_NAMES <= names
+    assert CONTEXT_BUDGET_NAMES <= set(payload["configuration_space"])
+    for row in payload["recommendations"]:
+        if row["name"] in CONTEXT_BUDGET_NAMES:
+            assert row["confidence"] == "low"
+            assert row["category"] == "context_budget"
+            assert row["catalog_entry_id"].startswith("rag.")
+
+
+def test_external_paper_evidence_derives_low_confidence_honestly() -> None:
+    for entry in _new_entries():
+        refs = entry["evidence_refs"]
+        assert isinstance(refs, list) and refs
+        for ref in refs:
+            assert ref["scope"].startswith("external_paper:")
+            assert ref["delta"] is None
+            assert "external_paper_not_traigent_measured" in ref["limitations"]
+            assert "not_catalog_metric_delta" in ref["limitations"]
+
+    code_gen = recommend_configuration_space("code_gen", min_confidence="low")
+    rag = recommend_configuration_space("rag", min_confidence="low")
+    rows = [
+        row
+        for row in code_gen["recommendations"] + rag["recommendations"]
+        if row["name"] in NEW_NAMES
+    ]
+    assert len(rows) == 10
+    assert {row["confidence"] for row in rows} == {"low"}
+    assert all("observational support; no measured delta" in row["evidence_note"] for row in rows)
+
+
+def test_rows_do_not_expand_public_agent_types() -> None:
+    assert list_recommendation_agent_types() == ("code_gen", "rag")
+
+
+def test_cvar_vocabulary_only_appears_in_apply_guidance() -> None:
+    for entry in _new_entries():
+        assert "pack_id" not in entry
+        assert "cvars" not in entry
+        without_guidance = copy.deepcopy(entry)
+        without_guidance.pop("apply_guidance", None)
+        serialized = json.dumps(without_guidance, sort_keys=True)
+        assert not any(term in serialized for term in CVAR_VOCABULARY)

--- a/tests/unit/config_generator/test_recommendations_api.py
+++ b/tests/unit/config_generator/test_recommendations_api.py
@@ -57,15 +57,22 @@ def test_recommend_configuration_space_valid_type_returns_structured_rows() -> N
     assert result["agent_type"] == "rag"
     assert "task-dependent" in result["caveat"]
     assert result["valid_agent_types"] == ["code_gen", "rag"]
-    assert result["configuration_space"] == {"retrieval_k": {"low": 1, "high": 5}}
+    assert result["configuration_space"]["retrieval_k"] == {"low": 1, "high": 5}
+    assert {
+        "context_selection_policy",
+        "context_order",
+        "summary_style",
+        "compression_ratio",
+        "citation_policy",
+    } <= set(result["configuration_space"])
     config_space = ConfigSpace.from_decorator_args(
         configuration_space=result["configuration_space"]
     )
-    assert set(config_space.tvars) == {"retrieval_k"}
+    assert set(config_space.tvars) == set(result["configuration_space"])
 
     recommendations = result["recommendations"]
-    assert len(recommendations) == 1
-    retrieval_k = recommendations[0]
+    assert len(recommendations) >= 6
+    retrieval_k = next(row for row in recommendations if row["name"] == "retrieval_k")
     assert list(retrieval_k) == _EXPECTED_RECOMMENDATION_KEYS
     assert retrieval_k["name"] == "retrieval_k"
     assert retrieval_k["range_type"] == "IntRange"

--- a/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
+++ b/tests/unit/config_generator/test_subsystems/test_tvar_recommendations.py
@@ -42,6 +42,16 @@ _CATALOG_ENTRY_KINDS = {
     "code_gen.fewshot_k.v1": "cardinality",
     "code_gen.candidate_count.v1": "cardinality",
     "code_gen.repair_policy.v1": "topology",
+    "code_gen.repo_context_strategy.v1": "policy",
+    "code_gen.file_view_window.v1": "value",
+    "code_gen.edit_granularity.v1": "policy",
+    "code_gen.test_selection_strategy.v1": "policy",
+    "code_gen.patch_review_mode.v1": "policy",
+    "rag.context_selection_policy.v1": "policy",
+    "rag.context_order.v1": "policy",
+    "rag.summary_style.v1": "policy",
+    "rag.compression_ratio.v1": "value",
+    "rag.citation_policy.v1": "policy",
 }
 
 
@@ -379,7 +389,7 @@ class TestTVarCatalog:
     def test_catalog_loads_and_validates_all_ready_made_entries(self) -> None:
         entries = load_catalog()
 
-        assert len(entries) == 8
+        assert len(entries) == 18
         assert {entry["entry_id"] for entry in entries} == set(_CATALOG_ENTRY_KINDS)
         for entry in entries:
             assert entry["kind"] == _CATALOG_ENTRY_KINDS[entry["entry_id"]]
@@ -406,11 +416,18 @@ class TestTVarCatalog:
 
     def test_catalog_filters_by_agent_type(self) -> None:
         assert [entry["entry_id"] for entry in catalog_entries("rag")] == [
-            "rag.retrieval_k.v1"
+            "rag.retrieval_k.v1",
+            "rag.context_selection_policy.v1",
+            "rag.context_order.v1",
+            "rag.summary_style.v1",
+            "rag.compression_ratio.v1",
+            "rag.citation_policy.v1",
         ]
-        assert {entry["entry_id"] for entry in catalog_entries("code_gen")} == (
-            set(_CATALOG_ENTRY_KINDS) - {"rag.retrieval_k.v1"}
-        )
+        assert {entry["entry_id"] for entry in catalog_entries("code_gen")} == {
+            entry_id
+            for entry_id in _CATALOG_ENTRY_KINDS
+            if entry_id.startswith("code_gen.")
+        }
 
     def test_entry_to_recommendation_round_trips_catalog_fields(self) -> None:
         entry = next(

--- a/tests/unit/knobs/test_composites_runtime.py
+++ b/tests/unit/knobs/test_composites_runtime.py
@@ -180,37 +180,14 @@ class TestBinaryCascadeExecution:
 
 
 class TestSurvivingDeferrals:
-    """The two genuinely-deferred surfaces (pre-cascade dispatch + a
-    nested-composite LOOP body) raise NotImplementedError naming the gap.
+    """The one genuinely-deferred surface (a nested-composite LOOP body) raises
+    NotImplementedError naming the gap.
 
     Every OTHER former deferral (ensemble/loop roots, nested-composite cascade
-    AND ensemble arms, the K-chain unroll) is now executed end-to-end — proven
-    by the execution test classes below.
+    AND ensemble arms, the K-chain unroll, AND the pre-cascade dispatch
+    executor) is now executed end-to-end — proven by the execution test classes
+    below (pre-cascade dispatch: ``TestPreCascadeDispatch``).
     """
-
-    def test_pre_cascade_dispatch_raises_not_implemented(self):
-        node = CompositeNode(
-            name="dispatch",
-            kind=CompositeKind.CASCADE,
-            body=CascadeBody(
-                arms=(StageArm("a"), StageArm("b")),
-                gates=(
-                    GateDecl(
-                        kind=GateKind.SIGNAL_BELOW,
-                        threshold="t",
-                        signal=SignalUse(signal="router"),
-                    ),
-                ),
-                placement=Placement.PRE,
-            ),
-        )
-        with pytest.raises(NotImplementedError, match="pre-cascade"):
-            execute_composite(
-                node,
-                {"a": _stage(["x"]), "b": _stage(["y"])},
-                config={},
-                calibrated_values={"t": 0.5},
-            )
 
     def test_nested_composite_loop_body_raises_not_implemented(self):
         # A loop whose BODY is a nested composite has no v1 state-producing
@@ -1826,3 +1803,345 @@ def test_kchain_teeth_condition1_violation_diverges_detectably():
     # Concretely: the live loop accepts later (lower ambient start) than the
     # chain (which begins after the loop already advanced the shared counter).
     assert loop.measures["iterations_used"] != chain.measures["iterations_used"]
+
+
+# --------------------------------------------------------------------------- #
+# Pre-cascade DISPATCH execution (§3.2 / §3.2.1 / §3.10) — the router path     #
+# --------------------------------------------------------------------------- #
+
+
+def _pre_cascade(
+    arms,
+    gates_signals,
+    *,
+    name="dispatch",
+):
+    """A ``placement: pre`` cascade IR node.
+
+    ``arms`` is a tuple of stage names (or ``CompositeArm`` objects); the LAST
+    is the terminal fallback (no gate). ``gates_signals`` is a tuple of
+    ``(threshold, signal_name)`` pairs, one per non-terminal arm
+    (``|gates| = |arms| - 1``), each a ``signal_below`` PRE gate.
+    """
+    arm_objs = tuple(StageArm(a) if isinstance(a, str) else a for a in arms)
+    gate_objs = tuple(
+        GateDecl(
+            kind=GateKind.SIGNAL_BELOW,
+            threshold=threshold,
+            signal=SignalUse(signal=sig),
+        )
+        for threshold, sig in gates_signals
+    )
+    return CompositeNode(
+        name=name,
+        kind=CompositeKind.CASCADE,
+        body=CascadeBody(arms=arm_objs, gates=gate_objs, placement=Placement.PRE),
+    )
+
+
+class _SpyStage:
+    """A stage runner that records whether it was called (route-isolation proof)."""
+
+    def __init__(self, value):
+        self.value = value
+        self.called = False
+
+    def runner(self):
+        def run(_item):
+            self.called = True
+            return [self.value]
+
+        return StageRunner(run=run, key_fn=lambda x: x, samples=1)
+
+
+class TestPreCascadeDispatch:
+    """The §3.2 pre-cascade (dispatch) law: route(x) = arm_j where
+    j = min({i < m : σ_i(x) >= θ_i} ∪ {m}). FIRST-MATCH-WINS, exactly ONE arm
+    executes; the routed arm is TERMINAL (its no_accept/error is final, no
+    re-route)."""
+
+    def test_routes_to_first_adequate_arm_only(self):
+        # σ_0 = 0.9 >= θ_0 0.5 -> arm 0 selected; arms 1, 2 must NOT run.
+        a0, a1, a2 = _SpyStage("A0"), _SpyStage("A1"), _SpyStage("A2")
+        node = _pre_cascade(("a0", "a1", "a2"), (("t0", "s0"), ("t1", "s1")))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner(), "a2": a2.runner()},
+            config={},
+            calibrated_values={"t0": 0.5, "t1": 0.5},
+            signals={"s0": lambda _x: 0.9, "s1": lambda _x: 0.9},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A0"
+        assert a0.called is True
+        assert a1.called is False  # first-match-wins: no other arm runs
+        assert a2.called is False
+
+    def test_fall_through_to_terminal_when_all_gates_inadequate(self):
+        # σ_0, σ_1 both < θ -> terminal arm 2 selected.
+        a0, a1, a2 = _SpyStage("A0"), _SpyStage("A1"), _SpyStage("A2")
+        node = _pre_cascade(("a0", "a1", "a2"), (("t0", "s0"), ("t1", "s1")))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner(), "a2": a2.runner()},
+            config={},
+            calibrated_values={"t0": 0.5, "t1": 0.5},
+            signals={"s0": lambda _x: 0.1, "s1": lambda _x: 0.1},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A2"  # terminal fallback
+        assert a0.called is False
+        assert a1.called is False
+        assert a2.called is True
+        assert result.measures["route_selected"] == 2
+        # terminal fall-through: NO dispatch_signal_margin (no gated selection).
+        assert "dispatch_signal_margin" not in result.measures
+
+    def test_second_gate_adequate_when_first_inadequate(self):
+        # σ_0 < θ (inadequate), σ_1 >= θ -> arm 1 selected; arm 0 never runs.
+        a0, a1, a2 = _SpyStage("A0"), _SpyStage("A1"), _SpyStage("A2")
+        node = _pre_cascade(("a0", "a1", "a2"), (("t0", "s0"), ("t1", "s1")))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner(), "a2": a2.runner()},
+            config={},
+            calibrated_values={"t0": 0.5, "t1": 0.5},
+            signals={"s0": lambda _x: 0.1, "s1": lambda _x: 0.9},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A1"
+        assert a0.called is False  # arm 0 never runs
+        assert a1.called is True
+        assert a2.called is False
+        assert result.measures["route_selected"] == 1
+
+    def test_absent_value_signal_is_inadequate_continues(self):
+        # σ_0 returns None (abstaining) -> inadequate, route onward to arm 1.
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: None},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A1"  # fell through to terminal
+        assert a0.called is False
+        assert a1.called is True
+
+    def test_non_numeric_signal_value_is_inadequate_continues(self):
+        # σ_0 returns a string (non-numeric) -> inadequate, no crash, continue.
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: "not-a-number"},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A1"
+        assert a0.called is False
+        assert a1.called is True
+
+    def test_signal_that_raises_is_absorbing_error(self):
+        # §3.2: a signal that RAISES fails the item's evaluation (never silently
+        # routes). ERROR is absorbing; no arm executes.
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+
+        def boom(_x):
+            raise RuntimeError("signal blew up")
+
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": boom},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert result.output is None
+        assert "RuntimeError" in (result.error or "")
+        assert a0.called is False  # no arm executed
+        assert a1.called is False
+
+    def test_routed_arm_no_accept_is_cascade_no_accept_no_reroute(self):
+        # The routed arm yields no_accept -> the cascade's result is no_accept;
+        # routing selects the arm, it does NOT re-route on non-acceptance.
+        a1 = _SpyStage("A1")  # the later arm must NOT run
+
+        def no_accept_arm(_item, _state=None):  # pragma: no cover - via runner
+            return None
+
+        # arm 0 is a nested composite that yields no_accept (an ensemble whose
+        # accept gate fails); arm 1 is the terminal fallback that must NOT run.
+        inner = self_consistency(
+            "inner", stage="ia", cardinality="k", accept_threshold="acc"
+        ).structure
+        node = _pre_cascade((CompositeArm("inner"), "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {
+                "ia": _stage(["X", "Y"]),  # split -> margin 0 < acc -> no_accept
+                "a1": a1.runner(),
+            },
+            config={"k": 2},
+            calibrated_values={"t0": 0.5, "acc": 0.9},
+            signals={"s0": lambda _x: 0.9},  # routes to arm 0
+            registry={"dispatch": node, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert a1.called is False  # NO re-route to the later arm
+        assert result.measures["route_selected"] == 0
+
+    def test_routed_arm_error_is_cascade_error(self):
+        # The routed arm raises -> absorbing error (§3.2.1).
+        def explode(_item):
+            raise RuntimeError("routed arm blew up")
+
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {
+                "a0": StageRunner(run=explode, key_fn=lambda x: x, samples=1),
+                "a1": _stage(["A1"]),
+            },
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: 0.9},  # routes to arm 0
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "RuntimeError" in (result.error or "")
+        assert result.output is None
+
+    def test_threshold_read_live_at_decide_time(self):
+        # The SAME structure routes differently purely as a function of the LIVE
+        # calibrated_values — θ is read at decide time, never snapshotted.
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        stages = {"a0": _stage(["A0"]), "a1": _stage(["A1"])}
+        sigs = {"s0": lambda _x: 0.6}
+        adequate = execute_composite(
+            node, stages, config={}, calibrated_values={"t0": 0.5}, signals=sigs
+        )
+        inadequate = execute_composite(
+            node, stages, config={}, calibrated_values={"t0": 0.9}, signals=sigs
+        )
+        assert adequate.output == "A0"  # 0.6 >= 0.5 -> arm 0
+        assert inadequate.output == "A1"  # 0.6 < 0.9 -> terminal arm 1
+
+    def test_missing_calibrated_threshold_for_reached_gate_is_error(self):
+        # A reached gate whose threshold CVAR is unset fails CLOSED (calibration
+        # defect), exactly as POST does — never silently inadequate.
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": _stage(["A0"]), "a1": _stage(["A1"])},
+            config={},
+            calibrated_values={},  # 't0' absent
+            signals={"s0": lambda _x: 0.9},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert result.output is None
+
+    def test_preflight_missing_dispatch_signal_is_error_before_execution(self):
+        # FAIL-CLOSED preflight: a pre-gate signal not in the registry is an
+        # error BEFORE any arm/signal runs (mirrors signal_accept loop preflight).
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={},  # 's0' absent -> fail closed up front
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "not provided" in (result.error or "")
+        assert "s0" in (result.error or "")
+        assert a0.called is False  # nothing ran
+        assert a1.called is False
+
+    def test_preflight_missing_signal_in_unreached_nested_pre_arm_is_error(self):
+        # The deep preflight reaches a nested PRE-cascade arm too: a missing
+        # dispatch signal inside an unselected nested arm fails closed up front.
+        inner = _pre_cascade(
+            ("ia0", "ia1"), (("it0", "needed_sig"),), name="inner"
+        )
+        outer = _pre_cascade((CompositeArm("inner"), "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            outer,
+            {
+                "ia0": _stage(["IA0"]),
+                "ia1": _stage(["IA1"]),
+                "a1": _stage(["A1"]),
+            },
+            config={},
+            calibrated_values={"t0": 0.5, "it0": 0.5},
+            signals={"s0": lambda _x: 0.1},  # 'needed_sig' absent
+            registry={"dispatch": outer, "inner": inner},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert "needed_sig" in (result.error or "")
+
+    def test_gated_selection_emits_dispatch_signal_margin(self):
+        # A GATED selection (not terminal) carries dispatch_signal_margin =
+        # σ_sel − θ_sel; gate_signal_adequate is an index-keyed adequacy map.
+        node = _pre_cascade(("a0", "a1", "a2"), (("t0", "s0"), ("t1", "s1")))
+        result = execute_composite(
+            node,
+            {"a0": _stage(["A0"]), "a1": _stage(["A1"]), "a2": _stage(["A2"])},
+            config={},
+            calibrated_values={"t0": 0.5, "t1": 0.5},
+            signals={"s0": lambda _x: 0.2, "s1": lambda _x: 0.8},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.measures["route_selected"] == 1
+        assert result.measures["dispatch_signal_margin"] == pytest.approx(0.3)
+        # gate 0 evaluated inadequate (0), gate 1 evaluated adequate (1).
+        assert result.measures["gate_signal_adequate"] == {0: 0, 1: 1}
+
+    def test_telemetry_flattens_through_composite_measures_no_collision(self):
+        from traigent.knobs.telemetry import (
+            composite_measures,
+            merge_composite_measures,
+        )
+
+        node = _pre_cascade(("a0", "a1", "a2"), (("t0", "s0"), ("t1", "s1")))
+        result = execute_composite(
+            node,
+            {"a0": _stage(["A0"]), "a1": _stage(["A1"]), "a2": _stage(["A2"])},
+            config={},
+            calibrated_values={"t0": 0.5, "t1": 0.5},
+            signals={"s0": lambda _x: 0.2, "s1": lambda _x: 0.8},
+        )
+        flat = composite_measures(result)
+        assert flat["composite_route_selected"] == 1
+        assert flat["composite_dispatch_signal_margin"] == pytest.approx(0.3)
+        # the index-keyed gate_signal_adequate map flattens per gate index.
+        assert flat["composite_gate_0_signal_adequate"] == 0
+        assert flat["composite_gate_1_signal_adequate"] == 1
+        # merges into a user metrics dict without collision.
+        merged = merge_composite_measures({"accuracy": 0.9}, result)
+        assert merged["accuracy"] == 0.9
+        assert merged["composite_route_selected"] == 1
+
+    def test_terminal_telemetry_omits_dispatch_margin_and_flattens(self):
+        from traigent.knobs.telemetry import composite_measures
+
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": _stage(["A0"]), "a1": _stage(["A1"])},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: 0.1},  # inadequate -> terminal
+        )
+        flat = composite_measures(result)
+        assert flat["composite_route_selected"] == 1
+        assert "composite_dispatch_signal_margin" not in flat
+        # the single evaluated gate is recorded inadequate.
+        assert flat["composite_gate_0_signal_adequate"] == 0

--- a/tests/unit/knobs/test_composites_runtime.py
+++ b/tests/unit/knobs/test_composites_runtime.py
@@ -1916,7 +1916,11 @@ class TestPreCascadeDispatch:
         assert result.measures["route_selected"] == 1
 
     def test_absent_value_signal_is_inadequate_continues(self):
-        # σ_0 returns None (abstaining) -> inadequate, route onward to arm 1.
+        # codex MINOR coverage: σ_0 returns None -> ABSTENTION. This is §3.2's
+        # explicit license ("absent/abstaining signal value is INADEQUATE"):
+        # route onward to arm 1, NEVER an error. Contrast the malformed-score
+        # cases above (bool/non-numeric/non-finite), which DO error — None is the
+        # ONLY value that legitimately abstains.
         a0, a1 = _SpyStage("A0"), _SpyStage("A1")
         node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
         result = execute_composite(
@@ -1928,11 +1932,21 @@ class TestPreCascadeDispatch:
         )
         assert result.result_kind is ResultKind.OUTPUT
         assert result.output == "A1"  # fell through to terminal
+        assert result.measures["route_selected"] == 1
+        # the gate was evaluated and recorded inadequate (abstention), not skipped.
+        assert result.measures["gate_signal_adequate"] == {0: 0}
         assert a0.called is False
         assert a1.called is True
 
-    def test_non_numeric_signal_value_is_inadequate_continues(self):
-        # σ_0 returns a string (non-numeric) -> inadequate, no crash, continue.
+    def test_non_numeric_signal_value_is_absorbing_error(self):
+        # codex B2 (REAL): a non-numeric σ value (str, dict, ...) is a MALFORMED
+        # score — a defect, NOT an abstention. RFC 0002 §3.2.1 mandates finite
+        # numeric comparison ("never a silent comparison"); the LOOP signal_accept
+        # convention (runtime.py ~1587) RAISES on non-numeric. The PRE-gate is now
+        # at parity: a non-numeric σ is an absorbing ERROR, never a silent route.
+        # (Earlier this test pinned route-onward under the §3.2 "absent/abstaining
+        #  value is INADEQUATE" reading; that reading mis-classified a malformed
+        #  score as an abstention and is now rejected — flipped to ERROR.)
         a0, a1 = _SpyStage("A0"), _SpyStage("A1")
         node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
         result = execute_composite(
@@ -1942,10 +1956,58 @@ class TestPreCascadeDispatch:
             calibrated_values={"t0": 0.5},
             signals={"s0": lambda _x: "not-a-number"},
         )
-        assert result.result_kind is ResultKind.OUTPUT
-        assert result.output == "A1"
+        assert result.result_kind is ResultKind.ERROR
+        assert result.output is None
+        assert result.measures == {}
+        assert a0.called is False  # malformed-signal defect: no arm runs
+        assert a1.called is False  # never silently routes onward
+
+    def test_bool_signal_value_is_absorbing_error(self):
+        # codex B2 (REAL): bool is NOT a number (parity with the §3.10 measure
+        # rule AND the loop signal_accept rule at runtime.py ~1587). A bool σ is a
+        # malformed score -> absorbing ERROR, never a silent route onward.
+        # (Earlier the PRE-gate let a bool route onward as "non-numeric ->
+        #  inadequate"; that interpretation is now rejected.)
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: True},  # bool is not a finite score
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert result.output is None
+        assert result.measures == {}
         assert a0.called is False
-        assert a1.called is True
+        assert a1.called is False
+
+    @pytest.mark.parametrize(
+        "bad_sigma",
+        [float("nan"), float("inf"), float("-inf")],
+        ids=["nan", "pos_inf", "neg_inf"],
+    )
+    def test_non_finite_signal_value_is_absorbing_error(self, bad_sigma):
+        # codex B2 (REAL): a NON-FINITE σ (NaN/±inf) cannot satisfy the §3.2.1
+        # finite-comparison law ("comparisons are over finite numbers ... never a
+        # silent comparison") and the loop signal_accept convention RAISES on
+        # non-finite (runtime.py ~1592). The PRE-gate now RAISES too: a non-finite
+        # σ is an absorbing ERROR, NOT a silent fail-toward-the-stronger-arm route.
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: bad_sigma},
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert result.output is None
+        assert result.measures == {}
+        assert a0.called is False  # non-finite score: no arm runs
+        assert a1.called is False  # never silently routes onward
 
     def test_signal_that_raises_is_absorbing_error(self):
         # §3.2: a signal that RAISES fails the item's evaluation (never silently
@@ -2145,3 +2207,222 @@ class TestPreCascadeDispatch:
         assert "composite_dispatch_signal_margin" not in flat
         # the single evaluated gate is recorded inadequate.
         assert flat["composite_gate_0_signal_adequate"] == 0
+
+    def test_non_finite_threshold_on_reached_gate_is_error(self):
+        # codex MINOR coverage (existing behavior, previously untested): a REACHED
+        # gate whose calibrated θ is NON-FINITE (NaN) is a calibration defect ->
+        # absorbing ERROR, exactly as POST (_resolve_threshold fails closed). The
+        # signal is fine; the defect is the threshold. Distinct from the σ-side
+        # malformed-value cases — both σ and θ must be finite to compare.
+        a0, a1 = _SpyStage("A0"), _SpyStage("A1")
+        node = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        result = execute_composite(
+            node,
+            {"a0": a0.runner(), "a1": a1.runner()},
+            config={},
+            calibrated_values={"t0": math.nan},  # reached-gate θ non-finite
+            signals={"s0": lambda _x: 0.9},  # σ is a fine finite score
+        )
+        assert result.result_kind is ResultKind.ERROR
+        assert result.output is None
+        assert result.measures == {}
+        assert a0.called is False  # no arm runs on a calibration defect
+        assert a1.called is False
+
+    # ----------------------------------------------------------------------- #
+    # Adjudicated codex findings — PINNED with the adjudication rationale.     #
+    # The captain verified each by direct probe against POST cascades/loops    #
+    # and confirmed the PRE executor matches the shipped system-wide           #
+    # convention; these tests freeze that parity so a future change to one     #
+    # side must consciously touch the other.                                   #
+    # ----------------------------------------------------------------------- #
+
+    def test_pre_gate_signal_sees_full_config_not_declared_inputs_subset(self):
+        """codex B1 (ADJUDICATED): ``SignalUse.inputs`` is a freshness-bound
+        DECLARATION, not a runtime projection.
+
+        A pre-gate signal receives the FULL dispatch ``config`` even when its
+        ``SignalUse.inputs`` declares a strict subset. This is the SAME convention
+        as the loop ``signal_accept`` stop (runtime.py ~1563-1569): the signal sees
+        the full restricted state; ``signal.inputs`` is a §3.5 ctx_ext
+        calibration/freshness COVERAGE binding (§3.2 item 11 ``signal_inputs``),
+        NOT a runtime input filter, so it never narrows what σ observes.
+
+        ADJUDICATION: codex read RFC §3.2's prose as implying a runtime projection
+        of inputs onto the signal. The captain confirmed (a) the loop does NOT
+        project, and (b) projecting here would diverge from the loop and break
+        §3.5 freshness binding. The RFC §3.2 wording clarification (make the
+        "declaration not projection" reading explicit) is recorded as a
+        documentation follow-up, NOT a runtime change. Here we pin that the signal
+        reads a key OUTSIDE its declared ``inputs=("x",)`` and routing still works.
+        """
+        node = CompositeNode(
+            name="dispatch",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a0"), StageArm("a1")),
+                gates=(
+                    GateDecl(
+                        kind=GateKind.SIGNAL_BELOW,
+                        threshold="t0",
+                        # declares ONLY "x"; the signal below reads "y" too.
+                        signal=SignalUse(signal="s0", inputs=("x",)),
+                    ),
+                ),
+                placement=Placement.PRE,
+            ),
+        )
+        seen: dict[str, Any] = {}
+
+        def reads_undeclared_key(cfg):
+            # The signal observes the FULL config, including "y" which is NOT in
+            # its declared inputs=("x",). If inputs were a runtime filter, "y"
+            # would be absent and this would KeyError (-> absorbing error).
+            seen.update(cfg)
+            return float(cfg["x"] + cfg["y"])  # 0.4 + 0.4 = 0.8 >= θ 0.5
+
+        result = execute_composite(
+            node,
+            {"a0": _stage(["A0"]), "a1": _stage(["A1"])},
+            config={"x": 0.4, "y": 0.4},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": reads_undeclared_key},
+        )
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "A0"  # routed on σ=0.8 >= θ 0.5
+        # PROOF the signal saw the FULL config, not the declared subset:
+        assert seen == {"x": 0.4, "y": 0.4}
+        assert "y" in seen  # the undeclared key was visible
+
+    def test_routed_arm_error_measures_empty_parity_pre_and_post(self):
+        """codex M3 (ADJUDICATED): a routed/escalated arm ERROR returns
+        ``measures == {}`` — and this is PARITY with the POST cascade.
+
+        Captain probe: a POST cascade whose escalated arm RAISES also returns an
+        ``error`` result with ``measures == {}`` (``_error`` carries no telemetry,
+        runtime.py ~201). The PRE executor does the SAME on a routed-arm error.
+
+        ADJUDICATION: codex flagged "no telemetry on the error path" as a defect.
+        The captain confirmed it is the shipped system-wide convention (errors are
+        absorbing and content-free). We pin BOTH PRE and POST in ONE test so any
+        future "emit telemetry on error" change is forced to touch — and re-justify
+        — both placements together rather than silently diverging them.
+        """
+
+        def explode(_item):
+            raise RuntimeError("arm blew up")
+
+        # --- PRE: route to a raising arm 0. ---
+        pre = _pre_cascade(("a0", "a1"), (("t0", "s0"),))
+        pre_result = execute_composite(
+            pre,
+            {
+                "a0": StageRunner(run=explode, key_fn=lambda x: x, samples=1),
+                "a1": _stage(["A1"]),
+            },
+            config={},
+            calibrated_values={"t0": 0.5},
+            signals={"s0": lambda _x: 0.9},  # routes to arm 0 (the raiser)
+        )
+        assert pre_result.result_kind is ResultKind.ERROR
+        assert pre_result.measures == {}  # no route_selected, no adequacy map
+
+        # --- POST: escalate into a raising arm 1 (the captain's parity probe). ---
+        post = CompositeNode(
+            name="post",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), StageArm("b")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        post_result = execute_composite(
+            post,
+            {
+                "a": _stage(["x", "y"]),  # margin 0.5 < t 0.9 -> escalate to b
+                "b": StageRunner(run=explode, key_fn=lambda x: x, samples=1),
+            },
+            config={},
+            calibrated_values={"t": 0.9},
+        )
+        assert post_result.result_kind is ResultKind.ERROR
+        assert post_result.measures == {}  # PARITY: POST also drops telemetry
+
+    def test_nested_composite_measures_do_not_propagate_parity_pre_and_post(self):
+        """codex M4 (ADJUDICATED): a nested composite's measures do NOT propagate
+        to the outer run — and this is PARITY with the POST cascade.
+
+        Captain probe: a POST cascade that escalates into a nested ensemble arm
+        emits only the OUTER cascade measures (``stage_selected`` etc.); the inner
+        ensemble's ``vote_margin``/``samples_used`` never surface on the outer
+        result (``_cascade_measures`` builds outer-only telemetry, runtime.py
+        ~738). The PRE executor matches: an outer PRE cascade routing to a NESTED
+        PRE cascade arm emits only the OUTER ``route_selected`` — the inner's
+        ``route_selected`` / ``gate_signal_adequate`` are absent.
+
+        ADJUDICATION: codex flagged the missing inner telemetry as lost
+        observability. The captain confirmed outer-only measures are the shipped
+        convention for nested composites across PRE and POST (telemetry is
+        per-decided-composite, not recursively merged). We pin BOTH placements so
+        a future "bubble up nested telemetry" change must touch both.
+        """
+        # --- PRE: outer routes to a NESTED PRE-cascade arm. ---
+        inner = _pre_cascade(
+            ("ia0", "ia1"), (("it0", "is0"),), name="inner"
+        )
+        outer = _pre_cascade((CompositeArm("inner"), "a1"), (("t0", "s0"),))
+        pre_result = execute_composite(
+            outer,
+            {
+                "ia0": _stage(["IA0"]),
+                "ia1": _stage(["IA1"]),
+                "a1": _stage(["A1"]),
+            },
+            config={},
+            calibrated_values={"t0": 0.5, "it0": 0.5},
+            # outer s0 routes to arm 0 (inner); inner is0 routes to its arm 0.
+            signals={"s0": lambda _x: 0.9, "is0": lambda _x: 0.9},
+            registry={"dispatch": outer, "inner": inner},
+        )
+        assert pre_result.result_kind is ResultKind.OUTPUT
+        assert pre_result.output == "IA0"  # inner's routed arm output
+        # OUTER telemetry only: the outer route_selected is present...
+        assert pre_result.measures["route_selected"] == 0
+        # ...and the inner's measures do NOT bleed up. The inner ALSO selected
+        # route 0, so route_selected==0 is ambiguous; instead assert the inner's
+        # gate adequacy map is exactly the OUTER's single-gate map (inner had its
+        # own gate too — if inner telemetry merged, the map would differ/collide).
+        assert pre_result.measures["gate_signal_adequate"] == {0: 1}
+        assert "dispatch_signal_margin" in pre_result.measures  # outer gated route
+
+        # --- POST: outer escalates into a nested ensemble arm (parity probe). ---
+        inner_ens = self_consistency(
+            "inner_ens", stage="ie", cardinality="k"
+        ).structure
+        post = CompositeNode(
+            name="post",
+            kind=CompositeKind.CASCADE,
+            body=CascadeBody(
+                arms=(StageArm("a"), CompositeArm("inner_ens")),
+                gates=(GateDecl(kind=GateKind.MARGIN_BELOW, threshold="t"),),
+                placement=Placement.POST,
+            ),
+        )
+        post_result = execute_composite(
+            post,
+            {
+                "a": _stage(["x", "y"]),  # margin 0.5 < t 0.9 -> escalate
+                "ie": _stage(["W", "W"]),  # nested unanimous -> output W
+            },
+            config={"k": 2},
+            calibrated_values={"t": 0.9},
+            registry={"post": post, "inner_ens": inner_ens},
+        )
+        assert post_result.result_kind is ResultKind.OUTPUT
+        assert post_result.output == "W"  # nested ensemble's output
+        # OUTER-only telemetry: cascade keys present, NO ensemble keys (the inner
+        # majority_vote's vote_margin / samples_used never surface).
+        assert post_result.measures["stage_selected"] == 1
+        assert "vote_margin" not in post_result.measures
+        assert "samples_used" not in post_result.measures

--- a/tests/unit/knobs/test_patterns_moe.py
+++ b/tests/unit/knobs/test_patterns_moe.py
@@ -11,9 +11,11 @@ from traigent.knobs.composites import (
     AggregateKind,
     CascadeBody,
     CompositeArm,
+    CompositeProgram,
     EnsembleBody,
     LoopBody,
     StageArm,
+    validate_program,
 )
 from traigent.knobs.patterns import CompositeKnob, moe
 from traigent.knobs.runtime import ResultKind, StageRunner, execute_composite
@@ -127,12 +129,23 @@ def _stage(outputs: list[str]) -> StageRunner:
     )
 
 
+MOE_ACCEPT_THRESHOLD = "patch_moe.vote_margin_min"
+MOE_EXPERT_TVARS = frozenset(
+    {
+        "repo_context_strategy",
+        "edit_granularity",
+        "test_selection_strategy",
+        "patch_review_mode",
+    }
+)
+
+
 def _moe_vote() -> CompositeKnob:
     return moe(
         "patch_moe",
         experts=("fast_patch", "semantic_patch", "test_driven_patch"),
         aggregate="vote",
-        accept_threshold="patch_moe.vote_margin_min",
+        accept_threshold=MOE_ACCEPT_THRESHOLD,
         expert_tuned_params=(
             ("repo_context_strategy", "edit_granularity"),
             ("repo_context_strategy",),
@@ -149,6 +162,29 @@ def _moe_judge() -> CompositeKnob:
         judge_stage="rubric_judge",
         expert_tuned_params=(("style",), ("tests",)),
         judge_tuned_params=("judge_rubric", "judge_model"),
+    )
+
+
+def _moe_vote_program(
+    *,
+    cvar_signals: dict[str, str | None] | None = None,
+    cvar_depends_on: dict[str, frozenset[str]] | None = None,
+) -> CompositeProgram:
+    return CompositeProgram(
+        composites={"patch_moe": _moe_vote().structure},
+        tvars=MOE_EXPERT_TVARS,
+        cvars=frozenset({MOE_ACCEPT_THRESHOLD}),
+        cvar_types={MOE_ACCEPT_THRESHOLD: "float"},
+        cvar_signals=(
+            {MOE_ACCEPT_THRESHOLD: "vote_margin"}
+            if cvar_signals is None
+            else cvar_signals
+        ),
+        cvar_depends_on=(
+            {MOE_ACCEPT_THRESHOLD: MOE_EXPERT_TVARS}
+            if cvar_depends_on is None
+            else cvar_depends_on
+        ),
     )
 
 
@@ -206,6 +242,34 @@ def test_moe_judge_expands_to_judge_max_with_judge_tuned_params() -> None:
     assert body.aggregate.judge.name == "rubric_judge"
     assert body.aggregate.judge.tuned_params == ("judge_rubric", "judge_model")
     assert body.aggregate.accept is None
+
+
+class TestMoeAcceptThresholdAdmission:
+    def test_missing_calibration_signal_binding_rejects(self) -> None:
+        program = _moe_vote_program(
+            cvar_signals={MOE_ACCEPT_THRESHOLD: None},
+        )
+
+        with pytest.raises(ValueError, match="missing_calibration_signal"):
+            validate_program(program)
+
+    def test_signal_mismatch_rejects(self) -> None:
+        program = _moe_vote_program(
+            cvar_signals={MOE_ACCEPT_THRESHOLD: "other_signal"},
+        )
+
+        with pytest.raises(ValueError, match="signal_mismatch"):
+            validate_program(program)
+
+    def test_missing_parent_coverage_rejects(self) -> None:
+        program = _moe_vote_program(
+            cvar_depends_on={
+                MOE_ACCEPT_THRESHOLD: MOE_EXPERT_TVARS - {"patch_review_mode"}
+            },
+        )
+
+        with pytest.raises(ValueError, match="missing_composite_parent"):
+            validate_program(program)
 
 
 def test_p8_canary_raw_params_do_not_enter_provenance() -> None:
@@ -275,21 +339,33 @@ def test_judge_runtime_uses_judge_tuned_params_declaration() -> None:
 @pytest.mark.parametrize(
     "kwargs,match",
     [
-        ({"experts": ("only",)}, "at least two"),
-        ({"experts": ("a", "")}, "non-empty"),
-        ({"experts": ("a", "a")}, "distinct"),
-        ({"experts": ("a", "b"), "aggregate": "rank"}, "aggregate"),
+        ({"experts": ("only",)}, r"^committee_arity"),
+        ({"experts": ("a", "")}, r"^committee_arity"),
+        ({"experts": ("a", "a")}, r"^duplicate_stage"),
+        ({"experts": ("a", "b"), "aggregate": "rank"}, r"^invalid_aggregate"),
         (
             {"experts": ("a", "b"), "expert_tuned_params": (("x",),)},
-            "exactly one tuple per expert",
+            r"^invalid_tuned_param",
         ),
         (
             {"experts": ("a", "b"), "aggregate": "judge"},
-            "requires judge_stage",
+            r"^aggregate_argument_mismatch",
         ),
         (
             {"experts": ("a", "b"), "aggregate": "vote", "judge_stage": "j"},
-            "forbids judge_stage",
+            r"^aggregate_argument_mismatch",
+        ),
+        (
+            {
+                "experts": ("a", "b"),
+                "aggregate": "vote",
+                "judge_tuned_params": ("judge_rubric",),
+            },
+            r"^aggregate_argument_mismatch",
+        ),
+        (
+            {"experts": ("a", "b"), "aggregate": "judge", "judge_stage": "a"},
+            r"^duplicate_stage",
         ),
         (
             {
@@ -298,7 +374,7 @@ def test_judge_runtime_uses_judge_tuned_params_declaration() -> None:
                 "judge_stage": "j",
                 "accept_threshold": "theta",
             },
-            "accept_threshold",
+            r"^aggregate_argument_mismatch",
         ),
     ],
 )

--- a/tests/unit/knobs/test_patterns_moe.py
+++ b/tests/unit/knobs/test_patterns_moe.py
@@ -1,0 +1,307 @@
+"""Mixture-of-experts pattern factory tests (committee ensemble macro)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from traigent.knobs import canonical_hash
+from traigent.knobs.composites import (
+    AggregateKind,
+    CascadeBody,
+    CompositeArm,
+    EnsembleBody,
+    LoopBody,
+    StageArm,
+)
+from traigent.knobs.patterns import CompositeKnob, moe
+from traigent.knobs.runtime import ResultKind, StageRunner, execute_composite
+
+
+def _arm_to_dict(arm):
+    if isinstance(arm, StageArm):
+        return {
+            "tag": "stage",
+            "name": arm.name,
+            "tuned_params": list(arm.tuned_params),
+        }
+    if isinstance(arm, CompositeArm):
+        return {"tag": "composite", "ref": arm.ref}
+    raise TypeError(f"unknown arm type: {type(arm).__name__}")
+
+
+def _sig_to_dict(sig):
+    if sig is None:
+        return None
+    return {"signal": sig.signal, "inputs": list(sig.inputs)}
+
+
+def _prov_to_dict(prov):
+    if prov is None:
+        return None
+    return {
+        "pattern": prov.pattern,
+        "pattern_version": prov.pattern_version,
+        "param_hash": prov.param_hash,
+        "node_path": prov.node_path,
+    }
+
+
+def _scope_to_dict(scope):
+    if scope is None:
+        return None
+    return {"node": scope.node, "agent": scope.agent, "workflow": scope.workflow}
+
+
+def _body_to_dict(body):
+    if isinstance(body, CascadeBody):
+        return {
+            "type": "cascade",
+            "placement": body.placement.value,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "gates": [
+                {
+                    "kind": g.kind.value,
+                    "threshold": g.threshold,
+                    "signal": _sig_to_dict(g.signal),
+                }
+                for g in body.gates
+            ],
+        }
+    if isinstance(body, EnsembleBody):
+        agg = body.aggregate
+        return {
+            "type": "ensemble",
+            "cardinality": body.cardinality,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "aggregate": {
+                "kind": agg.kind.value,
+                "judge": _arm_to_dict(agg.judge) if agg.judge is not None else None,
+                "accept": (
+                    {
+                        "kind": agg.accept.kind,
+                        "stat": agg.accept.stat.value,
+                        "threshold": agg.accept.threshold,
+                    }
+                    if agg.accept is not None
+                    else None
+                ),
+            },
+        }
+    if isinstance(body, LoopBody):
+        return {
+            "type": "loop",
+            "body": _arm_to_dict(body.body),
+            "state_keys": list(body.state_keys),
+            "max_iters": body.max_iters,
+            "stop": {
+                "kind": body.stop.kind.value,
+                "threshold": body.stop.threshold,
+                "signal": _sig_to_dict(body.stop.signal),
+                "predicate": body.stop.predicate,
+            },
+        }
+    raise TypeError(f"unknown body type: {type(body).__name__}")
+
+
+def _node_to_dict(node):
+    return {
+        "name": node.name,
+        "kind": node.kind.value,
+        "body": _body_to_dict(node.body),
+        "scope": _scope_to_dict(node.scope),
+        "provenance": _prov_to_dict(node.provenance),
+    }
+
+
+def _golden_hash(node) -> str:
+    return canonical_hash(_node_to_dict(node))
+
+
+def _stage(outputs: list[str]) -> StageRunner:
+    return StageRunner(
+        run=lambda _item: list(outputs),
+        key_fn=lambda x: x,
+        samples=len(outputs),
+    )
+
+
+def _moe_vote() -> CompositeKnob:
+    return moe(
+        "patch_moe",
+        experts=("fast_patch", "semantic_patch", "test_driven_patch"),
+        aggregate="vote",
+        accept_threshold="patch_moe.vote_margin_min",
+        expert_tuned_params=(
+            ("repo_context_strategy", "edit_granularity"),
+            ("repo_context_strategy",),
+            ("test_selection_strategy", "patch_review_mode"),
+        ),
+    )
+
+
+def _moe_judge() -> CompositeKnob:
+    return moe(
+        "review_moe",
+        experts=("draft_a", "draft_b"),
+        aggregate="judge",
+        judge_stage="rubric_judge",
+        expert_tuned_params=(("style",), ("tests",)),
+        judge_tuned_params=("judge_rubric", "judge_model"),
+    )
+
+
+GOLDEN = {
+    "moe_vote": "e81cb5ef92f166cb1fdbc0647ef2f544b4b2b1979681a91a456b01a1af73a816",  # pragma: allowlist secret
+    "moe_judge": "0392e0c0916286fd1896a79f7c6690c76c0a30e8c42d8be4155044477f4f4e41",  # pragma: allowlist secret
+}
+
+
+def test_moe_vote_golden_hash_pinned() -> None:
+    assert _golden_hash(_moe_vote().structure) == GOLDEN["moe_vote"]
+
+
+def test_moe_judge_golden_hash_pinned() -> None:
+    assert _golden_hash(_moe_judge().structure) == GOLDEN["moe_judge"]
+
+
+def test_moe_returns_composite_knob_and_ensemble_telemetry() -> None:
+    knob = _moe_vote()
+
+    assert isinstance(knob, CompositeKnob)
+    assert knob.name == "patch_moe"
+    assert isinstance(knob.structure.body, EnsembleBody)
+    assert knob.structure.provenance.pattern == "moe"
+    assert knob.telemetry_names == (
+        "vote_agreement",
+        "vote_margin",
+        "candidates_evaluated",
+        "candidates_excluded",
+    )
+
+
+def test_moe_vote_expands_to_committee_majority_vote_with_accept_decl() -> None:
+    body = _moe_vote().structure.body
+
+    assert isinstance(body, EnsembleBody)
+    assert body.cardinality is None
+    assert [arm.name for arm in body.arms if isinstance(arm, StageArm)] == [
+        "fast_patch",
+        "semantic_patch",
+        "test_driven_patch",
+    ]
+    assert body.aggregate.kind is AggregateKind.MAJORITY_VOTE
+    assert body.aggregate.accept is not None
+    assert body.aggregate.accept.stat.value == "vote_margin"
+    assert body.aggregate.accept.threshold == "patch_moe.vote_margin_min"
+
+
+def test_moe_judge_expands_to_judge_max_with_judge_tuned_params() -> None:
+    body = _moe_judge().structure.body
+
+    assert isinstance(body, EnsembleBody)
+    assert body.aggregate.kind is AggregateKind.JUDGE_MAX
+    assert isinstance(body.aggregate.judge, StageArm)
+    assert body.aggregate.judge.name == "rubric_judge"
+    assert body.aggregate.judge.tuned_params == ("judge_rubric", "judge_model")
+    assert body.aggregate.accept is None
+
+
+def test_p8_canary_raw_params_do_not_enter_provenance() -> None:
+    sentinel = "SECRET-CANARY-moe-d4f1c0de"
+    knob = moe(
+        "sentinel_moe",
+        experts=(sentinel, "expert_b"),
+        accept_threshold=sentinel + "_threshold",
+        expert_tuned_params=((sentinel + "_tvar",), ()),
+    )
+
+    prov_blob = json.dumps(_prov_to_dict(knob.structure.provenance), sort_keys=True)
+    assert sentinel not in prov_blob
+    assert knob.structure.provenance.param_hash is not None
+    assert sentinel not in knob.structure.provenance.param_hash
+
+
+def test_committee_runtime_majority_vote_populates_telemetry() -> None:
+    node = moe(
+        "runtime_moe",
+        experts=("expert_a", "expert_b", "expert_c"),
+        aggregate="vote",
+    ).structure
+    result = execute_composite(
+        node,
+        {
+            "expert_a": _stage(["PATCH"]),
+            "expert_b": _stage(["PATCH"]),
+            "expert_c": _stage(["OTHER"]),
+        },
+        config={},
+        calibrated_values={},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "PATCH"
+    assert result.measures["candidates_evaluated"] == 3
+    assert result.measures["candidates_excluded"] == 0
+    assert result.measures["vote_margin"] == pytest.approx(2 / 3)
+    assert result.measures["vote_agreement"] == pytest.approx(1.0)
+
+
+def test_judge_runtime_uses_judge_tuned_params_declaration() -> None:
+    knob = _moe_judge()
+    result = execute_composite(
+        knob.structure,
+        {
+            "draft_a": _stage(["x"]),
+            "draft_b": _stage(["y"]),
+            "rubric_judge": StageRunner(
+                run=lambda candidate: [0.9 if candidate == "y" else 0.1],
+                samples=1,
+            ),
+        },
+        config={},
+        calibrated_values={},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "y"
+    assert result.measures["candidates_evaluated"] == 2
+    assert result.measures["candidates_excluded"] == 0
+    assert result.measures["vote_margin"] == 0.0
+    assert result.measures["vote_agreement"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"experts": ("only",)}, "at least two"),
+        ({"experts": ("a", "")}, "non-empty"),
+        ({"experts": ("a", "a")}, "distinct"),
+        ({"experts": ("a", "b"), "aggregate": "rank"}, "aggregate"),
+        (
+            {"experts": ("a", "b"), "expert_tuned_params": (("x",),)},
+            "exactly one tuple per expert",
+        ),
+        (
+            {"experts": ("a", "b"), "aggregate": "judge"},
+            "requires judge_stage",
+        ),
+        (
+            {"experts": ("a", "b"), "aggregate": "vote", "judge_stage": "j"},
+            "forbids judge_stage",
+        ),
+        (
+            {
+                "experts": ("a", "b"),
+                "aggregate": "judge",
+                "judge_stage": "j",
+                "accept_threshold": "theta",
+            },
+            "accept_threshold",
+        ),
+    ],
+)
+def test_moe_rejects_invalid_factory_arguments(kwargs, match) -> None:
+    with pytest.raises(ValueError, match=match):
+        moe("bad_moe", **kwargs)

--- a/tests/unit/knobs/test_patterns_react_tool_loop.py
+++ b/tests/unit/knobs/test_patterns_react_tool_loop.py
@@ -1,0 +1,467 @@
+"""react_tool_loop pattern tests (RFC 0002 loop-family catalog).
+
+This file is intentionally self-contained. It copies the local golden
+serializer convention from test_pattern_factories.py instead of editing that
+shared test module.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from traigent.knobs import Calibrated, Knob, Ref, SignalSpec, TargetProperty
+from traigent.knobs.canonical import canonical_hash
+from traigent.knobs.composites import (
+    CascadeBody,
+    CompositeArm,
+    CompositeKind,
+    CompositeProgram,
+    EnsembleBody,
+    LoopBody,
+    StageArm,
+    cal_fold,
+    validate_program,
+)
+from traigent.knobs.patterns import react_tool_loop
+from traigent.knobs.runtime import (
+    LoopBodyResult,
+    LoopBodyRunner,
+    ResultKind,
+    StopReason,
+    execute_composite,
+)
+
+# --------------------------------------------------------------------------- #
+# Byte-stable serializer (local copy of the golden-expansion oracle)          #
+# --------------------------------------------------------------------------- #
+
+
+def _arm_to_dict(arm):
+    if isinstance(arm, StageArm):
+        return {
+            "tag": "stage",
+            "name": arm.name,
+            "tuned_params": list(arm.tuned_params),
+        }
+    if isinstance(arm, CompositeArm):
+        return {"tag": "composite", "ref": arm.ref}
+    raise TypeError(f"unknown arm type: {type(arm).__name__}")
+
+
+def _sig_to_dict(sig):
+    if sig is None:
+        return None
+    return {"signal": sig.signal, "inputs": list(sig.inputs)}
+
+
+def _prov_to_dict(prov):
+    if prov is None:
+        return None
+    return {
+        "pattern": prov.pattern,
+        "pattern_version": prov.pattern_version,
+        "param_hash": prov.param_hash,
+        "node_path": prov.node_path,
+    }
+
+
+def _scope_to_dict(scope):
+    if scope is None:
+        return None
+    return {"node": scope.node, "agent": scope.agent, "workflow": scope.workflow}
+
+
+def _body_to_dict(body):
+    if isinstance(body, CascadeBody):
+        return {
+            "type": "cascade",
+            "placement": body.placement.value,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "gates": [
+                {
+                    "kind": g.kind.value,
+                    "threshold": g.threshold,
+                    "signal": _sig_to_dict(g.signal),
+                }
+                for g in body.gates
+            ],
+        }
+    if isinstance(body, EnsembleBody):
+        agg = body.aggregate
+        return {
+            "type": "ensemble",
+            "cardinality": body.cardinality,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "aggregate": {
+                "kind": agg.kind.value,
+                "judge": _arm_to_dict(agg.judge) if agg.judge is not None else None,
+                "accept": (
+                    {
+                        "kind": agg.accept.kind,
+                        "stat": agg.accept.stat.value,
+                        "threshold": agg.accept.threshold,
+                    }
+                    if agg.accept is not None
+                    else None
+                ),
+            },
+        }
+    if isinstance(body, LoopBody):
+        return {
+            "type": "loop",
+            "body": _arm_to_dict(body.body),
+            "state_keys": list(body.state_keys),
+            "max_iters": body.max_iters,
+            "stop": {
+                "kind": body.stop.kind.value,
+                "threshold": body.stop.threshold,
+                "signal": _sig_to_dict(body.stop.signal),
+                "predicate": body.stop.predicate,
+            },
+        }
+    raise TypeError(f"unknown body type: {type(body).__name__}")
+
+
+def _node_to_dict(node):
+    return {
+        "name": node.name,
+        "kind": node.kind.value,
+        "body": _body_to_dict(node.body),
+        "scope": _scope_to_dict(node.scope),
+        "provenance": _prov_to_dict(node.provenance),
+    }
+
+
+def _golden_hash(node) -> str:
+    return canonical_hash(_node_to_dict(node))
+
+
+# --------------------------------------------------------------------------- #
+# Shared fixtures                                                             #
+# --------------------------------------------------------------------------- #
+
+
+STAGE = "react_tool_step"
+SIGNAL = "tool_confidence"
+THRESHOLD = "tool_confidence_min"
+STAGE_TVARS = (
+    "planner_style",
+    "tool_allowlist",
+    "observation_format",
+    "failure_handler",
+)
+STATE_KEYS = (
+    "scratchpad",
+    "tool_calls",
+    "observations",
+    "confidence",
+    "last_error",
+)
+GOLDEN_REACT_TOOL_LOOP = "5f881392fed4ed0231445b40007cd859f6c72084f97fab4561982affe5ad4aad"  # pragma: allowlist secret
+
+
+def _code(excinfo: pytest.ExceptionInfo[ValueError]) -> str:
+    return str(excinfo.value).split(":", 1)[0]
+
+
+def _react_loop(**overrides):
+    args = {
+        "name": "qa_react",
+        "stage": STAGE,
+        "signal": SIGNAL,
+        "tool_confidence_min": THRESHOLD,
+        "max_tool_calls": 4,
+    }
+    args.update(overrides)
+    return react_tool_loop(**args)
+
+
+def _program(ck, **overrides) -> CompositeProgram:
+    base = {
+        "composites": {ck.name: ck.structure},
+        "tvars": frozenset(STAGE_TVARS),
+        "cvars": frozenset({THRESHOLD}),
+        "cvar_types": {THRESHOLD: "float"},
+        "cvar_signals": {THRESHOLD: SIGNAL},
+        "cvar_depends_on": {THRESHOLD: frozenset(STAGE_TVARS)},
+        "cvar_signal_inputs": {THRESHOLD: STATE_KEYS},
+    }
+    base.update(overrides)
+    return CompositeProgram(**base)
+
+
+def _signal_spec(name: str) -> SignalSpec:
+    return SignalSpec(
+        name=name,
+        version="1",
+        score_function="offline_stub",
+        score_function_version="1",
+        comparator="gte",
+        comparator_version="1",
+    )
+
+
+def _target() -> TargetProperty:
+    return TargetProperty(name="loop_stop_adequacy", mode="require_calibration")
+
+
+# --------------------------------------------------------------------------- #
+# Golden expansion + P8 provenance canary                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestGoldenExpansion:
+    def test_golden_hash_pinned(self):
+        ck = _react_loop()
+
+        assert _golden_hash(ck.structure) == GOLDEN_REACT_TOOL_LOOP
+
+    def test_exact_loop_shape_and_telemetry(self):
+        ck = _react_loop()
+        body = ck.structure.body
+
+        assert ck.kind is CompositeKind.LOOP
+        assert isinstance(body, LoopBody)
+        assert body.body == StageArm(STAGE, STAGE_TVARS)
+        assert body.max_iters == 4
+        assert body.state_keys == STATE_KEYS
+        assert body.stop.kind.value == "signal_accept"
+        assert body.stop.threshold == THRESHOLD
+        assert body.stop.signal.signal == SIGNAL
+        assert body.stop.signal.inputs == STATE_KEYS
+        assert ck.structure.provenance.pattern == "react_tool_loop"
+        assert ck.provenance == ck.structure.provenance
+        assert ck.telemetry_names == ("iterations_used", "stop_reason")
+
+
+class TestP8Canary:
+    def test_raw_params_never_serialize_into_provenance(self):
+        sentinel = "SECRET-CANARY-react-tool-loop-d4f1c0de"
+        ck = react_tool_loop(
+            "qa_react",
+            stage=sentinel,
+            signal=SIGNAL,
+            tool_confidence_min=THRESHOLD,
+            max_tool_calls=2,
+            stage_tuned_params=(sentinel + "_tvar",),
+        )
+
+        prov_blob = json.dumps(_prov_to_dict(ck.structure.provenance), sort_keys=True)
+        assert sentinel not in prov_blob
+        assert ck.structure.provenance.param_hash is not None
+        assert sentinel not in ck.structure.provenance.param_hash
+        assert canonical_hash(_prov_to_dict(ck.structure.provenance))
+
+
+# --------------------------------------------------------------------------- #
+# Validation rejects delegated to the sealed IR/program checks                #
+# --------------------------------------------------------------------------- #
+
+
+class TestValidationRejects:
+    @pytest.mark.parametrize("max_tool_calls", [0, True, "4"])
+    def test_invalid_max_tool_calls_rejects(self, max_tool_calls):
+        with pytest.raises(ValueError) as e:
+            _react_loop(max_tool_calls=max_tool_calls)
+
+        assert _code(e) == "invalid_max_iters"
+
+    def test_empty_threshold_rejects_missing_stop_threshold(self):
+        with pytest.raises(ValueError) as e:
+            _react_loop(tool_confidence_min="")
+
+        assert _code(e) == "missing_stop_threshold"
+
+    def test_signal_inputs_must_be_within_state_keys(self):
+        with pytest.raises(ValueError) as e:
+            _react_loop(signal_inputs=("observations", "unknown"))
+
+        assert _code(e) == "stop_signal_outside_state"
+
+    def test_default_program_validates(self):
+        validate_program(_program(_react_loop()))
+
+    def test_missing_threshold_ref_rejects(self):
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                _program(
+                    _react_loop(),
+                    cvars=frozenset(),
+                    cvar_types={},
+                    cvar_signals={},
+                    cvar_depends_on={},
+                    cvar_signal_inputs={},
+                )
+            )
+
+        assert _code(e) == "missing_ref"
+
+    def test_threshold_must_be_numeric_cvar(self):
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(_react_loop(), cvar_types={THRESHOLD: "string"}))
+
+        assert _code(e) == "invalid_threshold_type"
+
+    def test_missing_calibration_signal_rejects(self):
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(_react_loop(), cvar_signals={THRESHOLD: None}))
+
+        assert _code(e) == "missing_calibration_signal"
+
+    def test_signal_mismatch_rejects(self):
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(_react_loop(), cvar_signals={THRESHOLD: "other"}))
+
+        assert _code(e) == "signal_mismatch"
+
+    def test_unbound_signal_inputs_rejects(self):
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(_react_loop(), cvar_signal_inputs={}))
+
+        assert _code(e) == "unbound_signal_inputs"
+
+    def test_invalid_stage_tuned_param_rejects(self):
+        ck = _react_loop(stage_tuned_params=("planner_style", "ghost_tvar"))
+
+        with pytest.raises(ValueError) as e:
+            validate_program(_program(ck))
+
+        assert _code(e) == "invalid_tuned_param"
+
+    def test_body_tvar_must_be_covered_by_threshold_parentage(self):
+        with pytest.raises(ValueError) as e:
+            validate_program(
+                _program(
+                    _react_loop(),
+                    cvar_depends_on={
+                        THRESHOLD: frozenset(
+                            {
+                                "planner_style",
+                                "tool_allowlist",
+                                "observation_format",
+                            }
+                        )
+                    },
+                )
+            )
+
+        assert _code(e) == "missing_composite_parent"
+
+
+# --------------------------------------------------------------------------- #
+# Runtime behavior over execute_composite                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _react_step(confidences: list[float]) -> LoopBodyRunner:
+    counter = {"i": 0}
+
+    def run(_item, state):
+        i = counter["i"]
+        counter["i"] += 1
+        confidence = confidences[min(i, len(confidences) - 1)]
+        tool_calls = [*state.get("tool_calls", ()), f"tool-{i + 1}"]
+        observations = [*state.get("observations", ()), f"obs-{i + 1}"]
+        return LoopBodyResult(
+            output=f"answer-{i + 1}",
+            state={
+                "scratchpad": f"thought-{i + 1}",
+                "tool_calls": tool_calls,
+                "observations": observations,
+                "confidence": confidence,
+                "last_error": None,
+                "undeclared": "dropped",
+            },
+        )
+
+    return LoopBodyRunner(run=run)
+
+
+def _tool_confidence(state):
+    return state["confidence"]
+
+
+class TestRuntime:
+    def test_accepts_on_iteration_n_and_emits_loop_telemetry_only(self):
+        ck = _react_loop(max_tool_calls=4)
+
+        result = execute_composite(
+            ck.structure,
+            {STAGE: _react_step([0.2, 0.6, 0.91])},
+            config={},
+            calibrated_values={THRESHOLD: 0.9},
+            signals={SIGNAL: _tool_confidence},
+        )
+
+        assert result.result_kind is ResultKind.OUTPUT
+        assert result.output == "answer-3"
+        assert result.measures == {
+            "iterations_used": 3,
+            "stop_reason": StopReason.SIGNAL_ACCEPT.value,
+        }
+        assert tuple(result.measures) == ck.telemetry_names
+
+    def test_exhaustion_returns_no_accept(self):
+        ck = _react_loop(max_tool_calls=2)
+
+        result = execute_composite(
+            ck.structure,
+            {STAGE: _react_step([0.2, 0.6])},
+            config={},
+            calibrated_values={THRESHOLD: 0.9},
+            signals={SIGNAL: _tool_confidence},
+        )
+
+        assert result.result_kind is ResultKind.NO_ACCEPT
+        assert result.output is None
+        assert result.measures == {
+            "iterations_used": 2,
+            "stop_reason": StopReason.EXHAUSTED.value,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Cost-cap exclusion guard                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_tool_cost_cap_is_documented_not_active_in_current_loop_algebra():
+    tool_cost_cap = Knob(
+        name="tool_cost_cap",
+        binding=Calibrated(
+            signal=_signal_spec("tool_cost"),
+            target=_target(),
+            depends_on=(Ref(knob="planner_style"),),
+        ),
+    )
+    ck = _react_loop(members={"tool_cost_cap": tool_cost_cap})
+    program = _program(
+        ck,
+        cvars=frozenset({THRESHOLD, "tool_cost_cap"}),
+        cvar_types={THRESHOLD: "float", "tool_cost_cap": "float"},
+        cvar_signals={THRESHOLD: SIGNAL, "tool_cost_cap": "tool_cost"},
+        cvar_depends_on={
+            THRESHOLD: frozenset(STAGE_TVARS),
+            "tool_cost_cap": frozenset({"planner_style"}),
+        },
+        cvar_signal_inputs={THRESHOLD: STATE_KEYS},
+    )
+
+    validate_program(program)
+    assert "tool_cost_cap" in ck.members
+    assert cal_fold(program) == frozenset({THRESHOLD})
+    assert "tool_cost_cap" not in json.dumps(_node_to_dict(ck.structure))
+
+    result = execute_composite(
+        ck.structure,
+        {STAGE: _react_step([0.1, 0.2, 0.3, 0.4])},
+        config={},
+        calibrated_values={THRESHOLD: 0.9, "tool_cost_cap": 0.0},
+        signals={SIGNAL: _tool_confidence},
+    )
+
+    assert result.result_kind is ResultKind.NO_ACCEPT
+    assert result.measures["iterations_used"] == 4
+    assert result.measures["stop_reason"] == StopReason.EXHAUSTED.value

--- a/tests/unit/knobs/test_patterns_router_fallback.py
+++ b/tests/unit/knobs/test_patterns_router_fallback.py
@@ -1,0 +1,616 @@
+"""router/fallback catalog tests (pre-dispatch + no_accept fallback).
+
+This file is self-contained. It replicates the local golden-hash serializer
+instead of editing the shared ``test_pattern_factories.py`` fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from traigent.knobs import canonical_hash
+from traigent.knobs.composites import (
+    CascadeBody,
+    CompositeArm,
+    CompositeKind,
+    CompositeNode,
+    CompositeProgram,
+    EnsembleBody,
+    LoopBody,
+    Placement,
+    StageArm,
+    validate_program,
+)
+from traigent.knobs.patterns import (
+    binary_cascade,
+    fallback,
+    n_cascade,
+    router,
+    self_consistency,
+)
+from traigent.knobs.runtime import ResultKind, StageRunner, execute_composite
+
+POST_TELEMETRY = (
+    "escalation_rate",
+    "stage_selected",
+    "gate_margin_pass_rate",
+)
+PRE_TELEMETRY = (
+    "route_selected",
+    "dispatch_signal_margin",
+    "gate_signal_adequate",
+)
+ROUTER_TVARS = frozenset(
+    {
+        "retrieval_mode",
+        "query_complexity_strategy",
+        "retrieval_k",
+        "reranker",
+        "web_fallback",
+        "decompose_query",
+    }
+)
+ROUTER_GATE_PARENTS = frozenset(
+    {"retrieval_mode", "query_complexity_strategy", "retrieval_k"}
+)
+
+
+# Byte-stable serializer (local copy of the golden-expansion oracle) -------- #
+
+
+def _arm_to_dict(arm):
+    if isinstance(arm, StageArm):
+        return {
+            "tag": "stage",
+            "name": arm.name,
+            "tuned_params": list(arm.tuned_params),
+        }
+    if isinstance(arm, CompositeArm):
+        return {"tag": "composite", "ref": arm.ref}
+    raise TypeError(f"unknown arm type: {type(arm).__name__}")
+
+
+def _sig_to_dict(sig):
+    if sig is None:
+        return None
+    return {"signal": sig.signal, "inputs": list(sig.inputs)}
+
+
+def _prov_to_dict(prov):
+    if prov is None:
+        return None
+    return {
+        "pattern": prov.pattern,
+        "pattern_version": prov.pattern_version,
+        "param_hash": prov.param_hash,
+        "node_path": prov.node_path,
+    }
+
+
+def _scope_to_dict(scope):
+    if scope is None:
+        return None
+    return {"node": scope.node, "agent": scope.agent, "workflow": scope.workflow}
+
+
+def _body_to_dict(body):
+    if isinstance(body, CascadeBody):
+        return {
+            "type": "cascade",
+            "placement": body.placement.value,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "gates": [
+                {
+                    "kind": g.kind.value,
+                    "threshold": g.threshold,
+                    "signal": _sig_to_dict(g.signal),
+                }
+                for g in body.gates
+            ],
+        }
+    if isinstance(body, EnsembleBody):
+        agg = body.aggregate
+        return {
+            "type": "ensemble",
+            "cardinality": body.cardinality,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "aggregate": {
+                "kind": agg.kind.value,
+                "judge": _arm_to_dict(agg.judge) if agg.judge is not None else None,
+                "accept": (
+                    {
+                        "kind": agg.accept.kind,
+                        "stat": agg.accept.stat.value,
+                        "threshold": agg.accept.threshold,
+                    }
+                    if agg.accept is not None
+                    else None
+                ),
+            },
+        }
+    if isinstance(body, LoopBody):
+        return {
+            "type": "loop",
+            "body": _arm_to_dict(body.body),
+            "state_keys": list(body.state_keys),
+            "max_iters": body.max_iters,
+            "stop": {
+                "kind": body.stop.kind.value,
+                "threshold": body.stop.threshold,
+                "signal": _sig_to_dict(body.stop.signal),
+                "predicate": body.stop.predicate,
+            },
+        }
+    raise TypeError(f"unknown body type: {type(body).__name__}")
+
+
+def _node_to_dict(node):
+    return {
+        "name": node.name,
+        "kind": node.kind.value,
+        "body": _body_to_dict(node.body),
+        "scope": _scope_to_dict(node.scope),
+        "provenance": _prov_to_dict(node.provenance),
+    }
+
+
+def _golden_hash(node) -> str:
+    return canonical_hash(_node_to_dict(node))
+
+
+def _stage(outputs: list[str]) -> StageRunner:
+    return StageRunner(
+        run=lambda _item: list(outputs),
+        key_fn=lambda x: x,
+        samples=len(outputs),
+    )
+
+
+class _SpyStage:
+    def __init__(self, value: str) -> None:
+        self.value = value
+        self.called = False
+
+    def runner(self) -> StageRunner:
+        def run(_item):
+            self.called = True
+            return [self.value]
+
+        return StageRunner(run=run, key_fn=lambda x: x, samples=1)
+
+
+def _router():
+    return router(
+        "adaptive_rag_gate",
+        arms=("rag_light", "rag_heavy"),
+        signals=("query_light_adequacy",),
+        thresholds=("complexity_threshold",),
+        tuned_params=(
+            ("retrieval_mode", "query_complexity_strategy", "retrieval_k"),
+            (
+                "retrieval_mode",
+                "query_complexity_strategy",
+                "retrieval_k",
+                "reranker",
+                "web_fallback",
+                "decompose_query",
+            ),
+        ),
+        signal_inputs=(("question",),),
+    )
+
+
+def _fallback():
+    return fallback(
+        "llm_provider_fallback",
+        arms=("primary", "secondary", "last_resort"),
+        thresholds=("fallback_margin_floor", "fallback_margin_floor"),
+        tuned_params=(("primary_model",), ("secondary_model",), ()),
+    )
+
+
+GOLDEN = {
+    "router": "33004b6c6d6ea398498ede7da76a5a6a15aaed0403b48661ddd1baf8b176e999",  # pragma: allowlist secret
+    "fallback": "2ac8b027c0f1a91443f31b3dd9762d7e05b3cf50d877d749e1b81f6fb4643f6e",  # pragma: allowlist secret
+}
+
+
+def test_router_golden_hash_pinned_and_expands_to_pre_cascade() -> None:
+    knob = _router()
+    body = knob.structure.body
+
+    assert _golden_hash(knob.structure) == GOLDEN["router"]
+    assert knob.structure.kind is CompositeKind.CASCADE
+    assert isinstance(body, CascadeBody)
+    assert body.placement is Placement.PRE
+    assert body.gates[0].kind.value == "signal_below"
+    assert body.gates[0].signal is not None
+    assert body.gates[0].signal.signal == "query_light_adequacy"
+    assert body.gates[0].signal.inputs == ("question",)
+    assert knob.structure.provenance.pattern == "router"
+
+
+def test_fallback_golden_hash_pinned_and_expands_to_post_cascade() -> None:
+    knob = _fallback()
+    body = knob.structure.body
+
+    assert _golden_hash(knob.structure) == GOLDEN["fallback"]
+    assert knob.structure.kind is CompositeKind.CASCADE
+    assert isinstance(body, CascadeBody)
+    assert body.placement is Placement.POST
+    assert [gate.kind.value for gate in body.gates] == [
+        "margin_below",
+        "margin_below",
+    ]
+    assert [gate.threshold for gate in body.gates] == [
+        "fallback_margin_floor",
+        "fallback_margin_floor",
+    ]
+    assert knob.structure.provenance.pattern == "fallback"
+
+
+def test_p8_canary_router_and_fallback_provenance_does_not_leak_raw_params() -> None:
+    sentinel = "SECRET-CANARY-router-fallback-d4f1c0de"
+    r = router(
+        "sentinel_router",
+        arms=(sentinel, "terminal"),
+        signals=(sentinel + "_signal",),
+        thresholds=(sentinel + "_theta",),
+        tuned_params=((sentinel + "_tvar",), ()),
+    )
+    f = fallback(
+        "sentinel_fallback",
+        arms=(sentinel, "terminal"),
+        thresholds=(sentinel + "_theta",),
+        tuned_params=((sentinel + "_tvar",), ()),
+    )
+
+    for knob in (r, f):
+        prov_blob = json.dumps(_prov_to_dict(knob.structure.provenance))
+        assert sentinel not in prov_blob
+        assert knob.structure.provenance.param_hash is not None
+        assert sentinel not in knob.structure.provenance.param_hash
+
+
+def test_telemetry_names_are_truthful_for_pre_and_post_cascades() -> None:
+    assert _router().telemetry_names == PRE_TELEMETRY
+    assert "escalation_rate" not in _router().telemetry_names
+
+    assert _fallback().telemetry_names == POST_TELEMETRY
+    assert binary_cascade(
+        "bc",
+        base_stage="cheap",
+        expert_stage="strong",
+        threshold="theta",
+    ).telemetry_names == POST_TELEMETRY
+    assert n_cascade(
+        "nc", stages=("a", "b", "c"), thresholds=("t0", "t1")
+    ).telemetry_names == POST_TELEMETRY
+
+
+def test_fallback_docstring_states_no_accept_not_error_contract() -> None:
+    doc = fallback.__doc__ or ""
+
+    assert "leaf StageRunner cannot signal failure" in doc
+    assert "theta=0.0" in doc
+    assert "no_accept-triggered, NOT error-triggered" in doc
+    assert "errors stay absorbing" in doc
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (
+            {
+                "arms": (),
+                "signals": (),
+                "thresholds": (),
+            },
+            "empty_arms",
+        ),
+        (
+            {
+                "arms": ("a", "b", "c"),
+                "signals": ("s0",),
+                "thresholds": ("t0", "t1"),
+            },
+            "cascade_arity",
+        ),
+        (
+            {
+                "arms": ("a", "b", "c"),
+                "signals": ("s0", "s1"),
+                "thresholds": ("t0",),
+            },
+            "cascade_arity",
+        ),
+        (
+            {
+                "arms": ("a", "b"),
+                "signals": ("s0",),
+                "thresholds": ("t0",),
+                "tuned_params": (("m",),),
+            },
+            "invalid_tuned_param",
+        ),
+        (
+            {
+                "arms": ("a", "b"),
+                "signals": ("s0",),
+                "thresholds": ("t0",),
+                "signal_inputs": (("question",), ("unused",)),
+            },
+            "invalid_signal_use",
+        ),
+        (
+            {
+                "arms": ("a", "b"),
+                "signals": ("s0",),
+                "thresholds": ("t0",),
+                "signal_inputs": (["question"],),
+            },
+            "invalid_signal_use",
+        ),
+        (
+            {
+                "arms": ("a", "b"),
+                "signals": ("",),
+                "thresholds": ("t0",),
+            },
+            "invalid_signal_use",
+        ),
+        (
+            {
+                "arms": ("a", "a"),
+                "signals": ("s0",),
+                "thresholds": ("t0",),
+            },
+            "duplicate_stage",
+        ),
+    ],
+)
+def test_router_rejects_bad_factory_arguments(kwargs, match) -> None:
+    with pytest.raises(ValueError, match=match):
+        router("bad_router", **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"arms": (), "thresholds": ()}, "empty_arms"),
+        ({"arms": ("a", "b", "c"), "thresholds": ("t0",)}, "cascade_arity"),
+        (
+            {
+                "arms": ("a", "b"),
+                "thresholds": ("t0",),
+                "tuned_params": (("m",),),
+            },
+            "invalid_tuned_param",
+        ),
+        ({"arms": ("a", "a"), "thresholds": ("t0",)}, "duplicate_stage"),
+    ],
+)
+def test_fallback_rejects_bad_factory_arguments(kwargs, match) -> None:
+    with pytest.raises(ValueError, match=match):
+        fallback("bad_fallback", **kwargs)
+
+
+def test_router_program_validation_rejects_missing_calibration_signal() -> None:
+    program = CompositeProgram(
+        composites={"adaptive_rag_gate": _router().structure},
+        tvars=ROUTER_TVARS,
+        cvars=frozenset({"complexity_threshold"}),
+        cvar_types={"complexity_threshold": "float"},
+        cvar_depends_on={"complexity_threshold": ROUTER_GATE_PARENTS},
+    )
+
+    with pytest.raises(ValueError, match="missing_calibration_signal"):
+        validate_program(program)
+
+
+def test_router_program_validation_rejects_missing_threshold_ref() -> None:
+    program = CompositeProgram(
+        composites={"adaptive_rag_gate": _router().structure},
+        tvars=ROUTER_TVARS,
+        cvars=frozenset(),
+        cvar_depends_on={"complexity_threshold": ROUTER_GATE_PARENTS},
+    )
+
+    with pytest.raises(ValueError, match="missing_ref"):
+        validate_program(program)
+
+
+def test_router_program_validation_rejects_mismatched_signal() -> None:
+    program = CompositeProgram(
+        composites={"adaptive_rag_gate": _router().structure},
+        tvars=ROUTER_TVARS,
+        cvars=frozenset({"complexity_threshold"}),
+        cvar_types={"complexity_threshold": "float"},
+        cvar_signals={"complexity_threshold": "other_signal"},
+        cvar_depends_on={"complexity_threshold": ROUTER_GATE_PARENTS},
+        cvar_signal_inputs={"complexity_threshold": ("question",)},
+    )
+
+    with pytest.raises(ValueError, match="signal_mismatch"):
+        validate_program(program)
+
+
+def test_router_program_validation_rejects_uncovered_signal_inputs() -> None:
+    program = CompositeProgram(
+        composites={"adaptive_rag_gate": _router().structure},
+        tvars=ROUTER_TVARS,
+        cvars=frozenset({"complexity_threshold"}),
+        cvar_types={"complexity_threshold": "float"},
+        cvar_signals={"complexity_threshold": "query_light_adequacy"},
+        cvar_depends_on={"complexity_threshold": ROUTER_GATE_PARENTS},
+    )
+
+    with pytest.raises(ValueError, match="unbound_signal_inputs"):
+        validate_program(program)
+
+
+def test_router_program_validation_rejects_missing_leaf_parent_coverage() -> None:
+    program = CompositeProgram(
+        composites={"adaptive_rag_gate": _router().structure},
+        tvars=ROUTER_TVARS,
+        cvars=frozenset({"complexity_threshold"}),
+        cvar_types={"complexity_threshold": "float"},
+        cvar_signals={"complexity_threshold": "query_light_adequacy"},
+        cvar_signal_inputs={"complexity_threshold": ("question",)},
+        cvar_depends_on={"complexity_threshold": frozenset({"retrieval_mode"})},
+    )
+
+    with pytest.raises(ValueError, match="missing_composite_parent"):
+        validate_program(program)
+
+
+def test_fallback_program_validation_requires_vote_margin_signal() -> None:
+    program = CompositeProgram(
+        composites={"llm_provider_fallback": _fallback().structure},
+        tvars=frozenset({"primary_model", "secondary_model"}),
+        cvars=frozenset({"fallback_margin_floor"}),
+        cvar_types={"fallback_margin_floor": "float"},
+        cvar_signals={"fallback_margin_floor": "provider_health"},
+        cvar_depends_on={
+            "fallback_margin_floor": frozenset({"primary_model", "secondary_model"})
+        },
+    )
+
+    with pytest.raises(ValueError, match="signal_mismatch"):
+        validate_program(program)
+
+
+def test_fallback_program_validation_rejects_non_numeric_threshold_type() -> None:
+    program = CompositeProgram(
+        composites={"llm_provider_fallback": _fallback().structure},
+        tvars=frozenset({"primary_model", "secondary_model"}),
+        cvars=frozenset({"fallback_margin_floor"}),
+        cvar_types={"fallback_margin_floor": "str"},
+        cvar_signals={"fallback_margin_floor": "vote_margin"},
+        cvar_depends_on={
+            "fallback_margin_floor": frozenset({"primary_model", "secondary_model"})
+        },
+    )
+
+    with pytest.raises(ValueError, match="invalid_threshold_type"):
+        validate_program(program)
+
+
+def test_router_routes_through_shipped_pre_cascade_executor() -> None:
+    light = _SpyStage("light-answer")
+    heavy = _SpyStage("heavy-answer")
+    result = execute_composite(
+        _router().structure,
+        {"rag_light": light.runner(), "rag_heavy": heavy.runner()},
+        config={"question": "short factual question"},
+        calibrated_values={"complexity_threshold": 0.5},
+        signals={"query_light_adequacy": lambda payload: 0.9},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "light-answer"
+    assert light.called is True
+    assert heavy.called is False
+    assert result.measures["route_selected"] == 0
+    assert result.measures["dispatch_signal_margin"] == pytest.approx(0.4)
+    assert result.measures["gate_signal_adequate"] == {0: 1}
+
+
+def test_router_absent_signal_routes_to_terminal() -> None:
+    light = _SpyStage("light-answer")
+    heavy = _SpyStage("heavy-answer")
+    result = execute_composite(
+        _router().structure,
+        {"rag_light": light.runner(), "rag_heavy": heavy.runner()},
+        config={"question": "question with no complexity signal"},
+        calibrated_values={"complexity_threshold": 0.5},
+        signals={"query_light_adequacy": lambda payload: None},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "heavy-answer"
+    assert light.called is False
+    assert heavy.called is True
+    assert result.measures["route_selected"] == 1
+    assert result.measures["gate_signal_adequate"] == {0: 0}
+    assert "dispatch_signal_margin" not in result.measures
+
+
+def test_router_malformed_signal_absorbs_as_error() -> None:
+    result = execute_composite(
+        _router().structure,
+        {"rag_light": _stage(["light"]), "rag_heavy": _stage(["heavy"])},
+        config={"question": "bad score"},
+        calibrated_values={"complexity_threshold": 0.5},
+        signals={"query_light_adequacy": lambda payload: True},
+    )
+
+    assert result.result_kind is ResultKind.ERROR
+    assert result.measures == {}
+    assert "must return a finite number or None" in (result.error or "")
+
+
+def test_fallback_escalates_when_nested_non_terminal_arm_no_accepts() -> None:
+    inner = self_consistency(
+        "primary_gate",
+        stage="primary_leaf",
+        cardinality="k",
+        accept_threshold="accept_margin",
+    ).structure
+    base = fallback(
+        "provider_fallback",
+        arms=("primary_gate", "secondary"),
+        thresholds=("fallback_margin_floor",),
+    ).structure
+    body = replace(
+        base.body,
+        arms=(CompositeArm("primary_gate"), StageArm("secondary")),
+    )
+    outer = replace(base, body=body)
+
+    result = execute_composite(
+        outer,
+        {
+            "primary_leaf": _stage(["a", "b"]),
+            "secondary": _stage(["secondary-answer"]),
+        },
+        config={"k": 2},
+        calibrated_values={
+            "accept_margin": 0.9,
+            "fallback_margin_floor": 0.0,
+        },
+        registry={"provider_fallback": outer, "primary_gate": inner},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "secondary-answer"
+    assert result.measures["stage_selected"] == 1
+    assert result.measures["escalation_rate"] == 1.0
+
+
+def test_fallback_absorbs_errors_instead_of_trying_next_arm() -> None:
+    secondary = _SpyStage("secondary-answer")
+
+    def boom(_item):
+        raise RuntimeError("primary provider failed")
+
+    result = execute_composite(
+        fallback(
+            "provider_fallback",
+            arms=("primary", "secondary"),
+            thresholds=("fallback_margin_floor",),
+        ).structure,
+        {
+            "primary": StageRunner(run=boom, key_fn=lambda x: x, samples=1),
+            "secondary": secondary.runner(),
+        },
+        config={},
+        calibrated_values={"fallback_margin_floor": 0.0},
+    )
+
+    assert result.result_kind is ResultKind.ERROR
+    assert secondary.called is False
+    assert "primary provider failed" in (result.error or "")

--- a/tests/unit/knobs/test_patterns_verification_gate.py
+++ b/tests/unit/knobs/test_patterns_verification_gate.py
@@ -1,0 +1,506 @@
+"""Verification-gate catalog tests.
+
+This file is deliberately self-contained: it replicates the local golden-hash
+convention from ``test_pattern_factories.py`` without changing that fixture.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import fields
+
+import pytest
+
+from traigent.knobs import canonical_hash
+from traigent.knobs.composites import (
+    CascadeBody,
+    CompositeArm,
+    CompositeProgram,
+    EnsembleBody,
+    LoopBody,
+    SignalUse,
+    StageArm,
+    StopDecl,
+    StopKind,
+    validate_program,
+)
+from traigent.knobs.patterns import self_refine, verification_gate
+from traigent.knobs.runtime import (
+    LoopBodyResult,
+    LoopBodyRunner,
+    ResultKind,
+    StopReason,
+    execute_composite,
+)
+
+_THRESHOLD = "verifier_pass_threshold"
+_SIGNAL = "verifier_pass_score"
+_STAGE = "generate_verify_revise"
+_STATE_KEYS = (
+    "draft",
+    "verification_questions",
+    "verification_answers",
+    "verifier_pass_score",
+    "contradiction_score",
+    "revision",
+    "independent_context",
+)
+_SIGNAL_INPUTS = ("draft", "verification_answers", "independent_context")
+_TVARS = frozenset(
+    {
+        "verification_style",
+        "verification_question_count",
+        "verifier_model",
+        "independent_context",
+        "revision_policy",
+    }
+)
+
+
+# Byte-stable serializer (the golden-expansion oracle) ---------------------- #
+
+
+def _arm_to_dict(arm):
+    if isinstance(arm, StageArm):
+        return {
+            "tag": "stage",
+            "name": arm.name,
+            "tuned_params": list(arm.tuned_params),
+        }
+    if isinstance(arm, CompositeArm):
+        return {"tag": "composite", "ref": arm.ref}
+    raise TypeError(f"unknown arm type: {type(arm).__name__}")
+
+
+def _sig_to_dict(sig):
+    if sig is None:
+        return None
+    return {"signal": sig.signal, "inputs": list(sig.inputs)}
+
+
+def _prov_to_dict(prov):
+    if prov is None:
+        return None
+    return {
+        "pattern": prov.pattern,
+        "pattern_version": prov.pattern_version,
+        "param_hash": prov.param_hash,
+        "node_path": prov.node_path,
+    }
+
+
+def _scope_to_dict(scope):
+    if scope is None:
+        return None
+    return {"node": scope.node, "agent": scope.agent, "workflow": scope.workflow}
+
+
+def _body_to_dict(body):
+    if isinstance(body, CascadeBody):
+        return {
+            "type": "cascade",
+            "placement": body.placement.value,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "gates": [
+                {
+                    "kind": g.kind.value,
+                    "threshold": g.threshold,
+                    "signal": _sig_to_dict(g.signal),
+                }
+                for g in body.gates
+            ],
+        }
+    if isinstance(body, EnsembleBody):
+        agg = body.aggregate
+        return {
+            "type": "ensemble",
+            "cardinality": body.cardinality,
+            "arms": [_arm_to_dict(a) for a in body.arms],
+            "aggregate": {
+                "kind": agg.kind.value,
+                "judge": _arm_to_dict(agg.judge) if agg.judge is not None else None,
+                "accept": (
+                    {
+                        "kind": agg.accept.kind,
+                        "stat": agg.accept.stat.value,
+                        "threshold": agg.accept.threshold,
+                    }
+                    if agg.accept is not None
+                    else None
+                ),
+            },
+        }
+    if isinstance(body, LoopBody):
+        return {
+            "type": "loop",
+            "body": _arm_to_dict(body.body),
+            "state_keys": list(body.state_keys),
+            "max_iters": body.max_iters,
+            "stop": {
+                "kind": body.stop.kind.value,
+                "threshold": body.stop.threshold,
+                "signal": _sig_to_dict(body.stop.signal),
+                "predicate": body.stop.predicate,
+            },
+        }
+    raise TypeError(f"unknown body type: {type(body).__name__}")
+
+
+def _node_to_dict(node):
+    return {
+        "name": node.name,
+        "kind": node.kind.value,
+        "body": _body_to_dict(node.body),
+        "scope": _scope_to_dict(node.scope),
+        "provenance": _prov_to_dict(node.provenance),
+    }
+
+
+def _golden_hash(node) -> str:
+    return canonical_hash(_node_to_dict(node))
+
+
+def _vg(**overrides):
+    params = {
+        "name": "qa_verified",
+        "stage": _STAGE,
+        "verifier_signal": _SIGNAL,
+        "verifier_pass_threshold": _THRESHOLD,
+        "verification_style": "verification_style",
+        "verification_question_count": "verification_question_count",
+        "verifier_model": "verifier_model",
+        "independent_context": "independent_context",
+        "revision_policy": "revision_policy",
+        "max_iters": 2,
+    }
+    params.update(overrides)
+    return verification_gate(**params)
+
+
+def _program(**overrides) -> CompositeProgram:
+    ck = _vg()
+    params = {
+        "composites": {ck.name: ck.structure},
+        "tvars": _TVARS,
+        "cvars": frozenset({_THRESHOLD}),
+        "cvar_types": {_THRESHOLD: "float"},
+        "cvar_signals": {_THRESHOLD: _SIGNAL},
+        "cvar_depends_on": {_THRESHOLD: _TVARS},
+        "cvar_signal_inputs": {_THRESHOLD: _SIGNAL_INPUTS},
+    }
+    params.update(overrides)
+    return CompositeProgram(**params)
+
+
+def _code(exc: pytest.ExceptionInfo[ValueError]) -> str:
+    return str(exc.value).split(":", 1)[0]
+
+
+def _signal(state):
+    return state[_SIGNAL]
+
+
+def _verified_state(
+    *,
+    draft: str,
+    score: float,
+    revision: str,
+    contradiction_score: float = 0.1,
+) -> dict[str, object]:
+    return {
+        "draft": draft,
+        "verification_questions": 3,
+        "verification_answers": f"checked:{draft}",
+        "verifier_pass_score": score,
+        "contradiction_score": contradiction_score,
+        "revision": revision,
+        "independent_context": "offline_reference",
+    }
+
+
+# Golden expansion and P8 canary -------------------------------------------- #
+
+
+GOLDEN_VERIFICATION_GATE = "19ca7c1aae7c56cb4c3c274619cd029f02066f21b8179dbf082d0b1b671936a9"  # pragma: allowlist secret
+
+
+def test_golden_hash_pinned_and_deterministic():
+    actual = _golden_hash(_vg().structure)
+    assert actual == GOLDEN_VERIFICATION_GATE, actual
+    assert _golden_hash(_vg().structure) == _golden_hash(_vg().structure)
+
+
+def test_expands_to_signal_accept_loop_family():
+    ck = _vg()
+    body = ck.structure.body
+
+    assert ck.telemetry_names == ("iterations_used", "stop_reason")
+    assert body.body == StageArm(
+        _STAGE,
+        (
+            "verification_style",
+            "verification_question_count",
+            "verifier_model",
+            "independent_context",
+            "revision_policy",
+        ),
+    )
+    assert body.stop.kind is StopKind.SIGNAL_ACCEPT
+    assert body.stop.threshold == _THRESHOLD
+    assert body.stop.signal == SignalUse(signal=_SIGNAL, inputs=_SIGNAL_INPUTS)
+    assert body.state_keys == _STATE_KEYS
+    assert body.max_iters == 2
+
+
+def test_p8_canary_raw_verifier_params_never_serialize_into_provenance():
+    sentinel = "SECRET-CANARY-verifier-param"
+    ck = _vg(
+        verification_style=sentinel,
+        verifier_model=f"{sentinel}:model",
+        revision_policy=f"{sentinel}:revision",
+    )
+
+    prov_blob = json.dumps(_prov_to_dict(ck.structure.provenance), sort_keys=True)
+    assert sentinel not in prov_blob
+    assert ck.structure.provenance.param_hash is not None
+    assert sentinel not in ck.structure.provenance.param_hash
+    assert canonical_hash(_prov_to_dict(ck.structure.provenance))
+
+
+# Factory and program validation -------------------------------------------- #
+
+
+def test_contradiction_score_max_rejects_at_factory_boundary():
+    with pytest.raises(ValueError, match=r"^unsupported_compound_stop"):
+        _vg(contradiction_score_max="contradiction_score_max")
+
+
+def test_max_iters_is_literal_int_not_tuned_structural_bound():
+    with pytest.raises(ValueError, match="invalid_max_iters"):
+        _vg(max_iters="max_repair_rounds")  # type: ignore[arg-type]
+
+
+def test_validate_program_accepts_well_bound_gate():
+    validate_program(_program())
+
+
+def test_validate_program_rejects_missing_calibration_signal():
+    with pytest.raises(ValueError) as exc:
+        validate_program(_program(cvar_signals={_THRESHOLD: None}))
+    assert _code(exc) == "missing_calibration_signal"
+
+
+def test_validate_program_rejects_signal_mismatch():
+    with pytest.raises(ValueError) as exc:
+        validate_program(_program(cvar_signals={_THRESHOLD: "other_signal"}))
+    assert _code(exc) == "signal_mismatch"
+
+
+def test_validate_program_rejects_unbound_signal_inputs():
+    with pytest.raises(ValueError) as exc:
+        validate_program(_program(cvar_signal_inputs={_THRESHOLD: None}))
+    assert _code(exc) == "unbound_signal_inputs"
+
+
+def test_validate_program_rejects_missing_tvar_parent_coverage():
+    with pytest.raises(ValueError) as exc:
+        validate_program(
+            _program(
+                cvar_depends_on={
+                    _THRESHOLD: frozenset(_TVARS - {"revision_policy"})
+                }
+            )
+        )
+    assert _code(exc) == "missing_composite_parent"
+
+
+# Runtime behavior ----------------------------------------------------------- #
+
+
+def test_runtime_accepts_on_first_iteration():
+    seen_states: list[dict[str, object]] = []
+
+    def body(_config, state):
+        seen_states.append(dict(state))
+        return LoopBodyResult(
+            output="draft-1",
+            state=_verified_state(draft="draft-1", score=0.94, revision="none"),
+        )
+
+    result = execute_composite(
+        _vg().structure,
+        {_STAGE: LoopBodyRunner(run=body)},
+        config={},
+        calibrated_values={_THRESHOLD: 0.9},
+        signals={_SIGNAL: _signal},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "draft-1"
+    assert result.measures["iterations_used"] == 1
+    assert result.measures["stop_reason"] == StopReason.SIGNAL_ACCEPT.value
+    assert seen_states == [{}]
+
+
+def test_runtime_revises_then_accepts_on_second_iteration():
+    calls = {"n": 0}
+    seen_states: list[dict[str, object]] = []
+
+    def body(_config, state):
+        seen_states.append(dict(state))
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return LoopBodyResult(
+                output="draft-0",
+                state=_verified_state(
+                    draft="draft-0", score=0.3, revision="needs_revision"
+                ),
+            )
+        assert state["draft"] == "draft-0"
+        return LoopBodyResult(
+            output="draft-1",
+            state=_verified_state(draft="draft-1", score=0.93, revision="revised"),
+        )
+
+    result = execute_composite(
+        _vg().structure,
+        {_STAGE: LoopBodyRunner(run=body)},
+        config={},
+        calibrated_values={_THRESHOLD: 0.9},
+        signals={_SIGNAL: _signal},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "draft-1"
+    assert result.measures["iterations_used"] == 2
+    assert result.measures["stop_reason"] == StopReason.SIGNAL_ACCEPT.value
+    assert seen_states[0] == {}
+    assert seen_states[1]["revision"] == "needs_revision"
+
+
+def test_runtime_exhausts_to_no_accept():
+    scores = iter([0.2, 0.4])
+
+    def body(_config, _state):
+        score = next(scores)
+        return LoopBodyResult(
+            output=f"draft-{score}",
+            state=_verified_state(
+                draft=f"draft-{score}", score=score, revision="still_low"
+            ),
+        )
+
+    result = execute_composite(
+        _vg().structure,
+        {_STAGE: LoopBodyRunner(run=body)},
+        config={},
+        calibrated_values={_THRESHOLD: 0.9},
+        signals={_SIGNAL: _signal},
+    )
+
+    assert result.result_kind is ResultKind.NO_ACCEPT
+    assert result.output is None
+    assert result.measures["iterations_used"] == 2
+    assert result.measures["stop_reason"] == StopReason.EXHAUSTED.value
+
+
+# bounded_refine_loop recipe boundary --------------------------------------- #
+
+
+def test_bounded_refine_loop_recipe_threads_improvement_state_to_signal():
+    stage_tuned_params = (
+        "critic_model",
+        "feedback_rubric",
+        "repair_prompt",
+        "max_repair_rounds",
+        "stop_condition",
+    )
+    signal_inputs = ("draft", "score", "previous_score", "improvement_delta")
+    ck = self_refine(
+        name="bounded_refine_loop",
+        stage="critique_repair",
+        signal="refine_accept_score",
+        threshold="acceptance_threshold",
+        max_iters=3,
+        state_keys=(
+            "draft",
+            "critique",
+            "score",
+            "previous_score",
+            "improvement_delta",
+            "round",
+        ),
+        signal_inputs=signal_inputs,
+        stage_tuned_params=stage_tuned_params,
+    )
+    validate_program(
+        CompositeProgram(
+            composites={ck.name: ck.structure},
+            tvars=frozenset(stage_tuned_params),
+            cvars=frozenset({"acceptance_threshold"}),
+            cvar_types={"acceptance_threshold": "float"},
+            cvar_signals={"acceptance_threshold": "refine_accept_score"},
+            cvar_depends_on={"acceptance_threshold": frozenset(stage_tuned_params)},
+            cvar_signal_inputs={"acceptance_threshold": signal_inputs},
+        )
+    )
+
+    scores = iter([0.4, 0.86])
+    signal_views: list[dict[str, float]] = []
+
+    def body(_config, state):
+        previous = float(state.get("score", 0.0))
+        score = next(scores)
+        return LoopBodyResult(
+            output=f"draft:{score}",
+            state={
+                "draft": f"draft:{score}",
+                "critique": "stubbed critique",
+                "score": score,
+                "previous_score": previous,
+                "improvement_delta": score - previous,
+                "round": int(state.get("round", 0)) + 1,
+            },
+        )
+
+    def refine_accept_score(state):
+        signal_views.append(
+            {
+                "score": state["score"],
+                "previous_score": state["previous_score"],
+                "improvement_delta": state["improvement_delta"],
+            }
+        )
+        return state["score"]
+
+    result = execute_composite(
+        ck.structure,
+        {"critique_repair": LoopBodyRunner(run=body)},
+        config={},
+        calibrated_values={"acceptance_threshold": 0.8},
+        signals={"refine_accept_score": refine_accept_score},
+    )
+
+    assert result.result_kind is ResultKind.OUTPUT
+    assert result.output == "draft:0.86"
+    assert result.measures["stop_reason"] == StopReason.SIGNAL_ACCEPT.value
+    assert signal_views[1]["score"] == pytest.approx(0.86)
+    assert signal_views[1]["previous_score"] == pytest.approx(0.4)
+    assert signal_views[1]["improvement_delta"] == pytest.approx(0.46)
+
+
+def test_dual_threshold_acceptance_plus_improvement_stop_is_not_expressible():
+    threshold_fields = [
+        field.name for field in fields(StopDecl) if "threshold" in field.name
+    ]
+    assert threshold_fields == ["threshold"]
+    assert "improvement_threshold" not in inspect.signature(StopDecl).parameters
+
+    with pytest.raises(TypeError):
+        StopDecl(
+            kind=StopKind.SIGNAL_ACCEPT,
+            threshold="acceptance_threshold",
+            signal=SignalUse(signal="refine_accept_score"),
+            improvement_threshold="improvement_min_delta",  # type: ignore[call-arg]
+        )

--- a/traigent/config_generator/catalog/tvar_catalog.v1.json
+++ b/traigent/config_generator/catalog/tvar_catalog.v1.json
@@ -353,5 +353,399 @@
     "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch on cfg['repair_policy']: 'off' returns the first generation, 'sqlite_error_once' retries once when SQLite reports an error, and 'sqlite_error_or_empty_once' retries once on error or empty result. Add eval coverage for each policy. NOTE: apply_config() only inserts the decorator + imports; retry handling remains your code.",
     "status": "active",
     "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.repo_context_strategy.v1",
+    "schema_version": "1.0.0",
+    "name": "repo_context_strategy",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "issue_locality_first",
+        "focused_search",
+        "call_graph_plus_tests",
+        "repo_index"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "agent_computer_interface",
+    "reasoning": "External software-engineering-agent literature reports that agent-computer interface design affects issue-fix success, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:swe_agent_neurips_2024+swe_bench_iclr_2024",
+        "metric": "software_engineering_task_success",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_agent_interface",
+        "candidate": "agent_computer_interface_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch repository navigation on cfg['repo_context_strategy']: 'issue_locality_first' starts from issue-linked files, 'focused_search' searches targeted symbols and errors, 'call_graph_plus_tests' expands along callers/tests, and 'repo_index' uses a broader repository index. Validate on held-out issue-fix tasks. CVAR vocabulary for a future catalog version: confidence_to_edit and min_test_signal. Public type proposal: software_engineering_agent is intentionally not added to agent_types; this row remains on code_gen until that type is accepted.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.file_view_window.v1",
+    "schema_version": "1.0.0",
+    "name": "file_view_window",
+    "range_type": "IntRange",
+    "range_kwargs": {
+      "low": 50,
+      "high": 400,
+      "default": 120
+    },
+    "kind": "value",
+    "effectuation_status": "manual_guidance",
+    "category": "agent_computer_interface",
+    "reasoning": "External software-engineering-agent literature suggests interface context size affects edit quality, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:swe_agent_neurips_2024+swe_bench_iclr_2024",
+        "metric": "software_engineering_task_success",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_agent_interface",
+        "candidate": "file_view_window_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, read cfg['file_view_window'] as the number of surrounding lines or equivalent file-view budget exposed to the coding agent. Keep the baseline window in evals and measure patch acceptance plus regression rate. CVAR vocabulary for a future catalog version: confidence_to_edit and min_test_signal. Public type proposal: software_engineering_agent is intentionally not added to agent_types; this row remains on code_gen until that type is accepted.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.edit_granularity.v1",
+    "schema_version": "1.0.0",
+    "name": "edit_granularity",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "minimal_patch",
+        "function_scope",
+        "file_scope",
+        "multi_file_plan"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "agent_computer_interface",
+    "reasoning": "External software-engineering-agent literature suggests the edit interface shape affects task success, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:swe_agent_neurips_2024+swe_bench_iclr_2024",
+        "metric": "software_engineering_task_success",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_agent_interface",
+        "candidate": "edit_granularity_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch patch planning on cfg['edit_granularity']: 'minimal_patch' constrains edits to the smallest diff, 'function_scope' edits one function-level unit, 'file_scope' permits one file, and 'multi_file_plan' requires an explicit plan before multi-file changes. CVAR vocabulary for a future catalog version: confidence_to_edit and min_test_signal. Public type proposal: software_engineering_agent is intentionally not added to agent_types; this row remains on code_gen until that type is accepted.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.test_selection_strategy.v1",
+    "schema_version": "1.0.0",
+    "name": "test_selection_strategy",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "none",
+        "focused_changed_files",
+        "related_unit_tests",
+        "full_regression_budgeted"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "agent_computer_interface",
+    "reasoning": "External software-engineering-agent literature and SWE-bench-style tasks emphasize test feedback, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:swe_agent_neurips_2024+swe_bench_iclr_2024",
+        "metric": "software_engineering_task_success",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_agent_interface",
+        "candidate": "test_selection_strategy_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch validation on cfg['test_selection_strategy']: 'none' skips test execution, 'focused_changed_files' runs tests local to changed files, 'related_unit_tests' expands to likely related units, and 'full_regression_budgeted' runs the largest suite allowed by the budget. CVAR vocabulary for a future catalog version: confidence_to_edit and min_test_signal. Public type proposal: software_engineering_agent is intentionally not added to agent_types; this row remains on code_gen until that type is accepted.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "code_gen.patch_review_mode.v1",
+    "schema_version": "1.0.0",
+    "name": "patch_review_mode",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "off",
+        "self_review",
+        "diff_then_test_review",
+        "reviewer_agent"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "agent_computer_interface",
+    "reasoning": "External software-engineering-agent literature suggests review loops can affect patch quality, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "code_gen"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:swe_agent_neurips_2024+swe_bench_iclr_2024",
+        "metric": "software_engineering_task_success",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_agent_interface",
+        "candidate": "patch_review_mode_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch post-edit review on cfg['patch_review_mode']: 'off' returns the patch directly, 'self_review' asks the same agent to inspect its diff, 'diff_then_test_review' reviews both diff and test output, and 'reviewer_agent' invokes a separate reviewer. CVAR vocabulary for a future catalog version: confidence_to_edit and min_test_signal. Public type proposal: software_engineering_agent is intentionally not added to agent_types; this row remains on code_gen until that type is accepted.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "rag.context_selection_policy.v1",
+    "schema_version": "1.0.0",
+    "name": "context_selection_policy",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "similarity",
+        "recency",
+        "hybrid_relevance",
+        "evidence_first"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "context_budget",
+    "reasoning": "Lost-in-the-Middle reports that relevant information is used less robustly in long contexts, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "rag"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:lost_in_the_middle_tacl_2024",
+        "metric": "long_context_answer_quality",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_context_selection",
+        "candidate": "context_selection_policy_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch retrieval/context assembly on cfg['context_selection_policy']: 'similarity' ranks by vector score, 'recency' favors fresh items, 'hybrid_relevance' blends scores, and 'evidence_first' prioritizes directly supporting passages. CVAR vocabulary for a future catalog version: evidence_coverage_min and max_context_tokens.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "rag.context_order.v1",
+    "schema_version": "1.0.0",
+    "name": "context_order",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "relevance_desc",
+        "primacy_recency",
+        "question_then_evidence",
+        "key_evidence_edges"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "context_budget",
+    "reasoning": "Lost-in-the-Middle reports position sensitivity in long-context use, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "medium",
+    "agent_types": [
+      "rag"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:lost_in_the_middle_tacl_2024",
+        "metric": "long_context_answer_quality",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "unstructured_context_ordering",
+        "candidate": "context_order_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch context layout on cfg['context_order']: 'relevance_desc' sorts by rank, 'primacy_recency' places important evidence near beginning and end, 'question_then_evidence' places the query before evidence, and 'key_evidence_edges' anchors the strongest passages at context boundaries. CVAR vocabulary for a future catalog version: evidence_coverage_min and max_context_tokens.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "rag.summary_style.v1",
+    "schema_version": "1.0.0",
+    "name": "summary_style",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "none",
+        "extractive_bullets",
+        "claim_evidence_pairs",
+        "abstractive_brief"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "context_budget",
+    "reasoning": "Long-context evidence suggests context packaging can affect answer quality, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "rag"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:lost_in_the_middle_tacl_2024",
+        "metric": "long_context_answer_quality",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "raw_context",
+        "candidate": "summary_style_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch compression on cfg['summary_style']: 'none' keeps source text, 'extractive_bullets' keeps quoted key facts, 'claim_evidence_pairs' pairs each claim with support, and 'abstractive_brief' rewrites a short context brief. CVAR vocabulary for a future catalog version: evidence_coverage_min and max_context_tokens.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "rag.compression_ratio.v1",
+    "schema_version": "1.0.0",
+    "name": "compression_ratio",
+    "range_type": "Range",
+    "range_kwargs": {
+      "low": 0.2,
+      "high": 1.0,
+      "default": 0.5
+    },
+    "kind": "value",
+    "effectuation_status": "manual_guidance",
+    "category": "context_budget",
+    "reasoning": "Long-context evidence suggests budget and placement affect answer quality, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "rag"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:lost_in_the_middle_tacl_2024",
+        "metric": "long_context_answer_quality",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "uncompressed_context",
+        "candidate": "compression_ratio_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, read cfg['compression_ratio'] as the fraction of original retrieved content to retain before answer generation. Evaluate both answer support and cost, and keep an uncompressed baseline. CVAR vocabulary for a future catalog version: evidence_coverage_min and max_context_tokens.",
+    "status": "active",
+    "version": "1.0.0"
+  },
+  {
+    "entry_id": "rag.citation_policy.v1",
+    "schema_version": "1.0.0",
+    "name": "citation_policy",
+    "range_type": "Choices",
+    "range_kwargs": {
+      "values": [
+        "none",
+        "source_ids",
+        "inline_spans",
+        "claim_level"
+      ]
+    },
+    "kind": "policy",
+    "effectuation_status": "manual_guidance",
+    "category": "context_budget",
+    "reasoning": "Long-context evidence motivates preserving support structure, but Traigent has not measured a catalog delta for this row.",
+    "impact_estimate": "low",
+    "agent_types": [
+      "rag"
+    ],
+    "evidence_refs": [
+      {
+        "scope": "external_paper:lost_in_the_middle_tacl_2024",
+        "metric": "long_context_answer_quality",
+        "n": 0,
+        "model": "paper_reported",
+        "baseline": "no_citation_policy",
+        "candidate": "citation_policy_knob",
+        "delta": null,
+        "limitations": [
+          "external_paper_not_traigent_measured",
+          "not_catalog_metric_delta"
+        ]
+      }
+    ],
+    "apply_guidance": "Manual wiring: after `cfg = traigent.get_config()`, branch answer formatting on cfg['citation_policy']: 'none' emits no citations, 'source_ids' appends source identifiers, 'inline_spans' marks exact supporting spans, and 'claim_level' requires support per claim. CVAR vocabulary for a future catalog version: evidence_coverage_min and max_context_tokens.",
+    "status": "active",
+    "version": "1.0.0"
   }
 ]

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -64,6 +64,7 @@ __all__ = [
     "self_refine",
     "react_tool_loop",
     "verification_gate",
+    "moe",
 ]
 
 #: §3.10 standard telemetry measure names, per constructor kind. Content-free:
@@ -669,4 +670,101 @@ def verification_gate(
         members=dict(members or {}),
         provenance=prov,
         telemetry_names=_TELEMETRY[CompositeKind.LOOP],
+    )
+
+
+def moe(
+    name: str,
+    *,
+    experts: tuple[str, ...],
+    aggregate: str = "vote",
+    judge_stage: str | None = None,
+    accept_threshold: str | None = None,
+    expert_tuned_params: tuple[tuple[str, ...], ...] | None = None,
+    judge_tuned_params: tuple[str, ...] = (),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Ensemble(arms=[stage(expert_1)..stage(expert_m)], aggregate, committee)``.
+
+    Mixture-of-experts is the committee form of an ensemble: each distinct
+    expert stage contributes one representative candidate, then aggregation is
+    either majority vote or ``judge_max``. Sampling-form cardinality is
+    deliberately absent; use ``self_consistency``/``best_of_n`` for repeated
+    draws from one generator.
+    """
+    if (
+        not isinstance(experts, tuple)
+        or len(experts) < 2
+        or any(not isinstance(expert, str) or not expert for expert in experts)
+    ):
+        raise ValueError("moe experts must be at least two non-empty stage names")
+    if len(set(experts)) != len(experts):
+        raise ValueError("moe experts must be distinct")
+
+    if aggregate not in {"vote", "judge"}:
+        raise ValueError("moe aggregate must be 'vote' or 'judge'")
+    if expert_tuned_params is None:
+        expert_tuned_params = tuple(() for _ in experts)
+    elif len(expert_tuned_params) != len(experts):
+        raise ValueError(
+            "invalid_tuned_param: expert_tuned_params must declare exactly one "
+            f"tuple per expert (got {len(expert_tuned_params)} for "
+            f"{len(experts)} expert(s)); omit expert_tuned_params entirely to "
+            "leave all experts undeclared"
+        )
+
+    if aggregate == "vote":
+        if judge_stage is not None:
+            raise ValueError("aggregate='vote' forbids judge_stage")
+        if judge_tuned_params:
+            raise ValueError("aggregate='vote' forbids judge_tuned_params")
+        aggregate_decl = AggregateDecl(
+            kind=AggregateKind.MAJORITY_VOTE,
+            accept=(
+                AcceptDecl(stat=StatKind.VOTE_MARGIN, threshold=accept_threshold)
+                if accept_threshold is not None
+                else None
+            ),
+        )
+    else:
+        if not isinstance(judge_stage, str) or not judge_stage:
+            raise ValueError("aggregate='judge' requires judge_stage")
+        if judge_stage in experts:
+            raise ValueError("aggregate='judge' judge_stage must be distinct")
+        if accept_threshold is not None:
+            raise ValueError("aggregate='judge' does not support accept_threshold")
+        aggregate_decl = AggregateDecl(
+            kind=AggregateKind.JUDGE_MAX,
+            judge=StageArm(judge_stage, judge_tuned_params),
+        )
+
+    params = {
+        "name": name,
+        "experts": list(experts),
+        "aggregate": aggregate,
+        "judge_stage": judge_stage,
+        "accept_threshold": accept_threshold,
+        "expert_tuned_params": [list(tp) for tp in expert_tuned_params],
+        "judge_tuned_params": list(judge_tuned_params),
+    }
+    prov = _provenance("moe", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.ENSEMBLE,
+        body=EnsembleBody(
+            arms=tuple(
+                StageArm(expert, expert_tuned_params[i])
+                for i, expert in enumerate(experts)
+            ),
+            aggregate=aggregate_decl,
+            cardinality=None,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.ENSEMBLE],
     )

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -544,6 +544,13 @@ def react_tool_loop(
     algebra has no cost stop/gate or mid-loop budget hook, so this factory does
     not enforce cost stopping. Add a future cost-stop proposal before making
     that claim.
+
+    CALIBRATION RECIPE:
+    - CVAR ``tool_confidence_min`` binds ``calibration.signal`` to this
+      factory's ``signal`` arg.
+    - Target ``P(accepted state meets task target | sigma >= theta) >= p``
+      over held-out ReAct trajectories.
+    - ``depends_on`` must cover the body stage TVARs.
     """
     params = {
         "name": name,
@@ -620,6 +627,13 @@ def verification_gate(
     verifier-pass plus improvement/contradiction thresholds on one loop
     decision, or a tuned structural repair bound such as ``max_repair_rounds``;
     ``max_iters`` is the literal IR bound.
+
+    CALIBRATION RECIPE:
+    - CVAR ``verifier_pass_threshold`` binds ``calibration.signal`` to
+      ``verifier_signal``.
+    - Target ``P(accepted output satisfies verification target |
+      verifier_pass_score >= theta) >= p`` over held-out generate-verify
+      trajectories.
     """
     if contradiction_score_max is not None:
         raise ValueError(
@@ -693,18 +707,27 @@ def moe(
     either majority vote or ``judge_max``. Sampling-form cardinality is
     deliberately absent; use ``self_consistency``/``best_of_n`` for repeated
     draws from one generator.
+
+    CALIBRATION RECIPE:
+    - CVAR ``accept_threshold`` (vote form only) binds
+      ``calibration.signal='vote_margin'``.
+    - Target ``P(majority output correct | vote_margin >= theta) >= p`` with
+      all experts run once per item.
+    - ``depends_on`` covers all expert ``tuned_params``.
     """
     if (
         not isinstance(experts, tuple)
         or len(experts) < 2
         or any(not isinstance(expert, str) or not expert for expert in experts)
     ):
-        raise ValueError("moe experts must be at least two non-empty stage names")
+        raise ValueError(
+            "committee_arity: moe requires at least two non-empty expert stage names"
+        )
     if len(set(experts)) != len(experts):
-        raise ValueError("moe experts must be distinct")
+        raise ValueError("duplicate_stage: moe experts must be distinct")
 
     if aggregate not in {"vote", "judge"}:
-        raise ValueError("moe aggregate must be 'vote' or 'judge'")
+        raise ValueError("invalid_aggregate: moe aggregate must be 'vote' or 'judge'")
     if expert_tuned_params is None:
         expert_tuned_params = tuple(() for _ in experts)
     elif len(expert_tuned_params) != len(experts):
@@ -717,9 +740,14 @@ def moe(
 
     if aggregate == "vote":
         if judge_stage is not None:
-            raise ValueError("aggregate='vote' forbids judge_stage")
+            raise ValueError(
+                "aggregate_argument_mismatch: aggregate='vote' forbids judge_stage"
+            )
         if judge_tuned_params:
-            raise ValueError("aggregate='vote' forbids judge_tuned_params")
+            raise ValueError(
+                "aggregate_argument_mismatch: aggregate='vote' forbids "
+                "judge_tuned_params"
+            )
         aggregate_decl = AggregateDecl(
             kind=AggregateKind.MAJORITY_VOTE,
             accept=(
@@ -730,11 +758,18 @@ def moe(
         )
     else:
         if not isinstance(judge_stage, str) or not judge_stage:
-            raise ValueError("aggregate='judge' requires judge_stage")
+            raise ValueError(
+                "aggregate_argument_mismatch: aggregate='judge' requires judge_stage"
+            )
         if judge_stage in experts:
-            raise ValueError("aggregate='judge' judge_stage must be distinct")
+            raise ValueError(
+                "duplicate_stage: aggregate='judge' judge_stage must be distinct"
+            )
         if accept_threshold is not None:
-            raise ValueError("aggregate='judge' does not support accept_threshold")
+            raise ValueError(
+                "aggregate_argument_mismatch: aggregate='judge' does not support "
+                "accept_threshold"
+            )
         aggregate_decl = AggregateDecl(
             kind=AggregateKind.JUDGE_MAX,
             judge=StageArm(judge_stage, judge_tuned_params),
@@ -808,6 +843,13 @@ def router(
     adequate signal selects its arm; an abstaining signal routes onward; a
     malformed or raising signal is an absorbing runtime error. The terminal arm
     is ungated.
+
+    CALIBRATION RECIPE:
+    - Each ``thresholds[i]`` CVAR is route-conditional:
+      ``calibration.signal=signals[i]``.
+    - Target ``P(arm_i adequate | sigma_i(x) >= theta_i) >= p`` on a
+      calibration split, verified on a held-out route-validation split.
+    - ``signal_inputs[i]`` must be freshness-covered.
     """
     if len(signals) != len(thresholds):
         raise ValueError(
@@ -881,6 +923,13 @@ def fallback(
     disagreement-based escalation; with the theta=0.0 convention leaf arms
     NEVER escalate. v1 fallback is no_accept-triggered, NOT error-triggered;
     errors stay absorbing.
+
+    CALIBRATION RECIPE:
+    - Each ``thresholds[i]`` CVAR is a margin-floor CVAR with
+      ``calibration.signal='vote_margin'``.
+    - The ``theta=0.0`` convention makes the margin gate inert so ONLY
+      ``no_accept`` escalates.
+    - Any ``theta > 0`` turns it into an ordinary margin cascade.
     """
     if tuned_params is None:
         tuned_params = tuple(() for _ in arms)

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -62,6 +62,7 @@ __all__ = [
     "self_consistency",
     "self_debug",
     "self_refine",
+    "react_tool_loop",
 ]
 
 #: §3.10 standard telemetry measure names, per constructor kind. Content-free:
@@ -486,6 +487,83 @@ def self_refine(
             ),
             state_keys=state_keys,
             max_iters=max_iters,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.LOOP],
+    )
+
+
+def react_tool_loop(
+    name: str,
+    *,
+    stage: str,
+    signal: str,
+    tool_confidence_min: str,
+    max_tool_calls: int,
+    state_keys: tuple[str, ...] = (
+        "scratchpad",
+        "tool_calls",
+        "observations",
+        "confidence",
+        "last_error",
+    ),
+    signal_inputs: tuple[str, ...] = (
+        "scratchpad",
+        "tool_calls",
+        "observations",
+        "confidence",
+        "last_error",
+    ),
+    stage_tuned_params: tuple[str, ...] = (
+        "planner_style",
+        "tool_allowlist",
+        "observation_format",
+        "failure_handler",
+    ),
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Loop(body=stage(a), state_keys, stop=signal_accept(tool_confidence, θ), max_iters=K)``.
+
+    A catalog ReAct-style tool loop over the existing loop algebra only. Each
+    body invocation is assumed to perform at most one ReAct tool step, so
+    ``max_tool_calls`` maps to the sealed IR's literal ``max_iters`` bound. If
+    the opaque stage performs multiple tool calls per invocation, this is a
+    max-ReAct-iterations bound, not a precise tool-call cap.
+
+    ``tool_cost_cap`` is deliberately not part of this expansion: the current
+    algebra has no cost stop/gate or mid-loop budget hook, so this factory does
+    not enforce cost stopping. Add a future cost-stop proposal before making
+    that claim.
+    """
+    params = {
+        "name": name,
+        "stage": stage,
+        "signal": signal,
+        "tool_confidence_min": tool_confidence_min,
+        "max_tool_calls": max_tool_calls,
+        "state_keys": list(state_keys),
+        "signal_inputs": list(signal_inputs),
+        "stage_tuned_params": list(stage_tuned_params),
+    }
+    prov = _provenance("react_tool_loop", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.LOOP,
+        body=LoopBody(
+            body=StageArm(stage, stage_tuned_params),
+            stop=StopDecl(
+                kind=StopKind.SIGNAL_ACCEPT,
+                threshold=tool_confidence_min,
+                signal=SignalUse(signal=signal, inputs=signal_inputs),
+            ),
+            state_keys=state_keys,
+            max_iters=max_tool_calls,
         ),
         provenance=prov,
     )

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -63,6 +63,7 @@ __all__ = [
     "self_debug",
     "self_refine",
     "react_tool_loop",
+    "verification_gate",
 ]
 
 #: §3.10 standard telemetry measure names, per constructor kind. Content-free:
@@ -564,6 +565,101 @@ def react_tool_loop(
             ),
             state_keys=state_keys,
             max_iters=max_tool_calls,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_TELEMETRY[CompositeKind.LOOP],
+    )
+
+
+def verification_gate(
+    name: str,
+    *,
+    stage: str,
+    verifier_signal: str,
+    verifier_pass_threshold: str,
+    verification_style: str,
+    verification_question_count: str,
+    verifier_model: str,
+    independent_context: str,
+    revision_policy: str,
+    max_iters: int = 2,
+    state_keys: tuple[str, ...] = (
+        "draft",
+        "verification_questions",
+        "verification_answers",
+        "verifier_pass_score",
+        "contradiction_score",
+        "revision",
+        "independent_context",
+    ),
+    signal_inputs: tuple[str, ...] = (
+        "draft",
+        "verification_answers",
+        "independent_context",
+    ),
+    contradiction_score_max: str | None = None,
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """CoVe-style verifier loop: ``signal_accept(verifier_signal, θ)``.
+
+    This is a loop-family catalog macro over the sealed IR: the stage produces
+    threaded verification state, then the verifier signal accepts when
+    ``verifier_signal(state) >= verifier_pass_threshold``. Exhaustion yields
+    the runtime's ordinary ``no_accept`` result.
+
+    Not expressible in v1: a simultaneous ``contradiction_score_max`` stop, dual
+    verifier-pass plus improvement/contradiction thresholds on one loop
+    decision, or a tuned structural repair bound such as ``max_repair_rounds``;
+    ``max_iters`` is the literal IR bound.
+    """
+    if contradiction_score_max is not None:
+        raise ValueError(
+            "unsupported_compound_stop: verification_gate cannot express "
+            "contradiction_score_max until the loop IR supports compound stop "
+            "decisions"
+        )
+
+    stage_tuned_params = (
+        verification_style,
+        verification_question_count,
+        verifier_model,
+        independent_context,
+        revision_policy,
+    )
+    params = {
+        "name": name,
+        "stage": stage,
+        "verifier_signal": verifier_signal,
+        "verifier_pass_threshold": verifier_pass_threshold,
+        "verification_style": verification_style,
+        "verification_question_count": verification_question_count,
+        "verifier_model": verifier_model,
+        "independent_context": independent_context,
+        "revision_policy": revision_policy,
+        "max_iters": max_iters,
+        "state_keys": list(state_keys),
+        "signal_inputs": list(signal_inputs),
+        "contradiction_score_max": contradiction_score_max,
+    }
+    prov = _provenance("verification_gate", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.LOOP,
+        body=LoopBody(
+            body=StageArm(stage, stage_tuned_params),
+            stop=StopDecl(
+                kind=StopKind.SIGNAL_ACCEPT,
+                threshold=verifier_pass_threshold,
+                signal=SignalUse(signal=verifier_signal, inputs=signal_inputs),
+            ),
+            state_keys=state_keys,
+            max_iters=max_iters,
         ),
         provenance=prov,
     )

--- a/traigent/knobs/patterns.py
+++ b/traigent/knobs/patterns.py
@@ -58,7 +58,9 @@ __all__ = [
     "KChainStage",
     "best_of_n",
     "binary_cascade",
+    "fallback",
     "n_cascade",
+    "router",
     "self_consistency",
     "self_debug",
     "self_refine",
@@ -767,4 +769,152 @@ def moe(
         members=dict(members or {}),
         provenance=prov,
         telemetry_names=_TELEMETRY[CompositeKind.ENSEMBLE],
+    )
+
+
+def _telemetry_names_for(node: CompositeNode) -> tuple[str, ...]:
+    """Return the declared standard telemetry tuple for a concrete shape."""
+    if node.kind is CompositeKind.CASCADE:
+        body = node.body
+        if not isinstance(body, CascadeBody):  # pragma: no cover - IR guarded
+            raise ValueError(
+                "unknown_composite_field: cascade telemetry requires CascadeBody"
+            )
+        cascade_by_placement = {
+            Placement.POST: _TELEMETRY[CompositeKind.CASCADE],
+            Placement.PRE: (
+                "route_selected",
+                "dispatch_signal_margin",
+                "gate_signal_adequate",
+            ),
+        }
+        return cascade_by_placement[body.placement]
+    return _TELEMETRY[node.kind]
+
+
+def router(
+    name: str,
+    *,
+    arms: tuple[str, ...],
+    signals: tuple[str, ...],
+    thresholds: tuple[str, ...],
+    tuned_params: tuple[tuple[str, ...], ...] | None = None,
+    signal_inputs: tuple[tuple[str, ...], ...] | None = None,
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Cascade(arms=[stage(a_i)], gates=[signal_below σ_i θ_i], pre)``.
+
+    Dispatch evaluates gates left-to-right before any arm runs. The first
+    adequate signal selects its arm; an abstaining signal routes onward; a
+    malformed or raising signal is an absorbing runtime error. The terminal arm
+    is ungated.
+    """
+    if len(signals) != len(thresholds):
+        raise ValueError(
+            "cascade_arity: router requires exactly one signal per threshold "
+            f"(got {len(signals)} signal(s) for {len(thresholds)} threshold(s))"
+        )
+    if tuned_params is None:
+        tuned_params = tuple(() for _ in arms)
+    elif len(tuned_params) != len(arms):
+        raise ValueError(
+            "invalid_tuned_param: tuned_params must declare exactly one tuple "
+            f"per arm (got {len(tuned_params)} for {len(arms)} arm(s)); omit "
+            "tuned_params entirely to leave all arms undeclared"
+        )
+    if signal_inputs is None:
+        signal_inputs = tuple(() for _ in signals)
+    elif len(signal_inputs) != len(signals):
+        raise ValueError(
+            "invalid_signal_use: signal_inputs must declare exactly one tuple "
+            f"per signal (got {len(signal_inputs)} for {len(signals)} signal(s))"
+        )
+
+    params = {
+        "name": name,
+        "arms": list(arms),
+        "signals": list(signals),
+        "thresholds": list(thresholds),
+        "tuned_params": [list(tp) for tp in tuned_params],
+        "signal_inputs": [list(inputs) for inputs in signal_inputs],
+    }
+    prov = _provenance("router", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.CASCADE,
+        body=CascadeBody(
+            arms=tuple(StageArm(arm, tuned_params[i]) for i, arm in enumerate(arms)),
+            gates=tuple(
+                GateDecl(
+                    kind=GateKind.SIGNAL_BELOW,
+                    threshold=threshold,
+                    signal=SignalUse(signal=signals[i], inputs=signal_inputs[i]),
+                )
+                for i, threshold in enumerate(thresholds)
+            ),
+            placement=Placement.PRE,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_telemetry_names_for(structure),
+    )
+
+
+def fallback(
+    name: str,
+    *,
+    arms: tuple[str, ...],
+    thresholds: tuple[str, ...],
+    tuned_params: tuple[tuple[str, ...], ...] | None = None,
+    members: dict[str, Knob[Any]] | None = None,
+) -> CompositeKnob:
+    """``Cascade(arms=[stage(a_i)], gates=[margin_below θ_i], post)``.
+
+    A leaf StageRunner cannot signal failure. Non-terminal arms that need to
+    fall back must be no_accept-capable (a nested composite with an accept
+    threshold) OR use real margin thresholds (theta > 0) for
+    disagreement-based escalation; with the theta=0.0 convention leaf arms
+    NEVER escalate. v1 fallback is no_accept-triggered, NOT error-triggered;
+    errors stay absorbing.
+    """
+    if tuned_params is None:
+        tuned_params = tuple(() for _ in arms)
+    elif len(tuned_params) != len(arms):
+        raise ValueError(
+            "invalid_tuned_param: tuned_params must declare exactly one tuple "
+            f"per arm (got {len(tuned_params)} for {len(arms)} arm(s)); omit "
+            "tuned_params entirely to leave all arms undeclared"
+        )
+
+    params = {
+        "name": name,
+        "arms": list(arms),
+        "thresholds": list(thresholds),
+        "tuned_params": [list(tp) for tp in tuned_params],
+    }
+    prov = _provenance("fallback", params)
+    structure = CompositeNode(
+        name=name,
+        kind=CompositeKind.CASCADE,
+        body=CascadeBody(
+            arms=tuple(StageArm(arm, tuned_params[i]) for i, arm in enumerate(arms)),
+            gates=tuple(
+                GateDecl(kind=GateKind.MARGIN_BELOW, threshold=threshold)
+                for threshold in thresholds
+            ),
+            placement=Placement.POST,
+        ),
+        provenance=prov,
+    )
+    return CompositeKnob(
+        name=name,
+        structure=structure,
+        members=dict(members or {}),
+        provenance=prov,
+        telemetry_names=_telemetry_names_for(structure),
     )

--- a/traigent/knobs/runtime.py
+++ b/traigent/knobs/runtime.py
@@ -816,14 +816,22 @@ def _execute_cascade(
 
 
 class _SignalRaised(Exception):
-    """A pre-gate signal RAISED — the §3.2 absorbing-error case (NOT inadequate).
+    """A pre-gate signal produced an ABSORBING ERROR — fails the item (§3.2.1).
 
-    §3.2 is explicit and DELIBERATELY asymmetric with the loop ``signal_accept``
-    stop: an absent/abstaining/non-numeric signal VALUE is *inadequate* (route
-    onward — fail-toward-the-stronger-arm), but a signal that *raises* fails the
-    item's evaluation (never silently routes), feeding the fail-closed law under
-    strict modes. This wrapper carries the original exception's detail so the
-    dispatch driver can map it to a fail-closed ``error`` result.
+    Carries the three malformed-signal cases that fail the item's evaluation
+    (never silently routing), feeding the fail-closed law under strict modes:
+
+    1. the signal *raised* an exception;
+    2. the signal returned a ``bool`` or non-numeric value (a malformed score is
+       a defect, not an abstention);
+    3. the signal returned a non-finite ``float`` (NaN/±inf — it cannot enter the
+       §3.2.1 finite ``σ ≥ θ`` comparison).
+
+    All three are at PARITY with the loop ``signal_accept`` stop (runtime.py
+    ~1587-1593), which likewise raises on bool/non-numeric/non-finite. The ONLY
+    abstention §3.2 permits is a signal returning ``None`` (absent VALUE →
+    inadequate → route onward), which is NOT carried here. This wrapper holds the
+    detail so the dispatch driver can map it to a fail-closed ``error`` result.
     """
 
     def __init__(self, detail: str) -> None:
@@ -844,19 +852,31 @@ def _dispatch_adequate(
     - ``adequate`` is ``σ(x) ≥ θ`` — selecting arm ``i``;
     - ``sigma`` / ``theta`` are the resolved finite values when the gate was
       evaluated numerically (for the §3.10 ``dispatch_signal_margin``);
-      ``sigma`` is ``None`` when the signal abstained (absent/None/non-numeric/
-      non-finite — INADEQUATE per §3.2, route onward), in which case ``theta``
-      is still returned for symmetry but the margin is not emitted.
+      ``sigma`` is ``None`` only when the signal ABSTAINED — i.e. it returned
+      ``None`` (the signal id maps to an absent VALUE). An abstention is
+      INADEQUATE per §3.2 (route onward, "absent/abstaining signal value is
+      INADEQUATE"); ``theta`` is still returned for symmetry but no margin is
+      emitted.
 
     The signal is invoked with the dispatch input ``config`` (the item/config
     payload the stages receive) as a SINGLE positional argument — the SAME
     one-argument convention the ``signal_accept`` loop stop uses, with the
     dispatch payload instead of the threaded loop state. ``SignalUse.inputs``
     for a pre-gate is an opaque calibration/freshness declaration (§3.2 item 11
-    ``signal_inputs``), NOT a runtime input filter, so it never narrows what the
-    signal observes (mirrors the loop's documented note).
+    ``signal_inputs`` / §3.5 ctx_ext binding), NOT a runtime input filter, so it
+    never narrows what the signal observes (mirrors the loop's documented note).
 
-    A missing/non-finite threshold raises (a calibration defect → ``error`` at
+    VALUE rules (parity with the loop ``signal_accept`` stop, §3.2.1 finite
+    comparison law — "comparisons are over finite numbers ... never a silent
+    comparison"):
+
+    - ``None`` → ABSTENTION → inadequate, route onward (§3.2 explicit license);
+    - ``bool`` or any non-numeric (str/dict/...) → RAISE (a malformed score is a
+      defect, not an abstention) — absorbing ``error`` at the caller;
+    - a non-finite ``float`` (NaN/±inf) → RAISE — a non-finite σ cannot enter the
+      finite ``σ ≥ θ`` comparison; it is a malformed score, never a silent route.
+
+    A missing/non-finite THRESHOLD raises (a calibration defect → ``error`` at
     the caller, exactly as POST does). A signal that RAISES is the §3.2
     absorbing-error case (re-raised as :class:`_SignalRaised`).
     """
@@ -876,15 +896,22 @@ def _dispatch_adequate(
     except Exception as exc:  # noqa: BLE001 - a RAISING signal is absorbing (§3.2)
         raise _SignalRaised(f"{type(exc).__name__}: {exc}") from exc
 
-    # An absent/abstaining/non-numeric value is INADEQUATE (§3.2): route onward,
-    # NEVER an error. bool is not a number (parity with the §3.10 measure rule).
-    if raw is None or isinstance(raw, bool) or not isinstance(raw, (int, float)):
+    # None ABSTAINS (§3.2: absent/abstaining value is INADEQUATE → route onward).
+    if raw is None:
         return False, None, theta
+    # A bool/non-numeric value is a MALFORMED SCORE, not an abstention: fail
+    # closed (parity with the loop signal_accept rule, runtime.py ~1587). bool is
+    # not a number (parity with the §3.10 measure rule).
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise _SignalRaised(
+            f"signal {signal_id!r} must return a finite number or None, got {raw!r}"
+        )
     sigma = float(raw)
     if not math.isfinite(sigma):
-        # A non-finite σ cannot satisfy ``σ ≥ θ``; treat as abstaining (§3.2
-        # fail-toward-the-stronger-arm), NOT an error.
-        return False, None, theta
+        # A non-finite σ cannot enter the §3.2.1 finite ``σ ≥ θ`` comparison;
+        # it is a malformed score → absorbing error (parity with the loop,
+        # runtime.py ~1592), NOT a silent fail-toward-the-stronger-arm route.
+        raise _SignalRaised(f"signal {signal_id!r} returned non-finite {sigma!r}")
     return sigma >= theta, sigma, theta
 
 
@@ -974,9 +1001,13 @@ def _execute_pre_cascade(
     evaluated); all gates inadequate → the terminal fallback arm ``m``. Exactly
     ONE arm executes. Semantics:
 
-    - an absent/abstaining/non-numeric/non-finite signal VALUE is INADEQUATE —
-      routing continues to the next gate / terminal arm (§3.2
-      fail-toward-the-stronger-arm), NEVER an error;
+    - a signal returning ``None`` ABSTAINS (absent VALUE) → INADEQUATE: routing
+      continues to the next gate / terminal arm (§3.2 explicit license:
+      "absent/abstaining signal value is INADEQUATE"), NEVER an error;
+    - a signal returning ``bool``/non-numeric/non-finite is a MALFORMED SCORE →
+      absorbing ``error`` (a malformed score is a defect, not an abstention) —
+      parity with the loop ``signal_accept`` stop and the §3.2.1 finite-
+      comparison law; no arm executes;
     - a signal that RAISES is the §3.2 absorbing ``error`` — no arm executes;
     - a reached gate's missing/non-finite THRESHOLD is a calibration defect →
       ``error`` (fail closed, exactly as POST);
@@ -995,7 +1026,8 @@ def _execute_pre_cascade(
                 gate, config, calibrated_values, signals
             )
         except _SignalRaised as raised:
-            # §3.2: a signal that RAISES fails the item (absorbing error).
+            # §3.2.1: a signal that RAISES, or returns a malformed score
+            # (bool/non-numeric/non-finite), fails the item (absorbing error).
             return _error(f"composite-runtime: {raised.detail}")
         except Exception as exc:  # noqa: BLE001 - missing/non-finite θ -> error
             return _error(f"composite-runtime: {type(exc).__name__}: {exc}")

--- a/traigent/knobs/runtime.py
+++ b/traigent/knobs/runtime.py
@@ -1,8 +1,10 @@
 """The composite EXECUTION runtime — the full §3.2 algebra (RFC 0002).
 
-This module executes EVERY ``placement: post`` composite kind end-to-end:
-the post-cascade (cross-referenced as RFC 0001 §3.8), the ensemble (sampling
-and committee forms, ``majority_vote`` / ``judge_max``), and the loop
+This module executes EVERY composite kind end-to-end: the post-cascade
+(cross-referenced as RFC 0001 §3.8), the PRE-cascade dispatch/router (§3.2
+``route(x) = arm_j where j = min({i < m : σ_i(x) ≥ θ_i} ∪ {m})`` — left-to-right
+gates, first-match-wins, exactly one terminal-like arm runs), the ensemble
+(sampling and committee forms, ``majority_vote`` / ``judge_max``), and the loop
 (``signal_accept`` / ``external_accept`` / ``exhausted`` stops), closed under
 nested-composite arms, plus the §3.8 K-chain unroll executor.
 
@@ -766,12 +768,17 @@ def _execute_cascade(
     signals: Mapping[str, Callable[..., Any]],
     predicates: Mapping[str, Callable[..., Any]],
 ) -> CompositeRunResult:
-    """Execute one post-cascade body for one item (§3.2 / §3.2.1)."""
-    if body.placement is not Placement.POST:
-        raise NotImplementedError(
-            f"composite-runtime: pre-cascade (dispatch) execution is deferred to "
-            f"a follow-up packet (composite {node.name!r}); this packet executes "
-            "the post-cascade kind only"
+    """Execute one cascade body for one item (§3.2 / §3.2.1).
+
+    Dispatches on placement: ``post`` runs the §3.8 escalation cascade (the
+    fast :class:`CascadePolicy` path, or the manual driver when a GATED
+    nested-composite arm needs the nested arm's own vote); ``pre`` runs the
+    §3.2 dispatch (router) executor — gates score the input LEFT TO RIGHT,
+    first match wins, exactly one routed arm runs (terminal-like).
+    """
+    if body.placement is Placement.PRE:
+        return _execute_pre_cascade(
+            node, body, stages, registry, config, calibrated_values, signals, predicates
         )
 
     # F1: a GATED nested-composite arm needs the manual driver (the gate must
@@ -799,6 +806,235 @@ def _execute_cascade(
         output=step.output,
         result_kind=ResultKind.OUTPUT,
         measures=_cascade_measures(step, body),
+        error=None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Pre-cascade DISPATCH execution (§3.2 routing; the router path)              #
+# --------------------------------------------------------------------------- #
+
+
+class _SignalRaised(Exception):
+    """A pre-gate signal RAISED — the §3.2 absorbing-error case (NOT inadequate).
+
+    §3.2 is explicit and DELIBERATELY asymmetric with the loop ``signal_accept``
+    stop: an absent/abstaining/non-numeric signal VALUE is *inadequate* (route
+    onward — fail-toward-the-stronger-arm), but a signal that *raises* fails the
+    item's evaluation (never silently routes), feeding the fail-closed law under
+    strict modes. This wrapper carries the original exception's detail so the
+    dispatch driver can map it to a fail-closed ``error`` result.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _dispatch_adequate(
+    gate: Any,
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+) -> tuple[bool, float | None, float | None]:
+    """Evaluate ONE pre-gate against the dispatch input (§3.2 ``σ_i(x) ≥ θ_i``).
+
+    Returns ``(adequate, sigma, theta)``:
+
+    - ``adequate`` is ``σ(x) ≥ θ`` — selecting arm ``i``;
+    - ``sigma`` / ``theta`` are the resolved finite values when the gate was
+      evaluated numerically (for the §3.10 ``dispatch_signal_margin``);
+      ``sigma`` is ``None`` when the signal abstained (absent/None/non-numeric/
+      non-finite — INADEQUATE per §3.2, route onward), in which case ``theta``
+      is still returned for symmetry but the margin is not emitted.
+
+    The signal is invoked with the dispatch input ``config`` (the item/config
+    payload the stages receive) as a SINGLE positional argument — the SAME
+    one-argument convention the ``signal_accept`` loop stop uses, with the
+    dispatch payload instead of the threaded loop state. ``SignalUse.inputs``
+    for a pre-gate is an opaque calibration/freshness declaration (§3.2 item 11
+    ``signal_inputs``), NOT a runtime input filter, so it never narrows what the
+    signal observes (mirrors the loop's documented note).
+
+    A missing/non-finite threshold raises (a calibration defect → ``error`` at
+    the caller, exactly as POST does). A signal that RAISES is the §3.2
+    absorbing-error case (re-raised as :class:`_SignalRaised`).
+    """
+    # θ is read LIVE and fails closed on missing/non-finite (calibration defect).
+    theta = _resolve_threshold(gate.threshold, calibrated_values)
+
+    signal_use = gate.signal  # presence guaranteed by IR (signal_below requires it)
+    signal_id = signal_use.signal
+    # The signal is preflighted into the registry (fail-closed); guard anyway.
+    if signal_id not in signals:  # pragma: no cover - preflight short-circuits
+        raise ValueError(
+            f"signal {signal_id!r} is not provided (fail-closed: a missing "
+            "dispatch signal fails the item's evaluation)"
+        )
+    try:
+        raw = signals[signal_id](config)
+    except Exception as exc:  # noqa: BLE001 - a RAISING signal is absorbing (§3.2)
+        raise _SignalRaised(f"{type(exc).__name__}: {exc}") from exc
+
+    # An absent/abstaining/non-numeric value is INADEQUATE (§3.2): route onward,
+    # NEVER an error. bool is not a number (parity with the §3.10 measure rule).
+    if raw is None or isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return False, None, theta
+    sigma = float(raw)
+    if not math.isfinite(sigma):
+        # A non-finite σ cannot satisfy ``σ ≥ θ``; treat as abstaining (§3.2
+        # fail-toward-the-stronger-arm), NOT an error.
+        return False, None, theta
+    return sigma >= theta, sigma, theta
+
+
+def _run_routed_arm(
+    arm: Arm,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> _ArmOutcome:
+    """Execute the routed arm — TERMINAL-like (§3.2.1: its result IS final).
+
+    A stage arm runs exactly like a non-gated cascade arm (a routed stage is
+    never feeding a gate — routing already decided — so a non-voting
+    representative is fine; a key_fn'd stage still votes for its representative).
+    A nested-composite arm runs its OWN §3.2 semantics (any kind), mirroring the
+    POST terminal-nested branch — the dispatch restriction "gated arms must be
+    margin-bearing" does NOT apply because a PRE-routed arm is terminal, never
+    gated. The arm's ``no_accept`` becomes the cascade's ``no_accept`` (NO
+    re-route) and its ``error`` is absorbing — both surfaced via
+    :class:`_ArmOutcome.kind`.
+    """
+    if isinstance(arm, StageArm):
+        # gated=False: the routed stage feeds no gate (routing already decided).
+        return _evaluate_stage_arm(arm, stages, gated=False, config=config)
+    inner = _execute_node(
+        registry[arm.ref],
+        stages,
+        registry,
+        config,
+        calibrated_values,
+        signals,
+        predicates,
+    )
+    return _ArmOutcome(
+        output=inner.output,
+        vote=None,
+        kind=inner.result_kind,
+        error=inner.error,
+    )
+
+
+def _pre_cascade_measures(
+    selected: int,
+    adequacy: dict[int, int],
+    selected_margin: float | None,
+) -> dict[str, Any]:
+    """The §3.10 pre-cascade (dispatch) telemetry — content-free.
+
+    - ``route_selected``: the selected arm index (ALWAYS emitted);
+    - ``gate_signal_adequate``: an INDEX-keyed ``{i: 0|1}`` map of per-gate
+      adequacy for every EVALUATED gate (gates not reached — beyond the
+      selected arm — are absent, never a false 0);
+    - ``dispatch_signal_margin``: ``σ_sel − θ_sel``, emitted ONLY when a GATED
+      arm was selected (``selected_margin is not None``); OMITTED for terminal
+      fall-through (no gate selected the terminal arm).
+    """
+    measures: dict[str, Any] = {
+        "route_selected": selected,
+        "gate_signal_adequate": adequacy,
+    }
+    if selected_margin is not None:
+        measures["dispatch_signal_margin"] = selected_margin
+    return measures
+
+
+def _execute_pre_cascade(
+    node: CompositeNode,
+    body: CascadeBody,
+    stages: Mapping[str, StageEntry],
+    registry: Mapping[str, CompositeNode],
+    config: Mapping[str, Any],
+    calibrated_values: Mapping[str, float | int],
+    signals: Mapping[str, Callable[..., Any]],
+    predicates: Mapping[str, Callable[..., Any]],
+) -> CompositeRunResult:
+    """Execute one pre-cascade (dispatch) body for one item (§3.2 / §3.2.1).
+
+    The §3.2 dispatch law::
+
+        route(x) = arm_j  where  j = min({ i < m : σ_i(x) ≥ θ_i } ∪ {m})
+
+    Gates are evaluated LEFT TO RIGHT on the dispatch input ``config``; the
+    FIRST adequate gate selects its arm and STOPS (no other gate is even
+    evaluated); all gates inadequate → the terminal fallback arm ``m``. Exactly
+    ONE arm executes. Semantics:
+
+    - an absent/abstaining/non-numeric/non-finite signal VALUE is INADEQUATE —
+      routing continues to the next gate / terminal arm (§3.2
+      fail-toward-the-stronger-arm), NEVER an error;
+    - a signal that RAISES is the §3.2 absorbing ``error`` — no arm executes;
+    - a reached gate's missing/non-finite THRESHOLD is a calibration defect →
+      ``error`` (fail closed, exactly as POST);
+    - the routed arm is TERMINAL: its ``no_accept`` is the cascade's
+      ``no_accept`` (NO re-route, §3.2.1) and its ``error`` is absorbing.
+    """
+    gates = body.gates
+    last = len(body.arms) - 1  # the terminal fallback arm index (m)
+    adequacy: dict[int, int] = {}
+    selected_index = last
+    selected_margin: float | None = None
+
+    for index, gate in enumerate(gates):
+        try:
+            adequate, sigma, theta = _dispatch_adequate(
+                gate, config, calibrated_values, signals
+            )
+        except _SignalRaised as raised:
+            # §3.2: a signal that RAISES fails the item (absorbing error).
+            return _error(f"composite-runtime: {raised.detail}")
+        except Exception as exc:  # noqa: BLE001 - missing/non-finite θ -> error
+            return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+        adequacy[index] = 1 if adequate else 0
+        if adequate:
+            selected_index = index
+            # σ and θ are both finite here (adequate implies a numeric σ).
+            selected_margin = float(sigma) - float(theta)  # type: ignore[arg-type]
+            break
+
+    # Exactly the selected arm executes (the routed arm is TERMINAL-like).
+    try:
+        outcome = _run_routed_arm(
+            body.arms[selected_index],
+            stages,
+            registry,
+            config,
+            calibrated_values,
+            signals,
+            predicates,
+        )
+    except Exception as exc:  # noqa: BLE001 - error is absorbing (§3.2.1)
+        return _error(f"composite-runtime: {type(exc).__name__}: {exc}")
+
+    measures = _pre_cascade_measures(selected_index, adequacy, selected_margin)
+
+    if outcome.kind is ResultKind.ERROR:
+        return _error(
+            outcome.error
+            or f"composite-runtime: routed arm {selected_index} failed (no detail)"
+        )
+    if outcome.kind is ResultKind.NO_ACCEPT:
+        # §3.2.1: the routed arm's no_accept IS the cascade's no_accept — routing
+        # selects the arm; it does NOT re-route on non-acceptance.
+        return _no_accept(measures)
+    return CompositeRunResult(
+        output=outcome.output,
+        result_kind=ResultKind.OUTPUT,
+        measures=measures,
         error=None,
     )
 
@@ -1597,6 +1833,18 @@ def _preflight_reachable(
                         f"provided for composite {node.name!r} (fail-closed: a "
                         "missing predicate fails the item's evaluation)"
                     )
+        elif isinstance(body, CascadeBody) and body.placement is Placement.PRE:
+            # A pre-cascade (dispatch) gate's routing signal must be in the
+            # registry FAIL-CLOSED — a missing dispatch signal fails the item's
+            # evaluation BEFORE any arm runs, mirroring the signal_accept stop
+            # preflight (the IR guarantees a signal_below gate carries a signal).
+            for gate in body.gates:
+                if gate.signal is not None and gate.signal.signal not in signals:
+                    return _error(
+                        f"composite-runtime: signal {gate.signal.signal!r} is not "
+                        f"provided for composite {node.name!r} (fail-closed: a "
+                        "missing dispatch signal fails the item's evaluation)"
+                    )
 
         # Recurse into every present nested composite ref (missing refs already
         # short-circuited above, so every ref here resolves).
@@ -1722,9 +1970,11 @@ def execute_composite(
         §3.2.1 algebra tag and whose ``measures`` is the §3.10 telemetry.
 
     Raises:
-        NotImplementedError: for a ``placement: pre`` cascade or a
-            nested-composite LOOP body — each named explicitly (deferred, never
-            faked). Every other deferral has been replaced by tested behavior.
+        NotImplementedError: for a nested-composite LOOP body — the one
+            remaining v1 deferral, named explicitly (never faked). The
+            ``placement: pre`` cascade (dispatch/router) now executes
+            end-to-end; every other deferral has been replaced by tested
+            behavior.
     """
     sigs: Mapping[str, Callable[..., Any]] = signals or {}
     preds: Mapping[str, Callable[..., Any]] = predicates or {}

--- a/traigent/knobs/runtime.py
+++ b/traigent/knobs/runtime.py
@@ -34,8 +34,10 @@ The result codomain is the §3.2.1 algebra (closed, total, disjoint), named once
 Telemetry (:attr:`CompositeRunResult.measures`) is the §3.10 content-free dict,
 per kind:
 
-- cascade: ``escalation_rate``, ``stage_selected``, per-gate (INDEX-keyed)
+- post-cascade: ``escalation_rate``, ``stage_selected``, per-gate (INDEX-keyed)
   ``gate_margin_pass_rate``;
+- pre-cascade dispatch/router: ``route_selected``, ``gate_signal_adequate``,
+  and, on gated selection, ``dispatch_signal_margin``;
 - ensemble: ``vote_agreement``, ``vote_margin``, ``candidates_evaluated``,
   ``candidates_excluded``;
 - loop: ``iterations_used``, ``stop_reason`` (enum over StopDecl kinds).


### PR DESCRIPTION
## Composite-knob catalog v2 — dispatch execution + 5 generic patterns + knob packs

Owner-directed program: enough **generic, repeating composite patterns** that an agent (e.g. Claude Code with the traigent-skills) can instrument a client codebase and boost it. Companion skills PR: Traigent/traigent-skills#3.

### What ships

**Pre-cascade (dispatch) execution** — the deferred `placement: pre` path in `traigent/knobs/runtime.py` per RFC 0002 §3.2: first-match-wins `route(x)=arm_j, j=min({i: σᵢ(x)≥θᵢ} ∪ {m})`, exactly one arm executes; `None` = abstention routes onward (the §3.2 license); bool/non-numeric/non-finite signal values **fail closed** (absorbing ERROR, loop parity); fail-closed preflight for missing dispatch signals; telemetry `route_selected` / `dispatch_signal_margin` (gated selection only) / `gate_signal_adequate`.

**Five catalog factories** (each satisfying the RFC 0002 §3.7 six-point admission contract — sealed-algebra expansion, closed provenance + P8 canary, calibration recipe in docstring, truthful telemetry, byte-stable golden test, fail-closed admission coverage):
- `router` — pre-cascade dispatch (placement-keyed telemetry: declares exactly what the runtime emits)
- `fallback` — no_accept-triggered chain (docstring states plainly: NOT error-triggered; leaf arms cannot signal failure)
- `moe` — committee ensemble of heterogeneous experts (vote/judge, `judge_tuned_params`, prefix-coded validation)
- `react_tool_loop` — ReAct-bounded tool loop (`tool_cost_cap` documented-not-enforced; `max_tool_calls` = literal loop bound)
- `verification_gate` — CoVe-style loop (verifier-fed signal_accept; `contradiction_score_max` rejects `unsupported_compound_stop`)

**Knob packs** — 10 TVar catalog rows (agent_computer_interface → `code_gen`, context-budget → `rag`) with external-paper evidence (`delta: null` → honest `low` confidence); CVAR vocabulary in `apply_guidance` only; **no new agent_types** (recorded as future public-API expansion).

**Examples** — 4 new runnable offline examples under `examples/advanced/composite-knobs/`.

### Review chain (codex gpt-5.5 xhigh; captain probes interleaved)

| Stage | Verdict |
|---|---|
| 4 independent design sessions | captain-reviewed; verification_gate re-familied cascade→loop on IR evidence; ToT rejected from catalog (needs 4th constructor — handoff) |
| Pre-cascade executor round 1 | REJECT (2 BLOCKER + 2 MAJOR) → 1 real (B2 fail-open malformed σ, fixed red-first), 3 adjudicated as shipped-convention parity (captain probes), pinned |
| Pre-cascade round 2 | **ACCEPT** (incl. numpy/Decimal/complex edge probes) |
| Full-range cross-review | REJECT (4 MAJOR + 1 MINOR: missing docstring recipes, moe prose errors, moe admission-coverage gap, example run docs, stale runtime docstring) → all fixed |
| Full-range confirmation | **ACCEPT** (incl. reviewer mutation test: dropping moe's AcceptDecl fails the new admission tests) |

### Verification (captain-run, main worktree, full xdist)
`tests/unit/knobs/ + tests/unit/config_generator/` → **680 passed**; `tests/unit/evaluators/ + core/ + cloud/` → **3,686 passed, 3 skipped**; all 5 examples execute; telemetry-truthfulness probe: every factory declares exactly what the runtime emits.

### PR checklist
1. **Worst-case prod path** — composites are opt-in declarations; the dispatch executor fails closed on malformed signals/thresholds/missing registry entries; errors absorbing per §3.2.1. No policy surface touched.
2. **Production-branch test** — n/a (no production gating added); fail-closed behavior pinned by `TestPreCascadeDispatch` (23 tests) incl. preflight fail-closed.
3. **Contract regeneration** — none: no wire/schema change (telemetry rides the existing measures channel). JS parity deferred & recorded (JS has no composite execution).
4. **Public surface delta** — `traigent.knobs.patterns.__all__` +5 factories; recommendations catalog +10 rows on EXISTING agent types (`list_recommendation_agent_types()` unchanged, pinned by test). Docs + skills match runtime.
5. **Review threads resolved** — to be confirmed pre-merge (Rule 8 sweep).
6. **Quality gates not relaxed** — none touched; the 2 adjusted catalog-pin tests enumerate the new rows by exact id (extension, not relaxation).

RFC 0002 follow-ups (10 items: placement-dependent §3.10 names, §3.2 inputs wording, telemetry-on-error, nested measures, error-fallback, ToT `search` constructor, cost-stops, compound stops, tuned bounds, catalog-v2 shapes) banked in the program handoff for the tvl/spine session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
