### PR TITLE
fix(evaluators): invoke custom scoring/metric functions per documented contract

### DIFF
--- a/tests/unit/evaluators/test_local_evaluator_accuracy.py
+++ b/tests/unit/evaluators/test_local_evaluator_accuracy.py
@@ -1,7 +1,16 @@
 import pytest
 
+import traigent
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.evaluators.local import LocalEvaluator
+
+
+def _disable_backend_tracking(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+    monkeypatch.setattr(
+        "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client",
+        staticmethod(lambda _config: None),
+    )
 
 
 @pytest.mark.asyncio
@@ -136,3 +145,91 @@ async def test_local_evaluator_paraphrases_pass_with_user_supplied_semantic_scor
     assert result.metrics is not None
     # With a user-supplied semantic-style scorer, paraphrases pass.
     assert result.metrics.get("accuracy") == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_optimize_scoring_function_called_with_prediction_expected_plain_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_backend_tracking(monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    def scorer(prediction: str, expected: str) -> float:
+        calls.append((prediction, expected))
+        return 0.75 if prediction == expected else 0.0
+
+    @traigent.optimize(
+        eval_dataset=Dataset([EvaluationExample({"text": "q"}, "YES")], name="g4"),
+        objectives=["accuracy"],
+        configuration_space={"style": ["a", "b"]},
+        scoring_function=scorer,
+    )
+    def agent(text: str) -> str:
+        return "YES"
+
+    result = await agent.optimize(algorithm="grid", max_trials=2)
+
+    assert calls == [("YES", "YES"), ("YES", "YES")]
+    assert result.best_score == pytest.approx(0.75)
+    assert len(result.trials) == 2
+    assert all(
+        trial.metrics["accuracy"] == pytest.approx(0.75)
+        for trial in result.trials
+    )
+
+
+@pytest.mark.asyncio
+async def test_optimize_scoring_function_uses_unpacked_tuple_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_backend_tracking(monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    def scorer(prediction: str, expected: str) -> float:
+        calls.append((prediction, expected))
+        return 0.4 if prediction == expected else 0.0
+
+    @traigent.optimize(
+        eval_dataset=Dataset([EvaluationExample({"text": "q"}, "YES")], name="g4"),
+        objectives=["accuracy"],
+        configuration_space={"style": ["a"]},
+        scoring_function=scorer,
+    )
+    def agent(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", {"user_metric": 1.0}
+
+    result = await agent.optimize(algorithm="grid", max_trials=1)
+
+    assert calls == [("YES", "YES")]
+    assert result.best_score == pytest.approx(0.4)
+    assert result.trials[0].metrics["accuracy"] == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_optimize_three_argument_metric_function_receives_metrics_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_backend_tracking(monkeypatch)
+    calls: list[tuple[str, str, float]] = []
+
+    def scorer(prediction: str, expected: str, metrics: dict[str, float]) -> float:
+        calls.append((prediction, expected, metrics["total_tokens"]))
+        return 0.6 if prediction == expected and "total_tokens" in metrics else 0.0
+
+    @traigent.optimize(
+        eval_dataset=Dataset([EvaluationExample({"text": "q"}, "YES")], name="g4"),
+        objectives=["accuracy"],
+        configuration_space={"style": ["a"]},
+        metric_functions={"accuracy": scorer},
+    )
+    def agent(text: str) -> str:
+        return "YES"
+
+    result = await agent.optimize(algorithm="grid", max_trials=1)
+
+    assert len(calls) == 1
+    prediction, expected, total_tokens = calls[0]
+    assert (prediction, expected) == ("YES", "YES")
+    assert total_tokens == pytest.approx(2.0)
+    assert result.best_score == pytest.approx(0.6)
+    assert result.trials[0].metrics["accuracy"] == pytest.approx(0.6)

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -36,6 +36,23 @@ from traigent.utils.logging import get_logger
 logger = get_logger(__name__)
 _METADATA_PATCHES_ATTEMPTED = False
 
+_OUTPUT_METRIC_PARAM_NAMES = {
+    "actual",
+    "actual_output",
+    "output",
+    "prediction",
+    "predicted",
+    "result",
+}
+_EXPECTED_METRIC_PARAM_NAMES = {
+    "expected",
+    "expected_output",
+    "ground_truth",
+    "reference",
+    "target",
+}
+_LLM_METRIC_PARAM_NAMES = {"llm_metrics", "metrics"}
+
 
 @dataclass
 class PromptInfo:
@@ -579,6 +596,50 @@ class LocalEvaluator(BaseEvaluator):
                 float(value) if value is not None else 0.0
             )
 
+    def _build_metric_keyword_arguments(
+        self,
+        parameters: list[inspect.Parameter],
+        output: Any,
+        example_obj: Any,
+        config: dict[str, Any],
+        llm_payload: dict[str, Any],
+        example_index: int,
+    ) -> dict[str, Any]:
+        keyword_values: dict[str, Any] = {
+            "example": example_obj,
+            "input_data": example_obj.input_data,
+            "metadata": example_obj.metadata or {},
+            "config": config,
+            "example_index": example_index,
+        }
+        for name in _OUTPUT_METRIC_PARAM_NAMES:
+            keyword_values[name] = output
+        for name in _EXPECTED_METRIC_PARAM_NAMES:
+            keyword_values[name] = example_obj.expected_output
+        for name in _LLM_METRIC_PARAM_NAMES:
+            keyword_values[name] = llm_payload
+
+        kwargs: dict[str, Any] = {}
+        accepts_arbitrary_kwargs = False
+        for parameter in parameters:
+            if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                accepts_arbitrary_kwargs = True
+                continue
+            if parameter.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.VAR_POSITIONAL,
+            ):
+                continue
+            if parameter.name in keyword_values:
+                kwargs[parameter.name] = keyword_values[parameter.name]
+
+        if accepts_arbitrary_kwargs:
+            kwargs.setdefault("output", output)
+            kwargs.setdefault("expected", example_obj.expected_output)
+            kwargs.setdefault("llm_metrics", llm_payload)
+
+        return kwargs
+
     def _invoke_metric_function(
         self,
         metric_func: Callable[..., Any],
@@ -604,27 +665,44 @@ class LocalEvaluator(BaseEvaluator):
             Metric value or 0.0 on failure
         """
         try:
-            params = inspect.signature(metric_func).parameters.keys()
-            kwargs: dict[str, Any] = {}
+            signature = inspect.signature(metric_func)
+            parameters = list(signature.parameters.values())
+            positional_args = (output, example_obj.expected_output, llm_payload)
+            call_candidates: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
 
-            if "output" in params or "actual" in params:
-                kwargs["output"] = output
-            if "expected" in params:
-                kwargs["expected"] = example_obj.expected_output
-            if "example" in params:
-                kwargs["example"] = example_obj
-            if "input_data" in params:
-                kwargs["input_data"] = example_obj.input_data
-            if "metadata" in params:
-                kwargs["metadata"] = example_obj.metadata or {}
-            if "config" in params:
-                kwargs["config"] = config
-            if "llm_metrics" in params:
-                kwargs["llm_metrics"] = llm_payload
-            if "example_index" in params:
-                kwargs["example_index"] = example_index
+            if any(
+                parameter.kind is inspect.Parameter.VAR_POSITIONAL
+                for parameter in parameters
+            ):
+                call_candidates.append((positional_args, {}))
 
-            return cast(float, metric_func(**kwargs))
+            kwargs = self._build_metric_keyword_arguments(
+                parameters, output, example_obj, config, llm_payload, example_index
+            )
+            if kwargs:
+                call_candidates.append(((), kwargs))
+
+            call_candidates.extend(
+                [
+                    (positional_args, {}),
+                    (positional_args[:2], {}),
+                    (positional_args[:1], {}),
+                    ((), {}),
+                ]
+            )
+
+            bind_error: TypeError | None = None
+            for args, candidate_kwargs in call_candidates:
+                try:
+                    signature.bind(*args, **candidate_kwargs)
+                except TypeError as exc:
+                    bind_error = exc
+                    continue
+                return cast(float, metric_func(*args, **candidate_kwargs))
+
+            if bind_error is not None:
+                raise bind_error
+            return cast(float, metric_func(output, example_obj.expected_output))
         except Exception as exc:
             example_id = (
                 example_obj.metadata.get("example_id", f"example_{example_index}")


### PR DESCRIPTION
## Summary

Fixes #1176 — a documented decorator parameter silently did nothing: with a custom `scoring_function`, the scorer was never called and every trial reported `accuracy=0.0` while the run was actually correct.

**Root cause** (`traigent/evaluators/local.py`, `_invoke_metric_function`): kwargs were built only for a fixed set of recognized parameter names and the function was called as `metric_func(**kwargs)`. The documented `(prediction, expected)` shape got only `expected=...` → `TypeError` before the scorer body ran → blanket `except` → logged warning + silent `0.0`. A `*args` probe matched no names → invoked with zero positional args (exactly the issue's observation). The 3-arg `metric_functions` form hit the same catch-and-zero path. Tuple `(output, metrics)` returns were unpacked correctly upstream — they were zeroed by this same invocation bug, not a separate one.

**Fix:**
- alias maps for output-like (`prediction`, `predicted`, `actual`, `result`, `actual_output`), expected-like (`expected_output`, `ground_truth`, `target`, `reference`) and metrics-payload (`metrics`, `llm_metrics`) parameter names
- signature-bound candidate invocation: `*args` callables receive `(output, expected, llm_metrics)`; named params get matching keywords; positional fallbacks `(output, expected, llm_metrics)` / `(output, expected)` / `(output)` cover undocumented names
- also fixes the latent bug where a parameter literally named `actual` was passed as `output=` and never bound

**Compatibility invariant:** every previously-working signature receives identical values; only previously-broken (silently zero-scoring) shapes change behavior. Genuinely unbindable signatures (e.g. ≥4 unrecognized required params) keep the pre-existing warn-and-0.0 semantics rather than aborting a run mid-flight; all documented forms now bind and execute.

## Verification (captain-reviewed, fails-before checked)

- Issue repro before fix: `calls == []`, `best_score == 0.0`; after fix: `calls == [('YES','YES'),('YES','YES')]`, `best_score == 0.75` with scorer returning 0.75.
- 3 new regression tests track scorer invocations and assert trial accuracy equals the scorer's **distinctive** return (0.75 / 0.4 / 0.6 — deliberately ≠ built-in 1.0) for plain return, tuple return, and 3-arg `metric_functions`. **Fails-before verified**: with the `local.py` change stashed, exactly these 3 fail.
- Evaluator metric-flow cluster: 45/45 pass (incl. tuple-metrics channel hardening rounds 3/4).
- Full `tests/unit`: **13,158 passed**; 6 failures adjudicated against pristine develop — 5 are pre-existing on develop (effectuation catalog ×2, privacy/hybrid submission ×3, e.g. `_DummyBackend.finalize_session_sync() got an unexpected keyword argument 'certified_selection'`), 1 (`test_concurrent_auth_operations_performance`) is a load-sensitive stress test that passes solo and with its whole file (9/9) under the fix.
- pre-commit (isort/black/ruff/mypy/bandit/contract checks) all pass.

## Out of scope (issue's related minor finding)

The `execution_mode` validation-registry disagreement (decorator rejects `'local'`, runtime rejects `'standard'`) is untouched — follow-up issue to be filed and linked here.

## PR checklist

1. **Worst-case prod path** — local-evaluation scoring path only; no auth/billing/tenant surface. Failure semantics unchanged for user-function runtime errors (warn + 0.0, now actually reachable per contract).
2. **Production-branch test** — n/a (no policy branch).
3. **Contract regeneration** — none; no schema/API shape change. JS-SDK parity check: this is a Python-local evaluator invocation bug; traigent-js scorer wiring is separate code (no shared contract change).
4. **Public surface delta** — none (behavioral fix of an already-documented parameter).
5. **Review threads** — will resolve before merge.
6. **Quality gates** — none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)