### PR TITLE
fix(selection): multi-objective best_config tie-breaks on secondary objectives by default; tie-aware success-filtered results table; honest success rate

### DIFF
--- a/tests/unit/api/test_api_types.py
+++ b/tests/unit/api/test_api_types.py
@@ -176,6 +176,17 @@ class TestTrialResult:
         )
         assert not pruned_result.is_successful
 
+        zero_success_result = TrialResult(
+            trial_id="z1",
+            config={},
+            metrics={"accuracy": 0.0},
+            status=TrialStatus.COMPLETED,
+            duration=0.5,
+            timestamp=datetime.now(),
+            metadata={"successful_examples": 0, "examples_attempted": 20},
+        )
+        assert not zero_success_result.is_successful
+
     def test_get_metric(self):
         """Test get_metric method."""
         result = TrialResult(
@@ -399,6 +410,76 @@ class TestOptimizationResult:
         )
 
         assert result.success_rate == 2 / 3  # 2 successful out of 3
+
+    def test_success_rate_excludes_completed_zero_success_trials(self):
+        """Regression #1183: completed 0/20 trials are not successes."""
+        trials = [
+            TrialResult(
+                trial_id="all_errored",
+                config={"model": "legacy"},
+                metrics={"accuracy": 0.0, "cost": 0.0},
+                status=TrialStatus.COMPLETED,
+                duration=0.5,
+                timestamp=datetime.now(),
+                metadata={"successful_examples": 0, "examples_attempted": 20},
+            )
+        ]
+        result = OptimizationResult(
+            trials=trials,
+            best_config={},
+            best_score=None,
+            optimization_id="opt_zero_success",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime.now(),
+        )
+
+        assert result.success_rate == 0.0
+        assert result.successful_trials == []
+
+    def test_success_rate_reports_five_of_eight_when_three_all_errored(self):
+        trials = [
+            TrialResult(
+                trial_id=f"ok_{i}",
+                config={"model": f"ok-{i}"},
+                metrics={"accuracy": 1.0},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=datetime.now(),
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+            )
+            for i in range(5)
+        ]
+        trials.extend(
+            TrialResult(
+                trial_id=f"errored_{i}",
+                config={"model": f"legacy-{i}"},
+                metrics={"accuracy": 0.0, "cost": 0.0},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=datetime.now(),
+                metadata={"successful_examples": 0, "examples_attempted": 20},
+            )
+            for i in range(3)
+        )
+
+        result = OptimizationResult(
+            trials=trials,
+            best_config={"model": "ok-0"},
+            best_score=1.0,
+            optimization_id="opt_mixed_success",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime.now(),
+        )
+
+        assert result.success_rate == pytest.approx(5 / 8)
 
     def test_success_rate_empty_trials(self):
         """Test success_rate with no trials."""

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -741,6 +741,42 @@ class TestOptimizationOrchestrator:
         assert ranking["non_successful_count"] == 1
         assert ranking["eligible_count"] == 1
 
+    def test_create_optimization_result_success_rate_excludes_all_errored_trials(
+        self, orchestrator
+    ):
+        """Regression #1183: 3 all-errored completed trials yield 5/8."""
+        trials = [
+            TrialResult(
+                trial_id=f"ok_{i}",
+                config={"param1": i},
+                metrics={"accuracy": 1.0},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=datetime.now(UTC),
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+            )
+            for i in range(5)
+        ]
+        trials.extend(
+            TrialResult(
+                trial_id=f"errored_{i}",
+                config={"param1": i + 5},
+                metrics={"accuracy": 0.0, "cost": 0.0},
+                status=TrialStatus.COMPLETED,
+                duration=0.1,
+                timestamp=datetime.now(UTC),
+                metadata={"successful_examples": 0, "examples_attempted": 20},
+            )
+            for i in range(3)
+        )
+        orchestrator._trials = trials
+        orchestrator._status = OptimizationStatus.COMPLETED
+
+        result = orchestrator._create_optimization_result()
+
+        assert result.convergence_info["successful_trials"] == 5
+        assert result.convergence_info["success_rate"] == pytest.approx(5 / 8)
+
     def test_create_optimization_result_with_empty_objectives(self, orchestrator):
         """RED before the fix: objectives-free runs (a supported BaseOptimizer
         mode — weighted scoring disabled) hit an unguarded objectives[0] at

--- a/tests/unit/core/test_promotion_gate_integration.py
+++ b/tests/unit/core/test_promotion_gate_integration.py
@@ -3,19 +3,14 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from traigent.api.types import TrialResult, TrialStatus
 from traigent.core.orchestrator import OptimizationOrchestrator
 from traigent.evaluators.base import BaseEvaluator
 from traigent.optimizers.base import BaseOptimizer
 from traigent.tvl.models import PromotionPolicy
-from traigent.tvl.promotion_gate import (
-    ObjectiveSpec,
-    PromotionGate,
-)
+from traigent.tvl.promotion_gate import ObjectiveSpec, PromotionGate
 
 
 class _MockOptimizer(BaseOptimizer):
@@ -178,6 +173,36 @@ class TestPromotionGateIntegration:
             timestamp=datetime.now(UTC),
         )
         assert orchestrator._simple_is_better(trial3) is False
+
+    def test_simple_is_better_tie_breaks_on_declared_secondary_objective(self) -> None:
+        """Equal primary scores promote the lower-cost multi-objective trial."""
+        optimizer = _MockOptimizer()
+        optimizer.objectives = ["accuracy", "cost"]
+        orchestrator = OptimizationOrchestrator(
+            optimizer=optimizer,
+            evaluator=_MockEvaluator(),
+            max_trials=3,
+        )
+        incumbent = TrialResult(
+            trial_id="trial_1",
+            config={"x": 1},
+            metrics={"accuracy": 1.0, "cost": 0.00020},
+            status=TrialStatus.COMPLETED,
+            duration=0.1,
+            timestamp=datetime.now(UTC),
+        )
+        candidate = TrialResult(
+            trial_id="trial_2",
+            config={"x": 2},
+            metrics={"accuracy": 1.0, "cost": 0.00001},
+            status=TrialStatus.COMPLETED,
+            duration=0.1,
+            timestamp=datetime.now(UTC),
+        )
+
+        orchestrator._best_trial_cached = incumbent
+
+        assert orchestrator._simple_is_better(candidate) is True
 
     def test_evaluate_promotion_without_gate(self) -> None:
         """Test promotion evaluation falls back to simple comparison without gate."""

--- a/tests/unit/core/test_result_selection.py
+++ b/tests/unit/core/test_result_selection.py
@@ -395,10 +395,16 @@ class TestSelectBestConfigurationWithTieBreakers:
         assert result.best_config["model"] in ["A", "B", "C"]
 
     def test_no_tie_breaker_returns_first_tied(self) -> None:
-        """Without tie-breakers, first tied trial is returned."""
+        """Single-objective ties keep the historic first-wins behavior."""
         trials = [
-            FakeTrial(metrics={"accuracy": 0.9}, config={"model": "A"}),
-            FakeTrial(metrics={"accuracy": 0.9}, config={"model": "B"}),
+            FakeTrial(
+                metrics={"accuracy": 0.9, "cost": 0.2},
+                config={"model": "A"},
+            ),
+            FakeTrial(
+                metrics={"accuracy": 0.9, "cost": 0.1},
+                config={"model": "B"},
+            ),
         ]
 
         result = select_best_configuration(
@@ -407,10 +413,109 @@ class TestSelectBestConfigurationWithTieBreakers:
             config_space_keys={"model"},
             aggregate_configs=False,
             tie_breakers=None,  # No tie-breaker
+            objective_order=["accuracy"],
         )
 
-        # Should return first in list
         assert result.best_config["model"] == "A"
+
+    @pytest.mark.parametrize("aggregate_configs", [False, True])
+    def test_default_multi_objective_tie_breaks_equal_accuracy_on_lowest_cost(
+        self, aggregate_configs: bool
+    ) -> None:
+        """Regression #1184: equal primary accuracy picks the cheapest trial."""
+        costs = [0.00020, 0.00001, 0.00002, 0.00011]
+        trials = [
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": cost},
+                config={"model": f"m{i}", "cost": cost},
+            )
+            for i, cost in enumerate(costs, start=1)
+        ]
+
+        result = select_best_configuration(
+            trials=trials,
+            primary_objective="accuracy",
+            config_space_keys={"model", "cost"},
+            aggregate_configs=aggregate_configs,
+            tie_breakers=None,
+            objective_order=["accuracy", "cost"],
+        )
+
+        assert result.best_config["cost"] == pytest.approx(0.00001)
+        assert result.best_trial_id == trials[1].trial_id
+
+    def test_default_tie_break_follows_declared_objective_order(self) -> None:
+        trials = [
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": 0.00001, "latency": 1000.0},
+                config={"model": "low-cost-high-latency"},
+            ),
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": 0.00002, "latency": 1.0},
+                config={"model": "higher-cost-low-latency"},
+            ),
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": 0.00001, "latency": 10.0},
+                config={"model": "low-cost-low-latency"},
+            ),
+        ]
+
+        result = select_best_configuration(
+            trials=trials,
+            primary_objective="accuracy",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            tie_breakers=None,
+            objective_order=["accuracy", "cost", "latency"],
+        )
+
+        assert result.best_config["model"] == "low-cost-low-latency"
+
+    def test_primary_near_ties_use_secondary_objective(self) -> None:
+        trials = [
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": 0.00020},
+                config={"model": "slightly-higher-accuracy"},
+            ),
+            FakeTrial(
+                metrics={"accuracy": 0.9999999999995, "cost": 0.00001},
+                config={"model": "near-tied-cheaper"},
+            ),
+        ]
+
+        result = select_best_configuration(
+            trials=trials,
+            primary_objective="accuracy",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            tie_breakers=None,
+            objective_order=["accuracy", "cost"],
+        )
+
+        assert result.best_config["model"] == "near-tied-cheaper"
+
+    def test_explicit_custom_tie_breaker_takes_precedence_over_default(self) -> None:
+        trials = [
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": 0.00020},
+                config={"model": "first"},
+            ),
+            FakeTrial(
+                metrics={"accuracy": 1.0, "cost": 0.00001},
+                config={"model": "cheaper"},
+            ),
+        ]
+
+        result = select_best_configuration(
+            trials=trials,
+            primary_objective="accuracy",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            tie_breakers={"accuracy": "custom"},
+            objective_order=["accuracy", "cost"],
+        )
+
+        assert result.best_config["model"] == "first"
 
     def test_tie_breaker_only_applied_to_ties(self) -> None:
         """Tie-breaker should only affect trials with equal best scores."""

--- a/tests/unit/core/test_trial_result_factory.py
+++ b/tests/unit/core/test_trial_result_factory.py
@@ -143,7 +143,7 @@ class TestBuildSuccessResult:
         assert metadata["successful_examples"] == 2
 
     def test_zero_successful_examples_preserved(self, eval_config, eval_result):
-        """Zero successes must be explicit so ranking can suppress fake winners."""
+        """Zero successes must be explicit and mark the trial non-successful."""
         eval_result.successful_examples = 0
 
         result = build_success_result(
@@ -157,6 +157,9 @@ class TestBuildSuccessResult:
         )
 
         assert result.metadata["successful_examples"] == 0
+        assert result.metadata["example_success_summary"] == "0/10 examples succeeded"
+        assert result.status == TrialStatus.FAILED
+        assert result.error_message == "No examples succeeded"
 
     def test_example_results_included(self, eval_config, eval_result):
         """Test example_results are included in metadata."""

--- a/tests/unit/utils/test_results_table.py
+++ b/tests/unit/utils/test_results_table.py
@@ -15,7 +15,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from traigent.api.types import TrialResult, TrialStatus
-from traigent.utils.results_table import _trials_all_failed, print_results_table
+from traigent.utils.results_table import (
+    _find_best_per_objective,
+    _trials_all_failed,
+    print_results_table,
+)
 
 
 def _trial(
@@ -23,9 +27,10 @@ def _trial(
     metrics: dict[str, float],
     metadata: dict[str, Any] | None = None,
     status: TrialStatus = TrialStatus.COMPLETED,
+    trial_id: str = "t",
 ) -> TrialResult:
     return TrialResult(
-        trial_id="t",
+        trial_id=trial_id,
         config=config,
         metrics=metrics,
         status=status,
@@ -102,7 +107,7 @@ class TestTrialsAllFailed:
         ]
         assert _trials_all_failed(trials) is True
 
-    def test_positive_quality_metric_overrides_zero_success_metadata(self) -> None:
+    def test_explicit_zero_success_overrides_positive_quality_metric(self) -> None:
         trials = [
             _trial(
                 {"model": "m1"},
@@ -115,7 +120,7 @@ class TestTrialsAllFailed:
                 metadata={"successful_examples": 0},
             ),
         ]
-        assert _trials_all_failed(trials) is False
+        assert _trials_all_failed(trials) is True
 
     def test_non_numeric_metric_value_is_skipped(self) -> None:
         # Defensive: shouldn't crash on a stray non-numeric metric, and missing
@@ -129,8 +134,13 @@ class TestPrintResultsTableBanner:
     def _build_results(trials: list[TrialResult]) -> MagicMock:
         results = MagicMock()
         results.trials = trials
+        results.metadata = {}
+        results.best_trial_id = None
+        results.best_config = trials[0].config if trials else {}
+        results.best_score = None
         results.calculate_weighted_scores.return_value = {
             "best_weighted_config": trials[0].config if trials else {},
+            "weighted_scores": [],
         }
         return results
 
@@ -197,7 +207,7 @@ class TestPrintResultsTableBanner:
         assert "All trials failed" not in out
         assert "Overall Best" in out
 
-    def test_positive_quality_metric_emits_legend_even_with_zero_success_metadata(
+    def test_explicit_zero_success_emits_failed_banner_even_with_positive_metric(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         trials = [
@@ -219,5 +229,117 @@ class TestPrintResultsTableBanner:
         )
 
         out = capsys.readouterr().out
-        assert "All trials failed" not in out
-        assert "Overall Best" in out
+        assert "All trials failed" in out
+        assert "Overall Best" not in out
+
+
+class TestBestPerObjective:
+    def test_returns_all_tied_best_indices(self) -> None:
+        trials = [
+            _trial(
+                {"model": "m1"},
+                {"accuracy": 1.0},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+            ),
+            _trial(
+                {"model": "m2"},
+                {"accuracy": 1.0 + 5e-13},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+            ),
+            _trial(
+                {"model": "m3"},
+                {"accuracy": 0.5},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+            ),
+        ]
+
+        best = _find_best_per_objective(trials, [("accuracy", "maximize")])
+
+        assert best["accuracy"] == {0, 1}
+
+    def test_excludes_zero_success_trial_from_best_cost(self) -> None:
+        trials = [
+            _trial(
+                {"model": "failed-free"},
+                {"cost": 0.0},
+                metadata={"successful_examples": 0, "examples_attempted": 20},
+            ),
+            _trial(
+                {"model": "working"},
+                {"cost": 0.00001},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+            ),
+        ]
+
+        best = _find_best_per_objective(trials, [("cost", "minimize")])
+
+        assert best["cost"] == {1}
+
+
+class TestOverallBestIdentity:
+    @staticmethod
+    def _build_results(trials: list[TrialResult], best_trial_id: str) -> MagicMock:
+        results = MagicMock()
+        results.trials = trials
+        results.metadata = {"best_trial_id": best_trial_id}
+        results.best_config = trials[0].config
+        results.best_score = 1.0
+        results.calculate_weighted_scores.return_value = {"weighted_scores": []}
+        return results
+
+    def test_star_matches_best_trial_id_not_duplicate_config_equality(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        duplicate_config = {"model": "same"}
+        trials = [
+            _trial(
+                duplicate_config,
+                {"accuracy": 1.0, "cost": 0.00020},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+                trial_id="t1",
+            ),
+            _trial(
+                duplicate_config,
+                {"accuracy": 1.0, "cost": 0.00001},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+                trial_id="t2",
+            ),
+        ]
+
+        print_results_table(
+            self._build_results(trials, "t2"),
+            config_space={"model": ["same"]},
+            objectives=["accuracy", "cost"],
+        )
+
+        out = capsys.readouterr().out
+        assert out.count("★") == 2  # one row marker plus the legend marker
+
+    def test_table_surfaces_per_trial_example_success_counts(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        trials = [
+            _trial(
+                {"model": "legacy"},
+                {"accuracy": 0.0},
+                metadata={"successful_examples": 0, "examples_attempted": 20},
+                trial_id="t1",
+            ),
+            _trial(
+                {"model": "working"},
+                {"accuracy": 1.0},
+                metadata={"successful_examples": 20, "examples_attempted": 20},
+                trial_id="t2",
+            ),
+        ]
+
+        print_results_table(
+            self._build_results(trials, "t2"),
+            config_space={"model": ["legacy", "working"]},
+            objectives=["accuracy"],
+        )
+
+        out = capsys.readouterr().out
+        assert "examples" in out
+        assert "0/20" in out
+        assert "20/20" in out

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -329,8 +329,21 @@ class TrialResult:
 
     @property
     def is_successful(self) -> bool:
-        """Check if trial completed successfully."""
-        return self.status == TrialStatus.COMPLETED
+        """Check if trial completed and produced at least one successful example."""
+        if self.status != TrialStatus.COMPLETED:
+            return False
+        metadata = self.metadata or {}
+        successful_examples = metadata.get("successful_examples")
+        if isinstance(successful_examples, bool):
+            return True
+        if isinstance(successful_examples, (int, float)):
+            return successful_examples > 0
+        if successful_examples is not None:
+            try:
+                return float(successful_examples) > 0
+            except (TypeError, ValueError):
+                return True
+        return True
 
     def get_metric(self, name: str, default: float | None = None) -> float | None:
         """Get a specific metric value."""
@@ -1454,8 +1467,15 @@ class OptimizationResult:
                 else None
             )
             metadata = trial.metadata or {}
+            if "successful_examples" in metadata:
+                row["successful_examples"] = metadata.get("successful_examples")
             if "examples_attempted" in metadata:
                 row["examples_attempted"] = metadata.get("examples_attempted")
+            if "successful_examples" in metadata and "examples_attempted" in metadata:
+                row["example_success_summary"] = (
+                    f"{metadata.get('successful_examples')}/"
+                    f"{metadata.get('examples_attempted')} examples succeeded"
+                )
             if "total_example_cost" in metadata:
                 row["total_cost"] = metadata.get("total_example_cost")
             elif "total_cost" not in row:

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -77,7 +77,12 @@ from traigent.core.parallel_execution_manager import (
     PermittedTrialResult,
 )
 from traigent.core.progress_manager import ProgressManager
-from traigent.core.result_selection import TieBreaker, select_best_configuration
+from traigent.core.result_selection import (
+    TieBreaker,
+    _primary_scores_tied,
+    _secondary_metric_key,
+    select_best_configuration,
+)
 from traigent.core.sample_budget import SampleBudgetManager
 from traigent.core.stat_significance import compute_significance
 from traigent.core.stop_condition_manager import StopConditionManager
@@ -775,7 +780,8 @@ class OptimizationOrchestrator:
         if self._best_trial_cached is not None:
             return self._best_trial_cached
 
-        if not self._trials:
+        rankable_trials = [trial for trial in self._trials if trial.is_successful]
+        if not rankable_trials:
             return None
 
         # Find trial with best primary objective (assuming first objective is primary)
@@ -784,19 +790,19 @@ class OptimizationOrchestrator:
             minimization = is_minimization_objective(primary_objective)
             if minimization:
                 best_trial = min(
-                    self._trials,
+                    rankable_trials,
                     key=lambda t: t.metrics.get(primary_objective, float("inf")),
                 )
             else:
                 best_trial = max(
-                    self._trials,
+                    rankable_trials,
                     key=lambda t: t.metrics.get(primary_objective, float("-inf")),
                 )
             self._best_trial_cached = best_trial
             return best_trial
 
         # If no objectives defined, return last trial
-        return self._trials[-1] if self._trials else None
+        return rankable_trials[-1] if rankable_trials else None
 
     def _get_config_hash(self, config: dict[str, Any] | None) -> str:
         """Generate a hash for a configuration to track metrics across trials."""
@@ -1141,9 +1147,32 @@ class OptimizationOrchestrator:
         minimization = is_minimization_objective(primary_objective)
         new_score_value = cast(float, new_score)
         current_score_value = cast(float, current_score)
+        if _primary_scores_tied(new_score_value, current_score_value):
+            return self._secondary_tie_breaks_incumbent(trial_result, primary_objective)
         if minimization:
             return new_score_value < current_score_value
         return new_score_value > current_score_value
+
+    def _secondary_tie_breaks_incumbent(
+        self,
+        trial_result: TrialResult,
+        primary_objective: str,
+    ) -> bool:
+        """Return whether secondary declared objectives promote the candidate."""
+        if len(self.optimizer.objectives) <= 1 or self._best_trial_cached is None:
+            return False
+
+        candidate_key = _secondary_metric_key(
+            trial_result.metrics or {},
+            primary_objective,
+            self.optimizer.objectives,
+        )
+        incumbent_key = _secondary_metric_key(
+            self._best_trial_cached.metrics or {},
+            primary_objective,
+            self.optimizer.objectives,
+        )
+        return candidate_key > incumbent_key
 
     def _update_best_trial_cache(self, trial_result: TrialResult) -> None:
         if not self.optimizer.objectives:
@@ -2962,6 +2991,7 @@ class OptimizationOrchestrator:
             aggregate_configs=not self.traigent_config.is_edge_analytics_mode(),
             tie_breakers=self._tie_breakers or None,
             band_target=self._band_target,
+            objective_order=self.optimizer.objectives,
             comparability_mode=self.traigent_config.get_comparability_mode(),
             require_certified=strict_mode,
             certified_config=certified_config,
@@ -3027,6 +3057,14 @@ class OptimizationOrchestrator:
         now = datetime.now(UTC)
         run_label = generate_run_label(func_name, self._optimization_id, now)
 
+        result_metadata = self._build_result_metadata(
+            session_summary,
+            safeguards_telemetry,
+            strategy_preset_metadata,
+        )
+        if selection.best_trial_id:
+            result_metadata["best_trial_id"] = selection.best_trial_id
+
         # Create optimization result
         optimization_result = OptimizationResult(
             trials=self._trials.copy(),
@@ -3042,11 +3080,7 @@ class OptimizationOrchestrator:
             total_cost=total_cost if total_cost > 0 else None,
             total_tokens=total_tokens if total_tokens > 0 else None,
             metrics=processed_metrics,
-            metadata=self._build_result_metadata(
-                session_summary,
-                safeguards_telemetry,
-                strategy_preset_metadata,
-            ),
+            metadata=result_metadata,
             preset_selection=preset_selection,
             stop_reason=self._stop_reason,
             run_label=run_label,

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from traigent.api.types import TrialResult
 from traigent.utils.objectives import classify_objective, is_minimization_objective
@@ -22,6 +23,8 @@ TieBreaker = Literal["min_abs_deviation", "custom"]
 ComparabilityMode = Literal["legacy", "warn", "strict"]
 NO_RANKING_ELIGIBLE_TRIALS = "NO_RANKING_ELIGIBLE_TRIALS"
 NO_CERTIFIED_SELECTION = "NO_CERTIFIED_SELECTION"
+PRIMARY_SCORE_TIE_REL_TOL = 1e-9
+PRIMARY_SCORE_TIE_ABS_TOL = 1e-12
 
 
 @dataclass(slots=True)
@@ -32,6 +35,7 @@ class SelectionResult:
     best_score: float | None
     session_summary: dict[str, Any] | None
     reason_code: str | None = None
+    best_trial_id: str | None = None
 
 
 def _coerce_int(value: Any) -> int | None:
@@ -50,6 +54,28 @@ def _coerce_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _primary_scores_tied(score: float, best_score: float) -> bool:
+    return math.isclose(
+        score,
+        best_score,
+        rel_tol=PRIMARY_SCORE_TIE_REL_TOL,
+        abs_tol=PRIMARY_SCORE_TIE_ABS_TOL,
+    )
+
+
+def _declared_secondary_objectives(
+    primary_objective: str,
+    objective_order: Iterable[str] | None,
+) -> list[str]:
+    if objective_order is None:
+        return []
+
+    ordered = [str(objective) for objective in objective_order]
+    if primary_objective in ordered:
+        ordered = ordered[ordered.index(primary_objective) + 1 :]
+    return [objective for objective in ordered if objective != primary_objective]
 
 
 def _extract_trial_comparability(trial: TrialResult) -> dict[str, Any] | None:
@@ -245,6 +271,7 @@ def apply_tie_breaker(
     primary_objective: str,
     *,
     band_target: float | None = None,
+    objective_order: Iterable[str] | None = None,
 ) -> TrialResult:
     """Apply tie-breaker rules to select among equally-scored trials.
 
@@ -273,7 +300,12 @@ def apply_tie_breaker(
     tie_breaker = tie_breakers.get(primary_objective, "min_abs_deviation")
 
     if tie_breaker == "min_abs_deviation":
-        return _apply_min_abs_deviation(tied_trials, primary_objective, band_target)
+        return _apply_min_abs_deviation(
+            tied_trials,
+            primary_objective,
+            band_target,
+            objective_order,
+        )
 
     # For "custom" or unknown, return the first trial
     return tied_trials[0]
@@ -286,7 +318,11 @@ def _secondary_metric_total(
     """Sum secondary metrics, subtracting minimization objectives."""
     total = 0.0
     for name, value in metrics.items():
-        if not isinstance(value, (int, float)) or name == exclude_objective:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or name == exclude_objective
+        ):
             continue
         if is_minimization_objective(name):
             total -= float(value)
@@ -295,10 +331,40 @@ def _secondary_metric_total(
     return total
 
 
+def _secondary_metric_key(
+    metrics: dict[str, Any],
+    exclude_objective: str,
+    objective_order: Iterable[str] | None = None,
+) -> tuple[float, ...]:
+    """Return a secondary-objective ordering key.
+
+    Declared objectives break ties lexicographically in the run's objective order
+    after the primary. If the caller has no declared secondary objectives, retain
+    the legacy aggregate secondary score.
+    """
+    declared_secondaries = _declared_secondary_objectives(
+        exclude_objective, objective_order
+    )
+    if not declared_secondaries:
+        return (_secondary_metric_total(metrics, exclude_objective),)
+
+    ordered_scores: list[float] = []
+    for objective in declared_secondaries:
+        value = metrics.get(objective)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            ordered_scores.append(float("-inf"))
+            continue
+        ordered_scores.append(
+            _secondary_metric_total({objective: value}, exclude_objective)
+        )
+    return tuple(ordered_scores)
+
+
 def _apply_min_abs_deviation(
     trials: list[TrialResult],
     objective: str,
     band_target: float | None,
+    objective_order: Iterable[str] | None = None,
 ) -> TrialResult:
     """Select trial with minimum absolute deviation from target or best stability."""
     if band_target is not None:
@@ -309,8 +375,11 @@ def _apply_min_abs_deviation(
 
         return min(trials, key=deviation)
 
-    def secondary_score(t: TrialResult) -> tuple[float, str]:
-        return (_secondary_metric_total(t.metrics or {}, objective), t.trial_id or "")
+    def secondary_score(t: TrialResult) -> tuple[Any, ...]:
+        return (
+            *_secondary_metric_key(t.metrics or {}, objective, objective_order),
+            t.trial_id or "",
+        )
 
     return max(trials, key=secondary_score)
 
@@ -321,15 +390,16 @@ def _select_best_single_trial(
     tie_breakers: dict[str, TieBreaker],
     band_target: float | None,
     ranking_summary: dict[str, Any],
+    objective_order: Iterable[str] | None,
 ) -> SelectionResult:
     """Select best trial without aggregation, applying tie-breakers."""
     minimization = is_minimization_objective(primary_objective)
     chooser = min if minimization else max
 
     scored_trials = [
-        (t, t.get_metric(primary_objective))
+        (t, cast(float, _coerce_float(t.get_metric(primary_objective))))
         for t in successful_trials
-        if t.get_metric(primary_objective) is not None
+        if _coerce_float(t.get_metric(primary_objective)) is not None
     ]
     if not scored_trials:
         return SelectionResult(
@@ -342,16 +412,28 @@ def _select_best_single_trial(
             reason_code=NO_RANKING_ELIGIBLE_TRIALS,
         )
 
-    best_score = chooser(score for _, score in scored_trials if score is not None)
+    best_score = chooser(score for _, score in scored_trials)
 
-    # Find all trials with the best score (potential ties)
-    tied_trials = [trial for trial, score in scored_trials if score == best_score]
+    # Find all trials within the conservative primary-score tie tolerance.
+    tied_trials = [
+        trial
+        for trial, score in scored_trials
+        if _primary_scores_tied(score, best_score)
+    ]
 
-    # Apply tie-breaker if there are ties
-    if len(tied_trials) > 1 and tie_breakers:
+    # Apply tie-breaker if there are ties.
+    if len(tied_trials) > 1:
         best_trial = apply_tie_breaker(
-            tied_trials, tie_breakers, primary_objective, band_target=band_target
+            tied_trials,
+            tie_breakers,
+            primary_objective,
+            band_target=band_target,
+            objective_order=objective_order,
         )
+        if not tie_breakers and not _declared_secondary_objectives(
+            primary_objective, objective_order
+        ):
+            best_trial = tied_trials[0]
     else:
         best_trial = tied_trials[0] if tied_trials else successful_trials[0]
 
@@ -359,6 +441,7 @@ def _select_best_single_trial(
         best_config=best_trial.config or {},
         best_score=best_trial.get_metric(primary_objective),
         session_summary={"ranking": ranking_summary},
+        best_trial_id=best_trial.trial_id,
     )
 
 
@@ -385,8 +468,9 @@ def _aggregate_trials(
 
         entry = aggregated.setdefault(
             config_hash,
-            {"config": trial.config, "metrics_sum": {}, "count": 0},
+            {"config": trial.config, "metrics_sum": {}, "count": 0, "trial_ids": []},
         )
+        entry["trial_ids"].append(trial.trial_id)
 
         for metric_name, metric_value in (trial.metrics or {}).items():
             if metric_name == "examples_attempted":
@@ -414,6 +498,7 @@ def _apply_aggregated_tie_breaker(
     tie_breakers: dict[str, TieBreaker],
     primary_objective: str,
     band_target: float | None,
+    objective_order: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """Apply tie-breaker rules to aggregated entries with equal primary scores.
 
@@ -445,8 +530,10 @@ def _apply_aggregated_tie_breaker(
 
         return min(tied_entries, key=deviation)
 
-    def agg_secondary_score(entry: dict[str, Any]) -> float:
-        return _secondary_metric_total(_compute_mean_metrics(entry), primary_objective)
+    def agg_secondary_score(entry: dict[str, Any]) -> tuple[float, ...]:
+        return _secondary_metric_key(
+            _compute_mean_metrics(entry), primary_objective, objective_order
+        )
 
     return max(tied_entries, key=agg_secondary_score)
 
@@ -457,6 +544,7 @@ def _select_best_aggregated(
     tie_breakers: dict[str, TieBreaker],
     band_target: float | None,
     ranking_summary: dict[str, Any],
+    objective_order: Iterable[str] | None,
 ) -> SelectionResult:
     """Select best configuration from aggregated results with tie-breaking."""
     if not aggregated:
@@ -493,18 +581,30 @@ def _select_best_aggregated(
         )
     best_score_val = min(all_scores) if minimization else max(all_scores)
 
-    # Find all entries with the best score (ties)
+    # Find all entries within the conservative primary-score tie tolerance.
     tied_entries = [
         entry
         for entry in aggregated.values()
-        if _compute_mean_metrics(entry).get(primary_objective) == best_score_val
+        if _primary_scores_tied(
+            score_value := score(entry),
+            best_score_val,
+        )
+        and score_value not in (float("inf"), float("-inf"))
     ]
 
     # Apply tie-breaking for aggregated entries
-    if len(tied_entries) > 1 and tie_breakers:
+    if len(tied_entries) > 1:
         best_entry = _apply_aggregated_tie_breaker(
-            tied_entries, tie_breakers, primary_objective, band_target
+            tied_entries,
+            tie_breakers,
+            primary_objective,
+            band_target,
+            objective_order,
         )
+        if not tie_breakers and not _declared_secondary_objectives(
+            primary_objective, objective_order
+        ):
+            best_entry = tied_entries[0]
     else:
         best_entry = tied_entries[0]
 
@@ -533,6 +633,7 @@ def _select_best_aggregated(
         best_config=best_entry["config"] or {},
         best_score=best_metrics.get(primary_objective),
         session_summary=session_summary,
+        best_trial_id=(best_entry.get("trial_ids") or [None])[0],
     )
 
 
@@ -564,6 +665,7 @@ def select_best_configuration(
     aggregate_configs: bool,
     tie_breakers: dict[str, TieBreaker] | None = None,
     band_target: float | None = None,
+    objective_order: Iterable[str] | None = None,
     comparability_mode: ComparabilityMode = "warn",
     require_certified: bool = False,
     certified_config: dict[str, Any] | None = None,
@@ -589,6 +691,7 @@ def select_best_configuration(
         tie_breakers: Optional dict mapping objectives to tie-breaker strategies.
             From TVL 0.9 promotion_policy.tie_breakers.
         band_target: Optional target value for banded objectives.
+        objective_order: Declared objectives in preference order.
 
     Returns:
         SelectionResult with best configuration and score.
@@ -703,6 +806,7 @@ def select_best_configuration(
             tie_breakers,
             band_target,
             ranking_summary,
+            objective_order,
         )
 
     aggregated = _aggregate_trials(eligible_trials, set(config_space_keys))
@@ -712,4 +816,5 @@ def select_best_configuration(
         tie_breakers,
         band_target,
         ranking_summary,
+        objective_order,
     )

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -53,6 +53,15 @@ def _coerce_non_negative_int(value: Any) -> int:
         return 0
 
 
+def _coerce_optional_non_negative_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
 def _infer_total_examples(eval_result: Any) -> tuple[int, Any, bool]:
     """Infer total example count and whether detailed example results are present."""
     total_examples = _coerce_non_negative_int(getattr(eval_result, "total_examples", 0))
@@ -261,6 +270,13 @@ def _build_success_trial_metadata(
     if examples_attempted is not None:
         trial_metadata["examples_attempted"] = int(examples_attempted)
 
+    attempted = trial_metadata.get("examples_attempted")
+    successful = trial_metadata.get("successful_examples")
+    if successful is not None and attempted is not None:
+        trial_metadata["example_success_summary"] = (
+            f"{successful}/{attempted} examples succeeded"
+        )
+
     if total_cost is not None:
         try:
             trial_metadata["total_example_cost"] = float(total_cost)
@@ -268,6 +284,27 @@ def _build_success_trial_metadata(
             pass
 
     return trial_metadata
+
+
+def _all_attempted_examples_failed(
+    eval_result: Any,
+    examples_attempted: int | None,
+) -> bool:
+    successful_examples = _coerce_optional_non_negative_int(
+        getattr(eval_result, "successful_examples", None)
+    )
+    if successful_examples != 0:
+        return False
+
+    total_examples = _coerce_optional_non_negative_int(
+        getattr(eval_result, "total_examples", None)
+    )
+    attempted = (
+        _coerce_optional_non_negative_int(examples_attempted)
+        if examples_attempted is not None
+        else total_examples
+    )
+    return attempted is not None and attempted > 0
 
 
 def _set_metric_if_convertible(
@@ -362,9 +399,18 @@ def build_success_result(
         trial_id=trial_id,
         config=copy.deepcopy(evaluation_config),
         metrics=getattr(eval_result, "metrics", {}) or {},
-        status=TrialStatus.COMPLETED,
+        status=(
+            TrialStatus.FAILED
+            if _all_attempted_examples_failed(eval_result, examples_attempted)
+            else TrialStatus.COMPLETED
+        ),
         duration=duration,
         timestamp=datetime.now(UTC),
+        error_message=(
+            "No examples succeeded"
+            if _all_attempted_examples_failed(eval_result, examples_attempted)
+            else None
+        ),
         metadata=trial_metadata,
     )
 

--- a/traigent/utils/results_table.py
+++ b/traigent/utils/results_table.py
@@ -16,12 +16,16 @@ Example output::
 
 from __future__ import annotations
 
+import math
 import os
 import sys
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from traigent.core.result import OptimizationResult
+
+BEST_METRIC_REL_TOL = 1e-9
+BEST_METRIC_ABS_TOL = 1e-12
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +83,36 @@ def _format_metric_value(metric: str, val: float) -> str:
     return f"{val:.1%}"
 
 
+def _coerce_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _example_success_counts(trial: Any) -> tuple[int, int] | None:
+    metadata = getattr(trial, "metadata", {}) or {}
+    successful = _coerce_int(metadata.get("successful_examples"))
+    attempted = _coerce_int(metadata.get("examples_attempted"))
+    if attempted is None:
+        evaluation_result = metadata.get("evaluation_result")
+        attempted = _coerce_int(getattr(evaluation_result, "total_examples", None))
+    if successful is None or attempted is None:
+        return None
+    return successful, attempted
+
+
 def _get_objective_info(objectives: Any) -> list[tuple[str, str]]:
     """Return [(name, orientation)] from an objectives definition."""
     if hasattr(objectives, "objectives"):
@@ -100,37 +134,73 @@ def _get_objective_info(objectives: Any) -> list[tuple[str, str]]:
 
 def _find_best_per_objective(
     trials: list, metric_info: list[tuple[str, str]]
-) -> dict[str, int]:
-    """Return {metric_name: best_trial_index}."""
-    best_indices: dict[str, int] = {}
+) -> dict[str, set[int]]:
+    """Return {metric_name: {best_trial_indices}} for all tied bests."""
+    best_indices: dict[str, set[int]] = {}
     for metric_name, orientation in metric_info:
-        best_idx = 0
-        best_val = getattr(trials[0], "metrics", {}).get(metric_name, 0)
+        best_set: set[int] = set()
+        best_val: float | None = None
         is_minimize = orientation == "minimize"
-        for i, trial in enumerate(trials[1:], 1):
-            val = getattr(trial, "metrics", {}).get(metric_name, 0)
+        for i, trial in enumerate(trials):
+            if not _trial_is_best_candidate(trial):
+                continue
+            val = _coerce_float(getattr(trial, "metrics", {}).get(metric_name))
+            if val is None:
+                continue
+            if best_val is None:
+                best_val = val
+                best_set = {i}
+                continue
+            if math.isclose(
+                val,
+                best_val,
+                rel_tol=BEST_METRIC_REL_TOL,
+                abs_tol=BEST_METRIC_ABS_TOL,
+            ):
+                best_set.add(i)
+                continue
             if (val < best_val) if is_minimize else (val > best_val):
                 best_val = val
-                best_idx = i
-        best_indices[metric_name] = best_idx
+                best_set = {i}
+        best_indices[metric_name] = best_set
     return best_indices
 
 
-def _find_best_trial(trials: list, metric_names: list[str]) -> Any:
-    """Find the best trial by weighted score or accuracy."""
-    best_trial = trials[0]
-    for trial in trials:
-        score = getattr(trial, "weighted_score", None)
-        if score is not None:
-            best_score = getattr(best_trial, "weighted_score", float("-inf"))
-            if best_score < score:
-                best_trial = trial
-        elif metric_names and "accuracy" in metric_names:
-            trial_acc = getattr(trial, "metrics", {}).get("accuracy", 0)
-            best_acc = getattr(best_trial, "metrics", {}).get("accuracy", 0)
-            if trial_acc > best_acc:
-                best_trial = trial
-    return best_trial
+def _find_best_trial(
+    trials: list,
+    metric_names: list[str],
+    weighted_scores: list[tuple[Any, float]] | None = None,
+    metric_info: list[tuple[str, str]] | None = None,
+) -> Any:
+    """Find the best trial by weighted scores or the primary displayed metric."""
+    if weighted_scores:
+        return max(weighted_scores, key=lambda item: item[1])[0]
+
+    eligible_trials = [trial for trial in trials if _trial_is_best_candidate(trial)]
+    if not eligible_trials:
+        return None
+
+    orientation_by_metric = dict(metric_info or [])
+    primary_metric = (
+        "accuracy"
+        if "accuracy" in metric_names
+        else (metric_names[0] if metric_names else None)
+    )
+    if primary_metric is None:
+        return eligible_trials[0]
+
+    is_minimize = orientation_by_metric.get(primary_metric) == "minimize"
+    chooser = min if is_minimize else max
+    missing = float("inf") if is_minimize else float("-inf")
+
+    def primary_score(trial: Any) -> float:
+        value = _coerce_float(getattr(trial, "metrics", {}).get(primary_metric))
+        return missing if value is None else value
+
+    return chooser(
+        eligible_trials,
+        key=primary_score,
+    )
 
 
 def _has_positive_quality_metric(trial: Any) -> bool:
@@ -153,6 +223,93 @@ def _has_positive_quality_metric(trial: Any) -> bool:
     return False
 
 
+def _trial_is_best_candidate(trial: Any) -> bool:
+    if not getattr(trial, "is_successful", False):
+        return False
+    counts = _example_success_counts(trial)
+    if counts is None:
+        return True
+    successful, _attempted = counts
+    return successful > 0
+
+
+def _trial_identity_index(trials: list, target_trial: Any) -> int | None:
+    if target_trial is None:
+        return None
+    for index, trial in enumerate(trials):
+        if trial is target_trial:
+            return index
+    target_id = getattr(target_trial, "trial_id", None)
+    if target_id is None:
+        return None
+    for index, trial in enumerate(trials):
+        if getattr(trial, "trial_id", None) == target_id:
+            return index
+    return None
+
+
+def _find_trial_index_by_id(trials: list, trial_id: Any) -> int | None:
+    if trial_id is None:
+        return None
+    for index, trial in enumerate(trials):
+        if getattr(trial, "trial_id", None) == trial_id:
+            return index
+    return None
+
+
+def _find_best_trial_index(
+    results: OptimizationResult,
+    trials: list,
+    metric_info: list[tuple[str, str]],
+    objectives: Any,
+) -> int | None:
+    metric_names = [name for name, _orientation in metric_info]
+    metadata = getattr(results, "metadata", {}) or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    best_trial_id = metadata.get("best_trial_id") or getattr(
+        results, "best_trial_id", None
+    )
+    best_index = _find_trial_index_by_id(trials, best_trial_id)
+    if best_index is not None:
+        return best_index
+
+    try:
+        weighted = results.calculate_weighted_scores(objective_schema=objectives)
+        weighted_scores = weighted.get("weighted_scores") or []
+        best_trial = _find_best_trial(
+            trials, metric_names, weighted_scores, metric_info
+        )
+        best_index = _trial_identity_index(trials, best_trial)
+        if best_index is not None:
+            return best_index
+    except Exception:
+        pass
+
+    best_trial = _find_best_trial(trials, metric_names, metric_info=metric_info)
+    best_index = _trial_identity_index(trials, best_trial)
+    if best_index is not None:
+        return best_index
+
+    best_config = getattr(results, "best_config", None)
+    best_score = _coerce_float(getattr(results, "best_score", None))
+    primary_metric = metric_names[0] if metric_names else None
+    for index, trial in enumerate(trials):
+        if getattr(trial, "config", {}) != best_config:
+            continue
+        if best_score is None or primary_metric is None:
+            return index
+        trial_score = _coerce_float(getattr(trial, "metrics", {}).get(primary_metric))
+        if trial_score is not None and math.isclose(
+            trial_score,
+            best_score,
+            rel_tol=BEST_METRIC_REL_TOL,
+            abs_tol=BEST_METRIC_ABS_TOL,
+        ):
+            return index
+    return None
+
+
 def _trials_all_failed(trials: list) -> bool:
     """True iff every completed trial explicitly recorded zero successful examples.
 
@@ -160,16 +317,12 @@ def _trials_all_failed(trials: list) -> bool:
     because no winner can be honestly named. When older/external evaluators do
     not report ``metadata["successful_examples"]``, fall back to the completed
     trial status so honest 0.0 quality scores and cost-only runs remain rankable.
-    If the table is displaying positive quality metrics, treat that as scored
-    evidence too; otherwise mock/demo runs can show accuracy values and then
-    contradict themselves with a failed-trials banner.
+    Explicit zero-success metadata is authoritative even if a stale or mocked
+    metric payload also contains a positive quality score.
     """
     for trial in trials:
         if not getattr(trial, "is_successful", False):
             continue
-
-        if _has_positive_quality_metric(trial):
-            return False
 
         metadata = getattr(trial, "metadata", {}) or {}
         successful = metadata.get("successful_examples")
@@ -227,15 +380,13 @@ def print_results_table(
     # Best-per-objective indices
     best_per_objective = _find_best_per_objective(trials, metric_info)
 
-    # Overall best config (weighted scoring when available)
-    try:
-        weighted = results.calculate_weighted_scores(objective_schema=objectives)
-        best_config = weighted.get("best_weighted_config", {})
-    except Exception:
-        best_config = getattr(_find_best_trial(trials, metric_names), "config", {})
+    # Overall best trial identity, from optimizer selection metadata when present.
+    best_trial_index = _find_best_trial_index(results, trials, metric_info, objectives)
 
     # When every trial produced zero successful examples, refuse to crown a winner.
     all_failed = _trials_all_failed(trials)
+    example_counts = [_example_success_counts(trial) for trial in trials]
+    show_examples = any(count is not None for count in example_counts)
 
     # Column widths
     col_widths: dict[str, int] = {"#": 4}
@@ -251,8 +402,16 @@ def print_results_table(
             for t in trials
         )
         col_widths[metric] = max(len(metric), max_len) + 1
+    if show_examples:
+        max_len = max(
+            len(f"{count[0]}/{count[1]}") if count is not None else 1
+            for count in example_counts
+        )
+        col_widths["examples"] = max(len("examples"), max_len) + 1
 
-    all_cols = ["#"] + param_names + metric_names
+    all_cols = (
+        ["#"] + param_names + metric_names + (["examples"] if show_examples else [])
+    )
     total_width = sum(col_widths[c] for c in all_cols) + len(all_cols) * 3 - 1
 
     # Box-drawing characters
@@ -278,6 +437,10 @@ def print_results_table(
     header_parts.extend(
         f"{C.YELLOW}{m:^{col_widths[m]}}{C.RESET}" for m in metric_names
     )
+    if show_examples:
+        header_parts.append(
+            f"{C.YELLOW}{'examples':^{col_widths['examples']}}{C.RESET}"
+        )
     print(f"{V} " + f" {V} ".join(header_parts) + f" {V}")
 
     # Separator
@@ -287,7 +450,7 @@ def print_results_table(
     for i, trial in enumerate(trials):
         config = getattr(trial, "config", {})
         metrics = getattr(trial, "metrics", {})
-        is_overall_best = config == best_config and not all_failed
+        is_overall_best = i == best_trial_index and not all_failed
 
         prefix = f"{C.GREEN}★{C.RESET}" if is_overall_best else " "
         row_parts = [f"{prefix}{i + 1:>{col_widths['#'] - 1}}"]
@@ -299,11 +462,16 @@ def print_results_table(
         for metric in metric_names:
             metric_val = float(metrics.get(metric, 0))
             formatted = _format_metric_value(metric, metric_val)
-            if not all_failed and best_per_objective.get(metric) == i:
+            if not all_failed and i in best_per_objective.get(metric, set()):
                 cell = f"{C.GREEN}{C.BOLD}{formatted:^{col_widths[metric]}}{C.RESET}"
             else:
                 cell = f"{formatted:^{col_widths[metric]}}"
             row_parts.append(cell)
+
+        if show_examples:
+            counts = example_counts[i]
+            formatted_counts = f"{counts[0]}/{counts[1]}" if counts is not None else "?"
+            row_parts.append(f"{formatted_counts:^{col_widths['examples']}}")
 
         print(f"{V} " + f" {V} ".join(row_parts) + f" {V}")
 

--- a/walkthrough/utils/helpers.py
+++ b/walkthrough/utils/helpers.py
@@ -6,6 +6,7 @@ Common utilities for API key validation, logging setup, and environment configur
 from __future__ import annotations
 
 import logging
+import math
 import os
 from functools import reduce
 from pathlib import Path
@@ -18,6 +19,9 @@ if TYPE_CHECKING:
     from typing import Any
 
     from traigent.core.result import OptimizationResult
+
+BEST_METRIC_REL_TOL = 1e-9
+BEST_METRIC_ABS_TOL = 1e-12
 
 
 # Estimated times for real examples (in seconds) - from test_all_examples.sh
@@ -235,21 +239,81 @@ def print_optimization_config(
         print(f"    - {param}: [{values_str}]")
 
 
-def _find_best_trial(trials: list, metric_names: list[str]) -> Any:
-    """Find the best trial by weighted score or accuracy."""
-    best_trial = trials[0]
-    for trial in trials:
-        score = getattr(trial, "weighted_score", None)
-        if score is not None:
-            best_score = getattr(best_trial, "weighted_score", float("-inf"))
-            if best_score < score:
-                best_trial = trial
-        elif metric_names and "accuracy" in metric_names:
-            trial_acc = getattr(trial, "metrics", {}).get("accuracy", 0)
-            best_acc = getattr(best_trial, "metrics", {}).get("accuracy", 0)
-            if trial_acc > best_acc:
-                best_trial = trial
-    return best_trial
+def _coerce_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _example_success_counts(trial: Any) -> tuple[int, int] | None:
+    metadata = getattr(trial, "metadata", {}) or {}
+    successful = _coerce_int(metadata.get("successful_examples"))
+    attempted = _coerce_int(metadata.get("examples_attempted"))
+    if attempted is None:
+        evaluation_result = metadata.get("evaluation_result")
+        attempted = _coerce_int(getattr(evaluation_result, "total_examples", None))
+    if successful is None or attempted is None:
+        return None
+    return successful, attempted
+
+
+def _trial_is_best_candidate(trial: Any) -> bool:
+    if not getattr(trial, "is_successful", False):
+        return False
+    counts = _example_success_counts(trial)
+    if counts is None:
+        return True
+    successful, _attempted = counts
+    return successful > 0
+
+
+def _find_best_trial(
+    trials: list,
+    metric_names: list[str],
+    weighted_scores: list[tuple[Any, float]] | None = None,
+    metric_info: list[tuple[str, str]] | None = None,
+) -> Any:
+    """Find the best trial by weighted scores or the primary displayed metric."""
+    if weighted_scores:
+        return max(weighted_scores, key=lambda item: item[1])[0]
+
+    eligible_trials = [trial for trial in trials if _trial_is_best_candidate(trial)]
+    if not eligible_trials:
+        return None
+
+    orientation_by_metric = dict(metric_info or [])
+    primary_metric = (
+        "accuracy"
+        if "accuracy" in metric_names
+        else (metric_names[0] if metric_names else None)
+    )
+    if primary_metric is None:
+        return eligible_trials[0]
+
+    is_minimize = orientation_by_metric.get(primary_metric) == "minimize"
+    chooser = min if is_minimize else max
+    missing = float("inf") if is_minimize else float("-inf")
+
+    def primary_score(trial: Any) -> float:
+        value = _coerce_float(getattr(trial, "metrics", {}).get(primary_metric))
+        return missing if value is None else value
+
+    return chooser(
+        eligible_trials,
+        key=primary_score,
+    )
 
 
 def _format_config_value(val: Any) -> str:
@@ -294,27 +358,125 @@ def _get_objective_info(objectives: Any) -> list[tuple[str, str]]:
 
 
 def _find_best_per_objective(
-    trials: list, metric_info: list[tuple[str, str]]
-) -> dict[str, int]:
+    trials: list,
+    metric_info: list[tuple[str, str]],
+    metric_overrides: dict[str, list[float]] | None = None,
+) -> dict[str, set[int]]:
     """Find the best trial index for each objective metric.
 
-    Returns dict mapping metric name to trial index (0-based).
+    Returns dict mapping metric name to tied-best trial indices (0-based).
     """
-    best_indices = {}
+    best_indices: dict[str, set[int]] = {}
     for metric_name, orientation in metric_info:
-        best_idx = 0
-        best_val = getattr(trials[0], "metrics", {}).get(metric_name, 0)
-        # For minimize objectives, we want the smallest value
-        # For maximize objectives, we want the largest value
+        best_set: set[int] = set()
+        best_val: float | None = None
         is_minimize = orientation == "minimize"
-        for i, trial in enumerate(trials[1:], 1):
-            val = getattr(trial, "metrics", {}).get(metric_name, 0)
+        for i, trial in enumerate(trials):
+            if not _trial_is_best_candidate(trial):
+                continue
+            raw_val = (
+                metric_overrides[metric_name][i]
+                if metric_overrides and metric_name in metric_overrides
+                else getattr(trial, "metrics", {}).get(metric_name)
+            )
+            val = _coerce_float(raw_val)
+            if val is None:
+                continue
+            if best_val is None:
+                best_val = val
+                best_set = {i}
+                continue
+            if math.isclose(
+                val,
+                best_val,
+                rel_tol=BEST_METRIC_REL_TOL,
+                abs_tol=BEST_METRIC_ABS_TOL,
+            ):
+                best_set.add(i)
+                continue
             is_better = val < best_val if is_minimize else val > best_val
             if is_better:
                 best_val = val
-                best_idx = i
-        best_indices[metric_name] = best_idx
+                best_set = {i}
+        best_indices[metric_name] = best_set
     return best_indices
+
+
+def _trial_identity_index(trials: list, target_trial: Any) -> int | None:
+    if target_trial is None:
+        return None
+    for index, trial in enumerate(trials):
+        if trial is target_trial:
+            return index
+    target_id = getattr(target_trial, "trial_id", None)
+    if target_id is None:
+        return None
+    for index, trial in enumerate(trials):
+        if getattr(trial, "trial_id", None) == target_id:
+            return index
+    return None
+
+
+def _find_trial_index_by_id(trials: list, trial_id: Any) -> int | None:
+    if trial_id is None:
+        return None
+    for index, trial in enumerate(trials):
+        if getattr(trial, "trial_id", None) == trial_id:
+            return index
+    return None
+
+
+def _find_best_trial_index(
+    results: OptimizationResult,
+    trials: list,
+    metric_info: list[tuple[str, str]],
+    objectives: Any,
+) -> int | None:
+    metric_names = [name for name, _orientation in metric_info]
+    metadata = getattr(results, "metadata", {}) or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    best_trial_id = metadata.get("best_trial_id") or getattr(
+        results, "best_trial_id", None
+    )
+    best_index = _find_trial_index_by_id(trials, best_trial_id)
+    if best_index is not None:
+        return best_index
+
+    try:
+        weighted_result = results.calculate_weighted_scores(objective_schema=objectives)
+        weighted_scores = weighted_result.get("weighted_scores") or []
+        best_trial = _find_best_trial(
+            trials, metric_names, weighted_scores, metric_info
+        )
+        best_index = _trial_identity_index(trials, best_trial)
+        if best_index is not None:
+            return best_index
+    except Exception:
+        pass
+
+    best_trial = _find_best_trial(trials, metric_names, metric_info=metric_info)
+    best_index = _trial_identity_index(trials, best_trial)
+    if best_index is not None:
+        return best_index
+
+    best_config = getattr(results, "best_config", None)
+    best_score = _coerce_float(getattr(results, "best_score", None))
+    primary_metric = metric_names[0] if metric_names else None
+    for index, trial in enumerate(trials):
+        if getattr(trial, "config", {}) != best_config:
+            continue
+        if best_score is None or primary_metric is None:
+            return index
+        trial_score = _coerce_float(getattr(trial, "metrics", {}).get(primary_metric))
+        if trial_score is not None and math.isclose(
+            trial_score,
+            best_score,
+            rel_tol=BEST_METRIC_REL_TOL,
+            abs_tol=BEST_METRIC_ABS_TOL,
+        ):
+            return index
+    return None
 
 
 # ANSI color codes
@@ -369,10 +531,12 @@ def _build_table_row(
     param_names: list[str],
     metric_names: list[str],
     col_widths: dict[str, int],
-    best_per_objective: dict[str, int],
+    best_per_objective: dict[str, set[int]],
     is_overall_best: bool,
     mock_metrics: dict[str, float] | None = None,
     trailing_params: list[str] | None = None,
+    example_counts: tuple[int, int] | None = None,
+    show_examples: bool = False,
 ) -> list[str]:
     """Build a single table row string."""
     C = _Colors
@@ -396,11 +560,19 @@ def _build_table_row(
         else:
             val = metrics.get(metric, 0)
         formatted = _format_metric_value(metric, val)
-        if best_per_objective.get(metric) == idx:
+        if idx in best_per_objective.get(metric, set()):
             cell = f"{C.GREEN}{C.BOLD}{formatted:^{col_widths[metric]}}{C.RESET}"
         else:
             cell = f"{formatted:^{col_widths[metric]}}"
         row_parts.append(cell)
+
+    if show_examples:
+        formatted_counts = (
+            f"{example_counts[0]}/{example_counts[1]}"
+            if example_counts is not None
+            else "?"
+        )
+        row_parts.append(f"{formatted_counts:^{col_widths['examples']}}")
 
     # Trailing config values (shown after metrics)
     if trailing_params:
@@ -477,61 +649,18 @@ def print_results_table(
     if is_mock and "latency" in metric_names:
         mock_latencies = [_get_mock_latency_for_trial(t, task_type) for t in trials]
 
-    # Find best trials (using mock values if in mock mode)
-    if mock_costs or mock_latencies:
-        # Create modified metric_info for best calculation with mock values
-        best_per_objective = {}
-        for metric_name, orientation in metric_info:
-            if metric_name == "cost" and mock_costs:
-                # Use mock costs for finding best cost
-                is_minimize = orientation == "minimize"
-                best_idx = 0
-                best_val = mock_costs[0]
-                for i, cost in enumerate(mock_costs[1:], 1):
-                    is_better = cost < best_val if is_minimize else cost > best_val
-                    if is_better:
-                        best_val = cost
-                        best_idx = i
-                best_per_objective[metric_name] = best_idx
-            elif metric_name == "latency" and mock_latencies:
-                # Use mock latencies for finding best latency
-                is_minimize = orientation == "minimize"
-                best_idx = 0
-                best_val = mock_latencies[0]
-                for i, latency in enumerate(mock_latencies[1:], 1):
-                    is_better = (
-                        latency < best_val if is_minimize else latency > best_val
-                    )
-                    if is_better:
-                        best_val = latency
-                        best_idx = i
-                best_per_objective[metric_name] = best_idx
-            else:
-                # Use actual metrics for other objectives
-                best_idx = 0
-                best_val = getattr(trials[0], "metrics", {}).get(metric_name, 0)
-                is_minimize = orientation == "minimize"
-                for i, trial in enumerate(trials[1:], 1):
-                    val = getattr(trial, "metrics", {}).get(metric_name, 0)
-                    is_better = val < best_val if is_minimize else val > best_val
-                    if is_better:
-                        best_val = val
-                        best_idx = i
-                best_per_objective[metric_name] = best_idx
-    else:
-        best_per_objective = _find_best_per_objective(trials, metric_info)
+    metric_overrides: dict[str, list[float]] = {}
+    if mock_costs:
+        metric_overrides["cost"] = mock_costs
+    if mock_latencies:
+        metric_overrides["latency"] = mock_latencies
+    best_per_objective = _find_best_per_objective(
+        trials, metric_info, metric_overrides or None
+    )
 
-    # Use proper weighted scoring from OptimizationResult
-    # Note: In mock mode, trial.metrics may have cost=0 and similar latency for all
-    # trials, so weighted scoring may favor accuracy. The displayed costs/latencies
-    # are estimates for visualization only.
-    try:
-        weighted_result = results.calculate_weighted_scores(objective_schema=objectives)
-        best_config = weighted_result.get("best_weighted_config", {})
-    except Exception:
-        # Fallback to simple accuracy-based selection
-        best_trial = _find_best_trial(trials, metric_names)
-        best_config = getattr(best_trial, "config", {})
+    best_trial_index = _find_best_trial_index(results, trials, metric_info, objectives)
+    example_counts = [_example_success_counts(trial) for trial in trials]
+    show_examples = any(count is not None for count in example_counts)
 
     # Calculate column widths (use mock costs for width calculation if in mock mode)
     col_widths: dict[str, int] = {"#": 4}
@@ -541,7 +670,7 @@ def print_results_table(
             for t in trials
         )
         col_widths[param] = max(len(param), max_len) + 1
-    for idx, metric in enumerate(metric_names):
+    for metric in metric_names:
         if metric == "cost" and mock_costs:
             max_len = max(len(_format_metric_value(metric, c)) for c in mock_costs)
         elif metric == "latency" and mock_latencies:
@@ -558,6 +687,12 @@ def print_results_table(
                 for t in trials
             )
         col_widths[metric] = max(len(metric), max_len) + 1
+    if show_examples:
+        max_len = max(
+            len(f"{count[0]}/{count[1]}") if count is not None else 1
+            for count in example_counts
+        )
+        col_widths["examples"] = max(len("examples"), max_len) + 1
     # Calculate column widths for trailing params (shown after metrics)
     for param in trailing_params:
         max_len = max(
@@ -567,7 +702,9 @@ def print_results_table(
         col_widths[param] = max(len(param), max_len) + 1
 
     # Add trailing params after metrics
-    all_cols = ["#"] + param_names + metric_names + trailing_params
+    all_cols = ["#"] + param_names + metric_names + (
+        ["examples"] if show_examples else []
+    ) + trailing_params
     total_width = sum(col_widths[c] for c in all_cols) + len(all_cols) * 3 - 1
 
     # Box drawing characters
@@ -593,6 +730,8 @@ def print_results_table(
     header_parts.extend(
         f"{C.YELLOW}{m:^{col_widths[m]}}{C.RESET}" for m in metric_names
     )
+    if show_examples:
+        header_parts.append(f"{C.YELLOW}{'examples':^{col_widths['examples']}}{C.RESET}")
     # Trailing params after metrics (cyan like other config params)
     header_parts.extend(
         f"{C.CYAN}{p:^{col_widths[p]}}{C.RESET}" for p in trailing_params
@@ -604,8 +743,7 @@ def print_results_table(
 
     # Data rows
     for i, trial in enumerate(trials):
-        config = getattr(trial, "config", {})
-        is_overall_best = config == best_config
+        is_overall_best = i == best_trial_index
 
         # Build mock_metrics override for this trial
         mock_metrics = {}
@@ -624,6 +762,8 @@ def print_results_table(
             is_overall_best,
             mock_metrics if mock_metrics else None,
             trailing_params,
+            example_counts[i],
+            show_examples,
         )
         print(f"{V} " + f" {V} ".join(row_parts) + f" {V}")
 


### PR DESCRIPTION
Fixes #1184, fixes #1185, fixes #1183.

Walkthrough cold-start remediation (Israel's 04-Bedrock pass) — SDK correctness train. Governed under spine ChangeSession `cs_31ebba178419c83b` / packet `pkt_3cadd07c0a4887a1`. Implemented by codex gpt-5.5 (xhigh) worker; captain-reviewed (Claude Opus 4.8), independently re-tested.

## What

- **#1184** — the existing secondary-objective tie-break machinery (`_secondary_metric_total`) is no longer dead code gated behind TVL `tie_breakers`. On primary-score ties (conservative `isclose` rel 1e-9/abs 1e-12), `best_config` now tie-breaks by the **declared objectives in order after the primary** (e.g. `["accuracy","cost"]` → cheapest of the tied-best). Explicit TVL tie_breakers keep precedence; **single-objective runs keep legacy behavior exactly** (explicit preservation branch). The live incumbent (`_simple_is_better` path) uses the same key, so progress logging agrees with the terminal pick. `best_trial_id` is persisted in result metadata.
- **#1185** — `_find_best_per_objective` returns tied-best index **sets** (`math.isclose`); all tied-best cells highlight. Failed / zero-successful-example trials are excluded from best-per-column (no more "best cost" on a failed $0 trial). ★ resolves by **selected trial identity**, not config-dict equality. All mirrored in `walkthrough/utils/helpers.py`, plus a per-trial `N/M examples` column.
- **#1183** — `TrialResult.is_successful` now requires `successful_examples > 0` when the factory recorded it (backward-compatible when absent); the factory records all-errored evaluations as **failed** trials with reason `No examples succeeded`; success rate excludes them (8 trials with 3 all-errored → 5/8, not 100%).

## Canonical regression (from the issue)

4 trials at accuracy 1.0, costs `[0.00020, 0.00001, 0.00002, 0.00011]` → selects the `0.00001` trial, both `aggregate_configs` modes (`tests/unit/core/test_result_selection.py::test_default_multi_objective_tie_breaks_equal_accuracy_on_lowest_cost`). The new tests **fail on base develop** (verified) — non-tautological.

## Verification

Captain re-ran: `tests/unit/core/test_result_selection.py tests/unit/utils/test_results_table.py tests/unit/api/test_api_types.py tests/unit/core/test_trial_result_factory.py tests/unit/core/test_promotion_gate_integration.py` → **153 passed**. Worker's broader `-k "result_selection or results_table or multi_objective or orchestrator"` → 313 passed + 1 pre-existing failure (`tests/test_resampling_aggregation.py`, uses removed `'standard'` mode — pre-dates this PR, verified failing on base; sibling of #1178).

Pre-existing (verified on base develop, untouched): 11 failures in `tests/unit/core/test_orchestrator.py` (`MockEvaluator._metric_registry`, post-#1177).

## PR checklist

1. **Worst-case prod path** — selection/reporting only; no auth/billing/privacy surface. Worst case is a different (better-justified) best_config; fail direction is now *honest* (all-errored ≠ success).
2. **Production-branch test** — n/a (no policy surface); fail-closed accounting covered by `tests/unit/api/test_api_types.py:179,414,443`.
3. **Contract regeneration** — no schema shape change. `is_successful` semantics tightened and `best_trial_id`/`successful_examples` metadata are additive. **traigent-js parity follow-up flagged**: JS SDK should mirror tie-break + success accounting (tracked in the issues' cross-SDK note).
4. **Public surface delta** — no `__all__`/route changes; `OptimizationResult.to_dataframe()` gains additive columns.
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)