### PR TITLE
fix(ux): quiet LiteLLM by default; classify backend 403 pre-spend (abort unless opted in); single execution_mode registry

### DIFF
--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -116,6 +116,32 @@ class TestOptimizeDecorator:
         assert isinstance(sample_function, OptimizedFunction)
         assert sample_function.hybrid_api_transport is transport
 
+    def test_decorator_execution_mode_registry_matches_runtime(self):
+        """Decorator validation accepts the same modes advertised by runtime."""
+        from traigent.config.types import accepted_execution_mode_values
+
+        @optimize(configuration_space={"x": [1, 2]}, execution_mode="local")
+        def sample_function(x: int) -> int:
+            return x
+
+        assert isinstance(sample_function, OptimizedFunction)
+        assert sample_function.execution_mode == "edge_analytics"
+
+        with pytest.raises(ConfigurationError) as exc_info:
+
+            @optimize(configuration_space={"x": [1, 2]}, execution_mode="standard")
+            def removed_mode_function(x: int) -> int:
+                return x
+
+        assert str(list(accepted_execution_mode_values())) in str(exc_info.value)
+        for mode in accepted_execution_mode_values():
+
+            @optimize(configuration_space={"x": [1, 2]}, execution_mode=mode)
+            def accepted_mode_function(x: int) -> int:
+                return x
+
+            assert isinstance(accepted_mode_function, OptimizedFunction)
+
     def test_decorator_max_trials_reaches_optimized_function(self):
         """Regression: max_trials from decorator must reach OptimizedFunction.
 

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -405,8 +405,18 @@ class TestHandleSessionError:
         """Test 403 error raises AuthenticationError."""
         from traigent.cloud.auth import AuthenticationError
 
-        with pytest.raises(AuthenticationError, match="Authentication failed"):
-            self.ops._handle_session_error(403, "Forbidden")
+        with pytest.raises(AuthenticationError, match="Authentication failed") as exc:
+            self.ops._handle_session_error(
+                403,
+                '{"success":false,"error_code":"INSUFFICIENT_PERMISSIONS",'
+                '"message":"Missing required permissions: experiment.write",'
+                '"details":{"missing_permissions":["experiment.write"]}}',
+            )
+
+        detail = getattr(exc.value, "session_creation_failure")
+        assert detail.error_code == "INSUFFICIENT_PERMISSIONS"
+        assert detail.message == "Missing required permissions: experiment.write"
+        assert detail.missing_permissions == ("experiment.write",)
 
     def test_500_error_raises_cloud_service_error(self):
         """Test 500 error raises CloudServiceError."""
@@ -430,8 +440,12 @@ class TestHandleSessionError:
 
     def test_other_error_raises_cloud_service_error(self):
         """Test other errors raise CloudServiceError."""
-        with pytest.raises(CloudServiceError, match="Session creation failed"):
+        with pytest.raises(CloudServiceError, match="Session creation failed") as exc:
             self.ops._handle_session_error(400, "Bad Request")
+
+        detail = getattr(exc.value, "session_creation_failure")
+        assert detail.status_code == 400
+        assert detail.raw_body == "Bad Request"
 
 
 class TestHandleClientError:

--- a/tests/unit/config/test_config_validation_property.py
+++ b/tests/unit/config/test_config_validation_property.py
@@ -5,7 +5,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from traigent.config.types import ExecutionMode, TraigentConfig, resolve_execution_mode
-from traigent.utils.exceptions import ValidationError
+from traigent.utils.exceptions import ConfigurationError, ValidationError
 
 # ==============================================================================
 # Property-based tests for temperature validation
@@ -106,6 +106,7 @@ def test_presence_penalty_rejects_invalid_range(penalty):
     st.sampled_from(
         [
             "edge_analytics",
+            "local",
             "privacy",
             "hybrid",
             "hybrid_api",
@@ -123,6 +124,8 @@ def test_execution_mode_accepts_valid_values(mode):
     if isinstance(mode, str) and mode == "privacy":
         assert config.execution_mode == "hybrid"
         assert config.privacy_enabled is True
+    elif isinstance(mode, str) and mode == "local":
+        assert config.execution_mode == "edge_analytics"
     elif isinstance(mode, ExecutionMode) and mode == ExecutionMode.PRIVACY:
         assert config.execution_mode == "hybrid"
         assert config.privacy_enabled is True
@@ -147,6 +150,7 @@ def test_execution_mode_rejects_removed_or_reserved_values(mode):
         lambda x: x.strip().lower()
         not in [
             "edge_analytics",
+            "local",
             "privacy",
             "hybrid",
             "standard",
@@ -158,7 +162,7 @@ def test_execution_mode_rejects_removed_or_reserved_values(mode):
 )
 def test_execution_mode_rejects_invalid_values(mode):
     """Property: Invalid execution mode strings should be rejected."""
-    with pytest.raises((ValueError, ValidationError)):
+    with pytest.raises((ValueError, ValidationError, ConfigurationError)):
         TraigentConfig(execution_mode=mode)
 
 

--- a/tests/unit/config/test_types.py
+++ b/tests/unit/config/test_types.py
@@ -5,6 +5,7 @@ import pytest
 from traigent.config.types import (
     ExecutionMode,
     TraigentConfig,
+    accepted_execution_mode_values,
     resolve_execution_mode,
     validate_execution_mode,
 )
@@ -213,10 +214,30 @@ class TestValidateExecutionMode:
         """Privacy remains a legacy alias for hybrid."""
         assert validate_execution_mode("privacy") is ExecutionMode.HYBRID
 
+    def test_local_alias_validates_as_edge_analytics(self) -> None:
+        """Local is accepted as a public alias for edge_analytics."""
+        assert resolve_execution_mode("local") is ExecutionMode.EDGE_ANALYTICS
+        assert validate_execution_mode("local") is ExecutionMode.EDGE_ANALYTICS
+        assert TraigentConfig(execution_mode="local").execution_mode == "edge_analytics"
+
     def test_removed_standard_mode_raises_configuration_error(self) -> None:
         """The removed standard mode is rejected everywhere."""
-        with pytest.raises(ConfigurationError, match="No such mode 'standard'"):
+        with pytest.raises(ConfigurationError, match="No such mode 'standard'") as exc:
             validate_execution_mode("standard")
+        assert list(accepted_execution_mode_values()) == [
+            "edge_analytics",
+            "hybrid",
+            "hybrid_api",
+            "local",
+            "privacy",
+        ]
+        for mode in accepted_execution_mode_values():
+            assert validate_execution_mode(mode) in {
+                ExecutionMode.EDGE_ANALYTICS,
+                ExecutionMode.HYBRID,
+                ExecutionMode.HYBRID_API,
+            }
+        assert str(list(accepted_execution_mode_values())) in str(exc.value)
 
     def test_reserved_cloud_mode_raises_configuration_error(self) -> None:
         """Cloud remote execution is reserved and fails closed."""

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -1115,10 +1115,144 @@ class TestHandleSessionCreationResult:
         warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert len(warning_records) == 1
 
-    def test_auth_failure_warning(
+    def test_auth_failure_aborts_by_default_with_structured_reason(
+        self, traigent_config, objective_schema, mock_optimizer
+    ):
+        """403 session creation failures abort before trial spend by default."""
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+        from traigent.utils.exceptions import ConfigurationError
+
+        manager = BackendSessionManager(
+            backend_client=Mock(),
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        result = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.AUTH,
+            detail="Authentication failed (403)",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                403,
+                '{"success":false,"error_code":"INSUFFICIENT_PERMISSIONS",'
+                '"message":"Missing required permissions: experiment.write",'
+                '"details":{"missing_permissions":["experiment.write"]}}',
+            ),
+        )
+
+        with pytest.raises(ConfigurationError) as exc_info:
+            manager.handle_session_creation_result(result)
+
+        assert not manager.backend_tracking_enabled
+        message = str(exc_info.value)
+        assert "missing-permission" in message
+        assert "INSUFFICIENT_PERMISSIONS" in message
+        assert "experiment.write" in message
+        assert "Aborting before trials or LLM calls" in message
+        assert "TRAIGENT_ALLOW_UNTRACKED=1" in message
+
+    def test_create_session_auth_abort_before_trial_submission(
+        self,
+        backend_session_manager,
+        mock_backend_client,
+        mock_dataset,
+    ):
+        """Session-create auth failures stop before any trial backend write."""
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+        from traigent.utils.exceptions import ConfigurationError
+
+        mock_backend_client.create_session.return_value = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.AUTH,
+            detail="Authentication failed (403)",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                403,
+                '{"error_code":"INSUFFICIENT_PERMISSIONS",'
+                '"message":"Missing required permissions: experiment.write",'
+                '"details":{"missing_permissions":["experiment.write"]}}',
+            ),
+        )
+
+        def func(x):
+            return x
+
+        descriptor = resolve_function_descriptor(func)
+
+        with pytest.raises(ConfigurationError):
+            backend_session_manager.create_session(
+                func=func,
+                dataset=mock_dataset,
+                function_descriptor=descriptor,
+                max_trials=10,
+                start_time=1234567890.0,
+            )
+
+        mock_backend_client.submit_result.assert_not_called()
+        mock_backend_client.request_trial_slot.assert_not_called()
+        assert not backend_session_manager.backend_tracking_enabled
+
+    def test_auth_failure_allows_local_only_with_explicit_opt_in(
+        self, traigent_config, objective_schema, mock_optimizer, caplog, monkeypatch
+    ):
+        """TRAIGENT_ALLOW_UNTRACKED=1 preserves local-only fallback for auth errors."""
+        import logging
+
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+
+        monkeypatch.setenv("TRAIGENT_ALLOW_UNTRACKED", "1")
+        manager = BackendSessionManager(
+            backend_client=Mock(),
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        result = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.AUTH,
+            detail="Authentication failed (403)",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                403,
+                '{"success":false,"error_code":"INSUFFICIENT_PERMISSIONS",'
+                '"message":"Missing required permissions: experiment.write",'
+                '"details":{"missing_permissions":["experiment.write"]}}',
+            ),
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="traigent.core.backend_session_manager"
+        ):
+            session_id = manager.handle_session_creation_result(result)
+
+        assert session_id == "local_test"
+        assert not manager.backend_tracking_enabled
+        assert any("missing-permission" in msg for msg in caplog.messages)
+        assert any("experiment.write" in msg for msg in caplog.messages)
+        assert any("Continuing local-only" in msg for msg in caplog.messages)
+
+    def test_connection_failure_warns_and_continues_local(
         self, traigent_config, objective_schema, mock_optimizer, caplog
     ):
-        """handle_session_creation_result must emit WARNING for AUTH failure."""
+        """Transient backend unreachability remains warn-and-continue."""
         import logging
 
         from traigent.cloud.session_types import (
@@ -1138,17 +1272,61 @@ class TestHandleSessionCreationResult:
 
         result = SessionCreationResult.fallback(
             session_id="local_test",
-            reason=SessionCreationFailureReason.AUTH,
-            detail="Authentication failed (401)",
+            reason=SessionCreationFailureReason.SESSION_FAILED,
+            detail="Backend unavailable (connection failed)",
         )
 
         with caplog.at_level(
             logging.WARNING, logger="traigent.core.backend_session_manager"
         ):
-            manager.handle_session_creation_result(result)
+            session_id = manager.handle_session_creation_result(result)
 
+        assert session_id == "local_test"
         assert not manager.backend_tracking_enabled
-        assert any("authentication failed" in msg.lower() for msg in caplog.messages)
+        assert any("backend-unreachable" in msg for msg in caplog.messages)
+        assert any("Continuing local-only" in msg for msg in caplog.messages)
+
+    def test_unknown_4xx_warning_includes_raw_reason(
+        self, traigent_config, objective_schema, mock_optimizer, caplog
+    ):
+        """Unknown 4xx responses are classified without dropping the raw body."""
+        import logging
+
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+
+        manager = BackendSessionManager(
+            backend_client=Mock(),
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        result = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.SESSION_FAILED,
+            detail="HTTP 400",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                400, "Bad request from session endpoint"
+            ),
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="traigent.core.backend_session_manager"
+        ):
+            session_id = manager.handle_session_creation_result(result)
+
+        assert session_id == "local_test"
+        assert any("Classification: unknown" in msg for msg in caplog.messages)
+        assert any(
+            "Bad request from session endpoint" in msg for msg in caplog.messages
+        )
 
     def test_idempotent_warns_only_once(
         self, traigent_config, objective_schema, mock_optimizer, caplog
@@ -1173,7 +1351,8 @@ class TestHandleSessionCreationResult:
 
         result = SessionCreationResult.fallback(
             session_id="local_test",
-            reason=SessionCreationFailureReason.AUTH,
+            reason=SessionCreationFailureReason.SESSION_FAILED,
+            detail="Backend unavailable",
         )
 
         with caplog.at_level(

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -1,0 +1,46 @@
+"""Tests for SDK logging policy helpers."""
+
+import logging
+import types
+
+from traigent.utils.logging import configure_litellm_logging
+
+
+def test_litellm_logging_quiet_by_default(monkeypatch):
+    """Normal SDK logging suppresses LiteLLM banners and duplicate propagation."""
+    monkeypatch.delenv("TRAIGENT_LOG_LEVEL", raising=False)
+    litellm_module = types.ModuleType("litellm")
+    litellm_module.suppress_debug_info = False
+    litellm_logger = logging.getLogger("LiteLLM")
+    previous_level = litellm_logger.level
+    previous_propagate = litellm_logger.propagate
+
+    try:
+        configure_litellm_logging(litellm_module=litellm_module)
+
+        assert litellm_module.suppress_debug_info is True
+        assert litellm_logger.level == logging.WARNING
+        assert litellm_logger.propagate is False
+    finally:
+        litellm_logger.setLevel(previous_level)
+        litellm_logger.propagate = previous_propagate
+
+
+def test_litellm_logging_debug_opt_in_restores_verbose_logging(monkeypatch):
+    """TRAIGENT_LOG_LEVEL=DEBUG opts back into verbose LiteLLM diagnostics."""
+    monkeypatch.setenv("TRAIGENT_LOG_LEVEL", "DEBUG")
+    litellm_module = types.ModuleType("litellm")
+    litellm_module.suppress_debug_info = True
+    litellm_logger = logging.getLogger("LiteLLM")
+    previous_level = litellm_logger.level
+    previous_propagate = litellm_logger.propagate
+
+    try:
+        configure_litellm_logging(litellm_module=litellm_module)
+
+        assert litellm_module.suppress_debug_info is False
+        assert litellm_logger.level == logging.DEBUG
+        assert litellm_logger.propagate is True
+    finally:
+        litellm_logger.setLevel(previous_level)
+        litellm_logger.propagate = previous_propagate

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -1249,6 +1249,12 @@ def _resolve_execution_mode_enum(
     privacy_enabled: bool | None,
 ) -> tuple[ExecutionMode, bool | None]:
     """Resolve execution mode enum against the public support contract."""
+    raw_execution_mode = (
+        execution_mode.value
+        if isinstance(execution_mode, ExecutionMode)
+        else str(execution_mode)
+    )
+    requested_privacy_alias = raw_execution_mode.strip().lower() == "privacy"
     try:
         requested_mode = resolve_execution_mode(execution_mode)
         execution_mode_enum = validate_execution_mode(requested_mode)
@@ -1257,7 +1263,7 @@ def _resolve_execution_mode_enum(
     except (TypeError, ValueError) as exc:
         raise ConfigurationError(str(exc)) from None
 
-    if requested_mode is ExecutionMode.PRIVACY:
+    if requested_privacy_alias:
         logger.warning(
             "execution_mode='privacy' is deprecated. Use execution_mode='hybrid' "
             "with privacy_enabled=True. Mapping automatically."

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -29,6 +29,10 @@ from traigent.cloud.models import (
     TrialResultSubmission,
 )
 from traigent.config.backend_config import BackendConfig
+from traigent.core.session_types import (
+    SessionCreationFailureDetail,
+    SessionCreationHTTPError,
+)
 from traigent.utils.env_config import is_backend_offline
 from traigent.utils.exceptions import MetricExtractionError
 from traigent.utils.logging import get_logger
@@ -486,16 +490,28 @@ class ApiOperations:
         All logging is DEBUG — user-facing warnings are emitted by
         ``BackendSessionManager.handle_session_creation_result()``.
         """
+        detail = SessionCreationFailureDetail.from_http_response(status_code, error_msg)
+        structured_cause = SessionCreationHTTPError(detail)
         if status_code in (401, 403):
             logger.debug("Backend auth failed: %s", status_code)
-            raise AuthenticationError(f"Authentication failed ({status_code})")
+            auth_exc = AuthenticationError(
+                f"Authentication failed ({status_code}): {detail.one_line_summary()}"
+            )
+            cast(Any, auth_exc).session_creation_failure = detail
+            raise auth_exc from structured_cause
 
         if status_code in (500, 502, 503, 504):
             logger.debug("Backend HTTP error: %s", status_code)
-            raise CloudServiceError(f"Backend HTTP {status_code}")
+            service_exc = CloudServiceError(f"Backend HTTP {status_code}")
+            cast(Any, service_exc).session_creation_failure = detail
+            raise service_exc from structured_cause
 
         logger.debug("Backend session error: %s - %s", status_code, error_msg[:200])
-        raise CloudServiceError(f"Session creation failed: HTTP {status_code}")
+        service_exc = CloudServiceError(
+            f"Session creation failed: HTTP {status_code}: {detail.one_line_summary()}"
+        )
+        cast(Any, service_exc).session_creation_failure = detail
+        raise service_exc from structured_cause
 
     def _handle_connector_error(self, error: aiohttp.ClientConnectorError) -> None:
         """Handle aiohttp connector errors — DEBUG only."""

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -24,6 +24,7 @@ from traigent.cloud.models import (
     SessionCreationRequest,
 )
 from traigent.cloud.session_types import (
+    SessionCreationFailureDetail,
     SessionCreationFailureReason,
     SessionCreationResult,
 )
@@ -54,6 +55,15 @@ def _get_session_executor() -> concurrent.futures.ThreadPoolExecutor:
     if _SESSION_EXECUTOR is None:
         _SESSION_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     return _SESSION_EXECUTOR
+
+
+def _get_session_creation_failure_detail(
+    exc: Exception,
+) -> SessionCreationFailureDetail | None:
+    detail = getattr(exc, "session_creation_failure", None)
+    if isinstance(detail, SessionCreationFailureDetail):
+        return detail
+    return None
 
 
 class SessionOperations:
@@ -445,13 +455,19 @@ class SessionOperations:
                 if _must_fail_loud(e):
                     raise
                 logger.debug("Backend auth failed for '%s': %s", function_name, e)
+                failure_response = _get_session_creation_failure_detail(e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
                 )
                 return SessionCreationResult.fallback(
                     session_id=fallback_id,
                     reason=SessionCreationFailureReason.AUTH,
-                    detail=str(e)[:200],
+                    detail=(
+                        failure_response.one_line_summary()
+                        if failure_response
+                        else str(e)[:200]
+                    ),
+                    failure_response=failure_response,
                 )
 
             except (TimeoutError, CloudServiceError, OSError) as e:
@@ -459,14 +475,20 @@ class SessionOperations:
                 if _must_fail_loud(e):
                     raise
                 logger.debug("Backend unavailable for '%s': %s", function_name, e)
+                failure_response = _get_session_creation_failure_detail(e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
                 )
-                detail = str(e).split("\n", 1)[0][:200]
+                detail = (
+                    failure_response.one_line_summary()
+                    if failure_response
+                    else str(e).split("\n", 1)[0][:200]
+                )
                 return SessionCreationResult.fallback(
                     session_id=fallback_id,
                     reason=SessionCreationFailureReason.SESSION_FAILED,
                     detail=detail,
+                    failure_response=failure_response,
                 )
 
         # Run async method in sync context
@@ -500,13 +522,19 @@ class SessionOperations:
                 function_name,
                 exc,
             )
+            failure_response = _get_session_creation_failure_detail(exc)
             fallback_id = self._create_local_fallback_session(
                 function_name, search_space, optimization_goal, metadata
             )
             return SessionCreationResult.fallback(
                 session_id=fallback_id,
                 reason=SessionCreationFailureReason.AUTH,
-                detail=str(exc)[:200],
+                detail=(
+                    failure_response.one_line_summary()
+                    if failure_response
+                    else str(exc)[:200]
+                ),
+                failure_response=failure_response,
             )
 
         except (TimeoutError, CloudServiceError, OSError) as exc:
@@ -517,14 +545,20 @@ class SessionOperations:
                 function_name,
                 exc,
             )
+            failure_response = _get_session_creation_failure_detail(exc)
             fallback_id = self._create_local_fallback_session(
                 function_name, search_space, optimization_goal, metadata
             )
-            detail = str(exc).split("\n", 1)[0][:200]
+            detail = (
+                failure_response.one_line_summary()
+                if failure_response
+                else str(exc).split("\n", 1)[0][:200]
+            )
             return SessionCreationResult.fallback(
                 session_id=fallback_id,
                 reason=SessionCreationFailureReason.SESSION_FAILED,
                 detail=detail,
+                failure_response=failure_response,
             )
 
         except Exception as exc:

--- a/traigent/cloud/session_types.py
+++ b/traigent/cloud/session_types.py
@@ -1,8 +1,17 @@
 """Compatibility re-export for backend session creation types."""
 
 from traigent.core.session_types import (
+    SessionCreationFailureClassification,
+    SessionCreationFailureDetail,
     SessionCreationFailureReason,
+    SessionCreationHTTPError,
     SessionCreationResult,
 )
 
-__all__ = ["SessionCreationFailureReason", "SessionCreationResult"]
+__all__ = [
+    "SessionCreationFailureClassification",
+    "SessionCreationFailureDetail",
+    "SessionCreationFailureReason",
+    "SessionCreationHTTPError",
+    "SessionCreationResult",
+]

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -37,6 +37,33 @@ class ExecutionMode(StrEnum):
     HYBRID_API = "hybrid_api"
 
 
+# Canonical runtime-supported modes and accepted public aliases. Keep this as
+# the single source for decorator-time and runtime validation messages.
+_SUPPORTED_MODES = (
+    ExecutionMode.EDGE_ANALYTICS,
+    ExecutionMode.HYBRID,
+    ExecutionMode.HYBRID_API,
+)
+_EXECUTION_MODE_ALIASES: dict[str, ExecutionMode] = {
+    "local": ExecutionMode.EDGE_ANALYTICS,
+    "privacy": ExecutionMode.HYBRID,
+}
+_NOT_YET_SUPPORTED_MODES = {ExecutionMode.CLOUD}
+# STANDARD is removed; CLOUD is reserved for future remote execution.
+
+
+def accepted_execution_mode_values() -> tuple[str, ...]:
+    """Return accepted execution_mode strings for all public validators."""
+
+    values = {mode.value for mode in _SUPPORTED_MODES}
+    values.update(_EXECUTION_MODE_ALIASES)
+    return tuple(sorted(values))
+
+
+def _accepted_execution_mode_message() -> str:
+    return f"accepted values are {list(accepted_execution_mode_values())}"
+
+
 def resolve_execution_mode(
     mode: ExecutionMode | str | None,
     *,
@@ -47,30 +74,24 @@ def resolve_execution_mode(
     if mode is None:
         return default
     if isinstance(mode, ExecutionMode):
+        if mode is ExecutionMode.PRIVACY:
+            return ExecutionMode.HYBRID
         return mode
     if isinstance(mode, str):
         normalized = mode.strip().lower()
         if not normalized:
             return default
+        if normalized in _EXECUTION_MODE_ALIASES:
+            return _EXECUTION_MODE_ALIASES[normalized]
         try:
             return ExecutionMode(normalized)
         except ValueError as exc:  # pragma: no cover - defensive
             raise ValueError(
-                f"execution_mode must be one of {[m.value for m in ExecutionMode]}, got '{mode}'"
+                f"execution_mode must be one of {list(accepted_execution_mode_values())}, got '{mode}'"
             ) from exc
     raise TypeError(
         f"execution_mode must be a string or ExecutionMode, got {type(mode).__name__}"
     )
-
-
-# Currently supported execution modes
-_SUPPORTED_MODES = {
-    ExecutionMode.EDGE_ANALYTICS,
-    ExecutionMode.HYBRID,
-    ExecutionMode.HYBRID_API,
-}
-_NOT_YET_SUPPORTED_MODES = {ExecutionMode.CLOUD}
-# PRIVACY is a legacy alias for HYBRID + privacy_enabled=True. STANDARD is removed.
 
 
 def validate_execution_mode(mode: ExecutionMode | str | None) -> ExecutionMode:
@@ -87,17 +108,19 @@ def validate_execution_mode(mode: ExecutionMode | str | None) -> ExecutionMode:
     try:
         resolved = resolve_execution_mode(mode)
     except ValueError:
-        raise ConfigurationError(f"No such mode '{mode}'") from None
+        raise ConfigurationError(
+            f"No such mode '{mode}'; {_accepted_execution_mode_message()}"
+        ) from None
 
-    if resolved is ExecutionMode.PRIVACY:
-        return ExecutionMode.HYBRID
     if resolved in _NOT_YET_SUPPORTED_MODES:
         raise ConfigurationError(
             "Cloud remote execution is not available yet; use hybrid for "
-            "portal-tracked optimization."
+            f"portal-tracked optimization; {_accepted_execution_mode_message()}."
         )
     if resolved not in _SUPPORTED_MODES:
-        raise ConfigurationError(f"No such mode '{resolved.value}'")
+        raise ConfigurationError(
+            f"No such mode '{resolved.value}'; {_accepted_execution_mode_message()}"
+        )
 
     return resolved
 
@@ -189,6 +212,7 @@ class TraigentConfig:
     # Execution mode and storage configuration
     execution_mode: Literal[
         "edge_analytics",
+        "local",
         "privacy",
         "hybrid",
         "hybrid_api",
@@ -245,11 +269,11 @@ class TraigentConfig:
         # Validate execution mode against the public support contract.
         requested_mode = resolve_execution_mode(self.execution_mode)
         mode_enum = validate_execution_mode(requested_mode)
-        if requested_mode is ExecutionMode.PRIVACY:
+        if isinstance(self.execution_mode, str) and self.execution_mode == "privacy":
             self.privacy_enabled = True
 
         self.execution_mode = cast(
-            Literal["edge_analytics", "privacy", "hybrid", "hybrid_api"],
+            Literal["edge_analytics", "local", "privacy", "hybrid", "hybrid_api"],
             mode_enum.value,
         )
 
@@ -504,7 +528,7 @@ class TraigentConfig:
         elif key == "execution_mode" and value is not None:
             requested_mode = resolve_execution_mode(value)
             resolved_mode = validate_execution_mode(requested_mode)
-            if requested_mode is ExecutionMode.PRIVACY:
+            if isinstance(value, str) and value.strip().lower() == "privacy":
                 # Promote legacy alias to hybrid and enable privacy
                 object.__setattr__(self, "privacy_enabled", True)
                 object.__setattr__(self, "_privacy_enforced_by_execution_mode", True)

--- a/traigent/config_generator/llm_backend.py
+++ b/traigent/config_generator/llm_backend.py
@@ -12,6 +12,8 @@ import logging
 import threading
 from typing import Protocol, runtime_checkable
 
+from traigent.utils.logging import configure_litellm_logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -101,6 +103,7 @@ class LiteLLMBackend:
                 )
                 raise BudgetExhausted("litellm not installed") from exc
 
+            configure_litellm_logging(litellm_module=litellm)
             response = litellm.completion(
                 model=self._model,
                 messages=[{"role": "user", "content": prompt}],

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -22,22 +22,151 @@ from traigent.config.types import TraigentConfig
 if TYPE_CHECKING:
     from traigent.cloud.backend_client import BackendIntegratedClient
 
-from traigent.config.backend_config import SIGNUP_URL, get_no_credentials_hint
+from traigent.config.backend_config import get_no_credentials_hint
 from traigent.core.metadata_helpers import build_backend_metadata
 from traigent.core.objectives import ObjectiveSchema
 from traigent.core.session_context import SessionContext
 from traigent.core.session_types import (
+    SessionCreationFailureClassification,
+    SessionCreationFailureDetail,
     SessionCreationFailureReason,
     SessionCreationResult,
 )
 from traigent.evaluators.base import Dataset
 from traigent.metrics.content_features import SimhashFeatureExtractor
 from traigent.optimizers.base import BaseOptimizer
-from traigent.utils.env_config import is_backend_offline
+from traigent.utils.env_config import is_backend_offline, is_untracked_fallback_allowed
+from traigent.utils.exceptions import ConfigurationError
 from traigent.utils.function_identity import FunctionDescriptor
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+_WARNING_RULE = "=" * 72
+
+
+def _contains_any(value: str, needles: tuple[str, ...]) -> bool:
+    return any(needle in value for needle in needles)
+
+
+def _classify_session_creation_failure(
+    reason: SessionCreationFailureReason,
+    detail: SessionCreationFailureDetail | None,
+) -> SessionCreationFailureClassification:
+    if reason == SessionCreationFailureReason.SESSION_FAILED:
+        if detail and detail.status_code and 400 <= detail.status_code < 500:
+            return SessionCreationFailureClassification.UNKNOWN
+        return SessionCreationFailureClassification.BACKEND_UNREACHABLE
+
+    if reason == SessionCreationFailureReason.NO_API_KEY:
+        return SessionCreationFailureClassification.KEY_NOT_FOUND
+
+    if detail and detail.missing_permissions:
+        return SessionCreationFailureClassification.MISSING_PERMISSION
+
+    text = " ".join(
+        part
+        for part in (
+            detail.error_code if detail else None,
+            detail.message if detail else None,
+            detail.raw_body if detail else None,
+        )
+        if part
+    ).lower()
+
+    if _contains_any(text, ("key_not_found", "api_key_not_found", "key not found")):
+        return SessionCreationFailureClassification.KEY_NOT_FOUND
+    if _contains_any(
+        text,
+        (
+            "invalid",
+            "revoked",
+            "expired",
+            "rejected",
+            "unauthorized",
+            "authentication",
+        ),
+    ):
+        return SessionCreationFailureClassification.INVALID_OR_REVOKED_KEY
+    if detail and detail.status_code == 401:
+        return SessionCreationFailureClassification.INVALID_OR_REVOKED_KEY
+
+    return SessionCreationFailureClassification.UNKNOWN
+
+
+def _format_raw_reason(result: SessionCreationResult) -> str | None:
+    detail = result.failure_response
+    raw_reason = result.failure_detail
+    if detail and detail.raw_body:
+        raw_reason = detail.raw_body
+    if not raw_reason:
+        return None
+    return raw_reason.replace("\n", "\\n")[:500]
+
+
+def _format_untracked_warning_block(
+    result: SessionCreationResult,
+    classification: SessionCreationFailureClassification,
+    *,
+    aborting: bool,
+) -> str:
+    detail = result.failure_response
+    lines = [
+        _WARNING_RULE,
+        "TRAIGENT BACKEND TRACKING UNAVAILABLE",
+        "This run will NOT be tracked in the portal.",
+        f"Classification: {classification.value}",
+    ]
+
+    if detail and detail.status_code is not None:
+        lines.append(f"HTTP status: {detail.status_code}")
+    if detail and detail.error_code:
+        lines.append(f"Backend error_code: {detail.error_code}")
+    if detail and detail.message:
+        lines.append(f"Backend message: {detail.message}")
+    if detail and detail.missing_permissions:
+        permissions = ", ".join(f"`{p}`" for p in detail.missing_permissions)
+        lines.append(f"Missing permissions: {permissions}")
+
+    raw_reason = _format_raw_reason(result)
+    if raw_reason:
+        lines.append(f"Raw reason: {raw_reason}")
+
+    if classification == SessionCreationFailureClassification.MISSING_PERMISSION:
+        lines.append(
+            "Remedy: grant the missing permission(s) to the API key, or if the "
+            "key should already have them, verify the backend deployment and "
+            "permission middleware that returned this structured response."
+        )
+    elif classification == SessionCreationFailureClassification.INVALID_OR_REVOKED_KEY:
+        lines.append(
+            "Remedy: re-authenticate with `traigent auth login` or provide a "
+            "valid, non-revoked API key."
+        )
+    elif classification == SessionCreationFailureClassification.KEY_NOT_FOUND:
+        lines.append(
+            "Remedy: configure a valid Traigent API key or run `traigent auth login`."
+        )
+    elif classification == SessionCreationFailureClassification.BACKEND_UNREACHABLE:
+        lines.append(
+            "Remedy: check TRAIGENT_BACKEND_URL/network connectivity or retry later."
+        )
+    else:
+        lines.append(
+            "Remedy: inspect the raw backend response above; retry with "
+            "TRAIGENT_LOG_LEVEL=DEBUG for more diagnostics."
+        )
+
+    if aborting:
+        lines.append(
+            "Aborting before trials or LLM calls. To knowingly proceed local-only, "
+            "set TRAIGENT_ALLOW_UNTRACKED=1."
+        )
+    else:
+        lines.append("Continuing local-only; results will be saved on this machine.")
+
+    lines.append(_WARNING_RULE)
+    return "\n".join(lines)
 
 
 class BackendSessionManager:
@@ -131,23 +260,32 @@ class BackendSessionManager:
             if not was_enabled:
                 return str(result.session_id)
 
+            classification = _classify_session_creation_failure(
+                reason, result.failure_response
+            )
             if reason == SessionCreationFailureReason.AUTH:
-                logger.warning(
-                    "Backend authentication failed — results will be saved locally only. "
-                    "Run 'traigent auth login' or get a new key at %s",
-                    SIGNUP_URL,
+                allow_untracked = is_untracked_fallback_allowed()
+                warning = _format_untracked_warning_block(
+                    result,
+                    classification,
+                    aborting=not allow_untracked,
                 )
+                if not allow_untracked:
+                    raise ConfigurationError(warning)
+                logger.warning("%s", warning)
             elif reason == SessionCreationFailureReason.NO_API_KEY:
                 logger.warning(
                     "No API key found — results saved locally only. %s",
                     get_no_credentials_hint(),
                 )
             else:
-                detail = result.failure_detail or "unknown"
                 logger.warning(
-                    "Backend tracking unavailable — results will be saved locally only. "
-                    "reason=%s",
-                    detail[:200],
+                    "%s",
+                    _format_untracked_warning_block(
+                        result,
+                        classification,
+                        aborting=False,
+                    ),
                 )
         else:
             logger.info("Created backend session: %s", result.session_id)

--- a/traigent/core/session_types.py
+++ b/traigent/core/session_types.py
@@ -6,8 +6,10 @@ depend on it even when the optional cloud package is unavailable.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class SessionCreationFailureReason(Enum):
@@ -18,6 +20,89 @@ class SessionCreationFailureReason(Enum):
     SESSION_FAILED = "session_failed"  # transient: 5xx, connection, timeout
 
 
+class SessionCreationFailureClassification(Enum):
+    """User-facing classification for a failed backend session creation."""
+
+    MISSING_PERMISSION = "missing-permission"
+    INVALID_OR_REVOKED_KEY = "invalid-or-revoked-key"
+    KEY_NOT_FOUND = "key-not-found"
+    BACKEND_UNREACHABLE = "backend-unreachable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class SessionCreationFailureDetail:
+    """Structured backend response details for failed session creation."""
+
+    status_code: int | None = None
+    error_code: str | None = None
+    message: str | None = None
+    missing_permissions: tuple[str, ...] = ()
+    raw_body: str | None = None
+
+    @classmethod
+    def from_http_response(
+        cls, status_code: int, raw_body: str | None
+    ) -> SessionCreationFailureDetail:
+        """Parse the backend's structured session-creation error response."""
+
+        payload: dict[str, Any] = {}
+        if raw_body:
+            try:
+                parsed = json.loads(raw_body)
+            except (TypeError, ValueError):
+                parsed = None
+            if isinstance(parsed, dict):
+                payload = parsed
+
+        details = payload.get("details")
+        if not isinstance(details, dict):
+            details = {}
+
+        raw_missing = details.get("missing_permissions")
+        if isinstance(raw_missing, (list, tuple, set)):
+            missing_permissions = tuple(str(item) for item in raw_missing)
+        else:
+            missing_permissions = ()
+
+        error_code = payload.get("error_code") or payload.get("code")
+        message = payload.get("message") or payload.get("error")
+
+        return cls(
+            status_code=status_code,
+            error_code=str(error_code) if error_code else None,
+            message=str(message) if message else None,
+            missing_permissions=missing_permissions,
+            raw_body=raw_body,
+        )
+
+    def one_line_summary(self) -> str:
+        """Return a compact summary suitable for exception/log details."""
+
+        parts: list[str] = []
+        if self.status_code is not None:
+            parts.append(f"HTTP {self.status_code}")
+        if self.error_code:
+            parts.append(self.error_code)
+        if self.message:
+            parts.append(self.message)
+        if self.missing_permissions:
+            parts.append(
+                "missing_permissions=" + ",".join(sorted(set(self.missing_permissions)))
+            )
+        if not parts and self.raw_body:
+            parts.append(self.raw_body[:200])
+        return " | ".join(parts) or "unknown"
+
+
+class SessionCreationHTTPError(Exception):
+    """HTTP error raised while creating a backend tracking session."""
+
+    def __init__(self, detail: SessionCreationFailureDetail) -> None:
+        super().__init__(detail.one_line_summary())
+        self.detail = detail
+
+
 @dataclass
 class SessionCreationResult:
     """Structured outcome of a session creation attempt."""
@@ -26,6 +111,7 @@ class SessionCreationResult:
     backend_connected: bool
     failure_reason: SessionCreationFailureReason | None = None
     failure_detail: str | None = None
+    failure_response: SessionCreationFailureDetail | None = None
 
     def __str__(self) -> str:
         """Return the session ID string for backwards compatibility.
@@ -53,6 +139,7 @@ class SessionCreationResult:
         session_id: str,
         reason: SessionCreationFailureReason,
         detail: str | None = None,
+        failure_response: SessionCreationFailureDetail | None = None,
     ) -> SessionCreationResult:
         """Factory for a local-fallback session after backend failure."""
         return cls(
@@ -60,4 +147,5 @@ class SessionCreationResult:
             backend_connected=False,
             failure_reason=reason,
             failure_detail=detail,
+            failure_response=failure_response,
         )

--- a/traigent/integrations/utils/mock_adapter.py
+++ b/traigent/integrations/utils/mock_adapter.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, ClassVar
 
+from traigent.utils.logging import configure_litellm_logging
+
 logger = logging.getLogger(__name__)
 
 # Default mock delay in milliseconds (0 = no delay)
@@ -305,6 +307,7 @@ class MockAdapter:
     def _build_litellm_mock(cls, data: MockResponse) -> Any:
         """Build a LiteLLM ModelResponse-like mock response."""
         try:
+            import litellm
             from litellm import ModelResponse
         except Exception as exc:  # pragma: no cover - exercised only without litellm
             logger.debug("LiteLLM ModelResponse unavailable, using fallback: %s", exc)
@@ -330,6 +333,7 @@ class MockAdapter:
                 ),
             )
 
+        configure_litellm_logging(litellm_module=litellm)
         return ModelResponse(
             id=data.response_id,
             model=data.model,

--- a/traigent/utils/constraints.py
+++ b/traigent/utils/constraints.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from traigent.core.constants import DEFAULT_MODEL
-from traigent.utils.logging import get_logger
+from traigent.utils.logging import configure_litellm_logging, get_logger
 
 logger = get_logger(__name__)
 
@@ -484,6 +484,7 @@ def _try_litellm_pricing(model: str, max_tokens: int) -> float | None:
     try:
         import litellm
 
+        configure_litellm_logging(litellm_module=litellm)
         input_cost, output_cost = litellm.cost_per_token(
             model=model, prompt_tokens=1000, completion_tokens=1000
         )

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -19,6 +19,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
+from traigent.utils.logging import configure_litellm_logging
+
 logger = logging.getLogger(__name__)
 
 # Privacy default: force litellm to use its bundled pricing map instead of
@@ -35,6 +37,7 @@ os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 try:
     import litellm
 
+    configure_litellm_logging(litellm_module=litellm)
     LITELLM_AVAILABLE = True
 except (ImportError, KeyError):
     litellm = None  # type: ignore[assignment]

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -470,6 +470,12 @@ def is_backend_offline() -> bool:
     return get_env_var("TRAIGENT_OFFLINE_MODE", "false").lower() == "true"
 
 
+def is_untracked_fallback_allowed() -> bool:
+    """Return True when auth failures may proceed local-only by explicit opt-in."""
+
+    return is_truthy(os.environ.get("TRAIGENT_ALLOW_UNTRACKED"))
+
+
 def raise_if_backend_offline(operation: str = "This backend request") -> None:
     """Fail closed when offline mode is enabled.
 

--- a/traigent/utils/litellm_interceptor.py
+++ b/traigent/utils/litellm_interceptor.py
@@ -14,7 +14,7 @@ import time
 from typing import Any
 
 from traigent.utils.langchain_interceptor import capture_langchain_response
-from traigent.utils.logging import get_logger
+from traigent.utils.logging import configure_litellm_logging, get_logger
 
 logger = get_logger(__name__)
 
@@ -37,6 +37,8 @@ def patch_litellm_for_metadata_capture() -> bool:
     except ImportError:
         logger.debug("LiteLLM not available, skipping interceptor")
         return False
+
+    configure_litellm_logging(litellm_module=litellm)
 
     # Patch litellm.completion (sync)
     if not getattr(litellm, "_traigent_patched_completion", False):

--- a/traigent/utils/logging.py
+++ b/traigent/utils/logging.py
@@ -5,6 +5,49 @@
 from __future__ import annotations
 
 import logging
+import os
+import sys
+from types import ModuleType
+from typing import Any, cast
+
+
+def _resolve_logging_level(level: str | None = None) -> str:
+    """Resolve SDK logging level, honoring the documented env override."""
+
+    configured = os.environ.get("TRAIGENT_LOG_LEVEL") or level or "INFO"
+    return configured.strip().upper()
+
+
+def configure_litellm_logging(
+    level: str | None = None,
+    *,
+    litellm_module: ModuleType | None = None,
+) -> None:
+    """Apply Traigent's LiteLLM logging policy.
+
+    The logger policy can be applied before LiteLLM is imported. When a LiteLLM
+    module is available, the same function also toggles its debug banner flag.
+    """
+
+    log_level = _resolve_logging_level(level)
+    debug_enabled = log_level == "DEBUG"
+
+    litellm_logger = logging.getLogger("LiteLLM")
+    if debug_enabled:
+        litellm_logger.setLevel(logging.DEBUG)
+        litellm_logger.propagate = True
+    else:
+        litellm_logger.setLevel(logging.WARNING)
+        litellm_logger.propagate = False
+
+    module = litellm_module
+    if module is None:
+        candidate = sys.modules.get("litellm")
+        if isinstance(candidate, ModuleType):
+            module = candidate
+
+    if module is not None:
+        cast(Any, module).suppress_debug_info = not debug_enabled
 
 
 def setup_logging(
@@ -40,6 +83,7 @@ def setup_logging(
     # Set specific levels for third-party libraries
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    configure_litellm_logging(level)
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -56,3 +100,6 @@ def get_logger(name: str) -> logging.Logger:
 
 # Create default logger
 logger = get_logger(__name__)
+
+# Configure third-party loggers early without importing optional dependencies.
+configure_litellm_logging()


### PR DESCRIPTION
Fixes #1179, fixes #1181, fixes #1178.

Walkthrough cold-start remediation — SDK UX train. Governed under spine ChangeSession `cs_31ebba178419c83b` / packet `pkt_3cadd07c0a4887a1`. Implemented by codex gpt-5.5 (xhigh) worker; captain-reviewed (Claude Opus 4.8), independently re-tested.

## What

- **#1179** — central `configure_litellm_logging()` (`traigent/utils/logging.py`): by default `LiteLLM` logger → WARNING, `propagate=False` (kills the double emission), `litellm.suppress_debug_info=True` (kills the "Give Feedback" banner). Applied at logging setup AND after every SDK-owned lazy litellm import (cost_calculator, interceptor, constraints, llm_backend, mock_adapter) — import-order-safe, no hard litellm dependency. Debug opt-in via existing `TRAIGENT_LOG_LEVEL=DEBUG` convention restores verbose.
- **#1181** — session-creation failures now carry the backend's structured body (`error_code`, `message`, `details.missing_permissions`) into a classifier with one decision chokepoint (`handle_session_creation_result`). **Auth/permission failures (401/403) abort with a loud multi-line block BEFORE any trial/LLM spend** — naming the exact missing permission verbatim from the backend AND noting the 403 may be a backend deploy gap (the BE#831 lesson) — unless `TRAIGENT_ALLOW_UNTRACKED=1` explicitly opts into local-only. Transient unreachability/5xx keeps warn-and-continue-local. No documented always-continue contract exists (worker audited; changelog documents generic graceful fallback only — auth failures are config errors that don't self-heal).
- **#1178** — one accepted-mode registry in `traigent/config/types.py` (`accepted_execution_mode_values()`); decorator validation consumes the same resolver. `local` → alias of `edge_analytics`; `privacy` stays a legacy alias of `hybrid`; `standard` stays removed (docs/tests already treat it as removed); `cloud` stays reserved/fail-closed. Both layers now list exactly `['edge_analytics','hybrid','hybrid_api','local','privacy']`.

## Behavior change (deliberate, fail-closed)

403/401 at backend session creation **aborts by default** instead of silently running an untracked billed run. Opt-out: `TRAIGENT_ALLOW_UNTRACKED=1`. This is the issue's requested direction; flagging it loudly for review since it can stop runs that previously limped along locally. **New public env var: `TRAIGENT_ALLOW_UNTRACKED`** (documented in `utils/env_config.py` helper; docs-site follow-up flagged).

## Verification

Captain re-ran: logging + backend_session_manager + api_operations + config types + decorators suites → **203 passed**. Worker totals: 243 passed focused, 138 passed `-k "execution_mode or backend_session or logging"`. Tests cover: 403-with-structured-body names `experiment.write`, abort-by-default, opt-in continue, connection-error continue, unknown 4xx raw-reason, **no backend trial write before abort**, decorator/runtime accepted-set parity, alias resolution, debug opt-in restores verbose.

Known sibling (NOT fixed here): `tests/test_resampling_aggregation.py::test_orchestrator_end_aggregation_and_backend_submission` is pre-existing-broken on develop — written against the removed `'standard'` mode, and switching it to an accepted mode surfaces a second aggregation-semantics mismatch (best_score 0.9 vs expected aggregated 0.7). Needs its own issue; captain filing separately rather than a drive-by edit.

## PR checklist

1. **Worst-case prod path** — the new abort is fail-closed (stops spend); the fallback opt-in is explicit. Logging change is output-only. Mode registry rejects, never silently accepts.
2. **Production-branch test** — abort-before-spend: `tests/unit/core/test_backend_session_manager.py` (no-trial-before-abort case).
3. **Contract regeneration** — none; no request/response shape change. **traigent-js parity follow-up flagged** for the 403 classification behavior.
4. **Public surface delta** — additive: `TRAIGENT_ALLOW_UNTRACKED` env var, `accepted_execution_mode_values()`. Error messages now list the true accepted mode set.
5. **Review threads** — will resolve all before merge.
6. **Quality gates** — none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)