### PR TITLE
fix(walkthrough): non-ceiling Bedrock RAG eval so optimization has real signal (#1182)

### DIFF
--- a/walkthrough/README.md
+++ b/walkthrough/README.md
@@ -118,7 +118,9 @@ they are useful companion material:
 
 ## Datasets
 
-Each dataset contains **20 examples** with varying difficulty levels to ensure different model configurations show measurable differences.
+Datasets carry **varying difficulty levels** so different model configurations show
+measurable accuracy differences (most contain 20 examples; `rag_questions.jsonl` has 13
+tuned for spread — see issue #1182).
 
 ### simple_questions.jsonl (and simple_questions_10.jsonl)
 
@@ -143,10 +145,16 @@ Sentiment analysis with ambiguous cases:
 
 ### rag_questions.jsonl
 
-Traigent documentation Q&A for RAG testing:
+Traigent documentation Q&A for RAG testing, designed to be **non-ceiling** — the
+knowledge base states *rules* and the questions require *applying* them, so model
+accuracy actually spreads (issue #1182). 13 examples:
 
-- **Simple (10)**: Direct questions with factual answers from docs
-- **Complex (10)**: Questions requiring synthesis of multiple document sections
+- **Anchors (3)**: Single-fact lookups every model answers (e.g. which mode is hybrid).
+- **Rule-application (10)**: Counting and grid-search trial-count arithmetic
+  (`trials = product of candidate counts`) plus multi-step reasoning — strong models
+  (claude-haiku-4-5, llama-70b) score ~100%, mid models (Nova) ~85%, small models
+  (llama-8b) ~70% (measured live on Bedrock). This gives the multi-objective
+  accuracy/cost optimizer real signal to differentiate configurations.
 
 **Evaluation**: Semantic similarity - checks if key concepts from expected answer appear in response
 

--- a/walkthrough/datasets/rag_questions.jsonl
+++ b/walkthrough/datasets/rag_questions.jsonl
@@ -1,20 +1,13 @@
-{"input": {"question": "What does Traigent do?"}, "output": "Traigent optimizes AI applications without code changes"}
-{"input": {"question": "What is seamless mode?"}, "output": "Seamless mode intercepts and overrides hardcoded LLM parameters"}
-{"input": {"question": "What is parameter mode?"}, "output": "Parameter mode provides explicit configuration control via function parameters"}
-{"input": {"question": "What execution modes does Traigent support?"}, "output": "Local, cloud, and hybrid execution modes"}
-{"input": {"question": "How does local mode work?"}, "output": "Local mode keeps all data on your machine for complete privacy"}
-{"input": {"question": "What is edge_analytics mode?"}, "output": "Edge analytics mode runs optimization locally while sending analytics"}
-{"input": {"question": "What optimization algorithms does Traigent support?"}, "output": "Grid search, random search, and Bayesian optimization"}
-{"input": {"question": "What is the @traigent.optimize decorator?"}, "output": "A decorator that enables automatic optimization of LLM functions"}
-{"input": {"question": "How do you define objectives in Traigent?"}, "output": "Using the objectives parameter with metrics like accuracy, cost, latency"}
-{"input": {"question": "What is a configuration space?"}, "output": "A dictionary defining the hyperparameters and their possible values to optimize"}
-{"input": {"question": "How does Traigent balance multiple objectives?"}, "output": "Through weighted objective definitions using ObjectiveSchema with maximize/minimize orientations"}
-{"input": {"question": "Explain hybrid mode with privacy"}, "output": "Hybrid mode runs LLM calls locally but uses cloud for optimization intelligence with privacy enabled"}
-{"input": {"question": "How does Traigent handle RAG optimization?"}, "output": "It can optimize both retrieval parameters like k and method, plus generation parameters like model and temperature"}
-{"input": {"question": "What is the difference between seamless and context injection?"}, "output": "Seamless mode auto-overrides LLM calls; context mode adds config to prompts"}
-{"input": {"question": "How do custom evaluators work?"}, "output": "Custom evaluators let you define your own scoring logic for specialized use cases"}
-{"input": {"question": "Can Traigent optimize cost and accuracy simultaneously?"}, "output": "Yes, through multi-objective optimization with configurable weights for each metric"}
-{"input": {"question": "What privacy features does Traigent offer?"}, "output": "Local storage, privacy_enabled flag, and edge_analytics mode for data control"}
-{"input": {"question": "How does Traigent integrate with LangChain?"}, "output": "Via adapters that intercept LangChain LLM calls and inject optimized configurations"}
-{"input": {"question": "What is the eval_dataset parameter?"}, "output": "A JSONL file or Dataset object containing input/output pairs for evaluation"}
-{"input": {"question": "How does Traigent determine the best configuration?"}, "output": "By running trials, evaluating against objectives, and selecting the config with best weighted score"}
+{"input": {"question": "Which single execution mode runs the LLM calls locally but uses the cloud for optimization? Answer with one word."}, "output": "hybrid"}
+{"input": {"question": "Which optimization algorithm evaluates every combination in the configuration space? Answer with two words."}, "output": "grid search"}
+{"input": {"question": "Which optimization algorithm is the most sample-efficient? Answer with one word."}, "output": "Bayesian"}
+{"input": {"question": "How many of Traigent's execution modes keep raw data on the user's device? Number only."}, "output": "2"}
+{"input": {"question": "How many of Traigent's optimization algorithms do NOT use results from previous trials? Number only."}, "output": "2"}
+{"input": {"question": "With grid search over 5 models and 2 temperatures, how many trials run? Number only."}, "output": "10"}
+{"input": {"question": "With grid search over 3 models, 2 values of k, and 2 temperatures, how many trials run? Number only."}, "output": "12"}
+{"input": {"question": "With grid search over 4 models, 3 temperatures, and 2 values of k, how many trials run? Number only."}, "output": "24"}
+{"input": {"question": "With grid search over 5 models, 3 values of k, and 3 temperatures, how many trials run? Number only."}, "output": "45"}
+{"input": {"question": "With grid search over 3 algorithms, 4 models, 2 values of k, and 3 temperatures, how many trials run? Number only."}, "output": "72"}
+{"input": {"question": "With grid search over 5 models, 4 temperatures, 3 values of k, and 2 retrieval methods, how many trials run? Number only."}, "output": "120"}
+{"input": {"question": "Grid search over 7 models and 3 temperatures is planned, but 2 of those configurations are already cached and skipped. How many new trials run? Number only."}, "output": "19"}
+{"input": {"question": "Grid search over 6 models and 6 temperatures is planned; the 2 highest temperatures are dropped for every model. How many trials run? Number only."}, "output": "24"}

--- a/walkthrough/real/advanced/04_multi_agent_bedrock.py
+++ b/walkthrough/real/advanced/04_multi_agent_bedrock.py
@@ -133,86 +133,76 @@ DEFAULT_EMBEDDING_MODEL = os.getenv(
     "bedrock/amazon.titan-embed-text-v2:0",
 )
 
+# Knowledge base for a *non-ceiling* RAG eval (issue #1182).
+#
+# The previous KB/dataset asked questions whose verbatim answer was a single
+# retrieved sentence, so every model copied the context and scored ~100% —
+# optimization had no signal to differentiate configs. This KB instead states
+# the *rules* (e.g. "grid trials = product of candidate counts", which modes are
+# on-device) and the dataset asks questions that require **applying** those rules
+# (counting, multi-factor multiplication, multi-step reasoning). That spreads
+# model accuracy (strong models ~0.96, mid ~0.82, small ~0.68 — measured live on
+# Bedrock 2026-06-07), so the multi-objective accuracy/cost optimizer has real
+# signal. Anchors (single-fact lookups) keep the floor non-zero.
 KNOWLEDGE_BASE = [
     (
-        "Question: What does Traigent do?\n"
-        "Answer: Traigent optimizes AI applications without code changes"
+        "Traigent optimizes AI applications without code changes by wrapping a "
+        "function with the @traigent.optimize decorator."
     ),
     (
-        "Question: What is seamless mode?\n"
-        "Answer: Seamless mode intercepts and overrides hardcoded LLM parameters"
+        "Traigent supports four execution modes: local, cloud, hybrid, and "
+        "edge_analytics. Local keeps all data on the user's own machine and sends "
+        "nothing externally. Cloud runs everything on Traigent servers. Hybrid runs "
+        "the LLM calls locally but uses the cloud for optimization intelligence. "
+        "Edge_analytics runs optimization locally and sends only anonymized analytics."
     ),
     (
-        "Question: What is parameter mode?\n"
-        "Answer: Parameter mode provides explicit configuration control via function parameters"
+        "Traigent provides three optimization algorithms: grid search, random "
+        "search, and Bayesian optimization. Grid search evaluates every combination "
+        "in the configuration space. Random search samples a fixed number of random "
+        "combinations. Bayesian optimization uses results from previous trials to "
+        "choose the next combination and is the most sample-efficient of the three."
     ),
     (
-        "Question: What execution modes does Traigent support?\n"
-        "Answer: Local, cloud, and hybrid execution modes"
+        "A configuration space is a dictionary mapping each tunable parameter to its "
+        "candidate values, expressed with Choices. For grid search, the number of "
+        "trials equals the product of the number of candidate values across every "
+        "parameter."
     ),
     (
-        "Question: How does local mode work?\n"
-        "Answer: Local mode keeps all data on your machine for complete privacy"
+        "Multi-objective optimization uses ObjectiveSchema. Each objective has a "
+        "weight and the weights must sum to 1.0. Accuracy is maximized, while cost "
+        "and latency are minimized."
     ),
     (
-        "Question: What is edge_analytics mode?\n"
-        "Answer: Edge analytics mode runs optimization locally while sending analytics"
+        "Seamless mode intercepts and overrides hardcoded LLM parameters "
+        "automatically and requires no prompt changes. Context-injection mode "
+        "instead modifies the prompt by adding the configuration to it."
     ),
     (
-        "Question: What optimization algorithms does Traigent support?\n"
-        "Answer: Grid search, random search, and Bayesian optimization"
+        "Traigent integrates with LangChain through adapters that intercept "
+        "LangChain LLM calls and inject the optimized configuration."
     ),
     (
-        "Question: What is the @traigent.optimize decorator?\n"
-        "Answer: A decorator that enables automatic optimization of LLM functions"
+        "The eval_dataset parameter accepts a JSONL file of input and output pairs "
+        "that is used to score each candidate configuration."
     ),
     (
-        "Question: How do you define objectives in Traigent?\n"
-        "Answer: Using the objectives parameter with metrics like accuracy, cost, latency"
+        "Privacy: local mode and edge_analytics keep raw data on-device; the "
+        "privacy_enabled flag prevents prompts and outputs from being transmitted "
+        "when using hybrid mode."
     ),
     (
-        "Question: What is a configuration space?\n"
-        "Answer: A dictionary defining the hyperparameters and their possible values to optimize"
+        "Traigent's dashboard visualizes the Pareto frontier of accuracy versus cost "
+        "so users can compare configurations after a run completes."
     ),
     (
-        "Question: How does Traigent balance multiple objectives?\n"
-        "Answer: Through weighted objective definitions using ObjectiveSchema with maximize/minimize orientations"
+        "Traigent can resume an interrupted optimization run from its last completed "
+        "trial."
     ),
     (
-        "Question: Explain hybrid mode with privacy\n"
-        "Answer: Hybrid mode runs LLM calls locally but uses cloud for optimization intelligence with privacy enabled"
-    ),
-    (
-        "Question: How does Traigent handle RAG optimization?\n"
-        "Answer: It can optimize both retrieval parameters like k and method, plus generation parameters like model and temperature"
-    ),
-    (
-        "Question: What is the difference between seamless and context injection?\n"
-        "Answer: Seamless mode auto-overrides LLM calls; context mode adds config to prompts"
-    ),
-    (
-        "Question: How do custom evaluators work?\n"
-        "Answer: Custom evaluators let you define your own scoring logic for specialized use cases"
-    ),
-    (
-        "Question: Can Traigent optimize cost and accuracy simultaneously?\n"
-        "Answer: Yes, through multi-objective optimization with configurable weights for each metric"
-    ),
-    (
-        "Question: What privacy features does Traigent offer?\n"
-        "Answer: Local storage, privacy_enabled flag, and edge_analytics mode for data control"
-    ),
-    (
-        "Question: How does Traigent integrate with LangChain?\n"
-        "Answer: Via adapters that intercept LangChain LLM calls and inject optimized configurations"
-    ),
-    (
-        "Question: What is the eval_dataset parameter?\n"
-        "Answer: A JSONL file or Dataset object containing input/output pairs for evaluation"
-    ),
-    (
-        "Question: How does Traigent determine the best configuration?\n"
-        "Answer: By running trials, evaluating against objectives, and selecting the config with best weighted score"
+        "A measure in Traigent is a named numeric metric recorded for a "
+        "configuration run."
     ),
 ]
 
@@ -470,7 +460,8 @@ async def main() -> None:
     print("Generator models:")
     for model_id in BEDROCK_GENERATOR_MODEL_IDS:
         print(f"  - bedrock/{model_id}")
-    print(f"Grid: {total_trials} trials x 20 examples")
+    example_count = sum(1 for _ in open(DATASET_PATH, encoding="utf-8") if _.strip())
+    print(f"Grid: {total_trials} trials x {example_count} examples")
 
     results = await bedrock_multi_agent_rag.optimize(
         algorithm="grid",


### PR DESCRIPTION
Fixes #1182.

Validated **end-to-end on live AWS Bedrock** (account 340334787933, us-east-1, 2026-06-07).

## Problem
The 04 Bedrock RAG eval was a ceiling effect: every dataset question was a **verbatim KB question** whose answer was a single retrieved sentence, so every model just copied the context and scored ~100%. The multi-objective optimizer had **no signal** to differentiate configurations — the whole point of the demo was lost.

## Redesign
Shift from *lookup* to *rule-application*:
- **KB states rules**, not verbatim answers: `grid trials = product of candidate counts`, which execution modes keep data on-device, which algorithms use prior trials, etc. (+ a few distractor docs).
- **Dataset asks questions that require applying the rules**: counting, graduated grid-search trial-count arithmetic (2–4 factors + multi-step), and multi-hop counting — plus **3 single-fact anchors** so the floor stays non-zero.
- **No scorer change, no `k` change**: keeps the production `semantic_overlap_score` and `k=2`. Answers are short/exact (digits for counts) so the scorer cleanly separates correct from wrong reasoning. I built a standalone probe to measure per-model spread and iterate before touching the walkthrough (v1's pure-reasoning questions were still a ceiling — these models are all strong at single-fact reasoning; **arithmetic is the honest differentiator**).

## Verification — real end-to-end run (5 models × 13 examples)
```
#  model                  accuracy   cost       examples
1  claude-haiku-4-5        100.0%   $0.00022    13/13
2  nova-micro               84.6%   $0.00001    13/13
3  nova-lite                84.6%   $0.00001    13/13
4  llama-8b                 69.2%   $0.00004    13/13
★5 llama-70b               100.0%   $0.00017    13/13   ← Overall Best
```
Accuracy now spreads **69.2% → 84.6% → 100%** (was all ~100%). Two models tie at 100% and the optimizer's ★ correctly picks the **cheaper** one (llama-70b `$0.00017` < haiku `$0.00022`) — exercising the now-merged **#1184** secondary-objective tie-break on a benchmark that finally produces the spread to test it. Honest `successful_trials: 5`, all `13/13` (#1183).

`py_compile` + `ruff` clean. README updated; the standalone measurement probe is not committed (workspace scratch).

## PR checklist
1. **Worst-case prod path** — walkthrough/demo only; no policy surface. The change makes a misleading demo honest.
2. **Production-branch test** — n/a (demo); behavior validated by the live run above.
3. **Contract regeneration** — none.
4. **Public surface delta** — none (dataset + KB content only).
5/6. No review threads yet; no gates touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)