### PR TITLE
fix(observability): bind workflow trace spans to backend trial id

### DIFF
--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -1827,6 +1827,44 @@ class TestOptimizationOrchestrator:
             dataset_name="dataset",  # default value from orchestrator
         )
 
+    @pytest.mark.asyncio
+    async def test_backend_trial_rebind_updates_collected_workflow_spans(
+        self, orchestrator
+    ):
+        """Collected spans must use the backend trial id after submission rebinds it."""
+        span = MagicMock()
+        span.configuration_run_id = "client-trial-1"
+        orchestrator._workflow_trace_manager._collected_spans = [span]
+
+        async def submit_trial_rebinding_id(**kwargs):
+            kwargs["trial_result"].trial_id = "backend-trial-1"
+            return True
+
+        orchestrator.backend_session_manager.submit_trial = AsyncMock(
+            side_effect=submit_trial_rebinding_id
+        )
+
+        trial_result = TrialResult(
+            trial_id="client-trial-1",
+            config={"temperature": 0.5},
+            metrics={"accuracy": 0.5},
+            status=TrialStatus.COMPLETED,
+            duration=0.1,
+            timestamp=None,
+        )
+
+        await orchestrator._handle_trial_result(
+            trial_result=trial_result,
+            optimizer_config=trial_result.config,
+            current_trial_index=0,
+            session_id="session-123",
+            optuna_trial_id=None,
+            log_on_success=False,
+        )
+
+        assert trial_result.trial_id == "backend-trial-1"
+        assert span.configuration_run_id == "backend-trial-1"
+
 
 class TestStopReasonInResult:
     """Tests for stop_reason field in OptimizationResult."""

--- a/tests/unit/core/test_workflow_trace_manager.py
+++ b/tests/unit/core/test_workflow_trace_manager.py
@@ -66,6 +66,26 @@ class TestCollectSpan:
         mgr.collect_span(_FakeSpan())
         assert len(mgr._collected_spans) == 0
 
+    def test_rebind_configuration_run_id_updates_matching_collected_spans(self) -> None:
+        mgr = _make_manager(tracker=MagicMock())
+        mgr._collected_spans = [
+            _FakeSpan(configuration_run_id="client-trial-1"),
+            _FakeSpan(configuration_run_id="other-trial"),
+            _FakeSpan(configuration_run_id="client-trial-1"),
+        ]
+
+        updated = mgr.rebind_configuration_run_id(
+            "client-trial-1",
+            "backend-trial-1",
+        )
+
+        assert updated == 2
+        assert [span.configuration_run_id for span in mgr._collected_spans] == [
+            "backend-trial-1",
+            "other-trial",
+            "backend-trial-1",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # submit_traces

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1420,11 +1420,26 @@ class OptimizationOrchestrator:
             self._register_examples_attempted(trial_result)
 
         if self.backend_client and session_id:
+            pre_submit_trial_id = (
+                str(trial_result.trial_id)
+                if getattr(trial_result, "trial_id", None) is not None
+                else None
+            )
             await self.backend_session_manager.submit_trial(
                 trial_result=trial_result,
                 session_id=session_id,
                 dataset_name=getattr(self, "_dataset_name", "dataset"),
             )
+            post_submit_trial_id = (
+                str(trial_result.trial_id)
+                if getattr(trial_result, "trial_id", None) is not None
+                else None
+            )
+            if post_submit_trial_id != pre_submit_trial_id:
+                self._workflow_trace_manager.rebind_configuration_run_id(
+                    pre_submit_trial_id,
+                    post_submit_trial_id,
+                )
 
         if hasattr(self.optimizer, "tell"):
             try:

--- a/traigent/core/workflow_trace_manager.py
+++ b/traigent/core/workflow_trace_manager.py
@@ -99,6 +99,39 @@ class WorkflowTraceManager:
             with self._lock:
                 self._collected_spans.append(span_data)
 
+    def rebind_configuration_run_id(
+        self,
+        previous_configuration_run_id: str | None,
+        backend_configuration_run_id: str | None,
+    ) -> int:
+        """Rebind already-collected spans to the backend-minted trial id.
+
+        Trial execution collects spans before backend result submission can
+        acquire the backend configuration_run/trial id. If the backend rebinds
+        the TrialResult to its minted id, spans must follow that id or trace
+        ingestion will reference a non-existent ConfigurationRun and 404.
+
+        Returns:
+            Number of collected spans updated.
+        """
+        if (
+            not previous_configuration_run_id
+            or not backend_configuration_run_id
+            or previous_configuration_run_id == backend_configuration_run_id
+        ):
+            return 0
+
+        updated = 0
+        with self._lock:
+            for span in self._collected_spans:
+                if (
+                    getattr(span, "configuration_run_id", None)
+                    == previous_configuration_run_id
+                ):
+                    span.configuration_run_id = backend_configuration_run_id
+                    updated += 1
+        return updated
+
     def register_node(
         self,
         node_id: str,


### PR DESCRIPTION
Fixes #1191.

## What changed
- Rebind collected workflow trace spans from the SDK/client trial id to the backend-minted trial id after backend result submission.
- Keep the trace manager responsible for mutating already-collected spans, while the orchestrator triggers the rebind immediately after `BackendSessionManager.submit_trial(...)` mutates `trial_result.trial_id`.
- Add regression coverage for direct span rebinding and for the orchestrator backend-submission path.

## Why
Span collection can happen before the backend accepts the trial result. The backend may persist the configuration run under a different submitted trial id, so span ingestion must use that backend id or the trace POST references a missing configuration run and 404s.

## Validation
- `git commit` pre-commit hooks passed: isort, black, ruff, detect-secrets, bandit, mypy, and guardrail checks.
- `python3 -m pytest -n0 tests/unit/core/test_workflow_trace_manager.py tests/unit/core/test_orchestrator.py::TestOptimizationOrchestrator::test_backend_trial_rebind_updates_collected_workflow_spans -q --tb=short` -> `30 passed in 0.54s`.
- `git diff --check` passed.

## Notes
- Does not close #1191 locally; the issue will close through this PR if merged.
- No Backend or Schema changes are included in this PR.
