### PR TITLE
test: use hybrid for resampling aggregation contract

### DIFF
--- a/tests/test_resampling_aggregation.py
+++ b/tests/test_resampling_aggregation.py
@@ -113,7 +113,7 @@ class DummyBackend:
         return {"session_id": session_id, "finalized": True}
 
 
-async def _run_orchestrator(sequence, exec_mode="standard"):
+async def _run_orchestrator(sequence, exec_mode="hybrid"):
     opt = DummyOptimizer(sequence)
     ev = DummyEvaluator(metrics=["accuracy"], timeout=1.0)
     oc = OptimizationOrchestrator(
@@ -142,7 +142,7 @@ def test_orchestrator_end_aggregation_and_backend_submission():
         {"acc": 0.6, "p": 2},
     ]
 
-    result, backend = asyncio.run(_run_orchestrator(sequence, exec_mode="standard"))
+    result, backend = asyncio.run(_run_orchestrator(sequence, exec_mode="hybrid"))
 
     assert result.best_config["p"] == 1
     assert abs(result.best_score - 0.7) < 1e-9


### PR DESCRIPTION
Fixes #1188.

## Decision
The valid contract for this test is session-level aggregated best-score selection under the supported non-edge, portal-tracked `hybrid` mode.

`standard` was intentionally removed, and `edge_analytics` is not a semantic replacement here because it preserves single-best-trial behavior and does not exercise the same orchestrator-end session aggregation path.

## What changed
- Update the orphaned resampling aggregation backend-submission test from removed `standard` mode to supported `hybrid` mode.
- Keep the existing aggregation expectation: duplicated `p=1` trials aggregate to best score `0.7`, while backend summary metadata records session-level aggregation.

## Validation
- `python3 -m pytest -n0 tests/test_resampling_aggregation.py -q --tb=short` -> `3 passed in 0.91s`.
- `git diff --check HEAD~2..HEAD` passed.

## Notes
- This is a test-contract repair only; no runtime semantics were changed.
- I am not manually closing the issue before merge. If GitHub does not auto-close it on the develop merge, I will close it with a merge/validation explanation.
