### PR TITLE
fix(sync): preserve edge analytics trial costs

### DIFF
--- a/tests/storage/test_local_storage.py
+++ b/tests/storage/test_local_storage.py
@@ -607,3 +607,25 @@ class TestTrialResult:
         assert restored_trial.config == original_trial.config
         assert restored_trial.score == original_trial.score
         assert restored_trial.metadata == original_trial.metadata
+
+    def test_trial_cost_serialization(self):
+        """Test trial cost fields persist through serialization."""
+        original_trial = TrialResult(
+            trial_id="cost_trial",
+            config={"test": "config"},
+            score=0.75,
+            timestamp=datetime.now(UTC).isoformat(),
+            metadata={"provider": "mock"},
+            cost=0.03,
+            total_cost=0.03,
+            input_cost=0.01,
+            output_cost=0.02,
+        )
+
+        trial_dict = original_trial.to_dict()
+        restored_trial = TrialResult.from_dict(trial_dict)
+
+        assert restored_trial.cost == 0.03
+        assert restored_trial.total_cost == 0.03
+        assert restored_trial.input_cost == 0.01
+        assert restored_trial.output_cost == 0.02

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -98,6 +98,58 @@ class TestSyncManager:
             metadata={"optimizer": "bayesian"},
         )
 
+    def test_convert_trials_to_results_includes_local_cost_measures(
+        self, sync_manager: SyncManager
+    ) -> None:
+        """Synced configuration_runs include local edge_analytics cost measures."""
+        trial = TrialResult(
+            trial_id=1,
+            config={"model": "gpt-4", "temperature": 0.2},
+            score=0.91,
+            timestamp="2026-06-09T10:00:00Z",
+            metadata={"provider": "mock"},
+            cost=0.03,
+            total_cost=0.03,
+            input_cost=0.01,
+            output_cost=0.02,
+        )
+
+        results = sync_manager._convert_trials_to_results([trial])
+
+        measures = results[0]["measures"]
+        assert measures["score"] == 0.91
+        assert measures["accuracy"] == 0.91
+        assert measures["cost"] == 0.03
+        assert measures["total_cost"] == 0.03
+        assert measures["input_cost"] == 0.01
+        assert measures["output_cost"] == 0.02
+
+    def test_convert_trials_to_results_includes_metadata_cost_measures(
+        self, sync_manager: SyncManager
+    ) -> None:
+        """Legacy local trials with metadata-only costs still sync cost measures."""
+        trial = TrialResult(
+            trial_id=1,
+            config={"model": "gpt-4", "temperature": 0.2},
+            score=0.91,
+            timestamp="2026-06-09T10:00:00Z",
+            metadata={
+                "total_example_cost": 0.04,
+                "all_metrics": {
+                    "input_cost": 0.015,
+                    "output_cost": 0.025,
+                },
+            },
+        )
+
+        results = sync_manager._convert_trials_to_results([trial])
+
+        measures = results[0]["measures"]
+        assert measures["cost"] == 0.04
+        assert measures["total_cost"] == 0.04
+        assert measures["input_cost"] == 0.015
+        assert measures["output_cost"] == 0.025
+
     # Initialization Tests
 
     def test_init_with_api_key(self, mock_config: TraigentConfig) -> None:

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -20,7 +20,12 @@ except ImportError:
 
 from ..config.backend_config import BackendConfig, get_no_credentials_hint
 from ..config.types import TraigentConfig
-from ..storage.local_storage import LocalStorageManager, OptimizationSession
+from ..storage.local_storage import (
+    TRIAL_COST_FIELDS,
+    LocalStorageManager,
+    OptimizationSession,
+    extract_trial_cost_fields,
+)
 from ..utils.exceptions import TraigentStorageError
 from ..utils.logging import get_logger
 
@@ -269,6 +274,19 @@ class SyncManager:
         results = []
 
         for trial in trials:
+            trial_cost_payload = dict(trial.metadata or {})
+            for field in TRIAL_COST_FIELDS:
+                field_value = getattr(trial, field, None)
+                if field_value is not None:
+                    trial_cost_payload[field] = field_value
+            cost_measures = {
+                field: value
+                for field, value in extract_trial_cost_fields(
+                    trial_cost_payload
+                ).items()
+                if value is not None
+            }
+
             result = {
                 "id": f"config_run_{trial.trial_id}",
                 "trial_id": trial.trial_id,
@@ -276,6 +294,7 @@ class SyncManager:
                 "measures": {
                     "score": trial.score,
                     "accuracy": trial.score,  # Map score to accuracy for compatibility
+                    **cost_measures,
                 },
                 "timestamp": trial.timestamp,
                 "status": "completed" if trial.error is None else "failed",

--- a/traigent/storage/local_storage.py
+++ b/traigent/storage/local_storage.py
@@ -8,6 +8,7 @@ Inspired by DeepEval's approach to local JSON file storage.
 import json
 import os
 import time
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -27,6 +28,69 @@ from ..utils.secure_path import safe_open, validate_path
 
 logger = get_logger(__name__)
 
+TRIAL_COST_FIELDS = ("cost", "total_cost", "input_cost", "output_cost")
+
+
+def _coerce_optional_cost(value: Any) -> float | None:
+    """Coerce a cost-like value to float without accepting booleans."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_trial_cost_fields(
+    metadata: Mapping[str, Any | None] | None,
+) -> dict[str, float | None]:
+    """Extract canonical trial cost fields from stored trial metadata.
+
+    Local edge_analytics runs have historically carried cost in metadata rather
+    than first-class storage fields. Keep sync backward-compatible by accepting
+    top-level metrics and the older total_example_cost alias.
+    """
+    costs: dict[str, float | None] = dict.fromkeys(TRIAL_COST_FIELDS)
+
+    if not isinstance(metadata, Mapping):
+        return costs
+
+    sources: list[Mapping[str, Any | None]] = [metadata]
+    for nested_key in ("all_metrics", "metrics"):
+        nested_value = metadata.get(nested_key)
+        if isinstance(nested_value, Mapping):
+            sources.append(nested_value)
+
+    evaluation_result = metadata.get("evaluation_result")
+    if isinstance(evaluation_result, Mapping):
+        sources.append(evaluation_result)
+        evaluation_metrics = evaluation_result.get("metrics")
+        if isinstance(evaluation_metrics, Mapping):
+            sources.append(evaluation_metrics)
+
+    for source in sources:
+        for field in TRIAL_COST_FIELDS:
+            if costs[field] is None:
+                costs[field] = _coerce_optional_cost(source.get(field))
+
+        if costs["total_cost"] is None:
+            costs["total_cost"] = _coerce_optional_cost(
+                source.get("total_example_cost")
+            )
+
+    if costs["total_cost"] is None and costs["cost"] is not None:
+        costs["total_cost"] = costs["cost"]
+    if costs["cost"] is None and costs["total_cost"] is not None:
+        costs["cost"] = costs["total_cost"]
+    if costs["total_cost"] is None:
+        input_cost = costs["input_cost"]
+        output_cost = costs["output_cost"]
+        if input_cost is not None and output_cost is not None:
+            costs["total_cost"] = input_cost + output_cost
+            costs["cost"] = costs["total_cost"]
+
+    return costs
+
 
 @dataclass
 class TrialResult:
@@ -38,6 +102,10 @@ class TrialResult:
     timestamp: str
     metadata: dict[str, Any | None] | None = None
     error: str | None = None
+    cost: float | None = None
+    total_cost: float | None = None
+    input_cost: float | None = None
+    output_cost: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -282,6 +350,10 @@ class LocalStorageManager:
         score: float | None,
         metadata: dict[str, Any | None] | None = None,
         error: str | None = None,
+        cost: float | None = None,
+        total_cost: float | None = None,
+        input_cost: float | None = None,
+        output_cost: float | None = None,
     ) -> None:
         """
         Add a trial result to the session.
@@ -292,6 +364,10 @@ class LocalStorageManager:
             score: Score achieved with this configuration (may be None when unavailable)
             metadata: Additional trial metadata
             error: Error message if trial failed
+            cost: Optional total trial cost alias in USD
+            total_cost: Optional total trial cost in USD
+            input_cost: Optional input-token cost in USD
+            output_cost: Optional output-token cost in USD
         """
         session = self.load_session(session_id)
         if not session:
@@ -300,6 +376,29 @@ class LocalStorageManager:
         if session.trials is None:
             session.trials = []
 
+        extracted_costs = extract_trial_cost_fields(metadata)
+        explicit_costs = {
+            "cost": cost,
+            "total_cost": total_cost,
+            "input_cost": input_cost,
+            "output_cost": output_cost,
+        }
+        for field, value in explicit_costs.items():
+            coerced_value = _coerce_optional_cost(value)
+            if coerced_value is not None:
+                extracted_costs[field] = coerced_value
+
+        if (
+            extracted_costs["total_cost"] is None
+            and extracted_costs["cost"] is not None
+        ):
+            extracted_costs["total_cost"] = extracted_costs["cost"]
+        if (
+            extracted_costs["cost"] is None
+            and extracted_costs["total_cost"] is not None
+        ):
+            extracted_costs["cost"] = extracted_costs["total_cost"]
+
         trial_result = TrialResult(
             trial_id=len(session.trials) + 1,
             config=config,
@@ -307,6 +406,10 @@ class LocalStorageManager:
             timestamp=datetime.now(UTC).isoformat(),
             metadata=metadata,
             error=error,
+            cost=extracted_costs["cost"],
+            total_cost=extracted_costs["total_cost"],
+            input_cost=extracted_costs["input_cost"],
+            output_cost=extracted_costs["output_cost"],
         )
 
         session.trials.append(trial_result)


### PR DESCRIPTION
## Summary
- Addresses #1200 by storing local edge_analytics trial cost fields in `TrialResult`.
- Sync conversion now emits `cost`, `total_cost`, `input_cost`, and `output_cost` into backend configuration-run measures when available.
- Preserves legacy metadata-only cost extraction for existing local trial records.

## Validation
- `git diff --check origin/develop..HEAD`
- `python3 -m pytest -n0 tests/unit/cloud/test_sync_manager.py::TestSyncManager::test_convert_trials_to_results_includes_local_cost_measures tests/unit/cloud/test_sync_manager.py::TestSyncManager::test_convert_trials_to_results_includes_metadata_cost_measures tests/storage/test_local_storage.py::TestTrialResult::test_trial_cost_serialization -q`
- `bash skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop`

## Issue handling
- Related issue: #1200
- This PR intentionally does not use GitHub auto-closing keywords. The issue must remain open after merge until owner confirmation and Claude Code close approval are recorded.
