### PR TITLE
fix(sdk): quiet local mock warning noise

### DIFF
--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -1,6 +1,7 @@
 """Tests for Traigent Cloud Service authentication."""
 
 import asyncio
+import logging
 import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
@@ -169,6 +170,27 @@ class TestAuthManager:
         assert result.success is True
         assert manager._authenticated is True
         assert manager._api_key is not None
+
+    @pytest.mark.asyncio
+    async def test_api_key_validate_start_logs_info_not_warning(self, caplog):
+        """Validation-start is a normal lifecycle event; failures still warn."""
+        manager = AuthManager(api_key="tg_" + "x" * 61)
+
+        with (
+            caplog.at_level(logging.INFO, logger="traigent.cloud.auth"),
+            _mock_backend_validate(),
+        ):
+            result = await manager.authenticate()
+
+        assert result.success is True
+        start_records = [
+            record
+            for record in caplog.records
+            if record.message == "auth.api_key.validate_start"
+        ]
+        assert len(start_records) == 1
+        assert start_records[0].levelno == logging.INFO
+        assert not any(record.levelno >= logging.WARNING for record in start_records)
 
     @pytest.mark.asyncio
     async def test_authenticate_without_key(self):

--- a/tests/unit/cloud/test_cloud_authentication.py
+++ b/tests/unit/cloud/test_cloud_authentication.py
@@ -1680,6 +1680,6 @@ class TestSDK937_NoFabricatedPermissionGrants:
         assert info is not None
         assert info["name"] == "environment"
         # The honest empty answer:
-        assert info["permissions"] == {}, (
-            f"env-keyed permissions must be {{}}, got {info['permissions']}"
-        )
+        assert (
+            info["permissions"] == {}
+        ), f"env-keyed permissions must be {{}}, got {info['permissions']}"

--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -74,6 +74,29 @@ class TestBackendConfigStoredApiKey:
 
         assert result is None
 
+    def test_missing_api_key_logs_debug_not_warning(self, caplog):
+        """Local/mock missing credentials should not emit happy-path warnings."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "traigent.cloud.credential_manager.CredentialManager.get_stored_api_key_only",
+                return_value=None,
+            ),
+            patch("traigent.utils.env_config.is_backend_offline", return_value=False),
+            caplog.at_level(logging.DEBUG, logger="traigent.config.backend_config"),
+        ):
+            result = BackendConfig.get_api_key()
+
+        assert result is None
+        missing_key_records = [
+            record for record in caplog.records if "No API key found" in record.message
+        ]
+        assert len(missing_key_records) == 1
+        assert missing_key_records[0].levelno == logging.DEBUG
+        assert not any(
+            record.levelno >= logging.WARNING for record in missing_key_records
+        )
+
 
 class TestBackendConfigStoredBackendUrl:
     """BackendConfig.get_backend_url() should read stored backend_url when env missing."""

--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -584,8 +584,8 @@ class TestCentralizedCredentialHints:
         """BackendConfig.DEFAULT_PROD_URL must equal module-level DEFAULT_CLOUD_URL."""
         assert BackendConfig.DEFAULT_PROD_URL == DEFAULT_CLOUD_URL
 
-    def test_get_api_key_warning_includes_signup_url(self, caplog):
-        """get_api_key() warning must contain the signup URL."""
+    def test_get_api_key_debug_hint_includes_signup_url(self, caplog):
+        """get_api_key() debug hint must contain the signup URL."""
         import logging
 
         with (
@@ -595,10 +595,11 @@ class TestCentralizedCredentialHints:
                 return_value=None,
             ),
             patch("traigent.utils.env_config.is_backend_offline", return_value=False),
-            caplog.at_level(logging.WARNING, logger="traigent.config.backend_config"),
+            caplog.at_level(logging.DEBUG, logger="traigent.config.backend_config"),
         ):
             BackendConfig.get_api_key()
 
         assert any(
-            SIGNUP_URL in msg for msg in caplog.messages
-        ), f"Expected {SIGNUP_URL!r} in warning messages: {caplog.messages}"
+            SIGNUP_URL in record.message and record.levelno == logging.DEBUG
+            for record in caplog.records
+        ), f"Expected {SIGNUP_URL!r} in debug messages: {caplog.messages}"

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -3,6 +3,7 @@
 Tests the extracted backend session lifecycle manager with stub backend client.
 """
 
+import logging
 import re
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -1077,9 +1078,7 @@ class TestHandleSessionCreationResult:
     def test_no_api_key_warning_includes_signup_url(
         self, traigent_config, objective_schema, mock_optimizer, caplog
     ):
-        """handle_session_creation_result must emit WARNING with signup URL for NO_API_KEY."""
-        import logging
-
+        """NO_API_KEY local fallback emits INFO with signup URL, not WARNING."""
         from traigent.cloud.session_types import (
             SessionCreationFailureReason,
             SessionCreationResult,
@@ -1103,17 +1102,20 @@ class TestHandleSessionCreationResult:
         )
 
         with caplog.at_level(
-            logging.WARNING, logger="traigent.core.backend_session_manager"
+            logging.INFO, logger="traigent.core.backend_session_manager"
         ):
             session_id = manager.handle_session_creation_result(result)
 
         assert session_id == "local_test"
         assert not manager.backend_tracking_enabled
-        assert any(
-            SIGNUP_URL in msg for msg in caplog.messages
-        ), f"Expected {SIGNUP_URL!r} in warning: {caplog.messages}"
+        no_key_records = [
+            record for record in caplog.records if "No API key found" in record.message
+        ]
+        assert len(no_key_records) == 1
+        assert no_key_records[0].levelno == logging.INFO
+        assert SIGNUP_URL in no_key_records[0].message
         warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert len(warning_records) == 1
+        assert len(warning_records) == 0
 
     def test_auth_failure_aborts_by_default_with_structured_reason(
         self, traigent_config, objective_schema, mock_optimizer

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -1175,16 +1175,18 @@ class TestHandleSessionCreationResult:
         )
         from traigent.utils.exceptions import ConfigurationError
 
-        mock_backend_client.create_session.return_value = SessionCreationResult.fallback(
-            session_id="local_test",
-            reason=SessionCreationFailureReason.AUTH,
-            detail="Authentication failed (403)",
-            failure_response=SessionCreationFailureDetail.from_http_response(
-                403,
-                '{"error_code":"INSUFFICIENT_PERMISSIONS",'
-                '"message":"Missing required permissions: experiment.write",'
-                '"details":{"missing_permissions":["experiment.write"]}}',
-            ),
+        mock_backend_client.create_session.return_value = (
+            SessionCreationResult.fallback(
+                session_id="local_test",
+                reason=SessionCreationFailureReason.AUTH,
+                detail="Authentication failed (403)",
+                failure_response=SessionCreationFailureDetail.from_http_response(
+                    403,
+                    '{"error_code":"INSUFFICIENT_PERMISSIONS",'
+                    '"message":"Missing required permissions: experiment.write",'
+                    '"details":{"missing_permissions":["experiment.write"]}}',
+                ),
+            )
         )
 
         def func(x):

--- a/tests/unit/examples/test_mock_walkthrough_logging_hygiene.py
+++ b/tests/unit/examples/test_mock_walkthrough_logging_hygiene.py
@@ -1,0 +1,42 @@
+"""Logging-hygiene guards for bundled mock walkthroughs."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _mock_mode_config_keys(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "MOCK_MODE_CONFIG"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            return set()
+        keys: set[str] = set()
+        for key in node.value.keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                keys.add(key.value)
+        return keys
+    return set()
+
+
+def test_mock_walkthrough_configs_do_not_use_inert_mock_keys() -> None:
+    """Bundled examples must not trip the SDK's own inert-key warning."""
+    repo_root = Path(__file__).resolve().parents[3]
+    walkthroughs = sorted((repo_root / "walkthrough" / "mock").glob("[0-9][0-9]_*.py"))
+    assert walkthroughs
+
+    inert_keys = {"optimizer", "sampler", "random_seed"}
+    offenders = {
+        path.name: sorted(_mock_mode_config_keys(path) & inert_keys)
+        for path in walkthroughs
+        if _mock_mode_config_keys(path) & inert_keys
+    }
+
+    assert offenders == {}

--- a/tests/unit/security/test_credentials.py
+++ b/tests/unit/security/test_credentials.py
@@ -172,7 +172,9 @@ class TestEnhancedCredentialStore:
 
         with caplog.at_level(logging.WARNING, logger="traigent.security.credentials"):
             for _ in range(2):
-                with pytest.raises(AuthenticationError, match="master secret is required"):
+                with pytest.raises(
+                    AuthenticationError, match="master secret is required"
+                ):
                     EnhancedCredentialStore(
                         storage_path=storage_path,
                         use_env_vars=False,

--- a/tests/unit/security/test_credentials.py
+++ b/tests/unit/security/test_credentials.py
@@ -1,6 +1,7 @@
 """Comprehensive unit tests for secure credential management."""
 
 import json
+import logging
 import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -138,6 +139,52 @@ class TestEnhancedCredentialStore:
             storage_path=str(Path(temp_dir) / "creds"),
         )
         assert store is not None
+
+    def test_ignored_legacy_master_without_store_logs_info_not_warning(
+        self, tmp_path, caplog
+    ):
+        """A stale legacy key alone must not warn during local/mock probes."""
+        storage_path = tmp_path / "secure_credentials.enc"
+        master_key_path = tmp_path / EnhancedCredentialStore.MASTER_PASSWORD_FILENAME
+        master_key_path.write_text("legacy-master", encoding="utf-8")
+
+        with (
+            caplog.at_level(logging.INFO, logger="traigent.security.credentials"),
+            pytest.raises(AuthenticationError, match="master secret is required"),
+        ):
+            EnhancedCredentialStore(storage_path=storage_path, use_env_vars=False)
+
+        records = [
+            record
+            for record in caplog.records
+            if "Ignoring legacy local master secret file" in record.message
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.INFO
+
+    def test_ignored_legacy_master_with_store_warns_once(self, tmp_path, caplog):
+        """An actual legacy vault migration warning remains actionable but deduped."""
+        credentials_module._IGNORED_LEGACY_MASTER_SECRET_WARNING_PATHS.clear()
+        storage_path = tmp_path / "secure_credentials.enc"
+        storage_path.write_bytes(b"encrypted-store-placeholder")
+        master_key_path = tmp_path / EnhancedCredentialStore.MASTER_PASSWORD_FILENAME
+        master_key_path.write_text("legacy-master", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="traigent.security.credentials"):
+            for _ in range(2):
+                with pytest.raises(AuthenticationError, match="master secret is required"):
+                    EnhancedCredentialStore(
+                        storage_path=storage_path,
+                        use_env_vars=False,
+                    )
+
+        records = [
+            record
+            for record in caplog.records
+            if "Ignoring legacy local master secret file" in record.message
+        ]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
 
     def test_set_and_get_credential(self, store):
         """Test setting and getting a credential."""

--- a/tests/unit/utils/test_local_analytics.py
+++ b/tests/unit/utils/test_local_analytics.py
@@ -1072,6 +1072,25 @@ class TestConvenienceFunctions:
         result = collect_and_submit_analytics(config)
         assert result is None  # Function returns None
 
+    def test_collect_and_submit_analytics_skips_mock_mode(
+        self, temp_storage_path: str
+    ) -> None:
+        """Mock walkthroughs must not schedule remote analytics auth."""
+        config = TraigentConfig(
+            execution_mode=ExecutionMode.EDGE_ANALYTICS.value,
+            enable_usage_analytics=True,
+            local_storage_path=temp_storage_path,
+        )
+
+        with (
+            patch("traigent.utils.env_config.is_mock_llm", return_value=True),
+            patch("traigent.utils.local_analytics.LocalAnalytics") as mock_analytics,
+        ):
+            result = collect_and_submit_analytics(config)
+
+        assert result is None
+        mock_analytics.assert_not_called()
+
     def test_collect_and_submit_analytics_in_async_context(
         self, temp_storage_path: str
     ) -> None:

--- a/traigent/cloud/auth.py
+++ b/traigent/cloud/auth.py
@@ -1126,8 +1126,9 @@ class AuthManager:
                 error_message="Invalid API key format",
             )
 
-        # Structured warning: never log the key value or any value derived from it.
-        logger.warning(
+        # Structured lifecycle event: never log the key value or any value
+        # derived from it. Validation failures remain WARNING below.
+        logger.info(
             "auth.api_key.validate_start",
             extra={
                 "auth_mode": AuthMode.API_KEY.value,

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -273,11 +273,14 @@ class BackendConfig:
         except Exception:
             pass
 
-        # Only warn if not in offline mode - offline mode doesn't need API keys
+        # Missing credentials are expected for local/mock runs. Keep the
+        # actionable user-facing notice in the session fallback path; this
+        # lower-level probe stays debug-only to avoid duplicate happy-path
+        # warnings.
         from traigent.utils.env_config import is_backend_offline
 
         if not is_backend_offline():
-            logger.warning(
+            logger.debug(
                 "No API key found (checked TRAIGENT_API_KEY and stored credentials). %s",
                 get_no_credentials_hint(),
             )

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -274,7 +274,7 @@ class BackendSessionManager:
                     raise ConfigurationError(warning)
                 logger.warning("%s", warning)
             elif reason == SessionCreationFailureReason.NO_API_KEY:
-                logger.warning(
+                logger.info(
                     "No API key found — results saved locally only. %s",
                     get_no_credentials_hint(),
                 )

--- a/traigent/security/credentials.py
+++ b/traigent/security/credentials.py
@@ -43,6 +43,7 @@ _MASTER_SECRET_ENV = f"TRAIGENT_MASTER_{_SECRET_ENV_SUFFIX}"
 _ALLOW_LEGACY_MASTER_SECRET_ENV = (
     f"TRAIGENT_ALLOW_LEGACY_LOCAL_MASTER_{_SECRET_ENV_SUFFIX}"
 )
+_IGNORED_LEGACY_MASTER_SECRET_WARNING_PATHS: set[Path] = set()
 _WEAK_CREDENTIAL_PATTERNS = (
     "password123",
     "12345",
@@ -70,6 +71,26 @@ _SECRET_FIELD_NAMES = {
 
 def _truthy(value: str | None) -> bool:
     return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _log_ignored_legacy_master_secret(
+    master_key_path: Path, *, secure_store_exists: bool
+) -> None:
+    """Log ignored legacy master-secret state without noisy local-run repeats."""
+    message = (
+        "Ignoring legacy local master secret file at %s. Set the "
+        "documented master-key environment variable or explicitly "
+        "enable legacy local vault migration."
+    )
+    if not secure_store_exists:
+        logger.info(message, master_key_path)
+        return
+
+    if master_key_path in _IGNORED_LEGACY_MASTER_SECRET_WARNING_PATHS:
+        return
+
+    _IGNORED_LEGACY_MASTER_SECRET_WARNING_PATHS.add(master_key_path)
+    logger.warning(message, master_key_path)
 
 
 def _normalized_field_name(field: str) -> str:
@@ -359,11 +380,9 @@ class EnhancedCredentialStore:
                 master_key_value = self._load_master_password_from_file(master_key_path)
                 master_key_source = "legacy_file"
             elif master_key_path.exists():
-                logger.warning(
-                    "Ignoring legacy local master secret file at %s. Set the "
-                    "documented master-key environment variable or explicitly "
-                    "enable legacy local vault migration.",
+                _log_ignored_legacy_master_secret(
                     master_key_path,
+                    secure_store_exists=self.storage_path.exists(),
                 )
 
         if master_key_value is None:
@@ -1062,7 +1081,7 @@ def get_secure_credential_store() -> EnhancedCredentialStore:
         security_level = SecurityLevel.HIGH
     else:
         security_level = SecurityLevel.STANDARD
-        logger.warning(f"Credential store in {environment} mode - reduced security")
+        logger.info(f"Credential store in {environment} mode - reduced security")
 
     # Check for HSM availability
     enable_hsm = os.getenv("TRAIGENT_ENABLE_HSM", "false").lower() == "true"

--- a/traigent/utils/local_analytics.py
+++ b/traigent/utils/local_analytics.py
@@ -493,9 +493,15 @@ def collect_and_submit_analytics(config: TraigentConfig) -> None:
     This function is designed to work from both sync and async contexts.
     It runs analytics submission in the background without blocking.
     """
+    from traigent.utils.env_config import is_mock_llm
+
     if not config.enable_usage_analytics or config.execution_mode not in {
         ExecutionMode.EDGE_ANALYTICS.value,
     }:
+        return
+
+    if is_mock_llm():
+        logger.debug("Skipping usage analytics submission in mock LLM mode")
         return
 
     try:

--- a/walkthrough/mock/01_tuning_qa.py
+++ b/walkthrough/mock/01_tuning_qa.py
@@ -43,7 +43,6 @@ SIMULATED_BEST = {"model": "gpt-4o", "temperature": 0.1, "accuracy": 0.80}
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],
     "variance": 0.0,
-    "random_seed": 42,
 }
 OBJECTIVES = ["accuracy", "cost"]
 CONFIG_SPACE = {

--- a/walkthrough/mock/02_zero_code_change.py
+++ b/walkthrough/mock/02_zero_code_change.py
@@ -39,7 +39,6 @@ SIMULATED_BEST = {"model": "gpt-4o", "temperature": 0.1, "accuracy": 0.9}
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],
     "variance": 0.0,
-    "random_seed": 42,
 }
 OBJECTIVES = ["accuracy", "cost"]
 CONFIG_SPACE = {

--- a/walkthrough/mock/03_parameter_mode.py
+++ b/walkthrough/mock/03_parameter_mode.py
@@ -40,7 +40,6 @@ SIMULATED_BEST = {
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],
     "variance": 0.0,
-    "random_seed": 42,
 }
 OBJECTIVES = ["accuracy", "cost"]
 CONFIG_SPACE = {

--- a/walkthrough/mock/04_multi_objective.py
+++ b/walkthrough/mock/04_multi_objective.py
@@ -44,7 +44,6 @@ SIMULATED_BEST = {
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],
     "variance": 0.0,
-    "random_seed": 42,
 }
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini", "gpt-4o"],

--- a/walkthrough/mock/05_rag_parallel.py
+++ b/walkthrough/mock/05_rag_parallel.py
@@ -41,7 +41,6 @@ SIMULATED_BEST = {
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],
     "variance": 0.0,
-    "random_seed": 42,
 }
 OBJECTIVES = ["accuracy", "cost"]
 CONFIG_SPACE = {

--- a/walkthrough/mock/06_custom_evaluator.py
+++ b/walkthrough/mock/06_custom_evaluator.py
@@ -38,7 +38,6 @@ SIMULATED_BEST = {
 MOCK_MODE_CONFIG = {
     "base_accuracy": SIMULATED_BEST["accuracy"],
     "variance": 0.0,
-    "random_seed": 42,
 }
 OBJECTIVES = ["accuracy", "cost"]
 CONFIG_SPACE = {

--- a/walkthrough/mock/07_multi_provider.py
+++ b/walkthrough/mock/07_multi_provider.py
@@ -73,7 +73,6 @@ CONFIG_SPACE = {
 MOCK_MODE_CONFIG = {
     "base_accuracy": 0.85,
     "variance": 0.0,
-    "random_seed": 42,
 }
 
 

--- a/walkthrough/mock/08_privacy_modes.py
+++ b/walkthrough/mock/08_privacy_modes.py
@@ -37,7 +37,7 @@ traigent.initialize(
 DATASETS = Path(__file__).parent.parent / "datasets"
 RESULTS_DIR = os.getenv("TRAIGENT_RESULTS_FOLDER", "./local_results")
 SIMULATED_BEST = {"model": "gpt-3.5-turbo", "temperature": 0.1}
-MOCK_MODE_CONFIG = {"base_accuracy": 0.9, "variance": 0.0, "random_seed": 42}
+MOCK_MODE_CONFIG = {"base_accuracy": 0.9, "variance": 0.0}
 OBJECTIVES = ["accuracy"]
 CONFIG_SPACE = {
     "model": ["gpt-3.5-turbo", "gpt-4o-mini"],


### PR DESCRIPTION
## Summary
- Addresses #1198 by demoting normal local/mock no-key and auth-start lifecycle log paths below `WARNING` while preserving genuine auth failures at warning level.
- Dedupes legacy credential-store stale-state warnings and skips background usage analytics in mock LLM mode.
- Removes inert mock walkthrough config keys and adds focused logging-hygiene regressions.

## Validation
- `python3 -m pytest -n0 tests/unit/config/test_backend_config_stored_creds.py::TestBackendConfigStoredApiKey::test_missing_api_key_logs_debug_not_warning tests/unit/cloud/test_cloud_authentication.py::TestAuthManager::test_api_key_validate_start_logs_info_not_warning tests/unit/security/test_credentials.py::TestEnhancedCredentialStore::test_ignored_legacy_master_without_store_logs_info_not_warning tests/unit/security/test_credentials.py::TestEnhancedCredentialStore::test_ignored_legacy_master_with_store_warns_once tests/unit/examples/test_mock_walkthrough_logging_hygiene.py tests/unit/utils/test_local_analytics.py::TestConvenienceFunctions::test_collect_and_submit_analytics_skips_mock_mode -q`
- `python3 -m pytest -n0 tests/unit/core/test_backend_session_manager.py -k "NO_API_KEY or no_api_key" -q`
- `HOME=/tmp/traigent-1198-home PYTHONPATH=. TRAIGENT_MOCK_LLM=true TRAIGENT_SKIP_DOTENV=1 env -u TRAIGENT_API_KEY -u TRAIGENT_JWT_TOKEN -u TRAIGENT_DEV_API_KEY -u TRAIGENT_DEV_MODE timeout 90s /home/nimrodbu/Traigent_enterprise/Traigent/.venv/bin/python walkthrough/mock/04_multi_objective.py`
- `git diff --check origin/develop..HEAD`
- `bash /home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop`
- `bash /home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/check_formatting.sh origin/develop`

## Issue handling
- Related issue: #1198
- This PR intentionally does not use GitHub auto-closing keywords. The issue must remain open after merge until owner confirmation and Claude Code close approval are recorded.

## Residual risk
- The walkthrough still emits third-party Pydantic `UnsupportedFieldAttributeWarning` stderr lines, but no SDK/logger `WARNING` lines remain for the #1198 happy path smoke.
- `.secrets.baseline` changed only because hooks updated existing metadata/line tracking after import/test shifts.
