### PR TITLE
fix(sdk): make mock dry-run preflight free

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,11 @@ pip install -e ".[recommended]"
 Cost estimates, budgets, limits, alerts, and thresholds are best-effort software controls, not
 provider-side billing guarantees. Actual billing is determined by your LLM/cloud providers, and you
 remain responsible for provider charges. The legacy `TRAIGENT_MOCK_LLM=true` env var is supported
-only for backwards-compatible local scripts and is disabled when `ENVIRONMENT=production`. See
-[DISCLAIMER.md](DISCLAIMER.md) for details.
+only for backwards-compatible local scripts and is disabled when `ENVIRONMENT=production`.
+Mock mode skips the optimized-function pricing preflight for supported calls made through
+Traigent's integration/interceptor path; direct provider calls made outside that path should
+be stubbed explicitly for a guaranteed $0 rehearsal. See [DISCLAIMER.md](DISCLAIMER.md)
+for details.
 
 ### Evaluation
 

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -2,7 +2,7 @@
 
 Traigent publishes [Agent Skills](https://agentskills.io/) — sets of instructions that teach your AI coding agent how to set up and run Traigent optimizations.
 
-When you ask your agent to "optimize this function with Traigent," the skill guides it through a **dry-run-first workflow**: validate everything at zero cost in mock mode, then switch to real execution only when you say so.
+When you ask your agent to "optimize this function with Traigent," the skill guides it through a **dry-run-first workflow**: validate the documented Traigent path at zero provider cost in mock mode, then switch to real execution only when you say so. If your code makes provider calls outside Traigent's optimized/evaluated path, stub those calls explicitly before treating the rehearsal as guaranteed $0.
 
 ## Compatible Agents
 

--- a/tests/unit/core/test_cost_enforcement_no_bypass.py
+++ b/tests/unit/core/test_cost_enforcement_no_bypass.py
@@ -17,7 +17,9 @@ These tests pin the post-fix behavior:
   locked path.
 * The bypass machinery (``_check_mock_mode`` / ``is_mock_mode`` /
   ``_mock_mode_cached``) is removed from the public+private API.
-* ``CostEstimator.check_cost_approval`` no longer skips when mock-mode is set.
+* ``CostEstimator.check_cost_approval`` may skip only the pre-run pricing
+  estimate when the central mock-mode source of truth says LLM calls are
+  mocked; it must still run normally when that source of truth is false.
 """
 
 from __future__ import annotations
@@ -147,10 +149,12 @@ class TestCostEnforcerNoMockBypass:
             # Now budget is exhausted; the bypass would have granted id=0,
             # but the real path must deny.
             second = enforcer.acquire_permit()
-            assert not second.is_granted, (
-                "Mock-mode must not override real cost limits after exhaustion"
-            )
-            assert second.id == -1, "Denied permit must use sentinel id=-1, not bypass id=0"
+            assert (
+                not second.is_granted
+            ), "Mock-mode must not override real cost limits after exhaustion"
+            assert (
+                second.id == -1
+            ), "Denied permit must use sentinel id=-1, not bypass id=0"
 
     def test_release_permit_uses_real_locked_path_under_mock_env(
         self, mock_env: dict[str, str]
@@ -169,10 +173,37 @@ class TestCostEnforcerNoMockBypass:
             assert enforcer._in_flight_count == 0
 
 
-class TestCostEstimatorNoMockBypass:
-    """CostEstimator.check_cost_approval must not skip on TRAIGENT_MOCK_LLM=true."""
+class TestCostEstimatorMockPreflight:
+    """CostEstimator mock behavior is limited to optimized-function preflight."""
 
-    def test_check_cost_approval_does_not_short_circuit(
+    def test_check_cost_approval_skips_only_preflight_when_mock_llm_enabled(
+        self, mock_env: dict[str, str]
+    ) -> None:
+        from traigent.core.cost_estimator import CostEstimator
+
+        with patch.dict(os.environ, mock_env, clear=False):
+            enforcer = CostEnforcer(CostEnforcerConfig(limit=0.01, approved=False))
+
+            estimator = CostEstimator.__new__(CostEstimator)
+            estimator._cost_enforcer = enforcer
+            with (
+                patch("traigent.core.cost_estimator.is_mock_llm", return_value=True),
+                patch.object(
+                    CostEstimator,
+                    "estimate_optimization_cost",
+                    return_value=999.0,
+                ) as estimate_cost,
+                patch(
+                    "traigent.core.cost_enforcement.CostEnforcer._request_user_approval",
+                    return_value=False,
+                ) as request_approval,
+            ):
+                estimator.check_cost_approval(dataset=None)
+
+            estimate_cost.assert_not_called()
+            request_approval.assert_not_called()
+
+    def test_raw_mock_env_does_not_bypass_when_mock_sot_false(
         self, mock_env: dict[str, str]
     ) -> None:
         from traigent.core.cost_enforcement import OptimizationAborted
@@ -183,8 +214,8 @@ class TestCostEstimatorNoMockBypass:
 
             estimator = CostEstimator.__new__(CostEstimator)
             estimator._cost_enforcer = enforcer
-            # Force a high estimate via patching the estimation method
             with (
+                patch("traigent.core.cost_estimator.is_mock_llm", return_value=False),
                 patch.object(
                     CostEstimator,
                     "estimate_optimization_cost",

--- a/tests/unit/core/test_cost_estimator.py
+++ b/tests/unit/core/test_cost_estimator.py
@@ -317,22 +317,29 @@ class TestEstimateOptimizationCost:
 
 
 class TestCheckCostApproval:
-    def test_does_not_skip_in_mock_mode(self) -> None:
-        """S2-B Round 3: mock-mode bypass was removed; approval always runs."""
+    def test_skips_optimized_function_preflight_in_mock_mode(self) -> None:
+        """Mock provider calls spend $0, so dry-runs skip the pre-run estimate gate."""
         enforcer = MagicMock()
-        # is_mock_mode is no longer consulted; spec it away so attribute access
-        # would fail and prove the new code path doesn't read it.
-        del enforcer.is_mock_mode
         enforcer.check_and_approve.return_value = True
         estimator = CostEstimator(enforcer, max_trials=5, max_total_examples=None)
-        estimator.check_cost_approval(_FakeDataset())
-        enforcer.check_and_approve.assert_called_once()
+        with (
+            patch("traigent.core.cost_estimator.is_mock_llm", return_value=True),
+            patch.object(
+                estimator,
+                "estimate_optimization_cost",
+                return_value=999.0,
+            ) as estimate_cost,
+        ):
+            estimator.check_cost_approval(_FakeDataset())
+        estimate_cost.assert_not_called()
+        enforcer.check_and_approve.assert_not_called()
 
     def test_passes_when_approved(self) -> None:
         enforcer = MagicMock(is_mock_mode=False)
         enforcer.check_and_approve.return_value = True
         estimator = CostEstimator(enforcer, max_trials=5, max_total_examples=None)
-        estimator.check_cost_approval(_FakeDataset())
+        with patch("traigent.core.cost_estimator.is_mock_llm", return_value=False):
+            estimator.check_cost_approval(_FakeDataset())
         enforcer.check_and_approve.assert_called_once()
 
     def test_raises_when_declined(self) -> None:
@@ -343,7 +350,10 @@ class TestCheckCostApproval:
 
         from traigent.core.cost_enforcement import OptimizationAborted
 
-        with pytest.raises(OptimizationAborted, match="Cost approval declined"):
+        with (
+            patch("traigent.core.cost_estimator.is_mock_llm", return_value=False),
+            pytest.raises(OptimizationAborted, match="Cost approval declined"),
+        ):
             estimator.check_cost_approval(_FakeDataset())
 
 

--- a/traigent/core/cost_estimator.py
+++ b/traigent/core/cost_estimator.py
@@ -10,6 +10,7 @@ from traigent.api.types import TrialResult
 from traigent.core.cost_enforcement import CostEnforcer
 from traigent.evaluators.base import Dataset
 from traigent.utils.cost_calculator import UnknownModelError, get_model_token_pricing
+from traigent.utils.env_config import is_mock_llm
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -199,9 +200,13 @@ class CostEstimator:
         Raises:
             OptimizationAborted: If cost approval is declined
         """
-        # S2-B Round 3: cost approval no longer skips on TRAIGENT_MOCK_LLM.
-        # The mock-mode bypass was removed because it could disable approval
-        # if the env var leaked into a production environment.
+        if is_mock_llm():
+            logger.info(
+                "Skipping optimized-function pricing preflight in mock LLM mode; "
+                "runtime CostEnforcer permits and accounting remain active."
+            )
+            return
+
         estimated_cost = self.estimate_optimization_cost(dataset)
         if not self._cost_enforcer.check_and_approve(estimated_cost):
             from traigent.core.cost_enforcement import OptimizationAborted

--- a/traigent/skills/traigent-debugging/references/mock-mode.md
+++ b/traigent/skills/traigent-debugging/references/mock-mode.md
@@ -6,7 +6,7 @@ Traigent provides two environment variables for running without external depende
 
 | Variable | Purpose |
 |---|---|
-| `TRAIGENT_MOCK_LLM=true` | Mock all LLM API calls. No API keys required. |
+| `TRAIGENT_MOCK_LLM=true` | Mock supported LLM calls made through Traigent's integration/interceptor path. No API keys required for the documented local dry-run path. |
 | `TRAIGENT_OFFLINE_MODE=true` | Skip backend/cloud connection. No Traigent service needed. |
 
 These are typically used together for testing, CI/CD, and development.
@@ -56,9 +56,9 @@ TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true pytest tests/
 
 When `TRAIGENT_MOCK_LLM=true`:
 
-- LLM API calls return synthetic/mock responses instead of calling real providers
+- supported LLM API calls return synthetic/mock responses instead of calling real providers
 - No API keys are required (OpenAI, Anthropic, etc.)
-- No network calls are made to LLM providers
+- No network calls are made to LLM providers for supported calls made while Traigent's interceptors are active
 - Cost tracking reports zero or minimal cost
 - Response times are near-instant
 
@@ -66,7 +66,7 @@ When `TRAIGENT_MOCK_LLM=true`:
 
 - OpenAI API calls (`openai.chat.completions.create`)
 - Anthropic API calls (`anthropic.messages.create`)
-- LiteLLM completion calls
+- LiteLLM completion calls made inside optimized/evaluated Traigent runs after the SDK installs its LiteLLM interceptor
 - Any provider accessed through Traigent's integration layer
 
 ### What Is NOT Mocked
@@ -76,6 +76,8 @@ When `TRAIGENT_MOCK_LLM=true`:
 - Dataset loading and validation
 - Configuration space sampling
 - The optimization loop itself
+- Provider calls made before the Traigent optimization/evaluation path installs interceptors
+- Provider clients that Traigent does not support yet; stub those calls explicitly for a guaranteed $0 rehearsal
 
 This means mock mode is useful for testing:
 - Configuration space setup
@@ -110,7 +112,7 @@ TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true python my_script.py
 This gives you a fully self-contained environment:
 - No API keys needed
 - No backend connection needed
-- No network calls at all
+- No provider network calls for supported calls made through the documented Traigent dry-run path
 - Fast execution (no real LLM latency)
 
 ## Limitations of Mock Mode

--- a/traigent/skills/traigent-quickstart/SKILL.md
+++ b/traigent/skills/traigent-quickstart/SKILL.md
@@ -61,7 +61,7 @@ export TRAIGENT_MOCK_LLM=true
 export TRAIGENT_OFFLINE_MODE=true
 ```
 
-- `TRAIGENT_MOCK_LLM=true` -- Mocks all LLM API calls so you do not need provider API keys or incur costs.
+- `TRAIGENT_MOCK_LLM=true` -- Mocks supported LLM calls made through Traigent's integration/interceptor path so local dry-runs do not need provider API keys or incur provider costs.
 - `TRAIGENT_OFFLINE_MODE=true` -- Skips backend communication so you do not need a running Traigent backend.
 
 ### Using a .env File

--- a/traigent/skills/traigent-quickstart/references/environment-variables.md
+++ b/traigent/skills/traigent-quickstart/references/environment-variables.md
@@ -6,7 +6,7 @@ Complete reference of environment variables recognized by the Traigent SDK.
 
 | Variable                           | Default         | Description                                                                                         |
 | ---------------------------------- | --------------- | --------------------------------------------------------------------------------------------------- |
-| `TRAIGENT_MOCK_LLM`               | `false`         | When `true`, mocks all LLM API calls. No provider API keys needed. Use for development and testing. |
+| `TRAIGENT_MOCK_LLM`               | `false`         | When `true`, mocks supported LLM calls made through Traigent's integration/interceptor path. No provider API keys needed for the documented local dry-run path. |
 | `TRAIGENT_OFFLINE_MODE`            | `false`         | When `true`, skips all backend communication. Use for local-only development.                       |
 | `TRAIGENT_RUN_COST_LIMIT`         | `2.0`           | Maximum cost budget (in USD) per optimization run. Optimization stops when this limit is reached.    |
 | `TRAIGENT_COST_APPROVED`          | `false`         | Exact value `true` pre-approves both the cost-limit prompt and unpriced-model preflight. `1`, `yes`, and `on` do not approve. |
@@ -43,6 +43,12 @@ export TRAIGENT_OFFLINE_MODE=true
 export TRAIGENT_LOG_LEVEL=DEBUG
 python my_optimization.py
 ```
+
+Mock mode skips the optimized-function pricing preflight because supported
+provider calls are intercepted and return canned responses. It is not a global
+network sandbox: direct provider calls made before Traigent installs its
+interceptors, or calls through unsupported clients, should be stubbed explicitly
+or protected with provider-side spend controls.
 
 ### CI/CD Pipeline
 


### PR DESCRIPTION
## Summary

Addresses #1196.

- skip the optimized-function pricing preflight when the SDK mock-mode source of truth reports that LLM calls are mocked
- keep `CostEnforcer` permits/accounting active so mock mode is not a global billing-control bypass
- update mock/dry-run docs to make the supported free path explicit and call out direct provider calls outside Traigent's interceptor path as requiring explicit stubs/provider-side controls

## Validation

- `python3 -m pytest -n0 tests/unit/core/test_cost_estimator.py tests/unit/core/test_cost_enforcement_no_bypass.py tests/unit/utils/test_litellm_interceptor.py -q --tb=short` -> 58 passed
- pre-commit hooks on commit/amend: isort, black, ruff, Detect secrets, bandit, mypy, strict cost guardrails -> passed
- `/home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop` -> no secrets detected
- `/home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/check_formatting.sh origin/develop` -> formatting passed

## Residual risks

- This does not make arbitrary provider calls a process-wide network sandbox. Calls made before Traigent installs its interceptors, or through unsupported clients, still need explicit stubs or provider-side spend controls.
- This intentionally does not bypass runtime `CostEnforcer` permits/accounting in mock mode.
