### PR TITLE
docs(skills): fix bundled custom-evaluator snippet to shipped 0.12.0 API + executable drift guard (#1195)

### DIFF
--- a/tests/unit/skills/test_decorator_setup_snippets.py
+++ b/tests/unit/skills/test_decorator_setup_snippets.py
@@ -1,0 +1,69 @@
+"""Regression tests for bundled skill snippets."""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from pathlib import Path
+
+from traigent.api.types import ExampleResult
+from traigent.evaluators.base import EvaluationExample
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EVALUATION_OPTIONS_DOC = (
+    REPO_ROOT
+    / "traigent"
+    / "skills"
+    / "traigent-decorator-setup"
+    / "references"
+    / "evaluation-options.md"
+)
+
+
+def _extract_custom_evaluator_snippet() -> str:
+    markdown = EVALUATION_OPTIONS_DOC.read_text(encoding="utf-8")
+    blocks = re.findall(r"```python\n(.*?)\n```", markdown, flags=re.DOTALL)
+    for block in blocks:
+        if "def my_evaluator" in block and "ExampleResult(" in block:
+            return textwrap.dedent(block)
+    raise AssertionError("custom evaluator ExampleResult snippet not found")
+
+
+def test_custom_evaluator_snippet_executes_with_current_api() -> None:
+    snippet = _extract_custom_evaluator_snippet()
+
+    assert "score=" not in snippet
+    assert "prediction=" not in snippet
+    assert 'example["' not in snippet
+    assert "example.input_data" in snippet
+    assert "example.expected_output" in snippet
+    assert "metrics=" in snippet
+
+    namespace: dict[str, object] = {}
+    exec(snippet, namespace)
+    my_evaluator = namespace["my_evaluator"]
+
+    example = EvaluationExample(
+        input_data={"question": "What is Python?"},
+        expected_output="programming language",
+        metadata={"example_id": "qa-1", "db_path": "eval.sqlite"},
+    )
+
+    def answer(question: str) -> str:
+        assert question == "What is Python?"
+        return "Python is a programming language."
+
+    result = my_evaluator(answer, {"model": "mock-model"}, example)
+
+    assert isinstance(result, ExampleResult)
+    assert result.example_id == "qa-1"
+    assert result.input_data == example.input_data
+    assert result.expected_output == "programming language"
+    assert result.actual_output == "Python is a programming language."
+    assert result.metrics == {"accuracy": 1.0}
+    assert result.success is True
+    assert result.error_message is None
+    assert result.execution_time >= 0.0
+    assert result.metadata["db_path"] == "eval.sqlite"
+    assert result.metadata["model"] == "mock-model"

--- a/traigent/skills/traigent-decorator-setup/SKILL.md
+++ b/traigent/skills/traigent-decorator-setup/SKILL.md
@@ -77,8 +77,8 @@ Configure how Traigent evaluates each trial using `EvaluationOptions`.
 
 | Field | Type | Description |
 |---|---|---|
-| `eval_dataset` | `str \| list[str] \| Dataset \| None` | Path to JSONL dataset or list of paths |
-| `custom_evaluator` | `Callable \| None` | Full-control evaluator: `(func, config, example) -> ExampleResult` |
+| `eval_dataset` | `str \| list[str] \| Dataset \| None` | Path to JSONL dataset or list of paths. JSONL rows use `input` or `input_data` plus an expected output field. |
+| `custom_evaluator` | `Callable \| None` | Full-control evaluator: `(func, config, example: EvaluationExample) -> ExampleResult` |
 | `scoring_function` | `Callable \| None` | Lightweight scorer: `(prediction, expected) -> float` |
 | `metric_functions` | `dict[str, Callable] \| None` | Named metrics: `{"accuracy": fn, "relevance": fn}` |
 
@@ -89,7 +89,7 @@ Configure how Traigent evaluates each trial using `EvaluationOptions`.
 | `eval_dataset` only | Built-in evaluation with default metrics | N/A (path string) |
 | `scoring_function` | Simple pass/fail or numeric scoring | `(prediction, expected) -> float` |
 | `metric_functions` | Multiple named metrics per example | `{"name": (prediction, expected, input_data) -> float}` |
-| `custom_evaluator` | Full control over execution and measurement | `(func, config, example) -> ExampleResult` |
+| `custom_evaluator` | Full control over execution and measurement | `(func, config, example: EvaluationExample) -> ExampleResult` |
 
 ### Example: Scoring Function
 

--- a/traigent/skills/traigent-decorator-setup/references/evaluation-options.md
+++ b/traigent/skills/traigent-decorator-setup/references/evaluation-options.md
@@ -10,8 +10,8 @@ from traigent.api.decorators import EvaluationOptions
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `eval_dataset` | `str \| list[str] \| Dataset \| None` | `None` | Path to a JSONL evaluation dataset, a list of dataset paths, or a `Dataset` object. Each row should contain input fields and an expected output. |
-| `custom_evaluator` | `Callable \| None` | `None` | A callable with signature `(func, config, example) -> ExampleResult`. Gives full control over how each example is executed and scored. |
+| `eval_dataset` | `str \| list[str] \| Dataset \| None` | `None` | Path to a JSONL evaluation dataset, a list of dataset paths, or a `Dataset` object. Each row should contain `input` or `input_data` plus an expected output field. |
+| `custom_evaluator` | `Callable \| None` | `None` | A callable with signature `(func, config, example: EvaluationExample) -> ExampleResult`. Gives full control over how each example is executed and scored. |
 | `scoring_function` | `Callable \| None` | `None` | A lightweight callable with signature `(prediction, expected) -> float`. Returns a numeric score for each example. |
 | `metric_functions` | `dict[str, Callable] \| None` | `None` | Dictionary mapping metric names to callables. Each callable has signature `(prediction, expected, input_data) -> float`. |
 
@@ -25,7 +25,7 @@ The `custom_evaluator` gives you full control over trial execution and measureme
 def custom_evaluator(
     func: Callable,
     config: dict[str, Any],
-    example: dict[str, Any],
+    example: EvaluationExample,
 ) -> ExampleResult:
     ...
 ```
@@ -34,32 +34,65 @@ def custom_evaluator(
 
 - `func` - The original decorated function (not wrapped).
 - `config` - The configuration being tested in this trial (e.g., `{"model": "gpt-4", "temperature": 0.5}`).
-- `example` - A single row from the eval dataset as a dictionary.
+- `example` - An `EvaluationExample` object. Read function inputs from `example.input_data`, expected values from `example.expected_output`, and extra JSONL fields from `example.metadata`.
 
 ### Return Value
 
-Must return an `ExampleResult` (or compatible dict) containing at minimum:
-- `score` (float) - The primary score for this example.
-- `prediction` (str) - The model output.
+Must return an `ExampleResult` containing at minimum:
+- `example_id` (str) - Unique identifier for this example.
+- `input_data` (dict) - The inputs used for the function call.
+- `expected_output` - The expected value from the dataset.
+- `actual_output` - The function output.
+- `metrics` (dict[str, float]) - Per-objective scores, such as `{"accuracy": 1.0}`.
+- `execution_time` (float) - Elapsed time in seconds.
+- `success` (bool) - Whether the example evaluation succeeded.
 
 ### Example
 
 ```python
-from traigent.evaluators.base import ExampleResult
+import time
+from collections.abc import Callable
+from typing import Any
 
-def my_evaluator(func, config, example):
-    import time
-    start = time.time()
-    prediction = func(example["question"])
-    latency = time.time() - start
+from traigent.api.types import ExampleResult
+from traigent.evaluators.base import EvaluationExample
 
-    score = 1.0 if example["expected"] in prediction else 0.0
+def my_evaluator(
+    func: Callable[..., Any],
+    config: dict[str, Any],
+    example: EvaluationExample,
+) -> ExampleResult:
+    start = time.perf_counter()
+    actual_output = func(example.input_data["question"])
+    execution_time = time.perf_counter() - start
+
+    expected = example.expected_output
+    accuracy = (
+        1.0
+        if expected is not None
+        and str(expected).lower() in str(actual_output).lower()
+        else 0.0
+    )
+
+    metadata = dict(example.metadata or {})
+    if "model" in config:
+        metadata["model"] = config["model"]
 
     return ExampleResult(
-        score=score,
-        prediction=prediction,
-        measures={"latency_ms": latency * 1000},
+        example_id=str(metadata.get("example_id", "example")),
+        input_data=example.input_data,
+        expected_output=example.expected_output,
+        actual_output=actual_output,
+        metrics={"accuracy": accuracy},
+        execution_time=execution_time,
+        success=True,
+        metadata=metadata,
     )
+```
+
+```python
+import traigent
+from traigent.api.decorators import EvaluationOptions
 
 @traigent.optimize(
     evaluation=EvaluationOptions(custom_evaluator=my_evaluator),
@@ -167,11 +200,11 @@ def summarize(text: str) -> str:
 
 ## Dataset Format
 
-The `eval_dataset` JSONL file should have one JSON object per line. At minimum, include input fields that match your function parameters and an `expected` field:
+The `eval_dataset` JSONL file should have one JSON object per line. At minimum, include an `input` object whose keys match your function parameters and an expected output field. Extra top-level fields become `example.metadata`:
 
 ```json
-{"question": "What is Python?", "expected": "A programming language"}
-{"question": "What is 2+2?", "expected": "4"}
+{"input": {"question": "What is Python?"}, "expected": "A programming language", "db_path": "eval.sqlite"}
+{"input": {"question": "What is 2+2?"}, "expected": "4", "db_path": "eval.sqlite"}
 ```
 
 Multiple datasets can be provided as a list:


### PR DESCRIPTION
## Summary
The bundled `traigent-decorator-setup` custom-evaluator snippet used an `ExampleResult(score=…, prediction=…)` shape and `example["…"]` indexing that **do not match the shipped SDK**, so code written by following the skill verbatim raised at runtime (**#1195**). Corrected to the real 0.12.0 API:

- **Scores go in `metrics={...}`** (e.g. `{"accuracy": 1.0}`); construct `ExampleResult(example_id, input_data, expected_output, actual_output, metrics, execution_time, success, …)`.
- `custom_evaluator` receives an **`EvaluationExample`** (`.input_data` / `.expected_output` / `.metadata`), **not** the raw JSONL row dict (a top-level key like `db_path` lands in `.metadata`).

## Drift guard (the issue's suggested CI check)
Adds `tests/unit/skills/test_decorator_setup_snippets.py`, which **extracts the actual ```python``` block from `evaluation-options.md`, `exec`s it**, builds a real `EvaluationExample`, calls the evaluator, and asserts the returned `ExampleResult` shape (and that the old `score=`/`prediction=`/`example["` patterns are gone). The doc can no longer silently drift from the API — the test fails if it does. **Not tautological**: it runs the documented snippet against the real shipped classes.

## Verified against shipped source (corrections noted)
- `EvaluationExample` is defined in `traigent/evaluators/base.py` (not `api/types.py`); `ExampleResult` also has an optional `user_metrics` field. Snippet matches the real signatures.

## Validation
- `pytest -n0 tests/unit/skills/` → **1 passed**.
- `ruff format --check` clean.

## PR checklist
- **Public surface delta:** bundled-skill docs corrected to match runtime API; no code/contract changes. Docs now match shipped 0.12.0.
- **Contract regeneration:** none.
- **Quality gates not relaxed:** none.

## Issue handling
Addresses **#1195**. Intentionally **no auto-close keywords** — issue stays open until owner confirmation. (Related canonical-skills tracker: `traigent-skills#8`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)