### PR TITLE
docs(skills): align custom evaluator examples with SDK API

### DIFF
--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -331,6 +331,55 @@ class TestDocumentationConsistency(unittest.TestCase):
 
         self.assertTrue(hasattr(optimized_function, "optimize"))
 
+    def test_decorator_skill_custom_evaluator_example_matches_public_api(self):
+        """Execute the bundled skill's custom_evaluator snippet against public DTOs."""
+        from traigent.api.types import ExampleResult
+        from traigent.evaluators.base import EvaluationExample
+
+        reference_path = (
+            self.project_root
+            / "traigent"
+            / "skills"
+            / "traigent-decorator-setup"
+            / "references"
+            / "evaluation-options.md"
+        )
+        content = reference_path.read_text()
+
+        self.assertNotIn("score=score", content)
+        self.assertNotIn("prediction=prediction", content)
+        self.assertNotIn('example["', content)
+        self.assertIn("example.input_data", content)
+        self.assertIn("example.expected_output", content)
+        self.assertIn('metrics={"accuracy": accuracy', content)
+
+        python_blocks = re.findall(r"```python\n(.*?)\n```", content, re.DOTALL)
+        snippet = next(block for block in python_blocks if "def my_evaluator" in block)
+        evaluator_only = snippet.split("\n@traigent.optimize", 1)[0]
+
+        namespace = {}
+        exec(compile(evaluator_only, str(reference_path), "exec"), namespace)
+
+        example = EvaluationExample(
+            input_data={"question": "What is 2+2?"},
+            expected_output="4",
+            metadata={"id": "qa-2", "db_path": "text2sql.sqlite"},
+        )
+
+        result = namespace["my_evaluator"](
+            lambda question: f"The answer to {question} is 4.",
+            {"model": "mock-model"},
+            example,
+        )
+
+        self.assertIsInstance(result, ExampleResult)
+        self.assertEqual("qa-2", result.example_id)
+        self.assertEqual(example.input_data, result.input_data)
+        self.assertEqual("4", result.expected_output)
+        self.assertEqual(1.0, result.metrics["accuracy"])
+        self.assertIn("latency_ms", result.metrics)
+        self.assertTrue(result.success)
+
     def test_public_docs_root_traigent_imports_exist(self):
         """Validate root traigent imports advertised in public docs/examples."""
         import traigent

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -306,7 +306,7 @@ class TestDocumentationConsistency(unittest.TestCase):
         self.assertIn(privacy_example, entries)
 
         script = script_path.read_text()
-        self.assertIn(f"\"{privacy_example}\"", script)
+        self.assertIn(f'"{privacy_example}"', script)
         self.assertIn("SDK Publication Manifest (39 examples)", script)
         self.assertIn("--- Walkthrough (8) ---", script)
 

--- a/traigent/skills/traigent-decorator-setup/references/evaluation-options.md
+++ b/traigent/skills/traigent-decorator-setup/references/evaluation-options.md
@@ -22,10 +22,16 @@ The `custom_evaluator` gives you full control over trial execution and measureme
 ### Signature
 
 ```python
+from collections.abc import Callable
+from typing import Any
+
+from traigent.evaluators.base import EvaluationExample
+from traigent.api.types import ExampleResult
+
 def custom_evaluator(
-    func: Callable,
+    func: Callable[..., Any],
     config: dict[str, Any],
-    example: dict[str, Any],
+    example: EvaluationExample,
 ) -> ExampleResult:
     ...
 ```
@@ -34,31 +40,52 @@ def custom_evaluator(
 
 - `func` - The original decorated function (not wrapped).
 - `config` - The configuration being tested in this trial (e.g., `{"model": "gpt-4", "temperature": 0.5}`).
-- `example` - A single row from the eval dataset as a dictionary.
+- `example` - An `EvaluationExample` object. Use `example.input_data` for the row input, `example.expected_output` for the expected answer, and `example.metadata` for extra top-level JSONL keys such as IDs or routing hints.
 
 ### Return Value
 
 Must return an `ExampleResult` (or compatible dict) containing at minimum:
-- `score` (float) - The primary score for this example.
-- `prediction` (str) - The model output.
+- `example_id` (str) - Stable example identifier, often from `example.metadata`.
+- `input_data` (dict) - Usually `example.input_data`.
+- `expected_output` - Usually `example.expected_output`.
+- `actual_output` - The function output.
+- `metrics` (dict[str, float]) - Numeric scores keyed by objective name, for example `{"accuracy": 1.0}`.
+- `execution_time` (float) - Seconds spent evaluating this example.
+- `success` (bool) - Whether the example evaluated successfully.
 
 ### Example
 
 ```python
-from traigent.evaluators.base import ExampleResult
+from collections.abc import Callable
+from typing import Any
 
-def my_evaluator(func, config, example):
+from traigent.evaluators.base import EvaluationExample
+from traigent.api.types import ExampleResult
+
+def my_evaluator(
+    func: Callable[..., str],
+    config: dict[str, Any],
+    example: EvaluationExample,
+) -> ExampleResult:
     import time
-    start = time.time()
-    prediction = func(example["question"])
-    latency = time.time() - start
 
-    score = 1.0 if example["expected"] in prediction else 0.0
+    start = time.time()
+    question = str(example.input_data["question"])
+    prediction = func(question)
+    execution_time = time.time() - start
+
+    expected = "" if example.expected_output is None else str(example.expected_output)
+    accuracy = 1.0 if expected.lower() in prediction.lower() else 0.0
 
     return ExampleResult(
-        score=score,
-        prediction=prediction,
-        measures={"latency_ms": latency * 1000},
+        example_id=str(example.metadata.get("id", question)),
+        input_data=example.input_data,
+        expected_output=example.expected_output,
+        actual_output=prediction,
+        metrics={"accuracy": accuracy, "latency_ms": execution_time * 1000},
+        execution_time=execution_time,
+        success=True,
+        metadata={"model": config.get("model")},
     )
 
 @traigent.optimize(
@@ -167,11 +194,11 @@ def summarize(text: str) -> str:
 
 ## Dataset Format
 
-The `eval_dataset` JSONL file should have one JSON object per line. At minimum, include input fields that match your function parameters and an `expected` field:
+The `eval_dataset` JSONL file should have one JSON object per line. At minimum, include `input` (or `input_data`) for the function arguments and an expected-output field such as `expected_output` or `expected`. Extra top-level keys are preserved in `example.metadata`:
 
 ```json
-{"question": "What is Python?", "expected": "A programming language"}
-{"question": "What is 2+2?", "expected": "4"}
+{"input": {"question": "What is Python?"}, "expected_output": "A programming language", "id": "qa-1"}
+{"input": {"question": "What is 2+2?"}, "expected_output": "4", "id": "qa-2"}
 ```
 
 Multiple datasets can be provided as a list:


### PR DESCRIPTION
## Summary

Addresses #1195.

Updates the bundled `traigent-decorator-setup` custom evaluator reference to match the SDK 0.12.0 public API shapes:

- `custom_evaluator(func, config, example)` receives an `EvaluationExample`, not a raw JSONL row dict.
- Evaluators read `example.input_data`, `example.expected_output`, and `example.metadata`.
- Evaluators return `ExampleResult(..., metrics={...})` instead of obsolete `score=` / `prediction=` / `measures=` fields.
- JSONL guidance now shows `input` / `expected_output`, with extra top-level keys preserved as metadata.

## Drift guard

Adds a focused documentation guard that extracts the bundled skill snippet, executes the documented evaluator against the shipped public DTOs, and asserts the returned `ExampleResult` uses `metrics`.

## Validation

- `pytest -n0 tests/test_documentation.py::TestDocumentationConsistency::test_decorator_skill_custom_evaluator_example_matches_public_api -q --tb=short`
- `/home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop`
- `/home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/check_formatting.sh origin/develop`
- Commit hooks: isort, detect-secrets, mypy, strict cost guardrails, public test assertion contracts

## Residual risk

This guards the custom evaluator snippet in `traigent-decorator-setup`. It does not execute every Markdown code block across all bundled skills; broader skill-snippet execution remains a separate hardening step if we want full docs-as-tests coverage.
