### PR TITLE
fix(sdk): persist edge-analytics trials past breaker + align sync API contract (#1210, #1211)

### DIFF
--- a/tests/cloud/test_sync_manager.py
+++ b/tests/cloud/test_sync_manager.py
@@ -3,6 +3,7 @@ Comprehensive test suite for SyncManager.
 Tests data conversion, API interactions, and sync operations.
 """
 
+import re
 import shutil
 import tempfile
 from datetime import datetime
@@ -12,11 +13,22 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from traigent.cloud.sync_manager import SyncManager
+from traigent.cloud.sync_manager import SyncManager, sanitize_backend_name
 from traigent.config.backend_config import BackendConfig
 from traigent.config.types import TraigentConfig
 from traigent.storage.local_storage import LocalStorageManager, TrialResult
 from traigent.utils.exceptions import TraigentStorageError
+
+VALID_AGENT_TYPE_IDS = {
+    "chat",
+    "classification",
+    "completion",
+    "qa",
+    "retrieval",
+    "tool",
+    "function",
+}
+BACKEND_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9 _-]+$")
 
 
 class TestSyncManager:
@@ -161,12 +173,14 @@ class TestSyncManager:
         # Check agent data
         agent = traigent_data["agent"]
         assert agent["name"] == "Local Agent: test_llm_function"
-        assert agent["agent_type"] == "custom"
+        assert "agent_type" not in agent
+        assert agent["agent_type_id"] in VALID_AGENT_TYPE_IDS
         assert agent["source"] == "local_import"
 
         # Check dataset data
         dataset = traigent_data["dataset"]
-        assert dataset["name"] == "Local Dataset: test_llm_function"
+        assert dataset["name"] == "Local Dataset test_llm_function"
+        assert BACKEND_NAME_PATTERN.fullmatch(dataset["name"])
         assert dataset["dataset_id"] == dataset["id"]
         assert dataset["benchmark_id"] == dataset["id"]
         assert dataset["type"] == "custom"
@@ -208,6 +222,8 @@ class TestSyncManager:
         """Ensure blocking HTTP calls include an explicit timeout."""
         sync_manager = self.sync_manager
         payload = {"id": "resource-123"}
+        if method_name == "_sync_experiment_run":
+            payload["experiment_id"] = "experiment-123"
         mock_response = Mock(status_code=201, text="created")
         original_post = sync_manager._session.post
 
@@ -216,7 +232,12 @@ class TestSyncManager:
             method = getattr(sync_manager, method_name)
             result = method(payload)
 
-            expected_url = f"{sync_manager.base_url}/{resource_path}"
+            expected_url = (
+                f"{sync_manager.base_url}/experiment-runs/"
+                f"{payload['experiment_id']}/runs"
+                if method_name == "_sync_experiment_run"
+                else f"{sync_manager.base_url}/{resource_path}"
+            )
             sync_manager._session.post.assert_called_once_with(
                 expected_url,
                 json=payload,
@@ -240,7 +261,9 @@ class TestSyncManager:
 
         try:
             sync_manager._session.post = Mock(side_effect=responses)
-            sync_manager._session.get = Mock(return_value=Mock(status_code=404, text="missing"))
+            sync_manager._session.get = Mock(
+                return_value=Mock(status_code=404, text="missing")
+            )
             result = sync_manager._sync_benchmark(payload)
 
             assert result["success"] is True
@@ -254,6 +277,49 @@ class TestSyncManager:
         finally:
             sync_manager._session.post = original_post
             sync_manager._session.get = original_get
+
+    def test_convert_session_payloads_match_backend_contract(self):
+        """Generated sync payloads satisfy current backend validation contracts."""
+        sanitized_name = sanitize_backend_name("Local Dataset: fn/with?punctuation")
+        assert sanitized_name == "Local Dataset fn with punctuation"
+        assert BACKEND_NAME_PATTERN.fullmatch(sanitized_name)
+
+        storage = self.sync_manager.storage
+        session_id = storage.create_session("fn:with/slash?and*punctuation")
+        storage.add_trial_result(
+            session_id,
+            {"param": 1},
+            0.91,
+            metadata={"total_cost": 0.17},
+        )
+        storage.finalize_session(session_id, "completed")
+        session = storage.load_session(session_id)
+
+        traigent_data = self.sync_manager.convert_session_to_traigent_format(session)
+
+        benchmark_name = traigent_data["benchmark"]["name"]
+        assert BACKEND_NAME_PATTERN.fullmatch(benchmark_name)
+        assert ":" not in benchmark_name
+
+        agent = traigent_data["agent"]
+        assert "agent_type" not in agent
+        assert agent["agent_type_id"] in VALID_AGENT_TYPE_IDS
+
+    def test_sync_experiment_run_posts_to_nested_backend_route(self):
+        """Experiment run creation uses the route exposed by the backend."""
+        run_data = {"id": "test_run", "experiment_id": "test_experiment"}
+        with patch.object(self.sync_manager.session, "post") as mock_post:
+            mock_response = Mock(status_code=201, text="created")
+            mock_post.return_value = mock_response
+
+            result = self.sync_manager._sync_experiment_run(run_data)
+
+            assert result["success"] is True
+            mock_post.assert_called_once_with(
+                f"{self.sync_manager.base_url}/experiment-runs/test_experiment/runs",
+                json=run_data,
+                timeout=self.sync_manager._request_timeout,
+            )
 
     def test_convert_trials_to_results(self):
         """Test converting local trials to Traigent configuration_run format."""
@@ -341,6 +407,55 @@ class TestSyncManager:
 
         # Should have made 4 API calls (agent, benchmark, experiment, experiment_run)
         assert mock_post.call_count == 4
+
+    def test_sync_session_to_cloud_contract_payloads_with_cost(self):
+        """A full mocked sync emits corrected URLs and a cost-bearing run body."""
+        storage = self.sync_manager.storage
+        session_id = storage.create_session("contract:sync/fn")
+        storage.add_trial_result(
+            session_id,
+            {"model": "gpt-test", "temperature": 0.2},
+            0.88,
+            metadata={"total_cost": 0.42, "input_cost": 0.2, "output_cost": 0.22},
+        )
+        storage.finalize_session(session_id, "completed")
+        mock_response = Mock(status_code=201, text="Created")
+        original_post = self.sync_manager._session.post
+
+        try:
+            self.sync_manager._session.post = Mock(return_value=mock_response)
+            result = self.sync_manager.sync_session_to_cloud(session_id, dry_run=False)
+        finally:
+            post_mock = self.sync_manager._session.post
+            self.sync_manager._session.post = original_post
+
+        assert result["status"] == "success"
+        assert post_mock.call_count == 4
+
+        calls = post_mock.call_args_list
+        experiment_id = f"local_import_{session_id}"
+        assert [call.args[0] for call in calls] == [
+            f"{self.sync_manager.base_url}/agents",
+            f"{self.sync_manager.base_url}/datasets",
+            f"{self.sync_manager.base_url}/experiments",
+            f"{self.sync_manager.base_url}/experiment-runs/{experiment_id}/runs",
+        ]
+
+        agent_payload = calls[0].kwargs["json"]
+        assert agent_payload["agent_type_id"] in VALID_AGENT_TYPE_IDS
+        assert "agent_type" not in agent_payload
+
+        benchmark_payload = calls[1].kwargs["json"]
+        assert BACKEND_NAME_PATTERN.fullmatch(benchmark_payload["name"])
+
+        experiment_payload = calls[2].kwargs["json"]
+        assert experiment_payload["agent_id"] == agent_payload["id"]
+
+        run_payload = calls[3].kwargs["json"]
+        result_payload = run_payload["results"][0]
+        assert result_payload["measures"]["cost"] == 0.42
+        assert result_payload["measures"]["total_cost"] == 0.42
+        assert result_payload["measures"]["cost"] > 0
 
     @patch("requests.Session.post")
     def test_sync_session_to_cloud_partial_failure(self, mock_post):

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import requests
 
-from traigent.cloud.sync_manager import SyncManager
+from traigent.cloud.sync_manager import DEFAULT_SYNC_AGENT_TYPE_ID, SyncManager
 from traigent.config.types import TraigentConfig
 from traigent.storage.local_storage import OptimizationSession, TrialResult
 from traigent.utils.exceptions import TraigentStorageError
@@ -345,11 +345,12 @@ class TestSyncManager:
 
         # Check agent data
         assert result["agent"]["name"] == "Local Agent: test_function"
-        assert result["agent"]["agent_type"] == "custom"
+        assert "agent_type" not in result["agent"]
+        assert result["agent"]["agent_type_id"] == DEFAULT_SYNC_AGENT_TYPE_ID
         assert result["agent"]["source"] == "local_import"
 
         # Check dataset/benchmark compatibility payload
-        assert result["benchmark"]["name"] == "Local Dataset: test_function"
+        assert result["benchmark"]["name"] == "Local Dataset test_function"
         assert result["benchmark"]["examples_count"] == 3
         assert result["benchmark"]["type"] == "custom"
 

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -3,18 +3,28 @@
 Tests the extracted backend session lifecycle manager with stub backend client.
 """
 
+import json
 import logging
 import re
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
-from traigent.api.types import OptimizationResult, OptimizationStatus, TrialResult
-from traigent.cloud.session_types import SessionCreationResult
+from traigent.api.types import (
+    OptimizationResult,
+    OptimizationStatus,
+    TrialResult,
+    TrialStatus,
+)
+from traigent.cloud.session_types import (
+    SessionCreationFailureReason,
+    SessionCreationResult,
+)
 from traigent.config.types import TraigentConfig
 from traigent.core.backend_session_manager import BackendSessionManager
 from traigent.core.objectives import create_default_objectives
 from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.storage.local_storage import LocalStorageManager
 from traigent.utils.function_identity import resolve_function_descriptor
 
 
@@ -215,6 +225,18 @@ class TestBackendSessionManagerCreation:
 class TestBackendSessionManagerTrialSubmission:
     """Test trial submission."""
 
+    @staticmethod
+    def _wire_submit_result_to_storage(mock_backend_client, storage):
+        def submit_result(session_id, config, score, metadata=None):
+            storage.add_trial_result(
+                session_id=session_id,
+                config=config,
+                score=score,
+                metadata=metadata or {},
+            )
+
+        mock_backend_client.submit_result.side_effect = submit_result
+
     @pytest.mark.asyncio
     async def test_submit_trial_success(
         self, backend_session_manager, mock_trial_result, mock_backend_client
@@ -246,6 +268,130 @@ class TestBackendSessionManagerTrialSubmission:
         assert backend_session_manager.is_trial_backend_acknowledged(
             "test-session-id", "be_trial_mint_1"
         )
+
+    @pytest.mark.asyncio
+    async def test_submit_trial_persists_locally_when_backend_tracking_disabled(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_optimizer,
+        mock_backend_client,
+        mock_trial_result,
+        tmp_path,
+    ):
+        """The backend breaker must not suppress local edge analytics storage."""
+        storage = LocalStorageManager(str(tmp_path))
+        session_id = storage.create_session(
+            "offline_func",
+            optimization_config={"objective_schema": {"primary": "accuracy"}},
+        )
+        self._wire_submit_result_to_storage(mock_backend_client, storage)
+        manager = BackendSessionManager(
+            backend_client=mock_backend_client,
+            traigent_config=traigent_config,
+            objectives=["accuracy", "cost"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+        manager.disable_backend_tracking(SessionCreationFailureReason.NO_API_KEY)
+
+        result = await manager.submit_trial(
+            trial_result=mock_trial_result,
+            session_id=session_id,
+        )
+
+        assert result is False
+        mock_backend_client.submit_result.assert_called_once()
+        mock_backend_client._submit_trial_result_via_session.assert_not_called()
+        stored_session = storage.load_session(session_id)
+        assert stored_session is not None
+        assert stored_session.completed_trials == 1
+        assert len(stored_session.trials or []) == 1
+        stored_trial = stored_session.trials[0]
+        assert stored_trial.config == mock_trial_result.config
+        assert stored_trial.score == 0.9
+        assert stored_trial.cost == 0.5
+        assert stored_trial.total_cost == 0.5
+
+    @pytest.mark.asyncio
+    async def test_submit_trial_records_locally_once_when_backend_enabled(
+        self,
+        backend_session_manager,
+        mock_backend_client,
+        mock_trial_result,
+        tmp_path,
+    ):
+        """A backend-enabled submit should perform one local compatibility write."""
+        storage = LocalStorageManager(str(tmp_path))
+        session_id = storage.create_session("online_func")
+        self._wire_submit_result_to_storage(mock_backend_client, storage)
+
+        result = await backend_session_manager.submit_trial(
+            trial_result=mock_trial_result,
+            session_id=session_id,
+        )
+
+        assert result is True
+        mock_backend_client.submit_result.assert_called_once()
+        stored_session = storage.load_session(session_id)
+        assert stored_session is not None
+        assert stored_session.completed_trials == 1
+        assert len(stored_session.trials or []) == 1
+
+    @pytest.mark.asyncio
+    async def test_offline_two_trial_session_json_keeps_trials_and_cost(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_optimizer,
+        mock_backend_client,
+        tmp_path,
+    ):
+        """Regression boundary for edge_analytics sessions becoming empty husks."""
+        storage = LocalStorageManager(str(tmp_path))
+        session_id = storage.create_session("offline_func")
+        self._wire_submit_result_to_storage(mock_backend_client, storage)
+        manager = BackendSessionManager(
+            backend_client=mock_backend_client,
+            traigent_config=traigent_config,
+            objectives=["accuracy", "cost"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+        manager.disable_backend_tracking(SessionCreationFailureReason.NO_API_KEY)
+
+        for index, cost in enumerate((0.11, 0.22), start=1):
+            trial = Mock(spec=TrialResult)
+            trial.trial_id = f"trial-{index}"
+            trial.config = {"param1": index}
+            trial.metrics = {"accuracy": 0.7 + index / 10, "total_cost": cost}
+            trial.is_successful = True
+            trial.status = TrialStatus.COMPLETED
+            trial.duration = 1.0
+            trial.error_message = None
+            trial.metadata = {}
+            trial.get_metric = Mock(
+                side_effect=lambda key, default=None, t=trial: t.metrics.get(
+                    key, default
+                )
+            )
+
+            await manager.submit_trial(trial_result=trial, session_id=session_id)
+
+        session_json = json.loads(
+            (tmp_path / "sessions" / f"{session_id}.json").read_text()
+        )
+        assert session_json["status"] == "pending"
+        assert session_json["completed_trials"] == 2
+        assert len(session_json["trials"]) == 2
+        assert [trial["total_cost"] for trial in session_json["trials"]] == [
+            0.11,
+            0.22,
+        ]
 
     @pytest.mark.asyncio
     async def test_submit_trial_fails_closed_when_no_backend_slot(
@@ -1366,9 +1512,9 @@ class TestHandleSessionCreationResult:
             manager.handle_session_creation_result(result)
 
         warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert (
-            len(warning_records) == 1
-        ), f"Expected exactly 1 warning, got {len(warning_records)}"
+        assert len(warning_records) == 1, (
+            f"Expected exactly 1 warning, got {len(warning_records)}"
+        )
 
     def test_success_logs_info(
         self, traigent_config, objective_schema, mock_optimizer, caplog

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -6,6 +6,7 @@ Handles migration of local data to Traigent backend when users upgrade.
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013
 
 import os
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -31,6 +32,13 @@ from ..utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+VALID_SYNC_AGENT_TYPE_IDS = frozenset(
+    {"chat", "classification", "completion", "qa", "retrieval", "tool", "function"}
+)
+DEFAULT_SYNC_AGENT_TYPE_ID = "completion"
+_BACKEND_NAME_DISALLOWED = re.compile(r"[^a-zA-Z0-9 _-]+")
+_BACKEND_NAME_SPACES = re.compile(r"\s+")
+
 
 def build_experiment_url(base_url: str, experiment_id: str) -> str:
     """Build the portal URL for an experiment.
@@ -39,6 +47,14 @@ def build_experiment_url(base_url: str, experiment_id: str) -> str:
     used by both SyncManager and the orchestrator.
     """
     return f"{base_url.rstrip('/')}/experiments/{experiment_id}"
+
+
+def sanitize_backend_name(value: str, fallback: str = "Local Dataset") -> str:
+    """Normalize generated sync names to the backend name pattern."""
+
+    sanitized = _BACKEND_NAME_DISALLOWED.sub(" ", value)
+    sanitized = _BACKEND_NAME_SPACES.sub(" ", sanitized).strip()
+    return sanitized or fallback
 
 
 class SyncManager:
@@ -194,7 +210,9 @@ class SyncManager:
         agent_data = {
             "id": agent_id,
             "name": f"Local Agent: {session.function_name}",
-            "agent_type": "custom",
+            # Local imports are generic function-completion optimizations; use a
+            # deterministic backend enum value rather than the legacy "custom".
+            "agent_type_id": DEFAULT_SYNC_AGENT_TYPE_ID,
             "description": f"Imported from local optimization of {session.function_name}",
             "source": "local_import",
             "created_at": session.created_at,
@@ -205,7 +223,7 @@ class SyncManager:
             "id": dataset_id,
             "dataset_id": dataset_id,
             "benchmark_id": dataset_id,
-            "name": f"Local Dataset: {session.function_name}",
+            "name": sanitize_backend_name(f"Local Dataset {session.function_name}"),
             "label": f"{session.function_name}_eval",
             "description": f"Evaluation dataset for {session.function_name}",
             "type": "custom",
@@ -561,8 +579,15 @@ class SyncManager:
     def _sync_experiment_run(self, run_data: dict[str, Any]) -> dict[str, Any]:
         """Sync experiment run data to cloud."""
         try:
+            experiment_id = run_data.get("experiment_id")
+            if not experiment_id:
+                return {
+                    "success": False,
+                    "error": "Experiment run sync requires experiment_id",
+                }
+
             response = self._session.post(
-                f"{self.base_url}/experiment-runs",
+                f"{self.base_url}/experiment-runs/{experiment_id}/runs",
                 json=run_data,
                 timeout=self._request_timeout,
             )

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -617,13 +617,6 @@ class BackendSessionManager:
         if not self._backend_client or not session_id:
             return False
 
-        if not self._backend_tracking_enabled:
-            logger.debug(
-                "Skipping trial submission (backend disabled: %s)",
-                self._backend_disabled_reason,
-            )
-            return False
-
         _ = content_scores
 
         primary_objective = (
@@ -641,6 +634,20 @@ class BackendSessionManager:
         if self._strategy_preset_metadata is not None:
             trial_metadata["strategy_preset"] = dict(self._strategy_preset_metadata)
 
+        self._persist_trial_locally(
+            session_id=session_id,
+            trial_result=trial_result,
+            score=score,
+            metadata=trial_metadata,
+        )
+
+        if not self._backend_tracking_enabled:
+            logger.debug(
+                "Skipping trial submission (backend disabled: %s)",
+                self._backend_disabled_reason,
+            )
+            return False
+
         await self._log_trial_to_backend(
             session_id=session_id,
             trial_result=trial_result,
@@ -649,6 +656,39 @@ class BackendSessionManager:
         )
 
         return True
+
+    def _persist_trial_locally(
+        self,
+        *,
+        session_id: str,
+        trial_result: TrialResult,
+        score: float | None,
+        metadata: dict[str, Any],
+    ) -> None:
+        """Record local analytics before any remote backend breaker can short-circuit."""
+
+        if not self._backend_client or not session_id:
+            return
+
+        sanitized_score = float(score) if score is not None else None
+        metadata_payload = dict(metadata)
+        if score is None:
+            metadata_payload["primary_objective_missing"] = True
+
+        try:
+            self._backend_client.submit_result(
+                session_id=session_id,
+                config=trial_result.config,
+                score=sanitized_score,
+                metadata=metadata_payload,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Local trial logging failed for session %s trial %s: %s",
+                session_id,
+                trial_result.trial_id,
+                exc,
+            )
 
     def is_trial_backend_acknowledged(self, session_id: str, trial_id: str) -> bool:
         """Whether the backend minted+accepted a result for ``trial_id``.
@@ -707,7 +747,7 @@ class BackendSessionManager:
         score: float | None,
         metadata: dict[str, Any],
     ) -> None:
-        """Persist trial outcome locally and submit metrics to backend when possible."""
+        """Submit trial metrics to backend when possible."""
 
         if not self._backend_client or not session_id:
             return
@@ -719,22 +759,6 @@ class BackendSessionManager:
         metadata_payload = dict(metadata)
         if score is None:
             metadata_payload["primary_objective_missing"] = True
-
-        # Always record locally so analytics remain available even without backend.
-        try:
-            self._backend_client.submit_result(
-                session_id=session_id,
-                config=trial_result.config,
-                score=sanitized_score,
-                metadata=metadata_payload,
-            )
-        except Exception as exc:
-            logger.debug(
-                "Local trial logging failed for session %s trial %s: %s",
-                session_id,
-                trial_result.trial_id,
-                exc,
-            )
 
         # Skip remote submission when no API key is configured (offline/local only).
         auth_manager = getattr(self._backend_client, "auth_manager", None)


### PR DESCRIPTION
Closes #1210 and #1211 — the two remaining SDK legs of the edge-analytics-cost-to-portal epic (#1213).

## #1210 — async runs never persisted trials locally
The run-scoped circuit breaker (`6dd7a15c`) gated `submit_trial` and returned **before** `_log_trial_to_backend` — but the only local-persistence call site lived **inside** that gated path, so every offline/fallback session was an empty `status=pending` husk (the "results saved locally only" log was false). This made #1201's cost serializer unreachable (sync had only empty sessions to read).

**Fix:** `submit_trial` now calls a new `_persist_trial_locally()` **before** the breaker check; `_log_trial_to_backend` is remote-only. Local write is **exactly-once** (single call site) and breaker-independent. `backend_client.submit_result` is the **local-only** shim (→ `local_storage.add_trial_result`, verified no network call), so local analytics return without re-introducing the backend calls / log-spam the breaker was added to stop.

## #1211 — `traigent edge-analytics sync` failed at 4 API-contract mismatches
Fixed in `sync_manager.py` (cost serializer #1201 untouched), backend contract verified against TraigentBackend `develop`:
1. Benchmark name `Local Dataset: <fn>` — colon violates `^[a-zA-Z0-9 _-]+$` → `sanitize_backend_name`.
2. `agent_type:"custom"` → explicit `agent_type_id:"completion"` (valid AgentType enum value).
3. Experiment 404 — cascade from (2), cleared by the agent fix.
4. Experiment-run POST → `/experiment-runs/<experiment_id>/runs` (the actual backend route).

## Verification
PYTHONPATH-pinned to the worktree (not the 301-behind root clone): changed modules **136 passed**, `submit_trial`/`backend_session`/sync sweep **137 passed**, ruff + black + mypy + bandit clean. **Captain regression gate:** every failure in the broad `-k async` sweep (privacy/security test-doubles, cloud/standard env-gated modes, a timeout-parallel timing test) reproduces **identically on a clean `origin/develop` baseline** (same `certified_selection` test-double drift) — **zero regressions** from this change.

## Acceptance gate
#1210 + #1211 are unit-verified here. The full **live edge-analytics sync E2E** (real backend → `configuration_run` with `(measures::jsonb)->>'cost' > 0`) is the **#1213 epic's** separate acceptance gate; #1200 and #1213 stay open until that live run confirms cost reaches the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)