### PR TITLE
fix(sdk): green tests/unit — privacy-alias defect + 6 stale-test drifts (unblocks #1214)

### DIFF
--- a/tests/unit/cli/test_recommend_command.py
+++ b/tests/unit/cli/test_recommend_command.py
@@ -45,8 +45,12 @@ def test_recommend_command_smoke_table() -> None:
     assert result.exit_code == 0
     assert "TVar Recommendations for rag" in result.output
     assert "retrieval_k" in result.output
-    assert "manual_guidance" in result.output
+    assert "Manual wiring" in result.output
     assert "task-dependent" in result.output
+    assert {
+        row["effectuation_status"]
+        for row in recommend_configuration_space("rag")["recommendations"]
+    } == {"manual_guidance"}
 
 
 def test_recommend_command_json_filters() -> None:

--- a/tests/unit/effectuation/test_framework_param.py
+++ b/tests/unit/effectuation/test_framework_param.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from traigent.config_generator.catalog import load_catalog
-from traigent.effectuation import get_strategy
+from traigent.effectuation import STRATEGY_REGISTRY, _strategy_id_for_knob, get_strategy
 
 
 def test_framework_param_projects_plain_value_set_for_optimizer() -> None:
@@ -36,9 +36,17 @@ def test_framework_param_wrap_callable_returns_same_callable() -> None:
     assert effect.emit_events() == []
 
 
-def test_catalog_value_entries_are_only_marked_executable_when_strategy_exists() -> None:
+def test_catalog_value_entries_are_only_marked_executable_when_strategy_exists() -> (
+    None
+):
     value_entries = [entry for entry in load_catalog() if entry["kind"] == "value"]
 
     for entry in value_entries:
-        assert entry["effectuation_status"] == "executable"
-        assert entry["effectuation_strategy"] == "framework_param"
+        strategy_id = _strategy_id_for_knob(entry)
+        if entry["effectuation_status"] == "executable":
+            assert entry["effectuation_strategy"] == strategy_id == "framework_param"
+            assert strategy_id in STRATEGY_REGISTRY
+        else:
+            assert entry["effectuation_status"] == "manual_guidance"
+            assert strategy_id is None
+            assert entry.get("effectuation_strategy", "") == ""

--- a/tests/unit/effectuation/test_regression.py
+++ b/tests/unit/effectuation/test_regression.py
@@ -15,7 +15,12 @@ from traigent.config_generator.subsystems.tvar_recommendations import (
     generate_recommendations,
 )
 from traigent.config_generator.types import AutoConfigResult
-from traigent.effectuation import apply_effectuation, compile_effectuation
+from traigent.effectuation import (
+    STRATEGY_REGISTRY,
+    _strategy_id_for_knob,
+    apply_effectuation,
+    compile_effectuation,
+)
 from traigent.evaluators.base import EvaluationExample
 
 
@@ -96,20 +101,20 @@ def test_catalog_executable_and_manual_statuses_are_honest() -> None:
     assert by_name["candidate_count"]["effectuation_status"] == "executable"
     assert by_name["candidate_count"]["effectuation_strategy"] == "self_consistency"
 
+    executable_strategies = {
+        entry["name"]: strategy_id
+        for entry in entries
+        if (strategy_id := _strategy_id_for_knob(entry)) is not None
+    }
+    assert executable_strategies == {"candidate_count": "self_consistency"}
+    assert set(executable_strategies.values()) <= set(STRATEGY_REGISTRY)
+
     manual_names = {
         entry["name"]
         for entry in entries
         if entry["effectuation_status"] == "manual_guidance"
     }
-    assert manual_names == {
-        "retrieval_k",
-        "schema_context",
-        "evidence_usage",
-        "fewshot_selector",
-        "generation_path",
-        "fewshot_k",
-        "repair_policy",
-    }
+    assert manual_names == set(by_name) - set(executable_strategies)
 
 
 def test_generate_config_json_recommendation_keys_remain_unchanged() -> None:

--- a/tests/unit/test_hybrid_async_and_privacy.py
+++ b/tests/unit/test_hybrid_async_and_privacy.py
@@ -145,10 +145,21 @@ class DummyBackend:
         search_space: dict,
         optimization_goal: str,
         metadata: dict,
+        objectives: list[Any] | None = None,
+        promotion_policy: dict[str, Any] | None = None,
+        tvl_governance: dict[str, Any] | None = None,
     ):
         sid = f"sess-{len(self.sessions) + 1}"
         self.sessions.append(
-            {"id": sid, "fn": function_name, "space": search_space, "meta": metadata}
+            {
+                "id": sid,
+                "fn": function_name,
+                "space": search_space,
+                "meta": metadata,
+                "objectives": objectives,
+                "promotion_policy": promotion_policy,
+                "tvl_governance": tvl_governance,
+            }
         )
         return SessionCreationResult.connected(sid)
 
@@ -164,8 +175,19 @@ class DummyBackend:
             }
         )
 
-    def finalize_session_sync(self, session_id: str, succeeded: bool):
-        self.finalized.append({"id": session_id, "ok": succeeded})
+    def finalize_session_sync(
+        self,
+        session_id: str,
+        succeeded: bool,
+        certified_selection: dict[str, Any] | None = None,
+    ):
+        self.finalized.append(
+            {
+                "id": session_id,
+                "ok": succeeded,
+                "certified_selection": certified_selection,
+            }
+        )
         return {"status": "ok", "succeeded": succeeded}
 
 
@@ -300,7 +322,7 @@ async def test_local_mode_includes_aggregated_summary_in_submission():
         ):
             self.submissions.append({"session_id": session_id, "metadata": metadata})
 
-        def finalize_session_sync(self, session_id: str, *_):
+        def finalize_session_sync(self, session_id: str, *_, **__):
             self.finalized.append(session_id)
             return {"ok": True}
 

--- a/tests/unit/test_privacy_mode.py
+++ b/tests/unit/test_privacy_mode.py
@@ -107,15 +107,12 @@ class TestPrivacyCompliance:
             "constraints",
             "default_config",
             "promotion_policy",
+            "tvl_governance",
             "optimization_strategy",
             "user_id",
             "billing_tier",
             "metadata",
             "problem_type",  # Added as this is a valid non-sensitive field
-            "promotion_policy",
-            "default_config",
-            "constraints",
-            "budget",
         }
 
         for req in dummy_server.received_data:

--- a/tests/unit/test_safeguards.py
+++ b/tests/unit/test_safeguards.py
@@ -328,14 +328,17 @@ class TestDeduplication:
             "test_func", "other_dataset", {"x": 1.0, "y": 2.0}
         )
 
-    def test_cache_policy_filtering(self):
+    def test_cache_policy_filtering(self, tmp_path):
         """Test that cache policy correctly filters configurations."""
         # Create minimal optimizer
         optimizer = MockOptimizer(config_space={"x": [1, 2, 3]}, objectives=["score"])
 
         evaluator = MockEvaluator()
 
-        config = TraigentConfig(execution_mode="edge_analytics")
+        config = TraigentConfig(
+            execution_mode="edge_analytics",
+            local_storage_path=str(tmp_path),
+        )
         orchestrator = OptimizationOrchestrator(
             optimizer=optimizer,
             evaluator=evaluator,

--- a/traigent/api/config_builder.py
+++ b/traigent/api/config_builder.py
@@ -12,12 +12,7 @@ from typing import Any
 from traigent.api.decorators import get_optimize_default
 from traigent.api.parameter_validator import OptimizeParameters
 from traigent.config.parallel import coerce_parallel_config
-from traigent.config.types import (
-    ExecutionMode,
-    InjectionMode,
-    resolve_execution_mode,
-    validate_execution_mode,
-)
+from traigent.config.types import ExecutionMode, InjectionMode, validate_execution_mode
 from traigent.core.objectives import normalize_objectives
 from traigent.utils.exceptions import ConfigurationError
 
@@ -145,10 +140,11 @@ class ConfigurationBuilder:
 
     @staticmethod
     def _is_privacy_alias(execution_mode: str | ExecutionMode) -> bool:
-        try:
-            return resolve_execution_mode(execution_mode) is ExecutionMode.PRIVACY
-        except (TypeError, ValueError):
-            return False
+        if isinstance(execution_mode, ExecutionMode):
+            return execution_mode is ExecutionMode.PRIVACY
+        if isinstance(execution_mode, str):
+            return execution_mode.strip().lower() == ExecutionMode.PRIVACY.value
+        return False
 
     def _resolve_injection_mode(
         self, injection_mode: InjectionMode, config_param: str | None

--- a/traigent/api/parameter_validator.py
+++ b/traigent/api/parameter_validator.py
@@ -11,12 +11,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import MISSING, dataclass, field, fields
 from typing import Any
 
-from traigent.config.types import (
-    ExecutionMode,
-    InjectionMode,
-    resolve_execution_mode,
-    validate_execution_mode,
-)
+from traigent.config.types import ExecutionMode, InjectionMode, validate_execution_mode
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.utils.exceptions import ValidationError
 
@@ -75,8 +70,8 @@ class ParameterValidator:
             ValidationError: If any parameter is invalid
         """
         # Validate individual parameter groups
+        requested_privacy_alias = self._is_privacy_alias(params.execution_mode)
         execution_mode_enum = self._validate_execution_mode(params.execution_mode)
-        requested_execution_mode = resolve_execution_mode(params.execution_mode)
         self._validate_injection_mode(params.injection_mode)
         self._validate_dataset(params.eval_dataset)
         self._validate_objectives(params.objectives)
@@ -86,14 +81,19 @@ class ParameterValidator:
 
         # Normalize parameters
         params.injection_mode = self._normalize_injection_mode(params.injection_mode)
-        if (
-            requested_execution_mode is ExecutionMode.PRIVACY
-            and params.privacy_enabled is None
-        ):
+        if requested_privacy_alias and params.privacy_enabled is None:
             params.privacy_enabled = True
         params.execution_mode = execution_mode_enum.value
 
         return params
+
+    @staticmethod
+    def _is_privacy_alias(execution_mode: str | ExecutionMode) -> bool:
+        if isinstance(execution_mode, ExecutionMode):
+            return execution_mode is ExecutionMode.PRIVACY
+        if isinstance(execution_mode, str):
+            return execution_mode.strip().lower() == ExecutionMode.PRIVACY.value
+        return False
 
     def _validate_execution_mode(
         self, execution_mode: str | ExecutionMode


### PR DESCRIPTION
Greens `pytest tests/unit` (9 pre-existing failures → **0**) so the develop PR gate (#1214) can pass. Per Rule 9, each failure root-caused as stale-test vs real bug; the **right** side fixed, gate not relaxed.

**Real privacy bug fixed:** `execution_mode="privacy"` (legacy alias for hybrid+privacy) silently did NOT enable privacy — the alias check ran after `resolve_execution_mode` normalized "privacy"→"hybrid". Now detected on the raw alias. (3 tests.)

**Stale-test updates (product honest):** catalog `manual_guidance` vs `executable` now asserted against the real strategy registry; privacy test-double signatures updated for governance kwargs (assertions unchanged — still prove no raw I/O leaks); `tvl_governance` allowlisted — **verified content-free** (`{cvars:[{name,type,governed}]}` from knob declarations); +1 sandbox tmp_path fix.

Captain re-run: **13196 passed, 0 failed**; black+ruff clean; tvl_governance content-free independently verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)