### PR TITLE
fix(sync): re-align edge-analytics sync to backend contract + live contract test (#1211, #868)

### DIFF
--- a/tests/cloud/test_sync_live_contract.py
+++ b/tests/cloud/test_sync_live_contract.py
@@ -1,0 +1,134 @@
+"""Live-backend contract test for edge-analytics sync (#868, gates #1211/#1213).
+
+Boots nothing itself: requires a running TraigentBackend + a scoped API key. It
+builds a finalized cost-bearing local session, syncs it, and asserts the full
+chain landed — agent -> benchmark -> experiment -> experiment-run -> per-trial
+configuration_run with cost INSIDE measures. This is the only test that catches
+sync<->backend contract drift end-to-end; mocked-transport unit tests cannot.
+
+Enable with:
+    TRAIGENT_LIVE_SYNC_E2E=1 \
+    TRAIGENT_BACKEND_URL=http://localtest.me:5001 \
+    TRAIGENT_API_KEY=<scoped key: agents/benchmarks/experiments :write> \
+    pytest tests/cloud/test_sync_live_contract.py -m contract
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import pytest
+import requests
+
+pytestmark = [
+    pytest.mark.contract,
+    pytest.mark.skipif(
+        not os.getenv("TRAIGENT_LIVE_SYNC_E2E"),
+        reason="live backend not configured (set TRAIGENT_LIVE_SYNC_E2E=1 + URL + key)",
+    ),
+]
+
+_BACKEND = os.getenv("TRAIGENT_BACKEND_URL", "http://localtest.me:5001")
+_KEY = os.getenv("TRAIGENT_API_KEY", "")
+
+
+def _api(path: str) -> str:
+    return f"{_BACKEND.rstrip('/')}/api/v1{path}"
+
+
+def test_edge_analytics_sync_lands_cost_in_configuration_run():
+    """A finalized cost session syncs with zero step errors and lands cost>0."""
+    store = tempfile.mkdtemp(prefix="traigent-sync-contract-")
+    os.environ.update(
+        TRAIGENT_BACKEND_URL=_BACKEND,
+        TRAIGENT_API_URL=_BACKEND,
+        TRAIGENT_ALLOW_INSECURE_BACKEND="true",
+        ENVIRONMENT="development",
+        TRAIGENT_RESULTS_FOLDER=store,
+        TRAIGENT_API_KEY=_KEY,
+    )
+    try:
+        from traigent.cloud.sync_manager import SyncManager
+        from traigent.config.types import TraigentConfig
+        from traigent.storage.local_storage import LocalStorageManager
+
+        lsm = LocalStorageManager(storage_path=store)
+        sid = lsm.create_session(
+            "contract_probe",
+            optimization_config={
+                "objectives": ["accuracy"],
+                "search_space": {"model": ["a", "b"]},
+            },
+        )
+        lsm.add_trial_result(
+            sid,
+            config={"model": "a"},
+            score=1.0,
+            cost=0.000123,
+            total_cost=0.000123,
+            metadata={"accuracy": 1.0},
+        )
+        lsm.add_trial_result(
+            sid,
+            config={"model": "b"},
+            score=1.0,
+            cost=0.000456,
+            total_cost=0.000456,
+            metadata={"accuracy": 1.0},
+        )
+        lsm.update_session_status(sid, "completed")
+
+        result = SyncManager(
+            TraigentConfig.from_environment(), _KEY
+        ).sync_session_to_cloud(sid)
+
+        # 1) Zero step errors, all trials converted.
+        assert result.get("status") == "success", result.get("errors")
+        assert result.get("trials_converted") == 2
+        experiment_id = result.get("cloud_experiment_id")
+        assert experiment_id
+
+        # 2) Read the cost back through the API and assert it landed in measures.
+        headers = {"x-api-key": _KEY}
+        runs = requests.get(
+            _api(f"/experiment-runs/{experiment_id}/runs"), headers=headers, timeout=10
+        )
+        assert runs.status_code == 200, runs.text
+        runs_body = runs.json()
+        run_items = (
+            runs_body.get("runs")
+            or (runs_body.get("data") or {}).get("items")
+            or runs_body.get("data")
+            or []
+        )
+        first_run = run_items[0] if run_items else {}
+        run_id = (
+            first_run.get("run_id")
+            or first_run.get("id")
+            or first_run.get("experiment_run_id")
+        )
+        assert run_id, runs.text
+
+        configs = requests.get(
+            _api(f"/configuration-runs/runs/{run_id}/configurations"),
+            headers=headers,
+            timeout=10,
+        )
+        assert configs.status_code == 200, configs.text
+        cfg_items = (
+            (configs.json().get("data") or {}).get("items")
+            or configs.json().get("data")
+            or []
+        )
+        costs = [
+            float((c.get("measures") or {}).get("cost", 0))
+            for c in cfg_items
+            if isinstance(c.get("measures"), dict)
+        ]
+        assert any(cost > 0 for cost in costs), (
+            f"no configuration_run carried cost>0: {cfg_items}"
+        )
+    finally:
+        shutil.rmtree(store, ignore_errors=True)

--- a/tests/cloud/test_sync_manager.py
+++ b/tests/cloud/test_sync_manager.py
@@ -31,6 +31,14 @@ VALID_AGENT_TYPE_IDS = {
 BACKEND_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9 _-]+$")
 
 
+def backend_response(status_code=201, payload=None, text="Created"):
+    response = Mock(status_code=status_code, text=text)
+    response.json.return_value = (
+        payload if payload is not None else {"id": "created-id"}
+    )
+    return response
+
+
 class TestSyncManager:
     """Test suite for SyncManager with comprehensive data conversion and sync tests."""
 
@@ -164,56 +172,65 @@ class TestSyncManager:
 
         # Check structure
         assert "agent" in traigent_data
-        assert "dataset" in traigent_data
         assert "benchmark" in traigent_data
-        assert "model_parameters" in traigent_data
         assert "experiment" in traigent_data
         assert "experiment_run" in traigent_data
+        assert "configuration_runs" in traigent_data
+        assert "model_parameters" not in traigent_data
 
         # Check agent data
         agent = traigent_data["agent"]
-        assert agent["name"] == "Local Agent: test_llm_function"
-        assert "agent_type" not in agent
-        assert agent["agent_type_id"] in VALID_AGENT_TYPE_IDS
-        assert agent["source"] == "local_import"
+        assert agent == {
+            "name": "Local Agent: test_llm_function",
+            "agent_type_id": "completion",
+        }
 
-        # Check dataset data
-        dataset = traigent_data["dataset"]
-        assert dataset["name"] == "Local Dataset test_llm_function"
-        assert BACKEND_NAME_PATTERN.fullmatch(dataset["name"])
-        assert dataset["dataset_id"] == dataset["id"]
-        assert dataset["benchmark_id"] == dataset["id"]
-        assert dataset["type"] == "custom"
-        assert dataset["examples_count"] == 4
-
-        # Legacy alias remains available for older callers
+        # Check benchmark data
         benchmark = traigent_data["benchmark"]
-        assert benchmark == dataset
+        assert benchmark["name"] == "Local Dataset test_llm_function"
+        assert BACKEND_NAME_PATTERN.fullmatch(benchmark["name"])
+        assert benchmark["type"] == "input-output"
+        assert benchmark["label"]
 
-        # Check experiment data
+        # Check experiment template data; returned backend IDs are filled at sync time.
         experiment = traigent_data["experiment"]
         assert experiment["name"] == "Local Import: test_llm_function"
-        assert experiment["agent_id"] == agent["id"]
-        assert experiment["dataset_id"] == dataset["id"]
-        assert experiment["benchmark_id"] == dataset["id"]
-        assert experiment["evaluation_set_id"] == dataset["id"]
-        assert experiment["eval_dataset_id"] == dataset["id"]
-        assert experiment["status"] == "completed"
-        assert "original_session_id" in experiment["metadata"]
+        assert experiment["status"] == "COMPLETED"
+        assert experiment["measures"]
+        assert "agent_id" not in experiment
+        assert "dataset_id" not in experiment
+        assert "model_parameters_id" not in experiment
 
-        # Check experiment run data
-        experiment_run = traigent_data["experiment_run"]
-        assert experiment_run["experiment_id"] == experiment["id"]
-        assert experiment_run["status"] == "completed"
-        assert len(experiment_run["results"]) == 4
-        assert experiment_run["metadata"]["total_trials"] == 4
-        assert experiment_run["metadata"]["best_score"] == 0.85
+        experiment_payload = self.sync_manager._build_experiment_payload(
+            experiment, "agent-123", "benchmark-456"
+        )
+        assert experiment_payload["agent_id"] == "agent-123"
+        assert experiment_payload["dataset_id"] == "benchmark-456"
+
+        # Check experiment run and configuration-run payloads
+        experiment_run = self.sync_manager._build_experiment_run_payload(
+            traigent_data["experiment_run"], "agent-123", "benchmark-456"
+        )
+        assert set(experiment_run) == {"experiment_data"}
+        assert experiment_run["experiment_data"] == {
+            "agent_id": "agent-123",
+            "benchmark_id": "benchmark-456",
+            "measures": traigent_data["experiment_run"]["measures"],
+            "configurations": traigent_data["experiment_run"]["configurations"],
+        }
+        assert len(traigent_data["configuration_runs"]) == 4
+        assert {
+            "experiment_parameters",
+            "measures",
+            "status",
+        } == set(traigent_data["configuration_runs"][0])
+        assert traigent_data["configuration_runs"][0]["status"] == "COMPLETED"
 
     @pytest.mark.parametrize(
         "method_name,resource_path,payload_key",
         [
             ("_sync_agent", "agents", "agent_id"),
-            ("_sync_benchmark", "datasets", "dataset_id"),
+            ("_sync_benchmark", "benchmarks", "benchmark_id"),
             ("_sync_experiment", "experiments", "experiment_id"),
             ("_sync_experiment_run", "experiment-runs", "run_id"),
         ],
@@ -221,20 +238,31 @@ class TestSyncManager:
     def test_sync_operations_use_timeout(self, method_name, resource_path, payload_key):
         """Ensure blocking HTTP calls include an explicit timeout."""
         sync_manager = self.sync_manager
-        payload = {"id": "resource-123"}
+        payload = {"name": "resource"}
         if method_name == "_sync_experiment_run":
-            payload["experiment_id"] = "experiment-123"
-        mock_response = Mock(status_code=201, text="created")
+            payload = {
+                "experiment_data": {
+                    "agent_id": "agent-123",
+                    "benchmark_id": "benchmark-123",
+                    "measures": ["score"],
+                    "configurations": {},
+                }
+            }
+        mock_response = backend_response(payload={"id": "resource-123"}, text="created")
         original_post = sync_manager._session.post
+        original_get = sync_manager._session.get
 
         try:
             sync_manager._session.post = Mock(return_value=mock_response)
+            sync_manager._session.get = Mock(return_value=backend_response(404))
             method = getattr(sync_manager, method_name)
-            result = method(payload)
+            if method_name == "_sync_experiment_run":
+                result = method("experiment-123", payload)
+            else:
+                result = method(payload)
 
             expected_url = (
-                f"{sync_manager.base_url}/experiment-runs/"
-                f"{payload['experiment_id']}/runs"
+                f"{sync_manager.base_url}/experiment-runs/experiment-123/runs"
                 if method_name == "_sync_experiment_run"
                 else f"{sync_manager.base_url}/{resource_path}"
             )
@@ -247,33 +275,30 @@ class TestSyncManager:
             assert payload_key in result
         finally:
             sync_manager._session.post = original_post
+            sync_manager._session.get = original_get
 
-    def test_sync_benchmark_falls_back_to_legacy_route(self):
-        """Test dataset sync falls back to legacy benchmark route on 404."""
+    def test_sync_benchmark_posts_to_canonical_route(self):
+        """Benchmark sync uses the canonical current backend route."""
         sync_manager = self.sync_manager
-        payload = {"id": "dataset-123", "dataset_id": "dataset-123"}
-        responses = [
-            Mock(status_code=404, text="not found"),
-            Mock(status_code=201, text="created"),
-        ]
+        payload = {"name": "Dataset 123", "type": "input-output", "label": "eval"}
         original_post = sync_manager._session.post
         original_get = sync_manager._session.get
 
         try:
-            sync_manager._session.post = Mock(side_effect=responses)
-            sync_manager._session.get = Mock(
-                return_value=Mock(status_code=404, text="missing")
+            sync_manager._session.post = Mock(
+                return_value=backend_response(payload={"id": "benchmark-123"})
             )
+            sync_manager._session.get = Mock(return_value=backend_response(404))
             result = sync_manager._sync_benchmark(payload)
 
             assert result["success"] is True
-            assert result["dataset_id"] == "dataset-123"
-            assert result["benchmark_id"] == "dataset-123"
-            assert sync_manager._session.post.call_count == 2
-            first_call = sync_manager._session.post.call_args_list[0]
-            second_call = sync_manager._session.post.call_args_list[1]
-            assert first_call.args[0] == f"{sync_manager.base_url}/datasets"
-            assert second_call.args[0] == f"{sync_manager.base_url}/benchmarks"
+            assert result["dataset_id"] == "benchmark-123"
+            assert result["benchmark_id"] == "benchmark-123"
+            sync_manager._session.post.assert_called_once_with(
+                f"{sync_manager.base_url}/benchmarks",
+                json=payload,
+                timeout=sync_manager._request_timeout,
+            )
         finally:
             sync_manager._session.post = original_post
             sync_manager._session.get = original_get
@@ -304,15 +329,37 @@ class TestSyncManager:
         agent = traigent_data["agent"]
         assert "agent_type" not in agent
         assert agent["agent_type_id"] in VALID_AGENT_TYPE_IDS
+        assert set(agent) == {"name", "agent_type_id"}
+
+        benchmark = traigent_data["benchmark"]
+        assert benchmark["type"] == "input-output"
+        assert benchmark["label"]
+
+        experiment_run = self.sync_manager._build_experiment_run_payload(
+            traigent_data["experiment_run"], "agent-id", "benchmark-id"
+        )
+        assert set(experiment_run["experiment_data"]) == {
+            "agent_id",
+            "benchmark_id",
+            "measures",
+            "configurations",
+        }
 
     def test_sync_experiment_run_posts_to_nested_backend_route(self):
         """Experiment run creation uses the route exposed by the backend."""
-        run_data = {"id": "test_run", "experiment_id": "test_experiment"}
+        run_data = {
+            "experiment_data": {
+                "agent_id": "agent-123",
+                "benchmark_id": "benchmark-123",
+                "measures": ["score"],
+                "configurations": {},
+            }
+        }
         with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock(status_code=201, text="created")
+            mock_response = backend_response(payload={"id": "run-123"})
             mock_post.return_value = mock_response
 
-            result = self.sync_manager._sync_experiment_run(run_data)
+            result = self.sync_manager._sync_experiment_run("test_experiment", run_data)
 
             assert result["success"] is True
             mock_post.assert_called_once_with(
@@ -392,10 +439,17 @@ class TestSyncManager:
         """Test successful session sync to cloud."""
         # Mock successful API responses
         self.test_session = self._create_test_session()
-        mock_response = Mock()
-        mock_response.status_code = 201
-        mock_response.text = "Created"
-        mock_post.return_value = mock_response
+        self.sync_manager._session.get = Mock(return_value=backend_response(404))
+        mock_post.side_effect = [
+            backend_response(payload={"id": "agent-id"}),
+            backend_response(payload={"id": "benchmark-id"}),
+            backend_response(payload={"id": "experiment-id"}),
+            backend_response(payload={"id": "experiment-run-id"}),
+            *[
+                backend_response(payload={"id": f"configuration-run-{index}"})
+                for index in range(4)
+            ],
+        ]
 
         result = self.sync_manager.sync_session_to_cloud(
             self.test_session.session_id, dry_run=False
@@ -405,8 +459,8 @@ class TestSyncManager:
         assert len(result["errors"]) == 0
         assert "cloud_url" in result
 
-        # Should have made 4 API calls (agent, benchmark, experiment, experiment_run)
-        assert mock_post.call_count == 4
+        # agent, benchmark, experiment, experiment_run, and one config row per trial.
+        assert mock_post.call_count == 8
 
     def test_sync_session_to_cloud_contract_payloads_with_cost(self):
         """A full mocked sync emits corrected URLs and a cost-bearing run body."""
@@ -419,55 +473,88 @@ class TestSyncManager:
             metadata={"total_cost": 0.42, "input_cost": 0.2, "output_cost": 0.22},
         )
         storage.finalize_session(session_id, "completed")
-        mock_response = Mock(status_code=201, text="Created")
         original_post = self.sync_manager._session.post
+        original_get = self.sync_manager._session.get
 
         try:
-            self.sync_manager._session.post = Mock(return_value=mock_response)
+            self.sync_manager._session.get = Mock(return_value=backend_response(404))
+            self.sync_manager._session.post = Mock(
+                side_effect=[
+                    backend_response(payload={"id": "agent-id"}),
+                    backend_response(payload={"id": "benchmark-id"}),
+                    backend_response(payload={"id": "experiment-id"}),
+                    backend_response(payload={"id": "experiment-run-id"}),
+                    backend_response(payload={"id": "configuration-run-id"}),
+                ]
+            )
             result = self.sync_manager.sync_session_to_cloud(session_id, dry_run=False)
         finally:
             post_mock = self.sync_manager._session.post
             self.sync_manager._session.post = original_post
+            self.sync_manager._session.get = original_get
 
         assert result["status"] == "success"
-        assert post_mock.call_count == 4
+        assert post_mock.call_count == 5
 
         calls = post_mock.call_args_list
-        experiment_id = f"local_import_{session_id}"
         assert [call.args[0] for call in calls] == [
             f"{self.sync_manager.base_url}/agents",
-            f"{self.sync_manager.base_url}/datasets",
+            f"{self.sync_manager.base_url}/benchmarks",
             f"{self.sync_manager.base_url}/experiments",
-            f"{self.sync_manager.base_url}/experiment-runs/{experiment_id}/runs",
+            f"{self.sync_manager.base_url}/experiment-runs/experiment-id/runs",
+            f"{self.sync_manager.base_url}/configuration-runs/runs/"
+            "experiment-run-id/configurations",
         ]
 
         agent_payload = calls[0].kwargs["json"]
-        assert agent_payload["agent_type_id"] in VALID_AGENT_TYPE_IDS
-        assert "agent_type" not in agent_payload
+        assert agent_payload == {
+            "name": "Local Agent: contract:sync/fn",
+            "agent_type_id": "completion",
+        }
 
         benchmark_payload = calls[1].kwargs["json"]
         assert BACKEND_NAME_PATTERN.fullmatch(benchmark_payload["name"])
+        assert benchmark_payload["type"] == "input-output"
+        assert benchmark_payload["label"]
 
         experiment_payload = calls[2].kwargs["json"]
-        assert experiment_payload["agent_id"] == agent_payload["id"]
+        assert experiment_payload["agent_id"] == "agent-id"
+        assert experiment_payload["dataset_id"] == "benchmark-id"
+        assert experiment_payload["status"] == "COMPLETED"
+        assert experiment_payload["measures"]
+        assert "model_parameters_id" not in experiment_payload
 
         run_payload = calls[3].kwargs["json"]
-        result_payload = run_payload["results"][0]
-        assert result_payload["measures"]["cost"] == 0.42
-        assert result_payload["measures"]["total_cost"] == 0.42
-        assert result_payload["measures"]["cost"] > 0
+        assert set(run_payload) == {"experiment_data"}
+        assert run_payload["experiment_data"] == {
+            "agent_id": "agent-id",
+            "benchmark_id": "benchmark-id",
+            "measures": experiment_payload["measures"],
+            "configurations": experiment_payload["configurations"],
+        }
+
+        configuration_payload = calls[4].kwargs["json"]
+        assert configuration_payload["experiment_parameters"] == {
+            "model": "gpt-test",
+            "temperature": 0.2,
+        }
+        assert configuration_payload["status"] == "COMPLETED"
+        assert isinstance(configuration_payload["measures"]["cost"], float)
+        assert configuration_payload["measures"]["cost"] == 0.42
+        assert configuration_payload["measures"]["total_cost"] == 0.42
+        assert configuration_payload["measures"]["input_cost"] == 0.2
+        assert configuration_payload["measures"]["output_cost"] == 0.22
 
     @patch("requests.Session.post")
     def test_sync_session_to_cloud_partial_failure(self, mock_post):
         """Test session sync with partial failures."""
         # Mock mixed success/failure responses
         responses = [
-            Mock(status_code=201, text="Created"),  # Agent success
-            Mock(status_code=400, text="Bad Request"),  # Benchmark failure
-            Mock(status_code=201, text="Created"),  # Experiment success
-            Mock(status_code=201, text="Created"),  # Run success
+            backend_response(payload={"id": "agent-id"}),  # Agent success
+            backend_response(status_code=400, text="Bad Request"),  # Benchmark failure
         ]
         self.test_session = self._create_test_session()
+        self.sync_manager._session.get = Mock(return_value=backend_response(404))
         mock_post.side_effect = responses
 
         result = self.sync_manager.sync_session_to_cloud(
@@ -482,6 +569,7 @@ class TestSyncManager:
     def test_sync_session_to_cloud_complete_failure(self, mock_post):
         """Test session sync with complete failure."""
         self.test_session = self._create_test_session()
+        self.sync_manager._session.get = Mock(return_value=backend_response(404))
         mock_post.side_effect = Exception("Network error")
 
         result = self.sync_manager.sync_session_to_cloud(
@@ -509,9 +597,8 @@ class TestSyncManager:
         # Create test session for this test
         self.test_session = self._create_test_session()
         # Mock successful API responses
-        mock_response = Mock()
-        mock_response.status_code = 201
-        mock_post.return_value = mock_response
+        self.sync_manager._session.get = Mock(return_value=backend_response(404))
+        mock_post.return_value = backend_response()
 
         result = self.sync_manager.sync_all_sessions(dry_run=False)
 
@@ -533,15 +620,12 @@ class TestSyncManager:
         failed_session_id = storage.create_session("failed_function")
         storage.finalize_session(failed_session_id, "completed")
 
-        # Mock responses - first session succeeds, second fails
-        success_response = Mock(status_code=201, text="Created")
-        failure_response = Mock(status_code=400, text="Bad Request")
+        self.sync_manager._session.get = Mock(return_value=backend_response(404))
+        success_response = backend_response()
+        failure_response = backend_response(status_code=400, text="Bad Request")
 
         mock_post.side_effect = [
-            success_response,
-            success_response,
-            success_response,
-            success_response,  # First session
+            *[success_response for _ in range(8)],  # First session
             failure_response,  # Second session fails on first call
         ]
 
@@ -555,12 +639,14 @@ class TestSyncManager:
 
     def test_sync_agent_success(self):
         """Test successful agent sync."""
-        agent_data = {"id": "test_agent", "name": "Test Agent"}
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
 
-        with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock()
-            mock_response.status_code = 201
-            mock_post.return_value = mock_response
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(404)
+            mock_post.return_value = backend_response(payload={"id": "test_agent"})
 
             result = self.sync_manager._sync_agent(agent_data)
 
@@ -576,27 +662,39 @@ class TestSyncManager:
             )
 
     def test_sync_agent_already_exists(self):
-        """Test agent sync when agent already exists (409 conflict)."""
-        agent_data = {"id": "existing_agent", "name": "Existing Agent"}
+        """Test agent sync reuses an existing matching agent."""
+        agent_data = {"name": "Existing Agent", "agent_type_id": "completion"}
 
-        with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock()
-            mock_response.status_code = 409  # Conflict
-            mock_post.return_value = mock_response
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(
+                200,
+                payload={
+                    "agents": [{"id": "existing_agent", "name": "Existing Agent"}]
+                },
+            )
 
             result = self.sync_manager._sync_agent(agent_data)
 
-            assert result["success"] is True  # 409 is treated as success
+            assert result["success"] is True
+            assert result["agent_id"] == "existing_agent"
+            assert result["reused"] is True
+            mock_post.assert_not_called()
 
     def test_sync_agent_failure(self):
         """Test agent sync failure."""
-        agent_data = {"id": "test_agent", "name": "Test Agent"}
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
 
-        with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock()
-            mock_response.status_code = 400
-            mock_response.text = "Validation error"
-            mock_post.return_value = mock_response
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(404)
+            mock_post.return_value = backend_response(
+                status_code=400, text="Validation error"
+            )
 
             result = self.sync_manager._sync_agent(agent_data)
 
@@ -605,9 +703,13 @@ class TestSyncManager:
 
     def test_sync_agent_exception(self):
         """Test agent sync with network exception."""
-        agent_data = {"id": "test_agent", "name": "Test Agent"}
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
 
-        with patch.object(self.sync_manager.session, "post") as mock_post:
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(404)
             mock_post.side_effect = requests.ConnectionError("Network error")
 
             result = self.sync_manager._sync_agent(agent_data)
@@ -617,46 +719,70 @@ class TestSyncManager:
 
     def test_sync_benchmark_operations(self):
         """Test benchmark sync operations."""
-        benchmark_data = {"id": "test_benchmark", "name": "Test Benchmark"}
+        benchmark_data = {
+            "name": "Test Benchmark",
+            "type": "input-output",
+            "label": "eval",
+        }
 
         # Test success
-        with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock(status_code=201)
-            mock_post.return_value = mock_response
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(404)
+            mock_post.return_value = backend_response(payload={"id": "test_benchmark"})
 
             result = self.sync_manager._sync_benchmark(benchmark_data)
             assert result["success"] is True
 
         # Test failure
-        with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock(status_code=500, text="Server error")
-            mock_post.return_value = mock_response
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(404)
+            mock_post.return_value = backend_response(
+                status_code=400, text="Bad request"
+            )
 
             result = self.sync_manager._sync_benchmark(benchmark_data)
             assert result["success"] is False
 
     def test_sync_experiment_operations(self):
         """Test experiment sync operations."""
-        experiment_data = {"id": "test_experiment", "name": "Test Experiment"}
+        experiment_data = {
+            "name": "Test Experiment",
+            "agent_id": "agent-123",
+            "dataset_id": "benchmark-123",
+            "measures": ["score"],
+            "configurations": {},
+            "status": "COMPLETED",
+        }
 
         # Test success
         with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock(status_code=201)
-            mock_post.return_value = mock_response
+            mock_post.return_value = backend_response(payload={"id": "test_experiment"})
 
             result = self.sync_manager._sync_experiment(experiment_data)
             assert result["success"] is True
 
     def test_sync_experiment_run_operations(self):
         """Test experiment run sync operations."""
-        run_data = {"id": "test_run", "experiment_id": "test_experiment"}
+        run_data = {
+            "experiment_data": {
+                "agent_id": "agent-123",
+                "benchmark_id": "benchmark-123",
+                "measures": ["score"],
+                "configurations": {},
+            }
+        }
 
         # Test success
         with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock(status_code=200)
-            mock_post.return_value = mock_response
+            mock_post.return_value = backend_response(payload={"id": "test_run"})
 
-            result = self.sync_manager._sync_experiment_run(run_data)
+            result = self.sync_manager._sync_experiment_run("test_experiment", run_data)
             assert result["success"] is True
 
     def test_get_cloud_analytics_preview_empty(self):
@@ -746,8 +872,8 @@ class TestSyncManager:
         )
 
         # Should handle empty trials gracefully
-        assert len(traigent_data["experiment_run"]["results"]) == 0
-        assert traigent_data["experiment_run"]["metadata"]["total_trials"] == 0
+        assert len(traigent_data["configuration_runs"]) == 0
+        assert traigent_data["experiment_run"]["measures"] == ["score"]
 
     def test_edge_case_large_session(self):
         """Test handling of session with many trials."""
@@ -768,8 +894,7 @@ class TestSyncManager:
         )
 
         # Should handle large number of trials
-        assert len(traigent_data["experiment_run"]["results"]) == 100
-        assert traigent_data["experiment_run"]["metadata"]["total_trials"] == 100
+        assert len(traigent_data["configuration_runs"]) == 100
 
     def test_edge_case_special_characters(self):
         """Test handling of special characters in session data."""
@@ -793,7 +918,7 @@ class TestSyncManager:
         # Should handle special characters without issues
         assert "测试" in traigent_data["agent"]["name"]
         assert (
-            traigent_data["experiment_run"]["results"][0]["experiment_parameters"][
+            traigent_data["configuration_runs"][0]["experiment_parameters"][
                 "unicode_param"
             ]
             == "测试"
@@ -808,13 +933,20 @@ class TestSyncManager:
         assert "X-API-Key" in headers or "Authorization" in headers
 
         # Test that session is reused for multiple requests
-        with patch.object(self.sync_manager.session, "post") as mock_post:
-            mock_response = Mock(status_code=201)
-            mock_post.return_value = mock_response
+        with (
+            patch.object(self.sync_manager.session, "get") as mock_get,
+            patch.object(self.sync_manager.session, "post") as mock_post,
+        ):
+            mock_get.return_value = backend_response(404)
+            mock_post.return_value = backend_response()
 
             # Make multiple sync calls
-            self.sync_manager._sync_agent({"id": "agent1"})
-            self.sync_manager._sync_benchmark({"id": "benchmark1"})
+            self.sync_manager._sync_agent(
+                {"name": "agent1", "agent_type_id": "completion"}
+            )
+            self.sync_manager._sync_benchmark(
+                {"name": "benchmark1", "type": "input-output", "label": "eval"}
+            )
 
             # Should use same session instance
             assert mock_post.call_count == 2

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -20,6 +20,14 @@ from traigent.storage.local_storage import OptimizationSession, TrialResult
 from traigent.utils.exceptions import TraigentStorageError
 
 
+def backend_response(status_code=201, payload=None, text="Created"):
+    response = Mock(status_code=status_code, text=text)
+    response.json.return_value = (
+        payload if payload is not None else {"id": "created-id"}
+    )
+    return response
+
+
 class TestSyncManager:
     """Tests for SyncManager class."""
 
@@ -339,35 +347,48 @@ class TestSyncManager:
         # Check structure
         assert "agent" in result
         assert "benchmark" in result
-        assert "model_parameters" in result
         assert "experiment" in result
         assert "experiment_run" in result
+        assert "configuration_runs" in result
+        assert "model_parameters" not in result
 
         # Check agent data
-        assert result["agent"]["name"] == "Local Agent: test_function"
-        assert "agent_type" not in result["agent"]
-        assert result["agent"]["agent_type_id"] == DEFAULT_SYNC_AGENT_TYPE_ID
-        assert result["agent"]["source"] == "local_import"
+        assert result["agent"] == {
+            "name": "Local Agent: test_function",
+            "agent_type_id": DEFAULT_SYNC_AGENT_TYPE_ID,
+        }
 
-        # Check dataset/benchmark compatibility payload
+        # Check benchmark payload
         assert result["benchmark"]["name"] == "Local Dataset test_function"
-        assert result["benchmark"]["examples_count"] == 3
-        assert result["benchmark"]["type"] == "custom"
+        assert result["benchmark"]["type"] == "input-output"
+        assert result["benchmark"]["label"]
 
-        # Check experiment data
+        # Check experiment template
         assert result["experiment"]["name"] == "Local Import: test_function"
-        assert result["experiment"]["status"] == "completed"
-        assert result["experiment"]["source"] == "local_import"
-        assert (
-            result["experiment"]["metadata"]["original_session_id"]
-            == "test_session_123"
-        )
+        assert result["experiment"]["status"] == "COMPLETED"
+        assert result["experiment"]["measures"]
+        assert "agent_id" not in result["experiment"]
+        assert "dataset_id" not in result["experiment"]
+        assert "model_parameters_id" not in result["experiment"]
 
-        # Check experiment run
-        assert result["experiment_run"]["status"] == "completed"
-        assert len(result["experiment_run"]["results"]) == 3
-        assert result["experiment_run"]["metadata"]["total_trials"] == 3
-        assert result["experiment_run"]["metadata"]["best_score"] == 0.92
+        experiment_payload = sync_manager._build_experiment_payload(
+            result["experiment"], "agent-id", "benchmark-id"
+        )
+        assert experiment_payload["agent_id"] == "agent-id"
+        assert experiment_payload["dataset_id"] == "benchmark-id"
+
+        experiment_run_payload = sync_manager._build_experiment_run_payload(
+            result["experiment_run"], "agent-id", "benchmark-id"
+        )
+        assert set(experiment_run_payload) == {"experiment_data"}
+        assert set(experiment_run_payload["experiment_data"]) == {
+            "agent_id",
+            "benchmark_id",
+            "measures",
+            "configurations",
+        }
+        assert len(result["configuration_runs"]) == 3
+        assert result["configuration_runs"][0]["status"] == "COMPLETED"
 
     def test_convert_session_to_traigent_format_minimal_data(
         self, sync_manager: SyncManager
@@ -387,8 +408,88 @@ class TestSyncManager:
         result = sync_manager.convert_session_to_traigent_format(minimal_session)
 
         assert result["agent"]["name"] == "Local Agent: minimal_func"
-        assert len(result["experiment_run"]["results"]) == 0
-        assert result["experiment_run"]["metadata"]["total_trials"] == 0
+        assert len(result["configuration_runs"]) == 0
+        assert result["experiment_run"]["measures"] == ["score"]
+
+    def test_payload_builder_matches_current_backend_contract_with_cost(
+        self, sync_manager: SyncManager
+    ) -> None:
+        """Build current-contract payloads without legacy fields."""
+        session = OptimizationSession(
+            session_id="cost_session",
+            function_name="cost/fn?demo",
+            created_at="2026-06-09T10:00:00Z",
+            updated_at="2026-06-09T10:01:00Z",
+            status="completed",
+            total_trials=2,
+            completed_trials=2,
+            trials=[
+                TrialResult(
+                    trial_id=1,
+                    config={"temperature": 0.1},
+                    score=0.9,
+                    timestamp="2026-06-09T10:00:00Z",
+                    metadata={"total_cost": 0.11, "latency_ms": 120},
+                ),
+                TrialResult(
+                    trial_id=2,
+                    config={"temperature": 0.2},
+                    score=0.91,
+                    timestamp="2026-06-09T10:01:00Z",
+                    cost=0.12,
+                    total_cost=0.12,
+                    input_cost=0.05,
+                    output_cost=0.07,
+                ),
+            ],
+            optimization_config={"search_space": {"temperature": [0.1, 0.2]}},
+        )
+
+        result = sync_manager.convert_session_to_traigent_format(session)
+
+        assert result["agent"] == {
+            "name": "Local Agent: cost/fn?demo",
+            "agent_type_id": "completion",
+        }
+        assert result["benchmark"]["name"] == "Local Dataset cost fn demo"
+        assert result["benchmark"]["type"] == "input-output"
+        assert result["benchmark"]["label"]
+
+        experiment_payload = sync_manager._build_experiment_payload(
+            result["experiment"], "agent-id", "benchmark-id"
+        )
+        assert set(experiment_payload) == {
+            "name",
+            "agent_id",
+            "dataset_id",
+            "measures",
+            "configurations",
+            "status",
+        }
+        assert experiment_payload["agent_id"] == "agent-id"
+        assert experiment_payload["dataset_id"] == "benchmark-id"
+        assert experiment_payload["measures"]
+        assert experiment_payload["status"] == "COMPLETED"
+
+        experiment_run_payload = sync_manager._build_experiment_run_payload(
+            result["experiment_run"], "agent-id", "benchmark-id"
+        )
+        assert experiment_run_payload["experiment_data"] == {
+            "agent_id": "agent-id",
+            "benchmark_id": "benchmark-id",
+            "measures": result["experiment_run"]["measures"],
+            "configurations": result["experiment_run"]["configurations"],
+        }
+
+        for configuration_payload in result["configuration_runs"]:
+            assert set(configuration_payload) == {
+                "experiment_parameters",
+                "measures",
+                "status",
+            }
+            assert configuration_payload["status"] == "COMPLETED"
+            assert isinstance(configuration_payload["measures"]["cost"], (int, float))
+            assert not isinstance(configuration_payload["measures"]["cost"], bool)
 
     # Trial Conversion Tests
 
@@ -469,11 +570,8 @@ class TestSyncManager:
         sync_manager.storage.load_session.return_value = sample_session
 
         # Mock successful responses
-        mock_response = Mock()
-        mock_response.status_code = 201
-        mock_response.text = "OK"
-
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.return_value = backend_response()
 
         result = sync_manager.sync_session_to_cloud("test_session_123")
 
@@ -483,21 +581,153 @@ class TestSyncManager:
         assert "cloud_url" in result
         assert len(result["errors"]) == 0
 
+    def test_sync_session_to_cloud_posts_current_sequence_and_threads_ids(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """Full mocked flow posts current endpoints and returned IDs."""
+        sync_manager.storage.load_session.return_value = sample_session
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.side_effect = [
+            backend_response(payload={"id": "agent-id"}),
+            backend_response(payload={"id": "benchmark-id"}),
+            backend_response(payload={"id": "experiment-id"}),
+            backend_response(payload={"id": "experiment-run-id"}),
+            backend_response(payload={"id": "configuration-run-1"}),
+            backend_response(payload={"id": "configuration-run-2"}),
+            backend_response(payload={"id": "configuration-run-3"}),
+        ]
+
+        result = sync_manager.sync_session_to_cloud("test_session_123")
+
+        assert result["status"] == "success"
+        assert result["cloud_experiment_id"] == "experiment-id"
+        post_calls = sync_manager._session.post.call_args_list
+        assert [call.args[0] for call in post_calls] == [
+            f"{sync_manager.base_url}/agents",
+            f"{sync_manager.base_url}/benchmarks",
+            f"{sync_manager.base_url}/experiments",
+            f"{sync_manager.base_url}/experiment-runs/experiment-id/runs",
+            f"{sync_manager.base_url}/configuration-runs/runs/"
+            "experiment-run-id/configurations",
+            f"{sync_manager.base_url}/configuration-runs/runs/"
+            "experiment-run-id/configurations",
+            f"{sync_manager.base_url}/configuration-runs/runs/"
+            "experiment-run-id/configurations",
+        ]
+
+        experiment_payload = post_calls[2].kwargs["json"]
+        assert experiment_payload["agent_id"] == "agent-id"
+        assert experiment_payload["dataset_id"] == "benchmark-id"
+        assert experiment_payload["measures"]
+        assert experiment_payload["status"] == "COMPLETED"
+
+        experiment_run_payload = post_calls[3].kwargs["json"]
+        assert set(experiment_run_payload) == {"experiment_data"}
+        assert experiment_run_payload["experiment_data"] == {
+            "agent_id": "agent-id",
+            "benchmark_id": "benchmark-id",
+            "measures": experiment_payload["measures"],
+            "configurations": experiment_payload["configurations"],
+        }
+
+    def test_sync_session_to_cloud_reuses_agent_and_benchmark_for_idempotency(
+        self, sync_manager: SyncManager
+    ) -> None:
+        """Quota and duplicate-name failures fall back to existing resources."""
+        session = OptimizationSession(
+            session_id="idem-session",
+            function_name="idem_fn",
+            created_at="2026-06-09T10:00:00Z",
+            updated_at="2026-06-09T10:00:00Z",
+            status="completed",
+            total_trials=1,
+            completed_trials=1,
+            trials=[
+                TrialResult(
+                    trial_id=1,
+                    config={"model": "gpt-test"},
+                    score=1.0,
+                    timestamp="2026-06-09T10:00:00Z",
+                    metadata={"total_cost": 0.001},
+                )
+            ],
+            optimization_config={"search_space": {"model": ["gpt-test"]}},
+        )
+        sync_manager.storage.load_session.return_value = session
+        sync_manager._session.get.side_effect = [
+            backend_response(404),
+            backend_response(
+                200,
+                payload={
+                    "agents": [
+                        {"id": "existing-agent-id", "name": "Local Agent: idem_fn"}
+                    ]
+                },
+            ),
+            backend_response(404),
+            backend_response(
+                200,
+                payload={
+                    "benchmarks": [
+                        {
+                            "id": "existing-benchmark-id",
+                            "name": "Local Dataset idem_fn",
+                        }
+                    ]
+                },
+            ),
+        ]
+        sync_manager._session.post.side_effect = [
+            backend_response(status_code=429, text="quota exceeded"),
+            backend_response(status_code=500, text="duplicate benchmark"),
+            backend_response(payload={"id": "experiment-id"}),
+            backend_response(payload={"id": "experiment-run-id"}),
+            backend_response(payload={"id": "configuration-run-id"}),
+        ]
+
+        result = sync_manager.sync_session_to_cloud("idem-session")
+
+        assert result["status"] == "success"
+        post_calls = sync_manager._session.post.call_args_list
+        assert post_calls[0].args[0] == f"{sync_manager.base_url}/agents"
+        assert post_calls[1].args[0] == f"{sync_manager.base_url}/benchmarks"
+        experiment_payload = post_calls[2].kwargs["json"]
+        assert experiment_payload["agent_id"] == "existing-agent-id"
+        assert experiment_payload["dataset_id"] == "existing-benchmark-id"
+
+    def test_sync_session_to_cloud_configuration_failure_is_partial(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """A failed configuration-row POST prevents success status."""
+        sync_manager.storage.load_session.return_value = sample_session
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.side_effect = [
+            backend_response(payload={"id": "agent-id"}),
+            backend_response(payload={"id": "benchmark-id"}),
+            backend_response(payload={"id": "experiment-id"}),
+            backend_response(payload={"id": "experiment-run-id"}),
+            backend_response(payload={"id": "configuration-run-1"}),
+            backend_response(status_code=500, text="config failed"),
+            backend_response(payload={"id": "configuration-run-3"}),
+        ]
+
+        result = sync_manager.sync_session_to_cloud("test_session_123")
+
+        assert result["status"] == "partial"
+        assert any("Configuration run sync failed" in err for err in result["errors"])
+
     def test_sync_session_to_cloud_partial_success(
         self, sync_manager: SyncManager, sample_session: OptimizationSession
     ) -> None:
         """Test partial success when some steps fail."""
         sync_manager.storage.load_session.return_value = sample_session
+        sync_manager._session.get.return_value = backend_response(404)
 
         # Mock mixed responses (some succeed, some fail)
         def mock_post(url: str, *args, **kwargs):
-            response = Mock()
             if "agents" in url or "benchmarks" in url:
-                response.status_code = 201
-            else:
-                response.status_code = 500
-                response.text = "Internal Server Error"
-            return response
+                return backend_response()
+            return backend_response(status_code=500, text="Internal Server Error")
 
         sync_manager._session.post.side_effect = mock_post
 
@@ -511,23 +741,23 @@ class TestSyncManager:
     ) -> None:
         """Test sync when all steps fail."""
         sync_manager.storage.load_session.return_value = sample_session
-
-        mock_response = Mock()
-        mock_response.status_code = 500
-        mock_response.text = "Internal Server Error"
-
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.return_value = backend_response(
+            status_code=500, text="Internal Server Error"
+        )
 
         result = sync_manager.sync_session_to_cloud("test_session_123")
 
         assert result["status"] == "error"
-        assert len(result["errors"]) == 4  # All 4 steps failed
+        assert len(result["errors"]) == 1
+        assert "Agent sync failed" in result["errors"][0]
 
     def test_sync_session_to_cloud_exception(
         self, sync_manager: SyncManager, sample_session: OptimizationSession
     ) -> None:
         """Test sync handles exceptions gracefully."""
         sync_manager.storage.load_session.return_value = sample_session
+        sync_manager._session.get.return_value = backend_response(404)
         sync_manager._session.post.side_effect = Exception("Network error")
 
         result = sync_manager.sync_session_to_cloud("test_session_123")
@@ -630,11 +860,12 @@ class TestSyncManager:
 
     def test_sync_agent_success(self, sync_manager: SyncManager) -> None:
         """Test successful agent sync."""
-        agent_data = {"id": "agent_123", "name": "Test Agent"}
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
 
-        mock_response = Mock()
-        mock_response.status_code = 201
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.return_value = backend_response(
+            payload={"id": "agent_123"}
+        )
 
         result = sync_manager._sync_agent(agent_data)
 
@@ -642,26 +873,28 @@ class TestSyncManager:
         assert result["agent_id"] == "agent_123"
 
     def test_sync_agent_already_exists(self, sync_manager: SyncManager) -> None:
-        """Test agent sync when agent already exists (409)."""
-        agent_data = {"id": "agent_123", "name": "Test Agent"}
+        """Test agent sync reuses an existing matching agent."""
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
 
-        mock_response = Mock()
-        mock_response.status_code = 409  # Conflict
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(
+            200, payload={"agents": [{"id": "agent_123", "name": "Test Agent"}]}
+        )
 
         result = sync_manager._sync_agent(agent_data)
 
         assert result["success"] is True
         assert result["agent_id"] == "agent_123"
+        assert result["reused"] is True
+        sync_manager._session.post.assert_not_called()
 
     def test_sync_agent_failure(self, sync_manager: SyncManager) -> None:
         """Test agent sync failure."""
-        agent_data = {"id": "agent_123", "name": "Test Agent"}
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
 
-        mock_response = Mock()
-        mock_response.status_code = 500
-        mock_response.text = "Internal Server Error"
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.return_value = backend_response(
+            status_code=500, text="Internal Server Error"
+        )
 
         result = sync_manager._sync_agent(agent_data)
 
@@ -670,7 +903,8 @@ class TestSyncManager:
 
     def test_sync_agent_exception(self, sync_manager: SyncManager) -> None:
         """Test agent sync handles exceptions."""
-        agent_data = {"id": "agent_123", "name": "Test Agent"}
+        agent_data = {"name": "Test Agent", "agent_type_id": "completion"}
+        sync_manager._session.get.return_value = backend_response(404)
         sync_manager._session.post.side_effect = Exception("Network error")
 
         result = sync_manager._sync_agent(agent_data)
@@ -680,11 +914,16 @@ class TestSyncManager:
 
     def test_sync_benchmark_success(self, sync_manager: SyncManager) -> None:
         """Test successful benchmark sync."""
-        benchmark_data = {"id": "bench_123", "name": "Test Benchmark"}
+        benchmark_data = {
+            "name": "Test Benchmark",
+            "type": "input-output",
+            "label": "eval",
+        }
 
-        mock_response = Mock()
-        mock_response.status_code = 200
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.return_value = backend_response(
+            payload={"id": "bench_123"}
+        )
 
         result = sync_manager._sync_benchmark(benchmark_data)
 
@@ -693,61 +932,57 @@ class TestSyncManager:
 
     def test_sync_benchmark_failure(self, sync_manager: SyncManager) -> None:
         """Test benchmark sync failure."""
-        benchmark_data = {"id": "bench_123", "name": "Test Benchmark"}
+        benchmark_data = {
+            "name": "Test Benchmark",
+            "type": "input-output",
+            "label": "eval",
+        }
 
-        mock_response = Mock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad Request"
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.return_value = backend_response(
+            status_code=400, text="Bad Request"
+        )
 
         result = sync_manager._sync_benchmark(benchmark_data)
 
         assert result["success"] is False
         assert "HTTP 400" in result["error"]
 
-    def test_sync_benchmark_does_not_fallback_when_datasets_route_exists(
+    def test_sync_benchmark_reuses_existing_by_name(
         self, sync_manager: SyncManager
     ) -> None:
-        """A 404 from an existing /datasets endpoint should not hit the legacy route."""
-        benchmark_data = {"id": "bench_123", "name": "Test Benchmark"}
+        """Benchmark sync reuses an existing exact-name benchmark."""
+        benchmark_data = {
+            "name": "Test Benchmark",
+            "type": "input-output",
+            "label": "eval",
+        }
 
-        sync_manager._session.post.return_value = Mock(
-            status_code=404, text="dataset not found"
+        sync_manager._session.get.return_value = backend_response(
+            200, payload={"benchmarks": [{"id": "bench_123", "name": "Test Benchmark"}]}
         )
-        sync_manager._session.get.return_value = Mock(status_code=200)
 
         result = sync_manager._sync_benchmark(benchmark_data)
 
-        assert result["success"] is False
-        assert "HTTP 404" in result["error"]
-        sync_manager._session.post.assert_called_once_with(
-            f"{sync_manager.base_url}/datasets",
-            json=benchmark_data,
-            timeout=sync_manager._request_timeout,
-        )
-
-    def test_dataset_route_probe_exception_does_not_cache_support(
-        self, sync_manager: SyncManager
-    ) -> None:
-        """Transient probe failures should not become cached route truth."""
-        sync_manager._session.get.side_effect = requests.Timeout("timed out")
-
-        assert sync_manager._supports_dataset_route() is True
-        assert sync_manager._dataset_route_supported is None
-
-        sync_manager._session.get.side_effect = None
-        sync_manager._session.get.return_value = Mock(status_code=404)
-
-        assert sync_manager._supports_dataset_route() is False
-        assert sync_manager._dataset_route_supported is False
+        assert result["success"] is True
+        assert result["benchmark_id"] == "bench_123"
+        assert result["reused"] is True
+        sync_manager._session.post.assert_not_called()
 
     def test_sync_experiment_success(self, sync_manager: SyncManager) -> None:
         """Test successful experiment sync."""
-        experiment_data = {"id": "exp_123", "name": "Test Experiment"}
+        experiment_data = {
+            "name": "Test Experiment",
+            "agent_id": "agent-123",
+            "dataset_id": "benchmark-123",
+            "measures": ["score"],
+            "configurations": {},
+            "status": "COMPLETED",
+        }
 
-        mock_response = Mock()
-        mock_response.status_code = 201
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.post.return_value = backend_response(
+            payload={"id": "exp_123"}
+        )
 
         result = sync_manager._sync_experiment(experiment_data)
 
@@ -756,12 +991,18 @@ class TestSyncManager:
 
     def test_sync_experiment_failure(self, sync_manager: SyncManager) -> None:
         """Test experiment sync failure."""
-        experiment_data = {"id": "exp_123", "name": "Test Experiment"}
+        experiment_data = {
+            "name": "Test Experiment",
+            "agent_id": "agent-123",
+            "dataset_id": "benchmark-123",
+            "measures": ["score"],
+            "configurations": {},
+            "status": "COMPLETED",
+        }
 
-        mock_response = Mock()
-        mock_response.status_code = 403
-        mock_response.text = "Forbidden"
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.post.return_value = backend_response(
+            status_code=403, text="Forbidden"
+        )
 
         result = sync_manager._sync_experiment(experiment_data)
 
@@ -770,27 +1011,40 @@ class TestSyncManager:
 
     def test_sync_experiment_run_success(self, sync_manager: SyncManager) -> None:
         """Test successful experiment run sync."""
-        run_data = {"id": "run_123", "experiment_id": "exp_123"}
+        run_data = {
+            "experiment_data": {
+                "agent_id": "agent-123",
+                "benchmark_id": "benchmark-123",
+                "measures": ["score"],
+                "configurations": {},
+            }
+        }
 
-        mock_response = Mock()
-        mock_response.status_code = 200
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.post.return_value = backend_response(
+            payload={"id": "run_123"}
+        )
 
-        result = sync_manager._sync_experiment_run(run_data)
+        result = sync_manager._sync_experiment_run("exp_123", run_data)
 
         assert result["success"] is True
         assert result["run_id"] == "run_123"
 
     def test_sync_experiment_run_failure(self, sync_manager: SyncManager) -> None:
         """Test experiment run sync failure."""
-        run_data = {"id": "run_123", "experiment_id": "exp_123"}
+        run_data = {
+            "experiment_data": {
+                "agent_id": "agent-123",
+                "benchmark_id": "benchmark-123",
+                "measures": ["score"],
+                "configurations": {},
+            }
+        }
 
-        mock_response = Mock()
-        mock_response.status_code = 404
-        mock_response.text = "Not Found"
-        sync_manager._session.post.return_value = mock_response
+        sync_manager._session.post.return_value = backend_response(
+            status_code=404, text="Not Found"
+        )
 
-        result = sync_manager._sync_experiment_run(run_data)
+        result = sync_manager._sync_experiment_run("exp_123", run_data)
 
         assert result["success"] is False
         assert "HTTP 404" in result["error"]

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -7,6 +7,7 @@ Handles migration of local data to Traigent backend when users upgrade.
 
 import os
 import re
+from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from typing import Any
 
@@ -90,7 +91,6 @@ class SyncManager:
         if api_key:
             self._session.headers.update(self.headers)
         self._request_timeout = self._resolve_request_timeout()
-        self._dataset_route_supported: bool | None = None
 
     @property
     def session(self):
@@ -200,92 +200,111 @@ class SyncManager:
         Returns:
             Dict in Traigent experiment/experiment_run format
         """
-        # Generate placeholder IDs for required fields
-        experiment_id = f"local_import_{session.session_id}"
-        agent_id = f"local_agent_{session.function_name}"
-        dataset_id = f"local_dataset_{session.function_name}"
-        model_params_id = f"edge_analytics_model_params_{session.session_id}"
-
-        # Create minimal agent definition
-        agent_data = {
-            "id": agent_id,
-            "name": f"Local Agent: {session.function_name}",
-            # Local imports are generic function-completion optimizations; use a
-            # deterministic backend enum value rather than the legacy "custom".
-            "agent_type_id": DEFAULT_SYNC_AGENT_TYPE_ID,
-            "description": f"Imported from local optimization of {session.function_name}",
-            "source": "local_import",
-            "created_at": session.created_at,
-        }
-
-        # Create minimal dataset definition
-        dataset_data = {
-            "id": dataset_id,
-            "dataset_id": dataset_id,
-            "benchmark_id": dataset_id,
-            "name": sanitize_backend_name(f"Local Dataset {session.function_name}"),
-            "label": f"{session.function_name}_eval",
-            "description": f"Evaluation dataset for {session.function_name}",
-            "type": "custom",
-            "examples_count": session.completed_trials,  # Approximate
-            "source": "local_import",
-        }
-
-        # Create model parameters
         opt_config = session.optimization_config or {}
-        model_params_data = {
-            "id": model_params_id,
-            "model_id": (opt_config.get("search_space", {}) or {}).get(
-                "model", "unknown"
+        search_space = opt_config.get("search_space", {})
+        if not isinstance(search_space, dict):
+            search_space = {}
+        # The experiment-run create validator requires a top-level
+        # `infrastructure` key inside `configurations` (presence-checked); the
+        # canonical shape is {infrastructure, parameters}.
+        configurations = {"infrastructure": {}, "parameters": search_space}
+
+        configuration_runs = self._convert_trials_to_configuration_runs(
+            session.trials or []
+        )
+        measures = self._derive_experiment_measures(configuration_runs)
+
+        # Create minimal agent definition accepted by POST /agents.
+        agent_data = {
+            "name": f"Local Agent: {session.function_name}",
+            "agent_type_id": DEFAULT_SYNC_AGENT_TYPE_ID,
+        }
+
+        # The backend benchmark route is the dataset source for experiments.
+        benchmark_data = {
+            "name": sanitize_backend_name(f"Local Dataset {session.function_name}"),
+            "type": "input-output",
+            "label": sanitize_backend_name(
+                f"{session.function_name} eval", fallback="Local Eval"
             ),
-            "source": "local_import",
         }
 
-        # Create experiment
+        # agent_id and dataset_id are filled with returned backend IDs at sync time.
         experiment_data = {
-            "id": experiment_id,
             "name": f"Local Import: {session.function_name}",
-            "description": "Imported optimization session from Edge Analytics mode",
-            "agent_id": agent_id,
-            "dataset_id": dataset_id,
-            "benchmark_id": dataset_id,
-            "evaluation_set_id": dataset_id,
-            "eval_dataset_id": dataset_id,
-            "model_parameters_id": model_params_id,
-            "configurations": opt_config.get("search_space", {}),
-            "measures": ["score", "accuracy"],  # Default measures
-            "status": session.status,
-            "source": "local_import",
-            "metadata": {
-                "original_session_id": session.session_id,
-                "import_timestamp": datetime.now(UTC).isoformat(),
-                "edge_analytics_version": "1.0.0",
-            },
+            "measures": measures,
+            "configurations": configurations,
+            "status": "COMPLETED",
         }
 
-        # Create experiment run with trials
+        # experiment_data is filled with returned backend IDs at sync time.
         experiment_run_data = {
-            "id": f"{experiment_id}_run",
-            "experiment_id": experiment_id,
-            "experiment_data": experiment_data,
-            "status": session.status,
-            "results": self._convert_trials_to_results(session.trials or []),
-            "metadata": {
-                "total_trials": session.completed_trials,
-                "best_score": session.best_score,
-                "best_config": session.best_config,
-                "baseline_score": session.baseline_score,
-            },
+            "measures": measures,
+            "configurations": configurations,
         }
 
         return {
             "agent": agent_data,
-            "dataset": dataset_data,
-            "benchmark": dataset_data,
-            "model_parameters": model_params_data,
+            "benchmark": benchmark_data,
             "experiment": experiment_data,
             "experiment_run": experiment_run_data,
+            "configuration_runs": configuration_runs,
         }
+
+    def _convert_trials_to_configuration_runs(
+        self, trials: list[Any]
+    ) -> list[dict[str, Any]]:
+        """Reshape local trial results into configuration-run create payloads."""
+        configuration_runs: list[dict[str, Any]] = []
+
+        for result in self._convert_trials_to_results(trials):
+            measures = self._configuration_run_measures(result)
+            configuration_runs.append(
+                {
+                    "experiment_parameters": result.get("experiment_parameters", {}),
+                    "measures": measures,
+                    "status": "COMPLETED",
+                }
+            )
+
+        return configuration_runs
+
+    def _configuration_run_measures(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Build measures for the backend configuration-run schema."""
+        measures: dict[str, Any] = {}
+
+        metadata = result.get("metadata")
+        if isinstance(metadata, Mapping):
+            for key, value in metadata.items():
+                if self._is_numeric(value):
+                    measures[key] = value
+
+        for key, value in (result.get("measures") or {}).items():
+            if key in TRIAL_COST_FIELDS:
+                if self._is_numeric(value):
+                    measures[key] = float(value)
+            elif value is not None:
+                measures[key] = value
+
+        return measures
+
+    @staticmethod
+    def _is_numeric(value: Any) -> bool:
+        """Return True for JSON numeric values while excluding booleans."""
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+    @staticmethod
+    def _derive_experiment_measures(
+        configuration_runs: list[dict[str, Any]],
+    ) -> list[str]:
+        """Derive the experiment-level measure list from trial payloads."""
+        measures: list[str] = []
+        for configuration_run in configuration_runs:
+            for measure_name in configuration_run.get("measures", {}):
+                if measure_name not in measures:
+                    measures.append(measure_name)
+
+        return measures or ["score"]
 
     def _convert_trials_to_results(self, trials: list[Any]) -> list[dict[str, Any]]:
         """Convert local trials to Traigent configuration_run format."""
@@ -348,14 +367,14 @@ class SyncManager:
         # Convert to Traigent format
         traigent_data = self.convert_session_to_traigent_format(session)
 
-        sync_result = {
+        sync_result: dict[str, Any] = {
             "session_id": session_id,
             "function_name": session.function_name,
             "status": "success",
             "dry_run": dry_run,
             "data_converted": True,
-            "cloud_experiment_id": traigent_data["experiment"]["id"],
-            "trials_converted": len(traigent_data["experiment_run"]["results"]),
+            "cloud_experiment_id": None,
+            "trials_converted": len(traigent_data["configuration_runs"]),
             "errors": [],
         }
 
@@ -363,9 +382,8 @@ class SyncManager:
             sync_result["preview"] = {
                 "experiment_name": traigent_data["experiment"]["name"],
                 "agent_name": traigent_data["agent"]["name"],
-                "dataset_name": traigent_data["dataset"]["name"],
                 "benchmark_name": traigent_data["benchmark"]["name"],
-                "trial_count": len(traigent_data["experiment_run"]["results"]),
+                "trial_count": len(traigent_data["configuration_runs"]),
                 "best_score": session.best_score,
             }
             return sync_result
@@ -379,53 +397,78 @@ class SyncManager:
             return sync_result
 
         try:
-            # Track success/failure of each step
             successful_steps = 0
-            total_steps = 4
+            total_steps = 4 + len(traigent_data["configuration_runs"])
 
-            # Step 1: Create or verify agent
             agent_result = self._sync_agent(traigent_data["agent"])
             if not agent_result["success"]:
                 sync_result["errors"].append(
                     f"Agent sync failed: {agent_result['error']}"
                 )
-            else:
-                successful_steps += 1
+                sync_result["status"] = "error"
+                return sync_result
 
-            # Step 2: Create or verify benchmark
-            benchmark_result = self._sync_benchmark(traigent_data["dataset"])
+            successful_steps += 1
+            agent_id = agent_result["agent_id"]
+
+            benchmark_result = self._sync_benchmark(traigent_data["benchmark"])
             if not benchmark_result["success"]:
                 sync_result["errors"].append(
                     f"Benchmark sync failed: {benchmark_result['error']}"
                 )
-            else:
-                successful_steps += 1
+                sync_result["status"] = "partial"
+                return sync_result
 
-            # Step 3: Create experiment
-            experiment_result = self._sync_experiment(traigent_data["experiment"])
+            successful_steps += 1
+            benchmark_id = benchmark_result["benchmark_id"]
+
+            experiment_payload = self._build_experiment_payload(
+                traigent_data["experiment"], agent_id, benchmark_id
+            )
+            experiment_result = self._sync_experiment(experiment_payload)
             if not experiment_result["success"]:
                 sync_result["errors"].append(
                     f"Experiment sync failed: {experiment_result['error']}"
                 )
-            else:
-                successful_steps += 1
+                sync_result["status"] = "partial"
+                return sync_result
 
-            # Step 4: Create experiment run with results
-            run_result = self._sync_experiment_run(traigent_data["experiment_run"])
+            successful_steps += 1
+            experiment_id = experiment_result["experiment_id"]
+            sync_result["cloud_experiment_id"] = experiment_id
+
+            run_payload = self._build_experiment_run_payload(
+                traigent_data["experiment_run"], agent_id, benchmark_id
+            )
+            run_result = self._sync_experiment_run(experiment_id, run_payload)
             if not run_result["success"]:
                 sync_result["errors"].append(
                     f"Experiment run sync failed: {run_result['error']}"
                 )
-            else:
-                successful_steps += 1
+                sync_result["status"] = "partial"
+                return sync_result
 
-            # Determine status based on success rate
+            successful_steps += 1
+            experiment_run_id = run_result["experiment_run_id"]
+
+            configuration_result = self._sync_configuration_runs(
+                experiment_run_id, traigent_data["configuration_runs"]
+            )
+            successful_steps += configuration_result["synced"]
+            if not configuration_result["success"]:
+                sync_result["errors"].extend(
+                    [
+                        f"Configuration run sync failed: {error}"
+                        for error in configuration_result["errors"]
+                    ]
+                )
+
             if successful_steps == 0:
                 sync_result["status"] = "error"  # Complete failure
             elif successful_steps == total_steps:
                 sync_result["status"] = "success"
                 sync_result["cloud_url"] = build_experiment_url(
-                    self.base_url, traigent_data["experiment"]["id"]
+                    self.base_url, experiment_id
                 )
             else:
                 sync_result["status"] = "partial"  # Some steps succeeded
@@ -490,73 +533,107 @@ class SyncManager:
         }
 
     def _sync_agent(self, agent_data: dict[str, Any]) -> dict[str, Any]:
-        """Sync agent data to cloud."""
+        """Create or reuse the local-import agent by stable name."""
         try:
+            existing_agent = self._find_existing_by_name(
+                "agents", agent_data["name"], "agents"
+            )
+            if existing_agent:
+                agent_id = self._extract_resource_id(existing_agent)
+                if agent_id:
+                    return {"success": True, "agent_id": agent_id, "reused": True}
+
             response = self._session.post(
                 f"{self.base_url}/agents",
                 json=agent_data,
                 timeout=self._request_timeout,
             )
-            if response.status_code in [200, 201, 409]:  # 409 = already exists
-                return {"success": True, "agent_id": agent_data["id"]}
-            else:
-                return {
-                    "success": False,
-                    "error": f"HTTP {response.status_code}: {response.text}",
-                }
+
+            if response.status_code == 429:
+                existing_agent = self._find_existing_by_name(
+                    "agents", agent_data["name"], "agents"
+                )
+                if existing_agent:
+                    agent_id = self._extract_resource_id(existing_agent)
+                    if agent_id:
+                        return {
+                            "success": True,
+                            "agent_id": agent_id,
+                            "reused": True,
+                        }
+
+            if response.status_code in [200, 201]:
+                agent_id = self._extract_response_id(response)
+                if not agent_id:
+                    return {
+                        "success": False,
+                        "error": "Agent create response did not include id",
+                    }
+                return {"success": True, "agent_id": agent_id, "reused": False}
+
+            return {
+                "success": False,
+                "error": f"HTTP {response.status_code}: {response.text}",
+            }
         except Exception as e:
             return {"success": False, "error": str(e)}
 
     def _sync_benchmark(self, benchmark_data: dict[str, Any]) -> dict[str, Any]:
-        """Sync dataset data to cloud with legacy benchmark fallback."""
+        """Create or reuse the benchmark by stable name."""
         try:
+            existing_benchmark = self._find_existing_by_name(
+                "benchmarks", benchmark_data["name"], "benchmarks"
+            )
+            if existing_benchmark:
+                benchmark_id = self._extract_resource_id(existing_benchmark)
+                if benchmark_id:
+                    return {
+                        "success": True,
+                        "dataset_id": benchmark_id,
+                        "benchmark_id": benchmark_id,
+                        "reused": True,
+                    }
+
             response = self._session.post(
-                f"{self.base_url}/datasets",
+                f"{self.base_url}/benchmarks",
                 json=benchmark_data,
                 timeout=self._request_timeout,
             )
-            if response.status_code == 404 and not self._supports_dataset_route():
-                response = self._session.post(
-                    f"{self.base_url}/benchmarks",
-                    json=benchmark_data,
-                    timeout=self._request_timeout,
+
+            if response.status_code in [409, 500]:
+                existing_benchmark = self._find_existing_by_name(
+                    "benchmarks", benchmark_data["name"], "benchmarks"
                 )
-            if response.status_code in [200, 201, 409]:
-                dataset_id = benchmark_data.get("dataset_id", benchmark_data["id"])
+                if existing_benchmark:
+                    benchmark_id = self._extract_resource_id(existing_benchmark)
+                    if benchmark_id:
+                        return {
+                            "success": True,
+                            "dataset_id": benchmark_id,
+                            "benchmark_id": benchmark_id,
+                            "reused": True,
+                        }
+
+            if response.status_code in [200, 201]:
+                benchmark_id = self._extract_response_id(response)
+                if not benchmark_id:
+                    return {
+                        "success": False,
+                        "error": "Benchmark create response did not include id",
+                    }
                 return {
                     "success": True,
-                    "dataset_id": dataset_id,
-                    "benchmark_id": dataset_id,
+                    "dataset_id": benchmark_id,
+                    "benchmark_id": benchmark_id,
+                    "reused": False,
                 }
-            else:
-                return {
-                    "success": False,
-                    "error": f"HTTP {response.status_code}: {response.text}",
-                }
+
+            return {
+                "success": False,
+                "error": f"HTTP {response.status_code}: {response.text}",
+            }
         except Exception as e:
             return {"success": False, "error": str(e)}
-
-    def _supports_dataset_route(self) -> bool:
-        """Detect whether the canonical /datasets endpoint exists on the remote."""
-        if self._dataset_route_supported is not None:
-            return self._dataset_route_supported
-
-        try:
-            response = self._session.get(
-                f"{self.base_url}/datasets",
-                params={"page": 1, "per_page": 1},
-                timeout=self._request_timeout,
-            )
-        except requests.RequestException as exc:
-            logger.warning(
-                "Failed probing /datasets route support; using canonical endpoint "
-                "for this attempt without caching route support: %s",
-                exc,
-            )
-            return True
-
-        self._dataset_route_supported = response.status_code != 404
-        return self._dataset_route_supported
 
     def _sync_experiment(self, experiment_data: dict[str, Any]) -> dict[str, Any]:
         """Sync experiment data to cloud."""
@@ -566,20 +643,26 @@ class SyncManager:
                 json=experiment_data,
                 timeout=self._request_timeout,
             )
-            if response.status_code in [200, 201, 409]:
-                return {"success": True, "experiment_id": experiment_data["id"]}
-            else:
-                return {
-                    "success": False,
-                    "error": f"HTTP {response.status_code}: {response.text}",
-                }
+            if response.status_code in [200, 201]:
+                experiment_id = self._extract_response_id(response)
+                if not experiment_id:
+                    return {
+                        "success": False,
+                        "error": "Experiment create response did not include id",
+                    }
+                return {"success": True, "experiment_id": experiment_id}
+            return {
+                "success": False,
+                "error": f"HTTP {response.status_code}: {response.text}",
+            }
         except Exception as e:
             return {"success": False, "error": str(e)}
 
-    def _sync_experiment_run(self, run_data: dict[str, Any]) -> dict[str, Any]:
+    def _sync_experiment_run(
+        self, experiment_id: str, run_data: dict[str, Any]
+    ) -> dict[str, Any]:
         """Sync experiment run data to cloud."""
         try:
-            experiment_id = run_data.get("experiment_id")
             if not experiment_id:
                 return {
                     "success": False,
@@ -592,14 +675,164 @@ class SyncManager:
                 timeout=self._request_timeout,
             )
             if response.status_code in [200, 201]:
-                return {"success": True, "run_id": run_data["id"]}
-            else:
+                experiment_run_id = self._extract_response_id(response)
+                if not experiment_run_id:
+                    return {
+                        "success": False,
+                        "error": "Experiment-run create response did not include id",
+                    }
                 return {
-                    "success": False,
-                    "error": f"HTTP {response.status_code}: {response.text}",
+                    "success": True,
+                    "run_id": experiment_run_id,
+                    "experiment_run_id": experiment_run_id,
                 }
+            return {
+                "success": False,
+                "error": f"HTTP {response.status_code}: {response.text}",
+            }
         except Exception as e:
             return {"success": False, "error": str(e)}
+
+    def _sync_configuration_runs(
+        self, experiment_run_id: str, trials: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Create the cost-bearing configuration rows for an experiment run."""
+        errors: list[str] = []
+        configuration_run_ids: list[str] = []
+        synced = 0
+
+        for index, trial in enumerate(trials, start=1):
+            try:
+                response = self._session.post(
+                    f"{self.base_url}/configuration-runs/runs/"
+                    f"{experiment_run_id}/configurations",
+                    json=trial,
+                    timeout=self._request_timeout,
+                )
+            except Exception as exc:
+                errors.append(f"trial {index}: {exc}")
+                continue
+
+            if response.status_code == 201:
+                synced += 1
+                configuration_run_id = self._extract_response_id(response)
+                if configuration_run_id:
+                    configuration_run_ids.append(configuration_run_id)
+                continue
+
+            errors.append(
+                f"trial {index}: HTTP {response.status_code}: {response.text}"
+            )
+
+        return {
+            "success": not errors,
+            "synced": synced,
+            "errors": errors,
+            "configuration_run_ids": configuration_run_ids,
+        }
+
+    @staticmethod
+    def _build_experiment_payload(
+        experiment_data: dict[str, Any], agent_id: str, benchmark_id: str
+    ) -> dict[str, Any]:
+        """Fill returned backend IDs into the experiment create payload."""
+        return {
+            **experiment_data,
+            "agent_id": agent_id,
+            "dataset_id": benchmark_id,
+        }
+
+    @staticmethod
+    def _build_experiment_run_payload(
+        run_data: dict[str, Any], agent_id: str, benchmark_id: str
+    ) -> dict[str, Any]:
+        """Build the closed-schema experiment-run payload."""
+        return {
+            "experiment_data": {
+                "agent_id": agent_id,
+                "benchmark_id": benchmark_id,
+                "measures": run_data["measures"],
+                "configurations": run_data["configurations"],
+            }
+        }
+
+    def _find_existing_by_name(
+        self, resource_path: str, name: str, collection_key: str
+    ) -> dict[str, Any] | None:
+        """Find an existing backend resource by exact name."""
+        response = self._session.get(
+            f"{self.base_url}/{resource_path}",
+            params={"name": name},
+            timeout=self._request_timeout,
+        )
+        if response.status_code != 200:
+            return None
+
+        payload = self._response_json(response)
+        for item in self._iter_response_items(payload, collection_key):
+            if item.get("name") == name:
+                return item
+
+        return None
+
+    def _iter_response_items(
+        self, payload: Any, collection_key: str
+    ) -> Iterable[dict[str, Any]]:
+        """Yield resource dicts from common list-response envelope shapes."""
+        if isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, dict):
+                    yield item
+            return
+
+        if not isinstance(payload, dict):
+            return
+
+        if "name" in payload and self._extract_resource_id(payload):
+            yield payload
+
+        for key in (collection_key, "items", "data", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        yield item
+            elif isinstance(value, dict):
+                yield from self._iter_response_items(value, collection_key)
+
+    @staticmethod
+    def _response_json(response: requests.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _extract_resource_id(payload: Mapping[str, Any]) -> str | None:
+        for key in (
+            "id",
+            "agent_id",
+            "benchmark_id",
+            "dataset_id",
+            "experiment_id",
+            "experiment_run_id",
+            "run_id",
+        ):
+            value = payload.get(key)
+            if value is not None:
+                return str(value)
+        # Backend responses wrap the resource in the standard envelope
+        # {success, data: {id, ...}, message}; unwrap one level.
+        data = payload.get("data")
+        if isinstance(data, Mapping):
+            return SyncManager._extract_resource_id(data)
+        return None
+
+    def _extract_response_id(self, response: requests.Response) -> str | None:
+        payload = self._response_json(response)
+        if isinstance(payload, Mapping):
+            return self._extract_resource_id(payload)
+        return None
 
     def get_cloud_analytics_preview(self) -> dict[str, Any]:
         """Get preview of analytics available in cloud after sync."""


### PR DESCRIPTION
Closes #1211 and #868; unblocks #1213 (epic) and #1200. A live SDK→backend E2E proved the sync→cloud path was drifted in **every** entity; this rewrites SyncManager to the verified current contract and adds the live contract test that catches such drift (mock-transport unit tests structurally cannot).

## New flow (returned ids threaded through)
agent `{name, agent_type_id:completion}` → benchmark `{name, type:input-output, label}` → experiment `{…, status:COMPLETED}` → experiment-run (**closed schema**: only `experiment_data:{agent_id, benchmark_id, measures, configurations}`, configurations carries the required `infrastructure` key) → **NEW** per-trial `POST /configuration-runs/runs/<run>/configurations` with cost as a **numeric key inside `measures`** (the AC: `(measures::jsonb)->>'cost' > 0`). Idempotent agent/benchmark GET-or-create (free-tier 1-agent 429 + duplicate → reuse). Dropped the dead model_parameters ref and the legacy inline experiment-run `results`.

## Live verification (TraigentBackend develop, local stack, ordinary scoped key)
Sync of a finalized 2-trial cost session → **status=success, zero step errors, 2 configuration_runs with the exact costs (0.000166, 0.0005) in `measures.cost`**. Idempotent re-sync succeeds via reuse under the quota.

## Tests
99 sync unit tests pass; `tests/cloud/test_sync_live_contract.py` (#868, `@pytest.mark.contract`, skips unless `TRAIGENT_LIVE_SYNC_E2E`+backend+key) passes live and skips in the unit gate. mypy + ruff + black clean.

Two captain fixes only the live backend exposed: `_extract_resource_id` unwraps the `{success, data:{id}}` envelope; experiment-run `configurations` must include `infrastructure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)