### PR TITLE
fix(docker): upgrade base OS packages so SDK image pulls patched openssl (#1220 part b)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Install system dependencies and create non-root user for security
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     curl \
     build-essential \


### PR DESCRIPTION
## What

Companion to `TraigentBackend#955` for #1220. The Aikido finding is scoped to the `traigent-backend` container, but the SDK's own Dockerfile shares the same drift, so this hardens it too (part **b** of the reconciliation).

## Root cause

The Dockerfile's `base` stage (shared by the `development`, `testing`, and `production` stages) ran `apt-get update && apt-get install -y …` but **never `apt-get upgrade -y`**, leaving the vulnerable openssl from `python:3.14-slim` unpatched.

## Fix

Add `apt-get upgrade -y` to the `base` stage — one line, covers all downstream stages. No runtime/behavior change.

## Verification (against the actual base image)

`python:3.14-slim` = Debian 13.5 (trixie):

| | openssl-provider-legacy |
|---|---|
| BEFORE | `3.5.6-1~deb13u1` |
| AFTER `apt-get update && apt-get upgrade -y` | `3.5.6-1~deb13u2` ✅ |

## PR checklist

1. **Worst-case prod path** — none; build-time OS-package patch only.
2. **Production-branch test** — N/A; verified empirically above.
3. **Contract regeneration** — none.
4. **Public surface delta** — none.
5. **Review threads** — will resolve before merge.
6. **Quality gates** — not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
