### PR TITLE
chore: bump develop to 0.13.0.dev1 pre-release for public dev installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.12.0"
+version = "0.13.0.dev1"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## What
Bumps `pyproject.toml` `[project].version` on the develop line from `0.12.0` to **`0.13.0.dev1`** (PEP 440 dev pre-release). One-line change; no code touched.

## Why
`develop` is ~60 commits ahead of the published prod `traigent==0.12.0` but its version still reads `0.12.0`. To let the owner `pip install` the running-ahead develop SDK for internal demos (acting as a real client testing dev) — alongside, not over, prod `0.12.0` — develop needs a distinct public version that:

- **sorts above prod 0.12.0 and below the next prod release**: `0.12.0 < 0.13.0.dev1 < 0.13.0` (verified with `packaging.version`), and
- **is a recognized pre-release** (`Version("0.13.0.dev1").is_prerelease == True`), so a plain `pip install traigent` still resolves prod `0.12.0`; the dev build is only selected with an explicit pin or `--pre`.

`0.13.0` (not `0.12.1`) as the base because the develop-only sync-contract work (#1210/#1211) is a minor-line change. If the next prod release is decided to be a patch, rebase this to `0.12.1.dev1` — the mechanism is identical.

Version is single-sourced from `pyproject.toml` (`traigent/_version.get_version()` → wheel metadata at build), so this one line is the only change required. Verified locally: `python -m build` produces `traigent-0.13.0.dev1-py3-none-any.whl` with `Version: 0.13.0.dev1` in METADATA.

## How the owner publishes the dev build (TestPyPI — recommended channel)
The existing `.github/workflows/publish.yml` already has a `workflow_dispatch` path for TestPyPI. After this PR merges to `develop`:

```
gh workflow run "Publish to PyPI" --repo Traigent/Traigent --ref develop \
  -f environment=testpypi -f confirm_publish=true
```

A client then installs the dev SDK with:

```
pip install -i https://test.pypi.org/simple/ \
  --extra-index-url https://pypi.org/simple/ \
  "traigent==0.13.0.dev1"
```

(The `--extra-index-url` is required so TestPyPI's incomplete mirror still resolves real runtime deps from prod PyPI.)

**TestPyPI keeps the dev build off the prod PyPI listing entirely** — prod `pip install traigent` is wholly unaffected. The alternative (publish the pre-release to prod PyPI, install via `pip install --pre traigent`) is left for an explicit owner decision; it would put a `.dev` artifact in the public prod listing.

## OWNER-GATED — one remaining manual step
This PR does **not** publish anything (publishing to a public index is irreversible). The publish trigger is left for owner confirmation.

`publish.yml` uses **PyPI Trusted Publishing (OIDC)** — `id-token: write`, no `PYPI_API_TOKEN` secret in the repo. The remaining prerequisite is **outside the repo**: a **TestPyPI Trusted Publisher** must be registered for this repo's `publish` workflow + `testpypi` GitHub environment (the `testpypi` environment does not yet exist in repo settings and `traigent` does not yet exist on TestPyPI). The owner registers the pending publisher at https://test.pypi.org/manage/account/publishing/ (publisher: repo `Traigent/Traigent`, workflow `publish.yml`, environment `testpypi`). No secret value needs to be added to GitHub.

## PR checklist
- **Worst-case prod path**: none — version-string-only change on develop; does not touch policy surfaces, auth, billing, or prod `main`/`0.12.0`. Worst case if the dispatch runs is a dev artifact on TestPyPI, which is the intent.
- **Production-branch test**: n/a (no production code path changed).
- **Contract regeneration**: none.
- **Public surface delta**: none (no `__all__`/route/OpenAPI change).
- **Review threads resolved**: will resolve before un-drafting.
- **Quality gates not relaxed**: no gate touched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)