### PR TITLE
feat(playbook): agent build playbook artifact + traigent playbook CLI (init/validate/status)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,12 @@ include = ["traigent*", "traigent_validation*"]
 exclude = ["tests*", "demos*", "docs*", "traigent.experimental*"]
 
 [tool.setuptools.package-data]
-traigent = ["py.typed", "examples/**/*.jsonl", "skills/**/*.md"]
+traigent = [
+    "py.typed",
+    "examples/**/*.jsonl",
+    "skills/**/*.md",
+    "playbook/schemas/*.json",
+]
 traigent_validation = ["py.typed"]
 
 [tool.uv]

--- a/tests/cli/test_playbook_commands.py
+++ b/tests/cli/test_playbook_commands.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from traigent.cli.main import cli
+
+
+def test_playbook_init_creates_file_and_refuses_overwrite(tmp_path: Path) -> None:
+    path = tmp_path / "traigent.playbook.yaml"
+    runner = CliRunner()
+
+    first = runner.invoke(
+        cli,
+        [
+            "playbook",
+            "init",
+            "--name",
+            "support-agent",
+            "--agent-type",
+            "rag",
+            "--entrypoint",
+            "agent:run",
+            "--path",
+            str(path),
+        ],
+    )
+    assert first.exit_code == 0
+    assert path.exists()
+    original = path.read_text(encoding="utf-8")
+    assert "evaluation dataset" in original
+
+    second = runner.invoke(
+        cli,
+        ["playbook", "init", "--name", "other-agent", "--path", str(path)],
+    )
+
+    assert second.exit_code != 0
+    assert "already exists" in second.output
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_playbook_validate_green_on_scaffold_and_red_on_corruption(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "traigent.playbook.yaml"
+    runner = CliRunner()
+
+    init_result = runner.invoke(
+        cli,
+        ["playbook", "init", "--name", "support-agent", "--path", str(path)],
+    )
+    assert init_result.exit_code == 0
+
+    valid_result = runner.invoke(cli, ["playbook", "validate", "--path", str(path)])
+    assert valid_result.exit_code == 0
+    assert "playbook valid" in valid_result.output
+
+    contents = path.read_text(encoding="utf-8")
+    path.write_text(
+        contents.replace("status: pending", "status: done", 1), encoding="utf-8"
+    )
+
+    invalid_result = runner.invoke(cli, ["playbook", "validate", "--path", str(path)])
+
+    assert invalid_result.exit_code == 1
+    assert "$.stages.dataset.status" in invalid_result.output
+    assert "'done' is not one of" in invalid_result.output
+
+
+def test_playbook_status_renders_all_five_stages(tmp_path: Path) -> None:
+    path = tmp_path / "traigent.playbook.yaml"
+    runner = CliRunner()
+
+    init_result = runner.invoke(
+        cli,
+        ["playbook", "init", "--name", "support-agent", "--path", str(path)],
+    )
+    assert init_result.exit_code == 0
+
+    status_result = runner.invoke(cli, ["playbook", "status", "--path", str(path)])
+
+    assert status_result.exit_code == 0
+    for stage_name in ("dataset", "metric", "evaluator", "optimize", "gate"):
+        assert stage_name in status_result.output

--- a/tests/unit/playbook/test_loader.py
+++ b/tests/unit/playbook/test_loader.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from traigent.playbook import StageStatus, load_playbook, scaffold_playbook
+
+
+def test_load_playbook_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "traigent.playbook.yaml"
+    path.write_text(
+        scaffold_playbook(
+            name="support-agent",
+            agent_type="rag",
+            entrypoint="agent:run",
+        ),
+        encoding="utf-8",
+    )
+
+    playbook = load_playbook(path)
+
+    assert playbook.playbook_version == "1.0.0"
+    assert playbook.agent == {
+        "name": "support-agent",
+        "entrypoint": "agent:run",
+        "agent_type": "rag",
+    }
+    assert set(playbook.stages) == {
+        "dataset",
+        "metric",
+        "evaluator",
+        "optimize",
+        "gate",
+    }
+    assert playbook.stages["dataset"].status is StageStatus.PENDING
+    assert playbook.raw["agent"]["name"] == "support-agent"
+
+
+def test_load_playbook_missing_file_error(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="agent build playbook not found"):
+        load_playbook(tmp_path / "missing.yaml")

--- a/tests/unit/playbook/test_scaffold_validator_staleness.py
+++ b/tests/unit/playbook/test_scaffold_validator_staleness.py
@@ -1,0 +1,103 @@
+from datetime import UTC, datetime
+
+import yaml
+
+from traigent.playbook import (
+    STAGE_ORDER,
+    Playbook,
+    StageStatus,
+    compute_staleness,
+    scaffold_playbook,
+    validate_playbook,
+)
+from traigent.playbook.model import Stage
+
+
+def test_scaffold_validate_round_trip_has_zero_issues() -> None:
+    payload = yaml.safe_load(
+        scaffold_playbook(
+            name="support-agent",
+            agent_type="rag",
+            entrypoint="agent:run",
+        )
+    )
+
+    assert validate_playbook(payload) == []
+
+
+def test_validator_reports_schema_bad_enum_issue() -> None:
+    payload = yaml.safe_load(scaffold_playbook(name="support-agent"))
+    payload["stages"]["dataset"]["status"] = "done"
+
+    issues = validate_playbook(payload)
+
+    assert len(issues) == 1
+    assert issues[0].location == "$.stages.dataset.status"
+    assert "'done' is not one of" in issues[0].message
+
+
+def test_validator_reports_pinned_stage_without_pin() -> None:
+    payload = yaml.safe_load(scaffold_playbook(name="support-agent"))
+    payload["stages"]["dataset"]["status"] = "pinned"
+
+    issues = validate_playbook(payload)
+
+    assert [(issue.location, issue.message) for issue in issues] == [
+        ("$.stages.dataset", "pinned stages must include pin")
+    ]
+
+
+def test_validator_reports_deprecated_stage_without_reason() -> None:
+    payload = yaml.safe_load(scaffold_playbook(name="support-agent"))
+    payload["stages"]["metric"]["status"] = "deprecated"
+
+    issues = validate_playbook(payload)
+
+    assert [(issue.location, issue.message) for issue in issues] == [
+        ("$.stages.metric", "deprecated stages must include deprecation_reason")
+    ]
+
+
+def test_validator_reports_unparseable_pinned_at() -> None:
+    payload = yaml.safe_load(scaffold_playbook(name="support-agent"))
+    payload["stages"]["dataset"]["pinned_at"] = "2026-01-01"
+
+    issues = validate_playbook(payload)
+
+    assert [(issue.location, issue.message) for issue in issues] == [
+        ("$.stages.dataset.pinned_at", "pinned_at must be a parseable ISO datetime")
+    ]
+
+
+def test_staleness_marks_later_stage_stale_when_earlier_repin_is_later() -> None:
+    playbook = Playbook(
+        playbook_version="1.0.0",
+        agent={"name": "support-agent"},
+        stages={
+            "dataset": Stage(
+                status=StageStatus.PINNED,
+                pinned_at=datetime(2026, 2, 2, tzinfo=UTC),
+                pin={"dataset_ref": "eval.jsonl"},
+            ),
+            "metric": Stage(
+                status=StageStatus.PINNED,
+                pinned_at=datetime(2026, 2, 1, tzinfo=UTC),
+                pin={"metric_name": "accuracy"},
+            ),
+            "evaluator": Stage(status=StageStatus.PENDING),
+            "optimize": Stage(
+                status=StageStatus.PINNED,
+                pinned_at=None,
+                pin={"objectives": ["accuracy"]},
+            ),
+        },
+        provenance=None,
+        raw={},
+    )
+
+    stale = compute_staleness(playbook)
+
+    assert stale["dataset"] is False
+    assert stale["metric"] is True
+    assert stale["optimize"] is False
+    assert set(stale) == set(STAGE_ORDER)

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -2361,7 +2361,9 @@ def check(
             )
             return
 
-        console.print("\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]")
+        console.print(
+            "\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]"
+        )
         validator = OptimizationValidator(threshold_pct=threshold)
 
         async def run_validations() -> tuple[list[Any], int, int]:
@@ -2406,6 +2408,10 @@ cli.add_command(detect_tvars)
 from traigent.cli.generate_config_command import generate_config  # noqa: E402
 
 cli.add_command(generate_config)
+
+from traigent.cli.playbook_commands import playbook  # noqa: E402
+
+cli.add_command(playbook)
 
 from traigent.cli.onboard_commands import first_prompt, onboard  # noqa: E402
 

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -2362,7 +2362,7 @@ def check(
             return
 
         console.print(
-            "\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]"
+            "\n[bold yellow]⚖️  Step 2: Optimization Validation[/bold yellow]",
         )
         validator = OptimizationValidator(threshold_pct=threshold)
 

--- a/traigent/cli/playbook_commands.py
+++ b/traigent/cli/playbook_commands.py
@@ -1,0 +1,149 @@
+"""CLI commands for agent build playbooks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from traigent.playbook.loader import (
+    DEFAULT_PLAYBOOK_FILENAME,
+    _load_yaml_mapping,
+    load_playbook,
+)
+from traigent.playbook.model import STAGE_ORDER, Stage, StageStatus
+from traigent.playbook.scaffold import scaffold_playbook
+from traigent.playbook.staleness import compute_staleness
+from traigent.playbook.validator import validate_playbook
+
+console = Console()
+
+
+@click.group()
+def playbook() -> None:
+    """Manage the agent build playbook."""
+
+
+@playbook.command("init")
+@click.option("--name", prompt="Agent name", help="Agent name for the playbook.")
+@click.option("--agent-type", default=None, help="Optional recommendation agent type.")
+@click.option(
+    "--entrypoint", default=None, help="Optional module:function or file path."
+)
+@click.option(
+    "--path",
+    "path",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_PLAYBOOK_FILENAME,
+    show_default=True,
+    help="Path to write the agent build playbook.",
+)
+def init_playbook(
+    name: str,
+    agent_type: str | None,
+    entrypoint: str | None,
+    path: Path,
+) -> None:
+    """Create an initial agent build playbook."""
+    if path.exists():
+        raise click.ClickException(f"agent build playbook already exists: {path}")
+    if path.parent and not path.parent.exists():
+        raise click.ClickException(f"parent directory does not exist: {path.parent}")
+
+    path.write_text(
+        scaffold_playbook(name=name, agent_type=agent_type, entrypoint=entrypoint),
+        encoding="utf-8",
+    )
+    click.echo(f"created agent build playbook: {path}")
+
+
+@playbook.command("validate")
+@click.option(
+    "--path",
+    "path",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_PLAYBOOK_FILENAME,
+    show_default=True,
+    help="Path to the agent build playbook.",
+)
+def validate_playbook_command(path: Path) -> None:
+    """Validate an agent build playbook."""
+    try:
+        payload = _load_yaml_mapping(path)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    issues = validate_playbook(payload)
+    if issues:
+        for issue in issues:
+            click.echo(f"{issue.location}: {issue.message}")
+        raise SystemExit(1)
+
+    click.echo("playbook valid")
+
+
+@playbook.command("status")
+@click.option(
+    "--path",
+    "path",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_PLAYBOOK_FILENAME,
+    show_default=True,
+    help="Path to the agent build playbook.",
+)
+def playbook_status(path: Path) -> None:
+    """Show agent build playbook stage status."""
+    try:
+        loaded = load_playbook(path)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    stale_by_stage = compute_staleness(loaded)
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Stage")
+    table.add_column("Status")
+    table.add_column("Stale")
+    table.add_column("Pin")
+
+    for stage_name in STAGE_ORDER:
+        stage = loaded.stages.get(stage_name)
+        table.add_row(
+            stage_name,
+            _stage_status(stage),
+            _stale_label(stage, stale_by_stage[stage_name]),
+            _pin_summary(stage),
+        )
+
+    console.print(table)
+
+
+def _stage_status(stage: Stage | None) -> str:
+    if stage is None:
+        return "missing"
+    return stage.status.value
+
+
+def _stale_label(stage: Stage | None, stale: bool) -> str:
+    if (
+        stage is None
+        or stage.status is not StageStatus.PINNED
+        or stage.pinned_at is None
+    ):
+        return ""
+    return "yes" if stale else "no"
+
+
+def _pin_summary(stage: Stage | None) -> str:
+    if stage is None or not stage.pin:
+        return ""
+    return ", ".join(
+        f"{key}={_shorten(value)}" for key, value in list(stage.pin.items())[:3]
+    )
+
+
+def _shorten(value: Any) -> str:
+    text = str(value)
+    return f"{text[:57]}..." if len(text) > 60 else text

--- a/traigent/playbook/__init__.py
+++ b/traigent/playbook/__init__.py
@@ -1,0 +1,17 @@
+"""Agent build playbook helpers."""
+
+from traigent.playbook.loader import load_playbook
+from traigent.playbook.model import STAGE_ORDER, Playbook, StageStatus
+from traigent.playbook.scaffold import scaffold_playbook
+from traigent.playbook.staleness import compute_staleness
+from traigent.playbook.validator import validate_playbook
+
+__all__ = [
+    "Playbook",
+    "STAGE_ORDER",
+    "StageStatus",
+    "compute_staleness",
+    "load_playbook",
+    "scaffold_playbook",
+    "validate_playbook",
+]

--- a/traigent/playbook/loader.py
+++ b/traigent/playbook/loader.py
@@ -1,0 +1,89 @@
+"""Load agent build playbooks from YAML."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from traigent.playbook.model import Playbook, Stage, StageStatus
+
+DEFAULT_PLAYBOOK_FILENAME = "traigent.playbook.yaml"
+
+
+def load_playbook(path: str | Path) -> Playbook:
+    """Load a playbook YAML file into a parsed ``Playbook``."""
+    payload = _load_yaml_mapping(path)
+    return _playbook_from_mapping(payload)
+
+
+def _load_yaml_mapping(path: str | Path) -> dict[str, Any]:
+    playbook_path = Path(path)
+    if not playbook_path.exists():
+        raise FileNotFoundError(f"agent build playbook not found: {playbook_path}")
+
+    with playbook_path.open(encoding="utf-8") as playbook_file:
+        payload = yaml.safe_load(playbook_file)
+
+    if not isinstance(payload, dict):
+        raise ValueError("agent build playbook YAML must be a mapping")
+    return payload
+
+
+def _playbook_from_mapping(payload: dict[str, Any]) -> Playbook:
+    stages_payload = payload.get("stages", {})
+    if not isinstance(stages_payload, dict):
+        stages_payload = {}
+
+    stages = {
+        str(stage_name): _stage_from_mapping(stage_payload)
+        for stage_name, stage_payload in stages_payload.items()
+        if isinstance(stage_payload, dict)
+    }
+    agent = payload.get("agent", {})
+    provenance = payload.get("provenance")
+    return Playbook(
+        playbook_version=str(payload.get("playbook_version", "")),
+        agent=dict(agent) if isinstance(agent, dict) else {},
+        stages=stages,
+        provenance=dict(provenance) if isinstance(provenance, dict) else None,
+        raw=payload,
+    )
+
+
+def _stage_from_mapping(payload: dict[str, Any]) -> Stage:
+    return Stage(
+        status=StageStatus(payload.get("status", StageStatus.PENDING.value)),
+        pinned_at=_parse_datetime_value(payload.get("pinned_at")),
+        deprecation_reason=_optional_string(payload.get("deprecation_reason")),
+        pin=dict(payload["pin"]) if isinstance(payload.get("pin"), dict) else None,
+    )
+
+
+def _parse_datetime_value(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not _has_datetime_separator(text):
+            raise ValueError("pinned_at must be an ISO datetime string")
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        return datetime.fromisoformat(text)
+    raise ValueError(
+        f"pinned_at must be an ISO datetime string, got {type(value).__name__}"
+    )
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _has_datetime_separator(value: str) -> bool:
+    return "T" in value or " " in value

--- a/traigent/playbook/model.py
+++ b/traigent/playbook/model.py
@@ -1,0 +1,41 @@
+"""Dataclasses for the agent build playbook."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+
+class StageStatus(StrEnum):
+    """Lifecycle states for an agent build playbook stage."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    PINNED = "pinned"
+    DEPRECATED = "deprecated"
+
+
+STAGE_ORDER = ("dataset", "metric", "evaluator", "optimize", "gate")
+
+
+@dataclass
+class Stage:
+    """Parsed representation of a single playbook stage."""
+
+    status: StageStatus
+    pinned_at: datetime | None = None
+    deprecation_reason: str | None = None
+    pin: dict[str, Any] | None = None
+
+
+@dataclass
+class Playbook:
+    """Parsed agent build playbook plus the original mapping."""
+
+    playbook_version: str
+    agent: dict[str, Any]
+    stages: dict[str, Stage]
+    provenance: dict[str, Any] | None
+    raw: dict[str, Any]

--- a/traigent/playbook/scaffold.py
+++ b/traigent/playbook/scaffold.py
@@ -1,0 +1,56 @@
+"""Scaffold initial agent build playbooks."""
+
+from __future__ import annotations
+
+import json
+
+from traigent.playbook.model import STAGE_ORDER
+
+_STAGE_HINTS = {
+    "dataset": "Pin an evaluation dataset with dataset_ref, revision, and optional holdout_ref.",
+    "metric": "Pin a metric with metric_name, measure_type, and metric_output_type.",
+    "evaluator": "Pin evaluator wiring with evaluator_ref, evaluation_method, and audit_ref.",
+    "optimize": "Pin objectives plus the configuration_space_ref or last_run_id used for tuning.",
+    "gate": "Pin baseline_artifact plus budgets and policy thresholds for promotion decisions.",
+}
+
+
+def scaffold_playbook(
+    name: str,
+    agent_type: str | None = None,
+    entrypoint: str | None = None,
+) -> str:
+    """Render an initial YAML agent build playbook."""
+    lines = [
+        "# Agent build playbook for durable lifecycle state.",
+        'playbook_version: "1.0.0"',
+        "agent:",
+        f"  name: {_yaml_string(name)}",
+    ]
+    if entrypoint:
+        lines.append(f"  entrypoint: {_yaml_string(entrypoint)}")
+    if agent_type:
+        lines.append(f"  agent_type: {_yaml_string(agent_type)}")
+
+    lines.append("stages:")
+    for stage_name in STAGE_ORDER:
+        lines.extend(
+            [
+                f"  # {_STAGE_HINTS[stage_name]}",
+                f"  {stage_name}:",
+                "    status: pending",
+            ]
+        )
+
+    lines.extend(
+        [
+            "provenance:",
+            '  created_by: "traigent playbook init"',
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _yaml_string(value: str) -> str:
+    return json.dumps(str(value))

--- a/traigent/playbook/schemas/agent_playbook_schema.json
+++ b/traigent/playbook/schemas/agent_playbook_schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.traigent.ai/lifecycle/agent_playbook_schema.json",
+  "title": "AgentPlaybook",
+  "description": "Agent build playbook (traigent.playbook.yaml): a versioned lifecycle artifact in the user's repo pinning each agent-build stage (dataset, metric, evaluator, optimize, gate). Lifecycle states per stage: pending -> in_progress -> pinned; deprecated requires deprecation_reason. 'stale' is COMPUTED by tooling (an earlier stage re-pinned after a later one was pinned), never stored. Optimization runs record a playbook snapshot hash; in-flight runs stay locked to their snapshot. Semantic rule enforced by tooling, not this schema: status=pinned implies pin is present.",
+  "type": "object",
+  "required": ["playbook_version", "agent", "stages"],
+  "additionalProperties": false,
+  "properties": {
+    "playbook_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver of this playbook instance; bump on meaningful edits."
+    },
+    "agent": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "entrypoint": {"type": "string", "description": "module:function or file path of the callable under optimization"},
+        "agent_type": {"type": "string", "description": "Recommendation-catalog vocabulary, e.g. code_gen | rag | general"}
+      }
+    },
+    "stages": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dataset", "metric", "evaluator", "optimize", "gate"],
+      "properties": {
+        "dataset": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": {"$ref": "#/definitions/stage_status"},
+            "pinned_at": {"type": "string", "format": "date-time"},
+            "deprecation_reason": {"type": "string"},
+            "pin": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["dataset_ref"],
+              "properties": {
+                "dataset_ref": {"type": "string", "minLength": 1, "description": "Local path or traigent:// dataset reference"},
+                "revision": {"type": "integer", "minimum": 1},
+                "holdout_ref": {"type": "string", "description": "Held-out split never used for tuning claims"}
+              }
+            }
+          }
+        },
+        "metric": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": {"$ref": "#/definitions/stage_status"},
+            "pinned_at": {"type": "string", "format": "date-time"},
+            "deprecation_reason": {"type": "string"},
+            "pin": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["metric_name"],
+              "properties": {
+                "measure_type": {"type": "string", "enum": ["sanity_check", "accuracy", "quality", "latency", "safety", "efficiency", "reliability"]},
+                "metric_name": {"type": "string", "minLength": 1},
+                "metric_output_type": {"type": "string", "enum": ["binary", "discrete", "continuous", "ranking"]}
+              }
+            }
+          }
+        },
+        "evaluator": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": {"$ref": "#/definitions/stage_status"},
+            "pinned_at": {"type": "string", "format": "date-time"},
+            "deprecation_reason": {"type": "string"},
+            "pin": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["evaluator_ref"],
+              "properties": {
+                "evaluation_method": {"type": "string", "enum": ["deterministic", "llm_based", "statistical", "hybrid"]},
+                "evaluator_ref": {"type": "string", "minLength": 1, "description": "module:symbol of the evaluator / metric_functions / custom_evaluator wiring"},
+                "audit_ref": {"type": "string", "description": "Pointer to the evaluator audit evidence (e.g. tests or report path)"}
+              }
+            }
+          }
+        },
+        "optimize": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": {"$ref": "#/definitions/stage_status"},
+            "pinned_at": {"type": "string", "format": "date-time"},
+            "deprecation_reason": {"type": "string"},
+            "pin": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["objectives"],
+              "properties": {
+                "configuration_space_ref": {"type": "string", "description": "module:symbol or file holding the configuration space"},
+                "objectives": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+                "last_run_id": {"type": "string"}
+              }
+            }
+          }
+        },
+        "gate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status"],
+          "properties": {
+            "status": {"$ref": "#/definitions/stage_status"},
+            "pinned_at": {"type": "string", "format": "date-time"},
+            "deprecation_reason": {"type": "string"},
+            "pin": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["baseline_artifact"],
+              "properties": {
+                "baseline_artifact": {"type": "string", "description": "Path to the pinned incumbent baseline, e.g. .traigent/baseline.json"},
+                "budgets": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "max_cost_per_run": {"type": "number", "exclusiveMinimum": 0},
+                    "max_latency_p95_ms": {"type": "number", "exclusiveMinimum": 0}
+                  }
+                },
+                "policy": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "alpha": {"type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1},
+                    "min_effect": {"type": "number", "minimum": 0}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "created_by": {"type": "string"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "recommendations_used": {"type": "array", "items": {"type": "string"}, "description": "Catalog entry_ids that informed pins"}
+      }
+    }
+  },
+  "definitions": {
+    "stage_status": {
+      "type": "string",
+      "enum": ["pending", "in_progress", "pinned", "deprecated"]
+    }
+  }
+}

--- a/traigent/playbook/staleness.py
+++ b/traigent/playbook/staleness.py
@@ -1,0 +1,37 @@
+"""Computed staleness for agent build playbooks."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from traigent.playbook.model import STAGE_ORDER, Playbook, StageStatus
+
+
+def compute_staleness(playbook: Playbook) -> dict[str, bool]:
+    """Return computed staleness by stage.
+
+    Stage S is stale iff some earlier stage in ``STAGE_ORDER`` is pinned and has
+    ``pinned_at`` strictly later than S's ``pinned_at``. A comparison is made only
+    when both stages are pinned and both timestamps exist; missing timestamps and
+    non-pinned stages are not stale.
+    """
+    stale_by_stage: dict[str, bool] = {}
+    earlier_pinned_timestamps: list[datetime] = []
+
+    for stage_name in STAGE_ORDER:
+        stage = playbook.stages.get(stage_name)
+        if (
+            stage is None
+            or stage.status is not StageStatus.PINNED
+            or stage.pinned_at is None
+        ):
+            stale_by_stage[stage_name] = False
+            continue
+
+        stale_by_stage[stage_name] = any(
+            earlier_pinned_at > stage.pinned_at
+            for earlier_pinned_at in earlier_pinned_timestamps
+        )
+        earlier_pinned_timestamps.append(stage.pinned_at)
+
+    return stale_by_stage

--- a/traigent/playbook/validator.py
+++ b/traigent/playbook/validator.py
@@ -1,0 +1,130 @@
+"""Validation for agent build playbooks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft7Validator
+
+from traigent.playbook.model import Playbook
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parent / "schemas" / "agent_playbook_schema.json"
+)
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A validation issue with a JSON-path-ish location."""
+
+    location: str
+    message: str
+
+
+def validate_playbook(
+    playbook_or_dict: Playbook | dict[str, Any],
+) -> list[ValidationIssue]:
+    """Return all schema and semantic validation issues for a playbook."""
+    payload = _as_payload(playbook_or_dict)
+    issues = _schema_issues(payload)
+    if isinstance(payload, dict):
+        issues.extend(_semantic_issues(payload))
+    return issues
+
+
+def _as_payload(playbook_or_dict: Playbook | dict[str, Any]) -> Any:
+    if isinstance(playbook_or_dict, Playbook):
+        return playbook_or_dict.raw
+    return playbook_or_dict
+
+
+def _schema_issues(payload: Any) -> list[ValidationIssue]:
+    validator = Draft7Validator(_load_schema())
+    return [
+        ValidationIssue(location=_json_path(error.path), message=error.message)
+        for error in sorted(
+            validator.iter_errors(payload), key=lambda item: list(item.path)
+        )
+    ]
+
+
+def _semantic_issues(payload: dict[str, Any]) -> list[ValidationIssue]:
+    stages = payload.get("stages")
+    if not isinstance(stages, dict):
+        return []
+
+    issues: list[ValidationIssue] = []
+    for stage_name, stage in stages.items():
+        if not isinstance(stage, dict):
+            continue
+
+        location = f"$.stages.{stage_name}"
+        status = stage.get("status")
+        if status == "pinned" and "pin" not in stage:
+            issues.append(
+                ValidationIssue(
+                    location=location,
+                    message="pinned stages must include pin",
+                )
+            )
+        if (
+            status == "deprecated"
+            and not str(stage.get("deprecation_reason", "")).strip()
+        ):
+            issues.append(
+                ValidationIssue(
+                    location=location,
+                    message="deprecated stages must include deprecation_reason",
+                )
+            )
+        if "pinned_at" in stage and not _is_parseable_datetime(stage.get("pinned_at")):
+            issues.append(
+                ValidationIssue(
+                    location=f"{location}.pinned_at",
+                    message="pinned_at must be a parseable ISO datetime",
+                )
+            )
+    return issues
+
+
+def _load_schema() -> dict[str, Any]:
+    with _SCHEMA_PATH.open(encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+    if not isinstance(schema, dict):
+        raise ValueError("agent build playbook schema must be a JSON object")
+    return schema
+
+
+def _json_path(parts: Any) -> str:
+    path = "$"
+    for part in parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+        else:
+            path += f".{part}"
+    return path
+
+
+def _is_parseable_datetime(value: Any) -> bool:
+    if isinstance(value, datetime):
+        return True
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text or not _has_datetime_separator(text):
+        return False
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        datetime.fromisoformat(text)
+    except ValueError:
+        return False
+    return True
+
+
+def _has_datetime_separator(value: str) -> bool:
+    return "T" in value or " " in value


### PR DESCRIPTION
## Summary

PR-E of the **agent-build lifecycle** program: the `traigent.playbook` module + `traigent playbook` CLI — a small, versioned YAML artifact (`traigent.playbook.yaml`) that lives in the *user's* repo and pins each agent-build stage (dataset → metric → evaluator → optimize → gate) with explicit lifecycle states. It gives coding agents durable, diffable, cross-session lifecycle state and is the future home for CI baselines/budgets (`traigent ci`, next wave).

- `traigent/playbook/` — `Playbook`/`StageStatus`/`STAGE_ORDER` model, YAML loader, JSON-Schema + semantic validator (pinned ⇒ pin present; deprecated ⇒ reason present), computed staleness (an earlier stage re-pinned after a later one ⇒ later stage stale; **never stored**), commented scaffold.
- `traigent/playbook/schemas/agent_playbook_schema.json` — vendored copy of the canonical schema (byte-identical to the contract added to TraigentSchema in Traigent/TraigentSchema#120; sha256 verified). Stage states: `pending → in_progress → pinned`, explicit `deprecated` with reason.
- `traigent playbook init | validate | status` — scaffold (all stages `pending`, refuses overwrite), full validation (exit 1 on issues), rich status table with computed staleness. Registered in `cli/main.py` via the existing late-import pattern.
- Package-data entry for `playbook/schemas/*.json` (+ existing `MANIFEST.in` JSON rule covers sdists); `importlib.resources` resolution verified.

Design notes: snapshot semantics (runs will record a playbook snapshot hash — next wave), no auto-deprecation, no TVL coupling in v1 (a later `compile --to-tvl` bridge is planned and nothing here blocks it).

## Tests

- `tests/unit/playbook/` + `tests/cli/test_playbook_commands.py`: 11 new tests (loader round-trip, scaffold→validate zero-issue round-trip, schema + semantic violations, staleness rules, CLI init/refusal/validate/status).
- Full `tests/cli` + `tests/unit/playbook`: **60 passed** (no CLI regressions); ruff format + check clean on all new files.
- Captain re-verification: live `init → validate → status → re-init refusal` round-trip exercised end-to-end.

## PR checklist

1. **Worst-case prod path** — local-only tooling; no network, no auth, no billing. Worst case is a malformed playbook file, which `validate` reports and `status` fails loudly on.
2. **Production-branch test** — n/a (no policy surface); fail-closed behavior covered by validator/CLI tests.
3. **Contract regeneration** — schema contract added in TraigentSchema#120; this PR vendors the byte-identical copy. JS parity tracked as program debt item.
4. **Public surface delta** — new `traigent.playbook` module + `traigent playbook` CLI group (documented in module docstrings); no changes to existing surface.
5. **Review threads** — will be resolved before merge.
6. **Quality gates** — none relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
