### PR TITLE
security: enable CodeQL security-extended query suite

### DIFF
--- a/.github/workflows/release-review.yml
+++ b/.github/workflows/release-review.yml
@@ -241,6 +241,10 @@ jobs:
         uses: github/codeql-action/init@v4.36.0
         with:
           languages: python
+          # security-extended adds CodeQL's deeper data-flow/taint queries on
+          # top of the default suite (CWE-532 sensitive-data-in-logs, injection,
+          # SSRF, cleartext storage). Alerts surface in the Security tab.
+          queries: security-extended
       - name: Perform CodeQL analysis
         id: codeql_analyze
         continue-on-error: true


### PR DESCRIPTION
Adds `queries: security-extended` to the CodeQL init in `release-review.yml` — CodeQL's deeper data-flow/taint queries (sensitive-data-in-logs, injection, SSRF, cleartext storage) on top of the default suite. Alerts land in Security → Code scanning, not a blocking gate. Parity with TraigentBackend #993, part of the 2026-06-12 client data-flow inventory rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)