### PR TITLE
fix(sdk): address initial issue batch

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1080,15 +1080,6 @@
         "line_number": 43
       }
     ],
-    "tests/unit/utils/test_local_analytics.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/unit/utils/test_local_analytics.py",
-        "hashed_secret": "035bf17d591b5967aafe1700f7e7d0bf0f7d6bf3",
-        "is_verified": false,
-        "line_number": 457
-      }
-    ],
     "tests/unit/utils/test_reproducibility.py": [
       {
         "type": "Hex High Entropy String",
@@ -1231,5 +1222,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-09T19:22:18Z"
+  "generated_at": "2026-06-12T22:02:05Z"
 }

--- a/tests/test_analytics_integration.py
+++ b/tests/test_analytics_integration.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from traigent._version import get_version
 from traigent.config import TraigentConfig
 from traigent.utils.local_analytics import LocalAnalytics
 
@@ -51,7 +52,7 @@ async def test_analytics_submission():
         "avg_improvement_percent": 25.5,
         "sessions_last_30_days": 5,
         "days_since_first_use": 7,
-        "sdk_version": "1.1.0",
+        "sdk_version": get_version(),
         "execution_mode": "edge_analytics",
         "timestamp": datetime.now().isoformat(),
         "anonymous_user_id": "test-user-123",
@@ -162,9 +163,8 @@ async def test_analytics_submission():
 
     assert incentive_data is not None, "Failed to generate cloud incentive data"
     assert "usage_summary" in incentive_data, "Missing usage_summary in incentive data"
-    assert (
-        "cloud_benefits" in incentive_data
-    ), "Missing cloud_benefits in incentive data"
+    has_cloud_benefits = "cloud_benefits" in incentive_data
+    assert has_cloud_benefits, "Missing cloud_benefits in incentive data"
 
     logger.info("✅ Cloud incentive data generated:")
     logger.info(
@@ -220,9 +220,10 @@ async def test_privacy_mode():
 
     # At least some basic aggregated fields should be present or empty if no sessions exist
     if stats:  # Only check if there are stats
-        assert (
+        has_session_statistics = (
             "total_sessions" in stats or "completed_sessions" in stats
-        ), "No basic session statistics found"
+        )
+        assert has_session_statistics, "No basic session statistics found"
         logger.info("✅ Basic session statistics found when data exists")
     else:
         logger.info("✅ No stats returned when no sessions exist (expected behavior)")

--- a/tests/unit/cli/test_detect_tvars_command.py
+++ b/tests/unit/cli/test_detect_tvars_command.py
@@ -153,9 +153,8 @@ class TestJsonOutput:
             "detection_source",
         }
         for entry in data:
-            assert required.issubset(
-                entry.keys()
-            ), f"Missing keys: {required - entry.keys()}"
+            missing_keys = required - entry.keys()
+            assert not missing_keys, f"Missing keys: {missing_keys}"
 
     def test_json_has_suggested_range(
         self, runner: CliRunner, agent_file: Path
@@ -240,6 +239,18 @@ class TestEdgeCases:
         assert result.exit_code == 0
         data = json.loads(result.output)
         assert data == []
+
+    def test_non_utf8_file_reports_clean_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "bad.py"
+        p.write_bytes(b"\xff\xfe bad")
+
+        result = runner.invoke(detect_tvars, [str(p)])
+
+        assert result.exit_code == 1
+        assert "Could not read" in result.output
+        assert "Traceback" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_generate_config_command.py
+++ b/tests/unit/cli/test_generate_config_command.py
@@ -135,7 +135,9 @@ class TestGenerateConfigCLI:
             return_value=_make_result(),
         ):
             runner = CliRunner()
-            result = runner.invoke(generate_config, [str(source_file), "--json-detailed"])
+            result = runner.invoke(
+                generate_config, [str(source_file), "--json-detailed"]
+            )
             assert result.exit_code == 0
             data = json.loads(result.output)
             detailed = data["recommendations"][0]
@@ -245,6 +247,26 @@ class TestGenerateConfigCLI:
 
         with pytest.raises(ValueError, match="outside the allowed base directory"):
             _output_tvl(_make_result(), source_file)
+
+    def test_tvl_output_outside_base_reports_clean_cli_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        safe_dir = tmp_path / "safe"
+        safe_dir.mkdir()
+        source_file = tmp_path / "agent.py"
+        source_file.write_text(SAMPLE_SOURCE)
+        monkeypatch.chdir(safe_dir)
+
+        with patch(
+            "traigent.config_generator.generate_config",
+            return_value=_make_result(),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(generate_config, [str(source_file), "-o", "tvl"])
+
+        assert result.exit_code == 1
+        assert "outside the allowed base directory" in result.output
+        assert "Traceback" not in result.output
 
     def test_apply_decorator(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/cloud/test_backend_bridges.py
+++ b/tests/unit/cloud/test_backend_bridges.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import pytest
 
+from traigent._version import get_version
 from traigent.cloud.backend_bridges import (
     BackendConfigurationRunRequest,
     BackendExperimentRequest,
@@ -324,6 +325,7 @@ class TestSDKBackendBridge:
         assert "trial_id" in config_run.trial_metadata
         assert "mapping_created_at" in config_run.trial_metadata
         assert config_run.trial_metadata["trial_id"] == trial_suggestion.trial_id
+        assert exp_params["traigent_metadata"]["sdk_version"] == get_version()
 
     def test_agent_specification_to_backend(self, sdk_bridge, agent_specification):
         """Test converting agent specification to backend format."""

--- a/tests/unit/config/test_backend_config_stored_creds.py
+++ b/tests/unit/config/test_backend_config_stored_creds.py
@@ -386,8 +386,10 @@ class TestCliAuthPayload:
             patch.object(
                 TraigentAuthCLI,
                 "__init__",
-                lambda self: setattr(self, "backend_api_url", "http://test/api/v1")
-                or setattr(self, "backend_url", "http://test"),
+                lambda self: (
+                    setattr(self, "backend_api_url", "http://test/api/v1")
+                    or setattr(self, "backend_url", "http://test")
+                ),
             ),
         ):
             cli = object.__new__(TraigentAuthCLI)
@@ -603,3 +605,19 @@ class TestCentralizedCredentialHints:
             SIGNUP_URL in record.message and record.levelno == logging.DEBUG
             for record in caplog.records
         ), f"Expected {SIGNUP_URL!r} in debug messages: {caplog.messages}"
+
+    def test_get_api_key_happy_path_does_not_log_key_length(self, caplog):
+        import logging
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_API_KEY": "tg_test_key"},  # pragma: allowlist secret
+                clear=True,
+            ),
+            caplog.at_level(logging.INFO, logger="traigent.config.backend_config"),
+        ):
+            assert BackendConfig.get_api_key() == "tg_test_key"
+
+        assert "length" not in caplog.text
+        assert "TRAIGENT_API_KEY" not in caplog.text

--- a/tests/unit/core/test_ci_approval.py
+++ b/tests/unit/core/test_ci_approval.py
@@ -144,9 +144,13 @@ class TestValidateLegacyToken:
     def test_z_suffix_handled(self) -> None:
         # Z suffix gets replaced with +00:00, producing a tz-aware datetime
         # Code then uses datetime.now().replace(tzinfo=UTC) — use large delta to be safe
-        future = (datetime.now(UTC) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        future = (datetime.now(UTC) + timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
         token = {"approved_by": "tester", "expires_at": future}
         assert _validate_legacy_token(token) is True
+
+    def test_far_future_unsigned_token_rejected(self) -> None:
+        token = {"approved_by": "tester", "expires_at": "9999-12-31T23:59:59"}
+        assert _validate_legacy_token(token) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_license.py
+++ b/tests/unit/core/test_license.py
@@ -374,7 +374,8 @@ class TestLicenseValidatorInit:
     def test_init_with_api_key_env(self):
         """Test initialization falls back to TRAIGENT_API_KEY env var."""
         with patch.dict(
-            os.environ, {"TRAIGENT_API_KEY": "env-key-456"}  # pragma: allowlist secret
+            os.environ,
+            {"TRAIGENT_API_KEY": "env-key-456"},  # pragma: allowlist secret
         ):
             validator = LicenseValidator()
             assert validator._api_key == "env-key-456"  # pragma: allowlist secret
@@ -382,7 +383,8 @@ class TestLicenseValidatorInit:
     def test_init_explicit_api_key_overrides_env(self):
         """Test explicit api_key takes precedence over env var."""
         with patch.dict(
-            os.environ, {"TRAIGENT_API_KEY": "env-key"}  # pragma: allowlist secret
+            os.environ,
+            {"TRAIGENT_API_KEY": "env-key"},  # pragma: allowlist secret
         ):
             validator = LicenseValidator(
                 api_key="explicit-key"  # pragma: allowlist secret
@@ -397,6 +399,13 @@ class TestLicenseValidatorInit:
     def test_init_offline_mode_env(self):
         """Test initialization reads TRAIGENT_OFFLINE_MODE env var."""
         with patch.dict(os.environ, {"TRAIGENT_OFFLINE_MODE": "true"}):
+            validator = LicenseValidator()
+            assert validator._offline_mode is True
+
+    @pytest.mark.parametrize("raw_value", ["1", "yes", "on", " TRUE "])
+    def test_init_offline_mode_env_accepts_truthy_values(self, raw_value):
+        """Test initialization uses shared truthy parsing for offline mode."""
+        with patch.dict(os.environ, {"TRAIGENT_OFFLINE_MODE": raw_value}):
             validator = LicenseValidator()
             assert validator._offline_mode is True
 
@@ -1354,7 +1363,7 @@ class TestValidateSync:
             return expected
 
         with patch("asyncio.get_running_loop", side_effect=RuntimeError("no loop")):
-            with patch("asyncio.run", side_effect=_run_stub) as mock_run:
+            with patch("asyncio.run", side_effect=_run_stub):
                 result = validator.validate_sync()
 
         assert result is expected
@@ -1808,9 +1817,7 @@ class TestEnvLicenseFileBoundary:
             .rstrip("=")
         )
         body = (
-            base64.urlsafe_b64encode(json.dumps(payload).encode())
-            .decode()
-            .rstrip("=")
+            base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
         )
         sig = base64.urlsafe_b64encode(b"sig").decode().rstrip("=")
         token = f"{header}.{body}.{sig}"
@@ -1893,9 +1900,7 @@ class TestEnvLicenseFileBoundary:
         assert result is not None
         assert result.tier == LicenseTier.PRO
 
-    def test_env_path_rejection_does_not_log_file_contents(
-        self, tmp_path, caplog
-    ):
+    def test_env_path_rejection_does_not_log_file_contents(self, tmp_path, caplog):
         """The rejection log must NOT echo the file's contents.
 
         A file pointed at by ``TRAIGENT_LICENSE_FILE`` is potentially a

--- a/tests/unit/integrations/observability/test_workflow_traces.py
+++ b/tests/unit/integrations/observability/test_workflow_traces.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from traigent._version import get_version
 from traigent.config.backend_config import DEFAULT_CLOUD_URL
 from traigent.integrations.observability import workflow_traces as wt_module
 from traigent.integrations.observability.workflow_traces import (
@@ -346,6 +347,20 @@ class TestWorkflowGraphPayload:
         assert len(result["nodes"]) == 3
         assert len(result["edges"]) == 3
         assert result["sdk_version"] == "1.0.0"
+
+    def test_to_dict_defaults_sdk_version_from_resolver(
+        self, sample_nodes: list[WorkflowNode], sample_edges: list[WorkflowEdge]
+    ) -> None:
+        """Test default graph payload SDK version uses package metadata."""
+        graph = WorkflowGraphPayload(
+            experiment_id="exp_123",
+            nodes=sample_nodes,
+            edges=sample_edges,
+        )
+
+        result = graph.to_dict()
+
+        assert result["sdk_version"] == get_version()
 
     def test_compute_hash_deterministic(
         self, sample_nodes: list[WorkflowNode], sample_edges: list[WorkflowEdge]

--- a/tests/unit/observability/test_agent_spans.py
+++ b/tests/unit/observability/test_agent_spans.py
@@ -136,6 +136,21 @@ def test_add_agent_span_outside_trial_is_debug_noop(
     assert "no active optimization trial context" in caplog.text
 
 
+def test_add_agent_span_collection_failure_logs_warning(caplog: Any) -> None:
+    manager = _manager()
+
+    def fail_collect(_: Any) -> None:
+        raise RuntimeError("collector down")
+
+    manager.collect_span = fail_collect  # type: ignore[method-assign]
+
+    with _active_trial(manager), caplog.at_level(logging.WARNING):
+        add_agent_span("planner", input_tokens=1)
+
+    assert "Failed to collect agent workflow span" in caplog.text
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+
 def test_add_agent_span_drops_text_metadata() -> None:
     manager = _manager()
 

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -69,7 +69,7 @@ def test_version_package_metadata_path():
 
 
 def test_version_package_metadata_not_found():
-    """Test fallback when package metadata is not found."""
+    """Test loud failure when package metadata is not found."""
     import importlib
     import importlib.metadata
 
@@ -82,10 +82,8 @@ def test_version_package_metadata_not_found():
                 "importlib.metadata.version",
                 side_effect=importlib.metadata.PackageNotFoundError("traigent"),
             ):
-                importlib.reload(version_module)
-                result = version_module.get_version()
-                # Should fall back to hardcoded version
-                assert result == version_module._FALLBACK_VERSION
+                with pytest.raises(RuntimeError, match="Unable to resolve"):
+                    importlib.reload(version_module)
 
     # Clean up
     if "TRAIGENT_USE_PACKAGE_METADATA" in os.environ:
@@ -104,6 +102,7 @@ def test_get_version_info():
     assert "patch" in info
     # Verify version info is consistent with get_version()
     from traigent._version import get_version
+
     expected_parts = get_version().split(".")
     assert info["major"] == expected_parts[0]
     assert info["minor"] == expected_parts[1]

--- a/tests/unit/utils/test_env_config.py
+++ b/tests/unit/utils/test_env_config.py
@@ -188,3 +188,10 @@ def test_is_strict_cost_accounting(monkeypatch, raw_value, expected):
     """Strict cost accounting flag should parse bool-like env values."""
     monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", raw_value)
     assert env_config.is_strict_cost_accounting() is expected
+
+
+@pytest.mark.parametrize("raw_value", ["true", "1", "yes", "on", " TRUE "])
+def test_backend_offline_accepts_standard_truthy_values(monkeypatch, raw_value):
+    """Offline mode should honor the standard truthy env vocabulary."""
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", raw_value)
+    assert env_config.is_backend_offline() is True

--- a/tests/unit/utils/test_local_analytics.py
+++ b/tests/unit/utils/test_local_analytics.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 import pytest
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationStatus
 from traigent.config.backend_config import DEFAULT_CLOUD_URL
 from traigent.config.types import ExecutionMode, TraigentConfig
@@ -419,7 +420,7 @@ class TestCollectUsageStats:
             stats = analytics_instance.collect_usage_stats()
 
             assert "sdk_version" in stats
-            assert stats["sdk_version"] == "1.1.0"
+            assert stats["sdk_version"] == get_version()
 
     def test_collect_usage_stats_includes_execution_mode(
         self, analytics_instance: LocalAnalytics

--- a/tests/utils/test_local_analytics.py
+++ b/tests/utils/test_local_analytics.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from traigent._version import get_version
 from traigent.config.types import ExecutionMode, TraigentConfig
 from traigent.storage.local_storage import LocalStorageManager
 from traigent.utils.local_analytics import (
@@ -121,7 +122,7 @@ class TestLocalAnalytics:
         assert stats["avg_improvement_percent"] is None
         assert stats["sessions_last_30_days"] == 0
         assert stats["days_since_first_use"] == 0
-        assert stats["sdk_version"] == "1.1.0"
+        assert stats["sdk_version"] == get_version()
         assert stats["execution_mode"] == ExecutionMode.EDGE_ANALYTICS.value
         assert stats["anonymous_user_id"] == self.analytics.user_id
         assert "timestamp" in stats
@@ -611,7 +612,8 @@ class TestAnalyticsIntegration:
         """Test analytics error handling with corrupted data."""
         # Create session manually with invalid data to test error handling
         self.storage.create_session(
-            function_name="test_function", optimization_config=None  # Invalid config
+            function_name="test_function",
+            optimization_config=None,  # Invalid config
         )
 
         # Analytics should handle this gracefully

--- a/traigent/_version.py
+++ b/traigent/_version.py
@@ -10,8 +10,6 @@ import importlib.metadata
 import os
 from pathlib import Path
 
-_FALLBACK_VERSION = "0.12.0"
-
 
 def _read_pyproject_version() -> str | None:
     """Read version from pyproject.toml without external dependencies."""
@@ -43,10 +41,15 @@ def get_version() -> str:
     1. TRAIGENT_FORCE_VERSION env var (override for testing)
     2. pyproject.toml (development mode - single source of truth)
     3. Installed package metadata (pip-installed mode)
-    4. Hardcoded fallback
+    4. Loud failure if neither source is available
 
     Returns:
         Version string
+
+    Raises:
+        RuntimeError: If neither pyproject.toml nor installed package metadata
+            can provide a version. Returning a hand-maintained fallback risks
+            silently reporting a stale SDK version.
     """
     if override := os.getenv("TRAIGENT_FORCE_VERSION"):
         return override
@@ -60,9 +63,15 @@ def get_version() -> str:
     try:
         return importlib.metadata.version("traigent")
     except importlib.metadata.PackageNotFoundError:
-        pass
+        raise RuntimeError(
+            "Unable to resolve Traigent SDK version from pyproject.toml or "
+            "installed package metadata"
+        ) from None
 
-    return _FALLBACK_VERSION
+    raise RuntimeError(
+        "Unable to resolve Traigent SDK version from pyproject.toml or "
+        "installed package metadata"
+    )
 
 
 def get_version_info() -> dict[str, str]:

--- a/traigent/cli/detect_tvars_command.py
+++ b/traigent/cli/detect_tvars_command.py
@@ -38,6 +38,27 @@ from traigent.tuned_variables.detector import TunedVariableDetector
 console = Console()
 stderr = Console(stderr=True)
 
+
+def _detect_from_file(
+    detector: TunedVariableDetector,
+    path: Path,
+    function_name: str | None,
+    *,
+    strict: bool,
+) -> list[DetectionResult]:
+    try:
+        return detector.detect_from_file(path, function_name)
+    except UnicodeDecodeError:
+        message = f"Could not read {path} as UTF-8 text"
+    except OSError as exc:
+        message = f"Could not read {path}: {exc}"
+
+    if strict:
+        raise click.ClickException(message) from None
+    stderr.print(f"[yellow]Skipping {path}: {message}[/yellow]")
+    return []
+
+
 _CONFIDENCE_COLORS = {
     DetectionConfidence.HIGH: "green",
     DetectionConfidence.MEDIUM: "yellow",
@@ -93,7 +114,7 @@ def detect_tvars(
     if path.is_file():
         if path.suffix != ".py":
             raise click.ClickException(f"Expected a .py file, got: {path}")
-        results = detector.detect_from_file(path, function_name)
+        results = _detect_from_file(detector, path, function_name, strict=True)
     else:
         # Directory: scan all .py files recursively
         py_files = sorted(path.rglob("*.py"))
@@ -108,7 +129,9 @@ def detect_tvars(
                 for part in py_file.parts
             ):
                 continue
-            results.extend(detector.detect_from_file(py_file, function_name))
+            results.extend(
+                _detect_from_file(detector, py_file, function_name, strict=False)
+            )
 
     # Filter by confidence
     min_level = DetectionConfidence(min_confidence)

--- a/traigent/cli/generate_config_command.py
+++ b/traigent/cli/generate_config_command.py
@@ -168,7 +168,10 @@ def generate_config(
     elif output_format == "json-detailed":
         _output_json(result, detailed=True)
     elif output_format == "tvl":
-        _output_tvl(result, path)
+        try:
+            _output_tvl(result, path)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
     else:
         _output_table(result)
 

--- a/traigent/cloud/backend_bridges.py
+++ b/traigent/cloud/backend_bridges.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, cast
 
+from traigent._version import get_version
 from traigent.cloud.dataset_converter import (
     metadata_to_backend_tags,
     sanitize_backend_metadata,
@@ -259,7 +260,7 @@ class SDKBackendBridge:
             "traigent_metadata": {
                 "trial_id": trial.trial_id,
                 "trial_number": trial.trial_number,
-                "sdk_version": "1.1.0",
+                "sdk_version": get_version(),
                 "optimization_mode": "local_privacy",
                 "model_config": (
                     {

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -254,9 +254,7 @@ class BackendConfig:
         """
         api_key = os.environ.get("TRAIGENT_API_KEY")
         if api_key:
-            logger.info(
-                "✅ Using API key from TRAIGENT_API_KEY (length=%d)", len(api_key)
-            )
+            logger.debug("Using API key from TRAIGENT_API_KEY")
             return api_key
 
         # Fall through to CLI-stored credentials — api_key only, not JWT
@@ -265,10 +263,7 @@ class BackendConfig:
 
             stored_key = CredentialManager.get_stored_api_key_only()
             if stored_key:
-                logger.info(
-                    "✅ Using API key from stored CLI credentials (length=%d)",
-                    len(stored_key),
-                )
+                logger.debug("Using API key from stored CLI credentials")
                 return stored_key
         except Exception:
             pass

--- a/traigent/core/ci_approval.py
+++ b/traigent/core/ci_approval.py
@@ -24,6 +24,7 @@ logger = get_logger(__name__)
 
 # ISO 8601 timezone suffix for UTC (used in token validation)
 _UTC_TIMEZONE_SUFFIX = "+00:00"
+_LEGACY_TOKEN_MAX_TTL = timedelta(hours=24)
 
 
 def _is_ci_environment() -> bool:
@@ -61,7 +62,7 @@ def _sanitize_for_log(value: str, max_len: int = 50) -> str:
 
 
 def _validate_legacy_token(token_data: dict[str, Any]) -> bool:
-    """Validate a legacy format approval token."""
+    """Validate a legacy format approval token with a migration TTL cap."""
     if "approved_by" not in token_data or "expires_at" not in token_data:
         return False
     try:
@@ -71,10 +72,17 @@ def _validate_legacy_token(token_data: dict[str, Any]) -> bool:
         )
         now = datetime.now()
         if expires_at.tzinfo:
-            now = now.replace(tzinfo=UTC)
+            now = datetime.now(UTC)
+        if expires_at - now > _LEGACY_TOKEN_MAX_TTL:
+            logger.warning("Legacy CI approval token TTL exceeds 24 hours, rejecting")
+            return False
         if expires_at > now:
             safe_approver = _sanitize_for_log(token_data.get("approved_by", "unknown"))
-            logger.info("CI optimization approved by legacy token: %s", safe_approver)
+            logger.warning(
+                "CI optimization approved by unsigned legacy token for %s; "
+                "migrate to HMAC-signed approval tokens",
+                safe_approver,
+            )
             return True
     except (ValueError, KeyError):
         pass

--- a/traigent/core/license.py
+++ b/traigent/core/license.py
@@ -48,6 +48,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from traigent.utils.env_config import _is_truthy_env_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -169,7 +171,7 @@ class LicenseValidator:
         self._offline_mode = (
             offline_mode
             if offline_mode is not None
-            else os.environ.get("TRAIGENT_OFFLINE_MODE", "").lower() == "true"
+            else _is_truthy_env_value(os.environ.get("TRAIGENT_OFFLINE_MODE", ""))
         )
         # Track the path's origin: explicit caller paths are trusted and
         # may live anywhere on disk, while env-sourced paths are

--- a/traigent/integrations/observability/workflow_traces.py
+++ b/traigent/integrations/observability/workflow_traces.py
@@ -44,6 +44,7 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from traigent._version import get_version
 from traigent.config.backend_config import BackendConfig
 from traigent.utils.logging import get_logger
 
@@ -262,7 +263,7 @@ class WorkflowGraphPayload:
     edges: list[WorkflowEdge]
     loops: list[WorkflowLoop] = field(default_factory=list)
     experiment_run_id: str | None = None
-    sdk_version: str = "1.0.0"
+    sdk_version: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -272,7 +273,7 @@ class WorkflowGraphPayload:
             "nodes": [n.to_dict() for n in self.nodes],
             "edges": [e.to_dict() for e in self.edges],
             "loops": [loop.to_dict() for loop in self.loops],
-            "sdk_version": self.sdk_version,
+            "sdk_version": self.sdk_version or get_version(),
         }
         if self.experiment_run_id:
             result["experiment_run_id"] = self.experiment_run_id
@@ -1213,7 +1214,7 @@ class WorkflowTracesTracker:
         experiment_id: str,
         experiment_run_id: str,
         graph: Any,
-        sdk_version: str = "1.0.0",
+        sdk_version: str | None = None,
     ) -> str | None:
         """Extract and send a workflow graph from a LangGraph instance.
 
@@ -1237,7 +1238,7 @@ class WorkflowTracesTracker:
             nodes=nodes,
             edges=edges,
             loops=loops,
-            sdk_version=sdk_version,
+            sdk_version=sdk_version or get_version(),
         )
 
         response = self.client.ingest_traces(graph=graph_payload)
@@ -1258,7 +1259,7 @@ class WorkflowTracesTracker:
         nodes: list[dict[str, Any]],
         edges: list[dict[str, Any]],
         loops: list[dict[str, Any]] | None = None,
-        sdk_version: str = "1.0.0",
+        sdk_version: str | None = None,
     ) -> str | None:
         """Send a raw workflow graph without LangGraph extraction.
 
@@ -1306,7 +1307,7 @@ class WorkflowTracesTracker:
                 )
                 for loop in (loops or [])
             ],
-            sdk_version=sdk_version,
+            sdk_version=sdk_version or get_version(),
         )
 
         response = self.client.ingest_traces(graph=graph_payload)

--- a/traigent/observability/agent_spans.py
+++ b/traigent/observability/agent_spans.py
@@ -207,4 +207,4 @@ def add_agent_span(
         )
         workflow_trace_manager.collect_span(span)
     except Exception:
-        logger.debug("Failed to collect agent workflow span", exc_info=True)
+        logger.warning("Failed to collect agent workflow span", exc_info=True)

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -467,7 +467,7 @@ def is_backend_offline() -> bool:
     See also:
         - is_mock_llm(): Check if LLM API calls should be mocked
     """
-    return get_env_var("TRAIGENT_OFFLINE_MODE", "false").lower() == "true"
+    return _is_truthy_env_value(get_env_var("TRAIGENT_OFFLINE_MODE", "false"))
 
 
 def is_untracked_fallback_allowed() -> bool:

--- a/traigent/utils/local_analytics.py
+++ b/traigent/utils/local_analytics.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from traigent._version import get_version
 from traigent.api.types import OptimizationStatus
 from traigent.config.backend_config import DEFAULT_CLOUD_URL
 from traigent.config.types import ExecutionMode, TraigentConfig
@@ -184,7 +185,7 @@ class LocalAnalytics:
                 "sessions_last_30_days": len(recent_sessions),
                 "days_since_first_use": self._get_days_since_first_use(),
                 # Version and environment (non-sensitive)
-                "sdk_version": "1.1.0",  # Should be dynamic from version
+                "sdk_version": get_version(),
                 "execution_mode": self.config.execution_mode,
                 "timestamp": datetime.now(UTC).isoformat(),
                 # Anonymous user tracking
@@ -279,7 +280,7 @@ class LocalAnalytics:
                     search_space={
                         "type": "analytics",
                         "mode": "local_usage_stats",
-                        "version": stats.get("sdk_version", "1.1.0"),
+                        "version": stats.get("sdk_version") or get_version(),
                     },
                     optimization_config={
                         "objectives": ["track_usage"],  # Placeholder objective


### PR DESCRIPTION
## Summary

Refs #1249 #1248 #1247 #1246 #1241.

- remove stale hardcoded SDK-version fallbacks and route backend bridge, local analytics, and workflow graph metadata through the package version resolver
- make CI legacy approval tokens fail closed for long TTLs and log unsigned-token migration warnings
- avoid API-key length disclosure in happy-path credential logs and surface agent span collection failures at warning level
- make CLI file-read/path-containment failures render as Click errors instead of tracebacks
- align offline-mode parsing with the shared truthy parser across env helpers and licensing

## Production Safety

- This changes SDK metadata/logging/CLI behavior only; no database migrations or infrastructure changes.
- No quality gates were relaxed.
- Issue closure is intentionally not automatic; this PR uses `Refs` only.
- `.secrets.baseline` was updated by the detect-secrets commit hook after an obsolete baseline entry no longer matched the changed file.

## Validation

- `black --check` on touched Python files
- `isort --check-only` on touched Python files
- `ruff check` on touched Python files
- `git diff --check`
- `pytest -n 0 tests/unit/test_coverage_improvements.py tests/unit/cloud/test_backend_bridges.py tests/unit/observability/test_agent_spans.py tests/unit/config/test_backend_config_stored_creds.py tests/unit/core/test_ci_approval.py tests/unit/cli/test_detect_tvars_command.py tests/unit/cli/test_generate_config_command.py tests/unit/utils/test_env_config.py tests/unit/utils/test_local_analytics.py tests/utils/test_local_analytics.py tests/test_analytics_integration.py tests/unit/core/test_license.py tests/unit/integrations/observability/test_workflow_traces.py` (`525 passed`)
- `skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop` (`25 files scanned; no secrets or sensitive data detected`)
