### PR TITLE
fix(evaluators): harden metric attribution

### DIFF
--- a/tests/unit/evaluators/test_base.py
+++ b/tests/unit/evaluators/test_base.py
@@ -156,6 +156,38 @@ class TestDataset:
         assert dataset.size == 0
         assert dataset.name == "empty"
 
+    def test_dataset_rejects_duplicate_example_ids(self):
+        """Duplicate correlation keys would misattribute captured response metrics."""
+        examples = [
+            EvaluationExample(
+                input_data={"text": "one"},
+                expected_output="1",
+                metadata={"example_id": "same"},
+            ),
+            EvaluationExample(
+                input_data={"text": "two"},
+                expected_output="2",
+                metadata={"example_id": "same"},
+            ),
+        ]
+
+        with pytest.raises(ValidationError, match="Duplicate example_id 'same'"):
+            Dataset(examples=examples, name="duplicate-ids")
+
+    def test_dataset_rejects_explicit_id_colliding_with_fallback_id(self):
+        """Fallback and explicit example IDs share the same capture-key namespace."""
+        examples = [
+            EvaluationExample(input_data={"text": "one"}, expected_output="1"),
+            EvaluationExample(
+                input_data={"text": "two"},
+                expected_output="2",
+                metadata={"example_id": "example_0"},
+            ),
+        ]
+
+        with pytest.raises(ValidationError, match="Duplicate example_id 'example_0'"):
+            Dataset(examples=examples, name="fallback-collision")
+
     def test_dataset_creation_default_values(self):
         """Test creating Dataset with default name and description."""
         examples = [EvaluationExample({"test": "data"}, "output")]
@@ -305,6 +337,27 @@ class TestDataset:
 
         with pytest.raises(TypeError):
             dataset.add_example({"dict": "not_example"})
+
+    def test_dataset_add_example_rejects_duplicate_example_id(self):
+        """Test add_example keeps example_id correlation keys unique."""
+        dataset = Dataset(
+            [
+                EvaluationExample(
+                    {"text": "first"},
+                    "one",
+                    metadata={"example_id": "same"},
+                )
+            ]
+        )
+
+        with pytest.raises(ValidationError, match="Duplicate example_id 'same'"):
+            dataset.add_example(
+                EvaluationExample(
+                    {"text": "second"},
+                    "two",
+                    metadata={"example_id": "same"},
+                )
+            )
 
     def test_dataset_string_representation(self):
         """Test Dataset string representation."""

--- a/tests/unit/evaluators/test_local_evaluator_accuracy.py
+++ b/tests/unit/evaluators/test_local_evaluator_accuracy.py
@@ -173,8 +173,7 @@ async def test_optimize_scoring_function_called_with_prediction_expected_plain_r
     assert result.best_score == pytest.approx(0.75)
     assert len(result.trials) == 2
     assert all(
-        trial.metrics["accuracy"] == pytest.approx(0.75)
-        for trial in result.trials
+        trial.metrics["accuracy"] == pytest.approx(0.75) for trial in result.trials
     )
 
 
@@ -203,6 +202,64 @@ async def test_optimize_scoring_function_uses_unpacked_tuple_output(
     assert calls == [("YES", "YES")]
     assert result.best_score == pytest.approx(0.4)
     assert result.trials[0].metrics["accuracy"] == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_optimize_scoring_function_binds_to_custom_primary_objective(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_backend_tracking(monkeypatch)
+    calls: list[tuple[str, str]] = []
+
+    def scorer(prediction: str, expected: str) -> float:
+        calls.append((prediction, expected))
+        return 0.9 if prediction == expected else 0.0
+
+    @traigent.optimize(
+        eval_dataset=Dataset([EvaluationExample({"text": "q"}, "YES")], name="g4"),
+        objectives=["quality"],
+        configuration_space={"style": ["a", "b"]},
+        scoring_function=scorer,
+    )
+    def agent(text: str) -> str:
+        return "YES"
+
+    result = await agent.optimize(algorithm="grid", max_trials=2)
+
+    assert calls == [("YES", "YES"), ("YES", "YES")]
+    assert result.best_score == pytest.approx(0.9)
+    assert len(result.trials) == 2
+    assert all(
+        trial.metrics["quality"] == pytest.approx(0.9) for trial in result.trials
+    )
+
+
+@pytest.mark.asyncio
+async def test_optimize_dict_returning_scoring_function_merges_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_backend_tracking(monkeypatch)
+
+    def scorer(prediction: str, expected: str) -> dict[str, float]:
+        return {
+            "accuracy": 1.0 if prediction == expected else 0.0,
+            "f1": 0.5,
+        }
+
+    @traigent.optimize(
+        eval_dataset=Dataset([EvaluationExample({"text": "q"}, "YES")], name="g4"),
+        objectives=["accuracy"],
+        configuration_space={"style": ["a"]},
+        scoring_function=scorer,
+    )
+    def agent(text: str) -> str:
+        return "YES"
+
+    result = await agent.optimize(algorithm="grid", max_trials=1)
+
+    assert result.best_score == pytest.approx(1.0)
+    assert result.trials[0].metrics["accuracy"] == pytest.approx(1.0)
+    assert result.trials[0].metrics["f1"] == pytest.approx(0.5)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round3.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round3.py
@@ -115,9 +115,8 @@ async def test_local_lane_final_trial_metrics_capped_after_total_cost(
     assert len(metrics) <= TOTAL_MEASURES_CEILING
     # ALL 12 non-user (reserved) keys must survive the cap; only user keys shrink.
     present_non_user = {k for k in metrics if not k.startswith("composite_metric_")}
-    assert EXPECTED_NON_USER_KEYS <= present_non_user, (
-        f"reserved keys dropped: {EXPECTED_NON_USER_KEYS - present_non_user}"
-    )
+    missing_reserved = EXPECTED_NON_USER_KEYS - present_non_user
+    assert not missing_reserved, f"reserved keys dropped: {missing_reserved}"
     # total_cost (the post-cap writer) is present and is a reserved key, not a
     # casualty of the ceiling.
     assert "total_cost" in metrics
@@ -249,6 +248,43 @@ def test_near_miss_bad_value_logs_warning_no_unpack(
     ]
     assert len(warnings) == 1
     assert "good_key" in warnings[0].getMessage()
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), -float("inf")])
+def test_near_miss_non_finite_value_logs_warning_no_unpack(
+    bad_value: float,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-finite numeric values are rejected before aggregation."""
+    raw = ("YES", {"score": bad_value})
+    with caplog.at_level(logging.WARNING, logger="traigent.evaluators.base"):
+        output, user_metrics = SimpleScoringEvaluator._unpack_user_metrics(raw)
+
+    assert output is raw
+    assert user_metrics is None
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "not treated as" in r.getMessage().lower()
+    ]
+    assert len(warnings) == 1
+    assert "score" in warnings[0].getMessage()
+    assert "finite number" in warnings[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_non_finite_tuple_metric_does_not_reach_aggregate() -> None:
+    """NaN/Inf tuple metrics must not poison aggregate metrics."""
+
+    async def func(text: str) -> tuple[str, dict[str, float]]:
+        return "YES", {"custom_nan_metric": float("nan")}
+
+    result = await _local_evaluator().evaluate(func, {}, _two_example_dataset())
+
+    assert "custom_nan_metric" not in result.metrics
+    assert all(
+        "custom_nan_metric" not in example.metrics for example in result.example_results
+    )
 
 
 @pytest.mark.parametrize(

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -311,6 +311,8 @@ def build_metric_functions(
         target_metric = "accuracy"
     elif "score" in objectives:
         target_metric = "score"
+    elif objectives:
+        target_metric = objectives[0]
 
     if target_metric and target_metric not in effective_metric_functions:
         effective_metric_functions[target_metric] = scoring_function

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -442,6 +442,13 @@ def _coerce_dataset_example_mapping(
     return item[input_key], expected_output, metadata
 
 
+def _example_correlation_key(example: EvaluationExample, index: int) -> Any:
+    """Return the key used to correlate captured LLM responses for an example."""
+    if example.metadata:
+        return example.metadata.get("example_id", f"example_{index}")
+    return f"example_{index}"
+
+
 @dataclass
 class Dataset:
     """Dataset for evaluation."""
@@ -462,6 +469,25 @@ class Dataset:
         for i, example in enumerate(self.examples):
             if not isinstance(example, EvaluationExample):
                 raise TypeError(f"Example {i} must be an EvaluationExample instance")
+
+        seen_example_ids: dict[Any, int] = {}
+        for i, example in enumerate(self.examples):
+            example_id = _example_correlation_key(example, i)
+            try:
+                previous_index = seen_example_ids.get(example_id)
+            except TypeError as exc:
+                raise ValidationError(
+                    f"Example {i} in dataset '{self.name}' has an unhashable "
+                    f"example_id {example_id!r}; example_id values must be "
+                    "hashable and unique"
+                ) from exc
+            if previous_index is not None:
+                raise ValidationError(
+                    f"Duplicate example_id {example_id!r} in dataset "
+                    f"'{self.name}' at examples {previous_index} and {i}; "
+                    "example_id values must be unique"
+                )
+            seen_example_ids[example_id] = i
 
     @classmethod
     def from_jsonl(cls, file_path: str) -> Dataset:
@@ -530,6 +556,23 @@ class Dataset:
         """Add an example to the dataset."""
         if not isinstance(example, EvaluationExample):
             raise TypeError("Example must be an EvaluationExample instance")
+        new_index = len(self.examples)
+        new_example_id = _example_correlation_key(example, new_index)
+        try:
+            hash(new_example_id)
+            for i, existing in enumerate(self.examples):
+                if _example_correlation_key(existing, i) == new_example_id:
+                    raise ValidationError(
+                        f"Duplicate example_id {new_example_id!r} in dataset "
+                        f"'{self.name}' at examples {i} and {new_index}; "
+                        "example_id values must be unique"
+                    )
+        except TypeError as exc:
+            raise ValidationError(
+                f"Example {new_index} in dataset '{self.name}' has an "
+                f"unhashable example_id {new_example_id!r}; example_id values "
+                "must be hashable and unique"
+            ) from exc
         self.examples.append(example)
 
 
@@ -1157,7 +1200,11 @@ class BaseEvaluator(ABC):
                     USER_METRIC_KEY_PATTERN.pattern,
                 )
                 return raw, None
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+            ):
                 logger.warning(
                     "Return value %r looks like an (output, metrics) tuple but "
                     "value %r for key %r is not a finite number (got %s); the "
@@ -2251,11 +2298,7 @@ class BaseEvaluator(ABC):
         Returns:
             ExampleResult with detailed information
         """
-        example_id = (
-            example.metadata.get("example_id", f"example_{example_index}")
-            if example.metadata
-            else f"example_{example_index}"
-        )
+        example_id = _example_correlation_key(example, example_index)
         start_time = time.time()
 
         if getattr(self, "privacy_enabled", False):

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import inspect
 import math
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -15,7 +15,12 @@ if TYPE_CHECKING:
     from traigent.core.meta_types import TraigentMetadata
 
 from traigent.config.types import ExecutionMode, resolve_execution_mode
-from traigent.evaluators.base import BaseEvaluator, Dataset, EvaluationResult
+from traigent.evaluators.base import (
+    BaseEvaluator,
+    Dataset,
+    EvaluationResult,
+    _example_correlation_key,
+)
 from traigent.evaluators.metrics_tracker import (
     ExampleMetrics,
     MetricsCalculator,
@@ -433,11 +438,7 @@ class LocalEvaluator(BaseEvaluator):
         # Try correlation key (example_id)
         try:
             ex = dataset.examples[example_index]
-            ex_key = (
-                ex.metadata.get("example_id", f"example_{example_index}")
-                if ex.metadata
-                else f"example_{example_index}"
-            )
+            ex_key = _example_correlation_key(ex, example_index)
         except Exception:
             ex_key = f"example_{example_index}"
 
@@ -592,6 +593,14 @@ class LocalEvaluator(BaseEvaluator):
                 llm_payload,
                 example_index,
             )
+            if isinstance(value, Mapping):
+                for result_name, result_value in value.items():
+                    if result_value is None:
+                        continue
+                    example_metric.custom_metrics[str(result_name)] = float(
+                        result_value
+                    )
+                continue
             example_metric.custom_metrics[metric_name] = (
                 float(value) if value is not None else 0.0
             )


### PR DESCRIPTION
## Summary

Refs #1245 #1243 #1239.

- reject duplicate evaluator correlation keys during dataset construction and `add_example()` so captured response metrics cannot be silently overwritten by duplicate `example_id` values
- bind `scoring_function` to the primary objective when the user uses a custom objective name instead of only `accuracy`/`score`
- support dict-returning scoring/custom metric functions in the LocalEvaluator path by merging returned metric values
- reject NaN/+Inf/-Inf tuple-return user metrics before they reach per-example or aggregate metrics

## Production Safety

- This changes SDK evaluator validation and local metric aggregation only; no infrastructure or database changes.
- No quality gates were relaxed.
- Issue closure is intentionally not automatic; this PR uses `Refs` only.

## Validation

- `git diff --check`
- `black --check` on touched files
- `ruff format --check` on touched files
- `ruff check` on touched files
- `isort --check-only` on touched files
- `pytest -n 0 tests/unit/evaluators tests/unit/core/test_optimization_pipeline.py tests/unit/core/test_optimization_pipeline_hybrid_api.py` (`403 passed, 2 skipped`)
- post-rebase smoke: `pytest -n 0 tests/unit/evaluators/test_base.py tests/unit/evaluators/test_tuple_metrics_channel_hardening_round3.py tests/unit/evaluators/test_local_evaluator_accuracy.py tests/unit/core/test_optimization_pipeline.py tests/unit/core/test_optimization_pipeline_hybrid_api.py` (`79 passed`)
- `skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop` (`6 files scanned; no secrets or sensitive data detected`)
