### PR TITLE
fix(cli): honor user paths and strict validation

### DIFF
--- a/tests/unit/cli/test_main_cli_security.py
+++ b/tests/unit/cli/test_main_cli_security.py
@@ -1,7 +1,8 @@
-"""Security regression tests for CLI optimize command."""
+"""CLI optimize path handling regression tests."""
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from uuid import uuid4
 
@@ -10,39 +11,95 @@ from click.testing import CliRunner
 from traigent.cli.main import cli
 
 
-def test_optimize_rejects_paths_outside_workspace(tmp_path):
-    """Passing a file outside the repository workspace must fail fast."""
-    external_module = tmp_path / "malicious.py"
-    external_module.write_text("print('malicious')")
+def _write_optimizable_module(root: Path) -> Path:
+    module_path = root / f"module_{uuid4().hex}.py"
+    module_path.write_text("""
+last_kwargs = {}
+
+
+class DummyResult:
+    def __init__(self):
+        self.status = "COMPLETED"
+        trial = DummyTrial()
+        self.trials = [trial]
+        self.successful_trials = [trial]
+        self.best_config = {"param": 1}
+        self.best_score = 0.75
+        self.metadata = {"function_name": "fake_optimized_function"}
+        self.algorithm = "grid"
+        self.objectives = ["accuracy"]
+        self.preset_selection = None
+        self.success_rate = 1.0
+        self.duration = 0.01
+        self.convergence_info = {}
+
+
+class DummyTrial:
+    def __init__(self):
+        self.config = {"param": 1}
+        self.metrics = {"accuracy": 0.75}
+        self.duration = 0.01
+        self.status = "completed"
+        self.timestamp = None
+        self.metadata = {}
+
+
+async def _optimize_stub(*args, **kwargs):
+    global last_kwargs
+    last_kwargs = dict(kwargs)
+    return DummyResult()
+
+
+def fake_optimized_function():
+    return "ok"
+
+
+fake_optimized_function.optimize = _optimize_stub
+""")
+    return module_path
+
+
+def test_optimize_accepts_user_project_file_outside_package_dir(tmp_path):
+    module_path = _write_optimizable_module(tmp_path)
+    output_dir = tmp_path / "results"
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["optimize", str(external_module)])
+    result = runner.invoke(
+        cli,
+        [
+            "optimize",
+            str(module_path),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
 
-    assert result.exit_code != 0
-    assert "workspace" in result.output.lower()
+    try:
+        assert result.exit_code == 0, result.output
+        assert "Optimization Complete" in result.output
+        assert "workspace" not in result.output.lower()
+    finally:
+        sys.modules.pop("user_module", None)
 
 
-def test_optimize_rejects_output_directory_outside_workspace():
-    """--output-dir must be constrained to the repository workspace."""
-    modules_dir = Path(__file__).resolve().parent / "temp_modules"
-    modules_dir.mkdir(exist_ok=True)
-    module_path = modules_dir / f"module_{uuid4().hex}.py"
-    module_path.write_text("def plain_function():\n    return 42\n")
+def test_optimize_accepts_user_output_directory_outside_package_dir(tmp_path):
+    module_path = _write_optimizable_module(tmp_path)
+    output_dir = tmp_path / "user_results"
 
     try:
         runner = CliRunner()
-        outside_output = Path("/tmp") / f"traigent_outside_{uuid4().hex}"
         result = runner.invoke(
             cli,
             [
                 "optimize",
                 str(module_path),
                 "--output-dir",
-                str(outside_output),
+                str(output_dir),
             ],
         )
 
-        assert result.exit_code != 0
-        assert "output directory" in result.output.lower()
+        assert result.exit_code == 0, result.output
+        assert "Results saved to:" in result.output
+        assert output_dir.exists()
     finally:
-        module_path.unlink(missing_ok=True)
+        sys.modules.pop("user_module", None)

--- a/tests/unit/cli/test_main_cli_user_paths.py
+++ b/tests/unit/cli/test_main_cli_user_paths.py
@@ -1,0 +1,70 @@
+"""CLI user-path and strict validation regression tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from traigent.cli.main import cli
+
+
+def test_validate_config_accepts_user_project_file_outside_package_dir(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "optimization.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "configuration_space": {"temperature": [0.0, 0.5]},
+                "objectives": ["accuracy"],
+                "algorithm": "grid",
+            }
+        )
+    )
+
+    result = CliRunner().invoke(cli, ["validate-config", str(config_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Configuration validation passed" in result.output
+    assert "workspace" not in result.output.lower()
+
+
+def test_generate_accepts_user_output_path_outside_package_dir(tmp_path: Path) -> None:
+    output_path = tmp_path / "generated" / "traigent_example.py"
+
+    result = CliRunner().invoke(cli, ["generate", "--output", str(output_path)])
+
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+    assert "@traigent.optimize" in output_path.read_text()
+    assert "workspace" not in result.output.lower()
+
+
+def test_validate_strict_exits_nonzero_for_invalid_dataset(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "invalid.jsonl"
+    dataset_path.write_text(json.dumps({"output": "missing input"}) + "\n")
+
+    result = CliRunner().invoke(
+        cli,
+        ["validate", str(dataset_path), "--strict"],
+        env={"TRAIGENT_DATASET_ROOT": str(tmp_path)},
+    )
+
+    assert result.exit_code != 0
+    assert "Dataset content validation failed" in result.output
+
+
+def test_validate_strict_exits_zero_for_valid_dataset(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "valid.jsonl"
+    dataset_path.write_text(json.dumps({"input": "hello", "output": "world"}) + "\n")
+
+    result = CliRunner().invoke(
+        cli,
+        ["validate", str(dataset_path), "--strict"],
+        env={"TRAIGENT_DATASET_ROOT": str(tmp_path)},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Dataset content validation passed" in result.output

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -43,6 +43,7 @@ from traigent.utils.secure_path import (
     safe_open,
     safe_write_text,
     validate_path,
+    validate_user_path,
 )
 from traigent.utils.validation import OptimizationValidator
 from traigent.visualization.plots import create_quick_plot
@@ -83,6 +84,25 @@ def _resolve_workspace_path(
         raise click.ClickException(
             f"{description} must reside within the Traigent workspace ({WORKSPACE_ROOT})"
         ) from exc
+
+
+def _resolve_user_cli_path(
+    path: Path,
+    description: str,
+    *,
+    must_exist: bool = False,
+    for_write: bool = False,
+) -> Path:
+    """Resolve a user-supplied CLI path relative to the caller's CWD."""
+    try:
+        resolved = validate_user_path(path.expanduser(), for_write=for_write)
+        if must_exist and not resolved.exists():
+            raise FileNotFoundError(f"Path does not exist: {resolved}")
+        return resolved
+    except FileNotFoundError as exc:
+        raise click.ClickException(f"{description} does not exist: {exc}") from exc
+    except (PathTraversalError, ValueError) as exc:
+        raise click.ClickException(f"{description} is not allowed: {exc}") from exc
 
 
 def _print_optimization_header(
@@ -256,10 +276,14 @@ def _load_user_module(file_path_obj: Path) -> Any | None:
 
 def _resolve_output_dir(output_dir: str) -> Path:
     """Resolve and validate the output directory path."""
-    output_dir_candidate = Path(output_dir)
-    if not output_dir_candidate.is_absolute():
-        output_dir_candidate = WORKSPACE_ROOT / output_dir_candidate
-    return _resolve_workspace_path(output_dir_candidate, "Output directory")
+    resolved = _resolve_user_cli_path(
+        Path(output_dir),
+        "Output directory",
+        for_write=True,
+    )
+    if resolved.exists() and not resolved.is_dir():
+        raise click.ClickException(f"Output directory is not a directory: {resolved}")
+    return resolved
 
 
 def _parse_comma_separated_list(value: str | None) -> list[str] | None:
@@ -1064,7 +1088,7 @@ def optimize(
     )
 
     # Resolve paths
-    file_path_obj = _resolve_workspace_path(
+    file_path_obj = _resolve_user_cli_path(
         Path(file_path), "File path", must_exist=True
     )
     output_dir_resolved = _resolve_output_dir(output_dir)
@@ -1136,7 +1160,17 @@ def optimize(
     help="Objectives to validate (e.g., accuracy, latency)",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed validation output")
-def validate(dataset_path: str, objectives: tuple[str, ...], verbose: bool) -> None:
+@click.option(
+    "--strict",
+    is_flag=True,
+    help="Exit nonzero when dataset or objective validation fails",
+)
+def validate(
+    dataset_path: str,
+    objectives: tuple[str, ...],
+    verbose: bool,
+    strict: bool,
+) -> None:
     """Validate dataset format and optimization configuration."""
     console.print(f"\n[bold blue]Validating Dataset: {dataset_path}[/bold blue]\n")
 
@@ -1158,6 +1192,8 @@ def validate(dataset_path: str, objectives: tuple[str, ...], verbose: bool) -> N
             "\n[yellow]Hint:[/yellow] Dataset paths must reside under the current "
             "working directory or the path specified by TRAIGENT_DATASET_ROOT."
         )
+        if strict:
+            raise click.ClickException("Dataset validation failed") from e
         return
 
     # Step 2: Validate dataset content format
@@ -1171,6 +1207,8 @@ def validate(dataset_path: str, objectives: tuple[str, ...], verbose: bool) -> N
     if verbose or not path_result.is_valid:
         console.print(path_result.get_feedback())
 
+    has_failure = not path_result.is_valid
+
     # Validate objectives if provided
     if objectives:
         obj_result = Validators.validate_objectives(list(objectives))
@@ -1180,6 +1218,10 @@ def validate(dataset_path: str, objectives: tuple[str, ...], verbose: bool) -> N
         else:
             console.print("❌ [red]Objectives validation failed[/red]")
             console.print(obj_result.get_feedback())
+            has_failure = True
+
+    if strict and has_failure:
+        raise click.ClickException("Dataset validation failed")
 
 
 @cli.command(name="report-example-map")
@@ -2038,12 +2080,14 @@ def validate_config(config_file: str) -> None:
     console.print(f"\n[bold blue]Validating Configuration: {config_file}[/bold blue]\n")
 
     try:
-        config_path = _resolve_workspace_path(
+        config_path = _resolve_user_cli_path(
             Path(config_file),
             "Config file",
             must_exist=True,
         )
-        with safe_open(config_path, WORKSPACE_ROOT, mode="r", encoding="utf-8") as f:
+        with safe_open(
+            config_path, config_path.parent, mode="r", encoding="utf-8"
+        ) as f:
             config = json.load(f)
 
         # Extract configuration components
@@ -2094,9 +2138,10 @@ def generate(template: str, output: str) -> None:
 
     template_code = templates[template]
 
-    output_path = _resolve_workspace_path(
+    output_path = _resolve_user_cli_path(
         Path(output),
         "Output file",
+        for_write=True,
     )
 
     # Check if file already exists
@@ -2106,7 +2151,8 @@ def generate(template: str, output: str) -> None:
             return
 
     # Write template to file
-    safe_write_text(output_path, template_code, WORKSPACE_ROOT, encoding="utf-8")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    safe_write_text(output_path, template_code, output_path.parent, encoding="utf-8")
 
     console.print(f"✅ [green]Template generated: {output}[/green]")
 


### PR DESCRIPTION
## Summary

- Resolve user-supplied CLI source/output paths with the caller's CWD semantics instead of gating them to the installed package workspace.
- Add `traigent validate --strict` so dataset/objective validation failures produce a nonzero exit code.
- Replace stale workspace-rejection tests with user-project path coverage and add strict validation exit-code tests.

Refs #1244
Refs #1231

## Validation

- `pytest -n 0 tests/unit/cli/test_main_cli_security.py tests/unit/cli/test_main_cli_user_paths.py tests/unit/cli/test_main_cli_sample_limit.py`
- `black --check traigent/cli/main.py tests/unit/cli/test_main_cli_security.py tests/unit/cli/test_main_cli_user_paths.py`
- `ruff check traigent/cli/main.py tests/unit/cli/test_main_cli_security.py tests/unit/cli/test_main_cli_user_paths.py`
- `ruff format --check traigent/cli/main.py tests/unit/cli/test_main_cli_security.py tests/unit/cli/test_main_cli_user_paths.py`
- `isort --check-only traigent/cli/main.py tests/unit/cli/test_main_cli_security.py tests/unit/cli/test_main_cli_user_paths.py`
- `git diff --check`
- safe-push secret scan against `origin/develop`: passed, 3 files scanned
- safe-push formatting check against `origin/develop`: passed

## Notes

- Local push hook attempted SonarQube scan, but `sonar-scanner` is not installed in this environment; remote GitHub/Sonar checks remain authoritative.
- Local Aikido has no reproducible workspace command here; remote Aikido check remains authoritative.
