### PR TITLE
fix(optimizer): enforce validation invariants

### DIFF
--- a/tests/unit/api/decorator_tests/test_decorator_error_handling.py
+++ b/tests/unit/api/decorator_tests/test_decorator_error_handling.py
@@ -11,7 +11,9 @@ Tests error scenarios including:
 import pytest
 from pydantic import ValidationError as PydanticValidationError
 
+from traigent.api.constraints import require
 from traigent.api.decorators import ExecutionOptions, optimize
+from traigent.api.parameter_ranges import Choices
 from traigent.utils.exceptions import ConfigurationError, ValidationError
 
 from .test_base import DecoratorTestBase
@@ -358,6 +360,59 @@ class TestEnterpriseGatedFeatures(DecoratorTestBase):
         ExecutionOptions()
         # Explicit defaults
         ExecutionOptions(reps_per_trial=1, reps_aggregation="mean")
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("hybrid_api_batch_size", 0),
+            ("hybrid_api_batch_parallelism", 0),
+            ("hybrid_api_heartbeat_interval", 0.0),
+            ("hybrid_api_heartbeat_interval", -5.0),
+        ],
+    )
+    def test_hybrid_api_execution_options_reject_degenerate_values(self, field, value):
+        """Hybrid API execution controls must be positive."""
+        with pytest.raises(PydanticValidationError) as exc:
+            ExecutionOptions(**{field: value})
+
+        assert field in str(exc.value)
+
+    def test_max_trials_zero_rejected_at_decoration(self):
+        """max_trials=0 fails at decoration instead of producing a no-op run."""
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+
+            @optimize(
+                configuration_space={"model": ["gpt-3.5", "gpt-4"]},
+                max_trials=0,
+            )
+            def test_func(text: str) -> str:
+                return text
+
+    def test_unsatisfiable_finite_constraints_rejected_at_decoration(self):
+        """Contradictory finite-domain constraints fail before optimization starts."""
+        model = Choices(["a", "b"], name="model")
+
+        with pytest.raises(ValueError, match="constraints are unsatisfiable"):
+
+            @optimize(
+                configuration_space={"model": model},
+                constraints=[require(model.equals("a")), require(model.equals("b"))],
+            )
+            def test_func(text: str) -> str:
+                return text
+
+    def test_satisfiable_finite_constraints_still_decorate(self):
+        """A finite-domain constraint set with a valid config is unchanged."""
+        model = Choices(["a", "b"], name="model")
+
+        @optimize(
+            configuration_space={"model": model},
+            constraints=[require(model.equals("a"))],
+        )
+        def test_func(text: str) -> str:
+            return text
+
+        assert test_func("ok") == "ok"
 
     def test_reps_assignment_rejected_after_construction(self):
         """Assignment validation preserves the enterprise gate after construction."""

--- a/tests/unit/api/test_constraint_builders.py
+++ b/tests/unit/api/test_constraint_builders.py
@@ -6,6 +6,8 @@ to ensure all constraint methods work correctly for all ParameterRange types.
 
 from __future__ import annotations
 
+import pytest
+
 from traigent.api.constraints import Condition
 from traigent.api.parameter_ranges import Choices, IntRange, LogRange, Range
 
@@ -108,6 +110,24 @@ class TestNumericConstraintBuilders:
         assert cond.evaluate(0.5) is True
         assert cond.evaluate(0.0) is False
 
+    def test_range_rejects_out_of_domain_comparison(self) -> None:
+        temp = Range(0.0, 2.0, name="temperature")
+
+        with pytest.raises(ValueError, match="temperature.*outside.*domain"):
+            temp.equals(2.5)
+
+    def test_range_rejects_empty_membership(self) -> None:
+        temp = Range(0.0, 2.0, name="temperature")
+
+        with pytest.raises(ValueError, match="temperature.*cannot be empty"):
+            temp.is_in([])
+
+    def test_range_rejects_non_overlapping_in_range(self) -> None:
+        temp = Range(0.0, 2.0, name="temperature")
+
+        with pytest.raises(ValueError, match="temperature.*does not overlap"):
+            temp.in_range(3.0, 4.0)
+
     # =========================================================================
     # IntRange Tests
     # =========================================================================
@@ -199,6 +219,12 @@ class TestNumericConstraintBuilders:
         assert cond.operator == "not_in"
         assert cond.evaluate(512) is True
         assert cond.evaluate(256) is False
+
+    def test_int_range_rejects_out_of_domain_membership(self) -> None:
+        tokens = IntRange(100, 4096, name="max_tokens")
+
+        with pytest.raises(ValueError, match="max_tokens.*outside.*domain"):
+            tokens.not_in([64])
 
     # =========================================================================
     # LogRange Tests
@@ -333,6 +359,24 @@ class TestCategoricalConstraintBuilders:
         assert cond.operator == "not_in"
         assert cond.evaluate("gpt-4") is True
         assert cond.evaluate("claude") is False
+
+    def test_choices_rejects_out_of_domain_value(self) -> None:
+        model = Choices(["gpt-4", "gpt-3.5", "claude"], name="model")
+
+        with pytest.raises(ValueError, match="model.*outside.*choices"):
+            model.equals("gpt-four")
+
+    def test_choices_rejects_empty_membership(self) -> None:
+        model = Choices(["gpt-4", "gpt-3.5", "claude"], name="model")
+
+        with pytest.raises(ValueError, match="model.*cannot be empty"):
+            model.is_in([])
+
+    def test_choices_rejects_out_of_domain_membership(self) -> None:
+        model = Choices(["gpt-4", "gpt-3.5", "claude"], name="model")
+
+        with pytest.raises(ValueError, match="model.*outside.*choices"):
+            model.not_in(["gpt-four"])
 
     def test_choices_with_boolean_values(self) -> None:
         """Test Choices constraint methods with boolean values."""

--- a/tests/unit/api/test_constraints.py
+++ b/tests/unit/api/test_constraints.py
@@ -507,6 +507,28 @@ class TestPythonConstraintValidator:
 
         assert result.status == SatStatus.UNKNOWN
 
+    def test_check_satisfiability_finite_domain_sat(self) -> None:
+        """Finite domains return SAT when at least one config satisfies constraints."""
+        model = Choices(["a", "b"], name="model")
+        constraints = [require(model.equals("a"))]
+
+        validator = PythonConstraintValidator()
+        result = validator.check_satisfiability({"model": model}, constraints)
+
+        assert result.status == SatStatus.SAT
+        assert result.example_config == {"model": "a"}
+
+    def test_check_satisfiability_finite_domain_unsat(self) -> None:
+        """Finite domains return UNSAT when no config satisfies all constraints."""
+        model = Choices(["a", "b"], name="model")
+        constraints = [require(model.equals("a")), require(model.equals("b"))]
+
+        validator = PythonConstraintValidator()
+        result = validator.check_satisfiability({"model": model}, constraints)
+
+        assert result.status == SatStatus.UNSAT
+        assert result.unsat_core == [0, 1]
+
 
 class TestSATConstraintValidator:
     """Tests for SATConstraintValidator compatibility adapter."""

--- a/tests/unit/api/test_functions.py
+++ b/tests/unit/api/test_functions.py
@@ -272,10 +272,10 @@ class TestOverrideConfig:
 
     def test_override_config_invalid_max_trials(self):
         """Test invalid max trials."""
-        result = override_config(max_trials=0)
-        assert result == {"max_trials": 0}
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+            override_config(max_trials=0)
 
-        with pytest.raises(ValueError, match="max_trials must be non-negative"):
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
             override_config(max_trials=-10)
 
     def test_override_config_timeout(self):
@@ -454,7 +454,9 @@ class TestGetAvailableStrategies:
 
         assert strategies["optuna_tpe"]["name"] == "Optuna TPE Optimization"
         assert strategies["nsga2"]["name"] == "Optuna NSGA-II Optimization"
-        assert strategies["optuna_grid"]["description"] != "Custom optimization algorithm"
+        assert (
+            strategies["optuna_grid"]["description"] != "Custom optimization algorithm"
+        )
         assert "max_trials" in strategies["optuna_tpe"]["parameters"]
 
     @patch("traigent.api.functions.list_optimizers")

--- a/tests/unit/api/test_functions_additional.py
+++ b/tests/unit/api/test_functions_additional.py
@@ -119,7 +119,6 @@ class TestConfigureObjectives:
                 "traigent.core.objectives.schema_to_objective_names"
             ) as mock_schema_to_names,
         ):
-
             mock_schema = Mock()
             mock_normalize.return_value = mock_schema
             mock_schema_to_names.return_value = ["obj1", "obj2"]
@@ -568,10 +567,10 @@ class TestOverrideConfig:
 
     def test_override_config_max_trials_invalid(self):
         """Test override_config with invalid max_trials."""
-        result = override_config(max_trials=0)
-        assert result["max_trials"] == 0
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+            override_config(max_trials=0)
 
-        with pytest.raises(ValueError, match="max_trials must be non-negative"):
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
             override_config(max_trials=-5)
 
     def test_override_config_timeout_valid(self):

--- a/tests/unit/core/optimized_function_tests/test_initialization.py
+++ b/tests/unit/core/optimized_function_tests/test_initialization.py
@@ -168,7 +168,7 @@ class TestOptimizedFunctionInitialization:
 
     def test_negative_num_trials(self, simple_function, sample_config_space):
         """Test error with negative max_trials."""
-        with pytest.raises(ValueError, match="max_trials must be non-negative"):
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
             OptimizedFunction(
                 func=simple_function,
                 configuration_space=sample_config_space,

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -572,10 +572,10 @@ class TestOptimizedFunction:
                 assert call_args[1]["dataset"] == sample_dataset
 
     @pytest.mark.asyncio
-    async def test_optimize_zero_max_trials_short_circuits(
+    async def test_optimize_zero_max_trials_rejected(
         self, mock_function, sample_config_space, sample_objectives, sample_dataset
     ):
-        """Ensure optimize() respects max_trials=0 without executing trials."""
+        """Ensure optimize(max_trials=0) fails fast before executing trials."""
         opt_func = OptimizedFunction(
             func=mock_function,
             config_space=sample_config_space,
@@ -583,41 +583,8 @@ class TestOptimizedFunction:
             eval_dataset=sample_dataset,
         )
 
-        with (
-            patch("traigent.optimizers.get_optimizer") as mock_get_optimizer,
-            patch(
-                "traigent.core.optimized_function.OptimizationOrchestrator"
-            ) as mock_orchestrator_class,
-        ):
-            mock_optimizer = Mock()
-            mock_get_optimizer.return_value = mock_optimizer
-
-            mock_orchestrator = Mock()
-            mock_orchestrator_class.return_value = mock_orchestrator
-
-            from datetime import datetime
-
-            mock_result = OptimizationResult(
-                trials=[],
-                best_config={},
-                best_score=0.0,
-                optimization_id="opt_zero",
-                duration=0.0,
-                convergence_info={},
-                status=OptimizationStatus.COMPLETED,
-                objectives=sample_objectives,
-                algorithm="random",
-                timestamp=datetime.now(),
-                metadata={},
-            )
-            mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
-
-            result = await opt_func.optimize(max_trials=0)
-
-            assert result is mock_result
-            assert len(result.trials) == 0
-            assert mock_orchestrator_class.call_args[1]["max_trials"] == 0
-            mock_orchestrator.optimize.assert_awaited_once()
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+            await opt_func.optimize(max_trials=0)
 
     @pytest.mark.asyncio
     async def test_optimize_with_custom_evaluator(

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -100,6 +100,7 @@ class MockEvaluator(BaseEvaluator):
     """Mock evaluator for testing."""
 
     def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.evaluation_count = 0
         self.should_fail = False
         self.evaluation_delay = 0.0
@@ -424,40 +425,19 @@ class TestOptimizationOrchestrator:
         assert orchestrator._successful_trials == 2
         assert orchestrator._failed_trials == 0
 
-    @pytest.mark.asyncio
-    @pytest.mark.timeout(5)
-    async def test_optimize_zero_max_trials_short_circuits(
+    def test_zero_max_trials_rejected_at_construction(
         self,
         mock_optimizer,
         mock_evaluator,
-        sample_dataset,
-        mock_function,
     ):
-        """Ensure max_trials=0 exits without executing trials."""
-        mock_optimizer.set_max_suggestions(5)
-
-        with patch(
-            "traigent.cloud.backend_client.BackendIntegratedClient"
-        ) as mock_backend:
-            mock_client = MagicMock()
-            mock_client.create_session.return_value = "session-zero"
-            mock_backend.return_value = mock_client
-
-            orchestrator = OptimizationOrchestrator(
+        """max_trials=0 fails fast instead of creating an empty run."""
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+            OptimizationOrchestrator(
                 optimizer=mock_optimizer,
                 evaluator=mock_evaluator,
                 max_trials=0,
                 timeout=5.0,
             )
-            orchestrator.backend_client = mock_client
-
-            result = await orchestrator.optimize(mock_function, sample_dataset)
-
-        assert result.status == OptimizationStatus.COMPLETED
-        assert len(result.trials) == 0
-        assert orchestrator._successful_trials == 0
-        assert orchestrator._failed_trials == 0
-        assert orchestrator._stop_reason == "max_trials_reached"
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)
@@ -1057,12 +1037,10 @@ class TestOptimizationOrchestrator:
         # Should timeout within reasonable bounds (generous tolerance for CI)
         # The key assertion is that we stopped reasonably close to timeout,
         # not that we hit it exactly
-        assert (
-            actual_duration < timeout_duration + 1.0
-        ), f"Timeout took too long: {actual_duration:.2f}s (expected ~{timeout_duration}s)"
-        assert (
-            actual_duration >= timeout_duration * 0.5
-        ), f"Finished too quickly: {actual_duration:.2f}s (expected ~{timeout_duration}s)"
+        timeout_message = f"Timeout took too long: {actual_duration:.2f}s (expected ~{timeout_duration}s)"
+        too_fast_message = f"Finished too quickly: {actual_duration:.2f}s (expected ~{timeout_duration}s)"
+        assert actual_duration < timeout_duration + 1.0, timeout_message
+        assert actual_duration >= timeout_duration * 0.5, too_fast_message
         assert result.status == OptimizationStatus.CANCELLED
 
     # Performance Tests
@@ -1086,6 +1064,7 @@ class TestOptimizationOrchestrator:
         orchestrator.max_trials = 50
         orchestrator.optimizer.set_max_suggestions(50)
         orchestrator.evaluator.set_evaluation_delay(0.01)  # Fast evaluation
+        orchestrator.cost_enforcer.config.fallback_trial_limit = 50
 
         result = await orchestrator.optimize(mock_function, sample_dataset)
 
@@ -2299,12 +2278,12 @@ class TestOrchestratorCodeQuality:
         status_count = content.count("def status(self)")
         optimization_id_count = content.count("def optimization_id(self)")
 
-        assert (
-            status_count == 1
-        ), f"Found {status_count} status property definitions, expected 1"
-        assert (
-            optimization_id_count == 1
-        ), f"Found {optimization_id_count} optimization_id definitions, expected 1"
+        status_message = f"Found {status_count} status property definitions, expected 1"
+        optimization_id_message = (
+            f"Found {optimization_id_count} optimization_id definitions, expected 1"
+        )
+        assert status_count == 1, status_message
+        assert optimization_id_count == 1, optimization_id_message
 
 
 def test_allocate_parallel_ceilings_distribution():
@@ -2377,9 +2356,9 @@ class TestCostEstimation:
             f"Expected estimate > {clipped_to_dataset} (using full budget), got {estimate}. "
             "Cost estimate may be incorrectly clipping to dataset size."
         )
-        assert estimate == pytest.approx(
-            expected_full_budget, rel=0.1
-        ), f"Expected estimate ~{expected_full_budget}, got {estimate}"
+        estimate_message = f"Expected estimate ~{expected_full_budget}, got {estimate}"
+        estimate_approx = pytest.approx(expected_full_budget, rel=0.1)
+        assert estimate == estimate_approx, estimate_message
 
     def test_cost_estimate_without_budget_uses_dataset_size(
         self,

--- a/tests/unit/core/test_orchestrator_helpers.py
+++ b/tests/unit/core/test_orchestrator_helpers.py
@@ -86,16 +86,15 @@ class TestValidateConstructorArguments:
         )
         assert result is None
 
-    def test_zero_max_trials_allowed(self):
-        """Test that zero max_trials is allowed (no trials)."""
+    def test_zero_max_trials_rejected(self):
+        """Test that zero max_trials is rejected."""
         optimizer = MockOptimizer()
         evaluator = MockEvaluator()
 
-        # Should not raise any exception - returns None on success
-        result = validate_constructor_arguments(
-            optimizer, evaluator, max_trials=0, timeout=None
-        )
-        assert result is None
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+            validate_constructor_arguments(
+                optimizer, evaluator, max_trials=0, timeout=None
+            )
 
     def test_invalid_optimizer_type(self):
         """Test that invalid optimizer type raises TypeError."""
@@ -158,7 +157,7 @@ class TestValidateConstructorArguments:
         optimizer = MockOptimizer()
         evaluator = MockEvaluator()
 
-        with pytest.raises(ValueError, match="max_trials must be non-negative"):
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
             validate_constructor_arguments(
                 optimizer=optimizer,
                 evaluator=evaluator,
@@ -449,7 +448,7 @@ class TestModuleValidateConstructorArguments:
 
     def test_negative_max_trials_raises_value_error(self):
         """Test that negative max_trials raises ValueError."""
-        with pytest.raises(ValueError, match="max_trials must be non-negative"):
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
             validate_constructor_arguments(
                 MockOptimizer(), MockEvaluator(), max_trials=-1
             )

--- a/tests/unit/core/test_result_selection.py
+++ b/tests/unit/core/test_result_selection.py
@@ -156,6 +156,45 @@ def test_minimization_objective_is_respected():
     assert result.best_score == pytest.approx(0.1)
 
 
+def test_banded_primary_objective_selects_closest_single_trial():
+    trials = [
+        FakeTrial(metrics={"latency_ms": 100.0}, config={"model": "too-fast"}),
+        FakeTrial(metrics={"latency_ms": 500.0}, config={"model": "center"}),
+        FakeTrial(metrics={"latency_ms": 900.0}, config={"model": "too-slow"}),
+    ]
+
+    result = select_best_configuration(
+        trials=trials,
+        primary_objective="latency_ms",
+        config_space_keys={"model"},
+        aggregate_configs=False,
+        band_target=500.0,
+    )
+
+    assert result.best_config == {"model": "center"}
+    assert result.best_score == pytest.approx(500.0)
+
+
+def test_banded_primary_objective_selects_closest_aggregated_config():
+    trials = [
+        FakeTrial(metrics={"accuracy": 0.95}, config={"model": "high"}),
+        FakeTrial(metrics={"accuracy": 0.70}, config={"model": "center"}),
+        FakeTrial(metrics={"accuracy": 0.69}, config={"model": "center"}),
+        FakeTrial(metrics={"accuracy": 0.50}, config={"model": "low"}),
+    ]
+
+    result = select_best_configuration(
+        trials=trials,
+        primary_objective="accuracy",
+        config_space_keys={"model"},
+        aggregate_configs=True,
+        band_target=0.70,
+    )
+
+    assert result.best_config == {"model": "center"}
+    assert result.best_score == pytest.approx(0.695)
+
+
 def test_aggregated_selection_computes_means_and_metadata():
     trials = [
         FakeTrial(
@@ -362,11 +401,9 @@ class TestSelectBestConfigurationWithTieBreakers:
             band_target=0.90,
         )
 
-        # Without band_target, A would win (0.95 is max)
-        # With band_target=0.90, C (0.89) is closest
-        # But since scores aren't equal, tie-breaker shouldn't apply
-        # The max score is 0.95 (model A), so only A is in tied_trials
-        assert result.best_config["model"] == "A"
+        # Banded primary objectives rank by distance from the band target, so
+        # C (0.89) beats the raw max A (0.95).
+        assert result.best_config["model"] == "C"
 
     def test_tie_breaker_all_equal_scores_with_band(self) -> None:
         """When all trials have same primary score, band_target helps pick."""

--- a/tests/unit/test_traigent_client.py
+++ b/tests/unit/test_traigent_client.py
@@ -878,8 +878,10 @@ class TestOptimizeLocal:
                 assert result["best_configuration"] is not None
 
     @pytest.mark.asyncio
-    async def test_optimize_local_no_trials(self, mock_client: TraigentClient) -> None:
-        """Test local optimization with max_trials=0."""
+    async def test_optimize_local_rejects_zero_trials(
+        self, mock_client: TraigentClient
+    ) -> None:
+        """Test local optimization rejects max_trials=0."""
 
         def test_func() -> str:
             return "test"
@@ -888,14 +890,10 @@ class TestOptimizeLocal:
         config_space = {"model": ["gpt-3.5-turbo"]}
         objectives = ["accuracy"]
 
-        result = await mock_client.optimize(
-            test_func, dataset, config_space, objectives, max_trials=0
-        )
-
-        assert result["execution_mode"] == "edge_analytics"
-        assert result["completed_trials"] == 0
-        assert result["status"] == "no_trials"
-        assert result["best_configuration"] is None
+        with pytest.raises(ValueError, match="max_trials must be a positive integer"):
+            await mock_client.optimize(
+                test_func, dataset, config_space, objectives, max_trials=0
+            )
 
     @pytest.mark.asyncio
     async def test_optimize_local_missing_agent_builder(

--- a/traigent/api/constraint_builders.py
+++ b/traigent/api/constraint_builders.py
@@ -23,6 +23,87 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+def _parameter_label(tvar: Any) -> str:
+    return str(getattr(tvar, "name", None) or "parameter")
+
+
+def _numeric_bounds(tvar: Any) -> tuple[float, float] | None:
+    low = getattr(tvar, "low", None)
+    high = getattr(tvar, "high", None)
+    if low is None or high is None:
+        return None
+    return float(low), float(high)
+
+
+def _validate_numeric_value(tvar: Any, value: float, operator: str) -> None:
+    bounds = _numeric_bounds(tvar)
+    if bounds is None:
+        return
+    low, high = bounds
+    numeric_value = float(value)
+    if not low <= numeric_value <= high:
+        raise ValueError(
+            f"{_parameter_label(tvar)}.{operator}({value!r}) is outside "
+            f"the parameter domain [{low}, {high}]"
+        )
+
+
+def _validate_numeric_values(
+    tvar: Any, values: Sequence[float], operator: str
+) -> tuple[float, ...]:
+    normalized = tuple(values)
+    if not normalized:
+        raise ValueError(f"{_parameter_label(tvar)}.{operator}() cannot be empty")
+    for value in normalized:
+        _validate_numeric_value(tvar, value, operator)
+    return normalized
+
+
+def _validate_numeric_range(tvar: Any, low_value: float, high_value: float) -> None:
+    if low_value > high_value:
+        raise ValueError(
+            f"{_parameter_label(tvar)}.in_range() lower bound must be <= upper bound"
+        )
+    bounds = _numeric_bounds(tvar)
+    if bounds is None:
+        return
+    low, high = bounds
+    if high_value < low or low_value > high:
+        raise ValueError(
+            f"{_parameter_label(tvar)}.in_range({low_value!r}, {high_value!r}) "
+            f"does not overlap the parameter domain [{low}, {high}]"
+        )
+
+
+def _choices(tvar: Any) -> tuple[Any, ...] | None:
+    values = getattr(tvar, "values", None)
+    if values is None:
+        return None
+    return tuple(values)
+
+
+def _validate_choice_value(tvar: Any, value: Any, operator: str) -> None:
+    values = _choices(tvar)
+    if values is None:
+        return
+    if value not in values:
+        raise ValueError(
+            f"{_parameter_label(tvar)}.{operator}({value!r}) is outside "
+            f"the parameter choices {list(values)!r}"
+        )
+
+
+def _validate_choice_values(
+    tvar: Any, values: Sequence[Any], operator: str
+) -> tuple[Any, ...]:
+    normalized = tuple(values)
+    if not normalized:
+        raise ValueError(f"{_parameter_label(tvar)}.{operator}() cannot be empty")
+    for value in normalized:
+        _validate_choice_value(tvar, value, operator)
+    return normalized
+
+
 class NumericConstraintBuilderMixin:
     """Mixin providing constraint builder methods for numeric ParameterRanges.
 
@@ -50,6 +131,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_value(self, value, "equals")
         return Condition(_tvar=self, operator="==", value=value)  # type: ignore[arg-type]
 
     def not_equals(self, value: float) -> Condition:
@@ -61,6 +143,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_value(self, value, "not_equals")
         return Condition(_tvar=self, operator="!=", value=value)  # type: ignore[arg-type]
 
     def gt(self, value: float) -> Condition:
@@ -72,6 +155,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_value(self, value, "gt")
         return Condition(_tvar=self, operator=">", value=value)  # type: ignore[arg-type]
 
     def gte(self, value: float) -> Condition:
@@ -83,6 +167,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_value(self, value, "gte")
         return Condition(_tvar=self, operator=">=", value=value)  # type: ignore[arg-type]
 
     def lt(self, value: float) -> Condition:
@@ -94,6 +179,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_value(self, value, "lt")
         return Condition(_tvar=self, operator="<", value=value)  # type: ignore[arg-type]
 
     def lte(self, value: float) -> Condition:
@@ -105,6 +191,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_value(self, value, "lte")
         return Condition(_tvar=self, operator="<=", value=value)  # type: ignore[arg-type]
 
     def in_range(self, low: float, high: float) -> Condition:
@@ -116,6 +203,7 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_numeric_range(self, low, high)
         return Condition(_tvar=self, operator="in_range", value=(low, high))  # type: ignore[arg-type]
 
     def is_in(self, values: Sequence[float]) -> Condition:
@@ -129,7 +217,8 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
-        return Condition(_tvar=self, operator="in", value=tuple(values))  # type: ignore[arg-type]
+        normalized = _validate_numeric_values(self, values, "is_in")
+        return Condition(_tvar=self, operator="in", value=normalized)  # type: ignore[arg-type]
 
     def not_in(self, values: Sequence[float]) -> Condition:
         """Create condition: this parameter is not in the given values.
@@ -140,7 +229,8 @@ class NumericConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
-        return Condition(_tvar=self, operator="not_in", value=tuple(values))  # type: ignore[arg-type]
+        normalized = _validate_numeric_values(self, values, "not_in")
+        return Condition(_tvar=self, operator="not_in", value=normalized)  # type: ignore[arg-type]
 
 
 class CategoricalConstraintBuilderMixin:
@@ -165,6 +255,7 @@ class CategoricalConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_choice_value(self, value, "equals")
         return Condition(_tvar=self, operator="==", value=value)  # type: ignore[arg-type]
 
     def not_equals(self, value: Any) -> Condition:
@@ -176,6 +267,7 @@ class CategoricalConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
+        _validate_choice_value(self, value, "not_equals")
         return Condition(_tvar=self, operator="!=", value=value)  # type: ignore[arg-type]
 
     def is_in(self, values: Sequence[Any]) -> Condition:
@@ -187,7 +279,8 @@ class CategoricalConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
-        return Condition(_tvar=self, operator="in", value=tuple(values))  # type: ignore[arg-type]
+        normalized = _validate_choice_values(self, values, "is_in")
+        return Condition(_tvar=self, operator="in", value=normalized)  # type: ignore[arg-type]
 
     def not_in(self, values: Sequence[Any]) -> Condition:
         """Create condition: this parameter is not in the given values.
@@ -198,4 +291,5 @@ class CategoricalConstraintBuilderMixin:
         """
         from traigent.api.constraints import Condition
 
-        return Condition(_tvar=self, operator="not_in", value=tuple(values))  # type: ignore[arg-type]
+        normalized = _validate_choice_values(self, values, "not_in")
+        return Condition(_tvar=self, operator="not_in", value=normalized)  # type: ignore[arg-type]

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
     from traigent.api.constraints import BoolExpr, Constraint
     from traigent.api.safety import CompoundSafetyConstraint, SafetyConstraint
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from traigent.api.functions import _GLOBAL_CONFIG
 from traigent.api.parameter_ranges import (
@@ -210,10 +210,10 @@ class ExecutionOptions(BaseModel):
     tunable_id: str | None = None
     hybrid_api_transport: Any | None = None
     hybrid_api_transport_type: str = "auto"
-    hybrid_api_batch_size: int = 1
-    hybrid_api_batch_parallelism: int = 1
+    hybrid_api_batch_size: int = Field(default=1, ge=1)
+    hybrid_api_batch_parallelism: int = Field(default=1, ge=1)
     hybrid_api_keep_alive: bool = True
-    hybrid_api_heartbeat_interval: float = 30.0
+    hybrid_api_heartbeat_interval: float = Field(default=30.0, gt=0)
     hybrid_api_timeout: float | None = None
     hybrid_api_auth_header: str | None = None
     hybrid_api_auto_discover_tvars: bool = False
@@ -1532,6 +1532,58 @@ def _normalize_config_space_and_defaults(
     return normalized_space, default_config, constraints
 
 
+def _constraints_for_satisfiability(constraints: list[Any] | None) -> list[Any]:
+    """Return structural constraints that the satisfiability checker can evaluate."""
+    if not constraints:
+        return []
+
+    from traigent.api.constraints import BoolExpr, Constraint
+
+    satisfiability_constraints: list[Constraint] = []
+    for constraint in constraints:
+        if isinstance(constraint, Constraint):
+            satisfiability_constraints.append(constraint)
+        elif isinstance(constraint, BoolExpr):
+            satisfiability_constraints.append(Constraint(expr=constraint))
+    return satisfiability_constraints
+
+
+def _validate_constraint_satisfiability(
+    raw_configuration_space: dict[str, Any] | ConfigSpace | None,
+    inline_params: dict[str, Any],
+    constraints: list[Any] | None,
+) -> None:
+    """Fail fast when structural constraints make a finite space impossible."""
+    satisfiability_constraints = _constraints_for_satisfiability(constraints)
+    if not satisfiability_constraints:
+        return
+
+    from traigent.api.config_space import ConfigSpace
+    from traigent.api.validation_protocol import SatStatus
+
+    if isinstance(raw_configuration_space, ConfigSpace):
+        tvars = dict(raw_configuration_space.tvars)
+        if inline_params:
+            tvars.update(
+                ConfigSpace.from_decorator_args(inline_params=inline_params).tvars
+            )
+        space = ConfigSpace(tvars=tvars, constraints=tuple(satisfiability_constraints))
+    else:
+        space = ConfigSpace.from_decorator_args(
+            configuration_space=raw_configuration_space,
+            inline_params=inline_params,
+            constraints=satisfiability_constraints,
+        )
+
+    if not space.tvars:
+        return
+
+    result = space.check_satisfiability()
+    if result.status == SatStatus.UNSAT:
+        detail = result.message or "no valid configuration satisfies all constraints"
+        raise ValueError(f"constraints are unsatisfiable: {detail}")
+
+
 def _restore_text_document_markers(
     normalized_space: dict[str, Any],
     raw_configuration_space: dict[str, Any] | ConfigSpace | None,
@@ -2057,6 +2109,8 @@ def optimize(  # NOSONAR(S107)
         config_space_var_names,
     )
 
+    raw_configuration_space = configuration_space
+
     # Normalize configuration_space and merge defaults
     configuration_space, default_config, constraints = (
         _normalize_config_space_and_defaults(
@@ -2066,6 +2120,11 @@ def optimize(  # NOSONAR(S107)
             config_space_constraints,
             constraints,
         )
+    )
+    _validate_constraint_satisfiability(
+        raw_configuration_space,
+        inline_params,
+        constraints,
     )
 
     # Note: Constraint normalization is deferred until after TVL artifact application
@@ -2122,6 +2181,8 @@ def optimize(  # NOSONAR(S107)
     algorithm_value = combined_settings["algorithm"]
     # Optimizer limits
     max_trials_value = combined_settings["max_trials"]
+    if max_trials_value is not None and max_trials_value <= 0:
+        raise ValueError("max_trials must be a positive integer")
     # Tuned variable auto-detection
     auto_detect_tvars_value = combined_settings["auto_detect_tvars"]
     auto_detect_tvars_mode_value = combined_settings["auto_detect_tvars_mode"]

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -556,8 +556,8 @@ def override_config(
         override["constraints"] = constraints
 
     if max_trials is not None:
-        if max_trials < 0:
-            raise ValueError("max_trials must be non-negative")
+        if max_trials <= 0:
+            raise ValueError("max_trials must be a positive integer")
         override["max_trials"] = max_trials
 
     if timeout is not None:

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -70,8 +70,8 @@ def resolve_execution_parameters(
     resolved_algorithm: str = algorithm if algorithm else fallback_algorithm
 
     resolved_max_trials = max_trials if max_trials is not None else fallback_max_trials
-    if resolved_max_trials is not None and resolved_max_trials < 0:
-        raise ValueError("max_trials must be non-negative")
+    if resolved_max_trials is not None and resolved_max_trials <= 0:
+        raise ValueError("max_trials must be a positive integer")
 
     if not effective_config_space or effective_config_space == {}:
         raise ValueError(

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -866,9 +866,8 @@ class OptimizedFunction:
         if not callable(self.func):
             raise TypeError("func must be callable") from None
 
-        # Validate max_trials and timeout for negative values
-        if self.max_trials < 0:
-            raise ValueError("max_trials must be non-negative")
+        if self.max_trials is not None and self.max_trials <= 0:
+            raise ValueError("max_trials must be a positive integer")
 
         if self.timeout is not None and self.timeout < 0:
             raise ValueError("timeout must be non-negative")
@@ -2274,10 +2273,6 @@ Remediation:
         # Initialize cloud client if not already done
         if self._cloud_client is None:
             self._cloud_client = TraigentCloudClient(enable_fallback=False)
-
-        if max_trials is not None and max_trials <= 0:
-            logger.info("Cloud optimization skipped due to max_trials=0.")
-            return self._build_empty_result("cloud_service")
 
         async with self._cloud_client as client:
             # Extract configuration_space from kwargs if provided

--- a/traigent/core/orchestrator_helpers.py
+++ b/traigent/core/orchestrator_helpers.py
@@ -45,20 +45,20 @@ def validate_constructor_arguments(
     Args:
         optimizer: Optimizer instance (must be BaseOptimizer subclass)
         evaluator: Evaluator instance (must be BaseEvaluator subclass)
-        max_trials: Maximum number of trials (None for unlimited, must be non-negative)
+        max_trials: Maximum number of trials (None for unlimited, must be positive)
         max_total_examples: Maximum examples to evaluate (None for unlimited)
         timeout: Timeout in seconds (None for no timeout, must be non-negative)
 
     Raises:
         TypeError: If optimizer or evaluator are not instances of their base classes
-        ValueError: If max_trials, max_total_examples, or timeout are negative
+        ValueError: If max_trials is non-positive, or max_total_examples/timeout are negative
     """
     if not isinstance(optimizer, BaseOptimizer):
         raise TypeError("optimizer must be an instance of BaseOptimizer")
     if not isinstance(evaluator, BaseEvaluator):
         raise TypeError("evaluator must be an instance of BaseEvaluator")
-    if max_trials is not None and max_trials < 0:
-        raise ValueError("max_trials must be non-negative")
+    if max_trials is not None and max_trials <= 0:
+        raise ValueError("max_trials must be a positive integer")
     if max_total_examples is not None and max_total_examples < 0:
         raise ValueError("max_total_examples must be non-negative")
     if timeout is not None and timeout < 0:

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -412,14 +412,22 @@ def _select_best_single_trial(
             reason_code=NO_RANKING_ELIGIBLE_TRIALS,
         )
 
-    best_score = chooser(score for _, score in scored_trials)
+    if band_target is not None:
+        best_deviation = min(abs(score - band_target) for _, score in scored_trials)
+        tied_trials = [
+            trial
+            for trial, score in scored_trials
+            if _primary_scores_tied(abs(score - band_target), best_deviation)
+        ]
+    else:
+        best_score = chooser(score for _, score in scored_trials)
 
-    # Find all trials within the conservative primary-score tie tolerance.
-    tied_trials = [
-        trial
-        for trial, score in scored_trials
-        if _primary_scores_tied(score, best_score)
-    ]
+        # Find all trials within the conservative primary-score tie tolerance.
+        tied_trials = [
+            trial
+            for trial, score in scored_trials
+            if _primary_scores_tied(score, best_score)
+        ]
 
     # Apply tie-breaker if there are ties.
     if len(tied_trials) > 1:
@@ -579,18 +587,29 @@ def _select_best_aggregated(
             },
             reason_code=NO_RANKING_ELIGIBLE_TRIALS,
         )
-    best_score_val = min(all_scores) if minimization else max(all_scores)
-
-    # Find all entries within the conservative primary-score tie tolerance.
-    tied_entries = [
-        entry
-        for entry in aggregated.values()
-        if _primary_scores_tied(
-            score_value := score(entry),
-            best_score_val,
+    if band_target is not None:
+        best_deviation = min(
+            abs(score_value - band_target) for score_value in all_scores
         )
-        and score_value not in (float("inf"), float("-inf"))
-    ]
+        tied_entries = [
+            entry
+            for entry in aggregated.values()
+            if (score_value := score(entry)) not in (float("inf"), float("-inf"))
+            and _primary_scores_tied(abs(score_value - band_target), best_deviation)
+        ]
+    else:
+        best_score_val = min(all_scores) if minimization else max(all_scores)
+
+        # Find all entries within the conservative primary-score tie tolerance.
+        tied_entries = [
+            entry
+            for entry in aggregated.values()
+            if _primary_scores_tied(
+                score_value := score(entry),
+                best_score_val,
+            )
+            and score_value not in (float("inf"), float("-inf"))
+        ]
 
     # Apply tie-breaking for aggregated entries
     if len(tied_entries) > 1:

--- a/traigent/traigent_client.py
+++ b/traigent/traigent_client.py
@@ -460,14 +460,7 @@ class TraigentClient:
         adapter = LocalExecutionAdapter(self.agent_builder)
 
         if max_trials is not None and max_trials <= 0:
-            logger.info("Edge Analytics optimization skipped due to max_trials<=0")
-            return {
-                "execution_mode": ExecutionMode.EDGE_ANALYTICS.value,
-                "best_configuration": None,
-                "all_results": [],
-                "completed_trials": 0,
-                "status": "no_trials",
-            }
+            raise ValueError("max_trials must be a positive integer")
 
         optimizer = self._create_local_optimizer(
             configuration_space,

--- a/traigent_validation/validators.py
+++ b/traigent_validation/validators.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from itertools import product
 from typing import TYPE_CHECKING, Any
 
 from traigent_validation.base import (
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from traigent.tvl.models import StructuralConstraint
 
 _PARAM_REF_PATTERN = re.compile(r"\bparams\.([A-Za-z_][A-Za-z0-9_]*)\b")
+_MAX_SAT_ENUMERATION_CONFIGS = 10_000
 
 
 def _extract_param_refs(expression: str) -> set[str]:
@@ -85,6 +87,39 @@ class PythonConstraintValidator:
         if not tvars:
             return SatResult(status=SatStatus.UNSAT, message="No parameters defined")
 
+        domains = self._finite_domains(tvars)
+        if domains is not None:
+            names = list(domains)
+            total_configs = 1
+            for values in domains.values():
+                total_configs *= len(values)
+                if total_configs > _MAX_SAT_ENUMERATION_CONFIGS:
+                    return SatResult(
+                        status=SatStatus.UNKNOWN,
+                        message=(
+                            "Finite satisfiability check skipped because the "
+                            f"space has more than {_MAX_SAT_ENUMERATION_CONFIGS} "
+                            "candidate configurations."
+                        ),
+                    )
+
+            var_names = {id(tvar): name for name, tvar in tvars.items()}
+            for values in product(*(domains[name] for name in names)):
+                config = dict(zip(names, values, strict=True))
+                result = self.validate_config(config, constraints, var_names)
+                if result.is_valid:
+                    return SatResult(
+                        status=SatStatus.SAT,
+                        example_config=config,
+                        message="At least one configuration satisfies all constraints",
+                    )
+
+            return SatResult(
+                status=SatStatus.UNSAT,
+                unsat_core=list(range(len(constraints))),
+                message="No finite-domain configuration satisfies all constraints",
+            )
+
         return SatResult(
             status=SatStatus.UNKNOWN,
             message=(
@@ -92,6 +127,33 @@ class PythonConstraintValidator:
                 "Consider a SAT/SMT validator for complex constraints."
             ),
         )
+
+    def _finite_domains(
+        self, tvars: Mapping[str, ParameterRange]
+    ) -> dict[str, tuple[Any, ...]] | None:
+        domains: dict[str, tuple[Any, ...]] = {}
+        for name, tvar in tvars.items():
+            domain = self._finite_domain(tvar)
+            if domain is None:
+                return None
+            domains[name] = domain
+        return domains
+
+    def _finite_domain(self, tvar: ParameterRange) -> tuple[Any, ...] | None:
+        values = getattr(tvar, "values", None)
+        if values is not None:
+            return tuple(values)
+
+        low = getattr(tvar, "low", None)
+        high = getattr(tvar, "high", None)
+        if not isinstance(low, int) or not isinstance(high, int):
+            return None
+
+        step = getattr(tvar, "step", None) or 1
+        if not isinstance(step, int) or step <= 0:
+            return None
+
+        return tuple(range(low, high + 1, step))
 
     def validate_structural_constraints(
         self,


### PR DESCRIPTION
## Summary

- Reject invalid atomic constraints early when numeric/categorical values are outside their declared domains, membership sets are empty, or ranges cannot overlap the domain.
- Reject non-positive `max_trials` and degenerate hybrid API execution options at construction/configuration boundaries instead of allowing silent empty runs.
- Add finite-domain satisfiability checking for constraint objects at decoration time, while preserving UNKNOWN for continuous or large spaces.
- Select banded primary objectives by closeness to the target band instead of raw min/max distance.

Refs #1238
Refs #1237
Refs #1233

## Notes

- `traigent/core/orchestrator_helpers.py` had CRLF line endings. Touching constructor validation made `git diff --check` flag newly added CRs, so this PR normalizes that file to LF while applying the semantic max-trials guard.

## Validation

- `black --check tests/unit/api/decorator_tests/test_decorator_error_handling.py tests/unit/api/test_constraint_builders.py tests/unit/api/test_constraints.py tests/unit/api/test_functions.py tests/unit/api/test_functions_additional.py tests/unit/core/optimized_function_tests/test_initialization.py tests/unit/core/test_optimized_function.py tests/unit/core/test_orchestrator.py tests/unit/core/test_orchestrator_helpers.py tests/unit/core/test_result_selection.py tests/unit/test_traigent_client.py traigent/api/constraint_builders.py traigent/api/decorators.py traigent/api/functions.py traigent/core/optimization_pipeline.py traigent/core/optimized_function.py traigent/core/orchestrator_helpers.py traigent/core/result_selection.py traigent/traigent_client.py traigent_validation/validators.py`
- `ruff format --check tests/unit/api/decorator_tests/test_decorator_error_handling.py tests/unit/api/test_constraint_builders.py tests/unit/api/test_constraints.py tests/unit/api/test_functions.py tests/unit/api/test_functions_additional.py tests/unit/core/optimized_function_tests/test_initialization.py tests/unit/core/test_optimized_function.py tests/unit/core/test_orchestrator.py tests/unit/core/test_orchestrator_helpers.py tests/unit/core/test_result_selection.py tests/unit/test_traigent_client.py traigent/api/constraint_builders.py traigent/api/decorators.py traigent/api/functions.py traigent/core/optimization_pipeline.py traigent/core/optimized_function.py traigent/core/orchestrator_helpers.py traigent/core/result_selection.py traigent/traigent_client.py traigent_validation/validators.py`
- `ruff check tests/unit/api/decorator_tests/test_decorator_error_handling.py tests/unit/api/test_constraint_builders.py tests/unit/api/test_constraints.py tests/unit/api/test_functions.py tests/unit/api/test_functions_additional.py tests/unit/core/optimized_function_tests/test_initialization.py tests/unit/core/test_optimized_function.py tests/unit/core/test_orchestrator.py tests/unit/core/test_orchestrator_helpers.py tests/unit/core/test_result_selection.py tests/unit/test_traigent_client.py traigent/api/constraint_builders.py traigent/api/decorators.py traigent/api/functions.py traigent/core/optimization_pipeline.py traigent/core/optimized_function.py traigent/core/orchestrator_helpers.py traigent/core/result_selection.py traigent/traigent_client.py traigent_validation/validators.py`
- `isort --check-only tests/unit/api/decorator_tests/test_decorator_error_handling.py tests/unit/api/test_constraint_builders.py tests/unit/api/test_constraints.py tests/unit/api/test_functions.py tests/unit/api/test_functions_additional.py tests/unit/core/optimized_function_tests/test_initialization.py tests/unit/core/test_optimized_function.py tests/unit/core/test_orchestrator.py tests/unit/core/test_orchestrator_helpers.py tests/unit/core/test_result_selection.py tests/unit/test_traigent_client.py traigent/api/constraint_builders.py traigent/api/decorators.py traigent/api/functions.py traigent/core/optimization_pipeline.py traigent/core/optimized_function.py traigent/core/orchestrator_helpers.py traigent/core/result_selection.py traigent/traigent_client.py traigent_validation/validators.py`
- `git diff --check origin/develop`
- `pytest -n 0 tests/unit/api/test_constraint_builders.py tests/unit/api/test_constraints.py tests/unit/api/decorator_tests/test_decorator_error_handling.py tests/unit/core/test_result_selection.py tests/unit/api/test_functions.py tests/unit/api/test_functions_additional.py tests/unit/core/test_orchestrator_helpers.py tests/unit/core/optimized_function_tests/test_initialization.py tests/unit/core/test_optimized_function.py tests/unit/core/test_orchestrator.py tests/unit/test_traigent_client.py` (673 passed, 4 skipped)
- `bash /home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop` (20 files scanned, no secrets)
- `bash /home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/check_formatting.sh origin/develop` (passed)

## Local-only blockers

- Local push hook attempted SonarQube scan but skipped because `sonar-scanner` is not installed. Remote SonarCloud/Aikido checks remain authoritative.
