### PR TITLE
fix(observability): harden telemetry validation

### DIFF
--- a/tests/security/test_pii_canary_leak.py
+++ b/tests/security/test_pii_canary_leak.py
@@ -103,6 +103,7 @@ class _EchoCanaryEvaluator(BaseEvaluator):
     """Evaluator that returns the dataset's canary-laden content as the output."""
 
     def __init__(self) -> None:
+        super().__init__()
         self.call_count = 0
 
     async def evaluate(
@@ -401,9 +402,8 @@ def test_canary_regexes_match_their_own_values() -> None:
     meaningless even if it passes.
     """
     for label, value, rx in CANARIES:
-        assert rx.search(value), (
-            f"canary regex for {label!r} does not match its seed value"
-        )
+        message = f"canary regex for {label!r} does not match its seed value"
+        assert rx.search(value), message
 
 
 def test_contains_canary_detects_partial_embeddings() -> None:
@@ -414,9 +414,8 @@ def test_contains_canary_detects_partial_embeddings() -> None:
     """
     for label, value, _rx in CANARIES:
         blob = f"some prefix [{value}] suffix"
-        assert label in _contains_canary(blob), (
-            f"scanner missed {label!r} when embedded in surrounding text"
-        )
+        message = f"scanner missed {label!r} when embedded in surrounding text"
+        assert label in _contains_canary(blob), message
 
 
 def test_contains_canary_is_quiet_on_clean_text() -> None:

--- a/tests/unit/cloud/test_url_security.py
+++ b/tests/unit/cloud/test_url_security.py
@@ -92,6 +92,13 @@ def test_validate_cloud_base_url_allows_localhost_in_development() -> None:
         )
 
 
+def test_validate_cloud_base_url_honors_traigent_environment_development() -> None:
+    with patch.dict("os.environ", {"TRAIGENT_ENVIRONMENT": "development"}, clear=True):
+        assert (
+            validate_cloud_base_url("http://localhost:5000/") == "http://localhost:5000"
+        )
+
+
 def test_validate_cloud_base_url_production_signal_wins_over_dev_signal() -> None:
     with patch.dict(
         "os.environ",

--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -14,13 +14,14 @@ from traigent.observability import (
     ObservabilityClient,
     ObservabilityConfig,
     ObservationType,
+    ObserveContext,
     PromptReferenceDTO,
     ThumbRating,
     observe,
 )
 from traigent.observability.client import _SyncBatchTransport
 from traigent.observability.decorators import set_default_observability_client
-from traigent.observability.dtos import ObservationDTO
+from traigent.observability.dtos import ObservationDTO, TraceDTO
 from traigent.utils.exceptions import AuthenticationError, ClientError
 
 
@@ -37,6 +38,15 @@ FAKE_TRACE_API_KEY = (
 def _clear_observability_offline_mode(monkeypatch, jwt_development_mode):
     del jwt_development_mode
     monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+    monkeypatch.setenv("TRAIGENT_ENV", "development")
+
+
+def _mock_public_backend_dns(monkeypatch):
+    public_addr = ".".join(["93", "184", "216", "34"])
+    monkeypatch.setattr(
+        "traigent.cloud.url_security.socket.getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, (public_addr, 443))],
+    )
 
 
 def test_observability_config_uses_canonical_environment_resolution(monkeypatch):
@@ -44,8 +54,9 @@ def test_observability_config_uses_canonical_environment_resolution(monkeypatch)
     monkeypatch.delenv("ENVIRONMENT", raising=False)
     monkeypatch.delenv("TRAIGENT_ENVIRONMENT", raising=False)
     monkeypatch.setenv("TRAIGENT_ENV", "staging")
+    _mock_public_backend_dns(monkeypatch)
 
-    config = ObservabilityConfig(backend_origin="http://localhost:5000")
+    config = ObservabilityConfig(backend_origin="https://auth.example.com")
 
     assert config.default_environment == "staging"
 
@@ -56,11 +67,48 @@ def test_observability_config_does_not_emit_unknown_environment_content(monkeypa
     monkeypatch.delenv("ENVIRONMENT", raising=False)
     monkeypatch.delenv("TRAIGENT_ENVIRONMENT", raising=False)
     monkeypatch.setenv("TRAIGENT_ENV", sentinel)
+    _mock_public_backend_dns(monkeypatch)
 
-    config = ObservabilityConfig(backend_origin="http://localhost:5000")
+    config = ObservabilityConfig(backend_origin="https://auth.example.com")
 
     assert config.default_environment is None
     assert sentinel not in json.dumps(config.__dict__)
+
+
+@pytest.mark.parametrize(
+    ("origin", "message"),
+    [
+        ("http://api.traigent.example", "https"),
+        ("metadata-ip", "private or loopback"),
+    ],
+)
+def test_observability_config_rejects_unsafe_production_origins(
+    monkeypatch, origin, message
+):
+    monkeypatch.setenv("TRAIGENT_ENV", "production")
+    if origin == "metadata-ip":
+        origin = f"https://{'.'.join(['169', '254', '169', '254'])}"
+
+    with pytest.raises(ValueError, match=message):
+        ObservabilityConfig(backend_origin=origin)
+
+
+def test_observability_client_uses_no_redirect_http_opener():
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=10,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+            enable_atexit_flush=False,
+        )
+    )
+
+    handler_names = {type(handler).__name__ for handler in client._http_opener.handlers}
+    client.close()
+
+    assert "_NoRedirectHandler" in handler_names
 
 
 def test_observability_client_flushes_trace_payloads():
@@ -493,6 +541,27 @@ def test_sync_batch_transport_records_closed_transport_drops():
     )
 
 
+def test_sync_batch_transport_stats_snapshot_includes_locked_diagnostics():
+    transport = _SyncBatchTransport(
+        sender=lambda traces: None,
+        batch_size=100,
+        max_buffer_age=999.0,
+        max_queue_size=10,
+        max_batch_bytes=1024,
+    )
+
+    transport._append_error("error-1")
+    transport._append_warning("warning-1")
+
+    stats = transport.get_stats()
+    result = transport.close()
+
+    assert stats["errors"] == ["error-1"]
+    assert stats["warnings"] == ["warning-1"]
+    assert result.errors == ["error-1"]
+    assert result.warnings == ["warning-1"]
+
+
 def test_observability_client_chunks_flushes_by_byte_limit():
     sent_batches: list[list[dict]] = []
 
@@ -847,6 +916,106 @@ def test_observe_decorator_can_redact_inputs():
     assert trace_payload["observations"][0]["input_data"] == {"redacted": True}
 
 
+@pytest.mark.parametrize(
+    ("redact_input", "redact_output"),
+    [
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test_observe_decorator_redacts_input_output_combinations(
+    redact_input, redact_output
+):
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=10,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+        ),
+        sender=sender,
+    )
+
+    @observe(
+        "redaction-matrix",
+        client=client,
+        redact_input=redact_input,
+        redact_output=redact_output,
+    )
+    def sensitive(secret: str) -> dict[str, str]:
+        return {"answer": f"derived from {secret}"}
+
+    assert sensitive("top-secret-value") == {"answer": "derived from top-secret-value"}
+
+    result = client.flush()
+    client.close()
+
+    assert result.success is True
+    trace_payload = sent_batches[-1][-1]
+    observation = trace_payload["observations"][0]
+    if redact_input:
+        assert trace_payload["input_data"] == {"redacted": True}
+        assert observation["input_data"] == {"redacted": True}
+    else:
+        assert trace_payload["input_data"]["args"] == ["top-secret-value"]
+        assert observation["input_data"]["args"] == ["top-secret-value"]
+
+    if redact_output:
+        assert trace_payload["output_data"] == {"redacted": True}
+        assert observation["output_data"] == {"redacted": True}
+    else:
+        assert trace_payload["output_data"] == {
+            "answer": "derived from top-secret-value"
+        }
+        assert observation["output_data"] == {"answer": "derived from top-secret-value"}
+
+
+def test_observe_context_redacts_input_and_output():
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=10,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+        ),
+        sender=sender,
+    )
+
+    with ObserveContext(
+        name="context-redaction",
+        client=client,
+        input_data={"password": "top-secret-value"},  # pragma: allowlist secret
+        redact_input=True,
+        redact_output=True,
+    ) as ctx:
+        ctx._result = {"answer": "top-secret-value"}  # pragma: allowlist secret
+
+    result = client.flush()
+    client.close()
+
+    assert result.success is True
+    trace_payload = sent_batches[-1][-1]
+    observation = trace_payload["observations"][0]
+    assert trace_payload["input_data"] == {"redacted": True}
+    assert observation["input_data"] == {"redacted": True}
+    assert trace_payload["output_data"] == {"redacted": True}
+    assert observation["output_data"] == {"redacted": True}
+
+
 def test_observability_client_flush_surfaces_backend_warnings():
     client = ObservabilityClient(
         ObservabilityConfig(
@@ -904,6 +1073,109 @@ def test_observation_dto_rejects_negative_values():
             name="bad-observation",
             input_tokens=-1,
         )
+
+
+@pytest.mark.parametrize("status", ["", "x" * 65])
+def test_observation_dto_rejects_invalid_status(status):
+    with pytest.raises(ValueError, match="status"):
+        ObservationDTO(
+            id="obs_bad_status",
+            type=ObservationType.SPAN,
+            name="bad-observation",
+            status=status,
+        )
+
+
+@pytest.mark.parametrize("status", ["", "x" * 65])
+def test_trace_dto_rejects_invalid_status(status):
+    with pytest.raises(ValueError, match="status"):
+        TraceDTO(id="trace_bad_status", name="bad-trace", status=status)
+
+
+def test_observation_dto_rejects_event_with_children():
+    child = ObservationDTO(
+        id="obs_child",
+        type=ObservationType.SPAN,
+        name="child",
+    )
+
+    with pytest.raises(ValueError, match="event observations cannot have children"):
+        ObservationDTO(
+            id="obs_event",
+            type=ObservationType.EVENT,
+            name="event-parent",
+            children=[child],
+        )
+
+
+def test_observability_client_rejects_child_under_event_observation():
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=10,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+        ),
+        sender=lambda traces: None,
+    )
+
+    trace_id = client.start_trace("event-child-validation", trace_id="trace_event")
+    event_id = client.record_observation(
+        trace_id,
+        observation_id="obs_event",
+        name="event-parent",
+        observation_type=ObservationType.EVENT,
+    )
+
+    with pytest.raises(ValueError, match="event observations cannot have children"):
+        client.record_observation(
+            trace_id,
+            observation_id="obs_child",
+            parent_observation_id=event_id,
+            name="invalid-child",
+            observation_type=ObservationType.SPAN,
+        )
+
+    client.close()
+
+
+def test_observability_client_rejects_converting_parent_to_event():
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=10,
+            max_buffer_age=0.1,
+            max_queue_size=10,
+        ),
+        sender=lambda traces: None,
+    )
+
+    trace_id = client.start_trace("event-parent-validation", trace_id="trace_parent")
+    parent_id = client.record_observation(
+        trace_id,
+        observation_id="obs_parent",
+        name="parent",
+        observation_type=ObservationType.SPAN,
+    )
+    client.record_observation(
+        trace_id,
+        observation_id="obs_child",
+        parent_observation_id=parent_id,
+        name="child",
+        observation_type=ObservationType.SPAN,
+    )
+
+    with pytest.raises(ValueError, match="event observations cannot have children"):
+        client.record_observation(
+            trace_id,
+            observation_id=parent_id,
+            name="parent",
+            observation_type=ObservationType.EVENT,
+        )
+
+    client.close()
 
 
 def test_observability_client_collaboration_helpers_follow_backend_contract():
@@ -1343,8 +1615,7 @@ def test_observability_client_logs_ingest_warnings(monkeypatch, caplog):
     )
 
     monkeypatch.setattr(
-        "traigent.observability.client.request.urlopen",
-        lambda *args, **kwargs: _FakeResponse(),
+        client, "_open_http_request", lambda http_request: _FakeResponse()
     )
 
     with caplog.at_level(logging.WARNING):
@@ -1403,8 +1674,9 @@ def test_observability_client_closes_http_errors(
     )
 
     monkeypatch.setattr(
-        "traigent.observability.client.request.urlopen",
-        lambda *call_args, **call_kwargs: (_ for _ in ()).throw(http_error),
+        client,
+        "_open_http_request",
+        lambda http_request: (_ for _ in ()).throw(http_error),
     )
 
     with pytest.raises(ClientError, match=message):

--- a/traigent/cloud/url_security.py
+++ b/traigent/cloud/url_security.py
@@ -10,7 +10,13 @@ from urllib.parse import unquote, urlparse, urlunparse
 
 _DEVELOPMENT_ENV_NAMES = {"dev", "development", "local", "test", "testing"}
 _PRODUCTION_ENV_NAMES = {"prod", "production", "stage", "staging"}
-_ENV_KEYS = ("TRAIGENT_ENV", "ENVIRONMENT", "APP_ENV", "FLASK_ENV")
+_ENV_KEYS = (
+    "TRAIGENT_ENV",
+    "ENVIRONMENT",
+    "TRAIGENT_ENVIRONMENT",
+    "APP_ENV",
+    "FLASK_ENV",
+)
 
 
 def _is_development_environment() -> bool:

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -54,6 +54,21 @@ _TRACE_BATCH_SUFFIX_BYTES = len(b"]}")
 _TRACE_BATCH_ITEM_SEPARATOR_BYTES = len(b", ")
 
 
+class _NoRedirectHandler(request.HTTPRedirectHandler):
+    """Prevent credentialed observability requests from replaying headers elsewhere."""
+
+    def redirect_request(
+        self,
+        req: request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
 def _new_trace_id() -> str:
     return f"trace_{uuid.uuid4().hex}"
 
@@ -167,8 +182,8 @@ class _SyncBatchTransport:
     def get_stats(self) -> dict[str, Any]:
         with self._lock:
             snapshot: dict[str, Any] = dict(self._stats)
-        snapshot["errors"] = list(self._errors)
-        snapshot["warnings"] = list(self._warnings)
+            snapshot["errors"] = list(self._errors)
+            snapshot["warnings"] = list(self._warnings)
         return snapshot
 
     def _ensure_timer_locked(self) -> None:
@@ -300,14 +315,16 @@ class _SyncBatchTransport:
             )
 
     def _append_error(self, message: str) -> None:
-        self._errors.append(message)
-        if len(self._errors) > 20:
-            self._errors = self._errors[-20:]
+        with self._lock:
+            self._errors.append(message)
+            if len(self._errors) > 20:
+                self._errors = self._errors[-20:]
 
     def _append_warning(self, message: str) -> None:
-        self._warnings.append(message)
-        if len(self._warnings) > 50:
-            self._warnings = self._warnings[-50:]
+        with self._lock:
+            self._warnings.append(message)
+            if len(self._warnings) > 50:
+                self._warnings = self._warnings[-50:]
 
 
 class ObservabilityClient:
@@ -335,6 +352,7 @@ class ObservabilityClient:
         self._lock = threading.RLock()
         self._closed = False
         self._offline_notice_logged = False
+        self._http_opener = request.build_opener(_NoRedirectHandler)
         self._transport = self._create_transport()
 
         if self.config.enable_atexit_flush:
@@ -422,6 +440,12 @@ class ObservabilityClient:
             state = self._trace_states.get(trace_id)
             if state is None:
                 raise ValueError(f"Unknown trace_id '{trace_id}'")
+            self._validate_observation_relationship(
+                state,
+                observation_id=observation_id,
+                observation_type=observation_type,
+                parent_observation_id=parent_observation_id,
+            )
 
             existing = state.observations.get(observation_id)
             if existing is None:
@@ -559,28 +583,37 @@ class ObservabilityClient:
         return stats
 
     def close(self, timeout: float | None = None) -> FlushResult:
-        if self._closed:
-            return FlushResult(
-                success=True,
-                items_sent=0,
-                items_pending=0,
-                items_dropped=0,
-                successful_batches=0,
-                failed_batches=0,
-                errors=[],
-                warnings=[],
-            )
+        with self._lock:
+            if self._closed:
+                return FlushResult(
+                    success=True,
+                    items_sent=0,
+                    items_pending=0,
+                    items_dropped=0,
+                    successful_batches=0,
+                    failed_batches=0,
+                    errors=[],
+                    warnings=[],
+                )
 
         if self.config.offline_mode and not self._has_custom_trace_sender:
             self._log_offline_mode_once()
-            self._closed = True
+            with self._lock:
+                self._closed = True
             return self._offline_flush_result()
-        with self._lock:
-            trace_ids = list(self._trace_states.keys())
-        for trace_id in trace_ids:
-            self._queue_trace_snapshot(trace_id)
 
-        self._closed = True
+        with self._lock:
+            trace_payloads = [
+                (
+                    trace_id,
+                    cast(dict[str, Any], redact_sensitive_data(state.to_payload())),
+                )
+                for trace_id, state in self._trace_states.items()
+            ]
+            self._closed = True
+
+        for trace_id, payload in trace_payloads:
+            self._submit_trace_snapshot(trace_id, payload)
         result = self._transport.close()
         return FlushResult(
             success=result.success,
@@ -771,9 +804,7 @@ class ObservabilityClient:
             method="POST",
         )
         try:
-            with request.urlopen(  # nosec B310 - backend_origin is caller-configured API endpoint
-                http_request, timeout=self.config.request_timeout
-            ) as response:
+            with self._open_http_request(http_request) as response:
                 status_code = getattr(response, "status", 200)
                 body = response.read().decode("utf-8") if response else ""
                 if status_code >= 400:
@@ -834,8 +865,9 @@ class ObservabilityClient:
         path: str,
         payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        if self._closed:
-            raise ClientError("Observability client is closed")
+        with self._lock:
+            if self._closed:
+                raise ClientError("Observability client is closed")
         if self.config.offline_mode:
             self._log_offline_mode_once()
             raise ClientError(
@@ -864,9 +896,7 @@ class ObservabilityClient:
             method=method,
         )
         try:
-            with request.urlopen(  # nosec B310 - backend_origin is caller-configured API endpoint
-                http_request, timeout=self.config.request_timeout
-            ) as response:
+            with self._open_http_request(http_request) as response:
                 status_code = getattr(response, "status", 200)
                 body = response.read().decode("utf-8") if response else ""
                 parsed = json.loads(body) if body else {}
@@ -899,6 +929,34 @@ class ObservabilityClient:
             raise ClientError(f"Unexpected response structure for {label}")
         return data
 
+    def _open_http_request(self, http_request: request.Request) -> Any:
+        return self._http_opener.open(
+            http_request,
+            timeout=self.config.request_timeout,
+        )
+
+    @staticmethod
+    def _validate_observation_relationship(
+        state: _TraceState,
+        *,
+        observation_id: str,
+        observation_type: ObservationType,
+        parent_observation_id: str | None,
+    ) -> None:
+        if parent_observation_id is not None:
+            parent = state.observations.get(parent_observation_id)
+            if parent is not None and parent.type is ObservationType.EVENT:
+                raise ValueError("event observations cannot have children")
+
+        if observation_type is ObservationType.EVENT:
+            has_children = any(
+                existing_id != observation_id
+                and observation.parent_observation_id == observation_id
+                for existing_id, observation in state.observations.items()
+            )
+            if has_children:
+                raise ValueError("event observations cannot have children")
+
     def _queue_trace_snapshot(self, trace_id: str) -> None:
         if self.config.offline_mode and not self._has_custom_trace_sender:
             return
@@ -907,6 +965,9 @@ class ObservabilityClient:
             if state is None or self._closed:
                 return
             payload = cast(dict[str, Any], redact_sensitive_data(state.to_payload()))
+        self._submit_trace_snapshot(trace_id, payload)
+
+    def _submit_trace_snapshot(self, trace_id: str, payload: dict[str, Any]) -> None:
         submitted = self._transport.submit(trace_id, payload)
         if not submitted:
             stats = self._transport.get_stats()
@@ -1008,8 +1069,9 @@ class ObservabilityClient:
         return PromptReferenceDTO(**prompt_reference)
 
     def _atexit_close(self) -> None:
-        if self._closed:
-            return
+        with self._lock:
+            if self._closed:
+                return
         try:
             self.close(timeout=self.config.flush_timeout)
         except Exception as exc:

--- a/traigent/observability/config.py
+++ b/traigent/observability/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 
+from traigent.cloud.url_security import validate_cloud_base_url
 from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env, scope_api_path
 from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
@@ -48,7 +49,10 @@ class ObservabilityConfig:
     extra_headers: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        self.backend_origin = self.backend_origin.rstrip("/")
+        self.backend_origin = validate_cloud_base_url(
+            self.backend_origin,
+            purpose="observability backend",
+        )
         self.tenant_id = (
             self.tenant_id.strip() or None if self.tenant_id is not None else None
         )

--- a/traigent/observability/decorators.py
+++ b/traigent/observability/decorators.py
@@ -175,6 +175,7 @@ class ObserveContext:
         release: str | None = None,
         tags: list[str] | None = None,
         redact_input: bool = False,
+        redact_output: bool = False,
     ) -> None:
         self.name = name
         self.client = client
@@ -192,6 +193,7 @@ class ObserveContext:
         self.release = release
         self.tags = list(tags or [])
         self.redact_input = redact_input
+        self.redact_output = redact_output
 
         self._started_at: datetime | None = None
         self._trace_id: str | None = None
@@ -203,6 +205,12 @@ class ObserveContext:
         self._finished = False
         self._result: Any = None
         self._enriched_metadata = _build_observe_enrichment_metadata()
+
+    def _captured_input(self) -> Any:
+        return _redacted_input_payload() if self.redact_input else self.input_data
+
+    def _captured_output(self, result: Any) -> Any:
+        return _redacted_input_payload() if self.redact_output else result
 
     def __enter__(self) -> ObserveContext:
         self._started_at = utc_now()
@@ -225,7 +233,7 @@ class ObserveContext:
                 tags=self.tags,
                 metadata=trace_metadata,
                 started_at=self._started_at,
-                input_data=self.input_data,
+                input_data=self._captured_input(),
                 custom_trace_id=self.custom_trace_id,
             )
             self._created_trace = True
@@ -243,7 +251,7 @@ class ObserveContext:
             parent_observation_id=parent_observation_id,
             status="running",
             started_at=self._started_at,
-            input_data=self.input_data,
+            input_data=self._captured_input(),
             metadata=observation_metadata,
         )
         self._trace_id = trace_id
@@ -279,6 +287,7 @@ class ObserveContext:
             metadata["error_message"] = str(error)
 
         if self._trace_id and self._observation_id:
+            output_data = self._captured_output(result)
             client.record_observation(
                 self._trace_id,
                 observation_id=self._observation_id,
@@ -286,15 +295,15 @@ class ObserveContext:
                 observation_type=self.observation_type,
                 status=status,
                 ended_at=ended_at,
-                input_data=self.input_data,
-                output_data=result,
+                input_data=self._captured_input(),
+                output_data=output_data,
                 metadata=metadata,
             )
             if self._created_trace:
                 client.end_trace(
                     self._trace_id,
                     status=status,
-                    output_data=result,
+                    output_data=output_data,
                     ended_at=ended_at,
                 )
 
@@ -323,6 +332,7 @@ class _ObserveFactory:
         release: str | None = None,
         tags: list[str] | None = None,
         redact_input: bool = False,
+        redact_output: bool = False,
     ) -> None:
         self.name = name
         self.client = client
@@ -335,6 +345,7 @@ class _ObserveFactory:
         self.release = release
         self.tags = tags
         self.redact_input = redact_input
+        self.redact_output = redact_output
         self._context: ObserveContext | None = None
 
     def _require_context(self) -> ObserveContext:
@@ -369,6 +380,7 @@ class _ObserveFactory:
                     release=self.release,
                     tags=self.tags,
                     redact_input=self.redact_input,
+                    redact_output=self.redact_output,
                 ) as ctx:
                     result = await func(*args, **kwargs)
                     ctx._result = result
@@ -396,6 +408,7 @@ class _ObserveFactory:
                 release=self.release,
                 tags=self.tags,
                 redact_input=self.redact_input,
+                redact_output=self.redact_output,
             ) as ctx:
                 result = func(*args, **kwargs)
                 ctx._result = result
@@ -416,6 +429,7 @@ class _ObserveFactory:
             release=self.release,
             tags=self.tags,
             redact_input=self.redact_input,
+            redact_output=self.redact_output,
         )
         return self._context.__enter__()
 
@@ -435,6 +449,7 @@ class _ObserveFactory:
             release=self.release,
             tags=self.tags,
             redact_input=self.redact_input,
+            redact_output=self.redact_output,
         )
         return await self._context.__aenter__()
 
@@ -455,11 +470,15 @@ def observe(
     release: str | None = None,
     tags: list[str] | None = None,
     redact_input: bool = False,
+    redact_output: bool = False,
 ):
     """Create a decorator or context manager for observability instrumentation.
 
-    By default the decorator captures function arguments as trace input. Set
-    `redact_input=True` when arguments may include secrets, credentials, or PII.
+    By default the decorator captures function arguments as trace input and
+    return values as trace output. Set `redact_input=True` or
+    `redact_output=True` when arguments or return values may include secrets,
+    credentials, PII, or proprietary content. When redaction is not enabled,
+    the transport still applies pattern-based secret scrubbing before send.
     """
 
     if callable(name):
@@ -478,4 +497,5 @@ def observe(
         release=release,
         tags=tags,
         redact_input=redact_input,
+        redact_output=redact_output,
     )

--- a/traigent/observability/dtos.py
+++ b/traigent/observability/dtos.py
@@ -11,6 +11,7 @@ MAX_IDENTIFIER_LENGTH = 128
 MAX_NAME_LENGTH = 255
 MAX_ENVIRONMENT_LENGTH = 64
 MAX_LABEL_LENGTH = 64
+MAX_STATUS_LENGTH = 64
 
 
 def utc_now() -> datetime:
@@ -196,6 +197,7 @@ class ObservationDTO:
     def __post_init__(self) -> None:
         _validate_required_string("id", self.id, max_length=MAX_IDENTIFIER_LENGTH)
         _validate_required_string("name", self.name, max_length=MAX_NAME_LENGTH)
+        _validate_required_string("status", self.status, max_length=MAX_STATUS_LENGTH)
         _validate_optional_string(
             "parent_observation_id",
             self.parent_observation_id,
@@ -212,6 +214,8 @@ class ObservationDTO:
         _validate_non_negative("output_tokens", self.output_tokens)
         _validate_non_negative("total_tokens", self.total_tokens)
         _validate_non_negative("cost_usd", self.cost_usd)
+        if self.type is ObservationType.EVENT and self.children:
+            raise ValueError("event observations cannot have children")
 
     def to_dict(self) -> dict[str, Any]:
         payload = {
@@ -271,6 +275,7 @@ class TraceDTO:
     def __post_init__(self) -> None:
         _validate_required_string("id", self.id, max_length=MAX_IDENTIFIER_LENGTH)
         _validate_required_string("name", self.name, max_length=MAX_NAME_LENGTH)
+        _validate_required_string("status", self.status, max_length=MAX_STATUS_LENGTH)
         _validate_optional_string(
             "session_id", self.session_id, max_length=MAX_IDENTIFIER_LENGTH
         )


### PR DESCRIPTION
## Summary

- Validate observability `backend_origin` through the shared cloud URL guard before credentialed sends, and use a no-redirect opener so API key/JWT headers are not replayed to redirect targets.
- Make observability close/diagnostic state lock-consistent: final snapshots are captured under the client lock, `_closed` is guarded, and transport errors/warnings are mutated/snapshotted under the transport lock.
- Add client-side validation for trace/observation status length and the backend rule that EVENT observations cannot have children.
- Add `redact_output` parity for `observe()` / `ObserveContext`, and make `ObserveContext(..., redact_input=True)` actually suppress input payloads.
- Teach the shared cloud URL validator to honor `TRAIGENT_ENVIRONMENT=development`, matching the repo test fixture and workspace environment policy.

Refs #1240
Refs #1236
Refs #1234
Refs #1229

## Validation

- `black --check traigent/cloud/url_security.py traigent/observability/config.py traigent/observability/client.py traigent/observability/dtos.py traigent/observability/decorators.py tests/unit/observability/test_observability_client.py tests/unit/cloud/test_url_security.py tests/security/test_pii_canary_leak.py`
- `ruff format --check traigent/cloud/url_security.py traigent/observability/config.py traigent/observability/client.py traigent/observability/dtos.py traigent/observability/decorators.py tests/unit/observability/test_observability_client.py tests/unit/cloud/test_url_security.py tests/security/test_pii_canary_leak.py`
- `ruff check traigent/cloud/url_security.py traigent/observability/config.py traigent/observability/client.py traigent/observability/dtos.py traigent/observability/decorators.py tests/unit/observability/test_observability_client.py tests/unit/cloud/test_url_security.py tests/security/test_pii_canary_leak.py`
- `isort --check-only traigent/cloud/url_security.py traigent/observability/config.py traigent/observability/client.py traigent/observability/dtos.py traigent/observability/decorators.py tests/unit/observability/test_observability_client.py tests/unit/cloud/test_url_security.py tests/security/test_pii_canary_leak.py`
- `git diff --check`
- `pytest -n 0 tests/unit/observability/test_observability_client.py tests/unit/cloud/test_url_security.py tests/security/test_pii_canary_leak.py` (70 passed)
- `bash /home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/scan_secrets.sh origin/develop` (8 files scanned, no secrets)
- `bash /home/nimrodbu/Traigent_enterprise/skills/agents-skills/skills/safe-push/scripts/check_formatting.sh origin/develop` (passed)
- Commit hook: isort, black, ruff, detect-secrets, whitespace/EOF checks, merge-conflict check, private-key check, bandit, mypy, strict cost-accounting guardrails, public test assertion contracts, dependency floor drift, ignored-file check.

## Local-only blockers

- Local push hook attempted SonarQube scan but skipped because `sonar-scanner` is not installed. Remote SonarCloud/Aikido checks remain authoritative.
