### PR TITLE
fix(hybrid): harden execute failure handling

### DIFF
--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -17,7 +17,7 @@ Tests cover:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,7 +32,11 @@ from traigent.hybrid.protocol import (
     HybridExecuteResponse,
     ServiceCapabilities,
 )
-from traigent.hybrid.transport import TransportError
+from traigent.hybrid.transport import (
+    TransportError,
+    TransportRateLimitError,
+    TransportServerError,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers / Fixtures
@@ -58,22 +62,25 @@ def _make_dataset(examples: list[dict[str, Any]] | None = None) -> Dataset:
 
 def _make_execute_response(
     *,
+    status: Literal["completed", "partial", "failed"] = "completed",
     outputs: list[dict[str, Any]] | None = None,
     operational_metrics: dict[str, float] | None = None,
     quality_metrics: dict[str, float] | None = None,
     session_id: str | None = None,
     execution_id: str = "exec-1",
+    error: dict[str, Any] | None = None,
 ) -> HybridExecuteResponse:
     """Create a mock HybridExecuteResponse."""
     return HybridExecuteResponse(
         request_id="req-1",
         execution_id=execution_id,
-        status="completed",
+        status=status,
         outputs=outputs or [],
         operational_metrics=operational_metrics
         or {"cost_usd": 0.01, "latency_ms": 100.0},
         quality_metrics=quality_metrics,
         session_id=session_id,
+        error=error,
     )
 
 
@@ -343,6 +350,31 @@ class TestGetCapabilities:
         caps2 = await evaluator._get_capabilities()
         assert caps2 is caps
         assert mock_transport.capabilities.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_capabilities_error_retries_before_caching(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """A transient handshake failure must not cache degraded capabilities."""
+        recovered = _default_capabilities(supports_evaluate=True)
+        mock_transport.capabilities = AsyncMock(
+            side_effect=[
+                TransportServerError("service unavailable", status_code=503),
+                recovered,
+            ]
+        )
+        evaluator = HybridAPIEvaluator(transport=mock_transport, keep_alive=False)
+
+        with patch("traigent.utils.retry.asyncio.sleep", new_callable=AsyncMock):
+            caps = await evaluator._get_capabilities()
+
+        assert caps is recovered
+        assert caps.supports_evaluate is True
+        assert mock_transport.capabilities.await_count == 2
+
+        caps2 = await evaluator._get_capabilities()
+        assert caps2 is recovered
+        assert mock_transport.capabilities.await_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -1253,6 +1285,113 @@ class TestExecuteBatch:
         assert results[1].expected_output == "a2"
 
     @pytest.mark.asyncio
+    async def test_failed_execute_status_marks_all_examples_failed(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """A top-level failed execute response is not scored as success."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id="cap",
+            keep_alive=False,
+        )
+        ev._benchmark_id = "test-bench"
+        mock_transport.execute = AsyncMock(
+            return_value=_make_execute_response(
+                status="failed",
+                outputs=[],
+                error={"code": "agent_error", "message": "upstream crashed"},
+            )
+        )
+        caps = _default_capabilities(supports_evaluate=False)
+
+        dataset = _make_dataset(
+            [
+                {"input_data": {"q": "1"}, "expected_output": "a1"},
+                {"input_data": {"q": "2"}, "expected_output": "a2"},
+            ]
+        )
+        batch = list(dataset)
+
+        results = await ev._execute_batch(mock_transport, caps, {}, batch)
+
+        assert [r.success for r in results] == [False, False]
+        assert all("agent_error: upstream crashed" == r.error for r in results)
+        assert all(r.cost_usd == 0.0 for r in results)
+        mock_transport.evaluate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_partial_execute_missing_outputs_are_failed(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """Partial execute responses do not treat omitted outputs as success."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id="cap",
+            keep_alive=False,
+        )
+        ev._benchmark_id = "test-bench"
+        mock_transport.execute = AsyncMock(
+            return_value=_make_execute_response(
+                status="partial",
+                outputs=[{"example_id": "ex_0", "output": "ok"}],
+                operational_metrics={"cost_usd": 0.02, "latency_ms": 25.0},
+            )
+        )
+        caps = _default_capabilities(supports_evaluate=False)
+
+        dataset = _make_dataset(
+            [
+                {"input_data": {"q": "1"}, "expected_output": "a1"},
+                {"input_data": {"q": "2"}, "expected_output": "a2"},
+            ]
+        )
+        batch = list(dataset)
+
+        results = await ev._execute_batch(mock_transport, caps, {}, batch)
+
+        assert len(results) == 2
+        assert results[0].success is True
+        assert results[0].actual_output == "ok"
+        assert results[1].success is False
+        assert "did not include output" in str(results[1].error)
+        assert results[1].cost_usd == 0.0
+
+    @pytest.mark.asyncio
+    async def test_execute_rate_limit_retries_before_error_rows(
+        self, mock_transport: MagicMock
+    ) -> None:
+        """A 429 execute response is retried with Retry-After before scoring."""
+        ev = HybridAPIEvaluator(
+            transport=mock_transport,
+            tunable_id="cap",
+            keep_alive=False,
+        )
+        ev._benchmark_id = "test-bench"
+        mock_transport.execute = AsyncMock(
+            side_effect=[
+                TransportRateLimitError("limited", retry_after=0.01),
+                _make_execute_response(
+                    outputs=[{"example_id": "ex_0", "output": "recovered"}],
+                ),
+            ]
+        )
+        caps = _default_capabilities(supports_evaluate=False)
+
+        dataset = _make_dataset([{"input_data": {"q": "?"}, "expected_output": "a"}])
+        batch = list(dataset)
+
+        with patch(
+            "traigent.utils.retry.asyncio.sleep", new_callable=AsyncMock
+        ) as wait:
+            results = await ev._execute_batch(mock_transport, caps, {}, batch)
+
+        assert len(results) == 1
+        assert results[0].success is True
+        assert results[0].actual_output == "recovered"
+        assert mock_transport.execute.await_count == 2
+        wait.assert_awaited_once_with(0.01)
+
+    @pytest.mark.asyncio
     async def test_session_id_updated_from_response(
         self, mock_transport: MagicMock
     ) -> None:
@@ -1352,9 +1491,7 @@ class TestExecuteBatch:
         mock_transport.execute = AsyncMock(return_value=exec_response)
         caps = _default_capabilities(supports_evaluate=False)
 
-        example = EvaluationExample(
-            input_data={"input_id": "consultant-fridge"}
-        )
+        example = EvaluationExample(input_data={"input_id": "consultant-fridge"})
         dataset = Dataset(examples=[example], name="test")
         batch = list(dataset)
 
@@ -1362,9 +1499,7 @@ class TestExecuteBatch:
         assert results[0].example_id == "consultant-fridge"
 
     @pytest.mark.asyncio
-    async def test_two_phase_input_id_matching(
-        self, mock_transport: MagicMock
-    ) -> None:
+    async def test_two_phase_input_id_matching(self, mock_transport: MagicMock) -> None:
         """Two-phase mode matches evaluate results keyed by input_id."""
         ev = HybridAPIEvaluator(
             transport=mock_transport,
@@ -1373,7 +1508,11 @@ class TestExecuteBatch:
         )
         exec_response = _make_execute_response(
             outputs=[
-                {"input_id": "consultant-fridge", "output": "result_0", "output_id": "out_0"},
+                {
+                    "input_id": "consultant-fridge",
+                    "output": "result_0",
+                    "output_id": "out_0",
+                },
             ],
             operational_metrics={"cost_usd": 0.01, "latency_ms": 100.0},
         )
@@ -1390,7 +1529,12 @@ class TestExecuteBatch:
         )
         dataset = Dataset(examples=[example], name="test")
         batch = list(dataset)
-        inputs = [{"example_id": "consultant-fridge", "data": {"input_id": "consultant-fridge"}}]
+        inputs = [
+            {
+                "example_id": "consultant-fridge",
+                "data": {"input_id": "consultant-fridge"},
+            }
+        ]
 
         results = await ev._evaluate_outputs(
             mock_transport, {}, batch, inputs, exec_response
@@ -1611,7 +1755,7 @@ class TestProcessCombinedResponse:
         assert results[1].expected_output == "6"  # From dataset
 
     def test_combined_no_matching_output(self, mock_transport: MagicMock) -> None:
-        """When output example_id doesn't match, output is None."""
+        """When output example_id doesn't match, the example is failed."""
         ev = HybridAPIEvaluator(
             transport=mock_transport,
             tunable_id="cap",
@@ -1631,6 +1775,8 @@ class TestProcessCombinedResponse:
         assert len(results) == 1
         assert results[0].actual_output is None
         assert results[0].metrics == {}
+        assert results[0].success is False
+        assert "did not include output" in str(results[0].error)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/hybrid/test_http_transport.py
+++ b/tests/unit/hybrid/test_http_transport.py
@@ -666,17 +666,44 @@ class TestHTTPTransportAdditionalMethods:
     async def test_capabilities_fallback_on_error(
         self, transport: HTTPTransport
     ) -> None:
-        """Test capabilities returns defaults on error."""
+        """Test capabilities returns defaults when the endpoint is absent."""
         with patch.object(
             transport,
             "_request",
             new_callable=AsyncMock,
-            side_effect=TransportError("Connection failed"),
+            side_effect=TransportError("Not found", status_code=404),
         ):
             caps = await transport.capabilities()
 
         assert caps.version == "1.0"
         assert caps.supports_evaluate is False  # Safe default
+
+    @pytest.mark.asyncio
+    async def test_capabilities_transient_error_is_not_cached(
+        self, transport: HTTPTransport
+    ) -> None:
+        """Transient capabilities failures should not cache safe defaults."""
+        response = {
+            "version": "1.0",
+            "supports_evaluate": True,
+            "supports_keep_alive": False,
+        }
+        request = AsyncMock(
+            side_effect=[
+                TransportServerError("service unavailable", status_code=503),
+                response,
+            ]
+        )
+
+        with patch.object(transport, "_request", request):
+            with pytest.raises(TransportServerError):
+                await transport.capabilities()
+
+            caps = await transport.capabilities()
+
+        assert caps.supports_evaluate is True
+        assert transport._capabilities is caps
+        assert request.await_count == 2
 
     @pytest.mark.asyncio
     async def test_discover_config_space(self, transport: HTTPTransport) -> None:

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -17,7 +17,7 @@ import warnings
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from traigent._version import get_version
 from traigent.api.types import ComparabilityInfo, MetricCoverage
@@ -30,13 +30,19 @@ from traigent.hybrid import (
     ConfigSpaceDiscovery,
     HybridEvaluateRequest,
     HybridExecuteRequest,
+    HybridExecuteResponse,
     HybridTransport,
     ServiceCapabilities,
+    TransportConnectionError,
     TransportError,
+    TransportRateLimitError,
+    TransportServerError,
+    TransportTimeoutError,
     create_transport,
 )
 from traigent.utils.logging import get_logger
 from traigent.utils.objectives import classify_objective
+from traigent.utils.retry import RetryConfig, RetryHandler
 
 if TYPE_CHECKING:
     from traigent.cloud.production_mcp_client import (
@@ -46,6 +52,19 @@ if TYPE_CHECKING:
     from traigent.core.sample_budget import SampleBudgetLease
 
 logger = get_logger(__name__)
+
+_HYBRID_TRANSPORT_RETRY_CONFIG = RetryConfig(
+    max_attempts=3,
+    initial_delay=0.25,
+    max_delay=2.0,
+    jitter=False,
+    retry_on_exception={
+        TransportRateLimitError,
+        TransportServerError,
+        TransportConnectionError,
+        TransportTimeoutError,
+    },
+)
 
 
 @dataclass
@@ -235,7 +254,15 @@ class HybridAPIEvaluator(BaseEvaluator):
         """Get service capabilities."""
         if self._capabilities is None:
             transport = await self._get_transport()
-            self._capabilities = await transport.capabilities()
+            retry = RetryHandler(_HYBRID_TRANSPORT_RETRY_CONFIG)
+            capabilities_call = cast(
+                Callable[[], ServiceCapabilities],
+                transport.capabilities,
+            )
+            self._capabilities = cast(
+                ServiceCapabilities,
+                await retry.execute_async(capabilities_call),
+            )
         return self._capabilities
 
     async def discover_config_space(self) -> dict[str, Any]:
@@ -410,12 +437,50 @@ class HybridAPIEvaluator(BaseEvaluator):
     def _find_output_item(
         outputs: list[dict[str, Any]],
         example_id: str,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | None:
         """Find output item for an example_id/input_id."""
         for out in outputs:
             if out.get("example_id") == example_id or out.get("input_id") == example_id:
                 return out
-        return {}
+        return None
+
+    @staticmethod
+    def _missing_output_error(example_id: str) -> str:
+        """Build the missing-output error used across hybrid response modes."""
+        return f"Execute response did not include output for example_id {example_id!r}"
+
+    @staticmethod
+    def _response_error_message(response: Any) -> str:
+        """Render a top-level hybrid response error into a stable message."""
+        error = getattr(response, "error", None)
+        if isinstance(error, dict):
+            message = error.get("message") or error.get("error") or error.get("detail")
+            code = error.get("code")
+            if message and code:
+                return f"{code}: {message}"
+            if message:
+                return str(message)
+            return str(error)
+        if isinstance(error, str):
+            return error
+        status = getattr(response, "status", "unknown")
+        return f"Hybrid execute response status={status}"
+
+    def _batch_error_results(
+        self,
+        batch: list[Any],
+        inputs: list[dict[str, Any]],
+        error: str,
+    ) -> list[HybridExampleResult]:
+        """Return deterministic error rows for every example in a batch."""
+        return [
+            HybridExampleResult(
+                example_id=str(inp["example_id"]),
+                expected_output=self._extract_expected(batch[i]),
+                error=error,
+            )
+            for i, inp in enumerate(inputs)
+        ]
 
     @staticmethod
     def _extract_target_fields(expected: Any) -> tuple[str, Any]:
@@ -775,7 +840,15 @@ class HybridAPIEvaluator(BaseEvaluator):
 
         try:
             # Execute
-            execute_response = await transport.execute(request)
+            retry = RetryHandler(_HYBRID_TRANSPORT_RETRY_CONFIG)
+            execute_call = cast(
+                Callable[[HybridExecuteRequest], HybridExecuteResponse],
+                transport.execute,
+            )
+            execute_response = cast(
+                HybridExecuteResponse,
+                await retry.execute_async(execute_call, request),
+            )
 
             # Log raw execute response for observability
             logger.info(
@@ -787,11 +860,19 @@ class HybridAPIEvaluator(BaseEvaluator):
             )
 
             # Update session ID if returned
-            if execute_response.session_id:
-                if self._session_id != execute_response.session_id:
-                    self._session_id = execute_response.session_id
+            new_session_id = execute_response.session_id
+            if new_session_id:
+                if self._session_id != new_session_id:
+                    self._session_id = new_session_id
                     if self._lifecycle_manager:
-                        await self._lifecycle_manager.register(self._session_id)
+                        await self._lifecycle_manager.register(new_session_id)
+
+            if execute_response.status == "failed":
+                return self._batch_error_results(
+                    batch,
+                    inputs,
+                    self._response_error_message(execute_response),
+                )
 
             # Check if combined mode (quality metrics included)
             if execute_response.quality_metrics:
@@ -811,14 +892,7 @@ class HybridAPIEvaluator(BaseEvaluator):
         except TransportError as e:
             logger.error(f"Batch execution failed: {e}")
             # Return error results for all examples
-            return [
-                HybridExampleResult(
-                    example_id=str(inp["example_id"]),
-                    expected_output=self._extract_expected(batch[i]),
-                    error=str(e),
-                )
-                for i, inp in enumerate(inputs)
-            ]
+            return self._batch_error_results(batch, inputs, str(e))
 
     def _extract_input(self, example: Any) -> dict[str, Any]:
         """Extract input data from dataset example."""
@@ -873,6 +947,20 @@ class HybridAPIEvaluator(BaseEvaluator):
 
             # Find matching output
             output_item = self._find_output_item(response.outputs, example_id)
+            if output_item is None:
+                results.append(
+                    HybridExampleResult(
+                        example_id=example_id,
+                        expected_output=expected,
+                        error=self._missing_output_error(example_id),
+                        metadata={
+                            "evaluation_mode": "evaluated",
+                            "accuracy_derivation_path": "none",
+                        },
+                    )
+                )
+                continue
+
             output_data = output_item.get("output")
             if output_data is None and "output_id" in output_item:
                 output_data = {"output_id": output_item["output_id"]}
@@ -927,6 +1015,8 @@ class HybridAPIEvaluator(BaseEvaluator):
 
             # Find matching output
             output_item = self._find_output_item(execute_response.outputs, example_id)
+            if output_item is None:
+                continue
 
             evaluation: dict[str, Any] = {
                 "example_id": example_id,
@@ -943,6 +1033,14 @@ class HybridAPIEvaluator(BaseEvaluator):
             target_key, target_value = self._extract_target_fields(expected)
             evaluation[target_key] = target_value
             evaluations.append(evaluation)
+
+        if not evaluations:
+            return self._process_execute_only_response(
+                batch,
+                inputs,
+                execute_response,
+                evaluation_mode="evaluate_fallback",
+            )
 
         eval_request = HybridEvaluateRequest(
             tunable_id=self._tunable_id or "default",
@@ -985,10 +1083,15 @@ class HybridAPIEvaluator(BaseEvaluator):
                 output_item = self._find_output_item(
                     execute_response.outputs, example_id
                 )
-                output_data = output_item.get("output")
-                if output_data is None and "output_id" in output_item:
-                    output_data = {"output_id": output_item["output_id"]}
-                execute_error = output_item.get("error")
+                execute_error: Any | None
+                if output_item is None:
+                    output_data = None
+                    execute_error = self._missing_output_error(example_id)
+                else:
+                    output_data = output_item.get("output")
+                    if output_data is None and "output_id" in output_item:
+                        output_data = {"output_id": output_item["output_id"]}
+                    execute_error = output_item.get("error")
 
                 # Find metrics from evaluate
                 per_example_metrics: dict[str, float] = {}
@@ -1011,9 +1114,17 @@ class HybridAPIEvaluator(BaseEvaluator):
                     derivation_path = "none"
 
                 # Prefer per-item operational metrics when present.
-                cost = self._coerce_metric(output_item.get("cost_usd"), fallback_cost)
-                latency = self._coerce_metric(
-                    output_item.get("latency_ms"), fallback_latency
+                cost = (
+                    0.0
+                    if output_item is None
+                    else self._coerce_metric(output_item.get("cost_usd"), fallback_cost)
+                )
+                latency = (
+                    0.0
+                    if output_item is None
+                    else self._coerce_metric(
+                        output_item.get("latency_ms"), fallback_latency
+                    )
                 )
 
                 # Log raw per-example result for observability
@@ -1022,7 +1133,7 @@ class HybridAPIEvaluator(BaseEvaluator):
                     "output_id=%s, accuracy=%s, cost=%.6f, "
                     "latency=%.0fms, error=%s",
                     example_id,
-                    output_item.get("output_id"),
+                    output_item.get("output_id") if output_item is not None else None,
                     per_example_metrics.get("accuracy"),
                     cost,
                     latency,
@@ -1082,6 +1193,20 @@ class HybridAPIEvaluator(BaseEvaluator):
 
             # Find matching output
             output_item = self._find_output_item(response.outputs, example_id)
+            if output_item is None:
+                results.append(
+                    HybridExampleResult(
+                        example_id=example_id,
+                        expected_output=expected,
+                        error=self._missing_output_error(example_id),
+                        metadata={
+                            "evaluation_mode": evaluation_mode,
+                            "accuracy_derivation_path": "none",
+                        },
+                    )
+                )
+                continue
+
             output_data = output_item.get("output")
             if output_data is None and "output_id" in output_item:
                 output_data = {"output_id": output_item["output_id"]}

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -295,7 +295,9 @@ class HTTPTransport:
                 self._capabilities.supports_keep_alive,
             )
             return self._capabilities
-        except TransportError:
+        except TransportError as exc:
+            if exc.status_code != 404:
+                raise
             # Missing capabilities must not claim support for optional endpoints.
             logger.warning("Capabilities endpoint not available, using safe defaults")
             self._capabilities = ServiceCapabilities(version="1.0")


### PR DESCRIPTION
## Summary
- retry transient hybrid execute/capabilities failures with the existing RetryHandler, preserving Retry-After for 429s
- treat top-level failed execute responses and missing output rows as explicit failed examples instead of successful zero-cost results
- only cache HTTP capabilities safe-default fallback when the capabilities endpoint is genuinely absent (404)

Refs #1242

## Validation
- commit hook: isort, black, ruff, detect-secrets, whitespace/EOF, merge-conflict, private-key, bandit, mypy, strict cost-accounting guardrails, public test assertion contracts, dependency floor drift, ignored-file check
- black --check traigent/evaluators/hybrid_api.py traigent/hybrid/http_transport.py tests/unit/evaluators/test_hybrid_api_evaluator.py tests/unit/hybrid/test_http_transport.py
- ruff format --check traigent/evaluators/hybrid_api.py traigent/hybrid/http_transport.py tests/unit/evaluators/test_hybrid_api_evaluator.py tests/unit/hybrid/test_http_transport.py
- ruff check traigent/evaluators/hybrid_api.py traigent/hybrid/http_transport.py tests/unit/evaluators/test_hybrid_api_evaluator.py tests/unit/hybrid/test_http_transport.py
- git diff --check origin/develop...HEAD
- pytest -n 0 tests/unit/evaluators/test_hybrid_api_evaluator.py tests/unit/hybrid/test_http_transport.py tests/unit/hybrid/test_transport.py tests/unit/hybrid/test_mcp_transport.py tests/unit/evaluators/test_hybrid_api_cancelled_error.py tests/unit/test_hybrid_protocol_privacy.py tests/unit/test_hybrid_async_and_privacy.py (242 passed)
- safe-push scan_secrets.sh origin/develop: clean
- safe-push check_formatting.sh origin/develop: passed

Note: local push hook skipped SonarQube because sonar-scanner is not installed.