### PR TITLE
fix(examples): make quickstart mocks config-sensitive

### DIFF
--- a/examples/quickstart/01_simple_qa.py
+++ b/examples/quickstart/01_simple_qa.py
@@ -41,6 +41,43 @@ DATASET_PATH = (
     Path(__file__).resolve().parents[1] / "datasets" / "quickstart" / "qa_samples.jsonl"
 )
 
+MOCK_QA_ANSWERS = [
+    ("What is the capital of France?", "Paris"),
+    ("What is 2 + 2?", "4"),
+    ("Who wrote Romeo and Juliet?", "William Shakespeare"),
+    ("What is the largest planet in our solar system?", "Jupiter"),
+    ("What year did World War II end?", "1945"),
+    ("What is the chemical symbol for water?", "H2O"),
+    ("Who painted the Mona Lisa?", "Leonardo da Vinci"),
+    ("What is the speed of light?", "299,792,458 meters per second"),
+]
+
+
+def _config_value(config, key: str, default):
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _mock_answer_for_config(question: str, config) -> str:
+    model = str(_config_value(config, "model", "gpt-3.5-turbo"))
+    temperature = float(_config_value(config, "temperature", 0.5) or 0.5)
+
+    answer_limit = {
+        "gpt-3.5-turbo": 3,
+        "gpt-4o-mini": 5,
+        "gpt-4o": len(MOCK_QA_ANSWERS),
+    }.get(model, 3)
+
+    if temperature <= 0.2:
+        answer_limit += 1
+    elif temperature >= 0.8:
+        answer_limit -= 2
+    answer_limit = max(1, min(len(MOCK_QA_ANSWERS), answer_limit))
+
+    mock_answers = dict(MOCK_QA_ANSWERS[:answer_limit])
+    return mock_answers.get(question, "I don't know")
+
 
 # Valid model names: https://models.litellm.ai/
 @traigent.optimize(
@@ -60,12 +97,7 @@ def simple_qa_agent(question: str) -> str:
     With real API keys, it calls the actual LLM.
     """
     if os.environ.get("TRAIGENT_MOCK_LLM", "").lower() in ("1", "true", "yes"):
-        mock_answers = {
-            "What is the capital of France?": "Paris",
-            "What is 2 + 2?": "4",
-            "Who wrote Romeo and Juliet?": "William Shakespeare",
-        }
-        return mock_answers.get(question, "I don't know")
+        return _mock_answer_for_config(question, traigent.get_config())
 
     from langchain_openai import ChatOpenAI
 

--- a/examples/quickstart/03_custom_objectives.py
+++ b/examples/quickstart/03_custom_objectives.py
@@ -14,8 +14,9 @@ import os
 import sys
 from pathlib import Path
 
-# Ensure mock mode for testing without API keys
-os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
+# Enable mock mode only when no API key is available
+if not os.environ.get("OPENAI_API_KEY"):
+    os.environ.setdefault("TRAIGENT_MOCK_LLM", "true")
 
 # Set results folder to local directory
 os.environ.setdefault(
@@ -43,6 +44,49 @@ os.environ.setdefault("TRAIGENT_COST_APPROVED", "true")
 DATASET_PATH = (
     Path(__file__).resolve().parents[1] / "datasets" / "quickstart" / "qa_samples.jsonl"
 )
+
+MOCK_QA_ANSWERS = [
+    ("What is the capital of France?", "Paris"),
+    ("What is 2 + 2?", "4"),
+    ("Who wrote Romeo and Juliet?", "William Shakespeare"),
+    ("What is the largest planet in our solar system?", "Jupiter"),
+    ("What year did World War II end?", "1945"),
+    ("What is the chemical symbol for water?", "H2O"),
+    ("Who painted the Mona Lisa?", "Leonardo da Vinci"),
+    ("What is the speed of light?", "299,792,458 meters per second"),
+]
+
+
+def _config_value(config, key: str, default):
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _mock_answer_for_config(question: str, config) -> str:
+    model = str(_config_value(config, "model", "gpt-3.5-turbo"))
+    temperature = float(_config_value(config, "temperature", 0.5) or 0.5)
+    top_p = float(_config_value(config, "top_p", 0.7) or 0.7)
+
+    answer_limit = {
+        "gpt-3.5-turbo": 3,
+        "gpt-4o-mini": 5,
+    }.get(model, 3)
+
+    if temperature <= 0.3:
+        answer_limit += 1
+    elif temperature >= 0.75:
+        answer_limit -= 2
+
+    if top_p >= 0.7:
+        answer_limit += 1
+    elif top_p < 0.3:
+        answer_limit -= 1
+
+    answer_limit = max(1, min(len(MOCK_QA_ANSWERS), answer_limit))
+    mock_answers = dict(MOCK_QA_ANSWERS[:answer_limit])
+    return mock_answers.get(question, "I don't know")
+
 
 # Define custom objectives with explicit weights and orientations
 custom_objectives = ObjectiveSchema.from_objectives(
@@ -74,13 +118,7 @@ def weighted_agent(question: str) -> str:
     - Continuous parameter spaces (temperature, top_p)
     - Mixed configuration space (continuous + categorical)
     """
-    # Mock response for demo
-    mock_answers = {
-        "What is the capital of France?": "Paris",
-        "What is 2 + 2?": "4",
-        "Who wrote Romeo and Juliet?": "William Shakespeare",
-    }
-    return mock_answers.get(question, "I don't know")
+    return _mock_answer_for_config(question, traigent.get_config())
 
 
 async def main():

--- a/tests/unit/examples/test_quickstart_mock_config_sensitive.py
+++ b/tests/unit/examples/test_quickstart_mock_config_sensitive.py
@@ -1,0 +1,112 @@
+"""Regression tests for config-sensitive quickstart mock examples."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from traigent.config.context import ConfigurationContext
+from traigent.testing import _reset_for_tests
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+QUICKSTART_DIR = ROOT_DIR / "examples" / "quickstart"
+_QUICKSTART_ENV_KEYS = (
+    "TRAIGENT_COST_APPROVED",
+    "TRAIGENT_DATASET_ROOT",
+    "TRAIGENT_MOCK_LLM",
+    "TRAIGENT_RESULTS_FOLDER",
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_quickstart_import_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reset_for_tests()
+    for key in _QUICKSTART_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    yield
+
+    for stem in ("01_simple_qa", "03_custom_objectives"):
+        sys.modules.pop(f"_quickstart_{stem}", None)
+    for key in _QUICKSTART_ENV_KEYS:
+        os.environ.pop(key, None)
+    _reset_for_tests()
+
+
+def _load_example_module(stem: str) -> ModuleType:
+    path = QUICKSTART_DIR / f"{stem}.py"
+    module_name = f"_quickstart_{stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_simple_qa_mock_varies_by_config() -> None:
+    module = _load_example_module("01_simple_qa")
+    hard_question = "What year did World War II end?"
+
+    cheap_answer = module._mock_answer_for_config(
+        hard_question,
+        {"model": "gpt-3.5-turbo", "temperature": 0.9},
+    )
+    strong_answer = module._mock_answer_for_config(
+        hard_question,
+        {"model": "gpt-4o", "temperature": 0.1},
+    )
+
+    assert cheap_answer == "I don't know"
+    assert strong_answer == "1945"
+
+
+def test_simple_qa_mock_branch_reads_config_context(monkeypatch) -> None:
+    module = _load_example_module("01_simple_qa")
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+    question = "What is the chemical symbol for water?"
+
+    with ConfigurationContext({"model": "gpt-3.5-turbo", "temperature": 0.9}):
+        assert module.simple_qa_agent.func(question) == "I don't know"
+
+    with ConfigurationContext({"model": "gpt-4o", "temperature": 0.1}):
+        assert module.simple_qa_agent.func(question) == "H2O"
+
+
+def test_custom_objectives_mock_varies_by_config() -> None:
+    module = _load_example_module("03_custom_objectives")
+    hard_question = "Who painted the Mona Lisa?"
+
+    weak_answer = module._mock_answer_for_config(
+        hard_question,
+        {"model": "gpt-3.5-turbo", "temperature": 0.95, "top_p": 0.2},
+    )
+    strong_answer = module._mock_answer_for_config(
+        hard_question,
+        {"model": "gpt-4o-mini", "temperature": 0.1, "top_p": 0.9},
+    )
+
+    assert weak_answer == "I don't know"
+    assert strong_answer == "Leonardo da Vinci"
+
+
+def test_custom_objectives_function_reads_config_context(monkeypatch) -> None:
+    module = _load_example_module("03_custom_objectives")
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+    question = "What is the largest planet in our solar system?"
+
+    with ConfigurationContext(
+        {"model": "gpt-3.5-turbo", "temperature": 0.95, "top_p": 0.2}
+    ):
+        assert module.weighted_agent.func(question) == "I don't know"
+
+    with ConfigurationContext(
+        {"model": "gpt-4o-mini", "temperature": 0.1, "top_p": 0.9}
+    ):
+        assert module.weighted_agent.func(question) == "Jupiter"


### PR DESCRIPTION
## Summary
- make `01_simple_qa.py` mock responses read `traigent.get_config()` and vary answer coverage by model/temperature
- make `03_custom_objectives.py` mock responses read config and vary by model/temperature/top_p
- stop forcing `TRAIGENT_MOCK_LLM=true` in `03_custom_objectives.py` when an OpenAI key is already present
- add regression tests for config-sensitive quickstart mock behavior

Refs #1235

## Validation
- commit hook: isort, detect-secrets, whitespace/EOF, merge-conflict, private-key, bandit, mypy, strict cost-accounting guardrails, public test assertion contracts, dependency floor drift, ignored-file check
- `black --check examples/quickstart/01_simple_qa.py examples/quickstart/03_custom_objectives.py tests/unit/examples/test_quickstart_mock_config_sensitive.py`
- `ruff format --check examples/quickstart/01_simple_qa.py examples/quickstart/03_custom_objectives.py tests/unit/examples/test_quickstart_mock_config_sensitive.py`
- `ruff check examples/quickstart/01_simple_qa.py examples/quickstart/03_custom_objectives.py tests/unit/examples/test_quickstart_mock_config_sensitive.py`
- `pytest -n 0 tests/unit/examples/test_quickstart_mock_config_sensitive.py tests/unit/examples/test_quickstart_entry.py` (10 passed)
- `TRAIGENT_MOCK_LLM=true TRAIGENT_OFFLINE_MODE=true python3 examples/quickstart/01_simple_qa.py` (non-degenerate trial spread: 1.0 / 0.75 / 0.625 / 0.375)
- safe-push `scan_secrets.sh origin/develop`: clean
- safe-push `check_formatting.sh origin/develop`: passed

Note: local `python3 examples/quickstart/03_custom_objectives.py` was attempted but did not progress past startup within the local smoke window; unit tests cover the config-sensitive mock path directly. Local push hook skipped SonarQube because `sonar-scanner` is not installed.
