### PR TITLE
fix(metrics): canonicalize timing metric units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   example at `examples/advanced/composite-knobs/composite_telemetry.py`.
 
 ### Changed
+- **Timing metrics now emit canonical millisecond keys** (#1225). Model latency is
+  reported as `response_time_ms`, evaluation wall time is reported as
+  `execution_time_ms`, and execution duration is no longer copied into
+  `response_time_ms`. Legacy seconds keys `model_response_time` and
+  `function_duration` remain populated for one minor-version compatibility window;
+  remove them after the next minor once downstream dashboards have migrated.
 - **Unpriced models now block instead of warn-and-continue.** When a real run includes
   models with no known pricing, the SDK now requires explicit confirmation: interactive
   terminals get a blocking prompt; non-interactive runs fail closed before any trial.

--- a/tests/unit/core/test_metadata_helpers.py
+++ b/tests/unit/core/test_metadata_helpers.py
@@ -441,7 +441,9 @@ class TestBuildMeasuresFull:
         assert len(full) == 1
         assert full[0]["metrics"]["accuracy"] == 1.0
         assert full[0]["metrics"]["score"] == 1.0
-        assert full[0]["metrics"]["response_time_ms"] == 10.0
+        assert full[0]["metrics"]["execution_time_ms"] == 10.0
+        assert full[0]["metrics"]["response_time"] == 0.01
+        assert "response_time_ms" not in full[0]["metrics"]
 
         sanitized = _build_measures_privacy([payload], "accuracy")
         assert len(sanitized) == 1
@@ -520,10 +522,11 @@ class TestBuildMeasuresFull:
 
         measures = _build_measures_full([example_result], "accuracy")
 
-        assert "response_time_ms" in measures[0]["metrics"]
-        assert measures[0]["metrics"]["response_time_ms"] == 1500.0
+        assert "execution_time_ms" in measures[0]["metrics"]
+        assert measures[0]["metrics"]["execution_time_ms"] == 1500.0
         assert "response_time" in measures[0]["metrics"]
         assert measures[0]["metrics"]["response_time"] == 1.5
+        assert "response_time_ms" not in measures[0]["metrics"]
 
     def test_multiple_examples(self, example_result):
         """Test building measures for multiple examples."""
@@ -580,16 +583,17 @@ class TestBuildMeasuresPrivacy:
         assert len(measures) == 1
         assert measures[0]["metrics"]["score"] == 0.9
 
-    def test_include_response_time(self, example_result):
+    def test_include_execution_time(self, example_result):
         """Test privacy mode includes explicit and legacy timing keys."""
         example_result.execution_time = 1.5
 
         measures = _build_measures_privacy([example_result], "accuracy")
 
-        assert "response_time_ms" in measures[0]["metrics"]
-        assert measures[0]["metrics"]["response_time_ms"] == 1500.0
+        assert "execution_time_ms" in measures[0]["metrics"]
+        assert measures[0]["metrics"]["execution_time_ms"] == 1500.0
         assert "response_time" in measures[0]["metrics"]
         assert measures[0]["metrics"]["response_time"] == 1.5
+        assert "response_time_ms" not in measures[0]["metrics"]
 
     def test_include_token_metrics(self, example_result):
         """Test token metrics are included in privacy mode metrics."""

--- a/tests/unit/core/test_timing_metric_canonicalization.py
+++ b/tests/unit/core/test_timing_metric_canonicalization.py
@@ -1,0 +1,114 @@
+"""Timing metric canonicalization regressions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from traigent.api.types import ExampleResult
+from traigent.core.evaluator_wrapper import CustomEvaluatorWrapper
+from traigent.core.metadata_helpers import _build_single_measure_full
+from traigent.evaluators.metrics_tracker import ExampleMetrics, MetricsTracker
+
+
+def _example_result(*, execution_time: float = 0.25) -> ExampleResult:
+    return ExampleResult(
+        example_id="ex-1",
+        input_data={"question": "q"},
+        expected_output="a",
+        actual_output="a",
+        metrics={"accuracy": 1.0},
+        execution_time=execution_time,
+        success=True,
+        metadata={},
+    )
+
+
+def _llm_metrics(response_time_ms: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        tokens=SimpleNamespace(
+            input_tokens=11,
+            output_tokens=7,
+            total_tokens=18,
+        ),
+        cost=SimpleNamespace(
+            input_cost=0.001,
+            output_cost=0.002,
+            total_cost=0.003,
+        ),
+        response=SimpleNamespace(response_time_ms=response_time_ms),
+    )
+
+
+def test_custom_evaluator_emits_canonical_timing_keys_with_legacy_compat() -> None:
+    wrapper = CustomEvaluatorWrapper(lambda *_args, **_kwargs: None)
+    result = _example_result(execution_time=0.0)
+
+    wrapper._enhance_result_with_llm_metrics(
+        result,
+        _llm_metrics(response_time_ms=1234.5),
+        per_example_duration=0.25,
+    )
+
+    assert result.metrics["response_time_ms"] == pytest.approx(1234.5)
+    assert result.metadata["response_time_ms"] == pytest.approx(1234.5)
+    assert result.metrics["execution_time_ms"] == pytest.approx(250.0)
+    assert result.metadata["execution_time_ms"] == pytest.approx(250.0)
+
+    # Legacy seconds keys remain only for one compatibility window.
+    assert result.metrics["model_response_time"] == pytest.approx(1.2345)
+    assert result.metadata["model_response_time"] == pytest.approx(1.2345)
+    assert result.metrics["function_duration"] == pytest.approx(0.25)
+    assert result.metadata["function_duration"] == pytest.approx(0.25)
+
+
+def test_measure_payload_keeps_model_latency_distinct_from_execution_time() -> None:
+    result = _example_result(execution_time=0.25)
+    result.metrics["response_time_ms"] = 1234.5
+    result.metrics["execution_time_ms"] = 250.0
+
+    measure = _build_single_measure_full(
+        result,
+        idx=0,
+        dataset_hash="dataset",
+        primary_objective="accuracy",
+    )
+
+    assert measure is not None
+    metrics = measure["metrics"]
+    assert metrics["response_time_ms"] == pytest.approx(1234.5)
+    assert metrics["execution_time_ms"] == pytest.approx(250.0)
+    assert metrics["response_time"] == pytest.approx(0.25)
+
+
+def test_measure_payload_does_not_route_execution_time_to_response_time_ms() -> None:
+    result = _example_result(execution_time=0.25)
+
+    measure = _build_single_measure_full(
+        result,
+        idx=0,
+        dataset_hash="dataset",
+        primary_objective="accuracy",
+    )
+
+    assert measure is not None
+    metrics = measure["metrics"]
+    assert "response_time_ms" not in metrics
+    assert metrics["execution_time_ms"] == pytest.approx(250.0)
+    assert metrics["response_time"] == pytest.approx(0.25)
+
+
+def test_metrics_tracker_adds_execution_time_ms_for_backend_format() -> None:
+    tracker = MetricsTracker()
+    tracker.start_tracking()
+    tracker.add_example_metrics(ExampleMetrics(success=True))
+    tracker.end_tracking()
+
+    formatted = tracker.format_for_backend()
+
+    assert "duration" in formatted
+    assert "execution_time_ms" in formatted
+    assert formatted["execution_time_ms"] == pytest.approx(
+        formatted["duration"] * 1000.0
+    )

--- a/tests/unit/evaluators/test_metrics_tracker.py
+++ b/tests/unit/evaluators/test_metrics_tracker.py
@@ -81,6 +81,7 @@ class TestMetricsTracker:
         assert "score" in formatted
         assert "accuracy" in formatted
         assert "duration" in formatted
+        assert "execution_time_ms" in formatted
         assert "input_tokens" in formatted  # Returns mean value directly
         assert "output_tokens" in formatted
         assert "total_tokens" in formatted

--- a/traigent/core/evaluator_wrapper.py
+++ b/traigent/core/evaluator_wrapper.py
@@ -298,12 +298,22 @@ class CustomEvaluatorWrapper(BaseEvaluator):
                 llm_metrics, "response.response_time_ms", 0
             )
             if response_time_ms > 0:
+                response_time_ms = float(response_time_ms)
+                example_result.metrics["response_time_ms"] = response_time_ms
+                example_result.metadata["response_time_ms"] = response_time_ms
+                # Compatibility: remove in <next-minor> once consumers have
+                # migrated to canonical response_time_ms.
                 model_response_time = response_time_ms / 1000.0
                 example_result.metrics["model_response_time"] = model_response_time
                 example_result.metadata["model_response_time"] = model_response_time
 
         # Track total function duration
         if per_example_duration is not None:
+            execution_time_ms = float(per_example_duration) * 1000.0
+            example_result.metrics["execution_time_ms"] = execution_time_ms
+            example_result.metadata["execution_time_ms"] = execution_time_ms
+            # Compatibility: remove in <next-minor> once consumers have
+            # migrated to canonical execution_time_ms.
             example_result.metrics["function_duration"] = per_example_duration
             example_result.metadata["function_duration"] = per_example_duration
 
@@ -312,6 +322,13 @@ class CustomEvaluatorWrapper(BaseEvaluator):
         if not current_execution_time:
             example_result.execution_time = per_example_duration
         else:
+            current_execution_time_ms = float(current_execution_time) * 1000.0
+            example_result.metrics.setdefault(
+                "execution_time_ms", current_execution_time_ms
+            )
+            example_result.metadata.setdefault(
+                "execution_time_ms", current_execution_time_ms
+            )
             example_result.metadata.setdefault(
                 "function_duration", current_execution_time
             )

--- a/traigent/core/metadata_helpers.py
+++ b/traigent/core/metadata_helpers.py
@@ -438,17 +438,17 @@ def _add_execution_time_metrics(
 ) -> None:
     """Add explicit and legacy timing metrics for compatibility.
 
-    `execution_time` on example results is tracked internally in seconds. The
-    canonical optimization payload key is `response_time_ms`, but the legacy
-    `response_time` key remains for one compatibility window.
+    ``execution_time`` on example results is tracked internally in seconds. Its
+    canonical optimization payload key is ``execution_time_ms``. The legacy
+    ``response_time`` seconds key remains for one compatibility window.
     """
     execution_time = _example_field(example_result, "execution_time")
     if execution_time is None or not isinstance(execution_time, (int, float)):
         return
 
-    response_time_seconds = float(execution_time)
-    metrics_dict["response_time_ms"] = response_time_seconds * 1000.0
-    metrics_dict["response_time"] = response_time_seconds
+    execution_time_seconds = float(execution_time)
+    metrics_dict.setdefault("execution_time_ms", execution_time_seconds * 1000.0)
+    metrics_dict["response_time"] = execution_time_seconds
 
 
 def _is_measure_metric_value(value: Any) -> bool:
@@ -600,7 +600,8 @@ def _build_measures_privacy(
         }
 
     Only includes in metrics:
-    - Score, explicit response_time_ms, legacy response_time, tokens, and cost metrics
+    - Score, explicit response_time_ms, execution_time_ms, legacy response_time,
+      tokens, and cost metrics
 
     Args:
         example_results: List of example evaluation results

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -568,11 +568,17 @@ class MetricsTracker:
         if accuracy_value is None and not strict_nulls:
             accuracy_value = 0.0
 
+        duration_value = safe_get(aggregated, "duration")
         formatted = {
             # Core metrics (single values)
             "score": accuracy_value,  # Use actual accuracy for score
             "accuracy": accuracy_value,  # Use actual accuracy
-            "duration": safe_get(aggregated, "duration"),
+            "duration": duration_value,
+            "execution_time_ms": (
+                duration_value * 1000.0
+                if isinstance(duration_value, (int, float))
+                else duration_value
+            ),
             # Use mean values as the primary metrics (without suffix)
             "input_tokens": safe_get(aggregated, "input_tokens", "mean"),
             "output_tokens": safe_get(aggregated, "output_tokens", "mean"),


### PR DESCRIPTION
## Summary
- emit canonical `response_time_ms` from model latency and `execution_time_ms` from evaluation wall time
- stop routing execution duration into `response_time_ms`
- keep legacy seconds keys for the documented one-minor compatibility window with `remove in <next-minor>` markers
- add regression coverage and an Unreleased changelog note

Refs #1225

## Validation
- `black --check traigent/core/evaluator_wrapper.py traigent/core/metadata_helpers.py traigent/evaluators/metrics_tracker.py tests/unit/core/test_timing_metric_canonicalization.py tests/unit/evaluators/test_metrics_tracker.py`
- `ruff format --check traigent/core/evaluator_wrapper.py traigent/core/metadata_helpers.py traigent/evaluators/metrics_tracker.py tests/unit/core/test_timing_metric_canonicalization.py tests/unit/evaluators/test_metrics_tracker.py`
- `ruff check traigent/core/evaluator_wrapper.py traigent/core/metadata_helpers.py traigent/evaluators/metrics_tracker.py tests/unit/core/test_timing_metric_canonicalization.py tests/unit/evaluators/test_metrics_tracker.py`
- `git diff --check`
- `pytest -n 0 tests/unit/core/test_timing_metric_canonicalization.py tests/unit/evaluators/test_metrics_tracker.py tests/integration/test_metrics_flow.py tests/integration/test_metrics_fix.py`
- safe-push secret scan against `origin/develop`
- safe-push formatting check against `origin/develop`

## Notes
- local push hook skipped SonarQube because `sonar-scanner` is not installed in this environment
