### PR TITLE
fix(sdk): close env and observability review gaps

### DIFF
--- a/tests/unit/observability/test_observability_client.py
+++ b/tests/unit/observability/test_observability_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import threading
 from datetime import UTC, datetime
 from urllib import error
 
@@ -11,6 +12,7 @@ import pytest
 from traigent.cloud.async_batch_transport import BatchFlushResult
 from traigent.config.context import ConfigurationContext, TrialContext
 from traigent.observability import (
+    FlushResult,
     ObservabilityClient,
     ObservabilityConfig,
     ObservationType,
@@ -519,6 +521,70 @@ def test_observability_client_close_flushes_active_trace_payloads_without_explic
     assert result.success is True
     assert result.items_sent == 1
     assert sent_batches[-1][-1]["id"] == "trace_close_flush"
+
+
+def test_observability_client_close_waits_for_inflight_snapshot_submission(monkeypatch):
+    sent_batches: list[list[dict]] = []
+
+    def sender(traces):
+        sent_batches.append(traces)
+
+    client = ObservabilityClient(
+        ObservabilityConfig(
+            backend_origin="http://localhost:5000",
+            api_key="test-key",  # pragma: allowlist secret
+            batch_size=100,
+            max_buffer_age=999.0,
+            max_queue_size=10,
+        ),
+        sender=sender,
+    )
+    trace_id = client.start_trace("close-race", trace_id="trace_close_race")
+
+    submit_entered = threading.Event()
+    release_submit = threading.Event()
+    original_submit = client._submit_trace_snapshot
+
+    def delayed_submit(trace_id: str, payload: dict) -> None:
+        submit_entered.set()
+        assert release_submit.wait(timeout=2.0)
+        original_submit(trace_id, payload)
+
+    monkeypatch.setattr(client, "_submit_trace_snapshot", delayed_submit)
+
+    record_error: list[BaseException] = []
+
+    def record_observation() -> None:
+        try:
+            client.record_observation(trace_id, name="close-race-observation")
+        except BaseException as exc:
+            record_error.append(exc)
+
+    record_thread = threading.Thread(target=record_observation)
+    record_thread.start()
+    assert submit_entered.wait(timeout=2.0)
+
+    close_result: list[FlushResult] = []
+    close_thread = threading.Thread(target=lambda: close_result.append(client.close()))
+    close_thread.start()
+
+    close_thread.join(timeout=0.05)
+    assert close_thread.is_alive()
+    release_submit.set()
+
+    record_thread.join(timeout=2.0)
+    close_thread.join(timeout=2.0)
+
+    assert not record_thread.is_alive()
+    assert not close_thread.is_alive()
+    assert record_error == []
+    assert close_result
+    assert close_result[0].items_dropped == 0
+    assert all(
+        "transport closed; dropped payload" not in error
+        for error in close_result[0].errors
+    )
+    assert sent_batches[-1][-1]["id"] == "trace_close_race"
 
 
 def test_sync_batch_transport_records_closed_transport_drops():

--- a/tests/unit/utils/test_env_config.py
+++ b/tests/unit/utils/test_env_config.py
@@ -180,7 +180,14 @@ def test_database_and_redis_are_required_in_production(monkeypatch):
     [
         ("true", True),
         ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        (" TRUE ", True),
         ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
         ("", False),
     ],
 )

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING
 
+from traigent.utils.env_config import is_truthy
 from traigent.utils.exceptions import CostLimitExceeded
 
 if TYPE_CHECKING:
@@ -323,12 +324,8 @@ class CostEnforcer:
     @staticmethod
     def _check_require_cost_tracking_mode() -> bool:
         """Read strict cost-tracking mode from environment."""
-        require_tracking = (
-            os.environ.get("TRAIGENT_REQUIRE_COST_TRACKING", "").lower() == "true"
-        )
-        strict_accounting = (
-            os.environ.get("TRAIGENT_STRICT_COST_ACCOUNTING", "").lower() == "true"
-        )
+        require_tracking = is_truthy(os.environ.get("TRAIGENT_REQUIRE_COST_TRACKING"))
+        strict_accounting = is_truthy(os.environ.get("TRAIGENT_STRICT_COST_ACCOUNTING"))
         return require_tracking or strict_accounting
 
     def _require_cost_tracking(self) -> bool:

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -350,6 +350,8 @@ class ObservabilityClient:
         self._request_sender_override = request_sender
         self._trace_states: dict[str, _TraceState] = {}
         self._lock = threading.RLock()
+        self._snapshot_submission_condition = threading.Condition(self._lock)
+        self._inflight_snapshot_submissions = 0
         self._closed = False
         self._offline_notice_logged = False
         self._http_opener = request.build_opener(_NoRedirectHandler)
@@ -611,6 +613,8 @@ class ObservabilityClient:
                 for trace_id, state in self._trace_states.items()
             ]
             self._closed = True
+            while self._inflight_snapshot_submissions:
+                self._snapshot_submission_condition.wait()
 
         for trace_id, payload in trace_payloads:
             self._submit_trace_snapshot(trace_id, payload)
@@ -965,7 +969,14 @@ class ObservabilityClient:
             if state is None or self._closed:
                 return
             payload = cast(dict[str, Any], redact_sensitive_data(state.to_payload()))
-        self._submit_trace_snapshot(trace_id, payload)
+            self._inflight_snapshot_submissions += 1
+        try:
+            self._submit_trace_snapshot(trace_id, payload)
+        finally:
+            with self._lock:
+                self._inflight_snapshot_submissions -= 1
+                if self._inflight_snapshot_submissions == 0:
+                    self._snapshot_submission_condition.notify_all()
 
     def _submit_trace_snapshot(self, trace_id: str, payload: dict[str, Any]) -> None:
         submitted = self._transport.submit(trace_id, payload)

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -432,7 +432,7 @@ def is_strict_cost_accounting() -> bool:
     - Require priced models (no silent 0.0 for unknown models)
     - Raise on unknown/missing trial cost instead of fallback mode
     """
-    return get_env_var("TRAIGENT_STRICT_COST_ACCOUNTING", "false").lower() == "true"
+    return is_truthy(get_env_var("TRAIGENT_STRICT_COST_ACCOUNTING", "false"))
 
 
 def should_show_cloud_notice(traigent_config: "TraigentConfig") -> bool:


### PR DESCRIPTION
## Summary
- parse TRAIGENT_STRICT_COST_ACCOUNTING and TRAIGENT_REQUIRE_COST_TRACKING with the shared truthy env helper
- wait for in-flight observability snapshot submissions before closing the transport
- add regression coverage for strict-cost truthy values and concurrent close/record_observation

Refs #1241
Refs #1240

## Validation
- pytest -n0 tests/unit/utils/test_env_config.py tests/unit/core/test_cost_enforcement.py tests/unit/observability/test_observability_client.py -q
- black --check traigent/utils/env_config.py traigent/core/cost_enforcement.py traigent/observability/client.py tests/unit/utils/test_env_config.py tests/unit/observability/test_observability_client.py
- isort --check-only traigent/utils/env_config.py traigent/core/cost_enforcement.py traigent/observability/client.py tests/unit/utils/test_env_config.py tests/unit/observability/test_observability_client.py
- python3 -m compileall -q traigent/utils/env_config.py traigent/core/cost_enforcement.py traigent/observability/client.py
- git diff --check
- safe-push scan_secrets.sh origin/develop
- safe-push check_formatting.sh origin/develop