### PR TITLE
chore(ci): skip SDK PR Gate on draft PRs (cut Actions spend)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -9,6 +9,8 @@ name: SDK Required PR Gate
 on:
   pull_request:
     branches: [develop]
+    # Default types + ready_for_review so flipping a draft to ready runs the gate.
+    types: [opened, synchronize, reopened, ready_for_review]
   # Merge-queue candidate refs (gh-readonly-queue/*); required checks must
   # report on the candidate commit.
   merge_group: {}
@@ -26,6 +28,9 @@ env:
 jobs:
   changes:
     name: detect-changes
+    # Skip CI on draft PRs (they can't merge); merge_group always runs.
+    # Downstream jobs skip and required-pr-gate still passes (skipped deps = pass).
+    if: ${{ github.event_name == 'merge_group' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
## Why
Cut Actions spend: the SDK Required PR Gate runs on every push to every develop PR, including draft PRs that cannot merge.

## What
Gate the `changes` job on `draft == false` (cascades skip to preflight + unit). `required-pr-gate` still passes — it treats `skipped` deps as pass. Added `ready_for_review` so flipping a draft to ready runs the full gate.

## Note
SDK `pr-gate` only governs develop PRs; the main release gate (release-review/tests/quality + CodeQL) is unchanged here. SDK main Actions cost is addressed by the separate CodeQL weekly/main-only conversion.

## Safety
No required-check names change; concurrency-cancel unchanged; CI-orchestration only.