### PR TITLE
docs(readme): lead install with pip/uv install traigent (no clone required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,37 @@ Our mission: **Anything you can measure, we can improve.** Whether it's accuracy
 
 **Quick Install:**
 
+Install from PyPI — no clone required (Python 3.11+):
+
+```bash
+# pip
+pip install "traigent[recommended]"
+
+# uv (into the active venv, or `uv add` into a uv project)
+uv pip install "traigent[recommended]"
+uv add "traigent[recommended]"
+```
+
+<details>
+<summary>Prefer an isolated virtual environment first?</summary>
+
 macOS / Linux:
 
 ```bash
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
-
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e ".[recommended]"
+pip install "traigent[recommended]"
 ```
 
 Windows PowerShell:
 
 ```powershell
-git clone https://github.com/Traigent/Traigent.git
-cd Traigent
-
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-pip install -e ".[recommended]"
+pip install "traigent[recommended]"
 ```
+
+</details>
 
 For more options, see [Installation details](#installation).
 
@@ -262,7 +272,7 @@ def multi_provider_agent(question: str) -> str:
 
 ### Installation
 
-Python 3.11+ on Linux, macOS, or Windows. For coordinated release validation, install from this repository source tree.
+Python 3.11+ on Linux, macOS, or Windows. The published package on [PyPI](https://pypi.org/project/traigent/) is the recommended way to install — `pip install "traigent[recommended]"` or `uv add "traigent[recommended]"`. No repository checkout is required to use the SDK or its `traigent` CLI.
 
 | Feature Set | Description |
 |-------------|-------------|
@@ -274,7 +284,8 @@ Python 3.11+ on Linux, macOS, or Windows. For coordinated release validation, in
 
 **[Full installation guide →](docs/getting-started/installation.md)**
 
-Source install with `pip`:
+Contributor / source install (only needed to hack on Traigent itself or run the
+coordinated release-validation suite — not required to use the SDK):
 
 ```bash
 git clone https://github.com/Traigent/Traigent.git


### PR DESCRIPTION
## Why
Users were being told to `git clone` + `pip install -e` to install Traigent, but the package is already published on PyPI and installs the standard way. This makes `pip install` / `uv install` the documented primary path so people don't need to clone the repo.

## Verified (clean venv, from PyPI)
- `uv pip install "traigent[recommended]"` → installs **0.12.0**, `import traigent` OK, `traigent --version` → `Traigent 0.12.0`.
- `pip install "traigent[integrations]"` → `traigent.examples.quickstart` imports (the README "Try it now" demo ships in the wheel).

## Changes (docs only)
- **Quick Install** now leads with `pip install "traigent[recommended]"` / `uv pip install` / `uv add`; the venv-first variant moved into a collapsible `<details>`.
- **Installation details** points at [PyPI](https://pypi.org/project/traigent/) as recommended and reframes the git-clone source install as the contributor / release-validation path.

No code or packaging change.

## Note on publishing
The package is live on PyPI (latest stable **0.12.0**, tag `v0.12.0`; `main`/`develop` are at `0.13.0.dev1`). Publishing is automated via `publish.yml` (trusted/OIDC) on a `v*` tag pushed to `main`. If we want the latest features installable as stable, that's a separate `v0.13.0` release tag — happy to cut it with a version sign-off.