### PR TITLE
chore(release): bump traigent SDK to 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.13.0.dev1"
+version = "0.13.0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
Drop the .dev1 suffix for the 0.13.0 release (coordinated 2026-06-14). Tag `v0.13.0` on main triggers the PyPI publish (publish.yml) — I'll pause for your go before that tag.