### PR TITLE
fix(hybrid): degrade to local + warn loudly + source marker when backend unreachable (#1265)

### DIFF
--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -1551,3 +1551,54 @@ class TestHandleSessionCreationResult:
         assert session_id == "real-session-123"
         assert manager.backend_tracking_enabled
         assert any("real-session-123" in msg for msg in caplog.messages)
+
+
+class TestRuntimeDegradationSourceMarker:
+    """Issue #1265: a backend that becomes unreachable mid-run degrades to
+    local-only, warns once, and marks the result source='local'."""
+
+    def test_result_source_backend_when_healthy(self, backend_session_manager):
+        manager = backend_session_manager
+        manager._backend_tracking_enabled = True
+        manager._acknowledged_trials.add(("session", "trial"))
+        assert manager.result_source(trial_count=1) == "backend"
+        assert manager.backend_degraded is False
+
+    def test_result_source_local_when_no_trial_acknowledged(
+        self, backend_session_manager
+    ):
+        # Tracking enabled but the backend never acknowledged a single trial
+        # despite the run producing trials => the run was not cloud-tracked.
+        manager = backend_session_manager
+        manager._backend_tracking_enabled = True
+        assert manager.result_source(trial_count=3) == "local"
+
+    def test_result_source_local_when_tracking_disabled(self, backend_session_manager):
+        manager = backend_session_manager
+        manager._backend_tracking_enabled = False
+        assert manager.result_source(trial_count=0) == "local"
+
+    def test_flag_degraded_marks_local_and_warns_once(
+        self, backend_session_manager, caplog
+    ):
+        manager = backend_session_manager
+        manager._backend_tracking_enabled = True
+        manager._acknowledged_trials.add(("session", "trial"))
+
+        with caplog.at_level(
+            logging.WARNING, logger="traigent.core.backend_session_manager"
+        ):
+            # Simulate the outage firing on several trials in a row.
+            manager._flag_backend_degraded("trial submission")
+            manager._flag_backend_degraded("trial submission")
+            manager._flag_backend_degraded("trial submission")
+
+        assert manager.backend_degraded is True
+        # Even with previously-acknowledged trials, a mid-run degradation pins
+        # the result to local provenance.
+        assert manager.result_source(trial_count=5) == "local"
+
+        local_only_warnings = [
+            record for record in caplog.records if "LOCAL-ONLY" in record.getMessage()
+        ]
+        assert len(local_only_warnings) == 1, "should warn once, not per trial"

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -582,6 +582,31 @@ class TestOptimizationOrchestrator:
         assert len(result.trials) >= 1  # At least one trial should complete
         assert result.duration >= 0.5  # Should take at least timeout duration
 
+    def test_result_source_is_local_when_backend_degraded(self, orchestrator):
+        """Issue #1265: when the backend becomes unreachable mid-run, the
+        result is marked source='local' (top-level field and metadata) rather
+        than appearing as a cloud-tracked run."""
+        bsm = orchestrator.backend_session_manager
+        bsm._backend_tracking_enabled = True
+        # Simulate the mid-run outage signal raised inside _log_trial_to_backend.
+        bsm._flag_backend_degraded("trial submission")
+
+        result = orchestrator._create_optimization_result()
+
+        assert result.source == "local"
+        assert result.metadata["source"] == "local"
+
+    def test_result_source_is_backend_when_tracking_healthy(self, orchestrator):
+        """A healthy, cloud-tracked run is marked source='backend'."""
+        bsm = orchestrator.backend_session_manager
+        bsm._backend_tracking_enabled = True
+        bsm._acknowledged_trials.add(("session", "trial"))
+
+        result = orchestrator._create_optimization_result()
+
+        assert result.source == "backend"
+        assert result.metadata["source"] == "backend"
+
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)
     async def test_optimize_optimizer_suggests_no_configs(

--- a/tests/unit/test_traigent_client_hybrid_degradation.py
+++ b/tests/unit/test_traigent_client_hybrid_degradation.py
@@ -1,0 +1,101 @@
+"""Regression tests for hybrid-mode graceful degradation in TraigentClient.
+
+Issue #1265: when the Traigent backend is unreachable, hybrid mode must
+gracefully fall back to local results instead of crashing. Previously
+``_optimize_hybrid`` called ``finalize_hybrid_session`` unguarded, so a
+``CloudServiceError`` raised by an unreachable backend at finalize propagated
+out of the whole ``optimize()`` call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from traigent.cloud.client import CloudServiceError
+from traigent.traigent_client import TraigentClient
+
+
+def _build_hybrid_client() -> TraigentClient:
+    client = object.__new__(TraigentClient)
+    backend = Mock()
+    backend.__aenter__ = AsyncMock(return_value=backend)
+    backend.__aexit__ = AsyncMock(return_value=None)
+    backend.create_hybrid_session = AsyncMock(
+        return_value=("sess-1", "token", "https://endpoint")
+    )
+    client.backend_client = backend
+    client.agent_builder = Mock()
+    return client
+
+
+def _patch_optimizer_loop(mp, *, has_next: bool = False) -> None:
+    """Patch the direct optimizer client + adapter so the trial loop exits
+    immediately (no real trials) and control reaches finalize."""
+    fake_optimizer = Mock()
+    fake_optimizer.get_next_configuration = AsyncMock(
+        return_value={"has_next": has_next}
+    )
+    direct_client = Mock()
+    direct_client.__aenter__ = AsyncMock(return_value=fake_optimizer)
+    direct_client.__aexit__ = AsyncMock(return_value=None)
+    mp.setattr(
+        "traigent.traigent_client.OptimizerDirectClient",
+        lambda *a, **k: direct_client,
+    )
+    mp.setattr("traigent.traigent_client.LocalExecutionAdapter", lambda *a, **k: Mock())
+
+
+@pytest.mark.asyncio
+async def test_hybrid_finalize_backend_unreachable_degrades_to_local(caplog):
+    """A CloudServiceError at finalize must NOT crash the run; it returns a
+    local result marked source='local'."""
+    client = _build_hybrid_client()
+    client.backend_client.finalize_hybrid_session = AsyncMock(
+        side_effect=CloudServiceError("backend unreachable")
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        _patch_optimizer_loop(mp, has_next=False)
+        result = await client._optimize_hybrid(
+            function=lambda **_kwargs: "ok",
+            dataset={"examples": []},
+            configuration_space={"model": ["gpt-4o-mini"]},
+            objectives=["accuracy"],
+            max_trials=2,
+            optimization_config={},
+            config_defaults={},
+        )
+
+    assert result["source"] == "local"
+    assert result["backend_finalized"] is False
+    assert result["execution_mode"] == "hybrid"
+
+
+@pytest.mark.asyncio
+async def test_hybrid_finalize_success_marks_source_backend():
+    """When the backend finalizes normally, the result is source='backend'."""
+    client = _build_hybrid_client()
+    client.backend_client.finalize_hybrid_session = AsyncMock(
+        return_value={"best_configuration": {"model": "gpt-4o-mini"}}
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        _patch_optimizer_loop(mp, has_next=False)
+        result = await client._optimize_hybrid(
+            function=lambda **_kwargs: "ok",
+            dataset={"examples": []},
+            configuration_space={"model": ["gpt-4o-mini"]},
+            objectives=["accuracy"],
+            max_trials=2,
+            optimization_config={},
+            config_defaults={},
+        )
+
+    assert result["source"] == "backend"
+    assert result["execution_mode"] == "hybrid"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/test_traigent_client_hybrid_degradation.py
+++ b/tests/unit/test_traigent_client_hybrid_degradation.py
@@ -40,11 +40,20 @@ def _patch_optimizer_loop(mp, *, has_next: bool = False) -> None:
     direct_client = Mock()
     direct_client.__aenter__ = AsyncMock(return_value=fake_optimizer)
     direct_client.__aexit__ = AsyncMock(return_value=None)
+    # raising=False: the optional cloud-optimizer extra may be absent in the
+    # unit-test environment (then `_CLOUD_AVAILABLE` is False and these names
+    # aren't bound on the module); we still inject the mocks the patched
+    # `_optimize_hybrid` resolves from module globals.
     mp.setattr(
         "traigent.traigent_client.OptimizerDirectClient",
         lambda *a, **k: direct_client,
+        raising=False,
     )
-    mp.setattr("traigent.traigent_client.LocalExecutionAdapter", lambda *a, **k: Mock())
+    mp.setattr(
+        "traigent.traigent_client.LocalExecutionAdapter",
+        lambda *a, **k: Mock(),
+        raising=False,
+    )
 
 
 @pytest.mark.asyncio

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -683,6 +683,13 @@ class OptimizationResult:
     experiment_id: str | None = None
     cloud_url: str | None = None
     run_label: str | None = None
+
+    # Provenance of this result (issue #1265): "backend" when the run was
+    # tracked end-to-end on the cloud backend, "local" when it was computed
+    # locally — either an intentionally local mode or a hybrid/cloud run that
+    # degraded to local-only because the backend was unreachable mid-run. Also
+    # mirrored in ``metadata["source"]`` for callers that inspect metadata.
+    source: str = "backend"
     _experiment_stats: ExperimentStats | None = field(
         default=None, init=False, repr=False
     )

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -241,10 +241,60 @@ class BackendSessionManager:
         # never acknowledged).
         self._acknowledged_trials: set[tuple[str, str]] = set()
 
+        # Issue #1265: a backend that becomes unreachable *mid-run* (transient
+        # outage / maintenance window) is distinct from the explicit
+        # TRAIGENT_OFFLINE_MODE air-gap. When it happens in a backend-tracking
+        # mode we degrade to local-only: trials are still optimized and
+        # persisted locally, but the run is no longer cloud-tracked. We record
+        # that here so the run's result can be marked source="local" and a
+        # single prominent warning is emitted (instead of one per trial).
+        self._runtime_degraded: bool = False
+        self._degraded_warning_emitted: bool = False
+
     @property
     def backend_tracking_enabled(self) -> bool:
         """Whether remote backend tracking is active for this run."""
         return self._backend_tracking_enabled
+
+    @property
+    def backend_degraded(self) -> bool:
+        """Whether the backend became unreachable mid-run (issue #1265)."""
+        return self._runtime_degraded
+
+    def _flag_backend_degraded(self, context: str) -> None:
+        """Mark the run as degraded to local-only and warn once (issue #1265).
+
+        Called when a backend-tracking interaction fails at runtime. The first
+        call emits a single, prominent warning; subsequent calls are quiet so a
+        long run doesn't spam one warning per trial.
+        """
+        self._runtime_degraded = True
+        if self._degraded_warning_emitted:
+            return
+        self._degraded_warning_emitted = True
+        logger.warning(
+            "⚠️  Traigent backend tracking became unavailable during %s — "
+            "continuing in LOCAL-ONLY mode. Trials are still optimized and "
+            "saved to local storage, but this run is NOT tracked on the cloud "
+            "backend; its result is marked source='local'. Locally-stored "
+            "results sync to the cloud on the next successful run.",
+            context,
+        )
+
+    def result_source(self, trial_count: int) -> str:
+        """Return the provenance of this run's result: 'backend' or 'local'.
+
+        'backend' only when remote tracking stayed healthy *and* at least one
+        trial was acknowledged by the backend. A run that degraded mid-flight,
+        never had tracking, or produced trials that the backend never
+        acknowledged is reported as 'local' so callers (and the UI) can tell a
+        cloud-tracked run from a locally-computed one (issue #1265).
+        """
+        if not self._backend_tracking_enabled or self._runtime_degraded:
+            return "local"
+        if trial_count > 0 and not self._acknowledged_trials:
+            return "local"
+        return "backend"
 
     def disable_backend_tracking(self, reason: SessionCreationFailureReason) -> None:
         """Disable backend tracking for this run. Idempotent — keeps first reason."""
@@ -873,6 +923,9 @@ class BackendSessionManager:
                 # Fail closed: no acknowledged backend slot ⇒ NO submission and
                 # NO acknowledgment. The certified-selection report will then
                 # withhold for this incumbent (never attest an unbound winner).
+                # A missing slot in a tracking-enabled run is the first symptom
+                # of a backend outage — degrade to local-only (issue #1265).
+                self._flag_backend_degraded("trial submission")
                 logger.warning(
                     "No backend trial slot acquired for session %s "
                     "(client trial %s); skipping submission (fail closed)",
@@ -912,8 +965,12 @@ class BackendSessionManager:
                 else submitted_result
             )
             if not submitted:
+                # A False return covers both a backend rejection and a network
+                # failure swallowed by the trial-submit layer; either way this
+                # trial is not cloud-tracked, so degrade to local-only (#1265).
+                self._flag_backend_degraded("trial submission")
                 logger.warning(
-                    "Backend session endpoint rejected trial %s for session %s",
+                    "Backend session endpoint did not accept trial %s for session %s",
                     backend_trial_id,
                     session_id,
                 )
@@ -929,6 +986,10 @@ class BackendSessionManager:
                     sorted(metrics_payload.keys()),
                 )
         except Exception as exc:
+            # A raised error here is a backend interaction failure; the run is
+            # no longer cloud-tracked for this trial, so degrade to local-only
+            # (issue #1265) rather than retrying the backend every trial.
+            self._flag_backend_degraded("trial submission")
             logger.warning(
                 "Failed to submit trial %s for session %s to backend: %s",
                 trial_result.trial_id,

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2599,6 +2599,18 @@ class OptimizationOrchestrator:
 
         self.callback_manager.on_optimization_complete(result)
 
+        # Issue #1265: if a backend-tracking run degraded to local-only, say so
+        # prominently at the end (the per-trial warning fired once mid-run; this
+        # is the final, unmissable summary tied to the result's source marker).
+        if self.backend_session_manager.backend_degraded:
+            logger.warning(
+                "⚠️  Optimization %s finished in LOCAL-ONLY mode (source='local'): "
+                "the Traigent backend was unreachable during the run, so results "
+                "were computed and stored locally and are NOT on the cloud "
+                "backend. They will sync on the next successful run.",
+                self._optimization_id,
+            )
+
         cost_status = self.cost_enforcer.get_status()
         logger.info(
             f"Optimization {self._optimization_id} completed: "
@@ -3080,6 +3092,12 @@ class OptimizationOrchestrator:
         if selection.best_trial_id:
             result_metadata["best_trial_id"] = selection.best_trial_id
 
+        # Provenance marker (issue #1265): "backend" only when remote tracking
+        # stayed healthy; "local" when an intentionally-local mode ran or a
+        # backend-tracking run degraded to local-only mid-flight.
+        source = self.backend_session_manager.result_source(len(self._trials))
+        result_metadata["source"] = source
+
         # Create optimization result
         optimization_result = OptimizationResult(
             trials=self._trials.copy(),
@@ -3099,6 +3117,7 @@ class OptimizationOrchestrator:
             preset_selection=preset_selection,
             stop_reason=self._stop_reason,
             run_label=run_label,
+            source=source,
         )
 
         # Log optimization completion

--- a/traigent/traigent_client.py
+++ b/traigent/traigent_client.py
@@ -23,6 +23,7 @@ try:
         BackendClientConfig,
         BackendIntegratedClient,
     )
+    from traigent.cloud.client import CloudServiceError
     from traigent.cloud.optimizer_client import OptimizerDirectClient
 
     _CLOUD_AVAILABLE = True
@@ -42,6 +43,7 @@ except (
             BackendClientConfig,
             BackendIntegratedClient,
         )
+        from traigent.cloud.client import CloudServiceError
         from traigent.cloud.optimizer_client import OptimizerDirectClient
 
 logger = get_logger(__name__)
@@ -290,10 +292,29 @@ class TraigentClient:
                         logger.error(f"Trial {trial_id} failed: {str(e)}")
                         # Continue with next trial
 
-                # Finalize and get results
-                final_results = await self.backend_client.finalize_hybrid_session(
-                    session_id
-                )
+                # Finalize and get results. If the backend is unreachable at
+                # finalize, degrade to local-only instead of crashing the whole
+                # optimize() call: the trials are already computed, so return
+                # the locally-tracked best result marked source="local" and warn
+                # loudly (issue #1265).
+                try:
+                    final_results = await self.backend_client.finalize_hybrid_session(
+                        session_id
+                    )
+                    final_results.setdefault("source", "backend")
+                except (CloudServiceError, ConnectionError, OSError, TimeoutError) as e:
+                    logger.warning(
+                        "⚠️  Traigent backend unreachable at finalize (%s); "
+                        "returning LOCAL-ONLY results (source='local'). %d trial(s) "
+                        "were completed locally; they will sync on the next "
+                        "successful run.",
+                        e,
+                        completed_trials,
+                    )
+                    final_results = {
+                        "source": "local",
+                        "backend_finalized": False,
+                    }
 
                 # Enhance with local best result if backend doesn't have it
                 if best_result and not final_results.get("best_configuration"):


### PR DESCRIPTION
## Summary

Fixes #1265 — hybrid mode advertises graceful degradation when the backend is unreachable, but it wasn't delivered:
- the orchestrator path silently kept retrying the backend every trial and surfaced **no provenance marker**, so a degraded run was indistinguishable from a cloud-tracked one;
- the legacy `TraigentClient._optimize_hybrid` path **crashed** — an unguarded `finalize_hybrid_session` raised `CloudServiceError` straight out of `optimize()`.

Root cause: `is_backend_offline()` only reflects the explicit `TRAIGENT_OFFLINE_MODE` air-gap env var — it does **not** detect a transient outage / maintenance window, which is exactly what this issue is about.

Per the owner's steer (**auto-degrade but warn loudly + `source` marker**):

### Changes
- **`BackendSessionManager`**: detect a mid-run outage (no backend trial slot acquired, rejected/failed submission, or a raised backend error), flip to a degraded state, and emit **one** prominent `LOCAL-ONLY` warning (not one per trial). New `backend_degraded` property and `result_source()` — `"backend"` only when tracking stayed healthy *and* at least one trial was acknowledged, else `"local"`.
- **`OptimizationResult`** gains an additive `source: str = "backend"` field; the orchestrator sets it (and `metadata["source"]`) from the session manager and logs a final unmissable `LOCAL-ONLY` summary when degraded.
- **Legacy `_optimize_hybrid`**: the finalize call is now guarded — a backend outage returns local results marked `source="local"` instead of crashing.

Trials are already persisted locally (`_persist_trial_locally`) and the existing `SyncManager` flushes them to the cloud on the next successful run, so **no data is lost** — this PR makes the degradation observable and crash-free.

## Tests (Israel's test plan: mock backend failure → local result, not exception, with source marker)
- `test_backend_session_manager.py::TestRuntimeDegradationSourceMarker` — source provenance + warn-once contract.
- `test_orchestrator.py` — `result.source`/`metadata["source"] == "local"` when degraded, `"backend"` when healthy.
- `test_traigent_client_hybrid_degradation.py` — finalize outage degrades to local. **Mutation-verified**: without the guard the `CloudServiceError` propagates and the test fails.
- Full `test_orchestrator` (107), `test_backend_session_manager` (44), `traigent_client` suites, and `api/types` (999) green.

## Note on the FE/BE `source` field
The FE comment on #1265 asks for a `source` field on the backend→FE `TrialResult` response shape. That is a **separate** TraigentSchema + BE + FE change (cross-repo contract) and is intentionally **not** in this SDK PR. This PR adds the SDK-local `OptimizationResult.source` provenance returned to user Python code.

## PR checklist
1. **Worst-case prod path** — a backend outage now degrades to a clearly-marked local run instead of crashing or silently mis-reporting as cloud-tracked. No auth/billing/tenant policy surface touched.
2. **Production-branch test** — degradation + source marker asserted across all three layers (mutation-verified on the legacy crash path).
3. **Contract regeneration** — `OptimizationResult.source` is SDK-local result provenance, not a backend API response shape; no `TraigentSchema` change. The backend→FE `source` field is a tracked follow-up.
4. **Public surface delta** — additive defaulted `OptimizationResult.source` (backward compatible); no routes / `__all__` change.
5. **Review threads** — will resolve all bot/human threads before merge.
6. **Quality gates** — not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
