### PR TITLE
feat(sync): first-class idempotent `traigent sync` for local runs

### DIFF
--- a/tests/unit/cli/test_sync_command.py
+++ b/tests/unit/cli/test_sync_command.py
@@ -74,6 +74,19 @@ def test_sync_dry_run_does_not_require_api_key():
     assert "Ready to sync s1" in result.output
 
 
+def test_sync_status_needs_no_api_key():
+    """Status-only `traigent sync` must work without an API key."""
+    manager = _patched_manager()
+    with (
+        patch("traigent.cli.sync_commands.SyncManager", return_value=manager),
+        patch("traigent.cli.sync_commands._resolve_api_key", return_value=None),
+    ):
+        result = CliRunner().invoke(cli, ["sync"])
+
+    assert result.exit_code == 0
+    assert "Traigent sync status" in result.output
+
+
 def test_sync_requires_api_key_when_not_dry_run():
     # No api key resolvable and not a dry run → clean error, exit 1.
     with patch("traigent.cli.sync_commands._resolve_api_key", return_value=None):

--- a/tests/unit/cli/test_sync_command.py
+++ b/tests/unit/cli/test_sync_command.py
@@ -1,0 +1,83 @@
+"""Tests for the top-level ``traigent sync`` CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from traigent.cli.main import cli
+
+
+def _patched_manager(**status):
+    manager = Mock()
+    manager.get_sync_status.return_value = {
+        "completed_sessions": status.get("completed", 2),
+        "synced": status.get("synced", 1),
+        "unsynced": status.get("unsynced", 1),
+        "partial": 0,
+        "failed": 0,
+        "sync_eligible": status.get("pending", 1),
+    }
+    return manager
+
+
+def test_sync_no_args_prints_status_only():
+    """`traigent sync` with no target reports status and uploads nothing."""
+    manager = _patched_manager()
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "--api-key", "k"])
+
+    assert result.exit_code == 0
+    assert "Traigent sync status" in result.output
+    assert "synced" in result.output
+    manager.get_sync_status.assert_called_once()
+    manager.sync_session_to_cloud.assert_not_called()
+    manager.sync_all_sessions.assert_not_called()
+
+
+def test_sync_status_json():
+    manager = _patched_manager()
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "--json", "--api-key", "k"])
+
+    assert result.exit_code == 0
+    assert '"synced"' in result.output
+
+
+def test_sync_single_session_idempotent_skip():
+    manager = _patched_manager()
+    manager.sync_session_to_cloud.return_value = {
+        "session_id": "s1",
+        "status": "already_synced",
+        "cloud_experiment_id": "e1",
+    }
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "s1", "--api-key", "k"])
+
+    assert result.exit_code == 0
+    assert "Skipped s1" in result.output
+    manager.sync_session_to_cloud.assert_called_once()
+
+
+def test_sync_dry_run_does_not_require_api_key():
+    manager = _patched_manager()
+    manager.sync_session_to_cloud.return_value = {
+        "session_id": "s1",
+        "status": "success",
+        "trials_converted": 3,
+    }
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "s1", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Ready to sync s1" in result.output
+
+
+def test_sync_requires_api_key_when_not_dry_run():
+    # No api key resolvable and not a dry run → clean error, exit 1.
+    with patch("traigent.cli.sync_commands._resolve_api_key", return_value=None):
+        result = CliRunner().invoke(cli, ["sync", "s1"])
+
+    assert result.exit_code == 1
+    assert "API key required" in result.output

--- a/tests/unit/cloud/test_sync_idempotency.py
+++ b/tests/unit/cloud/test_sync_idempotency.py
@@ -9,7 +9,7 @@ is re-synced, and free-text trial metadata never rides to the backend.
 from __future__ import annotations
 
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -161,6 +161,78 @@ def test_changed_session_is_resynced(sync_manager):
     result = sync_manager.sync_session_to_cloud(sid)
     assert result["status"] == "success"
     mocks["_sync_experiment"].assert_called_once()
+
+
+def test_partial_failure_then_resume_reuses_experiment(sync_manager):
+    """BLOCKER regression: a retry after a partial failure must reuse the
+    cloud experiment, never create a duplicate one."""
+    sid = _make_completed_session(sync_manager.storage)
+    mocks = _stub_backend_success(sync_manager)
+    # First attempt: experiment is created but the run step fails → partial.
+    mocks["_sync_experiment_run"].return_value = {"success": False, "error": "boom"}
+
+    first = sync_manager.sync_session_to_cloud(sid)
+    assert first["status"] == "partial"
+    state = sync_manager.storage.load_session(sid).sync_state
+    assert state["status"] == "partial"
+    assert state["cloud_experiment_id"] == "exp1"  # experiment was created
+
+    # Second attempt (same content): run now succeeds.
+    mocks["_sync_experiment_run"].return_value = {
+        "success": True,
+        "experiment_run_id": "run1",
+    }
+    for name in ("_sync_agent", "_sync_benchmark", "_sync_experiment"):
+        mocks[name].reset_mock()
+
+    second = sync_manager.sync_session_to_cloud(sid)
+
+    assert second["status"] == "success"
+    # The experiment was REUSED, not re-created → no duplicate.
+    mocks["_sync_experiment"].assert_not_called()
+    assert second["cloud_experiment_id"] == "exp1"
+
+
+def test_cleanup_skips_delete_when_backup_fails(sync_manager, monkeypatch):
+    """`--clean` must never delete a run whose backup failed."""
+    sid = _make_completed_session(sync_manager.storage)
+    monkeypatch.setattr(sync_manager.storage, "export_session", lambda *a, **k: False)
+
+    result = sync_manager.cleanup_after_sync([sid], keep_backup=True)
+
+    assert result["sessions_deleted"] == 0
+    assert any("backup" in e.lower() for e in result["errors"])
+    # The run is still on disk.
+    assert sync_manager.storage.load_session(sid) is not None
+
+
+def test_force_all_threads_force(sync_manager):
+    captured = {}
+
+    def fake_sync(session_id, dry_run=False, force=False):
+        captured["force"] = force
+        return {"session_id": session_id, "status": "success"}
+
+    _make_completed_session(sync_manager.storage)
+    with patch.object(sync_manager, "sync_session_to_cloud", side_effect=fake_sync):
+        sync_manager.sync_all_sessions(force=True)
+
+    assert captured["force"] is True
+
+
+def test_load_session_tolerates_unknown_future_keys(storage):
+    """A session file written by a newer SDK (extra keys) still loads."""
+    sid = _make_completed_session(storage)
+    session_file = storage.storage_path / "sessions" / f"{sid}.json"
+    data = json.loads(session_file.read_text())
+    data["some_future_field"] = {"added": "by a newer version"}
+    data["trials"][0]["future_trial_field"] = 123
+    session_file.write_text(json.dumps(data))
+
+    reloaded = storage.load_session(sid)
+    assert reloaded is not None
+    assert reloaded.session_id == sid
+    assert len(reloaded.trials) == 2
 
 
 def test_dry_run_uploads_nothing(sync_manager):

--- a/tests/unit/cloud/test_sync_idempotency.py
+++ b/tests/unit/cloud/test_sync_idempotency.py
@@ -1,0 +1,232 @@
+"""Tests for idempotent cloud sync of local optimization runs (Sync v2).
+
+Covers the W&B-style guarantees added to ``SyncManager`` + the local
+``sync_state`` marker: re-syncing an unchanged run is a no-op (no duplicate
+cloud experiments), sync state is persisted for status reporting, a changed run
+is re-synced, and free-text trial metadata never rides to the backend.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from traigent.cloud.sync_manager import SyncManager
+from traigent.config.types import TraigentConfig
+from traigent.storage.local_storage import LocalStorageManager
+
+
+@pytest.fixture
+def storage(tmp_path) -> LocalStorageManager:
+    return LocalStorageManager(str(tmp_path / "store"))
+
+
+@pytest.fixture
+def sync_manager(storage) -> SyncManager:
+    sm = SyncManager(TraigentConfig.from_environment(), api_key="test-key")
+    sm.storage = storage  # isolate to the temp store
+    return sm
+
+
+def _make_completed_session(storage: LocalStorageManager) -> str:
+    session_id = storage.create_session(
+        "answer_question",
+        optimization_config={"search_space": {"model": ["a", "b"], "temp": [0.0, 1.0]}},
+    )
+    storage.add_trial_result(
+        session_id, config={"model": "a", "temp": 0.0}, score=0.8, cost=0.001
+    )
+    storage.add_trial_result(
+        session_id, config={"model": "b", "temp": 1.0}, score=0.9, cost=0.002
+    )
+    storage.finalize_session(session_id, "completed")
+    return session_id
+
+
+def _stub_backend_success(sync_manager: SyncManager) -> dict[str, Mock]:
+    """Patch the legacy resource uploads so a sync 'succeeds' with no HTTP."""
+    mocks = {
+        "_sync_agent": Mock(return_value={"success": True, "agent_id": "ag1"}),
+        "_sync_benchmark": Mock(return_value={"success": True, "benchmark_id": "bm1"}),
+        "_sync_experiment": Mock(
+            return_value={"success": True, "experiment_id": "exp1"}
+        ),
+        "_sync_experiment_run": Mock(
+            return_value={"success": True, "experiment_run_id": "run1"}
+        ),
+    }
+
+    def _runs(_run_id, configuration_runs):
+        return {"success": True, "synced": len(configuration_runs), "errors": []}
+
+    mocks["_sync_configuration_runs"] = Mock(side_effect=_runs)
+    for name, mock in mocks.items():
+        setattr(sync_manager, name, mock)
+    return mocks
+
+
+# --------------------------------------------------------------------------- #
+# local_storage.update_sync_state
+# --------------------------------------------------------------------------- #
+
+
+def test_update_sync_state_merges_and_persists(storage):
+    sid = _make_completed_session(storage)
+
+    storage.update_sync_state(sid, {"status": "synced", "cloud_experiment_id": "e1"})
+    storage.update_sync_state(
+        sid, {"cloud_url": "https://x"}, trial_updates={"1": {"status": "uploaded"}}
+    )
+
+    reloaded = storage.load_session(sid)
+    assert reloaded.sync_state["status"] == "synced"  # preserved across merges
+    assert reloaded.sync_state["cloud_experiment_id"] == "e1"
+    assert reloaded.sync_state["cloud_url"] == "https://x"
+    assert reloaded.sync_state["trials"]["1"]["status"] == "uploaded"
+
+
+def test_sync_state_survives_round_trip_on_old_sessions(storage):
+    """A session written without sync_state loads fine (backward compatible)."""
+    sid = _make_completed_session(storage)
+    reloaded = storage.load_session(sid)
+    assert reloaded.sync_state is None
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency
+# --------------------------------------------------------------------------- #
+
+
+def test_first_sync_records_synced_state(sync_manager):
+    sid = _make_completed_session(sync_manager.storage)
+    mocks = _stub_backend_success(sync_manager)
+
+    result = sync_manager.sync_session_to_cloud(sid)
+
+    assert result["status"] == "success"
+    state = sync_manager.storage.load_session(sid).sync_state
+    assert state["status"] == "synced"
+    assert state["payload_hash"] == result["payload_hash"]
+    assert state["cloud_experiment_id"] == "exp1"
+    assert state["attempts"] == 1
+    mocks["_sync_agent"].assert_called_once()
+
+
+def test_resync_unchanged_is_noop(sync_manager):
+    """Re-syncing an unchanged, already-synced run must NOT create duplicates."""
+    sid = _make_completed_session(sync_manager.storage)
+    mocks = _stub_backend_success(sync_manager)
+
+    sync_manager.sync_session_to_cloud(sid)
+    for mock in mocks.values():
+        mock.reset_mock()
+
+    second = sync_manager.sync_session_to_cloud(sid)
+
+    assert second["status"] == "already_synced"
+    assert second["cloud_experiment_id"] == "exp1"
+    # No backend resource was created the second time → no duplicate experiment.
+    mocks["_sync_experiment"].assert_not_called()
+    mocks["_sync_agent"].assert_not_called()
+
+
+def test_force_reuploads_even_when_synced(sync_manager):
+    sid = _make_completed_session(sync_manager.storage)
+    mocks = _stub_backend_success(sync_manager)
+    sync_manager.sync_session_to_cloud(sid)
+    for mock in mocks.values():
+        mock.reset_mock()
+
+    forced = sync_manager.sync_session_to_cloud(sid, force=True)
+
+    assert forced["status"] == "success"
+    mocks["_sync_experiment"].assert_called_once()
+
+
+def test_changed_session_is_resynced(sync_manager):
+    sid = _make_completed_session(sync_manager.storage)
+    mocks = _stub_backend_success(sync_manager)
+    sync_manager.sync_session_to_cloud(sid)
+    for mock in mocks.values():
+        mock.reset_mock()
+
+    # New trial changes the payload fingerprint → no longer "already synced".
+    sync_manager.storage.add_trial_result(
+        sid, config={"model": "a", "temp": 1.0}, score=0.95
+    )
+    sync_manager.storage.finalize_session(sid, "completed")
+
+    result = sync_manager.sync_session_to_cloud(sid)
+    assert result["status"] == "success"
+    mocks["_sync_experiment"].assert_called_once()
+
+
+def test_dry_run_uploads_nothing(sync_manager):
+    sid = _make_completed_session(sync_manager.storage)
+    mocks = _stub_backend_success(sync_manager)
+
+    result = sync_manager.sync_session_to_cloud(sid, dry_run=True)
+
+    assert result["status"] == "success"  # legacy dry-run validation status
+    assert result["preview"]["already_synced"] is False
+    assert result["dry_run"] is True
+    for mock in mocks.values():
+        mock.assert_not_called()
+    # Dry run does not write a synced marker.
+    assert sync_manager.storage.load_session(sid).sync_state is None
+
+
+# --------------------------------------------------------------------------- #
+# Status reporting
+# --------------------------------------------------------------------------- #
+
+
+def test_get_sync_status_counts_by_state(sync_manager):
+    storage = sync_manager.storage
+    synced = _make_completed_session(storage)
+    _make_completed_session(storage)  # unsynced
+    failed = _make_completed_session(storage)
+    storage.update_sync_state(synced, {"status": "synced", "payload_hash": "h"})
+    storage.update_sync_state(failed, {"status": "failed"})
+
+    status = sync_manager.get_sync_status()
+
+    assert status["completed_sessions"] == 3
+    assert status["synced"] == 1
+    assert status["unsynced"] == 1
+    assert status["failed"] == 1
+    assert status["sync_eligible"] == 2  # unsynced + failed still pending
+
+
+# --------------------------------------------------------------------------- #
+# Privacy: free-text trial metadata must not ride to the backend
+# --------------------------------------------------------------------------- #
+
+
+def test_freetext_metadata_not_in_converted_payload(sync_manager):
+    sid = sync_manager.storage.create_session(
+        "fn", optimization_config={"search_space": {"model": ["a"]}}
+    )
+    sentinel = "SENTINEL_secret_prompt_text_should_never_sync"
+    sync_manager.storage.add_trial_result(
+        sid,
+        config={"model": "a"},
+        score=0.5,
+        metadata={"raw_prompt": sentinel, "tokens": 42},
+    )
+    sync_manager.storage.finalize_session(sid, "completed")
+
+    session = sync_manager.storage.load_session(sid)
+    converted = sync_manager.convert_session_to_traigent_format(session)
+    blob = json.dumps(converted, default=str)
+
+    assert sentinel not in blob, "free-text metadata leaked into sync payload"
+    # ...but numeric metadata is still forwarded as a measure.
+    measures = converted["configuration_runs"][0]["measures"]
+    assert measures.get("tokens") == 42
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -782,7 +782,7 @@ class TestSyncManager:
         sync_manager.storage.list_sessions.return_value = mock_sessions
 
         # Mock dry run results
-        def mock_sync(session_id, dry_run=False):
+        def mock_sync(session_id, dry_run=False, force=False):
             return {
                 "session_id": session_id,
                 "status": "success",
@@ -823,7 +823,7 @@ class TestSyncManager:
 
         sync_manager.storage.list_sessions.return_value = mock_sessions
 
-        def mock_sync(session_id, dry_run=False):
+        def mock_sync(session_id, dry_run=False, force=False):
             if session_id == "s1":
                 return {"session_id": session_id, "status": "success"}
             else:

--- a/traigent/cli/local_commands.py
+++ b/traigent/cli/local_commands.py
@@ -458,7 +458,15 @@ def manage_config(show: bool, set_path: str | None, reset: bool) -> None:
 def sync_to_cloud(
     api_key: str | None, session_id: str | None, dry_run: bool, cleanup: bool
 ) -> None:
-    """Sync local optimization sessions to Traigent Cloud."""
+    """Sync local optimization sessions to Traigent Cloud.
+
+    Deprecated alias: prefer the top-level `traigent sync` command.
+    """
+    click.echo(
+        "ℹ️  `traigent edge-analytics sync` is deprecated; use `traigent sync` "
+        "(it is idempotent and reports status).",
+        err=True,
+    )
     try:
         config = TraigentConfig.from_environment()
 

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -31,6 +31,7 @@ from traigent.api.types import PresetSelection
 from traigent.cli.auth_commands import auth
 from traigent.cli.hooks_commands import hooks
 from traigent.cli.local_commands import register_edge_analytics_commands
+from traigent.cli.sync_commands import register_sync_command
 from traigent.evaluators import (
     list_eval_recommendation_task_types,
     recommend_evaluator,
@@ -2639,6 +2640,8 @@ def check(
 
 # Register local commands
 register_edge_analytics_commands(cli)
+# Top-level `traigent sync` (promoted from `edge-analytics sync`).
+register_sync_command(cli)
 
 cli.add_command(auth)
 cli.add_command(hooks)

--- a/traigent/cli/sync_commands.py
+++ b/traigent/cli/sync_commands.py
@@ -1,0 +1,180 @@
+"""Top-level ``traigent sync`` command.
+
+First-class, idempotent sync of locally-logged optimization runs to the
+Traigent cloud, following the ``wandb sync`` convention: running it with no
+arguments prints a status summary (what is synced vs. still pending) and uploads
+nothing; an already-synced, unchanged run is skipped so re-running never creates
+duplicate cloud experiments.
+
+    traigent sync                 # status only — no upload
+    traigent sync <session_id>    # sync one run (idempotent)
+    traigent sync --all           # sync every run still pending
+    traigent sync --dry-run ...   # validate + preview, upload nothing
+    traigent sync --clean ...     # delete local only after a verified sync
+"""
+
+from __future__ import annotations
+
+import json as json_module
+import sys
+from typing import Any
+
+import click
+
+from traigent.cloud.sync_manager import SyncManager
+from traigent.config.types import TraigentConfig
+
+_PENDING_STATES = {"unsynced", "partial", "failed"}
+
+
+def _resolve_api_key(api_key: str | None) -> str | None:
+    if api_key:
+        return api_key
+    from traigent.config.backend_config import BackendConfig
+
+    return BackendConfig.get_api_key()
+
+
+def _print_status(sync_manager: SyncManager, *, as_json: bool) -> dict[str, Any]:
+    status = sync_manager.get_sync_status()
+    if as_json:
+        click.echo(json_module.dumps(status, indent=2, default=str))
+        return status
+
+    click.echo("\n📊 Traigent sync status")
+    click.echo("=" * 32)
+    click.echo(f"Completed runs : {status['completed_sessions']}")
+    click.echo(f"  ✅ synced    : {status.get('synced', 0)}")
+    click.echo(f"  ⬆️  unsynced  : {status.get('unsynced', 0)}")
+    click.echo(f"  ◐ partial    : {status.get('partial', 0)}")
+    click.echo(f"  ❌ failed     : {status.get('failed', 0)}")
+    pending = status.get("sync_eligible", 0)
+    if pending:
+        click.echo(f"\n💡 {pending} run(s) pending. Run `traigent sync --all` to push.")
+    else:
+        click.echo("\n✨ All completed runs are synced.")
+    return status
+
+
+def _emit_session_result(result: dict[str, Any], *, dry_run: bool) -> None:
+    status = result.get("status")
+    sid = result.get("session_id")
+    if status == "success":
+        if dry_run:
+            click.echo(
+                f"🔍 Ready to sync {sid} ({result.get('trials_converted', 0)} trials)"
+            )
+        else:
+            click.echo(f"✅ Synced {sid}")
+            if result.get("cloud_url"):
+                click.echo(f"   Cloud URL: {result['cloud_url']}")
+    elif status == "already_synced":
+        click.echo(f"⏭️  Skipped {sid} (already synced — use --force to re-upload)")
+    else:
+        click.echo(f"❌ {sid}: {status}")
+        for error in result.get("errors", []):
+            click.echo(f"   • {error}")
+
+
+@click.command(name="sync")
+@click.argument("session_id", required=False)
+@click.option("--all", "sync_all", is_flag=True, help="Sync every pending run")
+@click.option("--dry-run", is_flag=True, help="Preview without uploading")
+@click.option(
+    "--force", is_flag=True, help="Re-upload even if already synced and unchanged"
+)
+@click.option(
+    "--clean",
+    is_flag=True,
+    help="Delete local copies of runs after a verified sync (backup kept)",
+)
+@click.option("--json", "as_json", is_flag=True, help="Machine-readable output")
+@click.option("--api-key", help="API key (else TRAIGENT_API_KEY / stored credentials)")
+def sync_command(
+    session_id: str | None,
+    sync_all: bool,
+    dry_run: bool,
+    force: bool,
+    clean: bool,
+    as_json: bool,
+    api_key: str | None,
+) -> None:
+    """Sync locally-logged optimization runs to the Traigent cloud."""
+    try:
+        config = TraigentConfig.from_environment()
+        api_key = _resolve_api_key(api_key)
+
+        if not api_key and not dry_run:
+            click.echo(
+                "❌ API key required for cloud sync. Use --api-key or set "
+                "TRAIGENT_API_KEY.",
+                err=True,
+            )
+            click.echo("💡 Configure a key with `traigent auth login`.")
+            sys.exit(1)
+
+        sync_manager = SyncManager(config, api_key)
+
+        # No target → status only (wandb `sync` with no args).
+        if not session_id and not sync_all:
+            _print_status(sync_manager, as_json=as_json)
+            return
+
+        synced_ids: list[str] = []
+        if session_id:
+            result = sync_manager.sync_session_to_cloud(
+                session_id, dry_run=dry_run, force=force
+            )
+            if as_json:
+                click.echo(json_module.dumps(result, indent=2, default=str))
+            else:
+                _emit_session_result(result, dry_run=dry_run)
+            if result.get("status") in {"success", "already_synced"}:
+                synced_ids.append(session_id)
+        else:
+            result = sync_manager.sync_all_sessions(dry_run)
+            if as_json:
+                click.echo(json_module.dumps(result, indent=2, default=str))
+            else:
+                click.echo(
+                    f"\n📈 Synced {result['synced_successfully']}, "
+                    f"skipped {result.get('skipped', 0)}, "
+                    f"errors {result['sync_errors']} "
+                    f"(of {result['eligible_sessions']} eligible)"
+                )
+                for session_result in result["session_results"]:
+                    _emit_session_result(session_result, dry_run=dry_run)
+            synced_ids = [
+                r["session_id"]
+                for r in result["session_results"]
+                if r.get("status") in {"success", "already_synced"}
+            ]
+
+        # --clean: delete local copies only for runs verified synced, with backup.
+        if clean and not dry_run and synced_ids:
+            verified = _verified_synced(sync_manager, synced_ids)
+            if verified:
+                cleanup = sync_manager.cleanup_after_sync(verified, keep_backup=True)
+                click.echo(
+                    f"🧹 Cleaned {cleanup['sessions_deleted']} synced run(s) "
+                    "(backed up first)."
+                )
+
+    except Exception as e:  # noqa: BLE001 - CLI boundary surfaces a clean message
+        click.echo(f"Error syncing to cloud: {e}", err=True)
+        sys.exit(1)
+
+
+def _verified_synced(sync_manager: SyncManager, session_ids: list[str]) -> list[str]:
+    """Keep only sessions whose persisted sync_state confirms a full sync."""
+    verified: list[str] = []
+    for sid in session_ids:
+        session = sync_manager.storage.load_session(sid)
+        if session and (session.sync_state or {}).get("status") == "synced":
+            verified.append(sid)
+    return verified
+
+
+def register_sync_command(cli: click.Group) -> None:
+    """Register the top-level ``traigent sync`` command on the CLI group."""
+    cli.add_command(sync_command)

--- a/traigent/cli/sync_commands.py
+++ b/traigent/cli/sync_commands.py
@@ -103,7 +103,14 @@ def sync_command(
     try:
         config = TraigentConfig.from_environment()
         api_key = _resolve_api_key(api_key)
+        sync_manager = SyncManager(config, api_key)
 
+        # No target → status only (wandb `sync` with no args). Needs no key.
+        if not session_id and not sync_all:
+            _print_status(sync_manager, as_json=as_json)
+            return
+
+        # Only real uploads require a key; status and --dry-run do not.
         if not api_key and not dry_run:
             click.echo(
                 "❌ API key required for cloud sync. Use --api-key or set "
@@ -112,13 +119,6 @@ def sync_command(
             )
             click.echo("💡 Configure a key with `traigent auth login`.")
             sys.exit(1)
-
-        sync_manager = SyncManager(config, api_key)
-
-        # No target → status only (wandb `sync` with no args).
-        if not session_id and not sync_all:
-            _print_status(sync_manager, as_json=as_json)
-            return
 
         synced_ids: list[str] = []
         if session_id:
@@ -132,7 +132,7 @@ def sync_command(
             if result.get("status") in {"success", "already_synced"}:
                 synced_ids.append(session_id)
         else:
-            result = sync_manager.sync_all_sessions(dry_run)
+            result = sync_manager.sync_all_sessions(dry_run, force=force)
             if as_json:
                 click.echo(json_module.dumps(result, indent=2, default=str))
             else:

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -403,146 +403,195 @@ class SyncManager:
         Returns:
             Sync result with status and details
         """
-        session = self.storage.load_session(session_id)
-        if not session:
-            raise TraigentStorageError(f"Session {session_id} not found") from None
+        # Serialize per-session sync so two concurrent `traigent sync` processes
+        # can't both pass the "unsynced" check and create duplicate cloud
+        # resources. We re-read state inside the lock so we observe another
+        # process's just-written marker.
+        with self.storage.acquire_lock(f"sync_{session_id}"):
+            session = self.storage.load_session(session_id)
+            if not session:
+                raise TraigentStorageError(f"Session {session_id} not found") from None
 
-        # Convert to Traigent format
-        traigent_data = self.convert_session_to_traigent_format(session)
-        payload_hash = self._compute_payload_hash(traigent_data)
-        prior_state = dict(session.sync_state or {})
-        already_synced = (
-            prior_state.get("status") == "synced"
-            and prior_state.get("payload_hash") == payload_hash
-        )
+            # Convert to Traigent format
+            traigent_data = self.convert_session_to_traigent_format(session)
+            payload_hash = self._compute_payload_hash(traigent_data)
+            prior_state = dict(session.sync_state or {})
+            already_synced = (
+                prior_state.get("status") == "synced"
+                and prior_state.get("payload_hash") == payload_hash
+            )
 
-        sync_result: dict[str, Any] = {
-            "session_id": session_id,
-            "function_name": session.function_name,
-            "status": "success",
-            "dry_run": dry_run,
-            "data_converted": True,
-            "cloud_experiment_id": prior_state.get("cloud_experiment_id"),
-            "trials_converted": len(traigent_data["configuration_runs"]),
-            "payload_hash": payload_hash,
-            "errors": [],
-        }
-
-        # Idempotency: an unchanged, already-synced session is a no-op.
-        if already_synced and not force:
-            sync_result["status"] = "already_synced"
-            sync_result["cloud_url"] = prior_state.get("cloud_url")
-            sync_result["cloud_experiment_id"] = prior_state.get("cloud_experiment_id")
-            return sync_result
-
-        if dry_run:
-            # Preserve the legacy "success" status for an un-synced validation
-            # run; only flag the already-synced case distinctly.
-            sync_result["status"] = "already_synced" if already_synced else "success"
-            sync_result["preview"] = {
-                "experiment_name": traigent_data["experiment"]["name"],
-                "agent_name": traigent_data["agent"]["name"],
-                "benchmark_name": traigent_data["benchmark"]["name"],
-                "trial_count": len(traigent_data["configuration_runs"]),
-                "best_score": session.best_score,
-                "already_synced": already_synced,
+            sync_result: dict[str, Any] = {
+                "session_id": session_id,
+                "function_name": session.function_name,
+                "status": "success",
+                "dry_run": dry_run,
+                "data_converted": True,
+                "cloud_experiment_id": prior_state.get("cloud_experiment_id"),
+                "trials_converted": len(traigent_data["configuration_runs"]),
+                "payload_hash": payload_hash,
+                "errors": [],
             }
+
+            # Idempotency: an unchanged, already-synced session is a no-op.
+            if already_synced and not force:
+                sync_result["status"] = "already_synced"
+                sync_result["cloud_url"] = prior_state.get("cloud_url")
+                sync_result["cloud_experiment_id"] = prior_state.get(
+                    "cloud_experiment_id"
+                )
+                return sync_result
+
+            if dry_run:
+                # Preserve the legacy "success" status for an un-synced
+                # validation run; only flag the already-synced case distinctly.
+                sync_result["status"] = (
+                    "already_synced" if already_synced else "success"
+                )
+                sync_result["preview"] = {
+                    "experiment_name": traigent_data["experiment"]["name"],
+                    "agent_name": traigent_data["agent"]["name"],
+                    "benchmark_name": traigent_data["benchmark"]["name"],
+                    "trial_count": len(traigent_data["configuration_runs"]),
+                    "best_score": session.best_score,
+                    "already_synced": already_synced,
+                }
+                return sync_result
+
+            # Actually sync to backend.
+            if not self.api_key:
+                msg = (
+                    "No API key provided for backend sync. " + get_no_credentials_hint()
+                )
+                logger.warning(msg)
+                sync_result["status"] = "error"
+                sync_result["errors"].append(msg)
+                return sync_result
+
+            # Resume (reuse cloud ids) only when re-trying the SAME content
+            # after a partial/failed attempt — that is what prevents duplicate
+            # experiments. A changed run, or --force, starts a fresh experiment.
+            resume = (
+                prior_state.get("payload_hash") == payload_hash
+                and prior_state.get("status") in {"partial", "failed"}
+                and not force
+            )
+            try:
+                self._upload_session(
+                    traigent_data, sync_result, prior_state, resume=resume
+                )
+            except Exception as e:
+                sync_result["status"] = "error"
+                sync_result["errors"].append(f"Sync failed: {str(e)}")
+                logger.error(f"Failed to sync session {session_id}: {e}")
+
+            # Record the outcome on EVERY non-trivial exit (success, partial, or
+            # error) so a retry can reuse the cloud ids a prior attempt created
+            # instead of minting a fresh, duplicate experiment.
+            self._record_sync_state(session_id, sync_result, payload_hash)
             return sync_result
 
-        # Actually sync to backend.
-        if not self.api_key:
-            msg = "No API key provided for backend sync. " + get_no_credentials_hint()
-            logger.warning(msg)
-            sync_result["status"] = "error"
-            sync_result["errors"].append(msg)
-            return sync_result
+    def _upload_session(
+        self,
+        traigent_data: dict[str, Any],
+        sync_result: dict[str, Any],
+        prior_state: dict[str, Any],
+        *,
+        resume: bool,
+    ) -> None:
+        """Upload a converted session to the backend resource endpoints.
 
-        try:
-            successful_steps = 0
-            total_steps = 4 + len(traigent_data["configuration_runs"])
+        When ``resume`` is True, reuses any cloud ids a prior attempt already
+        created so a retry resumes rather than minting a duplicate experiment.
+        Mutates ``sync_result`` in place and returns early on a failed step.
+        """
+        reuse = resume
+        configuration_runs = traigent_data["configuration_runs"]
+        total_steps = 4 + len(configuration_runs)
+        successful_steps = 0
 
+        # Agent + benchmark dedup by name; reuse a saved id when present.
+        agent_id = prior_state.get("cloud_agent_id") if reuse else None
+        if not agent_id:
             agent_result = self._sync_agent(traigent_data["agent"])
             if not agent_result["success"]:
+                sync_result["status"] = "error"
                 sync_result["errors"].append(
                     f"Agent sync failed: {agent_result['error']}"
                 )
-                sync_result["status"] = "error"
-                return sync_result
-
-            successful_steps += 1
+                return
             agent_id = agent_result["agent_id"]
+        sync_result["cloud_agent_id"] = agent_id
+        successful_steps += 1
 
+        benchmark_id = prior_state.get("cloud_benchmark_id") if reuse else None
+        if not benchmark_id:
             benchmark_result = self._sync_benchmark(traigent_data["benchmark"])
             if not benchmark_result["success"]:
+                sync_result["status"] = "partial"
                 sync_result["errors"].append(
                     f"Benchmark sync failed: {benchmark_result['error']}"
                 )
-                sync_result["status"] = "partial"
-                return sync_result
-
-            successful_steps += 1
+                return
             benchmark_id = benchmark_result["benchmark_id"]
+        sync_result["cloud_benchmark_id"] = benchmark_id
+        successful_steps += 1
 
+        # The experiment is NOT name-deduped by the backend, so reusing a saved
+        # id is what prevents duplicate experiments on a retry (BLOCKER fix).
+        experiment_id = prior_state.get("cloud_experiment_id") if reuse else None
+        if not experiment_id:
             experiment_payload = self._build_experiment_payload(
                 traigent_data["experiment"], agent_id, benchmark_id
             )
             experiment_result = self._sync_experiment(experiment_payload)
             if not experiment_result["success"]:
+                sync_result["status"] = "partial"
                 sync_result["errors"].append(
                     f"Experiment sync failed: {experiment_result['error']}"
                 )
-                sync_result["status"] = "partial"
-                return sync_result
-
-            successful_steps += 1
+                return
             experiment_id = experiment_result["experiment_id"]
-            sync_result["cloud_experiment_id"] = experiment_id
+        sync_result["cloud_experiment_id"] = experiment_id
+        successful_steps += 1
 
+        experiment_run_id = (
+            prior_state.get("cloud_experiment_run_id") if reuse else None
+        )
+        if not experiment_run_id:
             run_payload = self._build_experiment_run_payload(
                 traigent_data["experiment_run"], agent_id, benchmark_id
             )
             run_result = self._sync_experiment_run(experiment_id, run_payload)
             if not run_result["success"]:
+                sync_result["status"] = "partial"
                 sync_result["errors"].append(
                     f"Experiment run sync failed: {run_result['error']}"
                 )
-                sync_result["status"] = "partial"
-                return sync_result
-
-            successful_steps += 1
+                return
             experiment_run_id = run_result["experiment_run_id"]
-            sync_result["cloud_experiment_run_id"] = experiment_run_id
+        sync_result["cloud_experiment_run_id"] = experiment_run_id
+        successful_steps += 1
 
-            configuration_result = self._sync_configuration_runs(
-                experiment_run_id, traigent_data["configuration_runs"]
+        configuration_result = self._sync_configuration_runs(
+            experiment_run_id, configuration_runs
+        )
+        successful_steps += configuration_result["synced"]
+        if not configuration_result["success"]:
+            sync_result["errors"].extend(
+                f"Configuration run sync failed: {error}"
+                for error in configuration_result["errors"]
             )
-            successful_steps += configuration_result["synced"]
-            if not configuration_result["success"]:
-                sync_result["errors"].extend(
-                    [
-                        f"Configuration run sync failed: {error}"
-                        for error in configuration_result["errors"]
-                    ]
-                )
 
-            if successful_steps == 0:
-                sync_result["status"] = "error"  # Complete failure
-            elif successful_steps == total_steps:
-                sync_result["status"] = "success"
-                sync_result["cloud_url"] = build_experiment_url(
-                    self.base_url, experiment_id
-                )
-            else:
-                sync_result["status"] = "partial"  # Some steps succeeded
-
-        except Exception as e:
-            # Override any partial status with error for complete failures
-            sync_result["status"] = "error"
-            sync_result["errors"].append(f"Sync failed: {str(e)}")
-            logger.error(f"Failed to sync session {session_id}: {e}")
-
-        self._record_sync_state(session_id, sync_result, payload_hash)
-        return sync_result
+        if successful_steps == 0:
+            sync_result["status"] = "error"  # Complete failure
+        elif successful_steps == total_steps:
+            sync_result["status"] = "success"
+            sync_result["cloud_url"] = build_experiment_url(
+                self.base_url, experiment_id
+            )
+        else:
+            sync_result["status"] = "partial"  # Some steps succeeded
 
     def _record_sync_state(
         self, session_id: str, sync_result: dict[str, Any], payload_hash: str
@@ -565,6 +614,10 @@ class SyncManager:
             "status": marker_status,
             "source": "offline_sync",
             "payload_hash": payload_hash,
+            # Persist all cloud ids so a retry of a partial sync reuses them
+            # instead of creating duplicate resources.
+            "cloud_agent_id": sync_result.get("cloud_agent_id"),
+            "cloud_benchmark_id": sync_result.get("cloud_benchmark_id"),
             "cloud_experiment_id": sync_result.get("cloud_experiment_id"),
             "cloud_experiment_run_id": sync_result.get("cloud_experiment_run_id"),
             "cloud_url": sync_result.get("cloud_url"),
@@ -573,8 +626,12 @@ class SyncManager:
         }
         prior_attempts = 0
         existing = self.storage.load_session(session_id)
-        if existing and existing.sync_state:
-            prior_attempts = int(existing.sync_state.get("attempts", 0) or 0)
+        prior_sync_state = getattr(existing, "sync_state", None)
+        if isinstance(prior_sync_state, dict):
+            try:
+                prior_attempts = int(prior_sync_state.get("attempts", 0) or 0)
+            except (TypeError, ValueError):
+                prior_attempts = 0
         patch["attempts"] = prior_attempts + 1
 
         try:
@@ -584,12 +641,15 @@ class SyncManager:
                 "Failed to persist sync_state for session %s: %s", session_id, exc
             )
 
-    def sync_all_sessions(self, dry_run: bool = False) -> dict[str, Any]:
+    def sync_all_sessions(
+        self, dry_run: bool = False, force: bool = False
+    ) -> dict[str, Any]:
         """
         Sync all eligible local sessions to cloud.
 
         Args:
             dry_run: If True, only validate data without uploading
+            force: If True, re-upload even runs already synced unchanged
 
         Returns:
             Overall sync result
@@ -605,7 +665,9 @@ class SyncManager:
 
         for session in completed_sessions:
             try:
-                result = self.sync_session_to_cloud(session.session_id, dry_run)
+                result = self.sync_session_to_cloud(
+                    session.session_id, dry_run, force=force
+                )
                 session_results.append(result)
 
                 status = result.get("status")
@@ -1002,6 +1064,9 @@ class SyncManager:
         sessions_deleted = 0
         errors: list[str] = []
 
+        # When backups are requested, only sessions whose backup succeeded are
+        # eligible for deletion — never delete a run we failed to back up.
+        deletable: list[str] = list(session_ids)
         if keep_backup:
             backup_dir = (
                 self.storage.storage_path
@@ -1010,6 +1075,7 @@ class SyncManager:
             )
             backup_dir.mkdir(parents=True, exist_ok=True)
 
+            backed_up: list[str] = []
             for session_id in session_ids:
                 try:
                     backup_success = self.storage.export_session(
@@ -1017,11 +1083,20 @@ class SyncManager:
                     )
                     if backup_success:
                         sessions_backed_up += 1
+                        backed_up.append(session_id)
+                    else:
+                        errors.append(
+                            f"Backup failed for {session_id}: export returned False; "
+                            "skipping deletion"
+                        )
                 except Exception as e:
-                    errors.append(f"Backup failed for {session_id}: {e}")
+                    errors.append(
+                        f"Backup failed for {session_id}: {e}; skipping deletion"
+                    )
+            deletable = backed_up
 
-        # Delete sessions
-        for session_id in session_ids:
+        # Delete sessions (only those safely backed up when backups are on).
+        for session_id in deletable:
             try:
                 if self.storage.delete_session(session_id):
                     sessions_deleted += 1

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -5,6 +5,8 @@ Handles migration of local data to Traigent backend when users upgrade.
 
 # Traceability: CONC-Layer-Infra CONC-Quality-Reliability FUNC-CLOUD-HYBRID FUNC-AGENTS REQ-CLOUD-009 REQ-AGNT-013
 
+import hashlib
+import json
 import os
 import re
 from collections.abc import Iterable, Mapping
@@ -148,18 +150,43 @@ class SyncManager:
 
         return default_timeout
 
+    @staticmethod
+    def _session_sync_status(session: OptimizationSession) -> str:
+        """Classify a local session's cloud-sync status from its sync_state."""
+        state = session.sync_state or {}
+        status = state.get("status")
+        if status in {"synced", "partial", "failed"}:
+            return str(status)
+        return "unsynced"
+
     def get_sync_status(self) -> dict[str, Any]:
-        """Get status of local sessions and sync eligibility."""
+        """Get status of local sessions and cloud-sync state.
+
+        Reports how many completed runs are already synced vs. still pending,
+        wandb-style, by reading each session's persisted ``sync_state``.
+        """
         sessions = self.storage.list_sessions()
         completed_sessions = [s for s in sessions if s.status == "completed"]
 
         total_trials = sum(s.completed_trials for s in sessions)
 
+        # Per-status counts across completed (sync-eligible) sessions.
+        counts = {"unsynced": 0, "synced": 0, "partial": 0, "failed": 0}
+        for session in completed_sessions:
+            counts[self._session_sync_status(session)] += 1
+        # Anything not already fully synced is eligible to (re)sync.
+        pending = counts["unsynced"] + counts["partial"] + counts["failed"]
+
         sync_status = {
             "total_sessions": len(sessions),
             "completed_sessions": len(completed_sessions),
             "total_trials": total_trials,
-            "sync_eligible": len(completed_sessions),
+            "synced": counts["synced"],
+            "unsynced": counts["unsynced"],
+            "partial": counts["partial"],
+            "failed": counts["failed"],
+            # Backwards-compatible field: count still pending an upload.
+            "sync_eligible": pending,
             "estimated_cloud_value": self._estimate_cloud_value(completed_sessions),
             "storage_info": self.storage.get_storage_info(),
         }
@@ -347,15 +374,31 @@ class SyncManager:
 
         return results
 
+    @staticmethod
+    def _compute_payload_hash(traigent_data: dict[str, Any]) -> str:
+        """Stable fingerprint of a session's syncable content.
+
+        Used as the idempotency key: re-syncing an unchanged session is a no-op
+        (so we never create duplicate cloud experiments), while a changed
+        session is detected and re-synced.
+        """
+        canonical = json.dumps(traigent_data, sort_keys=True, default=str)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
     def sync_session_to_cloud(
-        self, session_id: str, dry_run: bool = False
+        self, session_id: str, dry_run: bool = False, force: bool = False
     ) -> dict[str, Any]:
         """
         Sync a single session to cloud.
 
+        Idempotent: a session already synced with identical content is skipped
+        (status ``already_synced``) so re-running ``traigent sync`` never creates
+        duplicate cloud experiments. Pass ``force=True`` to re-upload anyway.
+
         Args:
             session_id: Local session ID to sync
             dry_run: If True, only validate data without uploading
+            force: If True, re-upload even when an unchanged sync already exists
 
         Returns:
             Sync result with status and details
@@ -366,6 +409,12 @@ class SyncManager:
 
         # Convert to Traigent format
         traigent_data = self.convert_session_to_traigent_format(session)
+        payload_hash = self._compute_payload_hash(traigent_data)
+        prior_state = dict(session.sync_state or {})
+        already_synced = (
+            prior_state.get("status") == "synced"
+            and prior_state.get("payload_hash") == payload_hash
+        )
 
         sync_result: dict[str, Any] = {
             "session_id": session_id,
@@ -373,18 +422,30 @@ class SyncManager:
             "status": "success",
             "dry_run": dry_run,
             "data_converted": True,
-            "cloud_experiment_id": None,
+            "cloud_experiment_id": prior_state.get("cloud_experiment_id"),
             "trials_converted": len(traigent_data["configuration_runs"]),
+            "payload_hash": payload_hash,
             "errors": [],
         }
 
+        # Idempotency: an unchanged, already-synced session is a no-op.
+        if already_synced and not force:
+            sync_result["status"] = "already_synced"
+            sync_result["cloud_url"] = prior_state.get("cloud_url")
+            sync_result["cloud_experiment_id"] = prior_state.get("cloud_experiment_id")
+            return sync_result
+
         if dry_run:
+            # Preserve the legacy "success" status for an un-synced validation
+            # run; only flag the already-synced case distinctly.
+            sync_result["status"] = "already_synced" if already_synced else "success"
             sync_result["preview"] = {
                 "experiment_name": traigent_data["experiment"]["name"],
                 "agent_name": traigent_data["agent"]["name"],
                 "benchmark_name": traigent_data["benchmark"]["name"],
                 "trial_count": len(traigent_data["configuration_runs"]),
                 "best_score": session.best_score,
+                "already_synced": already_synced,
             }
             return sync_result
 
@@ -450,6 +511,7 @@ class SyncManager:
 
             successful_steps += 1
             experiment_run_id = run_result["experiment_run_id"]
+            sync_result["cloud_experiment_run_id"] = experiment_run_id
 
             configuration_result = self._sync_configuration_runs(
                 experiment_run_id, traigent_data["configuration_runs"]
@@ -479,7 +541,48 @@ class SyncManager:
             sync_result["errors"].append(f"Sync failed: {str(e)}")
             logger.error(f"Failed to sync session {session_id}: {e}")
 
+        self._record_sync_state(session_id, sync_result, payload_hash)
         return sync_result
+
+    def _record_sync_state(
+        self, session_id: str, sync_result: dict[str, Any], payload_hash: str
+    ) -> None:
+        """Persist the outcome of a sync attempt onto the local session.
+
+        Records a durable ``synced`` marker (with the cloud ids + payload hash)
+        so a later ``traigent sync`` is idempotent, and a ``partial``/``failed``
+        marker otherwise so status reporting reflects reality. Best-effort:
+        never let a bookkeeping failure mask the sync result.
+        """
+        status = sync_result.get("status")
+        marker_status = {
+            "success": "synced",
+            "partial": "partial",
+            "error": "failed",
+        }.get(str(status), "failed")
+
+        patch: dict[str, Any] = {
+            "status": marker_status,
+            "source": "offline_sync",
+            "payload_hash": payload_hash,
+            "cloud_experiment_id": sync_result.get("cloud_experiment_id"),
+            "cloud_experiment_run_id": sync_result.get("cloud_experiment_run_id"),
+            "cloud_url": sync_result.get("cloud_url"),
+            "synced_at": datetime.now(UTC).isoformat(),
+            "last_error": "; ".join(sync_result.get("errors", [])) or None,
+        }
+        prior_attempts = 0
+        existing = self.storage.load_session(session_id)
+        if existing and existing.sync_state:
+            prior_attempts = int(existing.sync_state.get("attempts", 0) or 0)
+        patch["attempts"] = prior_attempts + 1
+
+        try:
+            self.storage.update_sync_state(session_id, patch)
+        except Exception as exc:  # pragma: no cover - bookkeeping must not break sync
+            logger.warning(
+                "Failed to persist sync_state for session %s: %s", session_id, exc
+            )
 
     def sync_all_sessions(self, dry_run: bool = False) -> dict[str, Any]:
         """
@@ -496,6 +599,7 @@ class SyncManager:
 
         session_results: list[dict[str, Any]] = []
         synced_successfully = 0
+        skipped = 0
         sync_errors = 0
         overall_status = "success"
 
@@ -504,8 +608,12 @@ class SyncManager:
                 result = self.sync_session_to_cloud(session.session_id, dry_run)
                 session_results.append(result)
 
-                if result["status"] == "success":
+                status = result.get("status")
+                if status == "success":
                     synced_successfully += 1
+                elif status in ("already_synced", "ready"):
+                    # Idempotent no-op: an unchanged, already-synced run.
+                    skipped += 1
                 else:
                     sync_errors += 1
 
@@ -526,6 +634,7 @@ class SyncManager:
             "total_sessions": len(sessions),
             "eligible_sessions": len(completed_sessions),
             "synced_successfully": synced_successfully,
+            "skipped": skipped,
             "sync_errors": sync_errors,
             "dry_run": dry_run,
             "session_results": session_results,

--- a/traigent/storage/local_storage.py
+++ b/traigent/storage/local_storage.py
@@ -134,6 +134,10 @@ class OptimizationSession:
     trials: list[TrialResult] | None = None
     optimization_config: dict[str, Any | None] | None = None
     metadata: dict[str, Any | None] | None = None
+    # Cloud-sync provenance & progress (Sync v2). Absent on never-synced
+    # sessions; populated by the syncer so re-sync is idempotent/resumable and
+    # `traigent sync` can report status. See traigent/cloud/session_sync.py.
+    sync_state: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         if self.trials is None:
@@ -507,6 +511,41 @@ class LocalStorageManager:
         self._save_session(session)
 
         logger.info(f"Finalized session {session_id} with status {status}")
+        return session
+
+    def update_sync_state(
+        self,
+        session_id: str,
+        patch: dict[str, Any],
+        *,
+        trial_updates: dict[str, dict[str, Any]] | None = None,
+    ) -> OptimizationSession | None:
+        """Merge a patch into a session's ``sync_state`` and persist atomically.
+
+        ``patch`` is shallow-merged into the top level of ``sync_state``.
+        ``trial_updates`` (keyed by the local trial id as a string) is merged
+        into ``sync_state["trials"]`` so per-trial upload progress accumulates
+        across resumable sync attempts. Returns the updated session, or None if
+        the session is missing.
+        """
+        session = self.load_session(session_id)
+        if not session:
+            logger.warning("Cannot update sync_state: session %s not found", session_id)
+            return None
+
+        state: dict[str, Any] = dict(session.sync_state or {})
+        state.update(patch)
+        if trial_updates:
+            trials_state: dict[str, Any] = dict(state.get("trials") or {})
+            for trial_key, trial_patch in trial_updates.items():
+                merged = dict(trials_state.get(trial_key) or {})
+                merged.update(trial_patch)
+                trials_state[trial_key] = merged
+            state["trials"] = trials_state
+
+        session.sync_state = state
+        session.updated_at = datetime.now(UTC).isoformat()
+        self._save_session(session)
         return session
 
     def load_session(self, session_id: str) -> OptimizationSession | None:

--- a/traigent/storage/local_storage.py
+++ b/traigent/storage/local_storage.py
@@ -10,7 +10,7 @@ import os
 import time
 from collections.abc import Mapping
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields as dataclass_fields
 from datetime import UTC, datetime
 from hashlib import sha256
 from pathlib import Path
@@ -160,6 +160,17 @@ class OptimizationSession:
 
         data["trials"] = trials
         return cls(**data)
+
+
+def _dataclass_kwargs(cls: type, data: dict[str, Any]) -> dict[str, Any]:
+    """Keep only keys that ``cls`` (a dataclass) accepts.
+
+    Lets a session file written by a newer SDK — with fields this version
+    doesn't know about — still load instead of raising ``TypeError`` from an
+    unexpected keyword argument.
+    """
+    allowed = {f.name for f in dataclass_fields(cls)}
+    return {key: value for key, value in data.items() if key in allowed}
 
 
 class LocalStorageManager:
@@ -563,10 +574,11 @@ class LocalStorageManager:
             with safe_open(session_file, self.storage_path, mode="r") as f:
                 data = json.load(f)
 
-            # Convert trial data back to TrialResult objects
+            # Convert trial data back to TrialResult objects. Drop unknown keys
+            # so a file written by a newer SDK (with extra fields) still loads.
             trials = []
             for trial_data in data.get("trials", []):
-                trials.append(TrialResult(**trial_data))
+                trials.append(TrialResult(**_dataclass_kwargs(TrialResult, trial_data)))
 
             data["trials"] = trials
 
@@ -581,7 +593,7 @@ class LocalStorageManager:
             if "updated_at" not in data:
                 data["updated_at"] = current_time
 
-            return OptimizationSession(**data)
+            return OptimizationSession(**_dataclass_kwargs(OptimizationSession, data))
 
         except Exception as e:
             logger.error(f"Failed to load session {session_id}: {e}")


### PR DESCRIPTION
## Summary

Makes syncing locally-logged optimization runs to the cloud a **first-class, idempotent** experience, following the `wandb sync` / Langfuse / Braintrust conventions for offline→cloud sync.

Today every run is logged locally, but the only way to push it (`traigent edge-analytics sync`) is buried, **creates duplicate cloud experiments on every re-run** (no idempotency), and reports no status. This PR fixes that.

### What changed
- **Top-level `traigent sync`** (wandb-style UX), with `edge-analytics sync` kept as a deprecated alias:
  - `traigent sync` (no args) → prints sync **status** (synced / unsynced / partial / failed), uploads nothing
  - `traigent sync <id>` / `--all` → push; `--dry-run`, `--force`, `--clean`, `--json`
- **Idempotency + resumability** via a persisted, backward-compatible `sync_state` on the local `OptimizationSession` (+ atomic `LocalStorageManager.update_sync_state`). `sync_session_to_cloud` fingerprints content (`payload_hash`): an unchanged, already-synced run returns `already_synced` with **no upload**; a partial/failed attempt **resumes** by reusing the cloud ids it already created (never a duplicate experiment); a changed run re-syncs.
- **`get_sync_status`** now reports per-state counts instead of treating every completed run as eligible.
- **Privacy preserved**: free-text trial metadata is not forwarded (only numeric measures + tuned config), locked with a canary test.

### Reviewed by codex (gpt-5.5 xhigh) — all findings fixed
BLOCKER partial-retry duplicate experiment → resume/reuse cloud ids + record state on every exit; concurrency → per-session lock; status/dry-run no longer require an API key; `cleanup --clean` deletes only runs with a verified backup; `--force` threaded through `--all`; `load_session` tolerates unknown future keys.

### Scope / follow-ups
This delivers the standard **behavior** (stable run identity, safe idempotent re-run, status, dry-run, resume) on the proven synchronous sync path. The deeper **session-model convergence** (a synced run sharing the exact live-run representation) and a **server-side idempotency contract** (cross-machine dedup, requires TraigentSchema + Backend + a DB migration verified against a live stack) are tracked follow-ups — see the plan. During grounding I also found the previously-suggested `/harness/sessions/{id}/backfill` endpoint is *metadata-only agent-harness telemetry*, not optimization runs, so it is intentionally not used.

## Tests
`tests/unit/cloud/test_sync_idempotency.py` (13) + `tests/unit/cli/test_sync_command.py` (6); full existing sync/storage/cli suites green (**211 passed, 1 skipped**). New tests cover idempotent re-sync, partial-failure resume (no dup experiment), privacy canary, status counts, cleanup backup-guard, status-without-key, and unknown-future-key tolerance.

## PR checklist
1. **Worst-case prod path** — sync is opt-in/manual; the risky op (`--clean` delete) only runs after a *verified* `sync_state == synced` with a backup. No auth/billing/tenant policy surface changed.
2. **Production-branch test** — idempotency + resume + cleanup-guard asserted (above).
3. **Contract regeneration** — none; reuses existing endpoints, no schema change. (Server-side idempotency contract is a tracked follow-up.)
4. **Public surface delta** — adds `traigent sync` CLI + an additive `OptimizationSession.sync_state` field (backward compatible). No `__all__`/route changes.
5. **Review threads** — will resolve all bot/human threads before merge.
6. **Quality gates** — not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Spine-Trail: st_78e4630fc014