### PR TITLE
fix(skill_train): surface stop_reason in SkillTrainResult.summary

### DIFF
--- a/traigent/generation/skill_train/trainer.py
+++ b/traigent/generation/skill_train/trainer.py
@@ -307,6 +307,7 @@ class SkillTrainer:
             epoch_summaries=epoch_summaries,
             artifacts_dir=None,
             summary={
+                "stop_reason": self._stop_reason,
                 "meta_skill": self._meta_skill,
                 "accept_history": self._accept_history,
                 "reject_history": self._reject_history,


### PR DESCRIPTION
The trainer tracks `self._stop_reason` (max_gate_evaluations / max_optimizer_calls) but never exposed it, so downstream reports reading `summary["stop_reason"]` always saw null. Add it to the result summary.

Verified: a run hitting `--max-gate-evaluations` now reports `stop_reason="max_trials"`-class values (e.g. `max_gate_evaluations`). Follow-up to merged #1232; used by the skill-evals `train` report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)