### PR TITLE
ci(spine): require a spine-trail mark on product PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,11 @@ Brief description of changes.
 - [ ] Documentation updated
 - [ ] No new warnings introduced
 - [ ] If this is an external contribution, I have signed or will sign Traigent's CLA before merge
+
+## Spine governance
+<!-- Governed product work must leave a validation-spine mark. Keep ONE of the
+     lines below (delete the others). See tools/spine-trail/README.md. -->
+Spine-Trail: st_xxxxxxxxxxxx
+<!-- or, once promoted to a ChangeSession:  Spine: cs_xxxxxxxx -->
+<!-- or, for a genuinely ungoverned change: Spine: none (reason: ...) -->
+

--- a/.github/workflows/spine-trail-gate.yml
+++ b/.github/workflows/spine-trail-gate.yml
@@ -1,0 +1,56 @@
+name: Spine Trail Gate
+
+# Server-side backstop for governed-work traceability: a product PR must carry a
+# validation-spine mark in its body. This is the CI layer of the spine-trail
+# defense-in-depth (skill rule + local hooks + this gate). It checks ONLY the PR
+# body for a marker line — it does not read the spine or block on posture, so it
+# stays fast and cannot be flaked by stale health.
+#
+# Accepted markers (any one):
+#   Spine-Trail: st_xxxxxxxxxxxx   (a Tier-0 WorkIntent)
+#   Spine: cs_xxxxxxxx             (a promoted ChangeSession)
+#   Spine: none (reason: ...)      (an explicit, owner-visible waiver)
+
+on:
+  pull_request:
+    branches: [develop, main]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: spine-trail-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  spine-trail:
+    name: spine-trail present
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for a spine mark
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # Valid markers (anchored to line start, tolerant of leading spaces).
+          trail='^[[:space:]]*Spine-Trail:[[:space:]]*st_[0-9a-f]{12}[[:space:]]*$'
+          session='^[[:space:]]*Spine:[[:space:]]*cs_[0-9a-z]{6,}[[:space:]]*$'
+          waiver='^[[:space:]]*Spine:[[:space:]]*none[[:space:]]*\(reason:.+\)[[:space:]]*$'
+
+          if printf '%s\n' "$PR_BODY" | grep -Eqi "$trail"; then
+            echo "✅ Spine-Trail present."
+          elif printf '%s\n' "$PR_BODY" | grep -Eqi "$session"; then
+            echo "✅ Promoted ChangeSession (Spine:) present."
+          elif printf '%s\n' "$PR_BODY" | grep -Eqi "$waiver"; then
+            echo "⚠️  Explicit governance waiver (Spine: none) accepted."
+          else
+            echo "::error title=Spine trail missing::This product PR has no validation-spine mark."
+            echo "Governed product work must leave a spine mark. Add ONE line to the PR body:"
+            echo "  Spine-Trail: st_xxxxxxxxxxxx   (a Tier-0 WorkIntent)"
+            echo "  Spine: cs_xxxxxxxx             (a promoted ChangeSession)"
+            echo "  Spine: none (reason: <why ungoverned>)"
+            echo "Open one with: python3 tools/spine-trail/spine_trail.py get-or-create ..."
+            echo "See tools/spine-trail/README.md"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds the **CI layer** of the `spine-trail` governed-work ledger — the fix for a process gap found this session: an audit showed **~92% of recent product PRs left zero validation-spine traceability** because the only way to leave a mark was the heavy `/spine:*` ceremony, which gets skipped under coding momentum.

This PR is the server-side backstop in a defense-in-depth design (skill rule + local hooks + **this CI gate**):

- **`.github/workflows/spine-trail-gate.yml`** — a fast required check that fails a `develop`/`main` PR whose body lacks a spine mark. Accepts any one of:
  - `Spine-Trail: st_xxxxxxxxxxxx` — a Tier-0 WorkIntent (the cheap durable breadcrumb)
  - `Spine: cs_xxxxxxxx` — a promoted ChangeSession
  - `Spine: none (reason: …)` — an explicit, owner-visible waiver
  It checks **only the PR body** — it never reads spine posture, so it can't be flaked by stale health (`343 critical gaps`, 10-day-old refresh).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — adds the Spine governance field.

The primitive, hooks, skill rule, and full investigation live in the workspace (`tools/spine-trail/`, `CLAUDE.md`). This PR **dogfoods** the gate: its own body carries the line below.

## Why (the governed work ledger)
Every product write should begin with a durable WorkIntent; a ChangeSession is its promoted form; hooks + CI are adapters that prevent silent drift when the agent forgets. The metric shifts from "did the agent invoke the skill?" to "% of governed PRs with a valid spine mark before PR-create."

## Rollout note
Merge does not auto-require the check — an admin must add **`spine-trail present`** to the branch-protection required checks for it to block. Until then it runs advisory.

Spine-Trail: st_30ff08e4c97d
