### PR TITLE
ci: advisory skill-contract gate — validate published skills against SDK PRs

### DIFF
--- a/.github/workflows/skill-contract.yml
+++ b/.github/workflows/skill-contract.yml
@@ -1,0 +1,74 @@
+name: Skill Contract
+
+# Advisory upstream gate: when a PR changes the SDK's public surface, validate the
+# traigent-skills contract against THIS PR's build, so SDK changes that would break a
+# published skill surface in-PR (instead of being caught nightly in the skills repo).
+# Self-contained + secret-gated: skips cleanly (green no-op) until SKILLS_REPO_TOKEN
+# (read-only access to Traigent/traigent-skills) is provisioned. Keep advisory (not a
+# required check) until it has been green across a few PRs.
+
+on:
+  pull_request:
+    paths:
+      - "traigent/**/*.py"
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: skill-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  skill-contract:
+    name: skill-contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Guard - require skills token
+        id: guard
+        env:
+          SKILLS_TOKEN: ${{ secrets.SKILLS_REPO_TOKEN }}
+        run: |
+          if [ -z "${SKILLS_TOKEN:-}" ]; then
+            echo "SKILLS_REPO_TOKEN not set - skipping skill contract (gate not yet armed)."
+            echo "armed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "armed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout SDK PR
+        if: steps.guard.outputs.armed == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Checkout skills contract harness
+        if: steps.guard.outputs.armed == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: Traigent/traigent-skills
+          token: ${{ secrets.SKILLS_REPO_TOKEN }}
+          path: _skills
+
+      - name: Set up Python
+        if: steps.guard.outputs.armed == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the PR SDK + harness deps
+        if: steps.guard.outputs.armed == 'true'
+        run: |
+          python -m pip install pytest pyyaml packaging
+          python -m pip install .
+
+      - name: Run the skill contract against this PR's SDK
+        if: steps.guard.outputs.armed == 'true'
+        run: |
+          python -m pytest \
+            _skills/tests/contract/test_python_contracts.py \
+            _skills/tests/contract/test_env_and_cli.py \
+            _skills/tests/contract/test_skill_lints.py \
+            _skills/tests/contract/test_text_requirements.py \
+            _skills/tests/contract/test_harness_selftest.py \
+            -p no:cacheprovider --sdk-version=develop -q -rs


### PR DESCRIPTION
## What

Live **advisory** caller for the skill⟷interface contract program. When an SDK PR changes `traigent/**/*.py` or `pyproject.toml`, it validates every taught Python fact in the **published skills** (`traigent-skills`) against **this PR's** SDK build (`--sdk-version=develop`) — so an SDK change that would break a skill is caught in-PR, not nightly (the issue #8 class).

- **Self-contained + secret-gated**: skips cleanly (green no-op) until you add a `SKILLS_REPO_TOKEN` secret (read-only access to `Traigent/traigent-skills`). No cross-repo reusable-workflow dependency.
- **Advisory**: keep it out of required checks until it's been green across a few PRs, then promote.

This is the canonical example from `traigent-skills/docs/keeping-skills-in-sync.md` (same caller pattern for backend / MCP / JS surfaces). Until armed, it does nothing.

## To arm
1. Create a read-only fine-grained PAT or GitHub App with access to `Traigent/traigent-skills`.
2. Add it as the `SKILLS_REPO_TOKEN` secret on this repo (or org-level).
3. The next SDK PR runs the contract; a taught symbol you removed shows up as a red `skill-contract` check naming the skill.

Spine-Trail: st_64379df61985

🤖 Generated with [Claude Code](https://claude.com/claude-code)