### PR TITLE
fix(hybrid): re-raise AuthenticationError on session-creation ladder (#1278)

### DIFF
--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -259,6 +259,49 @@ class TestCreateTraigentSessionViaApi:
             assert "mock_exp_" in exp_id
             assert "mock_run_" in run_id
 
+    @pytest.mark.asyncio
+    async def test_auth_error_on_create_propagates_as_authentication_error(self):
+        """#1278: a 401/403 during session creation must reach the caller AS an
+        AuthenticationError — NOT be demoted to a plain CloudServiceError by the
+        generic ``except Exception`` ladder.
+
+        Before the fix, AuthenticationError (raised by ``_handle_session_error``
+        with the structured 403 detail) fell through to ``except Exception`` and
+        was re-wrapped as CloudServiceError, so session_operations classified it
+        SESSION_FAILED -> BACKEND_UNREACHABLE ("check your network/URL") instead
+        of an auth/permission error. This test fails on the pre-fix ladder
+        (raises CloudServiceError) and passes once the dedicated
+        ``except AuthenticationError: raise`` clause is in place.
+        """
+        from traigent.cloud.auth import AuthenticationError
+
+        request = SessionCreationRequest(
+            function_name="test_func",
+            configuration_space={"param": [1, 2, 3]},
+            objectives=["maximize"],
+            max_trials=10,
+        )
+        # Simulate the 403 path: _post_session_creation -> _handle_session_error
+        # raises AuthenticationError carrying the structured detail.
+        with (
+            patch(
+                "traigent.cloud.api_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.api_operations.AIOHTTP_AVAILABLE", True),
+            patch.object(
+                self.ops,
+                "_post_session_creation",
+                new=AsyncMock(
+                    side_effect=AuthenticationError(
+                        "Authentication failed: missing permission"
+                    )
+                ),
+            ),
+        ):
+            with pytest.raises(AuthenticationError):
+                await self.ops.create_traigent_session_via_api(request)
+
 
 class TestResolveMaxTrials:
     """Test _resolve_max_trials method."""
@@ -413,7 +456,7 @@ class TestHandleSessionError:
                 '"details":{"missing_permissions":["experiment.write"]}}',
             )
 
-        detail = getattr(exc.value, "session_creation_failure")
+        detail = exc.value.session_creation_failure
         assert detail.error_code == "INSUFFICIENT_PERMISSIONS"
         assert detail.message == "Missing required permissions: experiment.write"
         assert detail.missing_permissions == ("experiment.write",)
@@ -443,7 +486,7 @@ class TestHandleSessionError:
         with pytest.raises(CloudServiceError, match="Session creation failed") as exc:
             self.ops._handle_session_error(400, "Bad Request")
 
-        detail = getattr(exc.value, "session_creation_failure")
+        detail = exc.value.session_creation_failure
         assert detail.status_code == 400
         assert detail.raw_body == "Bad Request"
 

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -293,6 +293,15 @@ class ApiOperations:
             # plain CloudServiceError and the local-fallback layer would
             # absorb them.
             raise
+        except AuthenticationError:
+            # #1278: a 401/403 on session creation must reach the caller AS
+            # ITSELF. _handle_session_error raises AuthenticationError with the
+            # structured 403 detail attached; the generic wrap below would
+            # demote it to a plain CloudServiceError (dropping the detail), so
+            # session_operations would classify it SESSION_FAILED →
+            # BACKEND_UNREACHABLE ("check your network/URL") instead of an
+            # auth/permission error (MISSING_PERMISSION / INVALID_OR_REVOKED_KEY).
+            raise
         except aiohttp.ClientConnectorError as e:
             self._handle_connector_error(e)
         except aiohttp.ClientError as e:


### PR DESCRIPTION
## Summary
A backend **401/403 during session creation** was misclassified as **`BACKEND_UNREACHABLE`** ("check `TRAIGENT_BACKEND_URL` / network, retry later") instead of an auth/permission error. `_handle_session_error` correctly raises `AuthenticationError` carrying the structured 403 detail, but the exception ladder in `ApiOperations.create_traigent_session_via_api` had no clause for it, so it fell through to `except Exception` → `_handle_generic_session_exception` → re-wrapped as a plain `CloudServiceError` (detail dropped). Downstream `session_operations.create_session` then never ran its `except AuthenticationError` branch → `reason=SESSION_FAILED`, `failure_response=None` → `_classify_session_creation_failure` → **`BACKEND_UNREACHABLE`**.

Fixes #1278. Live residual of #1181 (#1187 added the pre-spend abort, not this ladder re-raise).

## Fix
`traigent/cloud/api_operations.py`: add `except AuthenticationError: raise` immediately before the generic `except Exception` (mirroring the existing `SessionContractError` re-raise). The structured auth error now reaches the caller as itself, so `session_operations`' `except AuthenticationError` sets `reason=AUTH` and routes to `MISSING_PERMISSION` / `INVALID_OR_REVOKED_KEY` — never `BACKEND_UNREACHABLE`.

## Test
`tests/unit/cloud/test_api_operations.py::TestCreateTraigentSessionViaApi::test_auth_error_on_create_propagates_as_authentication_error`:
- **Pre-fix:** fails — `create_traigent_session_via_api` raises `CloudServiceError: Session creation failed: Authentication failed…` (mutation-verified).
- **Post-fix:** passes — propagates `AuthenticationError`.

Also fixes two pre-existing B009 ruff violations in the same test file so the changed-file ruff gate stays green (no gate relaxed).

`pytest tests/unit/cloud/test_api_operations.py` → **87 passed**. `ruff check` / `ruff format --check` clean.

## PR checklist
1. **Worst-case prod path** — an under-permissioned / revoked key is told "check your network" and the SDK silently falls back to local-only. No fail-open: this only changes *error classification*; an auth failure still aborts the cloud path (no permissive default introduced).
2. **Production-branch test** — `test_auth_error_on_create_propagates_as_authentication_error` (`tests/unit/cloud/test_api_operations.py`) asserts the auth error is preserved, not demoted.
3. **Contract regeneration** — none. (The absent hybrid wire-error contract is TraigentSchema#150, out of scope and called out in #1278.)
4. **Public surface delta** — none.
5. **Review threads resolved** — will resolve all bot/human threads before merge.
6. **Quality gates not relaxed** — none widened; 2 pre-existing B009 violations fixed (gate left tighter).

Spine-Trail: st_65f8c820be2f
