### PR TITLE
fix(hybrid): local-persistence safety net on connected runs (#1279)

### DIFF
--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -58,6 +58,10 @@ class FakeClient:
         self.backend_config = SimpleNamespace(api_base_url=None, backend_base_url=None)
         self.auth_manager = FakeAuthManager()
         self._register_security_session = MagicMock()
+        # Connected runs mirror the backend session into local_storage (#1279).
+        # Tests that care assign a real LocalStorageManager; default None keeps
+        # the connected path a no-op for unrelated tests.
+        self.local_storage = None
 
     async def _ensure_session(self):  # pragma: no cover - not used in validation tests
         return SimpleNamespace(post=AsyncMock(), get=AsyncMock())
@@ -143,6 +147,46 @@ def test_create_session_tracks_connected_session_locally(monkeypatch):
     assert tracked.max_trials == 3
     assert tracked.metadata["experiment_id"] == "experiment-123"
     assert tracked.metadata["experiment_run_id"] == "run-123"
+
+
+def test_connected_session_is_mirrored_to_local_storage(monkeypatch, tmp_path):
+    """#1279: the connected hybrid path must create a local_storage session
+    keyed to the backend session_id, so _persist_trial_locally has a durable
+    record on connected runs. Before the fix, local_storage never learned of the
+    connected session and add_trial_result raised "session not found".
+    """
+    from traigent.storage.local_storage import LocalStorageManager
+
+    client = FakeClient()
+    client.local_storage = LocalStorageManager(str(tmp_path))
+    ops = SessionOperations(client)
+
+    async def create_via_api(_request):
+        return ("backend-session-xyz", "experiment-xyz", "run-xyz")
+
+    monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
+
+    result = ops.create_session(
+        "demo-function",
+        {"model": ["gpt-4o"]},
+        metadata={"max_trials": 3},
+    )
+
+    assert result.session_id == "backend-session-xyz"
+    # The local mirror exists, keyed to the *backend* session id...
+    mirrored = client.local_storage.load_session("backend-session-xyz")
+    assert mirrored is not None
+    assert mirrored.metadata["execution_mode"] == "connected"
+    # ...so a trial keyed to the backend id now persists locally instead of
+    # raising TraigentStorageError("Session ... not found").
+    client.local_storage.add_trial_result(
+        session_id="backend-session-xyz",
+        config={"model": "gpt-4o"},
+        score=0.9,
+    )
+    reloaded = client.local_storage.load_session("backend-session-xyz")
+    assert reloaded.trials is not None
+    assert len(reloaded.trials) == 1
 
 
 def test_create_session_prunes_completed_sessions_with_aware_timestamps(monkeypatch):

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -332,6 +332,54 @@ def test_local_storage_lock_timeout_raises():
             lock_path.unlink()
 
 
+def test_local_storage_create_session_with_external_id():
+    """#1279: create_session accepts an externally-supplied id (a backend
+    session id) so connected hybrid runs persist trials under the same key the
+    backend uses. add_trial_result on that id must succeed, not raise
+    "session not found".
+    """
+    from traigent.storage.local_storage import LocalStorageManager
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        storage = LocalStorageManager(tmp_dir)
+        returned = storage.create_session("demo_func", session_id="backend-session-abc")
+        assert returned == "backend-session-abc"
+        assert storage.load_session("backend-session-abc") is not None
+
+        # The exact failure #1279 describes: a trial keyed to the backend id.
+        storage.add_trial_result(
+            session_id="backend-session-abc",
+            config={"model": "gpt-4o"},
+            score=0.5,
+        )
+        reloaded = storage.load_session("backend-session-abc")
+        assert reloaded.trials is not None
+        assert len(reloaded.trials) == 1
+
+
+def test_local_storage_create_session_external_id_is_idempotent():
+    """#1279: re-creating a session with an existing external id must not
+    clobber trials already recorded under it (connected runs may re-resolve the
+    same backend session)."""
+    from traigent.storage.local_storage import LocalStorageManager
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        storage = LocalStorageManager(tmp_dir)
+        storage.create_session("demo_func", session_id="backend-session-dup")
+        storage.add_trial_result(
+            session_id="backend-session-dup",
+            config={"model": "gpt-4o"},
+            score=0.5,
+        )
+
+        # Second create with the same id is a no-op (returns the id, keeps trials)
+        again = storage.create_session("demo_func", session_id="backend-session-dup")
+        assert again == "backend-session-dup"
+        reloaded = storage.load_session("backend-session-dup")
+        assert reloaded.trials is not None
+        assert len(reloaded.trials) == 1
+
+
 def test_local_storage_delete_session_validates_path():
     """Test delete_session uses path validation."""
     from traigent.storage.local_storage import LocalStorageManager

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -1226,7 +1226,13 @@ class BackendIntegratedClient:
                     metadata=metadata or {},
                 )
             except Exception as exc:
-                logger.debug("Local storage trial result fallback failed: %s", exc)
+                # #1279: do not silently drop the local record — on connected
+                # runs this is the only durable trace if the remote submit fails.
+                logger.warning(
+                    "Local storage trial result persistence failed for session %s: %s",
+                    session_id,
+                    exc,
+                )
 
         session = self._active_sessions.get(session_id)
         if session:

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -251,6 +251,61 @@ class SessionOperations:
         logger.debug("Using ephemeral session ID: %s", fallback_id)
         return fallback_id
 
+    def _persist_connected_session_locally(
+        self,
+        *,
+        session_id: str,
+        function_name: str,
+        search_space: dict[str, Any],
+        optimization_goal: str,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        """Mirror a connected backend session into local_storage (#1279).
+
+        On the connected hybrid path the session is registered only in the
+        in-memory ``_active_sessions``; ``local_storage`` never learns of it, so
+        ``_persist_trial_locally`` -> ``add_trial_result`` raises "session not
+        found" and the advertised "run locally, sync to backend" safety net does
+        not exist there. Creating a local session keyed to the backend
+        ``session_id`` gives every connected trial a durable local record, so a
+        completed (paid-for) trial survives a mid-run remote-submit failure.
+
+        Best-effort: a local-storage failure must never break the connected run,
+        but it is logged at WARNING — the safety net silently not existing is the
+        exact failure mode #1279 is about.
+        """
+        local_storage = getattr(self.client, "local_storage", None)
+        if not local_storage:
+            return
+        try:
+            optimization_config = {
+                "search_space": search_space,
+                "optimization_goal": optimization_goal,
+                "baseline_config": None,
+            }
+            connected_metadata = dict(metadata or {})
+            connected_metadata.update(
+                {
+                    "execution_mode": "connected",
+                    "backend_session": True,
+                    "created_with_version": "traigent-connected-mirror-1.0.0",
+                }
+            )
+            local_storage.create_session(
+                function_name=function_name,
+                optimization_config=optimization_config,
+                metadata=connected_metadata,
+                session_id=session_id,
+            )
+            logger.debug("Created local mirror for connected session: %s", session_id)
+        except Exception as storage_e:
+            logger.warning(
+                "Could not create local mirror for connected session %s; trials "
+                "on this run have no local-persistence safety net: %s",
+                session_id,
+                storage_e,
+            )
+
     def create_session(
         self,
         function_name: str,
@@ -444,6 +499,19 @@ class SessionOperations:
                     session_id,
                     experiment_id,
                     experiment_run_id,
+                )
+
+                # #1279: also mirror the connected session into local_storage
+                # keyed to the backend session_id, so _persist_trial_locally has
+                # a durable local record on connected runs too. Without this the
+                # only record of a completed (paid-for) trial is the breaker-gated
+                # remote submit; if that fails mid-run the trial is lost silently.
+                self._persist_connected_session_locally(
+                    session_id=session_id,
+                    function_name=function_name,
+                    search_space=search_space,
+                    optimization_goal=optimization_goal,
+                    metadata=metadata,
                 )
                 return SessionCreationResult.connected(session_id=session_id)
 

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -748,8 +748,12 @@ class BackendSessionManager:
                 metadata=metadata_payload,
             )
         except Exception as exc:
-            logger.debug(
-                "Local trial logging failed for session %s trial %s: %s",
+            # #1279: a failed local write means the trial's only record is the
+            # breaker-gated remote submit — if that also fails the completed
+            # (paid-for) trial is lost. This must never be silent.
+            logger.warning(
+                "Local trial logging failed for session %s trial %s — trial has "
+                "no durable local record if the remote submit also fails: %s",
                 session_id,
                 trial_result.trial_id,
                 exc,

--- a/traigent/storage/local_storage.py
+++ b/traigent/storage/local_storage.py
@@ -317,6 +317,7 @@ class LocalStorageManager:
         function_name: str,
         optimization_config: dict[str, Any | None] | None = None,
         metadata: dict[str, Any | None] | None = None,
+        session_id: str | None = None,
     ) -> str:
         """
         Create a new optimization session.
@@ -325,13 +326,24 @@ class LocalStorageManager:
             function_name: Name of the function being optimized
             optimization_config: Configuration for the optimization
             metadata: Additional metadata
+            session_id: Optional externally-supplied id (e.g. a backend
+                session id, so connected hybrid runs can durably persist
+                trials under the same key the backend uses — see #1279). When
+                omitted, a local id is minted. If a session with this id
+                already exists it is returned unchanged (idempotent — existing
+                trials are never clobbered).
 
         Returns:
             session_id: Unique identifier for the session
         """
         timestamp = datetime.now(UTC)
-        safe_function = sanitize_identifier(function_name)
-        session_id = f"{timestamp.strftime('%Y%m%d_%H%M%S_%f')}_{safe_function}_{uuid4().hex[:8]}"
+        if session_id is not None:
+            existing = self.load_session(session_id)
+            if existing is not None:
+                return session_id
+        else:
+            safe_function = sanitize_identifier(function_name)
+            session_id = f"{timestamp.strftime('%Y%m%d_%H%M%S_%f')}_{safe_function}_{uuid4().hex[:8]}"
 
         session = OptimizationSession(
             session_id=session_id,


### PR DESCRIPTION
## Summary
On the **connected** hybrid path, `_persist_trial_locally` was a **no-op**: the session was registered only in the in-memory `_active_sessions`, never in `local_storage`, so `_persist_trial_locally` → `backend_client.submit_result` → `local_storage.add_trial_result` raised `"Session <id> not found"` (swallowed at DEBUG twice). The advertised "run locally, sync to backend" safety net therefore did **not** exist on connected runs — a completed (paid-for) trial's only record was the breaker-gated remote submit, and if that failed mid-run the trial was **lost silently, with no durable local record**.

Fixes #1279. Connected-path leg of #1210 (#1216 fixed only the offline/fallback leg).

## Fix
1. **`traigent/storage/local_storage.py`** — `create_session` accepts an optional external `session_id` (idempotent: an existing session is returned unchanged, trials never clobbered), so connected runs can key a local session to the backend `session_id`.
2. **`traigent/cloud/session_operations.py`** — new `_persist_connected_session_locally`, called on the connected branch before returning, mirrors the backend session into `local_storage` keyed to its `session_id`. Best-effort: a local-storage failure never breaks the connected run, but is logged at **WARNING**.
3. **`backend_session_manager._persist_trial_locally`** and **`backend_client.submit_result`** — the two silent DEBUG swallows are raised to **WARNING**; a failed local write is the exact failure mode this issue is about and must never be invisible.

**Honest scope:** on a *healthy* connected run the trial still reaches the backend inline, so steady-state portal tracking is unchanged. This restores the local safety net for the **degradation** case (mid-run backend/breaker/transport failure). **Out of scope** (kept tight): the optional queue/retry of the failed remote submit (issue item 3) and the unreachable-fallback work (#1210/#1265).

## Tests (all mutation-verified to fail pre-fix)
- `tests/unit/cloud/test_session_operations_validation.py::test_connected_session_is_mirrored_to_local_storage` — connected create yields a local session keyed to the backend id; `add_trial_result` on that id persists (pre-fix: `mirrored is None` → fails).
- `tests/unit/test_coverage_improvements.py::test_local_storage_create_session_with_external_id` / `::..._is_idempotent`.

Related suites green: `backend_client`, `session_management`, `backend_components_fail_closed`, `hybrid/` — **300 passed**. `ruff check` / `ruff format --check` clean. pre-commit (incl. mypy, bandit) passed.

## PR checklist
1. **Worst-case prod path** — a completed paid-for trial vanishes silently on a transient mid-run backend failure. This change adds a durable local record (fail toward *preserving* the trial) and makes any local-write failure visible (WARNING). No fail-open policy path touched.
2. **Production-branch test** — `test_connected_session_is_mirrored_to_local_storage` asserts the connected path now persists locally; mutation-verified.
3. **Contract regeneration** — none (local persistence only; no wire-shape change).
4. **Public surface delta** — `local_storage.create_session` gains an optional keyword arg (`session_id`), backward-compatible; no `__all__`/route change.
5. **Review threads resolved** — will resolve all bot/human threads before merge.
6. **Quality gates not relaxed** — none widened.

Spine-Trail: st_bcdc805a7405
