### PR TITLE
ci(skill-contract): don't inherit SDK xdist addopts; self-test on workflow edits

### DIFF
--- a/.github/workflows/skill-contract.yml
+++ b/.github/workflows/skill-contract.yml
@@ -12,6 +12,9 @@ on:
     paths:
       - "traigent/**/*.py"
       - "pyproject.toml"
+      # Self-test: changes to this workflow re-run the gate so a fix/regression
+      # is caught in-PR (the job otherwise only triggers on SDK-surface changes).
+      - ".github/workflows/skill-contract.yml"
 
 permissions:
   contents: read
@@ -65,10 +68,18 @@ jobs:
       - name: Run the skill contract against this PR's SDK
         if: steps.guard.outputs.armed == 'true'
         run: |
+          # Run from the SDK repo root so pytest resolves the SDK's pyproject as
+          # rootdir, but override addopts to empty: the repo's test addopts pin
+          # `-n auto --dist loadgroup` (pytest-xdist), which this self-contained
+          # job deliberately does NOT install. Without the override the contract
+          # run aborts with "unrecognized arguments: -n --dist" (exit 4) before a
+          # single contract test executes. The skill-contract harness is
+          # independent of the SDK suite's parallelism/marker/ignore config, so it
+          # carries only its own explicit flags below.
           python -m pytest \
             _skills/tests/contract/test_python_contracts.py \
             _skills/tests/contract/test_env_and_cli.py \
             _skills/tests/contract/test_skill_lints.py \
             _skills/tests/contract/test_text_requirements.py \
             _skills/tests/contract/test_harness_selftest.py \
-            -p no:cacheprovider --sdk-version=develop -q -rs
+            -o addopts= -p no:cacheprovider --sdk-version=develop -q -rs


### PR DESCRIPTION
## Summary
The advisory **skill-contract** gate (added in #1277) was **red on every PR that triggered it**. The job is self-contained — it installs only `pytest pyyaml packaging` + the SDK (`pip install .`) — but runs `pytest` from the SDK repo root, so it inherits the SDK's `[tool.pytest.ini_options] addopts`, which pins `-n auto --dist loadgroup` (pytest-xdist). xdist is deliberately **not** installed in this job, so pytest aborted with `unrecognized arguments: -n --dist` (exit 4) **before a single contract test ran**.

It didn't block merges (it's advisory; the only required develop check is `required-pr-gate`), but it was permanent CI noise that trains reviewers to ignore a red check.

## Fix
- Pass `-o addopts=` to the contract `pytest` invocation, so it runs with only its own explicit flags, independent of the SDK suite's parallelism/marker/ignore config. Non-`addopts` ini keys (`asyncio_mode = "auto"`, `filterwarnings`, custom markers) are unaffected.
- Add `.github/workflows/skill-contract.yml` to the `pull_request.paths` trigger so the gate **re-runs on its own edits** — otherwise it only triggers on SDK-surface changes and a workflow-only fix can't be verified on its own PR.

## Verification
Reproduced + fixed the exact mechanic in a clean **no-xdist** venv:
```
# pyproject addopts = ["-n","auto","--dist","loadgroup", ...]
$ pytest test_demo.py -q                 # -> "unrecognized arguments: -n --dist"  (repro)
$ pytest test_demo.py -o addopts= -q     # -> 1 passed                              (fixed)
```
Because this PR now also touches the trigger path, the **real** skill-contract job runs on this PR — its result here is the live confirmation (it should go green where every prior PR went red, given `SKILLS_REPO_TOKEN` is provisioned; if the token is absent it cleanly skips green via the guard step).

## PR checklist
1. **Worst-case prod path** — n/a (CI workflow only; no runtime/policy surface).
2. **Production-branch test** — n/a; mechanic verified in a sandbox and self-verified by the gate running on this PR.
3. **Contract regeneration** — none.
4. **Public surface delta** — none.
5. **Review threads resolved** — will resolve any bot/human threads before merge.
6. **Quality gates not relaxed** — this *un-breaks* a gate (was always-failing); it does not loosen any threshold. The gate now actually executes its contract tests instead of erroring out.

Spine-Trail: st_3cea992ff91d
