### PR TITLE
fix(sdk): cap+warn per-example measures to avoid silent total loss on sync (#1285)

### DIFF
--- a/tests/unit/core/test_metadata_helpers.py
+++ b/tests/unit/core/test_metadata_helpers.py
@@ -322,6 +322,99 @@ class TestBuildBackendMetadataPrivacy:
         assert len(metadata["measures"]) == 1
 
 
+class TestMeasuresProducerCap:
+    """Regression tests for #1285: producer-side cap on per-example measures.
+
+    The backend rejects the WHOLE submission when ``measures`` exceeds 1000
+    examples, returning an empty list -- so an uncapped array silently loses ALL
+    measures. The SDK must cap to the backend limit (keeping the first 1000) and
+    warn loudly, never silently produce a payload the server rejects wholesale.
+    """
+
+    @staticmethod
+    def _make_example_results(count: int) -> list[Mock]:
+        results = []
+        for _ in range(count):
+            r = Mock()
+            r.metrics = {"accuracy": 0.9, "cost": 0.02}
+            r.execution_time = 0.5
+            r.expected_output = "expected"
+            r.actual_output = "expected"
+            results.append(r)
+        return results
+
+    def test_full_measures_capped_not_all_lost(
+        self, mock_trial_result, mock_config, caplog
+    ):
+        """>1000-example trial keeps first 1000 measures, not zero (non-privacy)."""
+        from traigent.core.metadata_helpers import MAX_EXAMPLES_PER_RUN
+
+        over = MAX_EXAMPLES_PER_RUN + 250
+        mock_config.execution_mode = "edge_analytics"
+        mock_trial_result.metadata = {
+            "example_results": self._make_example_results(over)
+        }
+
+        with caplog.at_level("WARNING"):
+            metadata = build_backend_metadata(
+                mock_trial_result, "accuracy", mock_config
+            )
+
+        # Measures must be present and capped -- NOT all lost, NOT over the cap.
+        assert "measures" in metadata
+        assert len(metadata["measures"]) == MAX_EXAMPLES_PER_RUN
+        # The first 1000 (not a random subset) are kept.
+        assert metadata["measures"][0]["example_id"].endswith("_0")
+        # The data loss is surfaced, not silent.
+        assert any(
+            "exceed the backend cap" in rec.message and rec.levelname == "WARNING"
+            for rec in caplog.records
+        )
+
+    def test_privacy_measures_capped_not_all_lost(
+        self, mock_trial_result, mock_config, caplog
+    ):
+        """>1000-example trial keeps first 1000 measures, not zero (privacy)."""
+        from traigent.core.metadata_helpers import MAX_EXAMPLES_PER_RUN
+
+        over = MAX_EXAMPLES_PER_RUN + 1
+        mock_config.privacy_enabled = True
+        mock_config.execution_mode = "edge_analytics"
+        mock_trial_result.metadata = {
+            "example_results": self._make_example_results(over)
+        }
+
+        with caplog.at_level("WARNING"):
+            metadata = build_backend_metadata(
+                mock_trial_result, "accuracy", mock_config
+            )
+
+        assert "measures" in metadata
+        assert len(metadata["measures"]) == MAX_EXAMPLES_PER_RUN
+        assert any("exceed the backend cap" in rec.message for rec in caplog.records)
+
+    def test_at_limit_not_capped_no_warning(
+        self, mock_trial_result, mock_config, caplog
+    ):
+        """Exactly 1000 examples passes through untouched with no warning."""
+        from traigent.core.metadata_helpers import MAX_EXAMPLES_PER_RUN
+
+        mock_config.execution_mode = "edge_analytics"
+        mock_trial_result.metadata = {
+            "example_results": self._make_example_results(MAX_EXAMPLES_PER_RUN)
+        }
+
+        with caplog.at_level("WARNING"):
+            metadata = build_backend_metadata(
+                mock_trial_result, "accuracy", mock_config
+            )
+
+        assert len(metadata["measures"]) == MAX_EXAMPLES_PER_RUN
+        assert not any(
+            "exceed the backend cap" in rec.message for rec in caplog.records
+        )
+
+
 class TestBuildMeasuresFull:
     """Test _build_measures_full function."""
 

--- a/traigent/core/metadata_helpers.py
+++ b/traigent/core/metadata_helpers.py
@@ -14,6 +14,54 @@ from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Producer-side cap on the per-example ``measures[]`` array submitted to the
+# backend on ``POST /sessions/{id}/results``. The backend enforces
+# ``MAX_EXAMPLES_PER_RUN = 1000`` and, on overflow, rejects the WHOLE submission
+# (returning an empty list) -- which silently loses ALL of a trial's measures.
+# We mirror that cap here so the SDK never emits a payload the server rejects
+# wholesale: keep the first ``MAX_EXAMPLES_PER_RUN`` measures and WARN loudly
+# about what was dropped, rather than losing everything. Keep in sync with the
+# backend ``MAX_EXAMPLES_PER_RUN`` and ``configuration_run_schema`` maxItems.
+MAX_EXAMPLES_PER_RUN = 1000
+
+
+def _cap_measures(
+    measures: list[dict[str, Any]], execution_mode: str
+) -> list[dict[str, Any]]:
+    """Cap per-example measures to the backend limit with a loud warning.
+
+    The backend rejects the entire submission when ``measures`` exceeds
+    :data:`MAX_EXAMPLES_PER_RUN`, so an uncapped array would lose ALL measures
+    for the trial. Truncate to the limit (keeping the first
+    ``MAX_EXAMPLES_PER_RUN`` entries) and surface the truncation via a WARNING
+    so the data loss is never silent.
+
+    Args:
+        measures: Per-example measure dicts (may exceed the backend cap).
+        execution_mode: Execution mode label, for the warning message.
+
+    Returns:
+        The measures list, truncated to at most ``MAX_EXAMPLES_PER_RUN`` items.
+    """
+    if len(measures) <= MAX_EXAMPLES_PER_RUN:
+        return measures
+
+    dropped = len(measures) - MAX_EXAMPLES_PER_RUN
+    logger.warning(
+        "Per-example measures (%s) exceed the backend cap of %s for %s mode; "
+        "truncating to the first %s and dropping %s. The backend rejects the "
+        "whole submission above this cap, so the trial would otherwise lose "
+        "ALL measures. Set max_examples<=%s to control which examples are "
+        "kept.",
+        len(measures),
+        MAX_EXAMPLES_PER_RUN,
+        execution_mode,
+        MAX_EXAMPLES_PER_RUN,
+        dropped,
+        MAX_EXAMPLES_PER_RUN,
+    )
+    return measures[:MAX_EXAMPLES_PER_RUN]
+
 
 def _validate_example_id(measure: dict[str, Any], example_index: int) -> None:
     """Validate example_id field in measure dict."""
@@ -191,8 +239,9 @@ def _add_measures_to_metadata(
     }
 
     if include_full_measures:
-        measures = _build_measures_full(
-            example_results, primary_objective, dataset_name
+        measures = _cap_measures(
+            _build_measures_full(example_results, primary_objective, dataset_name),
+            execution_mode,
         )
         if measures:
             trial_metadata["measures"] = measures
@@ -205,8 +254,9 @@ def _add_measures_to_metadata(
         else:
             trial_metadata.pop("measures", None)
     elif privacy_on:
-        measures = _build_measures_privacy(
-            example_results, primary_objective, dataset_name
+        measures = _cap_measures(
+            _build_measures_privacy(example_results, primary_objective, dataset_name),
+            execution_mode,
         )
         if measures:
             trial_metadata["measures"] = measures


### PR DESCRIPTION
## Summary

The SDK builds the per-example `measures[]` array **one entry per dataset example with no producer-side length cap** (`max_examples` defaults to `None` = uncapped). On the live connected/hybrid trial-result submission (`POST /sessions/{id}/results`), the backend caps the array at `MAX_EXAMPLES_PER_RUN = 1000` and, on overflow, **rejects the entire submission (4xx) and returns an empty list** — so a single trial evaluated over **>1000 examples silently lost ALL of its measures** (local↔portal divergence).

This PR adds a producer-side cap+warn so the SDK never emits a payload the server rejects wholesale: it keeps the first `MAX_EXAMPLES_PER_RUN` (1000) measures and emits a **loud WARNING** describing how many were dropped, rather than losing everything silently.

## Root cause

- `_build_measures_full` / `_build_measures_privacy` (`traigent/core/metadata_helpers.py`) emit one `measures` entry per example with no `[:N]` and no length guard.
- They feed the single chokepoint `_add_measures_to_metadata`, which sets `trial_metadata["measures"]`, threaded to the wire `metrics_payload` and posted on `POST /sessions/{id}/results`.
- Neither `_sanitize_for_json` nor `validate_measures_array` caps the array length; the only indirect bound is `max_examples`, which defaults to `None`.
- Per #1086 (PR #1139) the builders now reliably populate one non-empty entry per example, so large eval sets deterministically trip the backend's 1000-cliff.

## Fix

Added `MAX_EXAMPLES_PER_RUN = 1000` and a `_cap_measures(measures, execution_mode)` helper in `metadata_helpers.py`. The cap is applied in `_add_measures_to_metadata` — the single chokepoint covering **both** the full and privacy builder paths. On overflow it truncates to the first 1000 and logs a WARNING (count, dropped, and the `max_examples<=1000` guidance). Measures `<= 1000` pass through untouched with no warning. No silent swallow.

## Acceptance criteria addressed (SDK half)

- [x] A trial evaluated over >1000 examples syncs without losing measures — the SDK no longer emits a payload the server rejects wholesale.
- [x] No silent data-loss: truncation is surfaced via a `logger.warning`, keeping the first 1000 (consistent, non-empty state vs. the local run).

## Cross-repo (out of scope here, noted)

- **@backend half:** `validate_measures_list` still discards the valid first 1000 + opaque-4xx on overflow — should truncate-with-warning or 413. (Traigent/TraigentBackend)
- **@schema half:** `session_submit_results_request_schema` (flat-dict vs array shape) and `configuration_run_measures_request_schema` (array branch missing `maxItems:1000`) are out of sync with the enforced cap. (Traigent/TraigentSchema#171 sibling)

## Test

Added `TestMeasuresProducerCap` in `tests/unit/core/test_metadata_helpers.py`:
- `test_full_measures_capped_not_all_lost` — 1250 examples → exactly 1000 measures kept (first-N, asserts `_0` first id), WARNING emitted.
- `test_privacy_measures_capped_not_all_lost` — privacy path capped to 1000 + WARNING.
- `test_at_limit_not_capped_no_warning` — exactly 1000 passes through, no warning.

```
PYTHONPATH=/tmp/wt-sdk-1285 python3 -m pytest tests/unit/core/test_metadata_helpers.py -n0 -p no:randomly -q
# 52 passed (49 existing + 3 new); ruff check + ruff format --check clean
```

Spine-Trail: st_f8f55fb397ab

Closes #1285
