### PR TITLE
fix(optimizer): coerce numpy scalar best-config values to JSON-native (#1147)

### DIFF
--- a/tests/unit/core/test_best_config_runtime.py
+++ b/tests/unit/core/test_best_config_runtime.py
@@ -57,6 +57,55 @@ def test_canonical_json_rejects_non_json_native_values():
         canonical_json(circular)
 
 
+def test_canonical_json_coerces_numpy_scalars_losslessly():
+    """Optuna integer dimensions return numpy scalars (e.g. np.int64) into
+    best_config; np.int64 does not subclass int, so the strict normalizer used
+    to reject it. They must coerce losslessly via .item() at the JSON boundary.
+
+    Regression for TraigentBackend#1147: best-config serialization crashed for
+    any bayesian run tuning integer knobs (fewshot_k / candidate_count).
+    """
+    np = pytest.importorskip("numpy")
+
+    # numpy integer / bool scalars coerce to JSON-native Python values.
+    assert canonical_json(np.int64(3)) == "3"
+    assert canonical_json(np.bool_(True)) == "true"
+
+    # A full best_config carrying numpy scalars serializes clean.
+    config = {
+        "fewshot_k": np.int64(3),
+        "candidate_count": np.int64(5),
+        "use_voting": np.bool_(True),
+    }
+    serialized = canonical_json(config)
+    # Round-trips to native Python values, JSON-parseable.
+    assert json.loads(serialized) == {
+        "fewshot_k": 3,
+        "candidate_count": 5,
+        "use_voting": True,
+    }
+
+    # numpy float / str scalars already passed (they subclass float / str) and
+    # must keep working untouched.
+    assert canonical_json(np.float64(0.5)) == "0.5"
+    assert json.loads(canonical_json({"name": np.str_("gpt-4o")})) == {"name": "gpt-4o"}
+
+
+def test_canonical_json_still_rejects_multi_element_numpy_arrays():
+    """The .item() coercion must NOT swallow multi-element numpy arrays:
+    array.item() raises on >1 element, so we fall through to the reject.
+
+    Regression guard for TraigentBackend#1147.
+    """
+    np = pytest.importorskip("numpy")
+
+    with pytest.raises(ConfigurationError, match="non-JSON-native"):
+        canonical_json(np.array([1, 2]))
+
+    with pytest.raises(ConfigurationError, match="non-JSON-native"):
+        canonical_json({"bad": np.array([1, 2, 3])})
+
+
 def test_snapshot_deep_freezes_config():
     snapshot = BestConfigSnapshot.from_config(
         {"nested": {"values": [1, 2]}},

--- a/tests/unit/core/test_best_config_runtime.py
+++ b/tests/unit/core/test_best_config_runtime.py
@@ -106,6 +106,53 @@ def test_canonical_json_still_rejects_multi_element_numpy_arrays():
         canonical_json({"bad": np.array([1, 2, 3])})
 
 
+def test_canonical_json_rejects_size_one_arrays_keeping_shape():
+    """Size-one arrays are not scalars: ndim >= 1 means real shape that JSON
+    cannot represent. The coercion must NOT silently collapse np.array([1]) /
+    np.array([[1]]) to ``1`` (dropping shape) — it must reject.
+
+    Regression guard for TraigentBackend#1147 (codex review).
+    """
+    np = pytest.importorskip("numpy")
+
+    for arr in (np.array([1]), np.array([[1]])):
+        with pytest.raises(ConfigurationError, match="non-JSON-native"):
+            canonical_json(arr)
+
+
+def test_canonical_json_rejects_non_native_item_results():
+    """The guard accepts a 0-d numpy scalar only when .item() yields a plain
+    JSON-native primitive. A value whose .item() returns a non-native object
+    (extended-precision float that re-emits itself, a 0-d object array's dict,
+    or an arbitrary object) must be rejected — never recursed without progress
+    and never passed silently.
+
+    Regression guard for TraigentBackend#1147 (codex review).
+    """
+    np = pytest.importorskip("numpy")
+
+    # 0-d object array: .item() returns the dict -> non-native -> reject.
+    with pytest.raises(ConfigurationError, match="non-JSON-native"):
+        canonical_json(np.array({"silently": "accepted"}, dtype=object))
+
+    # Extended precision float, if the platform has it: .item() re-emits the same
+    # numpy type (no native Python equivalent) -> must reject, not RecursionError.
+    longdouble = getattr(np, "float128", None) or getattr(np, "longdouble", None)
+    if longdouble is not None:
+        value = longdouble("0.1")
+        if type(value.item()) not in (int, float, str, bool):
+            with pytest.raises(ConfigurationError, match="non-JSON-native"):
+                canonical_json(value)
+
+    # An arbitrary object that merely exposes .item() (no ndim) is not coerced.
+    class FakeScalar:
+        def item(self):
+            return {"silently": "accepted"}
+
+    with pytest.raises(ConfigurationError, match="non-JSON-native"):
+        canonical_json(FakeScalar())
+
+
 def test_snapshot_deep_freezes_config():
     snapshot = BestConfigSnapshot.from_config(
         {"nested": {"values": [1, 2]}},

--- a/traigent/core/best_config_runtime.py
+++ b/traigent/core/best_config_runtime.py
@@ -750,15 +750,22 @@ def _normalize_json_value(value: Any, seen: set[int] | None = None) -> Any:
         seen.remove(container_id)
         return normalized_list
 
-    # numpy scalar types (e.g. np.int64 from Optuna integer dimensions) coerce
-    # losslessly to a JSON-native Python value via .item(). The guard excludes
-    # str/bytes/dict/list so we never re-route already-handled containers, and
-    # multi-element numpy arrays raise inside .item() -> fall through to reject.
-    if hasattr(value, "item") and not isinstance(value, (str, bytes, dict, list)):
+    # numpy scalar types (e.g. np.int64 from Optuna integer dimensions) are not
+    # JSON-native and do not subclass Python int/bool. Coerce a genuine 0-d numpy
+    # scalar losslessly via .item(). We require ndim == 0 so size-one arrays
+    # (np.array([1]) / np.array([[1]]), ndim >= 1) keep their shape and fall through
+    # to reject instead of silently collapsing, and so arbitrary objects that merely
+    # expose .item() (no ndim) are not coerced. We then accept ONLY when .item()
+    # yields a plain JSON-native primitive; anything else (np.longdouble.item() ->
+    # np.longdouble, datetime64/complex.item(), a 0-d object array's dict) is
+    # rejected here rather than recursing without progress or passing silently.
+    if getattr(value, "ndim", None) == 0 and hasattr(value, "item"):
         try:
-            return _normalize_json_value(value.item(), seen)
+            coerced = value.item()
         except (ValueError, TypeError):
-            pass
+            coerced = value  # falls through to the reject below
+        if type(coerced) in (int, float, str, bool):
+            return _normalize_json_value(coerced, seen)
 
     raise ConfigurationError(
         f"Best config contains non-JSON-native value {type(value).__name__}"

--- a/traigent/core/best_config_runtime.py
+++ b/traigent/core/best_config_runtime.py
@@ -750,6 +750,16 @@ def _normalize_json_value(value: Any, seen: set[int] | None = None) -> Any:
         seen.remove(container_id)
         return normalized_list
 
+    # numpy scalar types (e.g. np.int64 from Optuna integer dimensions) coerce
+    # losslessly to a JSON-native Python value via .item(). The guard excludes
+    # str/bytes/dict/list so we never re-route already-handled containers, and
+    # multi-element numpy arrays raise inside .item() -> fall through to reject.
+    if hasattr(value, "item") and not isinstance(value, (str, bytes, dict, list)):
+        try:
+            return _normalize_json_value(value.item(), seen)
+        except (ValueError, TypeError):
+            pass
+
     raise ConfigurationError(
         f"Best config contains non-JSON-native value {type(value).__name__}"
     )


### PR DESCRIPTION
## Summary

Optimization runs tuning **integer knobs** (e.g. `fewshot_k`, `candidate_count`) with `algorithm="bayesian"` crashed at the end when serializing the winning config. Optuna integer dimensions return `numpy.int64`, and the strict best-config JSON normalizer (`_normalize_json_value`) rejected it because **`numpy.int64` does NOT subclass `int`** — raising `ConfigurationError("Best config contains non-JSON-native value int64")`. This is on the documented happy path.

(`numpy.float64` subclasses `float` and `numpy.str_` subclasses `str`, so those already passed — only the integer/bool case was broken.)

### Fix
In `traigent/core/best_config_runtime.py`, coerce numpy scalars losslessly via `.item()` at the JSON boundary, **before** the reject:

```python
if hasattr(value, "item") and not isinstance(value, (str, bytes, dict, list)):
    try:
        return _normalize_json_value(value.item(), seen)
    except (ValueError, TypeError):
        pass
raise ConfigurationError(...)
```

The guard excludes `str/bytes/dict/list` (already handled above) so containers are never re-routed, and multi-element numpy arrays raise inside `.item()` → fall through to the reject (still rejected).

### Cloud-path sibling: covered, no follow-up needed
The fix sits at the single normalization chokepoint. Every best-config serialization path funnels through `_normalize_json_value`: `canonical_json` (the JSON-emitting boundary), `BestConfigSnapshot.from_config`, `write_repo_best_config`, and `build_best_config_spec` (line 424 — the spec consumed by `BackendClient.publish_best_config_sync`). No sibling path bypasses the normalizer, so the cloud best-config payload path is fixed by this same one-line guard. No follow-up.

## Acceptance criteria
- [x] `best_config` containing `np.int64`/`np.bool_` serializes losslessly; full failing config becomes `json.dumps`-clean.
- [x] `np.float64`/`np.str_` still pass untouched.
- [x] Multi-element numpy arrays (`np.array([1,2])`) are still correctly rejected (`.item()` raises on >1 element → falls through to `ConfigurationError`).
- [x] Regression test added asserting `np.int64(3)→3`, `np.bool_(True)→True`, full numpy config serializes clean, and multi-element array still raises `ConfigurationError`. **The coercion test FAILS on develop before the fix** (verified: `ConfigurationError: ... non-JSON-native value int64`).

## Test evidence
- New tests: `tests/unit/core/test_best_config_runtime.py::test_canonical_json_coerces_numpy_scalars_losslessly` and `::test_canonical_json_still_rejects_multi_element_numpy_arrays`.
- Coercion test confirmed FAILING on unpatched develop, PASSING with fix.
- Full module: **19 passed** (`pytest -n0 tests/unit/core/test_best_config_runtime.py`).
- Related modules (no regression): **34 passed** across `test_best_config_runtime_integration.py`, `test_best_config_cloud_client.py`, `test_apply_best_config.py`.
- Preflight: `ruff format --check` clean, `ruff check` clean, pre-commit mypy passed.

## Release follow-up
PyPI release of this fix is an owner-gated DoD item — **not** part of this PR.

Spine-Trail: st_11f4985ab3ba

Closes Traigent/TraigentBackend#1147
