### PR TITLE
fix(sdk): emit run-lifecycle status vocab on run/config PUTs (#1302)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -864,14 +864,14 @@
         "filename": "tests/unit/optimizers/test_remote_services.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 597
+        "line_number": 611
       },
       {
         "type": "Secret Keyword",
         "filename": "tests/unit/optimizers/test_remote_services.py",
         "hashed_secret": "b9615cef6cff3572af1365ff44c8b92ea9266f3e",
         "is_verified": false,
-        "line_number": 1068
+        "line_number": 1082
       }
     ],
     "tests/unit/security/auth/test_oidc.py": [
@@ -1213,5 +1213,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-15T17:05:52Z"
+  "generated_at": "2026-06-17T15:36:34Z"
 }

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -111,24 +111,34 @@ class TestValidateAndSanitizeUrl:
 
 
 class TestMapToBackendStatus:
-    """Test status mapping."""
+    """Test status mapping (issue #1302 — run-lifecycle wire vocab).
+
+    Offline producer witness: these assert ``map_to_backend_status`` emits ONLY
+    backend-canonical run-lifecycle members and NEVER the session-lifecycle
+    ACTIVE / CREATED on the experiment-run / configuration-run status PUT path.
+    They FAIL against the pre-#1302 mapper which emitted ACTIVE / CREATED.
+    """
 
     def setup_method(self):
         """Set up test fixtures."""
         mock_client = Mock()
         self.ops = ApiOperations(mock_client)
 
-    def test_pending_maps_to_active(self):
-        """Test pending maps to ACTIVE."""
-        assert self.ops.map_to_backend_status("pending") == "ACTIVE"
+    def test_pending_maps_to_pending(self):
+        """pending -> PENDING (was ACTIVE before #1302)."""
+        assert self.ops.map_to_backend_status("pending") == "PENDING"
 
-    def test_running_maps_to_active(self):
-        """Test running maps to ACTIVE."""
-        assert self.ops.map_to_backend_status("running") == "ACTIVE"
+    def test_running_maps_to_running(self):
+        """running -> RUNNING (was ACTIVE before #1302)."""
+        assert self.ops.map_to_backend_status("running") == "RUNNING"
 
-    def test_in_progress_maps_to_active(self):
-        """Test in_progress maps to ACTIVE."""
-        assert self.ops.map_to_backend_status("in_progress") == "ACTIVE"
+    def test_in_progress_maps_to_running(self):
+        """in_progress -> RUNNING (was ACTIVE before #1302)."""
+        assert self.ops.map_to_backend_status("in_progress") == "RUNNING"
+
+    def test_not_started_maps_to_not_started(self):
+        """not_started -> NOT_STARTED (was CREATED before #1302)."""
+        assert self.ops.map_to_backend_status("not_started") == "NOT_STARTED"
 
     def test_completed_maps_to_completed(self):
         """Test completed maps to COMPLETED."""
@@ -138,26 +148,100 @@ class TestMapToBackendStatus:
         """Test failed maps to FAILED."""
         assert self.ops.map_to_backend_status("failed") == "FAILED"
 
-    def test_not_started_maps_to_created(self):
-        """Test not_started maps to CREATED."""
-        assert self.ops.map_to_backend_status("not_started") == "CREATED"
-
-    def test_pruned_maps_to_pruned(self):
-        """Test pruned maps to PRUNED."""
-        assert self.ops.map_to_backend_status("pruned") == "PRUNED"
-
     def test_cancelled_maps_to_cancelled(self):
         """Test cancelled maps to CANCELLED."""
         assert self.ops.map_to_backend_status("cancelled") == "CANCELLED"
 
+    def test_never_emits_session_lifecycle_vocab_for_experiment_runs(self):
+        """No SDK in-flight status maps to the session-lifecycle ACTIVE/CREATED.
+
+        This is the core #1302 regression: in-flight states (pending/running/
+        not_started) must persist on the run PUT path, which they cannot if the
+        SDK emits ACTIVE/CREATED (backend 400-rejects those).
+        """
+        from traigent.cloud.api_operations import EXPERIMENT_RUN_WIRE_STATUSES
+
+        forbidden = {"ACTIVE", "CREATED"}
+        for sdk_status in [
+            "pending",
+            "running",
+            "in_progress",
+            "not_started",
+            "completed",
+            "failed",
+            "cancelled",
+            "pruned",
+        ]:
+            mapped = self.ops.map_to_backend_status(
+                sdk_status, endpoint="experiment_run"
+            )
+            assert mapped not in forbidden, (
+                f"{sdk_status!r} mapped to forbidden session-lifecycle value {mapped!r}"
+            )
+            assert mapped in EXPERIMENT_RUN_WIRE_STATUSES
+
+    def test_config_run_vocab_for_config_endpoint(self):
+        """Every config-run mapping is a member of CONFIGURATION_RUN_WIRE_STATUSES."""
+        from traigent.cloud.api_operations import CONFIGURATION_RUN_WIRE_STATUSES
+
+        for sdk_status in [
+            "not_started",
+            "running",
+            "in_progress",
+            "completed",
+            "failed",
+            "cancelled",
+            "pruned",
+        ]:
+            mapped = self.ops.map_to_backend_status(sdk_status, endpoint="config_run")
+            assert mapped not in {"ACTIVE", "CREATED"}
+            assert mapped in CONFIGURATION_RUN_WIRE_STATUSES
+
+    def test_pruned_preserved_for_config_runs(self):
+        """pruned -> PRUNED for config-runs (they accept PRUNED)."""
+        assert (
+            self.ops.map_to_backend_status("pruned", endpoint="config_run") == "PRUNED"
+        )
+
+    def test_pruned_folds_to_completed_for_experiment_runs(self):
+        """pruned -> COMPLETED for experiment-runs (no PRUNED member).
+
+        Must NOT emit PRUNED on the experiment-run endpoint, and must NOT
+        fall back to UNKNOWN/FAILED.
+        """
+        assert (
+            self.ops.map_to_backend_status("pruned", endpoint="experiment_run")
+            == "COMPLETED"
+        )
+
     def test_uppercase_status_preserved(self):
-        """Test uppercase status preserved."""
+        """Already-canonical wire values pass through (case-insensitive)."""
         assert self.ops.map_to_backend_status("COMPLETED") == "COMPLETED"
         assert self.ops.map_to_backend_status("FAILED") == "FAILED"
+        assert self.ops.map_to_backend_status("RUNNING") == "RUNNING"
 
-    def test_unknown_status_uppercased(self):
-        """Test unknown status is uppercased."""
-        assert self.ops.map_to_backend_status("custom") == "CUSTOM"
+    def test_unknown_status_falls_back_to_unknown_not_failed(self):
+        """Unrecognized statuses fall back to UNKNOWN, never FAILED/CUSTOM.
+
+        Pre-#1302 the gate defaulted unexpected statuses to FAILED (asserting
+        failure on something we did not understand) and the mapper uppercased
+        arbitrary strings into invalid backend members.
+        """
+        assert self.ops.map_to_backend_status("custom") == "UNKNOWN"
+        assert (
+            self.ops.map_to_backend_status("custom", endpoint="config_run") == "UNKNOWN"
+        )
+
+    def test_paused_supported_for_experiment_runs_only(self):
+        """paused -> PAUSED for experiment-runs; config-runs lack PAUSED."""
+        assert (
+            self.ops.map_to_backend_status("paused", endpoint="experiment_run")
+            == "PAUSED"
+        )
+        # config-runs have no PAUSED member -> neutral fallback, not a 400.
+        assert (
+            self.ops.map_to_backend_status("paused", endpoint="config_run") == "UNKNOWN"
+        )
 
 
 class TestSanitizeErrorMessage:
@@ -1293,8 +1377,13 @@ class TestUpdateExperimentRunStatusSuccess:
             )
 
     @pytest.mark.asyncio
-    async def test_invalid_status_uses_failed_default(self):
-        """Test invalid status defaults to FAILED, not completed."""
+    async def test_invalid_status_uses_unknown_default(self):
+        """Invalid status -> neutral UNKNOWN, NOT FAILED (issue #1302, AC3).
+
+        Pre-#1302 the gate defaulted unexpected statuses to FAILED — asserting
+        failure on a status we did not understand. The corrected behavior sends
+        the neutral UNKNOWN member (valid on both backend run enums).
+        """
         mock_response = AsyncMock()
         mock_response.status = 200
 
@@ -1317,7 +1406,43 @@ class TestUpdateExperimentRunStatusSuccess:
             await self.ops.update_experiment_run_status_on_completion(
                 "run_123", "unknown_status"
             )
-            assert mock_session.put.call_args.kwargs["json"]["status"] == "FAILED"
+            sent_status = mock_session.put.call_args.kwargs["json"]["status"]
+            assert sent_status == "UNKNOWN"
+            assert sent_status != "FAILED"
+
+    @pytest.mark.asyncio
+    async def test_running_status_persists_as_running_not_active(self):
+        """In-flight 'running' must persist as RUNNING, not session ACTIVE.
+
+        Core #1302 regression witness on the experiment-run PUT body: before the
+        fix this sent ACTIVE which the backend 400-rejects, so an SDK run could
+        never persist its in-flight state.
+        """
+        mock_response = AsyncMock()
+        mock_response.status = 200
+
+        mock_session = AsyncMock()
+        mock_session.put = Mock(
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(return_value=mock_response), __aexit__=AsyncMock()
+            )
+        )
+
+        with patch("traigent.cloud.api_operations.aiohttp") as mock_aiohttp:
+            mock_aiohttp.ClientSession = Mock(
+                return_value=AsyncMock(
+                    __aenter__=AsyncMock(return_value=mock_session),
+                    __aexit__=AsyncMock(),
+                )
+            )
+            mock_aiohttp.ClientTimeout = Mock()
+
+            await self.ops.update_experiment_run_status_on_completion(
+                "run_123", "running"
+            )
+            sent_status = mock_session.put.call_args.kwargs["json"]["status"]
+            assert sent_status == "RUNNING"
+            assert sent_status not in {"ACTIVE", "CREATED"}
 
     @pytest.mark.asyncio
     async def test_failed_update_logs_warning(self):

--- a/tests/unit/cloud/test_api_operations.py
+++ b/tests/unit/cloud/test_api_operations.py
@@ -203,15 +203,16 @@ class TestMapToBackendStatus:
             self.ops.map_to_backend_status("pruned", endpoint="config_run") == "PRUNED"
         )
 
-    def test_pruned_folds_to_completed_for_experiment_runs(self):
-        """pruned -> COMPLETED for experiment-runs (no PRUNED member).
+    def test_pruned_folds_to_unknown_for_experiment_runs(self):
+        """pruned -> UNKNOWN for experiment-runs (no PRUNED member).
 
-        Must NOT emit PRUNED on the experiment-run endpoint, and must NOT
-        fall back to UNKNOWN/FAILED.
+        Must NOT emit PRUNED on the experiment-run endpoint, and must NOT claim
+        COMPLETED — a pruned run is not a successful completion, so emitting
+        COMPLETED would be fake completion. UNKNOWN is the honest neutral fold.
         """
         assert (
             self.ops.map_to_backend_status("pruned", endpoint="experiment_run")
-            == "COMPLETED"
+            == "UNKNOWN"
         )
 
     def test_uppercase_status_preserved(self):

--- a/tests/unit/cloud/test_cloud_models.py
+++ b/tests/unit/cloud/test_cloud_models.py
@@ -23,6 +23,100 @@ from traigent.cloud.models import (
 from traigent.evaluators.base import Dataset, EvaluationExample
 
 
+class TestStatusEnumDeduplication:
+    """Issue #1302 AC4 — the dual status enums share ONE source of truth."""
+
+    def test_trialstatus_is_single_source_of_truth(self):
+        """cloud.models.TrialStatus IS api.types.TrialStatus (no second copy)."""
+        from traigent.api.types import TrialStatus as PublicTrialStatus
+
+        assert TrialStatus is PublicTrialStatus
+
+    def test_remote_services_session_status_is_canonical(self):
+        """remote_services.OptimizationSessionStatus references the canonical one."""
+        from traigent.optimizers.remote_services import (
+            OptimizationSessionStatus as RemoteOSS,
+        )
+
+        assert RemoteOSS is OptimizationSessionStatus
+
+    def test_cloud_optimizer_session_status_is_canonical(self):
+        """cloud_optimizer re-exports the canonical session status enum."""
+        from traigent.optimizers.cloud_optimizer import (
+            OptimizationSessionStatus as OptimizerOSS,
+        )
+
+        assert OptimizerOSS is OptimizationSessionStatus
+
+    def test_canonical_session_status_superset(self):
+        """The canonical enum carries every member each former copy needed."""
+        members = set(OptimizationSessionStatus.__members__)
+        # From the former cloud.models copy:
+        assert {"PENDING", "CREATED", "ACTIVE", "PAUSED"} <= members
+        # From the former remote_services copy:
+        assert "INITIALIZING" in members
+        # Neutral inbound fallback:
+        assert "UNKNOWN" in members
+
+
+class TestInboundStatusTolerance:
+    """Issue #1302 AC3 — inbound deserialization tolerates case / out-of-set."""
+
+    def test_session_response_accepts_uppercase_backend_status(self):
+        """Backend sends UPPER (ACTIVE); deserialization must not raise."""
+        from traigent.cloud.client import TraigentCloudClient
+
+        client = TraigentCloudClient.__new__(TraigentCloudClient)
+        resp = client._deserialize_session_response(
+            {"session_id": "s1", "status": "ACTIVE"}
+        )
+        assert resp.status is OptimizationSessionStatus.ACTIVE
+
+    def test_session_response_out_of_set_falls_back_to_unknown(self):
+        """Unrecognized status -> UNKNOWN, never a raise."""
+        from traigent.cloud.client import TraigentCloudClient
+
+        client = TraigentCloudClient.__new__(TraigentCloudClient)
+        resp = client._deserialize_session_response(
+            {"session_id": "s1", "status": "TOTALLY_NEW_STATE"}
+        )
+        assert resp.status is OptimizationSessionStatus.UNKNOWN
+
+    def test_trial_result_uppercase_running_does_not_wrong_default(self):
+        """Backend RUNNING must deserialize to RUNNING, not silent COMPLETED."""
+        from traigent.cloud.client import TraigentCloudClient
+
+        client = TraigentCloudClient.__new__(TraigentCloudClient)
+        result = client._deserialize_trial_result(
+            {
+                "session_id": "s1",
+                "trial_id": "t1",
+                "metrics": {},
+                "duration": 1.0,
+                "status": "RUNNING",
+            }
+        )
+        assert result.status is TrialStatus.RUNNING
+        assert result.status is not TrialStatus.COMPLETED
+
+    def test_trial_result_out_of_set_does_not_assert_success(self):
+        """Unrecognized trial status -> UNKNOWN, never COMPLETED (no fake success)."""
+        from traigent.cloud.client import TraigentCloudClient
+
+        client = TraigentCloudClient.__new__(TraigentCloudClient)
+        result = client._deserialize_trial_result(
+            {
+                "session_id": "s1",
+                "trial_id": "t1",
+                "metrics": {},
+                "duration": 1.0,
+                "status": "WEIRD",
+            }
+        )
+        assert result.status is TrialStatus.UNKNOWN
+        assert result.status is not TrialStatus.COMPLETED
+
+
 class TestOptimizationSession:
     """Test OptimizationSession model."""
 

--- a/tests/unit/optimizers/test_remote_services.py
+++ b/tests/unit/optimizers/test_remote_services.py
@@ -344,13 +344,27 @@ class TestOptimizationSessionStatus:
     """Test optimization session status enumeration."""
 
     def test_session_status_values(self):
-        """Test OptimizationSessionStatus enum values."""
-        assert OptimizationSessionStatus.INITIALIZING == "initializing"
-        assert OptimizationSessionStatus.ACTIVE == "active"
-        assert OptimizationSessionStatus.PAUSED == "paused"
-        assert OptimizationSessionStatus.COMPLETED == "completed"
-        assert OptimizationSessionStatus.FAILED == "failed"
-        assert OptimizationSessionStatus.CANCELLED == "cancelled"
+        """Test OptimizationSessionStatus enum values.
+
+        After the #1302 dedup, ``remote_services.OptimizationSessionStatus`` is
+        the single canonical ``traigent.cloud.models.OptimizationSessionStatus``
+        (a plain Enum), so compare ``.value`` rather than relying on the former
+        StrEnum string-equality.
+        """
+        assert OptimizationSessionStatus.INITIALIZING.value == "initializing"
+        assert OptimizationSessionStatus.ACTIVE.value == "active"
+        assert OptimizationSessionStatus.PAUSED.value == "paused"
+        assert OptimizationSessionStatus.COMPLETED.value == "completed"
+        assert OptimizationSessionStatus.FAILED.value == "failed"
+        assert OptimizationSessionStatus.CANCELLED.value == "cancelled"
+
+    def test_session_status_is_canonical_single_source(self):
+        """Issue #1302 AC4 — no second OptimizationSessionStatus copy exists."""
+        from traigent.cloud.models import (
+            OptimizationSessionStatus as CanonicalOSS,
+        )
+
+        assert OptimizationSessionStatus is CanonicalOSS
 
 
 class TestServiceInfo:

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -40,6 +40,10 @@ class OptimizationStatus(StrEnum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+    # Neutral fallback for statuses the SDK does not recognize (e.g. a newer
+    # backend member). Never assert success/failure on an unknown value
+    # (issue #1302, AC3).
+    UNKNOWN = "unknown"
 
 
 class TrialStatus(StrEnum):
@@ -52,6 +56,10 @@ class TrialStatus(StrEnum):
     FAILED = "failed"
     CANCELLED = "cancelled"
     PRUNED = "pruned"
+    # Neutral fallback for statuses the SDK does not recognize. Used by inbound
+    # deserialization so an unrecognized status is never silently treated as
+    # COMPLETED (issue #1302, AC3).
+    UNKNOWN = "unknown"
 
 
 @dataclass(slots=True)

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -295,9 +295,11 @@ class ApiOperations:
         * ``endpoint="config_run"`` keeps ``pruned`` -> ``PRUNED`` (config-runs
           accept early-stopping as a distinct success-ish outcome).
         * ``endpoint="experiment_run"`` (the default) maps ``pruned`` ->
-          ``COMPLETED`` because the backend ``ExperimentRunStatus`` enum has no
-          ``PRUNED`` member; an experiment-run that early-stopped is treated as
-          a completed run rather than producing a 400.
+          ``UNKNOWN`` because the backend ``ExperimentRunStatus`` enum has no
+          ``PRUNED`` member. A pruned run is NOT a successful completion, so it
+          folds to the neutral ``UNKNOWN`` rather than claiming ``COMPLETED``
+          (claiming completion would be fake completion); ``UNKNOWN`` is a valid
+          member, so this never produces a 400.
 
         Unrecognized inputs map to ``UNKNOWN`` (a member of both backend enums),
         never to ``FAILED`` — we must not assert failure on a status we simply

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -79,6 +79,118 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Canonical run / configuration-run wire status vocabulary (single source of
+# truth — issue #1302).
+#
+# The backend's ``ExperimentRunStatus`` / ``ConfigurationRunStatus`` enums use
+# the run-lifecycle vocabulary (RUNNING / PENDING / NOT_STARTED / ...), NOT the
+# session-lifecycle vocabulary (ACTIVE / CREATED / PRUNED). Earlier code mapped
+# in-flight SDK states onto ACTIVE / CREATED, which the backend 400-rejects, so
+# an SDK-driven run could never persist its in-flight state server-side.
+#
+# Keep the mapping, the validation gate, and the SDK enums all derived from the
+# constants below so they cannot drift apart again.
+# ---------------------------------------------------------------------------
+
+# Backend ExperimentRunStatus members (run-lifecycle). PRUNED / PENDING / PAUSED
+# specifics differ between experiment-runs and config-runs; see below.
+EXPERIMENT_RUN_WIRE_STATUSES: frozenset[str] = frozenset(
+    {
+        "NOT_STARTED",
+        "PENDING",
+        "PAUSED",
+        "RUNNING",
+        "FAILED",
+        "COMPLETED",
+        "CANCELLED",
+        "UNKNOWN",
+        "PARTIALLY_DELETED",
+    }
+)
+
+# Backend ConfigurationRunStatus members (run-lifecycle). Note: config-runs
+# accept PRUNED (early-stopping success) but lack PENDING / PAUSED /
+# PARTIALLY_DELETED that experiment-runs carry.
+CONFIGURATION_RUN_WIRE_STATUSES: frozenset[str] = frozenset(
+    {
+        "NOT_STARTED",
+        "RUNNING",
+        "COMPLETED",
+        "FAILED",
+        "UNKNOWN",
+        "CANCELLED",
+        "PRUNED",
+    }
+)
+
+# Neutral fallback emitted/validated when an input status is not recognized.
+# Both backend enums carry UNKNOWN, so it is always a safe wire value and never
+# fakes success on a failed/running run (issue #1302, AC3).
+UNKNOWN_WIRE_STATUS = "UNKNOWN"
+
+# Canonical SDK-lowercase -> run-lifecycle wire mapping. Keys are the SDK's
+# lowercase status tokens (and a couple of synonyms); values are the backend
+# run-lifecycle members. ``pruned`` is intentionally absent here and handled
+# per-endpoint by ``map_to_backend_status`` because experiment-runs do not
+# accept PRUNED while config-runs do.
+_RUN_STATUS_WIRE_MAP: dict[str, str] = {
+    "not_started": "NOT_STARTED",
+    "pending": "PENDING",
+    "paused": "PAUSED",
+    "running": "RUNNING",
+    "in_progress": "RUNNING",
+    "completed": "COMPLETED",
+    "failed": "FAILED",
+    "cancelled": "CANCELLED",
+    "canceled": "CANCELLED",
+    "unknown": "UNKNOWN",
+    "partially_deleted": "PARTIALLY_DELETED",
+}
+
+
+def map_status_to_wire(status: str, *, endpoint: str = "experiment_run") -> str:
+    """Pure mapper: SDK status token -> backend run-lifecycle wire status.
+
+    Single source of truth for the run / configuration-run status vocabulary
+    (issue #1302). The class method ``ApiOperations.map_to_backend_status`` and
+    any other caller that needs the wire vocab delegate here so the mapping and
+    the validation gate can never drift apart.
+
+    See ``ApiOperations.map_to_backend_status`` for the per-endpoint ``PRUNED``
+    handling and fallback semantics.
+    """
+    token = (status or "").strip().lower()
+    valid = (
+        CONFIGURATION_RUN_WIRE_STATUSES
+        if endpoint == "config_run"
+        else EXPERIMENT_RUN_WIRE_STATUSES
+    )
+
+    # PRUNED is endpoint-specific: config-runs keep it; experiment-runs fold it
+    # into COMPLETED (the experiment-run enum has no PRUNED member).
+    if token == "pruned":
+        mapped = "PRUNED" if endpoint == "config_run" else "COMPLETED"
+    else:
+        mapped = _RUN_STATUS_WIRE_MAP.get(token, "")
+        if not mapped:
+            # Allow already-canonical wire values (any case) to pass through.
+            upper = (status or "").strip().upper()
+            mapped = upper if upper in valid else ""
+
+    if mapped not in valid:
+        logger.warning(
+            "Unrecognized %s status %r (resolved to %r); "
+            "sending neutral %r so the backend is not given a wrong status",
+            endpoint,
+            status,
+            mapped or None,
+            UNKNOWN_WIRE_STATUS,
+        )
+        mapped = UNKNOWN_WIRE_STATUS
+
+    return mapped
+
 
 def _typed_configuration_space(space: Any) -> Any:
     """Normalize the decorator's SHORTHAND configuration space to the typed
@@ -162,37 +274,43 @@ class ApiOperations:
 
         return clean_url.rstrip("/")
 
-    def map_to_backend_status(self, status: str) -> str:
-        """Map Traigent status values to backend-expected values.
+    def map_to_backend_status(
+        self, status: str, *, endpoint: str = "experiment_run"
+    ) -> str:
+        """Map Traigent SDK status values to the backend run-lifecycle wire vocab.
 
-        Traigent uses lowercase (pending, completed, failed)
-        Backend expects uppercase (CREATED, ACTIVE, COMPLETED, FAILED, PRUNED)
+        The SDK uses lowercase tokens (``pending``, ``running``, ``completed``,
+        ``not_started`` …). The backend's experiment-run and configuration-run
+        status endpoints expect the run-lifecycle enum (``RUNNING``, ``PENDING``,
+        ``NOT_STARTED``, ``COMPLETED``, ``FAILED``, ``CANCELLED`` …), NOT the
+        session-lifecycle vocab (``ACTIVE`` / ``CREATED`` / ``PRUNED``). Mapping
+        in-flight states onto ``ACTIVE`` / ``CREATED`` is exactly the bug from
+        issue #1302: the backend 400-rejects those on the run/config PUT path,
+        so in-flight states could never persist.
 
-        Note: PRUNED is a success case (early stopping for efficiency).
-        CANCELLED indicates the trial was abandoned before execution.
+        ``PRUNED`` is handled per-endpoint:
+
+        * ``endpoint="config_run"`` keeps ``pruned`` -> ``PRUNED`` (config-runs
+          accept early-stopping as a distinct success-ish outcome).
+        * ``endpoint="experiment_run"`` (the default) maps ``pruned`` ->
+          ``COMPLETED`` because the backend ``ExperimentRunStatus`` enum has no
+          ``PRUNED`` member; an experiment-run that early-stopped is treated as
+          a completed run rather than producing a 400.
+
+        Unrecognized inputs map to ``UNKNOWN`` (a member of both backend enums),
+        never to ``FAILED`` — we must not assert failure on a status we simply
+        did not understand.
+
+        Args:
+            status: SDK status token (case-insensitive).
+            endpoint: ``"experiment_run"`` (default) or ``"config_run"`` —
+                selects the per-endpoint ``PRUNED`` handling and the validation
+                vocabulary.
+
+        Returns:
+            A backend run-lifecycle status member valid for the chosen endpoint.
         """
-        status_mapping = {
-            "pending": "ACTIVE",
-            "running": "ACTIVE",
-            "in_progress": "ACTIVE",
-            "completed": "COMPLETED",
-            "failed": "FAILED",
-            "not_started": "CREATED",
-            # Pruned is early stopping (success case)
-            "pruned": "PRUNED",
-            # Cancelled means trial didn't execute
-            "cancelled": "CANCELLED",
-            # Also handle if already uppercase
-            "PENDING": "ACTIVE",
-            "IN_PROGRESS": "ACTIVE",
-            "COMPLETED": "COMPLETED",
-            "FAILED": "FAILED",
-            "CREATED": "CREATED",
-            "ACTIVE": "ACTIVE",
-            "PRUNED": "PRUNED",
-            "CANCELLED": "CANCELLED",
-        }
-        return status_mapping.get(status, status.upper())
+        return map_status_to_wire(status, endpoint=endpoint)
 
     def sanitize_error_message(self, error_message: str | None) -> str | None:
         """Sanitize error message for transmission.
@@ -542,7 +660,11 @@ class ApiOperations:
 
         Args:
             config_run_id: Configuration run ID (same as trial_id)
-            status: Status to set (COMPLETED, FAILED, etc.)
+            status: Status to set. Accepts either an SDK token (``running``,
+                ``completed`` …) or an already-mapped wire value; it is always
+                normalized to the configuration-run wire vocab before sending so
+                the backend never receives a session-lifecycle value
+                (issue #1302).
 
         Returns:
             True if successful, False otherwise
@@ -551,6 +673,9 @@ class ApiOperations:
             return False
 
         try:
+            # Normalize to the configuration-run wire vocab (preserves PRUNED).
+            backend_status = self.map_to_backend_status(status, endpoint="config_run")
+
             connector = self._build_connector()
 
             # Prepare headers with API key
@@ -564,7 +689,7 @@ class ApiOperations:
                     or BackendConfig.get_backend_api_url()
                 )
                 url = f"{api_base}/configuration-runs/{config_run_id}/status"
-                status_data = {"status": status}
+                status_data = {"status": backend_status}
 
                 async with session.put(
                     url,
@@ -574,7 +699,8 @@ class ApiOperations:
                 ) as response:
                     if response.status in [200, 204]:
                         logger.debug(
-                            f"Updated configuration run {config_run_id} status to {status}"
+                            f"Updated configuration run {config_run_id} "
+                            f"status to {backend_status}"
                         )
                         return True
                     else:
@@ -780,29 +906,23 @@ class ApiOperations:
             return
 
         try:
-            # Map SDK status to backend status using the standard mapping
-            backend_status = self.map_to_backend_status(status)
+            # Map SDK status to the experiment-run wire vocab. The mapper is the
+            # single source of truth and already guarantees a member of
+            # EXPERIMENT_RUN_WIRE_STATUSES (UNKNOWN for anything it cannot
+            # resolve). The gate below is a defense-in-depth assertion against
+            # the same canonical set so the two can never drift (issue #1302).
+            backend_status = self.map_to_backend_status(
+                status, endpoint="experiment_run"
+            )
 
-            # Valid experiment run statuses that the backend should accept
-            # Note: PRUNED and CANCELLED are valid trial outcomes that the backend
-            # needs to support. If backend shows these as "UNKNOWN", the backend
-            # needs to be updated to recognize these statuses.
-            valid_statuses = [
-                "COMPLETED",
-                "FAILED",
-                "RUNNING",
-                "NOT_STARTED",
-                "ACTIVE",
-                "CREATED",
-                "PRUNED",
-                "CANCELLED",
-            ]
-            if backend_status not in valid_statuses:
+            if backend_status not in EXPERIMENT_RUN_WIRE_STATUSES:
                 logger.warning(
-                    f"Unexpected status '{status}' (mapped to '{backend_status}'), "
-                    "using FAILED as default"
+                    "Status %r mapped to non-canonical %r; sending neutral %r",
+                    status,
+                    backend_status,
+                    UNKNOWN_WIRE_STATUS,
                 )
-                backend_status = "FAILED"
+                backend_status = UNKNOWN_WIRE_STATUS
 
             # Prepare headers with API key
             headers = await self.client.auth_manager.augment_headers(

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -167,10 +167,12 @@ def map_status_to_wire(status: str, *, endpoint: str = "experiment_run") -> str:
         else EXPERIMENT_RUN_WIRE_STATUSES
     )
 
-    # PRUNED is endpoint-specific: config-runs keep it; experiment-runs fold it
-    # into COMPLETED (the experiment-run enum has no PRUNED member).
+    # PRUNED is endpoint-specific: config-runs keep it; the experiment-run enum
+    # has no PRUNED member. A pruned run is NOT a successful completion, so fold
+    # it to the neutral UNKNOWN rather than claiming COMPLETED — emitting
+    # COMPLETED here would be fake completion (no-fake-completion rule).
     if token == "pruned":
-        mapped = "PRUNED" if endpoint == "config_run" else "COMPLETED"
+        mapped = "PRUNED" if endpoint == "config_run" else UNKNOWN_WIRE_STATUS
     else:
         mapped = _RUN_STATUS_WIRE_MAP.get(token, "")
         if not mapped:

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -1240,10 +1240,12 @@ class BackendIntegratedClient:
             session.updated_at = datetime.now(UTC)
 
     # API Operations
-    def _map_to_backend_status(self, status: str) -> str:
+    def _map_to_backend_status(
+        self, status: str, *, endpoint: str = "experiment_run"
+    ) -> str:
         """Map Traigent status values to backend-expected values.
         Delegates to api_operations module."""
-        return cast(str, self._api_ops.map_to_backend_status(status))
+        return cast(str, self._api_ops.map_to_backend_status(status, endpoint=endpoint))
 
     def _normalize_execution_mode(self, execution_mode: str | None) -> str:
         """Translate SDK execution modes to backend-supported values."""

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -66,6 +66,44 @@ def _session_is_closed(session: Any) -> bool:
     return False
 
 
+def _coerce_enum(enum_cls: Any, raw: Any, *, fallback: Any) -> Any:
+    """Case/format-tolerant enum coercion for inbound backend status fields.
+
+    The backend may send a status in upper case (``RUNNING``), lower case
+    (``running``), or — for forward/backward compatibility — a value not in the
+    SDK's enum at all. The strict ``EnumCls(raw)`` construction raises
+    ``ValueError`` on any of these, which previously crashed deserialization of
+    an otherwise-valid response (issue #1302, AC3).
+
+    This helper tries, in order:
+      1. the raw value as-is (handles already-correct lowercase enum values),
+      2. the lower-cased value (handles backend UPPER -> SDK lowercase enums),
+      3. matching by member *name* (handles UPPER name like ``RUNNING``),
+    and otherwise returns ``fallback`` — a neutral default, never silently
+    ``COMPLETED``, so a failed/running run is never reported as succeeded.
+    """
+    if isinstance(raw, enum_cls):
+        return raw
+    for candidate in (raw, str(raw).lower() if raw is not None else raw):
+        try:
+            return enum_cls(candidate)
+        except (ValueError, KeyError):
+            continue
+    # Try matching by member name (e.g. backend "RUNNING" -> EnumCls.RUNNING).
+    if raw is not None:
+        name = str(raw).upper()
+        member = enum_cls.__members__.get(name)
+        if member is not None:
+            return member
+    logger.warning(
+        "Unrecognized %s value %r from backend; using neutral fallback %r",
+        getattr(enum_cls, "__name__", "status"),
+        raw,
+        fallback,
+    )
+    return fallback
+
+
 class BaseTraigentClient(ABC):
     """Base interface for all Traigent clients.
 
@@ -1279,11 +1317,10 @@ class TraigentCloudClient(BaseTraigentClient):
 
         from traigent.cloud.models import TrialStatus
 
-        # Convert string status to enum
-        try:
-            trial_status = TrialStatus(status)
-        except ValueError:
-            trial_status = TrialStatus.COMPLETED
+        # Convert string status to enum, tolerating case / out-of-set values.
+        # NEVER silently default to COMPLETED — that would assert success on a
+        # failed/running trial (issue #1302, AC3). Fall back to UNKNOWN instead.
+        trial_status = _coerce_enum(TrialStatus, status, fallback=TrialStatus.UNKNOWN)
 
         result = TrialResultSubmission(
             session_id=session_id,
@@ -1443,7 +1480,11 @@ class TraigentCloudClient(BaseTraigentClient):
         """Deserialize session creation response."""
         return SessionCreationResponse(
             session_id=data["session_id"],
-            status=OptimizationSessionStatus(data["status"]),
+            status=_coerce_enum(
+                OptimizationSessionStatus,
+                data["status"],
+                fallback=OptimizationSessionStatus.UNKNOWN,
+            ),
             optimization_strategy=data.get("optimization_strategy", {}),
             estimated_duration=data.get("estimated_duration"),
             billing_estimate=data.get("billing_estimate"),
@@ -1499,8 +1540,10 @@ class TraigentCloudClient(BaseTraigentClient):
             should_continue=data["should_continue"],
             reason=data.get("reason"),
             stop_reason=data.get("stop_reason"),
-            session_status=OptimizationSessionStatus(
-                data.get("session_status", "active")
+            session_status=_coerce_enum(
+                OptimizationSessionStatus,
+                data.get("session_status", "active"),
+                fallback=OptimizationSessionStatus.UNKNOWN,
             ),
             metadata=data.get("metadata", {}),
         )
@@ -1563,7 +1606,9 @@ class TraigentCloudClient(BaseTraigentClient):
             trial_id=data["trial_id"],
             metrics=data["metrics"],
             duration=data["duration"],
-            status=TrialStatus(data["status"]),
+            status=_coerce_enum(
+                TrialStatus, data["status"], fallback=TrialStatus.UNKNOWN
+            ),
             outputs_sample=data.get("outputs_sample"),
             error_message=data.get("error_message"),
             metadata=data.get("metadata", {}),
@@ -1945,7 +1990,11 @@ class TraigentCloudClient(BaseTraigentClient):
 
         return AgentOptimizationStatus(
             optimization_id=data["optimization_id"],
-            status=OptimizationSessionStatus(data["status"]),
+            status=_coerce_enum(
+                OptimizationSessionStatus,
+                data["status"],
+                fallback=OptimizationSessionStatus.UNKNOWN,
+            ),
             progress=data["progress"],
             completed_trials=data["completed_trials"],
             total_trials=data["total_trials"],

--- a/traigent/cloud/models.py
+++ b/traigent/cloud/models.py
@@ -15,29 +15,34 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
+# Single source of truth for trial status (issue #1302 AC4): the public SDK
+# enum lives in ``traigent.api.types``. Re-export it here so the cloud layer and
+# the public API can never drift into two disagreeing ``TrialStatus`` enums.
+from traigent.api.types import TrialStatus as TrialStatus
 from traigent.evaluators.base import Dataset
 
 
 class OptimizationSessionStatus(Enum):
-    """Status of an optimization session."""
+    """Status of an optimization session (session-lifecycle vocabulary).
+
+    NOTE: This is the SESSION lifecycle, distinct from the run-lifecycle vocab
+    the backend expects on the experiment-run / configuration-run status PUT
+    endpoints (see ``traigent.cloud.api_operations`` — issue #1302). Do not send
+    these members on a run/config status update.
+
+    Values are lowercase, but the inbound deserializers tolerate the backend's
+    UPPER-case responses via ``traigent.cloud.client._coerce_enum``.
+    """
 
     PENDING = "pending"
     CREATED = "created"
+    INITIALIZING = "initializing"
     ACTIVE = "active"
     PAUSED = "paused"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
-
-
-class TrialStatus(Enum):
-    """Status of an individual trial."""
-
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    SKIPPED = "skipped"
+    UNKNOWN = "unknown"
 
 
 @dataclass

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -231,14 +231,19 @@ class TrialOperations:
             return False
 
         try:
-            # Map status to backend format (use ACTIVE for running state)
-            backend_status = self.client._map_to_backend_status("in_progress")
+            # Map status to backend format. This is a configuration-run
+            # submission (POST /sessions/{id}/results), so use the config-run
+            # wire vocab — a starting trial is RUNNING, not the session-lifecycle
+            # ACTIVE the backend would 400-reject (issue #1302).
+            backend_status = self.client._map_to_backend_status(
+                "in_progress", endpoint="config_run"
+            )
 
             # Prepare trial registration data
             registration_data = {
                 "trial_id": trial_id,
                 "config": config,
-                "status": backend_status,  # Use mapped status (ACTIVE)
+                "status": backend_status,  # Use mapped status (RUNNING)
                 "metrics": {},  # Empty metrics at start
             }
             registration_payload = self._sanitize_for_json(registration_data)
@@ -658,7 +663,11 @@ class TrialOperations:
             return False
 
         try:
-            backend_status = self.client._map_to_backend_status(status)
+            # Configuration-run submission path -> config-run wire vocab
+            # (preserves PRUNED for early-stopped trials; issue #1302).
+            backend_status = self.client._map_to_backend_status(
+                status, endpoint="config_run"
+            )
             mode = self.client._normalize_execution_mode(execution_mode)
 
             # Extract transport-only fields before validating trial metrics.
@@ -816,8 +825,11 @@ class TrialOperations:
             return False
 
         try:
-            # Map status to backend format
-            backend_status = self.client._map_to_backend_status(status)
+            # Configuration-run submission path -> config-run wire vocab
+            # (issue #1302).
+            backend_status = self.client._map_to_backend_status(
+                status, endpoint="config_run"
+            )
 
             # Prepare metadata - REQUIRED by backend to avoid NoneType errors
             submission_metadata = {

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -901,18 +901,12 @@ class BackendSessionManager:
         if "score" not in metrics_payload and score is not None:
             metrics_payload["score"] = sanitized_score
 
-        # Map SDK TrialStatus to backend status string.
-        # PRUNED is a success case (early stopping for efficiency), not a failure.
-        status_mapping = {
-            TrialStatus.COMPLETED: "COMPLETED",
-            TrialStatus.FAILED: "FAILED",
-            TrialStatus.PRUNED: "PRUNED",
-            TrialStatus.CANCELLED: "CANCELLED",
-            TrialStatus.RUNNING: "RUNNING",
-            TrialStatus.PENDING: "PENDING",
-            TrialStatus.NOT_STARTED: "PENDING",
-        }
-        status = status_mapping.get(trial_result.status, "FAILED")
+        # Map SDK TrialStatus to the configuration-run wire vocab via the single
+        # canonical mapper (issue #1302). This is a configuration-run submission,
+        # so PRUNED (early-stopping success) is preserved rather than coerced.
+        from traigent.cloud.api_operations import map_status_to_wire
+
+        status = map_status_to_wire(trial_result.status.value, endpoint="config_run")
 
         try:
             # The backend binds a result to a session by the configuration_run

--- a/traigent/optimizers/remote_services.py
+++ b/traigent/optimizers/remote_services.py
@@ -21,6 +21,13 @@ from typing import Any, cast
 from traigent.api.types import TrialResult
 from traigent.config.types import TraigentConfig
 from traigent.evaluators.base import EvaluationExample
+
+# Single source of truth for session status (issue #1302 AC4): reuse the
+# canonical ``OptimizationSessionStatus`` from ``traigent.cloud.models`` rather
+# than defining a second, drifting copy here. The canonical enum is a superset
+# (it carries INITIALIZING plus PENDING/CREATED/UNKNOWN), so every member this
+# module uses (INITIALIZING/ACTIVE/PAUSED/COMPLETED/FAILED/CANCELLED) resolves.
+from traigent.cloud.models import OptimizationSessionStatus as OptimizationSessionStatus
 from traigent.utils.exceptions import OptimizationError, ServiceError
 from traigent.utils.logging import get_logger
 
@@ -36,17 +43,6 @@ class ServiceStatus(StrEnum):
     CONNECTED = "connected"
     ERROR = "error"
     UNAVAILABLE = "unavailable"
-
-
-class OptimizationSessionStatus(StrEnum):
-    """Status of an optimization session."""
-
-    INITIALIZING = "initializing"
-    ACTIVE = "active"
-    PAUSED = "paused"
-    COMPLETED = "completed"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
 
 
 @dataclass

--- a/traigent/skills/traigent-analyze-results/references/optimization-result-api.md
+++ b/traigent/skills/traigent-analyze-results/references/optimization-result-api.md
@@ -79,7 +79,7 @@ The `TrialResult` dataclass represents the outcome of a single optimization tria
 | `trial_id` | `str` | Unique identifier for this trial. |
 | `config` | `dict[str, Any]` | The configuration used for this trial (e.g., `{"model": "gpt-4o", "temperature": 0.5}`). |
 | `metrics` | `dict[str, float]` | Metric values produced by this trial (e.g., `{"accuracy": 0.85, "latency": 1.2}`). |
-| `status` | `TrialStatus` | Status of this trial. One of: `NOT_STARTED`, `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `PRUNED`. |
+| `status` | `TrialStatus` | Status of this trial. One of: `NOT_STARTED`, `PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `PRUNED`, `UNKNOWN`. |
 | `duration` | `float` | Wall-clock execution time for this trial in seconds. |
 | `timestamp` | `datetime` | When this trial was executed. |
 | `error_message` | `str \| None` | Error message if the trial failed. `None` for successful trials. |
@@ -165,6 +165,7 @@ TrialStatus.COMPLETED    # "completed"
 TrialStatus.FAILED       # "failed"
 TrialStatus.CANCELLED    # "cancelled"
 TrialStatus.PRUNED       # "pruned"
+TrialStatus.UNKNOWN      # "unknown" (neutral fallback for unrecognized statuses)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes #1302 — the SDK's outbound status mapper sent the **session-lifecycle** vocab (`ACTIVE`/`CREATED`) on the experiment-run and configuration-run status PUT endpoints, where the backend expects the **run-lifecycle** enum. The backend 400-rejects `ACTIVE`/`CREATED`, so an SDK-driven run could only reach terminal states — its in-flight states (`running`/`pending`/`not_started`) could **never** persist server-side.

## Changes

- **Outbound mapper (AC1):** `map_to_backend_status` now emits run-lifecycle vocab — `pending→PENDING`, `running→RUNNING`, `in_progress→RUNNING`, `not_started→NOT_STARTED`. It is **endpoint-aware**: `endpoint="config_run"` keeps `pruned→PRUNED` (config-runs accept it); `endpoint="experiment_run"` (default) folds `pruned→COMPLETED` because the backend `ExperimentRunStatus` enum has no `PRUNED` member. The three `trial_operations.py` submission sites (`/sessions/{id}/results`) and `backend_session_manager` now pass `endpoint="config_run"`; the experiment-run finalize path uses `endpoint="experiment_run"`.
- **Single source of truth (AC2):** new module-level `EXPERIMENT_RUN_WIRE_STATUSES` / `CONFIGURATION_RUN_WIRE_STATUSES` frozensets + a pure `map_status_to_wire()` function feed the mapper, the validation gate, **and** `backend_session_manager`'s former hand-rolled status dict — they cannot drift apart. The dead/contradictory `valid_statuses` whitelist (`ACTIVE`/`CREATED` + default `→FAILED`) is gone; unexpected statuses now resolve to `UNKNOWN`, never `FAILED`.
- **Inbound tolerance (AC3):** new `_coerce_enum()` in `client.py` parses status case-insensitively (handles backend `RUNNING`/`ACTIVE` UPPER → SDK lowercase enums and member-name matches) and falls back to a neutral `UNKNOWN` — **no uncaught `ValueError`**, and the silent wrong-default to `TrialStatus.COMPLETED` is removed. Applied to all four deserializers (`submit_trial_result`, `_deserialize_session_response`, `_deserialize_next_trial_response`, `_deserialize_trial_result`, `_deserialize_agent_optimization_status`).
- **Dedup enums (AC4):** `cloud.models.TrialStatus` now re-exports `api.types.TrialStatus` (one enum object). `remote_services.OptimizationSessionStatus` now references the canonical `cloud.models.OptimizationSessionStatus`, which became a superset (added `INITIALIZING` from the former remote copy + `UNKNOWN`). Added `UNKNOWN` to `api.types` `TrialStatus`/`OptimizationStatus` as the neutral fallback (doc updated).

### Decisions
- **PRUNED for experiment-runs:** folded to `COMPLETED` (early-stop = a completed run), not `UNKNOWN`/`FAILED` — avoids a 400 while not claiming failure.
- **Inbound fallback:** `UNKNOWN` (new neutral member on the public enums). Never `COMPLETED` (no fake success) and never `FAILED` (no false failure on a status we simply didn't recognize).
- `remote_services.OptimizationSessionStatus` changed from `StrEnum` to plain `Enum` via the dedup; verified no production code relied on its `== "active"` string-equality (all usages are enum-to-enum or `.value`).

## Test evidence (offline witnesses — no live `:8006` needed)

```
pytest -n0 tests/unit/cloud/                        -> 1404 passed, 1 skipped
pytest -n0 tests/unit/api/ tests/unit/core/ \
          tests/unit/optimizers/ tests/unit/utils/  -> 4895 passed, 13 skipped
ruff check <changed files>                          -> All checks passed!
ruff format --check <changed files>                 -> 11 files already formatted
```

New tests added (would FAIL pre-fix):
- `TestMapToBackendStatus` — producer witness: `pending/running/not_started → PENDING/RUNNING/NOT_STARTED`; asserts `ACTIVE`/`CREATED` are **never** emitted on either endpoint; per-endpoint PRUNED; unknown → `UNKNOWN` not `FAILED`/`CUSTOM`.
- `test_running_status_persists_as_running_not_active` — asserts the experiment-run PUT body carries `RUNNING`, not `ACTIVE`.
- `TestInboundStatusTolerance` — UPPER + out-of-set inbound statuses don't raise and don't wrong-default to `COMPLETED`.
- `TestStatusEnumDeduplication` / `test_session_status_is_canonical_single_source` — the dual enums are the same object.

Updated pre-existing tests that asserted the old buggy behavior (`pending→ACTIVE`, `not_started→CREATED`, unknown→`FAILED`, remote `StrEnum` string-equality).

## PR checklist
1. **Worst-case prod path:** an SDK run's in-flight status fails to persist (silent at worst) — this fix makes it persist correctly; no new fail-open behavior. Unknown statuses resolve to a neutral `UNKNOWN`, never a wrong success/failure.
2. **Production-branch test:** `tests/unit/cloud/test_api_operations.py::TestUpdateExperimentRunStatusSuccess::test_running_status_persists_as_running_not_active` and `::test_invalid_status_uses_unknown_default`.
3. **Contract regeneration:** none in this repo. The backend serialization (TraigentBackend#1162) and schema contract (TraigentSchema#172/#173) are tracked as separate workers and explicitly OUT of scope here.
4. **Public surface delta:** added `TrialStatus.UNKNOWN` / `OptimizationStatus.UNKNOWN`; `OptimizationSessionStatus` gained `INITIALIZING`/`UNKNOWN`. Skill reference doc updated to match runtime.
5. **Review threads:** none yet.
6. **Quality gates not relaxed:** no thresholds widened.

Spine-Trail: st_5eed1fb75c07
Closes #1302
