### PR TITLE
chore(sdk): narrow governance import guard + drop always-true is_analytics_available (spine-gap triage)

### DIFF
--- a/tests/unit/test_init_imports.py
+++ b/tests/unit/test_init_imports.py
@@ -339,7 +339,6 @@ class TestAnalyticsInit:
             from traigent import analytics
 
             # Helper functions should be available
-            assert hasattr(analytics, "is_analytics_available")
             assert hasattr(analytics, "is_plugin_installed")
 
     def test_analytics_availability_check(self) -> None:
@@ -348,10 +347,8 @@ class TestAnalyticsInit:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            from traigent.analytics import is_analytics_available, is_plugin_installed
+            from traigent.analytics import is_plugin_installed
 
-            # is_analytics_available should always return True (embedded fallback)
-            assert is_analytics_available() is True
             # is_plugin_installed depends on whether plugin is installed
             assert isinstance(is_plugin_installed(), bool)
 
@@ -365,7 +362,7 @@ class TestAnalyticsInit:
 
             assert hasattr(analytics, "__all__")
             assert isinstance(analytics.__all__, list)
-            assert "is_analytics_available" in analytics.__all__
+            assert "is_plugin_installed" in analytics.__all__
 
 
 class TestOptimizersInit:

--- a/traigent/analytics/__init__.py
+++ b/traigent/analytics/__init__.py
@@ -123,11 +123,6 @@ except ImportError:
     )
 
 
-def is_analytics_available() -> bool:
-    """Check if analytics is available (either via plugin or embedded)."""
-    return True  # Always available through embedded fallback
-
-
 def is_plugin_installed() -> bool:
     """Check if the analytics plugin is installed."""
     return _PLUGIN_AVAILABLE
@@ -175,6 +170,5 @@ __all__ = [
     "AlertSeverity",
     "AnomalyType",
     # Helpers
-    "is_analytics_available",
     "is_plugin_installed",
 ]

--- a/traigent/cloud/governance.py
+++ b/traigent/cloud/governance.py
@@ -127,7 +127,7 @@ def build_tvl_governance(config_space: Any) -> dict[str, Any] | None:
 
     try:
         from traigent.knobs.bindings import Calibrated, is_governed
-    except Exception:  # pragma: no cover - knobs is a hard dep of ConfigSpace
+    except ImportError:  # pragma: no cover - knobs is a hard dep of ConfigSpace
         logger.warning("knobs bindings unavailable; omitting tvl_governance")
         return None
 


### PR DESCRIPTION
## Changes

**Fix A — `traigent/cloud/governance.py`**
In `build_tvl_governance`, the knobs-bindings import guard was `except Exception:`, silently swallowing any runtime error (not just a missing module) during the `from traigent.knobs.bindings import ...` import. Changed to `except ImportError:`. The `logger.warning(...)` and `return None` are unchanged.

**Fix C — `traigent/analytics/__init__.py`**
Removed `is_analytics_available()` — a public function that unconditionally `return True` with no conditional logic. Grep confirmed **zero product callers** (only `tests/unit/test_init_imports.py` + the def itself). Removed its `__all__` entry. Updated `test_init_imports.py` to drop the four assertions referencing it; all `is_plugin_installed` assertions are kept.

## Callers verified (is_analytics_available)
```
grep -rn "is_analytics_available" traigent/ --include="*.py"
# Only result: the def in analytics/__init__.py (now removed)
```
No other product code, examples, or docs reference it.

## Test evidence
- `ruff format` + `ruff check` — all passed, no changes
- `pytest -n0 tests/unit/test_init_imports.py` — **26/26 passed**
- `pytest -n0 tests/unit/ -k "governance or analytics"` (ignoring pre-existing pandas/mcp import errors unrelated to this PR) — **248 passed, 2 skipped**
- Pre-commit hooks: mypy passed, ruff passed, bandit passed, detect-secrets passed

## Spine-Trail
Spine-Trail: st_73e97135f6f4