### PR TITLE
chore(sdk/wave2b): remove MetaLearningEngine deprecated alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `TRAIGENT_CUSTOM_MODEL_PRICING_JSON`/`_FILE`. `TRAIGENT_STRICT_COST_ACCOUNTING=true`
   still hard-fails without prompting; mock runs are unaffected.
 
+### Removed
+- **`BudgetStopCondition` class removed.** The class is no longer exported from any
+  public module. Replace usage with `cost_limit=<value>` in `.optimize()` calls, or
+  use `metric_limit=<value>` + `metric_name=<name>` for metric-based stopping.
+- **`TRAIGENT_TRACES_ENABLED` environment variable removed.** The deprecated plural-form
+  alias is no longer read. Use `TRAIGENT_TRACE_ENABLED=true` (singular) instead. Setting
+  the old variable will have no effect and tracing will remain disabled.
+- **`OptimizedFunction.config_space` property removed.** The property has been removed
+  from the public API. Access the configuration space through the `TVLParameterAgent`
+  interface or via decorator introspection helpers.
+- **`strategy=` non-preset alias removed.** Passing an unrecognized string to `strategy=`
+  in `.optimize()` now raises `ValueError` immediately rather than falling back silently.
+  Use one of the documented preset names.
+- **`budget_limit`, `budget_metric`, `budget_include_pruned` runtime override keys
+  removed.** Passing any of these as keyword arguments to `.optimize()` now raises
+  `TypeError`. Migrate to `cost_limit=<value>` for cost-based stopping, or
+  `metric_limit=<value>` + `metric_name=<name>` for metric-based stopping.
+
 ## [0.12.0] - 2026-06-06
 
 ### Added

--- a/docs/api-reference/telemetry.md
+++ b/docs/api-reference/telemetry.md
@@ -77,9 +77,9 @@ export TRAIGENT_TRACE_ENABLED=true
 
 `TRAIGENT_TRACE_ENABLED` is the canonical tracing flag and defaults to
 `false`. It controls SDK span emission and workflow trace tracker creation.
-The older plural spelling `TRAIGENT_TRACES_ENABLED` remains as a deprecated
-alias when the canonical flag is unset; if both are set,
-`TRAIGENT_TRACE_ENABLED` takes precedence.
+The older plural spelling `TRAIGENT_TRACES_ENABLED` is **no longer supported**
+as of 0.13.0 and is silently ignored. If you were using `TRAIGENT_TRACES_ENABLED`,
+migrate to `TRAIGENT_TRACE_ENABLED`.
 
 ### Agent Workflow Spans
 

--- a/examples/core/error-handling/run.py
+++ b/examples/core/error-handling/run.py
@@ -169,28 +169,25 @@ async def demo_invalid_config():
 
 
 async def demo_budget_exceeded():
-    """Scenario 2: Sample-budget exceeded via budget_limit/budget_metric."""
-    print_scenario(2, "Sample-Budget Exceeded")
+    """Scenario 2: Cost limit exceeded via cost_limit."""
+    print_scenario(2, "Cost-Limit Exceeded")
 
     try:
-        # Use budget_limit with budget_metric="examples_attempted" to cap samples.
-        # The orchestrator maps "budget" to the internal cost_limit parameter.
+        # Use cost_limit to cap total spend for the optimization run.
         result = await explain_concept.optimize(
             max_trials=20,
-            budget_limit=2,
-            budget_metric="examples_attempted",
+            cost_limit=0.02,
         )
         print(f"  Optimization stopped: stop_reason={result.stop_reason}")
         print(f"  Trials completed: {len(result.trials)}")
-        # Budget stop is mapped to "cost_limit" by the orchestrator.
-        if result.stop_reason in ("budget", "cost_limit"):
-            print("  Budget/cost limit reached - optimization capped as expected.")
+        if result.stop_reason == "cost_limit":
+            print("  Cost limit reached - optimization capped as expected.")
         else:
             print(f"  Stopped for other reason: {result.stop_reason}")
-        print("  Resolution: Increase budget_limit or reduce dataset size.")
+        print("  Resolution: Increase cost_limit or reduce dataset size.")
     except Exception as e:
         print(f"  Caught error: {type(e).__name__}: {e}")
-        print("  Resolution: Check budget_metric matches a metric your trials produce.")
+        print("  Resolution: Check cost_limit value and model pricing.")
 
     print("  Status: HANDLED")
 

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna.py
@@ -616,7 +616,7 @@ _OPTIMIZE_KWARGS: dict[str, Any] = {
 }
 
 if BUDGET_LIMIT is not None and BUDGET_LIMIT > 0:
-    _OPTIMIZE_KWARGS["budget_limit"] = BUDGET_LIMIT
+    _OPTIMIZE_KWARGS["cost_limit"] = BUDGET_LIMIT
 
 
 # ==============================================================================
@@ -689,8 +689,7 @@ async def main() -> None:
     if runtime_budget is not None and runtime_budget > 0:
         optimize_kwargs.update(
             {
-                "budget_limit": runtime_budget,
-                "budget_metric": "total_cost",
+                "cost_limit": runtime_budget,
                 "algorithm": "random",
                 "objectives": ["cost"],
             }

--- a/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
+++ b/examples/core/multi-objective-tradeoff/run_openai_optuna_concurrency.py
@@ -595,7 +595,7 @@ _OPTIMIZE_KWARGS: dict[str, Any] = {
 }
 
 if BUDGET_LIMIT is not None and BUDGET_LIMIT > 0:
-    _OPTIMIZE_KWARGS["budget_limit"] = BUDGET_LIMIT
+    _OPTIMIZE_KWARGS["cost_limit"] = BUDGET_LIMIT
 
 
 @traigent.optimize(**_OPTIMIZE_KWARGS)
@@ -660,8 +660,7 @@ if __name__ == "__main__":
             if runtime_budget is not None and runtime_budget > 0:
                 optimize_kwargs.update(
                     {
-                        "budget_limit": runtime_budget,
-                        "budget_metric": "total_cost",
+                        "cost_limit": runtime_budget,
                     }
                 )
 

--- a/plugins/traigent-analytics/traigent_analytics/__init__.py
+++ b/plugins/traigent-analytics/traigent_analytics/__init__.py
@@ -46,7 +46,6 @@ from .intelligence import CostOptimizationAI
 from .meta_learning import (
     AlgorithmSelector,
     HistoricalAnalyticsEngine,
-    MetaLearningEngine,
     OptimizationHistory,
     PerformancePredictor,
 )
@@ -73,7 +72,6 @@ from .scheduling import (
 __all__ = [
     # Meta-learning
     "HistoricalAnalyticsEngine",
-    "MetaLearningEngine",
     "OptimizationHistory",
     "AlgorithmSelector",
     "PerformancePredictor",

--- a/plugins/traigent-analytics/traigent_analytics/meta_learning.py
+++ b/plugins/traigent-analytics/traigent_analytics/meta_learning.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import statistics
 import threading
-import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -813,15 +812,3 @@ class HistoricalAnalyticsEngine:
             ),
             "functions_optimized": len({r.function_name for r in records}),
         }
-
-
-class MetaLearningEngine(HistoricalAnalyticsEngine):
-    """Deprecated compatibility alias for HistoricalAnalyticsEngine."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        warnings.warn(
-            "MetaLearningEngine is deprecated; use HistoricalAnalyticsEngine instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)

--- a/plugins/traigent-tracing/README.md
+++ b/plugins/traigent-tracing/README.md
@@ -36,9 +36,9 @@ export OTEL_SERVICE_NAME=my-optimization-service
 ```
 
 `TRAIGENT_TRACE_ENABLED` is the canonical tracing flag and defaults to
-`false`. The older plural spelling `TRAIGENT_TRACES_ENABLED` is still honored
-as a deprecated alias when the canonical flag is unset; if both are set,
-`TRAIGENT_TRACE_ENABLED` takes precedence.
+`false`. The older plural spelling `TRAIGENT_TRACES_ENABLED` is **no longer
+supported** as of 0.13.0 and is silently ignored. Migrate any use of
+`TRAIGENT_TRACES_ENABLED` to `TRAIGENT_TRACE_ENABLED`.
 
 Or configure programmatically:
 

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -174,9 +174,9 @@ class TestOptimizeDecorator:
         assert isinstance(sample_function, OptimizedFunction)
         assert sample_function.algorithm == "grid"
 
-    def test_decorator_accepts_deprecated_strategy_alias(self):
-        """strategy=... should map to algorithm=... with deprecation warning."""
-        with pytest.warns(DeprecationWarning, match="strategy"):
+    def test_decorator_rejects_unknown_strategy_name(self):
+        """Non-preset strategy values should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown strategy preset"):
 
             @optimize(
                 configuration_space={"x": [1, 2]},
@@ -184,9 +184,6 @@ class TestOptimizeDecorator:
             )
             def sample_function(x: int) -> int:
                 return x
-
-        assert isinstance(sample_function, OptimizedFunction)
-        assert sample_function.algorithm == "grid"
 
     def test_decorator_accepts_strategy_preset(self):
         """Registered strategy names should configure advisory preset metadata."""

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -157,9 +157,9 @@ class TestOptimizeDecorator:
             return x
 
         assert isinstance(sample_function, OptimizedFunction)
-        assert (
-            sample_function.max_trials == 10
-        ), f"max_trials should be 10 (from decorator), got {sample_function.max_trials}"
+        assert sample_function.max_trials == 10, (
+            f"max_trials should be 10 (from decorator), got {sample_function.max_trials}"
+        )
 
     def test_decorator_accepts_algorithm_runtime_default(self):
         """Decorator-level algorithm should become the optimize() default."""

--- a/tests/unit/core/test_optimization_pipeline.py
+++ b/tests/unit/core/test_optimization_pipeline.py
@@ -88,7 +88,6 @@ def workflow_trace_backend_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TRAIGENT_BACKEND_URL", "https://backend.example")
     monkeypatch.setenv("TRAIGENT_API_KEY", "api-key")
     monkeypatch.delenv("TRAIGENT_TRACE_ENABLED", raising=False)
-    monkeypatch.delenv("TRAIGENT_TRACES_ENABLED", raising=False)
 
 
 def _patch_workflow_traces_tracker(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, Any]:
@@ -119,35 +118,6 @@ class TestCreateWorkflowTracesTrackerTraceEnv:
             backend_url="https://backend.example",
             auth_token="api-key",
         )
-
-    def test_alias_only_enabled_warns_and_creates_tracker(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        workflow_trace_backend_env: None,
-    ) -> None:
-        monkeypatch.setenv("TRAIGENT_TRACES_ENABLED", "true")
-        tracker, tracker_factory = _patch_workflow_traces_tracker(monkeypatch)
-
-        with pytest.warns(DeprecationWarning, match="TRAIGENT_TRACES_ENABLED"):
-            result = create_workflow_traces_tracker(None)  # type: ignore[arg-type]
-
-        assert result is tracker
-        tracker_factory.assert_called_once()
-
-    def test_both_set_canonical_takes_precedence(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        workflow_trace_backend_env: None,
-    ) -> None:
-        monkeypatch.setenv("TRAIGENT_TRACE_ENABLED", "false")
-        monkeypatch.setenv("TRAIGENT_TRACES_ENABLED", "true")
-        _, tracker_factory = _patch_workflow_traces_tracker(monkeypatch)
-
-        with pytest.warns(DeprecationWarning, match="ignored"):
-            result = create_workflow_traces_tracker(None)  # type: ignore[arg-type]
-
-        assert result is None
-        tracker_factory.assert_not_called()
 
     def test_neither_set_defaults_off(
         self,

--- a/tests/unit/core/test_optimization_pipeline.py
+++ b/tests/unit/core/test_optimization_pipeline.py
@@ -83,6 +83,48 @@ class TestCollectOrchestratorKwargsInvocations:
         assert result["invocations_per_example"] == 1
 
 
+class TestCollectOrchestratorKwargsRemovedBudgetKeys:
+    """Regression: removed budget_* keys must raise TypeError, not be silently dropped."""
+
+    def _call(self, **extra: Any) -> dict[str, Any]:
+        algorithm_kwargs: dict[str, Any] = {"cache_policy": "allow_repeats"}
+        algorithm_kwargs.update(extra)
+        return collect_orchestrator_kwargs(
+            algorithm_kwargs,
+            samples_include_pruned_value=False,
+            default_config=None,
+            constraints=None,
+            agents=None,
+            agent_prefixes=None,
+            agent_measures=None,
+            global_measures=None,
+            promotion_gate=None,
+        )
+
+    def test_budget_limit_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="budget_limit"):
+            self._call(budget_limit=10)
+
+    def test_budget_metric_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="budget_metric"):
+            self._call(budget_metric="examples_attempted")
+
+    def test_budget_include_pruned_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="budget_include_pruned"):
+            self._call(budget_include_pruned=True)
+
+    def test_multiple_budget_keys_raise_together(self) -> None:
+        with pytest.raises(TypeError, match="budget_limit"):
+            self._call(budget_limit=5, budget_metric="total_cost")
+
+    def test_valid_keys_still_pass_through(self) -> None:
+        """Sanity check: cost_limit and metric_limit are the correct replacements."""
+        result = self._call(cost_limit=1.5, metric_limit=0.9, metric_name="accuracy")
+        assert result["cost_limit"] == 1.5
+        assert result["metric_limit"] == 0.9
+        assert result["metric_name"] == "accuracy"
+
+
 @pytest.fixture
 def workflow_trace_backend_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TRAIGENT_BACKEND_URL", "https://backend.example")

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -136,7 +136,7 @@ class TestOptimizedFunction:
         )
 
         assert opt_func.func is mock_function
-        assert opt_func.config_space == sample_config_space
+        assert opt_func.configuration_space == sample_config_space
         assert opt_func.objectives == sample_objectives
         assert opt_func.algorithm == "random"  # default
         assert opt_func.max_trials == 50  # default

--- a/tests/unit/core/test_stop_conditions.py
+++ b/tests/unit/core/test_stop_conditions.py
@@ -4,7 +4,6 @@ import traigent.core.stop_conditions as stop_conditions
 from traigent.api.types import TrialResult, TrialStatus
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 from traigent.core.stop_conditions import (
-    BudgetStopCondition,
     HypervolumeConvergenceStopCondition,
     MaxSamplesStopCondition,
     MaxTrialsStopCondition,
@@ -197,29 +196,8 @@ def test_metric_limit_stop_condition_rejects_non_numeric_metric():
         stop_condition.should_stop([_make_trial("t1", {"total_cost": "free"})])
 
 
-def test_budget_stop_condition_alias_warns_and_uses_metric_limit_reason():
-    with pytest.warns(DeprecationWarning, match="BudgetStopCondition"):
-        stop_condition = BudgetStopCondition(budget=0.1, metric_name="tokens")
-
-    assert stop_condition.reason == "metric_limit"
-    assert stop_condition.should_stop([_make_trial("t1", {"tokens": 0.1})])
-
-
-def test_budget_stop_condition_without_metric_warns_to_use_cost_limit():
-    with pytest.warns(DeprecationWarning) as warnings_record:
-        stop_condition = BudgetStopCondition(budget=0.1)
-
-    warning_messages = [str(warning.message) for warning in warnings_record]
-    assert any("BudgetStopCondition" in msg for msg in warning_messages)
-    assert any("money spend control, use cost_limit" in msg for msg in warning_messages)
-
-    assert stop_condition.reason == "metric_limit"
-    assert stop_condition.should_stop([_make_trial("t1", {"cost": 0.1})])
-
-
 def test_stop_conditions_exports_are_explicit():
     assert set(stop_conditions.__all__) == {
-        "BudgetStopCondition",
         "CostLimitStopCondition",
         "HypervolumeConvergenceStopCondition",
         "MaxSamplesStopCondition",

--- a/tests/unit/core/test_stop_reason_contract.py
+++ b/tests/unit/core/test_stop_reason_contract.py
@@ -138,7 +138,6 @@ def test_metric_limit_requires_metric_name():
         _orchestrator(metric_limit=0.2)
 
 
-
 def test_cost_enforcer_limit_maps_to_cost_limit(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
     orchestrator = _orchestrator(cost_limit=0.5, cost_approved=True)

--- a/tests/unit/core/test_stop_reason_contract.py
+++ b/tests/unit/core/test_stop_reason_contract.py
@@ -138,32 +138,6 @@ def test_metric_limit_requires_metric_name():
         _orchestrator(metric_limit=0.2)
 
 
-def test_legacy_budget_limit_alias_warns_and_maps_to_metric_limit():
-    with pytest.warns(DeprecationWarning, match="budget_limit is deprecated"):
-        orchestrator = _orchestrator(budget_limit=0.2, budget_metric="total_cost")
-    orchestrator._trials = [_trial("t1", {"total_cost": 0.2})]
-
-    assert orchestrator._should_stop(trial_count=1)
-    assert orchestrator._stop_reason == "metric_limit"
-
-
-def test_legacy_budget_limit_without_metric_warns_about_cost_limit():
-    with pytest.warns(DeprecationWarning) as warnings_record:
-        orchestrator = _orchestrator(budget_limit=0.2)
-
-    warning_messages = [str(warning.message) for warning in warnings_record]
-    assert any("budget_limit is deprecated" in msg for msg in warning_messages)
-    assert any("money spend control, use cost_limit" in msg for msg in warning_messages)
-
-    orchestrator._trials = [_trial("t1", {"cost": 0.2})]
-    assert orchestrator._should_stop(trial_count=1)
-    assert orchestrator._stop_reason == "metric_limit"
-
-
-def test_metric_limit_conflicts_with_legacy_budget_limit():
-    with pytest.raises(ValueError, match="only one of metric_limit or budget_limit"):
-        _orchestrator(metric_limit=0.2, budget_limit=0.2, metric_name="tokens")
-
 
 def test_cost_enforcer_limit_maps_to_cost_limit(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")

--- a/tests/unit/core/test_trace_env.py
+++ b/tests/unit/core/test_trace_env.py
@@ -2,37 +2,16 @@
 
 from __future__ import annotations
 
-import pytest
-
-from traigent.core.trace_env import (
-    LEGACY_TRACES_ENABLED_ENV,
-    TRACE_ENABLED_ENV,
-    is_trace_enabled,
-)
+from traigent.core.trace_env import TRACE_ENABLED_ENV, is_trace_enabled
 
 
 def test_trace_enabled_canonical_only_is_honored() -> None:
     assert is_trace_enabled({TRACE_ENABLED_ENV: "true"}) is True
 
 
-def test_trace_enabled_alias_only_warns_and_is_honored() -> None:
-    with pytest.warns(DeprecationWarning, match=LEGACY_TRACES_ENABLED_ENV):
-        enabled = is_trace_enabled({LEGACY_TRACES_ENABLED_ENV: "true"})
-
-    assert enabled is True
-
-
-def test_trace_enabled_both_set_canonical_takes_precedence() -> None:
-    with pytest.warns(DeprecationWarning, match="ignored"):
-        enabled = is_trace_enabled(
-            {
-                TRACE_ENABLED_ENV: "false",
-                LEGACY_TRACES_ENABLED_ENV: "true",
-            }
-        )
-
-    assert enabled is False
-
-
-def test_trace_enabled_neither_set_defaults_off() -> None:
+def test_trace_enabled_not_set_defaults_off() -> None:
     assert is_trace_enabled({}) is False
+
+
+def test_trace_enabled_false_value_is_honored() -> None:
+    assert is_trace_enabled({TRACE_ENABLED_ENV: "false"}) is False

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -30,7 +30,7 @@ from traigent.analytics.cost_optimization import (
 from traigent.analytics.meta_learning import (
     AlgorithmSelector,
     AlgorithmType,
-    MetaLearningEngine,
+    HistoricalAnalyticsEngine,
     OptimizationHistory,
     OptimizationRecord,
     OptimizationStatus,
@@ -54,14 +54,14 @@ from traigent.analytics.scheduling import (
 )
 
 
-class TestMetaLearningEngine:
-    """Test meta-learning engine functionality."""
+class TestHistoricalAnalyticsEngine:
+    """Test historical analytics engine functionality."""
 
     def setup_method(self):
         """Setup test fixtures."""
         self.temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".jsonl")
         self.temp_file.close()
-        self.engine = MetaLearningEngine(storage_path=self.temp_file.name)
+        self.engine = HistoricalAnalyticsEngine(storage_path=self.temp_file.name)
 
     def teardown_method(self):
         """Clean up test fixtures."""

--- a/traigent/analytics/__init__.py
+++ b/traigent/analytics/__init__.py
@@ -33,7 +33,6 @@ try:
         CostOptimizationAI,
         HistoricalAnalyticsEngine,
         JobPriority,
-        MetaLearningEngine,
         OptimizationHistory,
         OptimizationStrategy,
         PerformanceForecaster,
@@ -89,7 +88,6 @@ except ImportError:
     from .meta_learning import (
         AlgorithmSelector,
         HistoricalAnalyticsEngine,
-        MetaLearningEngine,
         OptimizationHistory,
         PerformancePredictor,
     )
@@ -139,7 +137,6 @@ __all__ = [
     "NextStepsClient",
     # Historical analytics
     "HistoricalAnalyticsEngine",
-    "MetaLearningEngine",
     "OptimizationHistory",
     "AlgorithmSelector",
     "PerformancePredictor",

--- a/traigent/analytics/meta_learning.py
+++ b/traigent/analytics/meta_learning.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import statistics
 import threading
-import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -813,15 +812,3 @@ class HistoricalAnalyticsEngine:
             ),
             "functions_optimized": len({r.function_name for r in records}),
         }
-
-
-class MetaLearningEngine(HistoricalAnalyticsEngine):
-    """Deprecated compatibility alias for HistoricalAnalyticsEngine."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        warnings.warn(
-            "MetaLearningEngine is deprecated; use HistoricalAnalyticsEngine instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -43,7 +43,6 @@ Examples:
 from __future__ import annotations
 
 import inspect
-import warnings
 from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -460,9 +459,6 @@ _ALLOWED_RUNTIME_OVERRIDE_KEYS = frozenset(
         "metric_limit",
         "metric_name",
         "metric_include_pruned",
-        "budget_limit",
-        "budget_metric",
-        "budget_include_pruned",
         "plateau_window",
         "plateau_epsilon",
         "cost_limit",
@@ -803,33 +799,8 @@ def _extract_inline_params(
 def _normalize_runtime_override_aliases(
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
-    """Normalize deprecated runtime override aliases."""
-    if "strategy" not in overrides:
-        return dict(overrides)
-
-    normalized = dict(overrides)
-    strategy_value = normalized.pop("strategy")
-    existing_algorithm = normalized.get("algorithm")
-    if (
-        existing_algorithm is not None
-        and strategy_value is not None
-        and existing_algorithm != strategy_value
-    ):
-        raise TypeError(
-            "Conflicting optimization selector: received both "
-            f"'algorithm={existing_algorithm}' and 'strategy={strategy_value}'. "
-            "Use only 'algorithm'."
-        )
-
-    warnings.warn(
-        "'strategy' is deprecated; use 'algorithm' instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    normalized["algorithm"] = (
-        existing_algorithm if existing_algorithm is not None else strategy_value
-    )
-    return normalized
+    """Normalize runtime override keys."""
+    return dict(overrides)
 
 
 def _resolve_strategy_argument(
@@ -838,7 +809,7 @@ def _resolve_strategy_argument(
     strategy_params: Mapping[str, Any] | None,
     runtime_overrides: dict[str, Any],
 ) -> tuple[str | None, dict[str, Any]]:
-    """Split public ``strategy`` into preset selection or legacy algorithm alias."""
+    """Split public ``strategy`` into preset selection."""
     if strategy is None:
         if strategy_params is not None:
             normalize_strategy_preset(None, strategy_params)
@@ -847,22 +818,11 @@ def _resolve_strategy_argument(
     if is_strategy_preset_name(strategy) or strategy_params is not None:
         return strategy, runtime_overrides
 
-    normalized_overrides = dict(runtime_overrides)
-    existing_algorithm = normalized_overrides.get("algorithm")
-    if existing_algorithm is not None and existing_algorithm != strategy:
-        raise TypeError(
-            "Conflicting optimization selector: received both "
-            f"'algorithm={existing_algorithm}' and 'strategy={strategy}'. "
-            "Use only 'algorithm'."
-        )
-
-    warnings.warn(
-        "'strategy' as an optimizer selector is deprecated; use 'algorithm' instead.",
-        DeprecationWarning,
-        stacklevel=3,
+    raise ValueError(
+        f"Unknown strategy preset: {strategy!r}. "
+        "Use 'algorithm' to select an optimizer by name, or provide a valid "
+        "strategy preset name."
     )
-    normalized_overrides["algorithm"] = existing_algorithm or strategy
-    return None, normalized_overrides
 
 
 def _apply_strategy_preset_to_options(
@@ -1792,8 +1752,8 @@ def optimize(  # NOSONAR(S107)
             business-goal preset cannot silently override hand-set objectives.
         strategy: Optional advisory strategy preset name. Supported preset names
             are ``max_accuracy_then_cheapest_within_epsilon``,
-            ``quality_floor_min_cost``, and ``pareto_frontier``. Non-preset
-            values retain the deprecated optimizer-alias behavior.
+            ``quality_floor_min_cost``, and ``pareto_frontier``.
+            Use ``algorithm`` to select an optimizer by name.
         strategy_params: Typed parameters for the selected strategy preset.
             ``epsilon`` is required for
             ``max_accuracy_then_cheapest_within_epsilon`` and must be > 0 and
@@ -1903,10 +1863,7 @@ def optimize(  # NOSONAR(S107)
             **runtime_overrides: Stop-condition and budget knobs accepted by
                 the decorator. The currently supported keys are:
                 ``metric_limit``, ``metric_name``,
-                ``metric_include_pruned``,
-                ``budget_limit`` (deprecated alias for ``metric_limit``),
-                ``budget_metric``,
-                ``budget_include_pruned``, ``plateau_window``,
+                ``metric_include_pruned``, ``plateau_window``,
                 ``plateau_epsilon``, ``cost_limit``, ``cost_approved``,
                 ``tie_breakers``, and ``tvl_parameter_agents``.
                 Note: ``algorithm`` and ``max_trials`` are first-class

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -619,13 +619,21 @@ def collect_orchestrator_kwargs(
         "invocations_per_example": invocations_per_example,
     }
 
+    _removed_keys = frozenset(
+        ("budget_limit", "budget_metric", "budget_include_pruned")
+    )
+    invalid_keys = _removed_keys.intersection(algorithm_kwargs)
+    if invalid_keys:
+        raise TypeError(
+            f"Unknown keyword argument(s): {sorted(invalid_keys)}. "
+            "budget_limit/budget_metric/budget_include_pruned were removed in 0.13.0. "
+            "Use cost_limit=<value> and/or metric_limit=<value> with metric_name=<name> instead."
+        )
+
     optional_keys = [
         "metric_limit",
         "metric_name",
         "metric_include_pruned",
-        "budget_limit",
-        "budget_metric",
-        "budget_include_pruned",
         "plateau_window",
         "plateau_epsilon",
         "cost_limit",

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -850,11 +850,6 @@ class OptimizedFunction:
         return total
 
     @property
-    def config_space(self) -> dict[str, Any]:
-        """Backward compatibility property for configuration_space."""
-        return self.configuration_space
-
-    @property
     def objectives(self) -> list[str]:
         """Objective names derived from the active objective schema."""
         result: list[str] = schema_to_objective_names(self.objective_schema)

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -11,7 +11,6 @@ import math
 import sys
 import time
 import uuid
-import warnings
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -508,73 +507,22 @@ class OptimizationOrchestrator:
             raise ValueError(f"{name} must be a positive number")
         return limit
 
-    def _warn_deprecated_budget_limit(self) -> None:
-        warnings.warn(
-            "budget_limit is deprecated. Use metric_limit with metric_name for "
-            "soft cumulative metric stopping. For money spend, use cost_limit.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
     def _resolve_metric_limit_config(self) -> tuple[float | None, str | None, bool]:
-        """Resolve new metric_limit config plus deprecated budget_limit aliases."""
+        """Resolve metric_limit config."""
         raw_metric_limit = self.config.get("metric_limit")
-        raw_budget_limit = self.config.get("budget_limit")
-
-        if raw_metric_limit is not None and raw_budget_limit is not None:
-            raise ValueError("Specify only one of metric_limit or budget_limit")
-
-        metric_include_pruned = bool(
-            self.config.get(
-                "metric_include_pruned",
-                self.config.get("budget_include_pruned", True),
-            )
-        )
+        metric_include_pruned = bool(self.config.get("metric_include_pruned", True))
 
         if raw_metric_limit is not None:
             metric_name = self.config.get("metric_name")
-            if metric_name is None and "budget_metric" in self.config:
-                warnings.warn(
-                    "budget_metric is deprecated; use metric_name with metric_limit.",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
-                metric_name = self.config.get("budget_metric")
             if metric_name is None:
                 raise ValueError("metric_name is required when metric_limit is set")
-            if "budget_include_pruned" in self.config:
-                warnings.warn(
-                    "budget_include_pruned is deprecated; use metric_include_pruned.",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
             return (
                 self._coerce_positive_limit(raw_metric_limit, name="metric_limit"),
                 str(metric_name),
                 metric_include_pruned,
             )
 
-        if raw_budget_limit is None:
-            return (None, None, metric_include_pruned)
-
-        self._warn_deprecated_budget_limit()
-        metric_name = self.config.get("metric_name")
-        if metric_name is None:
-            metric_name = self.config.get("budget_metric")
-        if metric_name is None:
-            warnings.warn(
-                "budget_limit without metric_name defaults to total_cost for "
-                "compatibility. If this is money spend control, use cost_limit.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            metric_name = "total_cost"
-
-        return (
-            self._coerce_positive_limit(raw_budget_limit, name="budget_limit"),
-            str(metric_name),
-            metric_include_pruned,
-        )
+        return (None, None, metric_include_pruned)
 
     def _setup_convergence_condition(self) -> None:
         """Configure hypervolume-based convergence if specified in config."""

--- a/traigent/core/stop_conditions.py
+++ b/traigent/core/stop_conditions.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterable, Sequence
@@ -209,42 +208,6 @@ class MetricLimitStopCondition(StopCondition):
 
         self._last_index = len(trial_seq)
         return self._running_total >= self._limit
-
-
-class BudgetStopCondition(MetricLimitStopCondition):
-    """Deprecated alias for ``MetricLimitStopCondition``."""
-
-    def __init__(
-        self,
-        *,
-        budget: float,
-        metric_name: str | None = None,
-        include_pruned: bool = True,
-    ) -> None:
-        if metric_name is None:
-            warnings.warn(
-                "BudgetStopCondition and budget_limit are deprecated. "
-                "BudgetStopCondition without metric_name defaults to total_cost for "
-                "compatibility. If this is money spend control, use cost_limit; "
-                "otherwise use MetricLimitStopCondition(limit=..., metric_name=...) "
-                "or metric_limit with metric_name.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            metric_name = "total_cost"
-        else:
-            warnings.warn(
-                "BudgetStopCondition and budget_limit are deprecated for cumulative "
-                "metrics. Use MetricLimitStopCondition(limit=..., metric_name=...) "
-                "or metric_limit with metric_name. For money spend, use cost_limit.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        super().__init__(
-            limit=budget,
-            metric_name=metric_name,
-            include_pruned=include_pruned,
-        )
 
 
 class MaxSamplesStopCondition(StopCondition):
@@ -689,7 +652,6 @@ class HypervolumeConvergenceStopCondition(StopCondition):
 
 
 __all__ = [
-    "BudgetStopCondition",
     "CostLimitStopCondition",
     "HypervolumeConvergenceStopCondition",
     "MaxSamplesStopCondition",

--- a/traigent/core/trace_env.py
+++ b/traigent/core/trace_env.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import os
-import warnings
 from collections.abc import Mapping
 
 TRACE_ENABLED_ENV = "TRAIGENT_TRACE_ENABLED"
-LEGACY_TRACES_ENABLED_ENV = "TRAIGENT_TRACES_ENABLED"
 
 _TRUTHY_TRACE_VALUES = frozenset(("true", "1", "yes"))
 _FALSY_TRACE_VALUES = frozenset(("false", "0", "no"))
@@ -29,36 +27,17 @@ def is_trace_enabled(
 ) -> bool:
     """Return whether Traigent tracing is enabled by environment.
 
-    ``TRAIGENT_TRACE_ENABLED`` is canonical and always takes precedence.
-    ``TRAIGENT_TRACES_ENABLED`` is a deprecated alias that is honored only
-    when the canonical variable is unset.
+    ``TRAIGENT_TRACE_ENABLED`` is the canonical variable.
     """
     env = os.environ if environ is None else environ
     canonical_value = env.get(TRACE_ENABLED_ENV)
-    legacy_value = env.get(LEGACY_TRACES_ENABLED_ENV)
-
-    if legacy_value is not None:
-        if canonical_value is None:
-            message = (
-                f"{LEGACY_TRACES_ENABLED_ENV} is deprecated; use "
-                f"{TRACE_ENABLED_ENV} instead."
-            )
-        else:
-            message = (
-                f"{LEGACY_TRACES_ENABLED_ENV} is deprecated and ignored because "
-                f"{TRACE_ENABLED_ENV} is set."
-            )
-        warnings.warn(message, DeprecationWarning, stacklevel=2)
 
     if canonical_value is not None:
         return _parse_trace_enabled(canonical_value, default=default)
-    if legacy_value is not None:
-        return _parse_trace_enabled(legacy_value, default=default)
     return default
 
 
 __all__ = [
-    "LEGACY_TRACES_ENABLED_ENV",
     "TRACE_ENABLED_ENV",
     "is_trace_enabled",
 ]


### PR DESCRIPTION
## Summary

- Deletes `MetaLearningEngine` class from `traigent/analytics/meta_learning.py` and `plugins/traigent-analytics/traigent_analytics/meta_learning.py` — already a thin DeprecationWarning wrapper since v0.9.0
- Removes from `__all__` and imports in both `traigent/analytics/__init__.py` and `plugins/traigent-analytics/traigent_analytics/__init__.py`
- Updates `tests/unit/test_analytics.py` to use canonical `HistoricalAnalyticsEngine`

**Deferred:** `LegacyOptimizeArgs` — fields `cloud_fallback_policy` and `privacy_enabled` have no current `optimize()` equivalents after Wave 1/2 removals; removal requires a separate deprecation pass.

## PR checklist
1. Worst-case prod: DeprecationWarning wrapper was the prod path; deleting it forces callers to canonical class — safe
2. Production-branch test: N/A (no policy surface)
3. Contract regeneration: None required
4. Public surface delta: `MetaLearningEngine` removed from `__all__` in both packages
5. Review threads: will resolve on arrival
6. Quality gates: not relaxed

Spine-Trail: st_wave2sdk_metalearning

Spine-Trail: st_d9ee23e5a3a7