### PR TITLE
chore(sdk/wave3): remove benchmark_id deprecated param from discover_example_ids

### DIFF
--- a/tests/unit/evaluators/test_hybrid_api_evaluator.py
+++ b/tests/unit/evaluators/test_hybrid_api_evaluator.py
@@ -543,7 +543,7 @@ class TestDiscoverExampleIds:
     async def test_discover_example_ids_multiple_benchmarks_with_explicit_id(
         self, evaluator: HybridAPIEvaluator, mock_transport: MagicMock
     ) -> None:
-        """Selects correct benchmark when benchmark_id is provided explicitly."""
+        """Selects correct dataset when dataset_id is provided explicitly."""
         from traigent.hybrid.protocol import BenchmarkEntry, BenchmarksResponse
 
         mock_transport.benchmarks = AsyncMock(
@@ -564,8 +564,7 @@ class TestDiscoverExampleIds:
             )
         )
 
-        with pytest.warns(DeprecationWarning, match="benchmark_id is deprecated"):
-            ids = await evaluator.discover_example_ids(benchmark_id="bench_002")
+        ids = await evaluator.discover_example_ids(dataset_id="bench_002")
 
         assert ids == ["c", "d", "e"]
         assert evaluator._benchmark_id == "bench_002"

--- a/traigent/evaluators/hybrid_api.py
+++ b/traigent/evaluators/hybrid_api.py
@@ -13,7 +13,6 @@ import asyncio
 import os
 import statistics
 import time
-import warnings
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -293,7 +292,6 @@ class HybridAPIEvaluator(BaseEvaluator):
         tunable_id: str | None = None,
         *,
         dataset_id: str | None = None,
-        benchmark_id: str | None = None,
     ) -> list[str]:
         """Discover available example IDs from the external service.
 
@@ -305,7 +303,6 @@ class HybridAPIEvaluator(BaseEvaluator):
                 Falls back to self._tunable_id if not provided.
             dataset_id: Explicit dataset to use. Required when
                 multiple datasets match the tunable.
-            benchmark_id: Deprecated alias for ``dataset_id``.
 
         Returns:
             List of example IDs from the selected dataset.
@@ -324,13 +321,7 @@ class HybridAPIEvaluator(BaseEvaluator):
 
         transport = await self._get_transport()
         resp: BenchmarksResponse = await transport.benchmarks(tunable_id=tid)
-        if benchmark_id is not None:
-            warnings.warn(
-                "benchmark_id is deprecated; use dataset_id instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        selected_dataset_id = dataset_id or benchmark_id
+        selected_dataset_id = dataset_id
 
         # Filter datasets where this tunable is linked
         matching: list[BenchmarkEntry] = [


### PR DESCRIPTION
## Wave 3 — Benchmark Sunset: SDK benchmark_id param removal

Removes the deprecated `benchmark_id` parameter alias from `HybridAPIEvaluator.discover_example_ids()`. Use `dataset_id` instead.

Wire-level `benchmark_id` keys in DTOs/protocol are **retained** — the backend still expects them for backward compatibility and they are not part of the public user API.

Spine-Trail: st_4aa1f3ec5b30

Follows Schema PR #182 (merged) which annotated `benchmark_id` as `x-deprecated`.

### Changes
- `traigent/evaluators/hybrid_api.py`: removed `benchmark_id` param + DeprecationWarning block + unused `import warnings`
- `tests/unit/evaluators/test_hybrid_api_evaluator.py`: updated test to use `dataset_id=` instead