### PR TITLE
chore(sdk/wave1): promote privacy alias warning to DeprecationWarning

### DIFF
--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -1225,9 +1225,13 @@ def _resolve_execution_mode_enum(
         raise ConfigurationError(str(exc)) from None
 
     if requested_privacy_alias:
-        logger.warning(
+        import warnings
+
+        warnings.warn(
             "execution_mode='privacy' is deprecated. Use execution_mode='hybrid' "
-            "with privacy_enabled=True. Mapping automatically."
+            "with privacy_enabled=True. Mapping automatically.",
+            DeprecationWarning,
+            stacklevel=8,
         )
         if privacy_enabled is None:
             privacy_enabled = True


### PR DESCRIPTION
## Wave 1-C Gap Closure

Spine-Trail: st_5519d50ccb21

### Gap
`execution_mode='privacy'` used `logger.warning()` instead of `warnings.warn(..., DeprecationWarning)`. Users couldn't catch this with the standard Python warnings machinery.

### Fix
Single call site in `_resolve_execution_mode_enum()` changed from `logger.warning` to `warnings.warn(DeprecationWarning)`.

### Note
`cloud_fallback_policy` already had proper `DeprecationWarning` in `optimized_function.py` — no change needed there.