### PR TITLE
fix(cli): auth status recognizes TRAIGENT_API_KEY env-var (#1322)

### DIFF
--- a/tests/unit/cli/test_auth_status_command.py
+++ b/tests/unit/cli/test_auth_status_command.py
@@ -22,9 +22,13 @@ def cli() -> TraigentAuthCLI:
 
 def test_status_env_api_key_no_stored_creds(cli, monkeypatch):
     """status() returns True when TRAIGENT_API_KEY is set and no stored creds exist."""
-    monkeypatch.setenv("TRAIGENT_API_KEY", "trgnt-sk-test12345678-abcd")  # pragma: allowlist secret
-    with patch.object(cli, "_load_stored_credentials", return_value=None), \
-         patch("traigent.cli.auth_commands.console"):
+    monkeypatch.setenv(
+        "TRAIGENT_API_KEY", "trgnt-sk-test12345678-abcd"
+    )  # pragma: allowlist secret
+    with (
+        patch.object(cli, "_load_stored_credentials", return_value=None),
+        patch("traigent.cli.auth_commands.console"),
+    ):
         result = cli.status()
     assert result is True
 
@@ -32,21 +36,27 @@ def test_status_env_api_key_no_stored_creds(cli, monkeypatch):
 def test_status_no_creds_no_env_var(cli, monkeypatch):
     """status() returns False when neither stored creds nor env var exist."""
     monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
-    with patch.object(cli, "_load_stored_credentials", return_value=None), \
-         patch("traigent.cli.auth_commands.console"):
+    with (
+        patch.object(cli, "_load_stored_credentials", return_value=None),
+        patch("traigent.cli.auth_commands.console"),
+    ):
         result = cli.status()
     assert result is False
 
 
 def test_status_stored_creds_take_precedence(cli, monkeypatch):
     """status() returns True from stored creds (env var also present, both OK)."""
-    monkeypatch.setenv("TRAIGENT_API_KEY", "trgnt-sk-test12345678-abcd")  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "TRAIGENT_API_KEY", "trgnt-sk-test12345678-abcd"
+    )  # pragma: allowlist secret
     stored = {
         "user": {"email": "u@example.com", "id": 1},
         "api_key": "stored-key",  # pragma: allowlist secret
         "backend_url": "http://localhost",
     }
-    with patch.object(cli, "_load_stored_credentials", return_value=stored), \
-         patch("traigent.cli.auth_commands.console"):
+    with (
+        patch.object(cli, "_load_stored_credentials", return_value=stored),
+        patch("traigent.cli.auth_commands.console"),
+    ):
         result = cli.status()
     assert result is True

--- a/tests/unit/cli/test_auth_status_command.py
+++ b/tests/unit/cli/test_auth_status_command.py
@@ -1,0 +1,52 @@
+"""Tests for traigent auth status — env-var credential recognition.
+
+Regression for #1322: auth status reported "Not authenticated" even when
+TRAIGENT_API_KEY was set in the environment.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from traigent.cli.auth_commands import TraigentAuthCLI
+
+
+@pytest.fixture()
+def cli() -> TraigentAuthCLI:
+    obj = TraigentAuthCLI.__new__(TraigentAuthCLI)
+    obj.backend_url = "https://api.traigent.com"
+    return obj
+
+
+def test_status_env_api_key_no_stored_creds(cli, monkeypatch):
+    """status() returns True when TRAIGENT_API_KEY is set and no stored creds exist."""
+    monkeypatch.setenv("TRAIGENT_API_KEY", "trgnt-sk-test12345678-abcd")  # pragma: allowlist secret
+    with patch.object(cli, "_load_stored_credentials", return_value=None), \
+         patch("traigent.cli.auth_commands.console"):
+        result = cli.status()
+    assert result is True
+
+
+def test_status_no_creds_no_env_var(cli, monkeypatch):
+    """status() returns False when neither stored creds nor env var exist."""
+    monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+    with patch.object(cli, "_load_stored_credentials", return_value=None), \
+         patch("traigent.cli.auth_commands.console"):
+        result = cli.status()
+    assert result is False
+
+
+def test_status_stored_creds_take_precedence(cli, monkeypatch):
+    """status() returns True from stored creds (env var also present, both OK)."""
+    monkeypatch.setenv("TRAIGENT_API_KEY", "trgnt-sk-test12345678-abcd")  # pragma: allowlist secret
+    stored = {
+        "user": {"email": "u@example.com", "id": 1},
+        "api_key": "stored-key",  # pragma: allowlist secret
+        "backend_url": "http://localhost",
+    }
+    with patch.object(cli, "_load_stored_credentials", return_value=stored), \
+         patch("traigent.cli.auth_commands.console"):
+        result = cli.status()
+    assert result is True

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -1372,6 +1372,24 @@ class TraigentAuthCLI:
         creds = self._load_stored_credentials()
 
         if not creds:
+            env_api_key = os.environ.get("TRAIGENT_API_KEY")
+            if env_api_key:
+                env_table = Table(show_header=False, box=None)
+                env_table.add_column("Field", style="cyan")
+                env_table.add_column("Value")
+                env_table.add_row(
+                    "Status", "[green]✅ Authenticated (environment variable)[/green]"
+                )
+                masked = (
+                    f"{env_api_key[:10]}...{env_api_key[-4:]}"
+                    if len(env_api_key) > 14
+                    else "***"
+                )
+                env_table.add_row("TRAIGENT_API_KEY", masked)
+                env_table.add_row("Backend", self.backend_url)
+                console.print(env_table)
+                console.print()
+                return True
             console.print("[yellow]❌ Not authenticated[/yellow]")
             console.print("\nRun [cyan]traigent auth login[/cyan] to authenticate.\n")
             return False


### PR DESCRIPTION
Fixes #1322

`traigent auth status` now displays `Authenticated (environment variable)` and returns exit 0 when `TRAIGENT_API_KEY` is set and no stored credentials exist. Previously it always reported "Not authenticated" when the credentials file was absent, even if the key was actively being used at runtime.

**Change:** `TraigentAuthCLI.status()` checks `os.environ.get("TRAIGENT_API_KEY")` before returning False. Shows a masked key + backend URL table row, consistent with the stored-credentials display.

**Tests:** 3 new unit tests covering env-var-only auth, no-creds path, and stored-creds-take-precedence.

Spine-Trail: st_022862a3999f