### PR TITLE
fix(optimization): coerce numpy int64 in config-hash and trial-ID paths (#1316)

### DIFF
--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -1071,7 +1071,9 @@ class TrialOperations:
         Returns:
             Unique trial ID
         """
-        # Create a deterministic hash from session and config
-        config_str = json.dumps(config, sort_keys=True)
+        # Create a deterministic hash from session and config.
+        # Sanitize first so numpy scalars (e.g. np.int64 from Optuna suggest_int)
+        # don't crash json.dumps — same coercion as _sanitize_for_json.
+        config_str = json.dumps(self._sanitize_for_json(config), sort_keys=True)
         hash_input = f"{session_id}:{config_str}"
         return hashlib.sha256(hash_input.encode()).hexdigest()[:16]

--- a/traigent/storage/local_storage.py
+++ b/traigent/storage/local_storage.py
@@ -894,6 +894,10 @@ class LocalStorageManager:
         Returns:
             Normalized value with floats rounded and dicts sorted
         """
+        from traigent.utils.numpy_compat import convert_numpy_value, is_numpy_type
+
+        if is_numpy_type(value):
+            return self._normalize_config(convert_numpy_value(value))
         if isinstance(value, float):
             # Round floats to 8 decimal places for consistency
             return round(value, 8)


### PR DESCRIPTION
Fixes #1316

Optuna `suggest_int` returns `np.int64` for integer knobs. Two `json.dumps` call sites outside the main `best_config_runtime` path had no numpy coercion:
- `local_storage._normalize_config` now delegates to `numpy_compat` before recursing
- `trial_operations._generate_trial_id` now uses `_sanitize_for_json` before `json.dumps`

The main `BestConfigSnapshot` path was already fixed in #1303; this closes remaining ancillary gaps.

Spine-Trail: st_caebce89fc61