### PR TITLE
fix(optimization): warn when custom_evaluator omits objective metric (#1318)

### DIFF
--- a/tests/unit/api/test_types_advanced.py
+++ b/tests/unit/api/test_types_advanced.py
@@ -856,7 +856,9 @@ class TestOptimizationResultNormalizationMethods:
         # Schema-aware path: ObjectiveSchema drives orientation + weights.
         schema = ObjectiveSchema.from_objectives(
             [
-                ObjectiveDefinition(name="accuracy", orientation="maximize", weight=1.0),
+                ObjectiveDefinition(
+                    name="accuracy", orientation="maximize", weight=1.0
+                ),
                 ObjectiveDefinition(name="cost", orientation="minimize", weight=1.0),
             ]
         )

--- a/tests/unit/api/test_types_advanced.py
+++ b/tests/unit/api/test_types_advanced.py
@@ -912,6 +912,42 @@ class TestOptimizationResultNormalizationMethods:
         # 0.8 * 0.7 + 0.6 * 0.3 = 0.56 + 0.18 = 0.74
         assert score == pytest.approx(0.74)
 
+    def test_normalize_trial_metrics_warns_when_objective_missing_from_evaluator(self):
+        """Regression for #1318: custom_evaluator omitting a named objective metric
+        silently defaults that objective's score to 0. A UserWarning must be emitted
+        so users know they need to return the metric explicitly."""
+        result = OptimizationResult(
+            trials=[],
+            best_config={},
+            best_score=None,
+            optimization_id="opt_warn",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy", "cost", "latency"],
+            algorithm="bayesian",
+            timestamp=datetime.now(),
+        )
+        trial = TrialResult(
+            trial_id="t1",
+            config={"model": "gpt-4o-mini"},
+            metrics={"accuracy": 0.9},  # cost + latency missing
+            status=TrialStatus.COMPLETED,
+            duration=1.0,
+            timestamp=datetime.now(),
+        )
+        ranges = {"accuracy": (0.0, 1.0), "cost": (0.0, 1.0), "latency": (0.0, 1.0)}
+
+        with pytest.warns(UserWarning, match="Objective 'cost'"):
+            result._normalize_trial_metrics(trial, ranges, [], None)
+
+        # Both missing objectives should warn (one warn call each)
+        with pytest.warns(UserWarning) as record:
+            result._normalize_trial_metrics(trial, ranges, [], None)
+        warning_texts = [str(w.message) for w in record]
+        assert any("cost" in t for t in warning_texts)
+        assert any("latency" in t for t in warning_texts)
+
 
 class TestOptimizationResultHelperMethods:
     """Test various helper methods in OptimizationResult."""

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 import json
 import traceback as traceback_module
+import warnings
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -1257,7 +1258,17 @@ class OptimizationResult:
         minimize_lookup = set(minimize_objectives)
 
         for obj in self.objectives:
-            if obj not in trial.metrics or obj not in ranges:
+            if obj not in trial.metrics:
+                warnings.warn(
+                    f"Objective '{obj}' was not found in the evaluator's returned metrics "
+                    f"(got: {sorted(trial.metrics)}). Its weighted score defaults to 0. "
+                    "Return it explicitly from your custom_evaluator, e.g. "
+                    f"return {{'accuracy': ..., '{obj}': ...}}.",
+                    UserWarning,
+                    stacklevel=4,
+                )
+                continue
+            if obj not in ranges:
                 continue
 
             min_val, max_val = ranges[obj]


### PR DESCRIPTION
Fixes #1318

When using \`custom_evaluator\` with weighted objectives (e.g. \`accuracy=0.8, cost=0.15, latency=0.05\`), metric names that the evaluator doesn't return silently defaulted to 0.0 — making multi-objective weighting degrade to accuracy-only with no indication.

**Fix:** \`_normalize_trial_metrics\` now emits \`UserWarning\` when a named objective is absent from the evaluator's returned metrics dict, naming the missing objective and directing users to return it explicitly.

Spine-Trail: st_2a32ba680f83