### PR TITLE
fix(cost): capture OpenRouter provider-reported cost from LiteLLM hidden params

### DIFF
--- a/tests/unit/evaluators/test_metrics_tracker.py
+++ b/tests/unit/evaluators/test_metrics_tracker.py
@@ -389,3 +389,184 @@ class TestExtractLLMMetrics:
         assert metrics.tokens.total_tokens == 0
         assert metrics.response.response_time_ms == 0.0
         assert metrics.cost.total_cost == 0.0
+
+
+class TestOpenRouterCostExtraction:
+    """Tests for OpenRouter provider-reported cost extraction (issue #1317).
+
+    OpenRouter passes the actual call cost in LiteLLM's
+    ``response._hidden_params['response_cost']`` and/or ``response.usage.cost``.
+    Models served via OpenRouter are often absent from LiteLLM's static pricing
+    table, so ``cost_from_tokens`` returns $0.00 for them.  The SDK must fall
+    back to the provider-reported cost from these fields.
+    """
+
+    def test_extract_cost_from_hidden_params_response_cost(self):
+        """Cost in _hidden_params['response_cost'] is captured (OpenRouter via LiteLLM)."""
+        from traigent.evaluators.metrics_tracker import (
+            GenericResponseHandler,
+        )
+
+        class MockUsage:
+            prompt_tokens = 200
+            completion_tokens = 100
+            total_tokens = 300
+
+        class MockHiddenParams(dict):
+            """Minimal LiteLLM HiddenParams stand-in (dict + .get())."""
+
+        hidden = MockHiddenParams(response_cost=0.00456)
+
+        class MockLiteLLMResponse:
+            model = "openrouter/meta-llama/llama-3.1-8b-instruct"
+            usage = MockUsage()
+            _hidden_params = hidden
+            response_time_ms = 0.0
+
+        # Use GenericResponseHandler directly so we exercise extract_metadata_cost
+        # without depending on which handler wins the chain.
+        handler = GenericResponseHandler()
+        cost = handler.extract_metadata_cost(MockLiteLLMResponse())
+
+        assert cost.total_cost == pytest.approx(0.00456), (
+            "extract_metadata_cost must return the provider-reported cost from "
+            "_hidden_params['response_cost'] when the standard cost field is absent"
+        )
+
+    def test_extract_cost_from_usage_cost_field(self):
+        """Cost in usage.cost is captured as a fallback (LiteLLM Usage object)."""
+        from traigent.evaluators.metrics_tracker import GenericResponseHandler
+
+        class MockUsage:
+            prompt_tokens = 150
+            completion_tokens = 75
+            total_tokens = 225
+            cost = 0.00789  # LiteLLM Usage.cost field
+
+        class MockLiteLLMResponse:
+            model = "openrouter/google/gemma-7b-it"
+            usage = MockUsage()
+            response_time_ms = 0.0
+
+        handler = GenericResponseHandler()
+        cost = handler.extract_metadata_cost(MockLiteLLMResponse())
+
+        assert cost.total_cost == pytest.approx(0.00789), (
+            "extract_metadata_cost must return the provider-reported cost from "
+            "usage.cost when _hidden_params is absent"
+        )
+
+    def test_hidden_params_takes_precedence_over_usage_cost(self):
+        """_hidden_params.response_cost takes precedence over usage.cost."""
+        from traigent.evaluators.metrics_tracker import GenericResponseHandler
+
+        class MockUsage:
+            prompt_tokens = 100
+            completion_tokens = 50
+            total_tokens = 150
+            cost = 0.0001  # Should be ignored — _hidden_params wins
+
+        class MockHiddenParams(dict):
+            pass
+
+        class MockLiteLLMResponse:
+            model = "openrouter/mistralai/mistral-7b-instruct"
+            usage = MockUsage()
+            _hidden_params = MockHiddenParams(response_cost=0.00222)
+            response_time_ms = 0.0
+
+        handler = GenericResponseHandler()
+        cost = handler.extract_metadata_cost(MockLiteLLMResponse())
+
+        assert cost.total_cost == pytest.approx(0.00222), (
+            "_hidden_params.response_cost must take precedence over usage.cost"
+        )
+
+    def test_zero_response_cost_falls_through_to_usage_cost(self):
+        """A zero response_cost in _hidden_params does not block usage.cost."""
+        from traigent.evaluators.metrics_tracker import GenericResponseHandler
+
+        class MockUsage:
+            prompt_tokens = 100
+            completion_tokens = 50
+            total_tokens = 150
+            cost = 0.00333
+
+        class MockHiddenParams(dict):
+            pass
+
+        class MockLiteLLMResponse:
+            model = "openrouter/openai/gpt-3.5-turbo"
+            usage = MockUsage()
+            _hidden_params = MockHiddenParams(response_cost=0.0)
+            response_time_ms = 0.0
+
+        handler = GenericResponseHandler()
+        cost = handler.extract_metadata_cost(MockLiteLLMResponse())
+
+        assert cost.total_cost == pytest.approx(0.00333), (
+            "A zero response_cost must be treated as absent so usage.cost is used"
+        )
+
+    def test_no_provider_cost_returns_zero(self):
+        """When neither _hidden_params nor usage.cost is set, cost stays 0."""
+        from traigent.evaluators.metrics_tracker import GenericResponseHandler
+
+        class MockUsage:
+            prompt_tokens = 100
+            completion_tokens = 50
+            total_tokens = 150
+
+        class MockLiteLLMResponse:
+            model = "openrouter/some-provider/some-model"
+            usage = MockUsage()
+            response_time_ms = 0.0
+
+        handler = GenericResponseHandler()
+        cost = handler.extract_metadata_cost(MockLiteLLMResponse())
+
+        assert cost.total_cost == 0.0
+
+    def test_extract_llm_metrics_picks_up_openrouter_cost(self, monkeypatch):
+        """End-to-end: extract_llm_metrics returns the provider-reported cost.
+
+        Simulates a model absent from LiteLLM's pricing table (strict=False
+        returns 0.0 from cost_from_tokens) but whose actual cost is in
+        _hidden_params['response_cost'].
+        """
+        monkeypatch.setenv("TRAIGENT_GENERATE_MOCKS", "")
+
+        class MockUsage:
+            prompt_tokens = 200
+            completion_tokens = 80
+            total_tokens = 280
+
+        class MockHiddenParams(dict):
+            pass
+
+        class MockLiteLLMOpenRouterResponse:
+            model = "openrouter/meta-llama/llama-3.1-8b-instruct"
+            usage = MockUsage()
+            _hidden_params = MockHiddenParams(response_cost=0.00099)
+            response_time_ms = 50.0
+
+        # Stub cost_from_tokens to simulate an unpriced model returning (0, 0).
+        # The function is imported lazily inside _compute_cost, so patch it at
+        # its definition site in cost_calculator.
+        monkeypatch.setattr(
+            "traigent.utils.cost_calculator.cost_from_tokens",
+            lambda *a, **kw: (0.0, 0.0),
+        )
+
+        metrics = extract_llm_metrics(
+            MockLiteLLMOpenRouterResponse(),
+            model_name="openrouter/meta-llama/llama-3.1-8b-instruct",
+        )
+
+        assert metrics.tokens.input_tokens == 200
+        assert metrics.tokens.output_tokens == 80
+        assert metrics.cost.total_cost == pytest.approx(0.00099), (
+            "extract_llm_metrics must report the OpenRouter provider-reported cost "
+            "from _hidden_params['response_cost'] even when the model is not in "
+            "LiteLLM's pricing table (issue #1317)"
+        )

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -853,10 +853,20 @@ class ResponseHandler(ABC):
         pass
 
     def extract_metadata_cost(self, response: Any) -> CostMetrics:
-        """Extract cost information from response metadata if available."""
+        """Extract cost information from response metadata if available.
+
+        Checks the following sources in order:
+        1. ``response.cost`` — generic cost attribute (dict or scalar).
+        2. ``response._hidden_params['response_cost']`` — LiteLLM sets this for
+           OpenRouter and other providers that return per-call cost directly.
+           OpenRouter models are often missing from LiteLLM's pricing table, so
+           their ``_hidden_params['response_cost']`` is the only reliable source.
+        3. ``response.usage.cost`` — LiteLLM's Usage object exposes ``cost`` when
+           the provider (e.g. OpenRouter) includes it in the usage block.
+        """
         cost_metrics = CostMetrics()
 
-        # Check for existing cost information in response
+        # 1. Generic ``response.cost`` attribute (dict or scalar).
         if hasattr(response, "cost"):
             try:
                 if isinstance(response.cost, dict):
@@ -867,6 +877,46 @@ class ResponseHandler(ABC):
                     cost_metrics.total_cost = float(response.cost)
             except (TypeError, ValueError) as e:
                 logger.debug(f"Failed to parse cost from response: {e}")
+
+        if cost_metrics.total_cost > 0.0:
+            return cost_metrics
+
+        # 2. LiteLLM hidden params — OpenRouter and other providers that report
+        #    per-call cost populate ``_hidden_params['response_cost']``.
+        hidden_params = getattr(response, "_hidden_params", None)
+        if hidden_params is not None:
+            try:
+                response_cost = (
+                    hidden_params.get("response_cost")
+                    if hasattr(hidden_params, "get")
+                    else getattr(hidden_params, "response_cost", None)
+                )
+                if isinstance(response_cost, (int, float)) and response_cost > 0:
+                    cost_metrics.total_cost = float(response_cost)
+                    logger.debug(
+                        "Extracted cost $%.6f from _hidden_params.response_cost "
+                        "(OpenRouter/LiteLLM provider-reported cost).",
+                        cost_metrics.total_cost,
+                    )
+                    return cost_metrics
+            except Exception as e:  # pragma: no cover
+                logger.debug(f"Failed to parse cost from _hidden_params: {e}")
+
+        # 3. LiteLLM Usage.cost field — set for some provider responses.
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            try:
+                usage_cost = getattr(usage, "cost", None)
+                if isinstance(usage_cost, (int, float)) and usage_cost > 0:
+                    cost_metrics.total_cost = float(usage_cost)
+                    logger.debug(
+                        "Extracted cost $%.6f from usage.cost "
+                        "(LiteLLM provider-reported cost).",
+                        cost_metrics.total_cost,
+                    )
+                    return cost_metrics
+            except Exception as e:  # pragma: no cover
+                logger.debug(f"Failed to parse cost from usage.cost: {e}")
 
         return cost_metrics
 


### PR DESCRIPTION
## Summary

- **Bug #1317**: OpenRouter always reports \$0.00 cost even when calls cost money.
- **Root cause**: Many OpenRouter models (e.g. `meta-llama/llama-3.1-8b-instruct`, free-tier models) are absent from LiteLLM's static pricing table, so `cost_from_tokens` returns `(0.0, 0.0)` for them. The actual per-call cost that OpenRouter reports is stored in `response._hidden_params['response_cost']` (set by LiteLLM) and `response.usage.cost`, but `ResponseHandler.extract_metadata_cost` never looked there.
- **Fix**: Extend `extract_metadata_cost` in `traigent/evaluators/metrics_tracker.py` to check (in priority order): `response._hidden_params['response_cost']` → `response.usage.cost` — both of which LiteLLM populates with the provider-reported cost for OpenRouter calls.
- **Test**: 6 unit tests added to `TestOpenRouterCostExtraction` covering each path and the end-to-end `extract_llm_metrics` flow with a stubbed `cost_from_tokens` returning `(0.0, 0.0)`.

## Changed files

- `traigent/evaluators/metrics_tracker.py` — `ResponseHandler.extract_metadata_cost`: add two new fallback sources after the existing `response.cost` check.
- `tests/unit/evaluators/test_metrics_tracker.py` — `TestOpenRouterCostExtraction` class with 6 tests.

## PR checklist

1. **Worst-case prod path**: cost extraction is read-only analytics; the fix adds new sources to check — a false positive would over-report cost (conservative), never under-report auth or billing in a security-sensitive sense.
2. **Production-branch test**: n/a — not a policy surface.
3. **Contract regeneration**: no schema/DTO changes.
4. **Public surface delta**: no public API changes.
5. **Review threads resolved**: n/a — new PR.
6. **Quality gates not relaxed**: no threshold changes.

Spine-Trail: st_71be32f2579d

🤖 Generated with [Claude Code](https://claude.com/claude-code)