### PR TITLE
fix(sync): sync real per-objective metrics instead of aliasing score

### DIFF
--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -126,7 +126,8 @@ class TestSyncManager:
 
         measures = results[0]["measures"]
         assert measures["score"] == 0.91
-        assert measures["accuracy"] == 0.91
+        # No "accuracy" alias when no all_metrics in metadata (bug #1319 fix)
+        assert "accuracy" not in measures
         assert measures["cost"] == 0.03
         assert measures["total_cost"] == 0.03
         assert measures["input_cost"] == 0.01
@@ -157,6 +158,46 @@ class TestSyncManager:
         assert measures["total_cost"] == 0.04
         assert measures["input_cost"] == 0.015
         assert measures["output_cost"] == 0.025
+
+    def test_convert_trials_real_per_objective_metrics_not_clobbered(
+        self, sync_manager: SyncManager
+    ) -> None:
+        """Real per-objective metrics (accuracy, latency) survive into measures.
+
+        Regression test for bug #1319: previously ``accuracy`` was aliased to the
+        composite ``score``, clobbering the actual accuracy metric recorded by the
+        evaluator.  Per-objective metrics are stored under
+        ``trial.metadata["all_metrics"]``; they must appear in the synced measures
+        at their real values and must not be overwritten by the composite score.
+        """
+        trial = TrialResult(
+            trial_id=1,
+            config={"model": "gpt-4", "temperature": 0.3},
+            score=0.7,
+            timestamp="2026-06-18T10:00:00Z",
+            metadata={
+                "all_metrics": {
+                    "accuracy": 0.85,
+                    "latency": 120.0,
+                }
+            },
+        )
+
+        results = sync_manager._convert_trials_to_results([trial])
+
+        measures = results[0]["measures"]
+        # Real accuracy from evaluator — must NOT be clobbered by composite score
+        assert measures["accuracy"] == 0.85, (
+            f"accuracy should be 0.85 (real metric), got {measures['accuracy']}"
+        )
+        # Latency should be synced as a first-class measure
+        assert measures["latency"] == 120.0, (
+            f"latency should be 120.0, got {measures.get('latency')}"
+        )
+        # Composite score is preserved for backward compatibility
+        assert measures["score"] == 0.7, (
+            f"composite score should be 0.7, got {measures['score']}"
+        )
 
     # Initialization Tests
 
@@ -505,7 +546,8 @@ class TestSyncManager:
         assert results[0]["trial_id"] == 1
         assert results[0]["experiment_parameters"]["model"] == "gpt-3.5-turbo"
         assert results[0]["measures"]["score"] == 0.85
-        assert results[0]["measures"]["accuracy"] == 0.85
+        # "accuracy" is no longer aliased from score (bug #1319 fix)
+        assert "accuracy" not in results[0]["measures"]
         assert results[0]["status"] == "completed"
         assert "error" not in results[0]
 

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -351,13 +351,25 @@ class SyncManager:
                 if value is not None
             }
 
+            # Build measures from real per-objective metrics first so that
+            # user-provided values (e.g. "accuracy", "latency") are never
+            # clobbered by the composite score alias.  Per-objective metrics
+            # are stored by the evaluator under metadata["all_metrics"].  Cost
+            # fields come last so they also don't overwrite objective metrics
+            # that happen to share a name with a cost field.
+            all_metrics: dict[str, Any] = (trial.metadata or {}).get(
+                "all_metrics"
+            ) or {}
+            trial_metrics = {
+                k: v for k, v in all_metrics.items() if self._is_numeric(v)
+            }
             result = {
                 "id": f"config_run_{trial.trial_id}",
                 "trial_id": trial.trial_id,
                 "experiment_parameters": trial.config,
                 "measures": {
+                    **trial_metrics,
                     "score": trial.score,
-                    "accuracy": trial.score,  # Map score to accuracy for compatibility
                     **cost_measures,
                 },
                 "timestamp": trial.timestamp,


### PR DESCRIPTION
## Summary

- `_convert_trials_to_results` previously set `"accuracy": trial.score`, clobbering the user's actual accuracy metric and silently dropping all other per-objective measures (e.g., `latency`, `f1`).
- Per-objective metrics are stored by the evaluator under `trial.metadata["all_metrics"]` (a `dict[str, float]`). The fix reads them from there and merges them first, followed by the composite `"score"` key (backward compat), then cost fields.
- No real metric can be overwritten; `"score"` is preserved for any portal code already consuming it.

## Test plan

- New regression test `test_convert_trials_real_per_objective_metrics_not_clobbered`: creates a trial with `metadata["all_metrics"] = {"accuracy": 0.85, "latency": 120.0}` and `score=0.7`; asserts `accuracy==0.85`, `latency==120.0`, `score==0.7`.
- Updated `test_convert_trials_to_results_includes_local_cost_measures` and `test_convert_trials_to_results` to no longer expect the old spurious `accuracy==score` alias.
- All 58 tests in `tests/unit/cloud/test_sync_manager.py` pass.

## Checklist

1. **Worst-case prod path**: if `metadata["all_metrics"]` is absent or non-dict, the dict comprehension yields empty and we fall back to only `score` + cost fields — no regression, fails closed.
2. **Production-branch test**: not a policy-surface change; no auth/tenant/billing paths touched.
3. **Contract regeneration**: no schema change; this is a local→cloud payload transform.
4. **Public surface delta**: no changes to `__all__`, routes, or OpenAPI paths.
5. **Quality gates not relaxed**: no thresholds changed.

Fixes #1319

Spine-Trail: st_b530a279dd11