### PR TITLE
fix(ux): improve invalid-key-format remedy in TRACKING UNAVAILABLE block (#1314)

### DIFF
--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -151,10 +151,19 @@ def _format_untracked_warning_block(
             "permission middleware that returned this structured response."
         )
     elif classification == SessionCreationFailureClassification.INVALID_OR_REVOKED_KEY:
-        lines.append(
-            "Remedy: re-authenticate with `traigent auth login` or provide a "
-            "valid, non-revoked API key."
-        )
+        raw = (result.failure_detail or "").lower()
+        if "invalid api key format" in raw or "invalid_api_key_format" in raw:
+            lines.append(
+                "Remedy: your API key does not match the expected format. "
+                "Portal keys start with 'uk_' (46 chars) or 'tg_' (64 chars). "
+                "Copy the full key from Settings → API Keys and set "
+                "TRAIGENT_API_KEY to that exact value."
+            )
+        else:
+            lines.append(
+                "Remedy: re-authenticate with `traigent auth login` or provide a "
+                "valid, non-revoked API key."
+            )
     elif classification == SessionCreationFailureClassification.KEY_NOT_FOUND:
         lines.append(
             "Remedy: configure a valid Traigent API key or run `traigent auth login`."


### PR DESCRIPTION
Fixes #1314

When an API key fails format validation, the SDK emits a 'TRAIGENT BACKEND TRACKING UNAVAILABLE' warning block. Previously the remedy for `invalid-or-revoked-key` said 're-authenticate with `traigent auth login`' — which is misleading when the key is structurally wrong (e.g., user pasted a JWT or truncated the key).

**Change:** when the raw failure reason contains "Invalid API key format", show a targeted remedy explaining the expected formats (`uk_` 46 chars, `tg_` 64 chars) and where to find the correct key.

No logic change to format validation itself — only the diagnostic message.

Spine-Trail: st_a480f939e498

🤖 Generated with [Claude Code](https://claude.ai/claude-code)