### PR TITLE
fix: prevent UnicodeEncodeError on Windows cp1252 consoles (#1321)

### DIFF
--- a/tests/unit/utils/test_callbacks.py
+++ b/tests/unit/utils/test_callbacks.py
@@ -2209,7 +2209,12 @@ class TestCallbackManagerTimeoutAndIsolation:
 
 
 class TestUnicodeOutputSafety:
-    """Regression tests for UnicodeEncodeError on non-UTF-8 consoles (issue #1321)."""
+    """Regression tests for UnicodeEncodeError on non-UTF-8 consoles (issue #1321).
+
+    These tests patch sys.stdout at the traigent.utils.callbacks module level so
+    that _safe_print reads the encoding from (and writes to) our fake cp1252 stream
+    even under pytest's default stdout-capture mode.
+    """
 
     class _Cp1252Stdout:
         """Simulates a Windows cp1252 console that raises UnicodeEncodeError for non-cp1252 chars."""
@@ -2232,8 +2237,14 @@ class TestUnicodeOutputSafety:
 
     @pytest.fixture()
     def cp1252_stdout(self, monkeypatch: pytest.MonkeyPatch) -> _Cp1252Stdout:
+        """Patch sys.stdout at both the module level and globally for reliable capture."""
         fake = self._Cp1252Stdout()
+        # Patch at both places so _safe_print's getattr(sys.stdout, "encoding") sees
+        # "cp1252" even when pytest is capturing FD-level output.
         monkeypatch.setattr("sys.stdout", fake)
+        import traigent.utils.callbacks as _cb_mod
+
+        monkeypatch.setattr(_cb_mod.sys, "stdout", fake)
         return fake
 
     def _make_result(self) -> OptimizationResult:
@@ -2283,29 +2294,55 @@ class TestUnicodeOutputSafety:
     def test_progress_bar_callback_safe_on_cp1252(
         self, cp1252_stdout: _Cp1252Stdout
     ) -> None:
-        """ProgressBarCallback must not raise UnicodeEncodeError on cp1252 consoles."""
-        cb = ProgressBarCallback(width=20, update_interval=0.0)
-        cb.on_optimization_start(
-            config_space={"model": ["gpt-4o", "gpt-4o-mini"]},
-            objectives=["accuracy"],
-            algorithm="grid",
+        """ProgressBarCallback must not raise UnicodeEncodeError on cp1252 consoles.
+
+        Patches sys at the traigent.utils.callbacks module level so that
+        _safe_print checks the fake cp1252 encoding and sanitizes output
+        before it reaches print().  The test passes if no UnicodeEncodeError
+        propagates; written content (post-fallback) must be cp1252-encodable.
+        """
+        import traigent.utils.callbacks as _cb_mod
+
+        cp1252_stdout._buf.clear()
+        # Patch sys inside the callbacks module so _safe_print sees our fake
+        import unittest.mock as _mock
+
+        with _mock.patch.object(_cb_mod, "sys") as mock_sys:
+            mock_sys.stdout = cp1252_stdout
+            cb = ProgressBarCallback(width=20, update_interval=0.0)
+            cb.on_optimization_start(
+                config_space={"model": ["gpt-4o", "gpt-4o-mini"]},
+                objectives=["accuracy"],
+                algorithm="grid",
+            )
+            cb.on_trial_complete(self._make_trial(), self._make_progress())
+            cb.on_optimization_complete(self._make_result())
+
+        # All output was cp1252-encodable (no UnicodeEncodeError raised above)
+        assert len(cp1252_stdout.written) > 0, (
+            "Expected some output from ProgressBarCallback"
         )
-        cb.on_trial_complete(self._make_trial(), self._make_progress())
-        cb.on_optimization_complete(self._make_result())
-        # No UnicodeEncodeError raised; output contains only cp1252-safe chars.
-        assert len(cp1252_stdout.written) > 0
 
     def test_verbose_callback_safe_on_cp1252(
         self, cp1252_stdout: _Cp1252Stdout
     ) -> None:
         """DetailedProgressCallback must not raise UnicodeEncodeError on cp1252 consoles."""
-        cb = DetailedProgressCallback(show_config_details=True, show_metrics=True)
-        cb.on_optimization_start(
-            config_space={"model": ["gpt-4o"], "temperature": [0.5, 0.7]},
-            objectives=["accuracy"],
-            algorithm="random",
+        import traigent.utils.callbacks as _cb_mod
+        import unittest.mock as _mock
+
+        cp1252_stdout._buf.clear()
+        with _mock.patch.object(_cb_mod, "sys") as mock_sys:
+            mock_sys.stdout = cp1252_stdout
+            cb = DetailedProgressCallback(show_config_details=True, show_metrics=True)
+            cb.on_optimization_start(
+                config_space={"model": ["gpt-4o"], "temperature": [0.5, 0.7]},
+                objectives=["accuracy"],
+                algorithm="random",
+            )
+            cb.on_trial_start(0, {"model": "gpt-4o", "temperature": 0.5})
+            cb.on_trial_complete(self._make_trial(), self._make_progress())
+            cb.on_optimization_complete(self._make_result())
+
+        assert len(cp1252_stdout.written) > 0, (
+            "Expected some output from DetailedProgressCallback"
         )
-        cb.on_trial_start(0, {"model": "gpt-4o", "temperature": 0.5})
-        cb.on_trial_complete(self._make_trial(), self._make_progress())
-        cb.on_optimization_complete(self._make_result())
-        assert len(cp1252_stdout.written) > 0

--- a/tests/unit/utils/test_callbacks.py
+++ b/tests/unit/utils/test_callbacks.py
@@ -2206,3 +2206,106 @@ class TestCallbackManagerTimeoutAndIsolation:
         mock_callback.on_trial_start.assert_called_once()
         mock_callback.on_trial_complete.assert_called_once()
         mock_callback.on_optimization_complete.assert_called_once()
+
+
+class TestUnicodeOutputSafety:
+    """Regression tests for UnicodeEncodeError on non-UTF-8 consoles (issue #1321)."""
+
+    class _Cp1252Stdout:
+        """Simulates a Windows cp1252 console that raises UnicodeEncodeError for non-cp1252 chars."""
+
+        def __init__(self) -> None:
+            self.encoding = "cp1252"
+            self._buf: list[str] = []
+
+        def write(self, s: str) -> int:
+            s.encode("cp1252")  # raises UnicodeEncodeError for chars outside cp1252
+            self._buf.append(s)
+            return len(s)
+
+        def flush(self) -> None:
+            pass
+
+        @property
+        def written(self) -> str:
+            return "".join(self._buf)
+
+    @pytest.fixture()
+    def cp1252_stdout(self, monkeypatch: pytest.MonkeyPatch) -> _Cp1252Stdout:
+        fake = self._Cp1252Stdout()
+        monkeypatch.setattr("sys.stdout", fake)
+        return fake
+
+    def _make_result(self) -> OptimizationResult:
+        from datetime import UTC, datetime
+
+        return OptimizationResult(
+            trials=[],
+            best_config={"model": "gpt-4o", "temperature": 0.7},
+            best_score=0.92,
+            optimization_id="opt_1321",
+            duration=12.3,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="grid",
+            timestamp=datetime.now(UTC),
+        )
+
+    def _make_progress(self) -> ProgressInfo:
+        return ProgressInfo(
+            current_trial=1,
+            total_trials=5,
+            completed_trials=1,
+            successful_trials=1,
+            failed_trials=0,
+            best_score=0.85,
+            best_config={"model": "gpt-4o"},
+            elapsed_time=2.0,
+            estimated_remaining=8.0,
+            current_algorithm="grid",
+        )
+
+    def _make_trial(self, status: TrialStatus | None = None) -> TrialResult:
+        from datetime import UTC, datetime
+
+        from traigent.api.types import TrialStatus as TS
+
+        return TrialResult(
+            trial_id="trial_1321",
+            config={"model": "gpt-4o", "temperature": 0.7},
+            metrics={"accuracy": 0.85},
+            status=status or TS.COMPLETED,
+            duration=1.2,
+            timestamp=datetime.now(UTC),
+        )
+
+    def test_progress_bar_callback_safe_on_cp1252(
+        self, cp1252_stdout: _Cp1252Stdout
+    ) -> None:
+        """ProgressBarCallback must not raise UnicodeEncodeError on cp1252 consoles."""
+        cb = ProgressBarCallback(width=20, update_interval=0.0)
+        cb.on_optimization_start(
+            config_space={"model": ["gpt-4o", "gpt-4o-mini"]},
+            objectives=["accuracy"],
+            algorithm="grid",
+        )
+        cb.on_trial_complete(self._make_trial(), self._make_progress())
+        cb.on_optimization_complete(self._make_result())
+        # No UnicodeEncodeError raised; output contains only cp1252-safe chars.
+        assert len(cp1252_stdout.written) > 0
+
+    def test_verbose_callback_safe_on_cp1252(
+        self, cp1252_stdout: _Cp1252Stdout
+    ) -> None:
+        """DetailedProgressCallback must not raise UnicodeEncodeError on cp1252 consoles."""
+        cb = DetailedProgressCallback(show_config_details=True, show_metrics=True)
+        cb.on_optimization_start(
+            config_space={"model": ["gpt-4o"], "temperature": [0.5, 0.7]},
+            objectives=["accuracy"],
+            algorithm="random",
+        )
+        cb.on_trial_start(0, {"model": "gpt-4o", "temperature": 0.5})
+        cb.on_trial_complete(self._make_trial(), self._make_progress())
+        cb.on_optimization_complete(self._make_result())
+        assert len(cp1252_stdout.written) > 0

--- a/tests/unit/utils/test_console_encoding.py
+++ b/tests/unit/utils/test_console_encoding.py
@@ -1,0 +1,345 @@
+"""Tests for safe console output on non-UTF-8 (e.g. Windows cp1252) consoles.
+
+Regression tests for issue #1321: UnicodeEncodeError when printing progress
+output on Windows systems with a cp1252 or other narrow-encoding console.
+"""
+
+# Traceability: CONC-Layer-Core CONC-Quality-Usability FUNC-API-ENTRY
+
+from __future__ import annotations
+
+import io
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from traigent.utils.callbacks import (
+    DetailedProgressCallback,
+    ProgressBarCallback,
+    ProgressInfo,
+    _safe_print,
+)
+from traigent.utils.console import _safe_print as console_safe_print
+from traigent.utils.console import configure_stdout_encoding
+from traigent.utils.diagnostics import DiagnosticReport
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _Cp1252StdOut:
+    """Simulates a Windows cp1252 console that rejects characters outside cp1252.
+
+    Characters outside cp1252 (e.g. box-drawing chars, emoji) will raise
+    ``UnicodeEncodeError`` on ``write()``, reproducing the Windows bug.
+    """
+
+    encoding = "cp1252"
+    errors = "strict"
+
+    def __init__(self) -> None:
+        self._buf: list[str] = []
+
+    def write(self, s: str) -> int:
+        # Encode with strict errors to reproduce the Windows crash
+        s.encode(self.encoding, errors=self.errors)
+        self._buf.append(s)
+        return len(s)
+
+    def flush(self) -> None:
+        pass
+
+    @property
+    def value(self) -> str:
+        return "".join(self._buf)
+
+
+def _make_progress(
+    completed: int = 1,
+    total: int = 3,
+    best_score: float | None = 0.85,
+) -> ProgressInfo:
+    return ProgressInfo(
+        current_trial=completed,
+        total_trials=total,
+        completed_trials=completed,
+        successful_trials=completed,
+        failed_trials=0,
+        best_score=best_score,
+        best_config={"model": "gpt-4o"},
+        elapsed_time=10.0,
+        estimated_remaining=20.0,
+        current_algorithm="grid",
+    )
+
+
+def _make_trial(status: str = "completed") -> Any:
+    """Return a minimal trial-like object."""
+
+    class _Trial:
+        def __init__(self) -> None:
+            self.status = status
+            self.metrics = {"accuracy": 0.87}
+            self.config = {"model": "gpt-4o", "temperature": 0.5}
+
+    return _Trial()
+
+
+def _make_result(
+    best_score: float | None = 0.87,
+    stop_reason: str | None = None,
+) -> Any:
+    """Return a minimal OptimizationResult-like object."""
+
+    class _Result:
+        def __init__(self) -> None:
+            self.best_score = best_score
+            self.best_config = {"model": "gpt-4o"}
+            self.duration = 30.0
+            self.success_rate = 1.0
+            self.stop_reason = stop_reason
+            self.status = "completed"
+            self.run_label = "run-1"
+            self.cloud_url = None
+            self.metadata = {}
+            self.trials = None
+
+    return _Result()
+
+
+# ---------------------------------------------------------------------------
+# Tests for traigent.utils.console._safe_print
+# ---------------------------------------------------------------------------
+
+
+class TestConsoleSafePrint:
+    """_safe_print from traigent.utils.console must not raise on cp1252 stdout."""
+
+    def test_plain_ascii_passes_through(self, capsys: pytest.CaptureFixture) -> None:
+        """ASCII text is printed unchanged."""
+        console_safe_print("hello world")
+        captured = capsys.readouterr()
+        assert "hello world" in captured.out
+
+    def test_unicode_on_cp1252_does_not_raise(self) -> None:
+        """Unicode emoji/arrows must not raise UnicodeEncodeError on cp1252 console."""
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            # These chars are outside cp1252 and would crash a bare print()
+            console_safe_print("🚀 Starting optimization")
+            console_safe_print("✅ done ❌ failed ⏱️ time 🏆 best")
+            console_safe_print("▶️ trial 1/3 starting...")
+            console_safe_print("⚠️ Optimization stopped early")
+
+    def test_box_drawing_on_cp1252_does_not_raise(self) -> None:
+        """Box-drawing characters used in results_table must not raise."""
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            console_safe_print("┌─────┐")
+            console_safe_print("│ row │")
+            console_safe_print("└─────┘")
+            console_safe_print("★ best")
+
+    def test_star_char_on_cp1252_does_not_raise(self) -> None:
+        """The ★ best-trial marker must not raise on cp1252."""
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            console_safe_print("★ 2  gpt-4o  0.0  87.4%")
+
+    def test_flush_kwarg_accepted(self) -> None:
+        """flush=True should not cause an error."""
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            console_safe_print("flushed", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests for traigent.utils.callbacks._safe_print (defined in callbacks module)
+# ---------------------------------------------------------------------------
+
+
+class TestCallbacksSafePrint:
+    """The _safe_print in callbacks.py must also be robust."""
+
+    def test_emoji_on_cp1252_does_not_raise(self) -> None:
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            _safe_print("🚀 hello 📊 data ⚙️ config")
+
+    def test_sep_kwarg(self, capsys: pytest.CaptureFixture) -> None:
+        _safe_print("a", "b", "c", sep="-")
+        assert "a-b-c" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Tests for ProgressBarCallback on cp1252
+# ---------------------------------------------------------------------------
+
+
+class TestProgressBarCallbackEncoding:
+    """ProgressBarCallback output must not raise on cp1252 stdout (issue #1321)."""
+
+    def test_on_optimization_start_safe(self) -> None:
+        cb = ProgressBarCallback()
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_optimization_start(
+                config_space={"model": ["gpt-4o", "gpt-4o-mini"]},
+                objectives=["accuracy"],
+                algorithm="grid",
+            )
+
+    def test_on_trial_complete_progress_bar_safe(self) -> None:
+        cb = ProgressBarCallback(update_interval=0.0)
+        cb.start_time = 0.0
+        cb.last_update = 0.0
+        cb._config_space = {"model": ["gpt-4o"]}
+        cb._objectives = ["accuracy"]
+
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_trial_complete(_make_trial(), _make_progress())
+
+    def test_on_optimization_complete_safe(self) -> None:
+        cb = ProgressBarCallback()
+        cb._config_space = {"model": ["gpt-4o"]}
+        cb._objectives = ["accuracy"]
+
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_optimization_complete(_make_result())
+
+    def test_on_optimization_complete_timeout_safe(self) -> None:
+        cb = ProgressBarCallback()
+        cb._config_space = {}
+        cb._objectives = []
+
+        result = _make_result(stop_reason="timeout")
+        result.status = "cancelled"
+
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_optimization_complete(result)
+
+
+# ---------------------------------------------------------------------------
+# Tests for DetailedProgressCallback on cp1252
+# ---------------------------------------------------------------------------
+
+
+class TestDetailedProgressCallbackEncoding:
+    """DetailedProgressCallback output must not raise on cp1252 stdout."""
+
+    def test_on_optimization_start_safe(self) -> None:
+        cb = DetailedProgressCallback()
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_optimization_start(
+                config_space={"model": ["gpt-4o"], "temperature": [0.0, 0.5]},
+                objectives=["accuracy", "cost"],
+                algorithm="grid",
+            )
+
+    def test_on_trial_start_safe(self) -> None:
+        cb = DetailedProgressCallback(show_config_details=True)
+        cb.trial_count = 0
+        cb.total_trials = 3
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_trial_start(0, {"model": "gpt-4o", "temperature": 0.5})
+
+    def test_on_trial_complete_safe(self) -> None:
+        cb = DetailedProgressCallback(show_metrics=True)
+        cb.trial_count = 1
+        cb.total_trials = 3
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_trial_complete(_make_trial(), _make_progress())
+
+    def test_on_trial_complete_failed_trial_safe(self) -> None:
+        cb = DetailedProgressCallback()
+        cb.trial_count = 1
+        cb.total_trials = 3
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_trial_complete(_make_trial("failed"), _make_progress())
+
+    def test_on_optimization_complete_safe(self) -> None:
+        cb = DetailedProgressCallback()
+        cb.trial_count = 3
+        cb.total_trials = 3
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_optimization_complete(_make_result())
+
+    def test_on_optimization_complete_timeout_safe(self) -> None:
+        cb = DetailedProgressCallback()
+        result = _make_result(stop_reason="timeout")
+        result.status = "cancelled"
+        result.metadata = {"timeout": 60}
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            cb.on_optimization_complete(result)
+
+
+# ---------------------------------------------------------------------------
+# Tests for DiagnosticReport on cp1252
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticReportEncoding:
+    """DiagnosticReport.print_report() must not raise on cp1252 stdout."""
+
+    def test_print_report_safe_on_cp1252(self) -> None:
+        report = DiagnosticReport()
+        report.add_issue("SDK", "Backend unreachable", "Check your API key")
+        report.warnings.append({"category": "Config", "message": "Missing timeout"})
+        report.successes.append({"category": "Auth", "message": "Token valid"})
+        report.recommendations.append("Run traigent info for diagnostics")
+
+        fake_stdout = _Cp1252StdOut()
+        with patch("sys.stdout", fake_stdout):
+            report.print_report()
+
+
+# ---------------------------------------------------------------------------
+# Tests for configure_stdout_encoding()
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureStdoutEncoding:
+    """configure_stdout_encoding() should wrap stdout when encoding is narrow."""
+
+    def test_noop_when_already_utf8(self) -> None:
+        """If stdout is already UTF-8, configure_stdout_encoding is a no-op."""
+        original = sys.stdout
+        utf8_stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+        with patch("sys.stdout", utf8_stream):
+            configure_stdout_encoding()
+            # Should not have replaced the stream
+            assert sys.stdout is utf8_stream
+        assert sys.stdout is original
+
+    def test_noop_when_no_buffer(self) -> None:
+        """If stdout has no .buffer (e.g. StringIO), configure_stdout_encoding is a no-op."""
+        original = sys.stdout
+        string_io = io.StringIO()
+        with patch("sys.stdout", string_io):
+            configure_stdout_encoding()
+            assert sys.stdout is string_io
+        assert sys.stdout is original
+
+    def test_wraps_narrow_encoding(self) -> None:
+        """If stdout uses a narrow encoding, it should be replaced with UTF-8 wrapper."""
+        buf = io.BytesIO()
+        narrow_stream = io.TextIOWrapper(buf, encoding="cp1252")
+
+        with patch("sys.stdout", narrow_stream):
+            configure_stdout_encoding()
+            assert sys.stdout is not narrow_stream
+            new_encoding = getattr(sys.stdout, "encoding", "")
+            assert new_encoding.lower().replace("-", "") in ("utf8", "utf-8")

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -38,6 +38,7 @@ from traigent.evaluators import (
     recommend_metrics,
 )
 from traigent.utils.logging import setup_logging
+from traigent.utils.console import configure_stdout_encoding
 from traigent.utils.persistence import PersistenceManager
 from traigent.utils.secure_path import (
     PathTraversalError,
@@ -410,6 +411,10 @@ def cli(verbose: bool, debug: bool, quiet: bool) -> None:
         traigent --verbose info    # Verbose output
         traigent --quiet info      # Suppress logs
     """
+    # Wrap stdout with UTF-8 encoding on Windows consoles that default to
+    # narrow encodings (e.g. cp1252) to prevent UnicodeEncodeError from
+    # unicode progress/status characters (issue #1321).
+    configure_stdout_encoding()
     if quiet:
         setup_logging("ERROR")
     elif debug:

--- a/traigent/core/exception_handler.py
+++ b/traigent/core/exception_handler.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Protocol
 
 from traigent.utils.logging import get_logger
+from traigent.utils.console import _safe_print
 
 logger = get_logger(__name__)
 
@@ -165,27 +166,27 @@ class TerminalPausePrompt:
             return "stop"
 
         description = _CATEGORY_DESCRIPTIONS.get(category, str(error))
-        print(f"\n⚠️  Vendor error: {category.value}")
-        print(f"   {description}")
-        print(f"   Error: {error}")
+        _safe_print(f"\n⚠️  Vendor error: {category.value}")
+        _safe_print(f"   {description}")
+        _safe_print(f"   Error: {error}")
 
         # Insufficient funds is non-recoverable — stop immediately
         if category == VendorErrorCategory.INSUFFICIENT_FUNDS:
-            print()
-            print(
+            _safe_print()
+            _safe_print(
                 "Stopping optimization (insufficient funds cannot be resolved by retrying)."
             )
             return "stop"
 
-        print()
-        print("Options:")
-        print("  [r] Resume optimization")
-        print("  [s] Stop and return partial results")
+        _safe_print()
+        _safe_print("Options:")
+        _safe_print("  [r] Resume optimization")
+        _safe_print("  [s] Stop and return partial results")
 
         try:
             choice = input("\nYour choice (r/s): ").strip().lower()
         except (EOFError, KeyboardInterrupt):
-            print()
+            _safe_print()
             return "stop"
 
         if choice in ("r", "resume"):
@@ -210,16 +211,16 @@ class TerminalPausePrompt:
             )
             return "stop"
 
-        print(f"\n💰 Budget limit reached: ${accumulated:.2f} / ${limit:.2f}")
-        print()
-        print("Options:")
-        print("  Enter a new limit (e.g. 5.0) to raise and continue")
-        print("  [s] Stop and return partial results")
+        _safe_print(f"\n💰 Budget limit reached: ${accumulated:.2f} / ${limit:.2f}")
+        _safe_print()
+        _safe_print("Options:")
+        _safe_print("  Enter a new limit (e.g. 5.0) to raise and continue")
+        _safe_print("  [s] Stop and return partial results")
 
         try:
             choice = input("\nNew limit or 's' to stop: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
-            print()
+            _safe_print()
             return "stop"
 
         if choice in ("s", "stop", ""):
@@ -228,14 +229,14 @@ class TerminalPausePrompt:
         try:
             new_limit = float(choice)
             if new_limit <= accumulated:
-                print(
+                _safe_print(
                     f"  New limit must be greater than current spend (${accumulated:.2f})"
                 )
                 return "stop"
             if not (0 < new_limit < float("inf")):
-                print("  Invalid amount. Stopping.")
+                _safe_print("  Invalid amount. Stopping.")
                 return "stop"
             return f"raise:{new_limit}"
         except ValueError:
-            print("  Invalid input. Stopping.")
+            _safe_print("  Invalid input. Stopping.")
             return "stop"

--- a/traigent/utils/callbacks.py
+++ b/traigent/utils/callbacks.py
@@ -51,10 +51,16 @@ def _safe_print(*args: Any, **kwargs: Any) -> None:
 
     Replaces characters that the current stdout encoding cannot represent with
     ASCII equivalents instead of raising UnicodeEncodeError.
+
+    Writes directly to ``sys.stdout`` (resolved at call time) so that test
+    fixtures that patch ``sys.stdout`` at the module level are respected.
     """
-    encoding = getattr(sys.stdout, "encoding", "utf-8") or "utf-8"
-    sep = kwargs.get("sep", " ")
-    text = sep.join(str(a) for a in args)
+    stream = sys.stdout
+    encoding = getattr(stream, "encoding", "utf-8") or "utf-8"
+    sep = str(kwargs.get("sep", " "))
+    end = str(kwargs.get("end", "\n"))
+    flush = bool(kwargs.get("flush", False))
+    text = sep.join(str(a) for a in args) + end
     try:
         text.encode(encoding)
     except (UnicodeEncodeError, LookupError):
@@ -64,8 +70,9 @@ def _safe_print(*args: Any, **kwargs: Any) -> None:
             text.encode(encoding)
         except (UnicodeEncodeError, LookupError):
             text = text.encode(encoding, errors="replace").decode(encoding)
-    kwargs.pop("sep", None)
-    print(text, **kwargs)
+    stream.write(text)
+    if flush:
+        stream.flush()
 
 
 CallbackInvocationKey = tuple[int, str]

--- a/traigent/utils/callbacks.py
+++ b/traigent/utils/callbacks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextvars
+import sys
 import threading
 import time
 import weakref
@@ -20,6 +21,52 @@ if TYPE_CHECKING:
     from ..api.types import OptimizationResult, TrialResult
 
 logger = get_logger(__name__)
+
+# Emoji/unicode chars used in progress output and their ASCII fallbacks.
+_UNICODE_FALLBACKS: dict[str, str] = {
+    "🚀": "[>]",
+    "📊": "[~]",
+    "⚙️": "[*]",
+    "✅": "[OK]",
+    "❌": "[!!]",
+    "⏱️": "[T]",
+    "🏆": "[best]",
+    "📈": "[%]",
+    "🛑": "[stop]",
+    "🔖": "[run]",
+    "🔗": "[url]",
+    "🎯": "[obj]",
+    "🔧": "[cfg]",
+    "▶️": "[>]",
+    "⚠️": "[WARN]",
+    "✨": "[**]",
+    "█": "#",
+    "░": "-",
+    "•": "*",
+}
+
+
+def _safe_print(*args: Any, **kwargs: Any) -> None:
+    """Print with graceful fallback for non-UTF-8 consoles (e.g. Windows cp1252).
+
+    Replaces characters that the current stdout encoding cannot represent with
+    ASCII equivalents instead of raising UnicodeEncodeError.
+    """
+    encoding = getattr(sys.stdout, "encoding", "utf-8") or "utf-8"
+    sep = kwargs.get("sep", " ")
+    text = sep.join(str(a) for a in args)
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        for uni, asc in _UNICODE_FALLBACKS.items():
+            text = text.replace(uni, asc)
+        try:
+            text.encode(encoding)
+        except (UnicodeEncodeError, LookupError):
+            text = text.encode(encoding, errors="replace").decode(encoding)
+    kwargs.pop("sep", None)
+    print(text, **kwargs)
+
 
 CallbackInvocationKey = tuple[int, str]
 
@@ -134,10 +181,10 @@ class ProgressBarCallback(OptimizationCallback):
         self._objectives = list(objectives)
         # Note: ProgressBarCallback uses print for interactive console output
         # This is intentional for user-facing progress display
-        print(f"🚀 Starting optimization with {algorithm}")
-        print(f"📊 Objectives: {', '.join(objectives)}")
-        print(f"⚙️  Configuration space: {len(config_space)} parameters")
-        print()
+        _safe_print(f"🚀 Starting optimization with {algorithm}")
+        _safe_print(f"📊 Objectives: {', '.join(objectives)}")
+        _safe_print(f"⚙️  Configuration space: {len(config_space)} parameters")
+        _safe_print()
 
     def on_trial_start(self, trial_number: int, config: dict[str, Any]) -> None:
         """Called when a trial starts."""
@@ -169,7 +216,7 @@ class ProgressBarCallback(OptimizationCallback):
         )
 
         # Print progress line - using print for interactive console output
-        print(
+        _safe_print(
             f"\r[{bar}] {progress.progress_percent:5.1f}% "
             f"({progress.completed_trials}/{progress.total_trials}) "
             f"✅ {progress.successful_trials} "
@@ -195,7 +242,7 @@ class ProgressBarCallback(OptimizationCallback):
             )
             total = self._last_progress.total_trials
             # Using print for final progress display output
-            print(
+            _safe_print(
                 f"\r[{bar}] 100.0% "
                 f"({total}/{total}) "
                 f"✅ {self._last_progress.successful_trials} "
@@ -205,35 +252,35 @@ class ProgressBarCallback(OptimizationCallback):
                 flush=True,
             )
 
-        print("\n")
+        _safe_print("\n")
         if result.stop_reason == "timeout" or result.status == "cancelled":
             timeout_value = None
             if isinstance(result.metadata, dict):
                 timeout_value = result.metadata.get("timeout")
             timeout_hint = f" ({timeout_value}s)" if timeout_value else ""
-            print(f"⚠️ Optimization stopped early: timeout reached{timeout_hint}.")
+            _safe_print(f"⚠️ Optimization stopped early: timeout reached{timeout_hint}.")
         else:
-            print("✅ Optimization complete!")
+            _safe_print("✅ Optimization complete!")
         best_score_str = (
             f"{result.best_score:.3f}" if result.best_score is not None else "N/A"
         )
-        print(f"🏆 Best score: {best_score_str}")
-        print(f"⏱️  Total time: {result.duration:.1f}s")
-        print(f"📈 Success rate: {result.success_rate:.1%}")
+        _safe_print(f"🏆 Best score: {best_score_str}")
+        _safe_print(f"⏱️  Total time: {result.duration:.1f}s")
+        _safe_print(f"📈 Success rate: {result.success_rate:.1%}")
 
         if result.stop_reason and result.stop_reason != "timeout":
-            print(f"🛑 Stop reason: {result.stop_reason}")
+            _safe_print(f"🛑 Stop reason: {result.stop_reason}")
 
         if result.run_label:
-            print(f"🔖 Run: {result.run_label}")
+            _safe_print(f"🔖 Run: {result.run_label}")
         if result.cloud_url:
-            print(f"🔗 View: {result.cloud_url}")
+            _safe_print(f"🔗 View: {result.cloud_url}")
         elif (
             result.run_label
             and isinstance(result.metadata, dict)
             and result.metadata.get("offline_mode")
         ):
-            print("   Run locally — sync to cloud with `traigent sync`")
+            _safe_print("   Run locally — sync to cloud with `traigent sync`")
 
         self._print_results_table(result)
 
@@ -258,7 +305,7 @@ class ProgressBarCallback(OptimizationCallback):
                 metric_overrides=metric_overrides,
             )
             if self._table_footer_note:
-                print(self._table_footer_note)
+                _safe_print(self._table_footer_note)
         except Exception as exc:
             logger.warning("Failed to render results table: %s", exc)
 
@@ -321,7 +368,7 @@ class ResultsTableCallback(OptimizationCallback):
                 metric_overrides=metric_overrides,
             )
             if self._table_footer_note:
-                print(self._table_footer_note)
+                _safe_print(self._table_footer_note)
         except Exception as exc:
             logger.warning("Failed to render results table: %s", exc)
 
@@ -980,23 +1027,23 @@ class DetailedProgressCallback(OptimizationCallback):
         else:
             self.total_trials = total
 
-        print("\n" + "=" * 60)
-        print("🚀 OPTIMIZATION STARTING")
-        print("=" * 60)
-        print(f"📊 Algorithm: {algorithm}")
-        print(f"🎯 Objectives: {', '.join(objectives)}")
-        print("🔧 Configuration Space:")
+        _safe_print("\n" + "=" * 60)
+        _safe_print("🚀 OPTIMIZATION STARTING")
+        _safe_print("=" * 60)
+        _safe_print(f"📊 Algorithm: {algorithm}")
+        _safe_print(f"🎯 Objectives: {', '.join(objectives)}")
+        _safe_print("🔧 Configuration Space:")
 
         for param, values in config_space.items():
-            print(f"   • {param}: {values}")
+            _safe_print(f"   • {param}: {values}")
 
         if self.total_trials > 0:
-            print(f"\n📈 Total configurations to test: {self.total_trials}")
+            _safe_print(f"\n📈 Total configurations to test: {self.total_trials}")
         else:
-            print(
+            _safe_print(
                 "\n📈 Total configurations to test: unknown (will infer from observed trials)"
             )
-        print("-" * 60 + "\n")
+        _safe_print("-" * 60 + "\n")
 
     def on_trial_start(self, trial_number: int, config: dict[str, Any]) -> None:
         """Called when a trial starts."""
@@ -1004,15 +1051,15 @@ class DetailedProgressCallback(OptimizationCallback):
         self.configs_tested.append(config)
 
         total_display = self.total_trials if self.total_trials > 0 else "?"
-        print(f"▶️  Trial {self.trial_count}/{total_display} starting...")
+        _safe_print(f"▶️  Trial {self.trial_count}/{total_display} starting...")
 
         if self.show_config_details:
-            print("   Configuration:")
+            _safe_print("   Configuration:")
             for key, value in config.items():
                 if isinstance(value, float):
-                    print(f"     • {key}: {value:.2f}")
+                    _safe_print(f"     • {key}: {value:.2f}")
                 else:
-                    print(f"     • {key}: {value}")
+                    _safe_print(f"     • {key}: {value}")
 
     def on_trial_complete(self, trial: TrialResult, progress: ProgressInfo) -> None:
         """Called when a trial completes."""
@@ -1024,18 +1071,20 @@ class DetailedProgressCallback(OptimizationCallback):
         else:
             total_display_str = str(total_display)
 
-        print(f"{status_icon} Trial {self.trial_count}/{total_display_str} completed")
+        _safe_print(
+            f"{status_icon} Trial {self.trial_count}/{total_display_str} completed"
+        )
 
         if self.show_metrics and trial.metrics:
-            print("   Metrics:")
+            _safe_print("   Metrics:")
             for metric, value in trial.metrics.items():
                 if isinstance(value, float):
-                    print(f"     • {metric}: {value:.3f}")
+                    _safe_print(f"     • {metric}: {value:.3f}")
                 else:
-                    print(f"     • {metric}: {value}")
+                    _safe_print(f"     • {metric}: {value}")
 
         if progress.best_score is not None:
-            print(f"   🏆 Best score so far: {progress.best_score:.3f}")
+            _safe_print(f"   🏆 Best score so far: {progress.best_score:.3f}")
 
         # Progress bar
         denominator_candidates = [
@@ -1061,12 +1110,12 @@ class DetailedProgressCallback(OptimizationCallback):
         bar_length = 40
         filled = int(bar_length * percent / 100)
         bar = "█" * filled + "░" * (bar_length - filled)
-        print(f"   Progress: [{bar}] {percent:.0f}%")
-        print()
+        _safe_print(f"   Progress: [{bar}] {percent:.0f}%")
+        _safe_print()
 
     def _print_header(self, result: OptimizationResult) -> None:
         """Print the completion header."""
-        print("\n" + "=" * 60)
+        _safe_print("\n" + "=" * 60)
         is_early_stop = result.stop_reason == "timeout" or result.status == "cancelled"
         if is_early_stop:
             timeout_value = (
@@ -1075,49 +1124,49 @@ class DetailedProgressCallback(OptimizationCallback):
                 else None
             )
             timeout_hint = f" ({timeout_value}s)" if timeout_value else ""
-            print(f"⚠️ OPTIMIZATION STOPPED EARLY: TIMEOUT REACHED{timeout_hint}")
+            _safe_print(f"⚠️ OPTIMIZATION STOPPED EARLY: TIMEOUT REACHED{timeout_hint}")
         else:
-            print("✨ OPTIMIZATION COMPLETE!")
-        print("=" * 60)
+            _safe_print("✨ OPTIMIZATION COMPLETE!")
+        _safe_print("=" * 60)
 
     def _print_config(self, config: dict[str, Any]) -> None:
         """Print the best configuration."""
-        print("⚙️  Best Configuration:")
+        _safe_print("⚙️  Best Configuration:")
         for key, value in config.items():
             formatted = f"{value:.2f}" if isinstance(value, float) else str(value)
-            print(f"   • {key}: {formatted}")
+            _safe_print(f"   • {key}: {formatted}")
 
     def on_optimization_complete(self, result: OptimizationResult) -> None:
         """Called when optimization completes."""
         self._print_header(result)
 
         if result.best_score is not None:
-            print(f"🏆 Best Score: {result.best_score:.3f}")
+            _safe_print(f"🏆 Best Score: {result.best_score:.3f}")
 
         if result.best_config:
             self._print_config(result.best_config)
 
         if result.duration:
-            print(f"⏱️  Total Time: {result.duration:.1f} seconds")
+            _safe_print(f"⏱️  Total Time: {result.duration:.1f} seconds")
 
         if result.success_rate:
-            print(f"📊 Success Rate: {result.success_rate:.1%}")
+            _safe_print(f"📊 Success Rate: {result.success_rate:.1%}")
 
         if result.stop_reason and result.stop_reason != "timeout":
-            print(f"🛑 Stop reason: {result.stop_reason}")
+            _safe_print(f"🛑 Stop reason: {result.stop_reason}")
 
         if result.run_label:
-            print(f"🔖 Run: {result.run_label}")
+            _safe_print(f"🔖 Run: {result.run_label}")
         if result.cloud_url:
-            print(f"🔗 View: {result.cloud_url}")
+            _safe_print(f"🔗 View: {result.cloud_url}")
         elif (
             result.run_label
             and isinstance(result.metadata, dict)
             and result.metadata.get("offline_mode")
         ):
-            print("   Run locally — sync to cloud with `traigent sync`")
+            _safe_print("   Run locally — sync to cloud with `traigent sync`")
 
-        print("=" * 60 + "\n")
+        _safe_print("=" * 60 + "\n")
 
 
 # Convenience functions for common callback combinations

--- a/traigent/utils/console.py
+++ b/traigent/utils/console.py
@@ -30,7 +30,9 @@ import sys
 from typing import Any
 
 
-def _safe_print(*args: Any, sep: str = " ", end: str = "\n", flush: bool = False) -> None:
+def _safe_print(
+    *args: Any, sep: str = " ", end: str = "\n", flush: bool = False
+) -> None:
     """Print to stdout, replacing unencodable characters instead of crashing.
 
     This is a drop-in replacement for the built-in ``print()`` that gracefully

--- a/traigent/utils/console.py
+++ b/traigent/utils/console.py
@@ -1,0 +1,85 @@
+"""Safe console output utilities for cross-platform encoding compatibility.
+
+On Windows with a non-UTF-8 console (e.g. cp1252, cp850), ``print()`` calls
+that include characters outside the console's encoding raise
+``UnicodeEncodeError``.  This module provides two helpers:
+
+* ``_safe_print`` – a drop-in replacement for ``print()`` that catches
+  ``UnicodeEncodeError`` and falls back to ASCII by replacing unencodable
+  characters with ``?``.
+* ``configure_stdout_encoding`` – wraps ``sys.stdout`` with UTF-8 and
+  ``errors='replace'`` at the CLI entry point so that all output — including
+  Rich ``Console`` output — is safe.
+
+Usage at the CLI entry point::
+
+    from traigent.utils.console import configure_stdout_encoding
+    configure_stdout_encoding()
+
+Usage in progress / diagnostic output::
+
+    from traigent.utils.console import _safe_print as print
+"""
+
+# Traceability: CONC-Layer-Core CONC-Quality-Usability FUNC-API-ENTRY
+
+from __future__ import annotations
+
+import io
+import sys
+from typing import Any
+
+
+def _safe_print(*args: Any, sep: str = " ", end: str = "\n", flush: bool = False) -> None:
+    """Print to stdout, replacing unencodable characters instead of crashing.
+
+    This is a drop-in replacement for the built-in ``print()`` that gracefully
+    handles ``UnicodeEncodeError`` on Windows consoles with non-UTF-8 encodings
+    (e.g. cp1252, cp850).  Unencodable characters are replaced with ``?``.
+
+    Args:
+        *args: Objects to print (converted to str).
+        sep: String inserted between objects (default ``" "``).
+        end: String appended after the last object (default ``"\\n"``).
+        flush: Whether to flush the output buffer.
+    """
+    text = sep.join(str(a) for a in args) + end
+    stream = sys.stdout
+    try:
+        stream.write(text)
+    except UnicodeEncodeError:
+        encoding = getattr(stream, "encoding", "ascii") or "ascii"
+        safe_text = text.encode(encoding, errors="replace").decode(encoding)
+        stream.write(safe_text)
+    if flush:
+        stream.flush()
+
+
+def configure_stdout_encoding() -> None:
+    """Wrap ``sys.stdout`` with UTF-8 encoding and ``errors='replace'``.
+
+    Call this once at the CLI entry point.  When ``sys.stdout`` already uses
+    UTF-8 (most Linux/macOS terminals and Windows 10+ with UTF-8 mode) this
+    is a no-op.  On Windows consoles using legacy encodings (cp1252, cp850,
+    etc.) it replaces unencodable characters with ``?`` instead of crashing.
+
+    This also covers Rich ``Console`` objects that write to the default
+    ``sys.stdout`` because they share the same underlying stream.
+
+    Note: Only applies when ``sys.stdout`` has a ``buffer`` attribute (i.e. it
+    is a real text-mode stream, not a StringIO or similar replacement).
+    """
+    stdout = sys.stdout
+    if not hasattr(stdout, "buffer"):
+        return  # Already wrapped or replaced (e.g. in tests)
+
+    current_encoding = getattr(stdout, "encoding", None) or ""
+    if current_encoding.lower().replace("-", "") in ("utf8", "utf-8"):
+        return  # Already UTF-8; nothing to do
+
+    sys.stdout = io.TextIOWrapper(
+        stdout.buffer,
+        encoding="utf-8",
+        errors="replace",
+        line_buffering=getattr(stdout, "line_buffering", True),
+    )

--- a/traigent/utils/diagnostics.py
+++ b/traigent/utils/diagnostics.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from traigent.utils.console import _safe_print
 from typing import Any
 
 
@@ -59,46 +60,46 @@ class DiagnosticReport:
 
     def print_report(self) -> None:
         """Print formatted report to console."""
-        print("\n" + "=" * 60)
-        print("🔍 Traigent Diagnostic Report")
-        print("=" * 60)
+        _safe_print("\n" + "=" * 60)
+        _safe_print("🔍 Traigent Diagnostic Report")
+        _safe_print("=" * 60)
 
-        print("\n📊 System Info:")
-        print(
+        _safe_print("\n📊 System Info:")
+        _safe_print(
             f"  Python: {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
         )
-        print(f"  Platform: {self.platform}")
+        _safe_print(f"  Platform: {self.platform}")
 
         if self.successes:
-            print(f"\n✅ Successes ({len(self.successes)}):")
+            _safe_print(f"\n✅ Successes ({len(self.successes)}):")
             for success in self.successes:
-                print(f"  [{success['category']}] {success['message']}")
+                _safe_print(f"  [{success['category']}] {success['message']}")
 
         if self.warnings:
-            print(f"\n⚠️  Warnings ({len(self.warnings)}):")
+            _safe_print(f"\n⚠️  Warnings ({len(self.warnings)}):")
             for warning in self.warnings:
-                print(f"  [{warning['category']}] {warning['message']}")
+                _safe_print(f"  [{warning['category']}] {warning['message']}")
 
         if self.issues:
-            print(f"\n❌ Issues ({len(self.issues)}):")
+            _safe_print(f"\n❌ Issues ({len(self.issues)}):")
             for issue in self.issues:
-                print(f"  [{issue['category']}] {issue['message']}")
+                _safe_print(f"  [{issue['category']}] {issue['message']}")
                 if issue["fix"]:
-                    print(f"     💡 Fix: {issue['fix']}")
+                    _safe_print(f"     💡 Fix: {issue['fix']}")
 
         if self.recommendations:
-            print("\n💡 Recommendations:")
+            _safe_print("\n💡 Recommendations:")
             for rec in self.recommendations:
-                print(f"  • {rec}")
+                _safe_print(f"  • {rec}")
 
-        print("\n" + "=" * 60)
+        _safe_print("\n" + "=" * 60)
 
         if not self.issues:
-            print("✅ No critical issues found!")
+            _safe_print("✅ No critical issues found!")
         else:
-            print(f"❌ Found {len(self.issues)} issue(s) that need attention.")
+            _safe_print(f"❌ Found {len(self.issues)} issue(s) that need attention.")
 
-        print("=" * 60 + "\n")
+        _safe_print("=" * 60 + "\n")
 
 
 class TraigentDiagnostics:
@@ -339,7 +340,7 @@ def diagnose() -> DiagnosticReport:
 
 def main():
     """CLI entry point for diagnostics."""
-    print("Running Traigent diagnostics...")
+    _safe_print("Running Traigent diagnostics...")
     report = diagnose()
     report.print_report()
 
@@ -347,7 +348,7 @@ def main():
     report_file = Path("traigent_diagnostic_report.json")
     with open(report_file, "w") as f:
         json.dump(report.to_dict(), f, indent=2)
-    print(f"📄 Full report saved to: {report_file}")
+    _safe_print(f"📄 Full report saved to: {report_file}")
 
     # Return exit code based on issues
     return 1 if report.issues else 0

--- a/traigent/utils/results_table.py
+++ b/traigent/utils/results_table.py
@@ -27,6 +27,38 @@ if TYPE_CHECKING:
 BEST_METRIC_REL_TOL = 1e-9
 BEST_METRIC_ABS_TOL = 1e-12
 
+# Characters that cannot be encoded on narrow consoles (e.g. Windows cp1252) and
+# their ASCII fallbacks.  Applied lazily only when an encode error is detected.
+_TABLE_UNICODE_FALLBACKS: dict[str, str] = {
+    "─": "-",
+    "│": "|",
+    "┌": "+",
+    "┐": "+",
+    "└": "+",
+    "┘": "+",
+    "┴": "+",
+    "├": "+",
+    "┤": "+",
+    "┼": "+",
+    "★": "*",
+    "⚠": "!",
+}
+
+
+def _safe_table_print(text: str, **kwargs: Any) -> None:
+    """Print table output, replacing non-encodable chars instead of crashing."""
+    encoding = getattr(sys.stdout, "encoding", "utf-8") or "utf-8"
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        for uni, asc in _TABLE_UNICODE_FALLBACKS.items():
+            text = text.replace(uni, asc)
+        try:
+            text.encode(encoding)
+        except (UnicodeEncodeError, LookupError):
+            text = text.encode(encoding, errors="replace").decode(encoding)
+    print(text, **kwargs)
+
 
 # ---------------------------------------------------------------------------
 # ANSI helpers
@@ -386,7 +418,7 @@ def print_results_table(
     """
     trials = getattr(results, "trials", [])
     if not trials:
-        print("\nNo trials to display.")
+        _safe_table_print("\nNo trials to display.")
         return
 
     _Colors.refresh()
@@ -456,13 +488,13 @@ def print_results_table(
     title = f" Trial Results ({label_prefix}{len(trials)} trials) "
     padding = (total_width - len(title)) // 2
 
-    print()
-    print(f"{C.BOLD}{TL}{H * total_width}{TR}{C.RESET}")
-    print(
+    _safe_table_print("")
+    _safe_table_print(f"{C.BOLD}{TL}{H * total_width}{TR}{C.RESET}")
+    _safe_table_print(
         f"{C.BOLD}{V}{' ' * padding}{title}"
         f"{' ' * (total_width - padding - len(title))}{V}{C.RESET}"
     )
-    print(f"{C.BOLD}{LT}{H * total_width}{RT}{C.RESET}")
+    _safe_table_print(f"{C.BOLD}{LT}{H * total_width}{RT}{C.RESET}")
 
     # Column headers
     header_parts = [f"{C.BOLD}{'#':^{col_widths['#']}}{C.RESET}"]
@@ -474,10 +506,12 @@ def print_results_table(
         header_parts.append(
             f"{C.YELLOW}{'examples':^{col_widths['examples']}}{C.RESET}"
         )
-    print(f"{V} " + f" {V} ".join(header_parts) + f" {V}")
+    _safe_table_print(f"{V} " + f" {V} ".join(header_parts) + f" {V}")
 
     # Separator
-    print(f"{LT}" + XT.join(H * (col_widths[c] + 2) for c in all_cols) + f"{RT}")
+    _safe_table_print(
+        f"{LT}" + XT.join(H * (col_widths[c] + 2) for c in all_cols) + f"{RT}"
+    )
 
     # Data rows
     for i, trial in enumerate(trials):
@@ -506,14 +540,16 @@ def print_results_table(
             formatted_counts = f"{counts[0]}/{counts[1]}" if counts is not None else "?"
             row_parts.append(f"{formatted_counts:^{col_widths['examples']}}")
 
-        print(f"{V} " + f" {V} ".join(row_parts) + f" {V}")
+        _safe_table_print(f"{V} " + f" {V} ".join(row_parts) + f" {V}")
 
     # Bottom border
-    print(f"{BL}" + BT.join(H * (col_widths[c] + 2) for c in all_cols) + f"{BR}")
+    _safe_table_print(
+        f"{BL}" + BT.join(H * (col_widths[c] + 2) for c in all_cols) + f"{BR}"
+    )
 
     # Legend (or "all failed" banner when no trial succeeded)
     if all_failed:
-        print(
+        _safe_table_print(
             f"{C.YELLOW}⚠ All trials failed — no examples succeeded. "
             f"Inspect per-example errors in "
             f".traigent/optimization_logs/experiments/.../runs/{C.RESET}"
@@ -521,4 +557,4 @@ def print_results_table(
     else:
         legend = [f"{C.GREEN}★{C.RESET} Overall Best"]
         legend.extend(f"{C.GREEN}{C.BOLD}{m}{C.RESET} = Best {m}" for m in metric_names)
-        print(f"{C.DIM}Legend: {', '.join(legend)}{C.RESET}")
+        _safe_table_print(f"{C.DIM}Legend: {', '.join(legend)}{C.RESET}")


### PR DESCRIPTION
## Summary
- Add `traigent/utils/console.py` with `_safe_print()` (replaces unencodable chars with `?`) and `configure_stdout_encoding()` (wraps stdout with UTF-8+replace at CLI startup)
- Wire `configure_stdout_encoding()` into the CLI entry point (`traigent/cli/main.py`) so all print/Rich output is safe from startup
- Replace `print()` calls containing emoji, box-drawing chars, and other non-ASCII progress output in `callbacks.py`, `results_table.py`, `diagnostics.py`, and `exception_handler.py` with `_safe_print`
- Add `tests/unit/utils/test_console_encoding.py` (21 tests) covering all affected code paths under a simulated cp1252 stdout
- Add `TestUnicodeOutputSafety` class in `test_callbacks.py` as an additional regression guard

## Root cause
On Windows with a legacy console (cp1252, cp850, etc.), `sys.stdout.encoding` is not UTF-8. Direct `print()` calls with emoji (🚀 ✅ 🏆 …), box-drawing characters (┌ ─ │ …), and other Unicode above the cp1252 range crash with `UnicodeEncodeError`.

## Fix
Two complementary defences:
1. **CLI entry point**: `configure_stdout_encoding()` wraps `sys.stdout` with UTF-8 and `errors='replace'` so all subsequent output — including Rich Console — is safe
2. **Per-callsite**: `_safe_print()` catches `UnicodeEncodeError` and re-emits with `errors='replace'`, guarding output in non-CLI contexts (library use, tests) where the entry-point wrapper is not active

## Test plan
- [ ] 21 new tests in `test_console_encoding.py` pass (`TestConsoleSafePrint`, `TestCallbacksSafePrint`, `TestProgressBarCallbackEncoding`, `TestDetailedProgressCallbackEncoding`, `TestDiagnosticReportEncoding`, `TestConfigureStdoutEncoding`)
- [ ] 2 new tests in `TestUnicodeOutputSafety` pass
- [ ] `ruff check` clean on all changed files
- [ ] All existing `tests/unit/utils/test_callbacks.py` tests pass

Fixes #1321

Spine-Trail: st_756af5b50e8c