### PR TITLE
fix(skills): update bundled skill snippets for SDK 0.13.0 API (#1306)

### DIFF
--- a/traigent/skills/traigent-analyze-results/SKILL.md
+++ b/traigent/skills/traigent-analyze-results/SKILL.md
@@ -38,7 +38,7 @@ def classify(text):
     # ... LLM call using config ...
     return result
 
-results = classify.optimize()
+results = await classify.optimize()
 
 # Top-level results
 print(results.best_config)      # {"model": "gpt-4o", "temperature": 0.0}
@@ -195,8 +195,8 @@ elif results.stop_reason == "error":
 After optimization, apply the winning configuration so your function uses it in production:
 
 ```python
-# Run optimization
-results = classify.optimize()
+# Run optimization (async)
+results = await classify.optimize()
 
 # Apply the best configuration
 classify.apply_best_config(results)
@@ -213,7 +213,7 @@ response = classify("What category is this email?")
 Verify results before applying:
 
 ```python
-results = classify.optimize()
+results = await classify.optimize()
 
 if results.best_score is not None and results.best_score >= 0.85:
     classify.apply_best_config(results)
@@ -276,7 +276,7 @@ def summarize(text):
     return summary
 
 # 1. Run optimization
-results = summarize.optimize()
+results = await summarize.optimize()
 
 # 2. Quick summary
 print(f"Best config: {results.best_config}")

--- a/traigent/skills/traigent-debugging/SKILL.md
+++ b/traigent/skills/traigent-debugging/SKILL.md
@@ -112,7 +112,7 @@ traigent.utils.exceptions.CostLimitExceeded: Cost limit exceeded: $0.52 >= $0.50
 from traigent.utils.exceptions import CostLimitExceeded
 
 try:
-    results = func.optimize()
+    results = await func.optimize()
 except CostLimitExceeded as e:
     print(f"Budget exceeded: spent ${e.accumulated:.2f} of ${e.limit:.2f} limit")
     # Check if partial results are available
@@ -139,7 +139,7 @@ def my_func(text):
 my_func("hello")  # OptimizationStateError!
 
 # CORRECT: run optimization first, then apply
-results = my_func.optimize()
+results = my_func.optimize_sync()
 my_func.apply_best_config(results)
 my_func("hello")  # Works - get_config() returns applied config
 ```
@@ -190,7 +190,7 @@ Has `config`, `input_data`, and `original_error` attributes. Check the original 
 from traigent.utils.exceptions import InvocationError
 
 try:
-    results = func.optimize()
+    results = await func.optimize()
 except InvocationError as e:
     print(f"Config that caused failure: {e.config}")
     print(f"Original error: {e.original_error}")
@@ -265,7 +265,7 @@ def my_func(text):
     return "mock response"
 
 # Runs without API keys or backend
-results = my_func.optimize()
+results = await my_func.optimize()
 ```
 
 Mock mode is essential for:
@@ -375,7 +375,7 @@ def classify(text):
 
 # Attempt optimization with fallback
 try:
-    results = classify.optimize()
+    results = await classify.optimize()
 
     if results.best_score is not None and results.best_score >= 0.7:
         classify.apply_best_config(results)

--- a/traigent/skills/traigent-debugging/references/mock-mode.md
+++ b/traigent/skills/traigent-debugging/references/mock-mode.md
@@ -64,10 +64,10 @@ When `TRAIGENT_MOCK_LLM=true`:
 
 ### What Gets Mocked
 
-- OpenAI API calls (`openai.chat.completions.create`)
-- Anthropic API calls (`anthropic.messages.create`)
-- LiteLLM completion calls made inside optimized/evaluated Traigent runs after the SDK installs its LiteLLM interceptor
-- Any provider accessed through Traigent's integration layer
+- LiteLLM completion calls (`litellm.completion(...)`) made inside optimized/evaluated Traigent runs after the SDK installs its interceptor
+- LangChain model invocations made via Traigent's framework integration layer (e.g. `ChatOpenAI`, `ChatAnthropic` when `traigent[integrations]` is installed)
+
+**Important:** Raw `openai.chat.completions.create(...)` and `anthropic.messages.create(...)` calls made directly (outside the LiteLLM or LangChain integration layer) are **not** intercepted and will attempt to reach real provider APIs. Stub those calls explicitly (e.g. with `unittest.mock`) for a guaranteed $0 rehearsal.
 
 ### What Is NOT Mocked
 

--- a/traigent/skills/traigent-decorator-setup/SKILL.md
+++ b/traigent/skills/traigent-decorator-setup/SKILL.md
@@ -53,8 +53,8 @@ from traigent.core.objectives import ObjectiveSchema, ObjectiveDefinition
 
 schema = ObjectiveSchema(
     objectives=[
-        ObjectiveDefinition(name="accuracy", weight=0.7, direction="maximize"),
-        ObjectiveDefinition(name="cost", weight=0.3, direction="minimize"),
+        ObjectiveDefinition(name="accuracy", weight=0.7, orientation="maximize"),
+        ObjectiveDefinition(name="cost", weight=0.3, orientation="minimize"),
     ],
     weights_sum=1.0,
     weights_normalized={"accuracy": 0.7, "cost": 0.3},

--- a/traigent/skills/traigent-decorator-setup/references/injection-modes.md
+++ b/traigent/skills/traigent-decorator-setup/references/injection-modes.md
@@ -55,11 +55,12 @@ def parallel_processing(data_batch: list) -> list:
 
     import concurrent.futures
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        futures = []
-        for item in data_batch:
-            # Each worker inherits the trial config
-            future = executor.submit(snapshot.run, process_item, item, cfg)
-            futures.append(future)
+        def worker(item):
+            # Restore Traigent context in the worker thread
+            with snapshot.restore():
+                return process_item(item, cfg)
+
+        futures = [executor.submit(worker, item) for item in data_batch]
         return [f.result() for f in futures]
 ```
 

--- a/traigent/skills/traigent-integrations/SKILL.md
+++ b/traigent/skills/traigent-integrations/SKILL.md
@@ -85,6 +85,7 @@ The `auto_override_frameworks` flag lets Traigent automatically intercept LangCh
     objectives=["accuracy"],
     max_trials=12,
     auto_override_frameworks=True,
+    framework_targets=["langchain_openai.ChatOpenAI"],
 )
 def summarize_document(text):
     # LangChain model instantiation is intercepted by Traigent
@@ -92,6 +93,8 @@ def summarize_document(text):
     response = llm.invoke(text)
     return response.content
 ```
+
+**Note:** `auto_override_frameworks=True` alone is a no-op — you must also set `framework_targets` to specify which classes to intercept. The flag without targets is silently ignored.
 
 For finer control, use `framework_targets` to specify exactly which classes to override:
 
@@ -159,8 +162,8 @@ for trial in results.successful_trials:
 LiteLLM handles API key routing automatically based on the model prefix. Set provider API keys in environment variables:
 
 ```bash
-export OPENAI_API_KEY="sk-..."
-export ANTHROPIC_API_KEY="sk-ant-..."
+export OPENAI_API_KEY="sk-..."  # pragma: allowlist secret
+export ANTHROPIC_API_KEY="sk-ant-..."  # pragma: allowlist secret
 export GEMINI_API_KEY="..."
 ```
 
@@ -215,6 +218,13 @@ def dspy_qa(question):
 See [DSPy reference](references/dspy.md) for BootstrapFewShot patterns and advanced configuration.
 
 ## Observability Integrations
+
+MLflow and Weights & Biases are not included in the base `traigent` package. Install them separately:
+
+```bash
+pip install mlflow           # MLflow tracking
+pip install wandb            # Weights & Biases
+```
 
 ### MLflow
 

--- a/traigent/skills/traigent-quickstart/SKILL.md
+++ b/traigent/skills/traigent-quickstart/SKILL.md
@@ -56,12 +56,20 @@ See `references/installation-extras.md` for the full table of extras and their c
 
 Set these environment variables to develop and test without making real API calls or connecting to a backend:
 
+```python
+# Preferred: use the SDK helper (sets both TRAIGENT_MOCK_LLM and TRAIGENT_OFFLINE_MODE)
+import traigent
+traigent.enable_mock_mode_for_quickstart()
+```
+
+Or set environment variables directly:
+
 ```bash
 export TRAIGENT_MOCK_LLM=true
 export TRAIGENT_OFFLINE_MODE=true
 ```
 
-- `TRAIGENT_MOCK_LLM=true` -- Mocks supported LLM calls made through Traigent's integration/interceptor path so local dry-runs do not need provider API keys or incur provider costs.
+- `TRAIGENT_MOCK_LLM=true` -- Mocks supported LLM calls made through Traigent's integration/interceptor path so local dry-runs do not need provider API keys or incur provider costs. Note: raw `openai.chat.completions.create(...)` and `anthropic.messages.create(...)` calls made outside the Traigent interceptor path are **not** mocked — only calls made via LiteLLM or LangChain inside `@traigent.optimize` functions are intercepted. Set `TRAIGENT_OFFLINE_MODE=true` together.
 - `TRAIGENT_OFFLINE_MODE=true` -- Skips backend communication so you do not need a running Traigent backend.
 
 ### Using a .env File
@@ -99,7 +107,7 @@ from traigent import Range, Choices
     eval_dataset="eval_queries.jsonl",
     objectives=["accuracy"],
     model=Choices(["gpt-4o-mini", "gpt-4o"]),
-    temperature=Range(0.0, 1.0),
+    temperature=Choices([0.0, 0.5, 1.0]),
 )
 def classify_query(query: str) -> str:
     config = traigent.get_config()
@@ -119,7 +127,7 @@ def classify_query(query: str) -> str:
 
 async def main():
     # Run optimization (async)
-    results = await classify_query.optimize(max_trials=6, algorithm="grid")
+    results = await classify_query.optimize(max_trials=6, algorithm="random")
 
     # Inspect results
     print(f"Best config: {results.best_config}")
@@ -142,7 +150,7 @@ asyncio.run(main())
 If you prefer synchronous execution:
 
 ```python
-results = classify_query.optimize_sync(max_trials=6, algorithm="grid")
+results = classify_query.optimize_sync(max_trials=6, algorithm="random")
 ```
 
 ### Key Concepts
@@ -195,7 +203,7 @@ print(traigent.get_version_info())
 ### Validate an eval dataset
 
 ```bash
-traigent validate --dataset eval_queries.jsonl
+traigent validate eval_queries.jsonl
 ```
 
 ## CLI Quick Reference
@@ -209,6 +217,6 @@ traigent validate --dataset eval_queries.jsonl
 ## Next Steps
 
 - **Define parameter search spaces** -- See the `traigent-configuration-space` skill for `Range`, `IntRange`, `Choices`, `LogRange`, factory presets, and constraints.
-- **Choose an optimization algorithm** -- Run `traigent algorithms` to see available options (grid, random, bayesian, optuna, etc.).
+- **Choose an optimization algorithm** -- Run `traigent algorithms` to see available options. Locally, `grid` and `random` are available; `bayesian` and `optuna` require the cloud portal.
 - **Add multiple objectives** -- Use `objectives=["accuracy", "cost", "latency"]` for multi-objective optimization.
 - **Use framework integrations** -- Install `traigent[integrations]` for LangChain, OpenAI, and Anthropic adapters.

--- a/traigent/skills/traigent-run-optimization/references/parallel-config.md
+++ b/traigent/skills/traigent-run-optimization/references/parallel-config.md
@@ -147,10 +147,11 @@ def batch_process(items: list) -> list:
     snapshot = copy_context_to_thread()
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-        futures = [
-            executor.submit(snapshot.run, process_one, item, cfg)
-            for item in items
-        ]
+        def worker(item):
+            with snapshot.restore():
+                return process_one(item, cfg)
+
+        futures = [executor.submit(worker, item) for item in items]
         return [f.result() for f in futures]
 ```
 


### PR DESCRIPTION
## Summary

Fixes drifted/broken API snippets in the bundled `traigent/skills/` SKILL.md files (shipped in the wheel, mirrored to `~/.claude/skills/`). All fixes verified against `origin/develop` source.

## Fixes applied

| Sev | File | Was | Now |
|---|---|---|---|
| HIGH | `traigent-quickstart/SKILL.md:102` | `temperature=Range(0.0,1.0)` + `algorithm="grid"` (crashes: grid can't handle continuous params) | `temperature=Choices([0.0,0.5,1.0])` + `algorithm="random"` |
| HIGH | `traigent-quickstart/SKILL.md:122,145` | `algorithm="grid"` (both async and sync variants) | `algorithm="random"` |
| HIGH | `traigent-decorator-setup/SKILL.md:56-57` | `ObjectiveDefinition(direction="maximize")` (TypeError: unexpected kwarg) | `orientation="maximize"` |
| HIGH | `traigent-analyze-results/SKILL.md:41,199,216,279` | `results = func.optimize()` (coroutine, AttributeError on .best_config) | `results = await func.optimize()` |
| HIGH | `traigent-debugging/SKILL.md:115,142,193,268,378` | bare `func.optimize()` (coroutine) | `await func.optimize()` or `optimize_sync()` |
| HIGH | `traigent-debugging/references/mock-mode.md:66-69` | "What Gets Mocked" lists raw `openai.chat.completions.create` and `anthropic.messages.create` (false — real cost footgun) | Corrected to LiteLLM + LangChain only; explicit note that raw openai/anthropic calls are NOT intercepted |
| HIGH | `traigent-integrations/SKILL.md:80-94` | `auto_override_frameworks=True` with no `framework_targets` (silent no-op) | Added `framework_targets=["langchain_openai.ChatOpenAI"]` + note documenting the requirement |
| MED | `traigent-quickstart/SKILL.md:198` | `traigent validate --dataset eval_queries.jsonl` (exit 2: no such option) | `traigent validate eval_queries.jsonl` (positional) |
| MED | `traigent-decorator-setup/references/injection-modes.md:60`; `traigent-run-optimization/references/parallel-config.md:151` | `snapshot.run(fn, ...)` (AttributeError: ContextSnapshot has no .run) | `with snapshot.restore(): ...` |
| LOW | `traigent-quickstart/SKILL.md:212` | "grid, random, bayesian, optuna" in "available locally" framing | Clarified: grid/random local; bayesian/optuna cloud-only |
| LOW | `traigent-quickstart/SKILL.md:60-62` | `export TRAIGENT_MOCK_LLM=true` as primary toggle (DeprecationWarning) | Lead with `traigent.enable_mock_mode_for_quickstart()` SDK helper |
| LOW | `traigent-integrations/SKILL.md:217-263` | `import mlflow`/`import wandb` with no note about extras | Added install instructions: `pip install mlflow` / `pip install wandb` |

No `.py` files changed — only `.md` documentation/skill files.

## PR checklist
- Worst-case prod path: N/A — documentation-only change, no runtime code modified
- Production-branch test: N/A
- Contract regeneration: N/A
- Public surface delta: None
- Review threads resolved: N/A (new PR)
- Quality gates not relaxed: N/A (no .py changes)

Spine-Trail: st_89c6cc0c598c
Fixes #1306