### PR TITLE
feat(sdk): add experiment_name= param to @traigent.optimize() decorator (#1323)

### DIFF
--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -784,8 +784,10 @@ class TestOptimizedFunctionIntegration:
             "Decorating function test_func with @traigent.optimize"
         )
 
-        # Check info log for creation
-        mock_logger.info.assert_called_with("Created optimizable function: test_func")
+        # Check info log for creation (message includes experiment_name)
+        mock_logger.info.assert_called_with(
+            "Created optimizable function: test_func (experiment_name='test_func')"
+        )
 
     def test_decorator_factory_pattern(self):
         """Test that optimize returns a decorator function."""
@@ -1087,3 +1089,84 @@ class TestRemovedExecutionRuntimeOptions:
             return x
 
         assert isinstance(py_func_with_config, OptimizedFunction)
+
+
+class TestExperimentName:
+    """Tests for experiment_name parameter and TRAIGENT_EXPERIMENT_NAME env var."""
+
+    def test_experiment_name_default_is_func_name(self):
+        """When no experiment_name is passed, experiment_name == func.__name__."""
+
+        @optimize(configuration_space={"x": [1, 2]})
+        def my_pipeline(x: int) -> int:
+            return x
+
+        assert my_pipeline.experiment_name == "my_pipeline"
+
+    def test_experiment_name_override(self):
+        """Explicit experiment_name is used instead of func.__name__."""
+
+        @optimize(
+            configuration_space={"x": [1, 2]},
+            experiment_name="Amir txt2sql v1 (ACL 0.8, 0.15, 0.05)",
+        )
+        def my_pipeline(x: int) -> int:
+            return x
+
+        assert my_pipeline.experiment_name == "Amir txt2sql v1 (ACL 0.8, 0.15, 0.05)"
+        # __name__ still reflects the real function name
+        assert my_pipeline.__name__ == "my_pipeline"
+
+    def test_experiment_name_env_var(self, monkeypatch):
+        """TRAIGENT_EXPERIMENT_NAME env var is used when no explicit name is passed."""
+        monkeypatch.setenv("TRAIGENT_EXPERIMENT_NAME", "env_experiment")
+
+        @optimize(configuration_space={"x": [1, 2]})
+        def my_pipeline(x: int) -> int:
+            return x
+
+        assert my_pipeline.experiment_name == "env_experiment"
+
+    def test_experiment_name_param_beats_env_var(self, monkeypatch):
+        """Explicit experiment_name takes precedence over TRAIGENT_EXPERIMENT_NAME."""
+        monkeypatch.setenv("TRAIGENT_EXPERIMENT_NAME", "env_experiment")
+
+        @optimize(
+            configuration_space={"x": [1, 2]},
+            experiment_name="explicit name",
+        )
+        def my_pipeline(x: int) -> int:
+            return x
+
+        assert my_pipeline.experiment_name == "explicit name"
+
+    def test_experiment_name_env_var_cleared(self, monkeypatch):
+        """After env var is removed, falls back to func.__name__."""
+        monkeypatch.delenv("TRAIGENT_EXPERIMENT_NAME", raising=False)
+
+        @optimize(configuration_space={"x": [1, 2]})
+        def my_pipeline(x: int) -> int:
+            return x
+
+        assert my_pipeline.experiment_name == "my_pipeline"
+
+    def test_experiment_name_stored_on_optimized_function(self):
+        """_experiment_name is stored on the OptimizedFunction instance."""
+
+        @optimize(
+            configuration_space={"x": [1, 2]},
+            experiment_name="stored name",
+        )
+        def my_func(x: int) -> int:
+            return x
+
+        assert my_func._experiment_name == "stored name"
+
+    def test_experiment_name_none_stores_none(self):
+        """When experiment_name=None (default), _experiment_name is None."""
+
+        @optimize(configuration_space={"x": [1, 2]})
+        def my_func(x: int) -> int:
+            return x
+
+        assert my_func._experiment_name is None

--- a/tests/unit/core/test_best_config_runtime_integration.py
+++ b/tests/unit/core/test_best_config_runtime_integration.py
@@ -623,7 +623,7 @@ async def test_optimization_completion_refreshes_best_config_snapshot():
     )
 
     class FakeOrchestrator:
-        async def optimize(self, *, func, dataset):
+        async def optimize(self, *, func, dataset, function_name=None):
             return result
 
     await opt_func._run_and_finalize_optimization(

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -384,6 +384,7 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "eval_dataset": None,
     "objectives": None,
     "configuration_space": None,
+    "experiment_name": None,
     "default_config": None,
     "constraints": None,
     "safety_constraints": None,
@@ -491,6 +492,7 @@ class LegacyOptimizeArgs:
         str | list[str | dict[str, Any] | EvaluationExample] | Dataset | None
     ) = None
     objectives: list[str] | ObjectiveSchema | None = None
+    experiment_name: str | None = None
     configuration_space: dict[str, Any] | None = None
     default_config: dict[str, Any] | None = None
     constraints: list[Callable[..., Any]] | None = None
@@ -582,6 +584,7 @@ class LegacyOptimizeArgs:
         return [
             ("eval_dataset", self.eval_dataset),
             ("objectives", self.objectives),
+            ("experiment_name", self.experiment_name),
             ("configuration_space", self.configuration_space),
             ("default_config", self.default_config),
             ("constraints", self.constraints),
@@ -1694,6 +1697,7 @@ def optimize(  # NOSONAR(S107)
     *,
     objectives: list[str] | ObjectiveSchema | None = None,
     configuration_space: dict[str, Any] | ConfigSpace | None = None,
+    experiment_name: str | None = None,
     default_config: dict[str, Any] | None = None,
     constraints: list[Constraint | BoolExpr | Callable[..., Any]] | None = None,
     safety_constraints: list[SafetyConstraint | CompoundSafetyConstraint] | None = None,
@@ -1759,6 +1763,13 @@ def optimize(  # NOSONAR(S107)
         configuration_space: Dictionary describing the search space. Keys are
             parameter names; values can be discrete lists, numeric tuples, or nested
             dicts for composite parameters.
+        experiment_name: Human-readable display name for this experiment shown in
+            the Traigent portal and local storage. When ``None`` (default), the
+            decorated function's ``__name__`` is used. Falls back to the
+            ``TRAIGENT_EXPERIMENT_NAME`` environment variable if set and no
+            explicit value is passed. Allows names with spaces, punctuation, and
+            other characters not valid in Python identifiers, for example
+            ``"Amir txt2sql v1 (ACL 0.8)"``.
         default_config: Baseline configuration materialized before the first trial.
             In seamless/attribute modes these override literal values during the
             initial run. In parameter mode the dict is converted to a TraigentConfig
@@ -2007,6 +2018,7 @@ def optimize(  # NOSONAR(S107)
     direct_inputs = {
         "objectives": objectives,
         "configuration_space": configuration_space,
+        "experiment_name": experiment_name,
         "default_config": default_config,
         "constraints": constraints,
         "safety_constraints": safety_constraints,
@@ -2137,6 +2149,8 @@ def optimize(  # NOSONAR(S107)
     max_trials_value = combined_settings["max_trials"]
     if max_trials_value is not None and max_trials_value <= 0:
         raise ValueError("max_trials must be a positive integer")
+    # Experiment display name (decorator > env var > func.__name__ at decoration time)
+    experiment_name_value = combined_settings["experiment_name"]
     # Tuned variable auto-detection
     auto_detect_tvars_value = combined_settings["auto_detect_tvars"]
     auto_detect_tvars_mode_value = combined_settings["auto_detect_tvars_mode"]
@@ -2436,6 +2450,8 @@ def optimize(  # NOSONAR(S107)
             strategy_preset=strategy_preset,
             # Optimizer limits (extracted from combined_settings)
             max_trials=max_trials_value,
+            # Experiment display name (overrides func.__name__ in portal/storage)
+            experiment_name=experiment_name_value,
             # Guided-generation defaults (consumed by optimize_with_guidance)
             prompt_rewrite=prompt_rewrite,
             grow_dataset=grow_dataset,
@@ -2443,7 +2459,8 @@ def optimize(  # NOSONAR(S107)
             **combined_runtime_overrides,
         )
 
-        logger.info(f"Created optimizable function: {func.__name__}")
+        effective_name = experiment_name_value or func.__name__
+        logger.info(f"Created optimizable function: {func.__name__} (experiment_name={effective_name!r})")
 
         return optimized_func
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -2460,7 +2460,9 @@ def optimize(  # NOSONAR(S107)
         )
 
         effective_name = experiment_name_value or func.__name__
-        logger.info(f"Created optimizable function: {func.__name__} (experiment_name={effective_name!r})")
+        logger.info(
+            f"Created optimizable function: {func.__name__} (experiment_name={effective_name!r})"
+        )
 
         return optimized_func
 

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -569,7 +569,9 @@ class BackendSessionManager:
         function_identifier = function_descriptor.identifier
         # experiment_display_name (from @traigent.optimize(experiment_name=...)) overrides
         # the descriptor's __qualname__-derived display_name in portal/storage.
-        function_display_name = experiment_display_name or function_descriptor.display_name
+        function_display_name = (
+            experiment_display_name or function_descriptor.display_name
+        )
         function_slug = function_descriptor.slug
 
         if self._backend_client:

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -549,6 +549,7 @@ class BackendSessionManager:
         objectives: list[Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
+        experiment_display_name: str | None = None,
     ) -> SessionContext:
         """Create backend session and return context.
 
@@ -566,7 +567,9 @@ class BackendSessionManager:
         """
         session_id = None
         function_identifier = function_descriptor.identifier
-        function_display_name = function_descriptor.display_name
+        # experiment_display_name (from @traigent.optimize(experiment_name=...)) overrides
+        # the descriptor's __qualname__-derived display_name in portal/storage.
+        function_display_name = experiment_display_name or function_descriptor.display_name
         function_slug = function_descriptor.slug
 
         if self._backend_client:

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -556,6 +556,9 @@ class OptimizedFunction:
         self.max_trials = kwargs.pop("max_trials", 50)
         kwargs["max_trials"] = self.max_trials
 
+        # Experiment display name: decorator param > TRAIGENT_EXPERIMENT_NAME > func.__name__
+        self._experiment_name: str | None = kwargs.pop("experiment_name", None)
+
         self.timeout = kwargs.pop("timeout", None)
         kwargs["timeout"] = self.timeout
 
@@ -1792,11 +1795,13 @@ class OptimizedFunction:
                         result = await orchestrator.optimize(
                             func=trial_func,
                             dataset=dataset,
+                            function_name=self.experiment_name,
                         )
                 else:
                     result = await orchestrator.optimize(
                         func=trial_func,
                         dataset=dataset,
+                        function_name=self.experiment_name,
                     )
 
             # Store results
@@ -2299,7 +2304,7 @@ Remediation:
 
         with ConfigurationSpaceContext(effective_config_space):
             cloud_candidate = await client.optimize_function(
-                function_name=self.func.__name__,
+                function_name=self.experiment_name,
                 dataset=dataset,
                 configuration_space=effective_config_space,
                 objectives=self.objectives,
@@ -3113,6 +3118,22 @@ Remediation:
     def __name__(self) -> str:
         """Get function name."""
         return getattr(self.func, "__name__", "OptimizedFunction")
+
+    @property
+    def experiment_name(self) -> str:
+        """Resolved experiment display name for portal/storage.
+
+        Resolution order (highest to lowest priority):
+        1. ``experiment_name`` passed to ``@traigent.optimize()``
+        2. ``TRAIGENT_EXPERIMENT_NAME`` environment variable
+        3. Decorated function's ``__name__``
+        """
+        if self._experiment_name is not None:
+            return self._experiment_name
+        env_name = os.environ.get("TRAIGENT_EXPERIMENT_NAME")
+        if env_name:
+            return env_name
+        return self.__name__
 
     @property
     def __doc__(self) -> str | None:  # type: ignore[override]

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2080,7 +2080,10 @@ class OptimizationOrchestrator:
 
         if session_id:
             self._initialize_logger(
-                session_id, func, dataset, experiment_display_name=experiment_display_name
+                session_id,
+                func,
+                dataset,
+                experiment_display_name=experiment_display_name,
             )
 
         self.callback_manager.on_optimization_start(

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -1258,12 +1258,17 @@ class OptimizationOrchestrator:
 
     # --- Consolidated logging helpers (V2 + legacy) ---
     def _initialize_logger(
-        self, session_id: str | None, func: Callable[..., Any], dataset: Dataset
+        self,
+        session_id: str | None,
+        func: Callable[..., Any],
+        dataset: Dataset,
+        *,
+        experiment_display_name: str | None = None,
     ) -> None:
         if not session_id:
             return
 
-        experiment_name = (
+        experiment_name = experiment_display_name or (
             func.__name__ if hasattr(func, "__name__") else "unknown_function"
         )
 
@@ -2039,12 +2044,19 @@ class OptimizationOrchestrator:
 
         self._dataset_name = getattr(dataset, "name", "dataset")
 
+        # function_name may carry the user-supplied experiment_name override (from
+        # @traigent.optimize(experiment_name=...)). The fully-qualified descriptor
+        # identifier is still used for session keying; the override becomes the
+        # human-readable display name forwarded to the portal.
+        experiment_display_name: str | None = None
         if function_name and function_name != descriptor.identifier:
             logger.debug(
-                "Ignoring supplied function_name '%s' in favour of fully-qualified identifier '%s'",
+                "function_name='%s' supplied — using as experiment display name "
+                "(session keyed by descriptor identifier '%s')",
                 function_name,
                 descriptor.identifier,
             )
+            experiment_display_name = function_name
 
         # Create backend session using manager. Governance crosses the wire
         # content-free (Phase 8): the declared promotion policy and the
@@ -2061,12 +2073,15 @@ class OptimizationOrchestrator:
             objectives=list(self.optimizer.objectives or []),
             promotion_policy=wire_policy,
             tvl_governance=wire_governance,
+            experiment_display_name=experiment_display_name,
         )
         session_id: str | None = session_context.session_id
         self._active_session_id = session_id
 
         if session_id:
-            self._initialize_logger(session_id, func, dataset)
+            self._initialize_logger(
+                session_id, func, dataset, experiment_display_name=experiment_display_name
+            )
 
         self.callback_manager.on_optimization_start(
             config_space=self.optimizer.config_space,


### PR DESCRIPTION
Closes #1323

## Problem

The Traigent portal displays the experiment name as `decorated_func.__name__`, making names like `"Amir txt2sql 1 (ACL 0.8, 0.15, 0.05)"` impossible — Python identifiers can't contain spaces or parentheses.

## Solution

Add an `experiment_name: str | None = None` parameter to `@traigent.optimize()`.

**Resolution order (highest to lowest priority):**
1. `experiment_name` kwarg on the decorator
2. `TRAIGENT_EXPERIMENT_NAME` environment variable
3. Decorated function's `__name__` (existing default — fully backwards-compatible)

**Usage:**
```python
@traigent.optimize(
    eval_dataset="qa_test.jsonl",
    objectives=["accuracy"],
    experiment_name="Amir txt2sql v1 (ACL 0.8, 0.15, 0.05)",
)
def my_pipeline(question: str) -> str:
    ...
```

## Changes

- `traigent/api/decorators.py`: `experiment_name` added to `optimize()` signature, `_OPTIMIZE_DEFAULTS`, `LegacyOptimizeArgs`, `direct_inputs`
- `traigent/core/optimized_function.py`: `_experiment_name` stored; `experiment_name` property (env-var fallback); passed as `function_name` to orchestrator and cloud path
- `traigent/core/orchestrator.py`: `function_name` accepted as experiment display name override; threaded to `_initialize_logger` and `BackendSessionManager.create_session`
- `traigent/core/backend_session_manager.py`: `experiment_display_name` parameter overrides `function_descriptor.display_name` in session metadata and portal name
- **7 new unit tests** (`TestExperimentName` class), updated log-assertion test, fixed `FakeOrchestrator.optimize` signature

## Backwards compatibility

Default behavior (func.__name__) is unchanged. The `experiment_name` parameter defaults to `None`.

## Test plan

- [x] `test_experiment_name_default_is_func_name` — no override → `experiment_name == func.__name__`
- [x] `test_experiment_name_override` — explicit name used, `__name__` still correct
- [x] `test_experiment_name_env_var` — `TRAIGENT_EXPERIMENT_NAME` env var picked up
- [x] `test_experiment_name_param_beats_env_var` — decorator param > env var
- [x] `test_experiment_name_env_var_cleared` — falls back to func name when env var absent
- [x] `test_experiment_name_stored_on_optimized_function` — `_experiment_name` stored
- [x] `test_experiment_name_none_stores_none` — default stores None
- [x] All 13,472 unit tests pass

Spine-Trail: st_bd6a9cc629cf

🤖 Generated with [Claude Code](https://claude.com/claude-code)