### PR TITLE
docs(examples): expand text2sql eval to 40 rows + document SPIDER dataset (#1324)

### DIFF
--- a/examples/core/text-to-sql/README.md
+++ b/examples/core/text-to-sql/README.md
@@ -1,0 +1,110 @@
+# Text-to-SQL Optimization Example
+
+Demonstrates how to use Traigent to optimize a natural language to SQL
+pipeline over a telecom (Amdocs-style) database schema.
+
+## Schema
+
+Four tables live in `schema.sql`:
+
+| Table | Key columns |
+|---|---|
+| `customers` | `customer_id`, `name`, `city`, `status` |
+| `subscriptions` | `subscription_id`, `customer_id`, `plan_name`, `monthly_rate`, `start_date` |
+| `billing` | `billing_id`, `customer_id`, `amount`, `status`, `due_date` |
+| `network_usage` | `usage_id`, `customer_id`, `call_minutes`, `data_gb`, `record_date` |
+
+## Running the demo
+
+**Mock mode** — no API key required, deterministic answers:
+
+```bash
+TRAIGENT_MOCK_LLM=true python examples/core/text-to-sql/run.py
+```
+
+**Real LLM mode** — requires `ANTHROPIC_API_KEY`:
+
+```bash
+python examples/core/text-to-sql/run.py
+```
+
+Traigent explores the configuration space (model, temperature, include_schema)
+and reports the best-scoring combination according to the `sql_accuracy` metric.
+
+## Eval set
+
+The bundled eval set is at
+`examples/datasets/text-to-sql/evaluation_set.jsonl` (40 rows). Each row is a
+JSON object with two keys:
+
+```json
+{"question": "find customers with unpaid bills", "expected": "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid'"}
+```
+
+Questions cover:
+
+- Simple filters (`WHERE status = ...`, `LIKE`)
+- Aggregations (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`)
+- `GROUP BY` with and without `HAVING`
+- Inner and left-join patterns
+- Correlated subqueries and `NOT IN` NULL-safe patterns
+- `ORDER BY ... LIMIT`
+- Date arithmetic (`strftime`, `DATE(... '-30 days')`)
+- Multi-table joins across all four tables
+
+## Using SPIDER for rigorous benchmarking
+
+The built-in eval set is intentionally small — enough to explore the
+configuration space quickly. For production-grade text2SQL evaluation, the
+SPIDER benchmark (Yale, 2018) is the standard choice: 10,181 questions across
+200 databases and 138 domains.
+
+**Steps to integrate SPIDER:**
+
+1. Download Spider 1.0 from https://yale-lily.github.io/spider
+   (requires agreeing to a non-commercial research license).
+
+2. Convert the `train_spider.json` or `dev.json` rows to JSONL format:
+
+   ```python
+   import json, pathlib
+
+   spider_dev = json.loads(pathlib.Path("spider/dev.json").read_text())
+   with open("spider_eval.jsonl", "w") as f:
+       for row in spider_dev:
+           f.write(json.dumps({
+               "question": row["question"],
+               "expected": row["query"],
+           }) + "\n")
+   ```
+
+3. Update the `eval_dataset=` path in `run.py` (or pass it at runtime):
+
+   ```python
+   @traigent.optimize(
+       eval_dataset="path/to/spider_eval.jsonl",
+       ...
+   )
+   def generate_sql(question: str) -> str:
+       ...
+   ```
+
+4. Update the system prompt in `generate_sql` to include the relevant SPIDER
+   database schema for each question. SPIDER questions reference many different
+   databases, so you will need to look up the schema per `db_id`.
+
+**License note:** SPIDER is released for non-commercial research use only. Do
+not redistribute modified copies of the dataset or include SPIDER data in this
+repository.
+
+## Scoring
+
+The `sql_accuracy` metric in `run.py` first attempts a normalized exact match
+(case-insensitive, whitespace-collapsed). On a mismatch it falls back to
+token-coverage partial credit (up to 0.5), scoring how many schema names from
+the expected query appear in the generated query.
+
+For SPIDER-style evaluation you may want to replace this with an
+execution-accuracy metric: run both the expected and generated queries against
+the actual database and compare result sets. That requires a SQLite (or
+Postgres) instance loaded with each SPIDER database.

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -77,6 +77,7 @@ if MOCK:
 # Evaluation metric
 # ---------------------------------------------------------------------------
 
+
 def _normalize_sql(sql: str) -> str:
     """Lowercase, collapse whitespace, strip trailing semicolon."""
     sql = sql.strip().rstrip(";").lower()
@@ -99,10 +100,41 @@ def sql_accuracy(output: str, expected: str, **_: object) -> float:
     exp_tokens = set(norm_exp.split())
     out_tokens = set(norm_out.split())
     # Table/column names are any word that is not a SQL keyword
-    stop = {"select", "from", "where", "join", "on", "by", "and", "or",
-            "not", "in", "as", "is", "null", "the", "a", "an", "*", ">",
-            "<", "=", ">=", "<=", "<>", "(", ")", ",", ".", "'", "1", "5"}
-    exp_names = {t for t in exp_tokens if t not in stop and not t.replace(".", "").isnumeric()}
+    stop = {
+        "select",
+        "from",
+        "where",
+        "join",
+        "on",
+        "by",
+        "and",
+        "or",
+        "not",
+        "in",
+        "as",
+        "is",
+        "null",
+        "the",
+        "a",
+        "an",
+        "*",
+        ">",
+        "<",
+        "=",
+        ">=",
+        "<=",
+        "<>",
+        "(",
+        ")",
+        ",",
+        ".",
+        "'",
+        "1",
+        "5",
+    }
+    exp_names = {
+        t for t in exp_tokens if t not in stop and not t.replace(".", "").isnumeric()
+    }
     matched = sum(1 for t in exp_names if t in out_tokens)
     coverage = matched / len(exp_names) if exp_names else 0.0
     return round(0.5 * coverage, 3)
@@ -114,87 +146,47 @@ def sql_accuracy(output: str, expected: str, **_: object) -> float:
 
 _MOCK_ANSWERS: dict[str, str] = {
     # --- original 15 rows ---
-    "show all active customers":
-        "SELECT * FROM customers WHERE status = 'active'",
-    "count how many customers are in new york":
-        "SELECT COUNT(*) FROM customers WHERE city = 'New York'",
-    "find customers with unpaid bills":
-        "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid'",
-    "get the total billing revenue":
-        "SELECT SUM(amount) FROM billing",
-    "list the top 5 customers by data usage":
-        "SELECT c.name, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_data DESC LIMIT 5",
-    "find all premium plan subscribers":
-        "SELECT * FROM subscriptions WHERE plan_name = 'premium'",
-    "get average monthly rate per plan":
-        "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name",
-    "count customers by city":
-        "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city ORDER BY customer_count DESC",
-    "find overdue unpaid bills":
-        "SELECT * FROM billing WHERE status = 'unpaid' AND due_date < CURRENT_DATE",
-    "show total call minutes by customer":
-        "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_minutes DESC",
-    "find customers with no network usage":
-        "SELECT name FROM customers WHERE customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)",
-    "list customers on the enterprise plan":
-        "SELECT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.plan_name = 'enterprise'",
-    "get the highest monthly billing amount":
-        "SELECT MAX(amount) FROM billing",
-    "show customers who have more than one subscription":
-        "SELECT customer_id, COUNT(*) AS sub_count FROM subscriptions GROUP BY customer_id HAVING COUNT(*) > 1",
-    "find the average data usage per customer":
-        "SELECT c.name, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
+    "show all active customers": "SELECT * FROM customers WHERE status = 'active'",
+    "count how many customers are in new york": "SELECT COUNT(*) FROM customers WHERE city = 'New York'",
+    "find customers with unpaid bills": "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid'",
+    "get the total billing revenue": "SELECT SUM(amount) FROM billing",
+    "list the top 5 customers by data usage": "SELECT c.name, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_data DESC LIMIT 5",
+    "find all premium plan subscribers": "SELECT * FROM subscriptions WHERE plan_name = 'premium'",
+    "get average monthly rate per plan": "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name",
+    "count customers by city": "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city ORDER BY customer_count DESC",
+    "find overdue unpaid bills": "SELECT * FROM billing WHERE status = 'unpaid' AND due_date < CURRENT_DATE",
+    "show total call minutes by customer": "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name ORDER BY total_minutes DESC",
+    "find customers with no network usage": "SELECT name FROM customers WHERE customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)",
+    "list customers on the enterprise plan": "SELECT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.plan_name = 'enterprise'",
+    "get the highest monthly billing amount": "SELECT MAX(amount) FROM billing",
+    "show customers who have more than one subscription": "SELECT customer_id, COUNT(*) AS sub_count FROM subscriptions GROUP BY customer_id HAVING COUNT(*) > 1",
+    "find the average data usage per customer": "SELECT c.name, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
     # --- expanded rows (rows 16–40) ---
-    "list all distinct cities where we have customers":
-        "SELECT DISTINCT city FROM customers ORDER BY city",
-    "find the most expensive subscription plan":
-        "SELECT plan_name, monthly_rate FROM subscriptions ORDER BY monthly_rate DESC LIMIT 1",
-    "count the total number of subscriptions":
-        "SELECT COUNT(*) FROM subscriptions",
-    "show customers who started subscriptions in 2024":
-        "SELECT DISTINCT c.name FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE strftime('%Y', s.start_date) = '2024'",
-    "find all bills due this month":
-        "SELECT * FROM billing WHERE strftime('%Y-%m', due_date) = strftime('%Y-%m', CURRENT_DATE)",
-    "show total data usage per city":
-        "SELECT c.city, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.city ORDER BY total_data DESC",
-    "find customers with both unpaid bills and no network usage":
-        "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid' AND c.customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)",
-    "show the minimum and maximum billing amounts":
-        "SELECT MIN(amount) AS min_amount, MAX(amount) AS max_amount FROM billing",
-    "list all customers sorted by name alphabetically":
-        "SELECT * FROM customers ORDER BY name ASC",
-    "find customers on plans costing more than 50 per month":
-        "SELECT DISTINCT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.monthly_rate > 50",
-    "show the count of paid versus unpaid bills":
-        "SELECT status, COUNT(*) AS bill_count FROM billing GROUP BY status",
-    "find customers with total call minutes over 1000":
-        "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name HAVING SUM(nu.call_minutes) > 1000",
-    "list plans ordered by average monthly rate descending":
-        "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name ORDER BY avg_rate DESC",
-    "show the total amount billed to each customer":
-        "SELECT c.name, SUM(b.amount) AS total_billed FROM customers c JOIN billing b ON c.customer_id = b.customer_id GROUP BY c.customer_id, c.name ORDER BY total_billed DESC",
-    "find customers whose name starts with a":
-        "SELECT * FROM customers WHERE name LIKE 'A%'",
-    "count how many customers have at least one subscription":
-        "SELECT COUNT(DISTINCT customer_id) FROM subscriptions",
-    "show network usage records from the last 30 days":
-        "SELECT * FROM network_usage WHERE record_date >= DATE(CURRENT_DATE, '-30 days')",
-    "find the customer with the highest single bill":
-        "SELECT c.name, b.amount FROM customers c JOIN billing b ON c.customer_id = b.customer_id ORDER BY b.amount DESC LIMIT 1",
-    "list inactive customers with no unpaid bills":
-        "SELECT c.name FROM customers c WHERE c.status = 'inactive' AND c.customer_id NOT IN (SELECT customer_id FROM billing WHERE status = 'unpaid')",
-    "show average call minutes and average data usage per customer":
-        "SELECT c.name, AVG(nu.call_minutes) AS avg_minutes, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
-    "find cities with more than 3 customers":
-        "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city HAVING COUNT(*) > 3",
-    "list customers along with their plan names and monthly rates":
-        "SELECT c.name, s.plan_name, s.monthly_rate FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id ORDER BY c.name",
-    "show total revenue from paid bills only":
-        "SELECT SUM(amount) AS paid_revenue FROM billing WHERE status = 'paid'",
-    "find customers who have network usage records but no subscription":
-        "SELECT DISTINCT c.name FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id WHERE c.customer_id NOT IN (SELECT DISTINCT customer_id FROM subscriptions)",
-    "show the earliest subscription start date":
-        "SELECT MIN(start_date) AS earliest_start FROM subscriptions",
+    "list all distinct cities where we have customers": "SELECT DISTINCT city FROM customers ORDER BY city",
+    "find the most expensive subscription plan": "SELECT plan_name, monthly_rate FROM subscriptions ORDER BY monthly_rate DESC LIMIT 1",
+    "count the total number of subscriptions": "SELECT COUNT(*) FROM subscriptions",
+    "show customers who started subscriptions in 2024": "SELECT DISTINCT c.name FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE strftime('%Y', s.start_date) = '2024'",
+    "find all bills due this month": "SELECT * FROM billing WHERE strftime('%Y-%m', due_date) = strftime('%Y-%m', CURRENT_DATE)",
+    "show total data usage per city": "SELECT c.city, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.city ORDER BY total_data DESC",
+    "find customers with both unpaid bills and no network usage": "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid' AND c.customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)",
+    "show the minimum and maximum billing amounts": "SELECT MIN(amount) AS min_amount, MAX(amount) AS max_amount FROM billing",
+    "list all customers sorted by name alphabetically": "SELECT * FROM customers ORDER BY name ASC",
+    "find customers on plans costing more than 50 per month": "SELECT DISTINCT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.monthly_rate > 50",
+    "show the count of paid versus unpaid bills": "SELECT status, COUNT(*) AS bill_count FROM billing GROUP BY status",
+    "find customers with total call minutes over 1000": "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name HAVING SUM(nu.call_minutes) > 1000",
+    "list plans ordered by average monthly rate descending": "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name ORDER BY avg_rate DESC",
+    "show the total amount billed to each customer": "SELECT c.name, SUM(b.amount) AS total_billed FROM customers c JOIN billing b ON c.customer_id = b.customer_id GROUP BY c.customer_id, c.name ORDER BY total_billed DESC",
+    "find customers whose name starts with a": "SELECT * FROM customers WHERE name LIKE 'A%'",
+    "count how many customers have at least one subscription": "SELECT COUNT(DISTINCT customer_id) FROM subscriptions",
+    "show network usage records from the last 30 days": "SELECT * FROM network_usage WHERE record_date >= DATE(CURRENT_DATE, '-30 days')",
+    "find the customer with the highest single bill": "SELECT c.name, b.amount FROM customers c JOIN billing b ON c.customer_id = b.customer_id ORDER BY b.amount DESC LIMIT 1",
+    "list inactive customers with no unpaid bills": "SELECT c.name FROM customers c WHERE c.status = 'inactive' AND c.customer_id NOT IN (SELECT customer_id FROM billing WHERE status = 'unpaid')",
+    "show average call minutes and average data usage per customer": "SELECT c.name, AVG(nu.call_minutes) AS avg_minutes, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
+    "find cities with more than 3 customers": "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city HAVING COUNT(*) > 3",
+    "list customers along with their plan names and monthly rates": "SELECT c.name, s.plan_name, s.monthly_rate FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id ORDER BY c.name",
+    "show total revenue from paid bills only": "SELECT SUM(amount) AS paid_revenue FROM billing WHERE status = 'paid'",
+    "find customers who have network usage records but no subscription": "SELECT DISTINCT c.name FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id WHERE c.customer_id NOT IN (SELECT DISTINCT customer_id FROM subscriptions)",
+    "show the earliest subscription start date": "SELECT MIN(start_date) AS earliest_start FROM subscriptions",
 }
 
 
@@ -206,6 +198,7 @@ def _mock_generate_sql(question: str) -> str:
 # ---------------------------------------------------------------------------
 # Optimized function
 # ---------------------------------------------------------------------------
+
 
 @traigent.optimize(
     eval_dataset=DATASET,
@@ -256,10 +249,12 @@ def generate_sql(question: str) -> str:
         timeout=None,
         stop=None,
     )
-    response = llm.invoke([
-        SystemMessage(content="\n".join(system_parts)),
-        HumanMessage(content=question),
-    ])
+    response = llm.invoke(
+        [
+            SystemMessage(content="\n".join(system_parts)),
+            HumanMessage(content=question),
+        ]
+    )
     return str(response.content).strip()
 
 
@@ -279,7 +274,9 @@ if __name__ == "__main__":
         print("  - model: claude-3-haiku, claude-3-5-sonnet")
         print("  - temperature: 0.0, 0.2")
         print("  - include_schema: true, false")
-        print(f"Mode: {'MOCK (no API key required)' if MOCK else 'REAL (requires ANTHROPIC_API_KEY)'}")
+        print(
+            f"Mode: {'MOCK (no API key required)' if MOCK else 'REAL (requires ANTHROPIC_API_KEY)'}"
+        )
         print("-" * 60)
 
         async def main() -> None:
@@ -294,8 +291,15 @@ if __name__ == "__main__":
             print(f"Total trials: {len(result.trials)}")
 
             df = result.to_aggregated_dataframe(primary_objective="sql_accuracy")
-            preferred = ["model", "temperature", "include_schema",
-                         "samples_count", "sql_accuracy", "cost", "duration"]
+            preferred = [
+                "model",
+                "temperature",
+                "include_schema",
+                "samples_count",
+                "sql_accuracy",
+                "cost",
+                "duration",
+            ]
             cols = [c for c in preferred if c in df.columns]
             if cols:
                 df = df.sort_values("sql_accuracy", ascending=False)

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -11,6 +11,19 @@ Run without an API key (mock mode):
 
 Run with a real LLM (requires ANTHROPIC_API_KEY):
     python examples/core/text-to-sql/run.py
+
+Dataset note:
+    This demo ships with a small telecom (Amdocs-style) eval set covering
+    the customers, subscriptions, billing, and network_usage tables (40 rows
+    as of this writing). Questions span simple filters, aggregations, JOINs,
+    GROUP BY / HAVING, subqueries, NULL handling, and date arithmetic.
+
+    For production-scale text2SQL benchmarking, use the public SPIDER dataset
+    (https://yale-lily.github.io/spider) — download Spider 1.0, convert rows
+    to the same {"question": ..., "expected": ...} JSONL format (one object
+    per line), and pass the path via eval_dataset= in the @traigent.optimize
+    decorator or as a CLI argument. SPIDER is released under a non-commercial
+    research license; do not redistribute modified copies.
 """
 
 from __future__ import annotations
@@ -100,6 +113,7 @@ def sql_accuracy(output: str, expected: str, **_: object) -> float:
 # ---------------------------------------------------------------------------
 
 _MOCK_ANSWERS: dict[str, str] = {
+    # --- original 15 rows ---
     "show all active customers":
         "SELECT * FROM customers WHERE status = 'active'",
     "count how many customers are in new york":
@@ -130,6 +144,57 @@ _MOCK_ANSWERS: dict[str, str] = {
         "SELECT customer_id, COUNT(*) AS sub_count FROM subscriptions GROUP BY customer_id HAVING COUNT(*) > 1",
     "find the average data usage per customer":
         "SELECT c.name, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
+    # --- expanded rows (rows 16–40) ---
+    "list all distinct cities where we have customers":
+        "SELECT DISTINCT city FROM customers ORDER BY city",
+    "find the most expensive subscription plan":
+        "SELECT plan_name, monthly_rate FROM subscriptions ORDER BY monthly_rate DESC LIMIT 1",
+    "count the total number of subscriptions":
+        "SELECT COUNT(*) FROM subscriptions",
+    "show customers who started subscriptions in 2024":
+        "SELECT DISTINCT c.name FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE strftime('%Y', s.start_date) = '2024'",
+    "find all bills due this month":
+        "SELECT * FROM billing WHERE strftime('%Y-%m', due_date) = strftime('%Y-%m', CURRENT_DATE)",
+    "show total data usage per city":
+        "SELECT c.city, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.city ORDER BY total_data DESC",
+    "find customers with both unpaid bills and no network usage":
+        "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid' AND c.customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)",
+    "show the minimum and maximum billing amounts":
+        "SELECT MIN(amount) AS min_amount, MAX(amount) AS max_amount FROM billing",
+    "list all customers sorted by name alphabetically":
+        "SELECT * FROM customers ORDER BY name ASC",
+    "find customers on plans costing more than 50 per month":
+        "SELECT DISTINCT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.monthly_rate > 50",
+    "show the count of paid versus unpaid bills":
+        "SELECT status, COUNT(*) AS bill_count FROM billing GROUP BY status",
+    "find customers with total call minutes over 1000":
+        "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name HAVING SUM(nu.call_minutes) > 1000",
+    "list plans ordered by average monthly rate descending":
+        "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name ORDER BY avg_rate DESC",
+    "show the total amount billed to each customer":
+        "SELECT c.name, SUM(b.amount) AS total_billed FROM customers c JOIN billing b ON c.customer_id = b.customer_id GROUP BY c.customer_id, c.name ORDER BY total_billed DESC",
+    "find customers whose name starts with a":
+        "SELECT * FROM customers WHERE name LIKE 'A%'",
+    "count how many customers have at least one subscription":
+        "SELECT COUNT(DISTINCT customer_id) FROM subscriptions",
+    "show network usage records from the last 30 days":
+        "SELECT * FROM network_usage WHERE record_date >= DATE(CURRENT_DATE, '-30 days')",
+    "find the customer with the highest single bill":
+        "SELECT c.name, b.amount FROM customers c JOIN billing b ON c.customer_id = b.customer_id ORDER BY b.amount DESC LIMIT 1",
+    "list inactive customers with no unpaid bills":
+        "SELECT c.name FROM customers c WHERE c.status = 'inactive' AND c.customer_id NOT IN (SELECT customer_id FROM billing WHERE status = 'unpaid')",
+    "show average call minutes and average data usage per customer":
+        "SELECT c.name, AVG(nu.call_minutes) AS avg_minutes, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name",
+    "find cities with more than 3 customers":
+        "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city HAVING COUNT(*) > 3",
+    "list customers along with their plan names and monthly rates":
+        "SELECT c.name, s.plan_name, s.monthly_rate FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id ORDER BY c.name",
+    "show total revenue from paid bills only":
+        "SELECT SUM(amount) AS paid_revenue FROM billing WHERE status = 'paid'",
+    "find customers who have network usage records but no subscription":
+        "SELECT DISTINCT c.name FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id WHERE c.customer_id NOT IN (SELECT DISTINCT customer_id FROM subscriptions)",
+    "show the earliest subscription start date":
+        "SELECT MIN(start_date) AS earliest_start FROM subscriptions",
 }
 
 

--- a/examples/datasets/text-to-sql/evaluation_set.jsonl
+++ b/examples/datasets/text-to-sql/evaluation_set.jsonl
@@ -13,3 +13,28 @@
 {"question": "get the highest monthly billing amount", "expected": "SELECT MAX(amount) FROM billing"}
 {"question": "show customers who have more than one subscription", "expected": "SELECT customer_id, COUNT(*) AS sub_count FROM subscriptions GROUP BY customer_id HAVING COUNT(*) > 1"}
 {"question": "find the average data usage per customer", "expected": "SELECT c.name, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name"}
+{"question": "list all distinct cities where we have customers", "expected": "SELECT DISTINCT city FROM customers ORDER BY city"}
+{"question": "find the most expensive subscription plan", "expected": "SELECT plan_name, monthly_rate FROM subscriptions ORDER BY monthly_rate DESC LIMIT 1"}
+{"question": "count the total number of subscriptions", "expected": "SELECT COUNT(*) FROM subscriptions"}
+{"question": "show customers who started subscriptions in 2024", "expected": "SELECT DISTINCT c.name FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE strftime('%Y', s.start_date) = '2024'"}
+{"question": "find all bills due this month", "expected": "SELECT * FROM billing WHERE strftime('%Y-%m', due_date) = strftime('%Y-%m', CURRENT_DATE)"}
+{"question": "show total data usage per city", "expected": "SELECT c.city, SUM(nu.data_gb) AS total_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.city ORDER BY total_data DESC"}
+{"question": "find customers with both unpaid bills and no network usage", "expected": "SELECT DISTINCT c.name FROM customers c JOIN billing b ON c.customer_id = b.customer_id WHERE b.status = 'unpaid' AND c.customer_id NOT IN (SELECT DISTINCT customer_id FROM network_usage)"}
+{"question": "show the minimum and maximum billing amounts", "expected": "SELECT MIN(amount) AS min_amount, MAX(amount) AS max_amount FROM billing"}
+{"question": "list all customers sorted by name alphabetically", "expected": "SELECT * FROM customers ORDER BY name ASC"}
+{"question": "find customers on plans costing more than 50 per month", "expected": "SELECT DISTINCT c.name, c.city FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id WHERE s.monthly_rate > 50"}
+{"question": "show the count of paid versus unpaid bills", "expected": "SELECT status, COUNT(*) AS bill_count FROM billing GROUP BY status"}
+{"question": "find customers with total call minutes over 1000", "expected": "SELECT c.name, SUM(nu.call_minutes) AS total_minutes FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name HAVING SUM(nu.call_minutes) > 1000"}
+{"question": "list plans ordered by average monthly rate descending", "expected": "SELECT plan_name, AVG(monthly_rate) AS avg_rate FROM subscriptions GROUP BY plan_name ORDER BY avg_rate DESC"}
+{"question": "show the total amount billed to each customer", "expected": "SELECT c.name, SUM(b.amount) AS total_billed FROM customers c JOIN billing b ON c.customer_id = b.customer_id GROUP BY c.customer_id, c.name ORDER BY total_billed DESC"}
+{"question": "find customers whose name starts with A", "expected": "SELECT * FROM customers WHERE name LIKE 'A%'"}
+{"question": "count how many customers have at least one subscription", "expected": "SELECT COUNT(DISTINCT customer_id) FROM subscriptions"}
+{"question": "show network usage records from the last 30 days", "expected": "SELECT * FROM network_usage WHERE record_date >= DATE(CURRENT_DATE, '-30 days')"}
+{"question": "find the customer with the highest single bill", "expected": "SELECT c.name, b.amount FROM customers c JOIN billing b ON c.customer_id = b.customer_id ORDER BY b.amount DESC LIMIT 1"}
+{"question": "list inactive customers with no unpaid bills", "expected": "SELECT c.name FROM customers c WHERE c.status = 'inactive' AND c.customer_id NOT IN (SELECT customer_id FROM billing WHERE status = 'unpaid')"}
+{"question": "show average call minutes and average data usage per customer", "expected": "SELECT c.name, AVG(nu.call_minutes) AS avg_minutes, AVG(nu.data_gb) AS avg_data FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id GROUP BY c.customer_id, c.name"}
+{"question": "find cities with more than 3 customers", "expected": "SELECT city, COUNT(*) AS customer_count FROM customers GROUP BY city HAVING COUNT(*) > 3"}
+{"question": "list customers along with their plan names and monthly rates", "expected": "SELECT c.name, s.plan_name, s.monthly_rate FROM customers c JOIN subscriptions s ON c.customer_id = s.customer_id ORDER BY c.name"}
+{"question": "show total revenue from paid bills only", "expected": "SELECT SUM(amount) AS paid_revenue FROM billing WHERE status = 'paid'"}
+{"question": "find customers who have network usage records but no subscription", "expected": "SELECT DISTINCT c.name FROM customers c JOIN network_usage nu ON c.customer_id = nu.customer_id WHERE c.customer_id NOT IN (SELECT DISTINCT customer_id FROM subscriptions)"}
+{"question": "show the earliest subscription start date", "expected": "SELECT MIN(start_date) AS earliest_start FROM subscriptions"}


### PR DESCRIPTION
Closes #1324

## Summary

- Expands `examples/datasets/text-to-sql/evaluation_set.jsonl` from 15 to **40 rows**, adding coverage for `DISTINCT`, `ORDER BY LIMIT`, `HAVING`, correlated subqueries, date arithmetic (`strftime`, `DATE(... '-30 days')`), multi-table JOINs across all four schema tables, `NULL`-safe `NOT IN` patterns, and `MIN`/`MAX`.
- Adds matching entries in `_MOCK_ANSWERS` in `run.py` so mock mode scores correctly against all 40 rows without returning `-- unknown:` fallbacks.
- Adds a "Dataset note" to the `run.py` module docstring explaining the bundled eval set and how to swap in the SPIDER benchmark (`https://yale-lily.github.io/spider`).
- Adds `examples/core/text-to-sql/README.md` with schema overview, run instructions (mock + real LLM), SPIDER integration steps (download → JSONL conversion → eval_dataset= swap), and license note.

## Test plan

- [ ] `TRAIGENT_MOCK_LLM=true python examples/core/text-to-sql/run.py` completes without errors and all 40 eval rows resolve to exact-match scores (no `-- unknown:` fallbacks in mock mode)
- [ ] Eval set line count: `wc -l examples/datasets/text-to-sql/evaluation_set.jsonl` returns 40
- [ ] README renders correctly on GitHub

Spine-Trail: st_42f03a62af18

🤖 Generated with [Claude Code](https://claude.com/claude-code)