### PR TITLE
fix(sdk): sync best_metrics to best_config trial; respect declared ObjectiveDefinition orientation (#1340)

### DIFF
--- a/tests/unit/api/test_api_types.py
+++ b/tests/unit/api/test_api_types.py
@@ -499,10 +499,17 @@ class TestOptimizationResult:
         assert result.success_rate == 0.0
 
     def test_best_metrics_property(self):
-        """Test best_metrics property."""
+        """Test best_metrics returns metrics from the winning trial (best_config match).
+
+        best_metrics must reflect the trial whose config equals best_config, not
+        the trial with the highest metric value.  With accuracy as primary and
+        best_config pointing at t2 (gpt-4, accuracy=0.95, cost=0.10), the
+        returned metrics must be t2's, not t1's (gpt-3.5, accuracy=0.85,
+        cost=0.02).
+        """
         result = OptimizationResult(
             trials=self.trials,
-            best_config={},
+            best_config=self.trials[1].config,  # t2: gpt-4 (accuracy=0.95)
             best_score=0.95,
             optimization_id="opt_001",
             duration=10.0,

--- a/tests/unit/api/test_types.py
+++ b/tests/unit/api/test_types.py
@@ -474,10 +474,16 @@ class TestOptimizationResult:
         assert result.success_rate == 0.0
 
     def test_best_metrics_property(self):
-        """Test best_metrics property."""
+        """Test best_metrics returns the winner trial's metrics (best_config match).
+
+        best_config must point at the winning trial's config so that
+        best_metrics reflects that trial.  With best_config = t2's config
+        (gpt-4, accuracy=0.95, cost=0.10), best_metrics must return t2's
+        metrics, not the first trial's.
+        """
         result = OptimizationResult(
             trials=self.trials,
-            best_config={},
+            best_config=self.trials[1].config,  # t2: gpt-4 (accuracy=0.95)
             best_score=0.95,
             optimization_id="opt_001",
             duration=10.0,

--- a/tests/unit/core/test_best_config_result_integrity.py
+++ b/tests/unit/core/test_best_config_result_integrity.py
@@ -1,0 +1,249 @@
+"""Regression tests for results-integrity bugs fixed in #1340.
+
+F-C: best_metrics must match best_config's trial, not the max-score trial.
+F-B: declared ObjectiveDefinition.orientation is respected in best-config
+     selection; name-pattern heuristics are a fallback only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from traigent.api.types import OptimizationResult, OptimizationStatus, TrialResult, TrialStatus
+from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
+from traigent.core.result_selection import select_best_configuration
+from traigent.utils.objectives import is_minimization_objective
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_trial(
+    trial_id: str,
+    config: dict,
+    metrics: dict,
+    *,
+    status: TrialStatus = TrialStatus.COMPLETED,
+    successful_examples: int = 10,
+) -> TrialResult:
+    return TrialResult(
+        trial_id=trial_id,
+        config=config,
+        metrics=metrics,
+        status=status,
+        duration=0.1,
+        timestamp=datetime.now(),
+        metadata={"successful_examples": successful_examples, "examples_attempted": 10},
+    )
+
+
+def _make_result(
+    trials: list[TrialResult],
+    best_config: dict,
+    best_score: float | None,
+    objectives: list[str],
+    best_trial_id: str | None = None,
+) -> OptimizationResult:
+    metadata: dict = {}
+    if best_trial_id is not None:
+        metadata["best_trial_id"] = best_trial_id
+    return OptimizationResult(
+        trials=trials,
+        best_config=best_config,
+        best_score=best_score,
+        optimization_id="opt_test",
+        duration=1.0,
+        convergence_info={},
+        status=OptimizationStatus.COMPLETED,
+        objectives=objectives,
+        algorithm="random",
+        timestamp=datetime.now(),
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# F-C: best_metrics uses best_config's trial
+# ---------------------------------------------------------------------------
+
+
+class TestBestMetricsMatchesBestConfig:
+    """F-C regression: best_metrics must reflect the winning trial, not max()."""
+
+    def test_minimize_primary_metrics_match_winning_cheap_trial(self):
+        """Minimize latency: cheap wins; best_metrics must show cheap's numbers."""
+        cheap = _make_trial(
+            "cheap", {"model": "gpt-3.5"}, {"latency": 0.01, "accuracy": 0.70}
+        )
+        premium = _make_trial(
+            "premium", {"model": "gpt-4"}, {"latency": 0.50, "accuracy": 0.95}
+        )
+        # latency is a minimize objective; cheap is the winner
+        result = _make_result(
+            trials=[cheap, premium],
+            best_config=cheap.config,
+            best_score=0.01,
+            objectives=["latency"],
+            best_trial_id="cheap",
+        )
+        bm = result.best_metrics
+        assert bm["latency"] == pytest.approx(0.01), (
+            "best_metrics latency should match cheap trial (the winner), not premium"
+        )
+        assert bm["accuracy"] == pytest.approx(0.70), (
+            "best_metrics accuracy should match cheap trial (the winner)"
+        )
+
+    def test_maximize_primary_metrics_match_winning_accurate_trial(self):
+        """Maximize accuracy: premium wins; best_metrics must show premium's numbers."""
+        cheap = _make_trial(
+            "cheap", {"model": "gpt-3.5"}, {"accuracy": 0.70, "cost": 0.01}
+        )
+        premium = _make_trial(
+            "premium", {"model": "gpt-4"}, {"accuracy": 0.95, "cost": 0.50}
+        )
+        result = _make_result(
+            trials=[cheap, premium],
+            best_config=premium.config,
+            best_score=0.95,
+            objectives=["accuracy"],
+            best_trial_id="premium",
+        )
+        bm = result.best_metrics
+        assert bm["accuracy"] == pytest.approx(0.95)
+        assert bm["cost"] == pytest.approx(0.50)
+
+    def test_best_metrics_falls_back_to_best_trial_id_when_config_mismatch(self):
+        """If config match fails, fall back to metadata best_trial_id."""
+        trial_a = _make_trial("ta", {"x": 1}, {"score": 0.8})
+        trial_b = _make_trial("tb", {"x": 2}, {"score": 0.6})
+        # best_config points to an empty dict (aggregated path edge case);
+        # best_trial_id in metadata should resolve to trial_a
+        result = _make_result(
+            trials=[trial_a, trial_b],
+            best_config={},
+            best_score=0.8,
+            objectives=["score"],
+            best_trial_id="ta",
+        )
+        bm = result.best_metrics
+        assert bm["score"] == pytest.approx(0.8)
+
+    def test_best_metrics_no_winner_returns_empty(self):
+        """NO_CERTIFIED_SELECTION shape: empty best_config + None best_score."""
+        trial = _make_trial("t1", {"x": 1}, {"accuracy": 0.9})
+        result = _make_result(
+            trials=[trial],
+            best_config={},
+            best_score=None,
+            objectives=["accuracy"],
+        )
+        assert result.best_metrics == {}
+
+
+# ---------------------------------------------------------------------------
+# F-B: declared ObjectiveDefinition.orientation is respected
+# ---------------------------------------------------------------------------
+
+
+class TestDeclaredOrientationRespected:
+    """F-B regression: declared orientation must override name-pattern heuristics."""
+
+    def test_is_minimization_objective_respects_explicit_minimize(self):
+        """Explicit minimize orientation beats name-pattern logic."""
+        # "spend" is NOT in _MINIMIZE_OBJECTIVE_PATTERNS so heuristic → maximize
+        assert is_minimization_objective("spend") is False
+        # But explicit orientation must override:
+        assert is_minimization_objective("spend", orientation="minimize") is True
+
+    def test_is_minimization_objective_respects_explicit_maximize(self):
+        """Explicit maximize orientation beats name-pattern logic."""
+        # "cost" IS in patterns → heuristic says minimize
+        assert is_minimization_objective("cost") is True
+        # But explicit orientation=maximize must override:
+        assert is_minimization_objective("cost", orientation="maximize") is False
+
+    def test_is_minimization_objective_band_returns_false(self):
+        """Banded objectives use deviation logic; is_minimization must return False."""
+        assert is_minimization_objective("latency", orientation="band") is False
+
+    def test_is_minimization_objective_none_orientation_uses_heuristic(self):
+        """When orientation is None the heuristic fallback applies unchanged."""
+        assert is_minimization_objective("cost", orientation=None) is True
+        assert is_minimization_objective("accuracy", orientation=None) is False
+
+    def test_select_best_config_honors_declared_minimize_for_custom_name(self):
+        """Custom-named objective with declared minimize selects the lower value."""
+        # "spend" is not in _MINIMIZE_OBJECTIVE_PATTERNS (heuristic → maximize)
+        # but we declare orientation=minimize via objective_orientations.
+        # Use comparability_mode="legacy" to bypass comparability-metadata
+        # requirements and focus the test on the orientation fix.
+        cheap = _make_trial("cheap", {"model": "gpt-3.5"}, {"spend": 0.001})
+        premium = _make_trial("premium", {"model": "gpt-4"}, {"spend": 0.100})
+        selection = select_best_configuration(
+            trials=[cheap, premium],
+            primary_objective="spend",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            comparability_mode="legacy",
+            objective_orientations={"spend": "minimize"},
+        )
+        assert selection.best_config == cheap.config, (
+            "With declared minimize, cheap (spend=0.001) should win over premium (spend=0.100)"
+        )
+        assert selection.best_score == pytest.approx(0.001)
+
+    def test_select_best_config_honors_declared_maximize_for_cost_name(self):
+        """'cost' heuristic says minimize but declared maximize should pick the higher value."""
+        low_cost = _make_trial("low", {"model": "gpt-3.5"}, {"cost": 0.01})
+        high_cost = _make_trial("high", {"model": "gpt-4"}, {"cost": 0.99})
+        selection = select_best_configuration(
+            trials=[low_cost, high_cost],
+            primary_objective="cost",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            comparability_mode="legacy",
+            objective_orientations={"cost": "maximize"},
+        )
+        assert selection.best_config == high_cost.config, (
+            "With declared maximize on 'cost', high_cost should win"
+        )
+        assert selection.best_score == pytest.approx(0.99)
+
+    def test_select_best_config_without_orientations_uses_heuristic(self):
+        """Backward compat: no objective_orientations → heuristic applies."""
+        cheap = _make_trial("cheap", {"model": "gpt-3.5"}, {"cost": 0.01})
+        premium = _make_trial("premium", {"model": "gpt-4"}, {"cost": 0.99})
+        # heuristic: 'cost' → minimize → cheap wins
+        selection = select_best_configuration(
+            trials=[cheap, premium],
+            primary_objective="cost",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            comparability_mode="legacy",
+        )
+        assert selection.best_config == cheap.config
+        assert selection.best_score == pytest.approx(0.01)
+
+    def test_objective_schema_orientation_end_to_end_via_select_best(self):
+        """ObjectiveSchema with minimize on a custom name threads correctly."""
+        obj_def = ObjectiveDefinition(name="spend", orientation="minimize", weight=1.0)
+        schema = ObjectiveSchema.from_objectives([obj_def])
+        orientations = {obj.name: str(obj.orientation) for obj in schema.objectives}
+
+        cheap = _make_trial("cheap", {"model": "gpt-3.5"}, {"spend": 0.005})
+        premium = _make_trial("premium", {"model": "gpt-4"}, {"spend": 0.200})
+        selection = select_best_configuration(
+            trials=[cheap, premium],
+            primary_objective="spend",
+            config_space_keys={"model"},
+            aggregate_configs=False,
+            comparability_mode="legacy",
+            objective_orientations=orientations,
+        )
+        assert selection.best_config == cheap.config
+        assert selection.best_score == pytest.approx(0.005)

--- a/tests/unit/core/test_best_config_result_integrity.py
+++ b/tests/unit/core/test_best_config_result_integrity.py
@@ -11,7 +11,12 @@ from datetime import datetime
 
 import pytest
 
-from traigent.api.types import OptimizationResult, OptimizationStatus, TrialResult, TrialStatus
+from traigent.api.types import (
+    OptimizationResult,
+    OptimizationStatus,
+    TrialResult,
+    TrialStatus,
+)
 from traigent.core.objectives import ObjectiveDefinition, ObjectiveSchema
 from traigent.core.result_selection import select_best_configuration
 from traigent.utils.objectives import is_minimization_objective

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -754,16 +754,26 @@ class OptimizationResult:
                 if trial.metrics:
                     return dict(trial.metrics)
             return {}
-        # Find the best trial by score
-        best_trial = max(
-            self.trials,
-            key=lambda t: (
-                t.metrics.get(self.objectives[0], float("-inf"))
-                if t.metrics
-                else float("-inf")
-            ),
-        )
-        return dict(best_trial.metrics) if best_trial.metrics else {}
+        # F-C fix: match the trial whose config equals best_config so that
+        # best_metrics is always consistent with the actual winning trial, not
+        # the highest-scoring trial (which differs for minimize-primary or
+        # multi-objective runs).
+        if self.best_config:
+            for trial in self.trials:
+                if trial.metrics and trial.config == self.best_config:
+                    return dict(trial.metrics)
+        # Fall back to best_trial_id stored in metadata (set by result_selection)
+        # when no config match is found (aggregated configs, degenerate configs).
+        best_trial_id = self.metadata.get("best_trial_id") if self.metadata else None
+        if best_trial_id:
+            for trial in self.trials:
+                if trial.trial_id == best_trial_id and trial.metrics:
+                    return dict(trial.metrics)
+        # Last resort: return any successful trial's metrics.
+        for trial in self.trials:
+            if trial.metrics and trial.is_successful:
+                return dict(trial.metrics)
+        return {}
 
     def _calculate_objective_ranges(self) -> dict[str, tuple[float, float]]:
         """Calculate min/max ranges for each objective across all successful trials.

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -3003,6 +3003,14 @@ class OptimizationOrchestrator:
                 if primary and hasattr(incumbent, "get_metric")
                 else None
             )
+        # Build objective orientation map from ObjectiveSchema when available
+        # (F-B fix: honour declared orientation, not name-pattern heuristics).
+        _obj_orientations: dict[str, str] | None = None
+        if self.objective_schema and self.objective_schema.objectives:
+            _obj_orientations = {
+                obj.name: str(obj.orientation)
+                for obj in self.objective_schema.objectives
+            }
         selection = select_best_configuration(
             trials=self._trials,
             # Objectives-free runs are supported (weighted scoring disabled,
@@ -3022,6 +3030,7 @@ class OptimizationOrchestrator:
             require_certified=strict_mode,
             certified_config=certified_config,
             certified_score=certified_score,
+            objective_orientations=_obj_orientations,
         )
         best_config = selection.best_config
         best_score = selection.best_score

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -391,9 +391,13 @@ def _select_best_single_trial(
     band_target: float | None,
     ranking_summary: dict[str, Any],
     objective_order: Iterable[str] | None,
+    objective_orientations: dict[str, str] | None = None,
 ) -> SelectionResult:
     """Select best trial without aggregation, applying tie-breakers."""
-    minimization = is_minimization_objective(primary_objective)
+    minimization = is_minimization_objective(
+        primary_objective,
+        orientation=(objective_orientations or {}).get(primary_objective),
+    )
     chooser = min if minimization else max
 
     scored_trials = [
@@ -553,6 +557,7 @@ def _select_best_aggregated(
     band_target: float | None,
     ranking_summary: dict[str, Any],
     objective_order: Iterable[str] | None,
+    objective_orientations: dict[str, str] | None = None,
 ) -> SelectionResult:
     """Select best configuration from aggregated results with tie-breaking."""
     if not aggregated:
@@ -566,7 +571,10 @@ def _select_best_aggregated(
             reason_code=NO_RANKING_ELIGIBLE_TRIALS,
         )
 
-    minimization = is_minimization_objective(primary_objective)
+    minimization = is_minimization_objective(
+        primary_objective,
+        orientation=(objective_orientations or {}).get(primary_objective),
+    )
 
     def score(entry: dict[str, Any]) -> float:
         value = _compute_mean_metrics(entry).get(primary_objective)
@@ -689,6 +697,7 @@ def select_best_configuration(
     require_certified: bool = False,
     certified_config: dict[str, Any] | None = None,
     certified_score: float | None = None,
+    objective_orientations: dict[str, str] | None = None,
 ) -> SelectionResult:
     """Return the configuration that best satisfies the primary objective.
 
@@ -711,6 +720,11 @@ def select_best_configuration(
             From TVL 0.9 promotion_policy.tie_breakers.
         band_target: Optional target value for banded objectives.
         objective_order: Declared objectives in preference order.
+        objective_orientations: Optional mapping of objective name → declared
+            orientation (``"minimize"`` / ``"maximize"`` / ``"band"``).  When
+            present, the declared orientation for the primary objective is used
+            directly and name-pattern heuristics are bypassed.  Populated from
+            ``ObjectiveSchema.objectives[*].orientation`` by the orchestrator.
 
     Returns:
         SelectionResult with best configuration and score.
@@ -826,6 +840,7 @@ def select_best_configuration(
             band_target,
             ranking_summary,
             objective_order,
+            objective_orientations=objective_orientations,
         )
 
     aggregated = _aggregate_trials(eligible_trials, set(config_space_keys))
@@ -836,4 +851,5 @@ def select_best_configuration(
         band_target,
         ranking_summary,
         objective_order,
+        objective_orientations=objective_orientations,
     )

--- a/traigent/utils/objectives.py
+++ b/traigent/utils/objectives.py
@@ -28,15 +28,27 @@ _OPERATIONAL_OBJECTIVE_NAMES = {
 }
 
 
-def is_minimization_objective(objective_name: str) -> bool:
-    """Infer objective direction from objective name patterns.
+def is_minimization_objective(
+    objective_name: str,
+    orientation: str | None = None,
+) -> bool:
+    """Return True when the objective should be minimized.
 
-    This is a heuristic fallback for legacy objective-name-only flows.
-    It performs substring matching and can misclassify compound names like
-    ``"accuracy_cost_ratio"`` as minimization objectives.
+    When *orientation* is supplied (the value from an
+    ``ObjectiveDefinition.orientation`` field), it is used directly and
+    name-pattern heuristics are bypassed:
 
-    Prefer explicit objective orientation metadata when available.
+    * ``"minimize"`` → ``True``
+    * ``"maximize"`` → ``False``
+    * ``"band"``     → ``False`` (banded objectives use deviation, not direction)
+
+    When *orientation* is ``None`` this falls back to substring matching of
+    *objective_name* against ``_MINIMIZE_OBJECTIVE_PATTERNS``.  This heuristic
+    is retained for backward compatibility with legacy string-only objective
+    flows and can misclassify compound names like ``"accuracy_cost_ratio"``.
     """
+    if orientation is not None:
+        return orientation == "minimize"
     lowered = objective_name.lower()
     return any(pattern in lowered for pattern in _MINIMIZE_OBJECTIVE_PATTERNS)
 


### PR DESCRIPTION
Closes #1340

Spine-Trail: st_dacf9a1132ce

## Summary

- **F-C fix**: `OptimizationResult.best_metrics` was using unconditional `max()` to pick the winning trial, producing metrics inconsistent with `best_config` for minimize-primary or custom-named objectives. Now matches the trial whose `config == best_config`, with fallbacks to `metadata["best_trial_id"]` then any successful trial.

- **F-B fix**: `is_minimization_objective()` performed substring-pattern matching against `_MINIMIZE_OBJECTIVE_PATTERNS` regardless of any declared `ObjectiveDefinition.orientation`. Custom-named objectives like `"spend"` were silently misclassified (heuristic → maximize, even when `orientation="minimize"` was declared). Fixed by:
  - Adding `orientation: str | None = None` param to `is_minimization_objective`; explicit orientation short-circuits name heuristics.
  - Adding `objective_orientations: dict[str, str] | None = None` to `select_best_configuration`, threaded to `_select_best_single_trial` and `_select_best_aggregated`.
  - Orchestrator builds the orientation map from `self.objective_schema` and passes it at the `select_best_configuration` call site.
  - Name-pattern heuristics remain as backward-compatible fallback for string-only objective flows.

## Files changed

- `traigent/utils/objectives.py` — `is_minimization_objective` now accepts `orientation` override
- `traigent/core/result_selection.py` — `select_best_configuration` + internal helpers accept `objective_orientations`
- `traigent/core/orchestrator.py` — builds and passes orientation map from `objective_schema`
- `traigent/api/types.py` — `best_metrics` matches by `best_config` instead of `max()`
- `tests/unit/core/test_best_config_result_integrity.py` — 12 new regression tests (all green)
- `tests/unit/api/test_api_types.py`, `tests/unit/api/test_types.py` — corrected stale assertions that relied on the buggy `max()` behavior

## Test plan

- [ ] 12 new regression tests in `test_best_config_result_integrity.py` — all green locally
- [ ] 54 existing `test_api_types.py` tests — all green
- [ ] 1007 existing `tests/unit/api/` tests — all green
- [ ] 1996 existing `tests/unit/core/` tests (excluding flagged slow ones) — all green
- [ ] Pre-commit hooks (ruff, mypy, bandit, public-test-assertions) — all pass

## PR checklist

1. **Worst-case prod path**: orientation inference is a read-only heuristic; worst case is wrong sort direction — no data leak, no auth impact.
2. **Production-branch test**: no auth/billing code touched.
3. **Contract regeneration**: no schema changes.
4. **Public surface delta**: `is_minimization_objective` signature change is backward-compatible (new optional param with `None` default).
5. **Review threads resolved**: n/a (new PR).
6. **Quality gates not relaxed**: no thresholds changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)