### PR TITLE
fix(sdk): refresh stale Claude 3.x model presets to Claude 4.x family

### DIFF
--- a/traigent/agents/config_mapper.py
+++ b/traigent/agents/config_mapper.py
@@ -532,7 +532,7 @@ class ConfigurationMapper:
                 ParameterMapping(
                     source_key="model",
                     target_key="model",
-                    description="Anthropic model name (claude-3-opus, claude-3-sonnet, claude-3-haiku)",
+                    description="Anthropic model name (claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5-20251001)",
                 ),
                 ParameterMapping(
                     source_key="temperature",

--- a/traigent/analytics/intelligence.py
+++ b/traigent/analytics/intelligence.py
@@ -1098,7 +1098,7 @@ Generated: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")}
                         "resource_type": "compute",
                         "type": "model_downgrade",
                         "priority": "high",
-                        "action": "Consider using gpt-3.5-turbo or claude-3-5-haiku-latest",
+                        "action": "Consider using gpt-4o-mini or claude-haiku-4-5-20251001",
                         "potential_savings": "50-90%",
                         "impact": "Minimal accuracy loss for most tasks",
                         "confidence": 0.85,
@@ -1529,9 +1529,9 @@ Generated: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")}
                     "task": task.get("name", "unknown"),
                     "allocated_budget": allocation,
                     "recommended_model": (
-                        "claude-3-5-haiku-latest"
+                        "claude-haiku-4-5-20251001"
                         if allocation < 50
-                        else "gpt-3.5-turbo"
+                        else "gpt-4o-mini"
                     ),
                     "expected_performance": 0.85,
                 }
@@ -1778,10 +1778,9 @@ Generated: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")}
             model_mappings = {
                 "openai": ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo", "gpt-4-turbo"],
                 "anthropic": [
-                    "claude-3-5-sonnet-20241022",
-                    "claude-3-5-haiku-latest",
-                    "claude-3-opus-20240229",
-                    "claude-3-sonnet-20240229",
+                    "claude-opus-4-8",
+                    "claude-sonnet-4-6",
+                    "claude-haiku-4-5-20251001",
                 ],
             }
 

--- a/traigent/api/parameter_ranges.py
+++ b/traigent/api/parameter_ranges.py
@@ -789,12 +789,12 @@ class Choices(CategoricalConstraintBuilderMixin, ParameterRange, Generic[T]):
             ("openai", "fast"): ["gpt-4o-mini"],
             ("openai", "balanced"): ["gpt-4o-mini", "gpt-4o"],
             ("openai", "quality"): ["gpt-4o", "o1-preview"],
-            ("anthropic", "fast"): ["claude-3-haiku-20240307"],
-            ("anthropic", "balanced"): ["claude-3-5-sonnet-20241022"],
-            ("anthropic", "quality"): ["claude-3-opus-20240229"],
-            (None, "fast"): ["gpt-4o-mini", "claude-3-haiku-20240307"],
-            (None, "balanced"): ["gpt-4o-mini", "gpt-4o", "claude-3-5-sonnet-20241022"],
-            (None, "quality"): ["gpt-4o", "claude-3-opus-20240229"],
+            ("anthropic", "fast"): ["claude-haiku-4-5-20251001"],
+            ("anthropic", "balanced"): ["claude-sonnet-4-6"],
+            ("anthropic", "quality"): ["claude-opus-4-8"],
+            (None, "fast"): ["gpt-4o-mini", "claude-haiku-4-5-20251001"],
+            (None, "balanced"): ["gpt-4o-mini", "gpt-4o", "claude-sonnet-4-6"],
+            (None, "quality"): ["gpt-4o", "claude-opus-4-8"],
         }
 
         models_found = fallbacks.get((provider, tier))


### PR DESCRIPTION
Related to skills#29 item 3 (stale Claude presets).

Updates `Choices.model()` fallback presets and analytics model recommendations from Claude 3.x IDs to the current Claude 4.x family:
- `claude-haiku-4-5-20251001` (fast tier, replaces claude-3-haiku-20240307)
- `claude-sonnet-4-6` (balanced tier, replaces claude-3-5-sonnet-20241022)
- `claude-opus-4-8` (quality tier, replaces claude-3-opus-20240229)

Files changed:
- `traigent/api/parameter_ranges.py` — Choices.model() fallback dict
- `traigent/analytics/intelligence.py` — model recommendation strings + provider map
- `traigent/agents/config_mapper.py` — description string

Tests: existing test asserts `"claude" in m` (not specific ID) so no test changes needed.

Spine-Trail: st_57c045df0967