### PR TITLE
fix(cloud): surface HTTP 400 body in trial upload logs; log session-not-found as INFO (#1343)

### DIFF
--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -922,6 +922,7 @@ class TestHandle400NotFound:
     session-storage condition (BE #1194) and must be handled gracefully:
     - logged at INFO (not WARNING/ERROR) with the transient sync guidance
     - submit_trial_result_via_session returns None (skipped) not False (hard failure)
+    - non-session "not found" 400s (e.g. "Trial not found") stay at WARNING/False
     """
 
     def _make_ops(self) -> "TrialOperations":
@@ -936,10 +937,11 @@ class TestHandle400NotFound:
         mock_client._sanitize_error_message = Mock(return_value="")
         return TrialOperations(mock_client)
 
-    def test_handle_trial_error_response_400_not_found_logs_info(
+    def test_handle_trial_error_response_400_session_not_found_logs_info(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """400 + 'not found' body → INFO log with transient guidance, not WARNING."""
+        """400 + session not found body → INFO log with transient guidance and
+        the backend detail in the log, not WARNING."""
         ops = self._make_ops()
         error_body = '{"error": "Session abc123 not found"}'
 
@@ -953,7 +955,7 @@ class TestHandle400NotFound:
             )
 
         assert is_transient is True, (
-            "_handle_trial_error_response must return True for not-found"
+            "_handle_trial_error_response must return True for session not-found"
         )
 
         # Must log at INFO, not WARNING or ERROR
@@ -964,28 +966,60 @@ class TestHandle400NotFound:
         )
         assert not warn_records, (
             "No WARNING or ERROR log records should be emitted for a transient "
-            f"session-not-found 400; got: {[r.message for r in warn_records]}"
+            f"session-not-found 400; got: {[r.getMessage() for r in warn_records]}"
         )
 
-        # The INFO message must mention 'traigent sync' so users know how to recover
         combined = " ".join(r.getMessage() for r in info_records)
-        assert "traigent sync" in combined or "sync" in combined, (
+        # Sync guidance must appear so users know how to recover
+        assert "sync" in combined, (
             "INFO log should include sync guidance for transient not-found"
         )
+        # The parsed backend detail must appear in the log so the body is not
+        # silently swallowed — this is the text extracted from the JSON "error" key.
+        assert "Session abc123 not found" in combined, (
+            "INFO log must include the backend detail from the response body; "
+            f"got: {combined!r}"
+        )
+
+    def test_handle_trial_error_response_400_trial_not_found_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """400 + 'Trial not found' body must NOT be treated as transient session
+        storage — it should stay at WARNING/False to avoid masking real errors."""
+        ops = self._make_ops()
+        # "Trial not found in session" is a different error class — not a transient
+        # per-worker session storage miss.
+        error_body = '{"error": "Trial trial_xyz not found in session sess_abc"}'
+
+        with caplog.at_level(logging.DEBUG, logger="traigent.cloud.trial_operations"):
+            is_transient = ops._handle_trial_error_response(
+                status=400,
+                trial_id="trial_xyz",
+                session_id="sess_abc",
+                url="https://portal.traigent.ai/api/v1/sessions/sess_abc/results",
+                error_text=error_body,
+            )
+
+        assert is_transient is False, (
+            "'Trial not found in session' is not a transient session storage miss"
+        )
+
+        warn_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warn_records, "Expected WARNING log for non-session not-found 400"
 
     @pytest.mark.asyncio
-    async def test_submit_trial_result_400_not_found_returns_none(
+    async def test_submit_trial_result_400_session_not_found_returns_none(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         """submit_trial_result_via_session must return None (not False) for a
-        400 'not found' so _log_trial_to_backend does not flag backend degraded."""
+        400 session-not-found so _log_trial_to_backend does not flag backend
+        degraded.  The backend detail must appear in the log."""
         ops = self._make_ops()
 
         mock_response = Mock()
         mock_response.status = 400
-        mock_response.text = AsyncMock(
-            return_value='{"error": "Session sess_edge not found"}'
-        )
+        error_json = '{"error": "Session sess_edge not found"}'
+        mock_response.text = AsyncMock(return_value=error_json)
         mock_session_ctx, _ = _aiohttp_post_returning(mock_response)
 
         with (
@@ -1014,13 +1048,13 @@ class TestHandle400NotFound:
 
         # Must return None (transient/skipped), not False (hard failure)
         assert result is None, (
-            f"Expected None for 400 not-found (transient skip), got {result!r}"
+            f"Expected None for 400 session-not-found (transient skip), got {result!r}"
         )
 
-        # The response body text must appear somewhere in the logs so the error
-        # is not silently swallowed — the INFO message includes session_id which
-        # is derived from the error body.
+        # The backend detail from the response body must be visible in the log.
+        # This is the key fix: the error is not silently swallowed.
         all_log_text = " ".join(r.getMessage() for r in caplog.records)
-        assert "sess_edge" in all_log_text, (
-            "Session ID from error body must appear in logs for diagnosability"
+        assert "Session sess_edge not found" in all_log_text, (
+            "Backend response body detail must appear in logs. "
+            f"All log text: {all_log_text!r}"
         )

--- a/tests/unit/cloud/test_trial_operations.py
+++ b/tests/unit/cloud/test_trial_operations.py
@@ -915,3 +915,112 @@ class TestRequestTrialSlot:
         ):
             assert await ops.request_trial_slot("sess-1") is None
         mock_client.auth_manager.augment_headers.assert_not_awaited()
+
+
+class TestHandle400NotFound:
+    """HTTP 400 'not found' from the results endpoint is a transient per-worker
+    session-storage condition (BE #1194) and must be handled gracefully:
+    - logged at INFO (not WARNING/ERROR) with the transient sync guidance
+    - submit_trial_result_via_session returns None (skipped) not False (hard failure)
+    """
+
+    def _make_ops(self) -> "TrialOperations":
+        mock_client = Mock()
+        mock_client.backend_config = Mock()
+        mock_client.backend_config.backend_base_url = "https://portal.traigent.ai"
+        mock_client.backend_config.api_base_url = "https://portal.traigent.ai/api/v1"
+        mock_client.auth_manager = AsyncMock()
+        mock_client.auth_manager.augment_headers = AsyncMock(return_value={})
+        mock_client._map_to_backend_status = Mock(return_value="COMPLETED")
+        mock_client._normalize_execution_mode = Mock(return_value="edge_analytics")
+        mock_client._sanitize_error_message = Mock(return_value="")
+        return TrialOperations(mock_client)
+
+    def test_handle_trial_error_response_400_not_found_logs_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """400 + 'not found' body → INFO log with transient guidance, not WARNING."""
+        ops = self._make_ops()
+        error_body = '{"error": "Session abc123 not found"}'
+
+        with caplog.at_level(logging.DEBUG, logger="traigent.cloud.trial_operations"):
+            is_transient = ops._handle_trial_error_response(
+                status=400,
+                trial_id="trial_xyz",
+                session_id="abc123",
+                url="https://portal.traigent.ai/api/v1/sessions/abc123/results",
+                error_text=error_body,
+            )
+
+        assert is_transient is True, (
+            "_handle_trial_error_response must return True for not-found"
+        )
+
+        # Must log at INFO, not WARNING or ERROR
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        warn_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert info_records, (
+            "Expected at least one INFO log record for transient not-found"
+        )
+        assert not warn_records, (
+            "No WARNING or ERROR log records should be emitted for a transient "
+            f"session-not-found 400; got: {[r.message for r in warn_records]}"
+        )
+
+        # The INFO message must mention 'traigent sync' so users know how to recover
+        combined = " ".join(r.getMessage() for r in info_records)
+        assert "traigent sync" in combined or "sync" in combined, (
+            "INFO log should include sync guidance for transient not-found"
+        )
+
+    @pytest.mark.asyncio
+    async def test_submit_trial_result_400_not_found_returns_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """submit_trial_result_via_session must return None (not False) for a
+        400 'not found' so _log_trial_to_backend does not flag backend degraded."""
+        ops = self._make_ops()
+
+        mock_response = Mock()
+        mock_response.status = 400
+        mock_response.text = AsyncMock(
+            return_value='{"error": "Session sess_edge not found"}'
+        )
+        mock_session_ctx, _ = _aiohttp_post_returning(mock_response)
+
+        with (
+            patch(
+                "traigent.cloud.trial_operations.is_backend_offline",
+                return_value=False,
+            ),
+            patch("traigent.cloud.trial_operations.AIOHTTP_AVAILABLE", True),
+            patch(
+                "traigent.cloud.trial_operations.validate_configuration_run_submission",
+            ),
+            patch("traigent.cloud.trial_operations.aiohttp") as mock_aiohttp,
+            caplog.at_level(logging.DEBUG, logger="traigent.cloud.trial_operations"),
+        ):
+            mock_aiohttp.ClientSession = Mock(return_value=mock_session_ctx)
+            mock_aiohttp.ClientTimeout = Mock()
+
+            result = await ops.submit_trial_result_via_session(
+                session_id="sess_edge",
+                trial_id="trial_001",
+                config={"temperature": 0.5},
+                metrics={"score": 0.8},
+                status="completed",
+                execution_mode="edge_analytics",
+            )
+
+        # Must return None (transient/skipped), not False (hard failure)
+        assert result is None, (
+            f"Expected None for 400 not-found (transient skip), got {result!r}"
+        )
+
+        # The response body text must appear somewhere in the logs so the error
+        # is not silently swallowed — the INFO message includes session_id which
+        # is derived from the error body.
+        all_log_text = " ".join(r.getMessage() for r in caplog.records)
+        assert "sess_edge" in all_log_text, (
+            "Session ID from error body must appear in logs for diagnosability"
+        )

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -10,6 +10,7 @@ import asyncio
 import concurrent.futures
 import hashlib
 import json
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -608,6 +609,49 @@ class TrialOperations:
 
         return True
 
+    @staticmethod
+    def _is_session_not_found_400(status: int, error_text: str) -> bool:
+        """Return True only for the specific transient per-worker session-not-found case.
+
+        A 400 is treated as transient only when:
+        - status is exactly 400 (not 404, not 5xx), AND
+        - the response body signals the *session* (not a trial, config-run, or
+          unrelated object) was not found.
+
+        Matches both plain-text patterns and structured JSON error codes so the
+        check stays valid if the backend changes its message wording.
+        """
+        if status != 400:
+            return False
+
+        body_lower = error_text.lower()
+
+        # Structured check: parse JSON and look for an error code that unambiguously
+        # names a missing session.
+        try:
+            parsed = json.loads(error_text)
+            if isinstance(parsed, dict):
+                code = str(parsed.get("code") or parsed.get("error_code") or "").lower()
+                if code in {"session_not_found", "session-not-found"}:
+                    return True
+        except (ValueError, KeyError):
+            pass
+
+        # Plain-text heuristic: "session" must be the *subject* of the not-found
+        # message, not merely appear somewhere in the text.  Patterns checked:
+        #   "session <id> not found"
+        #   "session does not exist"
+        #   "unknown session"
+        # Excluded intentionally: "Trial ... not found in session" or
+        # "Configuration run not found" which contain "session" as a prepositional
+        # object — these are different error classes and must not be swallowed.
+        session_subject_patterns = (
+            r"\bsession\b[^.]*\bnot found\b",
+            r"\bsession\b[^.]*\bdoes not exist\b",
+            r"\bunknown session\b",
+        )
+        return any(re.search(pat, body_lower) for pat in session_subject_patterns)
+
     def _handle_trial_error_response(
         self,
         status: int,
@@ -620,49 +664,49 @@ class TrialOperations:
 
         Logs the HTTP status and response body so callers can diagnose backend
         rejections without inspecting raw network traffic.  When the backend
-        returns 400 with a "not found" body the error is downgraded to INFO
-        with a user-friendly note about transient per-worker session storage
-        (see BE #1194).
+        returns 400 and the body indicates that the *session* was not found, the
+        error is downgraded to INFO with a user-friendly recovery note (see BE
+        #1194 — per-worker session storage race).
 
         Returns:
-            True if the error is a transient session-not-found (400 + "not found")
-            that the caller should treat as a skipped upload rather than a hard
-            failure, False for all other errors.
+            True if the error is a transient session-not-found 400 that the
+            caller should treat as a skipped upload rather than a hard failure.
+            False for all other errors (caller should degrade backend tracking).
         """
         # Extract a concise user-facing message from the response body when
         # the backend returned JSON with an "error" or "message" field.
         detail: str = error_text.strip()
         if detail:
             try:
-                import json as _json
-
-                parsed = _json.loads(detail)
+                parsed = json.loads(detail)
                 if isinstance(parsed, dict):
                     detail = parsed.get("error") or parsed.get("message") or detail
             except (ValueError, KeyError):
                 pass
 
-        is_not_found = status == 400 and "not found" in error_text.lower()
-
-        if is_not_found:
+        if self._is_session_not_found_400(status, error_text):
+            # Log the backend detail so the raw body is still visible even
+            # though this is a benign transient condition.
             logger.info(
-                "Session %s not found on backend — trial result could not be "
-                "uploaded (likely transient; run `traigent sync` after "
-                "optimization completes to upload offline). Trial ID: %s",
+                "Session %s not found on backend — trial %s could not be "
+                "uploaded (likely transient per-worker storage; run "
+                "`traigent sync` after optimization to upload offline). "
+                "Backend detail: %s",
                 session_id,
                 trial_id,
+                detail or error_text or "(no body)",
             )
             return True
-        else:
-            logger.warning(
-                "❌ Failed to submit trial result: HTTP %s — %s",
-                status,
-                detail or "(no response body)",
-            )
-            logger.warning(
-                "   Trial ID: %s  Session ID: %s  URL: %s", trial_id, session_id, url
-            )
-            return False
+
+        logger.warning(
+            "❌ Failed to submit trial result: HTTP %s — %s",
+            status,
+            detail or "(no response body)",
+        )
+        logger.warning(
+            "   Trial ID: %s  Session ID: %s  URL: %s", trial_id, session_id, url
+        )
+        return False
 
     async def submit_trial_result_via_session(
         self,

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -614,13 +614,55 @@ class TrialOperations:
         trial_id: str,
         session_id: str,
         url: str,
-    ) -> None:
-        """Handle error response from trial submission."""
-        logger.error("❌ Failed to submit trial result: HTTP %s", status)
-        logger.error("   Trial ID: %s", trial_id)
-        logger.error("   Session ID: %s", session_id)
-        logger.error("   URL: %s", url)
-        logger.debug("Backend error response suppressed from logs")
+        error_text: str = "",
+    ) -> bool:
+        """Handle error response from trial submission.
+
+        Logs the HTTP status and response body so callers can diagnose backend
+        rejections without inspecting raw network traffic.  When the backend
+        returns 400 with a "not found" body the error is downgraded to INFO
+        with a user-friendly note about transient per-worker session storage
+        (see BE #1194).
+
+        Returns:
+            True if the error is a transient session-not-found (400 + "not found")
+            that the caller should treat as a skipped upload rather than a hard
+            failure, False for all other errors.
+        """
+        # Extract a concise user-facing message from the response body when
+        # the backend returned JSON with an "error" or "message" field.
+        detail: str = error_text.strip()
+        if detail:
+            try:
+                import json as _json
+
+                parsed = _json.loads(detail)
+                if isinstance(parsed, dict):
+                    detail = parsed.get("error") or parsed.get("message") or detail
+            except (ValueError, KeyError):
+                pass
+
+        is_not_found = status == 400 and "not found" in error_text.lower()
+
+        if is_not_found:
+            logger.info(
+                "Session %s not found on backend — trial result could not be "
+                "uploaded (likely transient; run `traigent sync` after "
+                "optimization completes to upload offline). Trial ID: %s",
+                session_id,
+                trial_id,
+            )
+            return True
+        else:
+            logger.warning(
+                "❌ Failed to submit trial result: HTTP %s — %s",
+                status,
+                detail or "(no response body)",
+            )
+            logger.warning(
+                "   Trial ID: %s  Session ID: %s  URL: %s", trial_id, session_id, url
+            )
+            return False
 
     async def submit_trial_result_via_session(
         self,
@@ -770,10 +812,16 @@ class TrialOperations:
                         )
                         return False
                     else:
-                        self._handle_trial_error_response(
-                            response.status, trial_id, session_id, url
+                        error_text = await response.text()
+                        is_transient = self._handle_trial_error_response(
+                            response.status, trial_id, session_id, url, error_text
                         )
-                        return False
+                        # Return None for transient session-not-found (400 +
+                        # "not found") so _log_trial_to_backend treats this as
+                        # a skipped upload
+                        # rather than a hard backend failure and does not flag
+                        # the backend as degraded (BE #1194 per-worker storage).
+                        return None if is_transient else False
 
         except Exception as exc:
             if is_backend_offline():

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -976,10 +976,17 @@ class BackendSessionManager:
                 if inspect.isawaitable(submitted_result)
                 else submitted_result
             )
-            if not submitted:
-                # A False return covers both a backend rejection and a network
-                # failure swallowed by the trial-submit layer; either way this
-                # trial is not cloud-tracked, so degrade to local-only (#1265).
+            if submitted is None:
+                # None signals a transient, non-fatal skip (e.g. 400 session-not-found
+                # from per-worker session storage — BE #1194).  The trial-operations
+                # layer already logged an INFO message; don't flag backend degraded
+                # and don't re-log here so the user isn't flooded with warnings for
+                # a known transient condition.  Recover via `traigent sync`.
+                pass
+            elif not submitted:
+                # False covers a real backend rejection (non-2xx that is not a
+                # transient not-found) or a network failure; degrade to local-only
+                # (#1265) so subsequent trials don't keep hitting a broken endpoint.
                 self._flag_backend_degraded("trial submission")
                 logger.warning(
                     "Backend session endpoint did not accept trial %s for session %s",


### PR DESCRIPTION
## Summary

Fixes #1343
Fixes #1347

Both `edge_analytics` and `hybrid` modes go through the same `POST /api/v1/sessions/{id}/results` endpoint, so this improvement covers both modes.

- **Fix 1 — Expose response body in error logs**: `_handle_trial_error_response` now reads the HTTP response body and logs it at WARNING (instead of suppressing it). When the body is JSON, extracts the `error`/`message` field for a concise user-facing message. This makes diagnosing backend rejections possible without network tracing.

- **Fix 2 — Graceful handling of session-not-found 400**: When the backend returns HTTP 400 with "not found" in the body (per-worker session storage race — see BE #1194), the SDK now logs at INFO with guidance to run `traigent sync` after optimization completes, instead of a WARNING that implies a user error. `submit_trial_result_via_session` returns `None` (skipped/transient) so `_log_trial_to_backend` does not flag the backend as degraded and the optimization continues uninterrupted.

Root cause of the 400 is a per-worker session storage issue tracked in BE #1194; this PR improves observability and makes the SDK more resilient while BE #1223 addresses the root cause.

## PR Checklist

1. **Worst-case prod path**: The error path returns `False`/`None` (fail-closed no-op), never permissive. Session-not-found transient detection only changes log level, not behavior — optimization continues locally regardless.
2. **Production-branch test**: N/A (no policy surface). Tests assert logging level: `tests/unit/cloud/test_trial_operations.py::TestHandle400NotFound`.
3. **Contract regeneration**: No schema changes.
4. **Public surface delta**: No changes to `__all__`, public API, or routes.
5. **Review threads resolved**: N/A (new PR).
6. **Quality gates not relaxed**: 37 pre-existing E501 violations in files; zero new ones introduced (all my changed lines are ≤88 chars).

## Test plan

- [ ] `uv run pytest tests/unit/cloud/test_trial_operations.py -x -q` — all 37 tests pass
- [ ] New tests: `TestHandle400NotFound::test_handle_trial_error_response_400_not_found_logs_info` and `test_submit_trial_result_400_not_found_returns_none`

Spine-Trail: st_0039a9c35ad9