### PR TITLE
fix(deps): bump pyjwt>=2.13.0, idna>=3.15 for security

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "requests>=2.33.0",  # Required by Langfuse integration sync fallback; CVE-2026-25645 / GHSA-9hjg-9r4m-mvj7 fix
     "jsonschema>=4.0.0",
     "cryptography>=46.0.7",  # CVE-2026-26007 + 3 more fixed in 46.0.7 (see #709)
-    "PyJWT[crypto]>=2.12.0,<3.0.0",  # CVE-2026-32597 floor; required by traigent.security.jwt_validator and traigent.cloud.auth at import time
+    "PyJWT[crypto]>=2.13.0,<3.0.0",  # >=2.13.0: Dependabot alerts — DoS, SSRF via JWKClient, HS256 forgery, alg bypass, kid DoS
     "backoff>=2.2.0",
     "litellm==1.87.1",  # Stable pin: 1.83.x python-dotenv==1.0.1 and 1.83.14 openai==2.24.0 sub-pins are gone from stable 1.84+ (1.87.1 ships openai>=2.20,<3 and python-dotenv>=1.0,<2, compatible with langchain-openai>=1.1.14). Keep pinned + verified on bumps; no need for RC/dev builds anymore.
     "rank-bm25",
@@ -263,6 +263,7 @@ traigent_validation = ["py.typed"]
 [tool.uv]
 constraint-dependencies = [
     "flask>=3.1.3",
+    "idna>=3.15",  # CVE-2024-3651 bypass in idna.encode()
     "langgraph>=1.0.10",
     "langsmith>=0.7.31",
     "mako>=1.3.11",

--- a/requirements/requirements-security.txt
+++ b/requirements/requirements-security.txt
@@ -4,7 +4,7 @@
 -r requirements.txt
 
 # Enterprise security features
-pyjwt>=2.12.0
+pyjwt>=2.13.0
 cryptography>=46.0.7
 passlib>=1.7.4
 python-multipart>=0.0.26

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "flask", specifier = ">=3.1.3" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "langgraph", specifier = ">=1.0.10" },
     { name = "langsmith", specifier = ">=0.7.31" },
     { name = "mako", specifier = ">=1.3.11" },
@@ -2141,11 +2142,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -4836,11 +4837,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -6406,7 +6407,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.8.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-ai-slim", marker = "extra == 'pydanticai'", specifier = ">=1.56.0,<2" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<3.0.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0,<3.0.0" },
     { name = "pyotp", marker = "extra == 'security'", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.0.3" },


### PR DESCRIPTION
Addresses all open Dependabot alerts with available fixes:

| Package | Alert | Severity |
|---------|-------|----------|
| pyjwt ≥2.13.0 | DoS, SSRF via JWKClient, HS256 forgery, alg bypass, kid DoS | high/medium |
| idna ≥3.15 | CVE-2024-3651 bypass in encode() | medium |
| chromadb | no fix — dismissed tolerable_risk (optional extra, not in prod path) | critical |

Also updated `requirements/requirements-security.txt` floor to match pyproject.toml (pre-commit drift guard).

Tests: 13396 passed, 39 skipped locally.

Spine-Trail: st_311c7bd2fa19