### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Traigent SDK are documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.14.0] - 2026-06-19
 
 ### Added
 - **Composite telemetry rides the measures channel.** `composite_measures(run)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## Version bump: 0.13.0 → 0.14.0

Finalizes the 0.14.0 release after the develop→main merge (PR #1354).

**Changes:**
- `pyproject.toml`: `version = "0.14.0"`
- `CHANGELOG.md`: `[Unreleased]` → `[0.14.0] - 2026-06-19`

**Why 0.14.0 (minor bump):** this release includes breaking removals — `BudgetStopCondition`, `TRAIGENT_TRACES_ENABLED`, `OptimizedFunction.config_space`, non-preset `strategy=` alias, and `budget_limit`/`budget_metric`/`budget_include_pruned` runtime keys.

After merge: push tag `v0.14.0` to trigger the `Publish to PyPI` workflow.

Spine-Trail: st_4d2b935eec0e

## PR checklist
1. **Worst-case prod path:** version-only change; no runtime code paths altered.
2. **Production-branch test:** N/A — no logic changes.
3. **Contract regeneration:** none.
4. **Public surface delta:** none — only version metadata.
5. **Review threads:** none expected.
6. **Quality gates:** not relaxed.