### PR TITLE
ci: add SonarQube Local Gate for Python SDK

### DIFF
--- a/.github/workflows/sonarqube-local.yml
+++ b/.github/workflows/sonarqube-local.yml
@@ -1,0 +1,76 @@
+name: SonarQube Local Gate
+
+# Quality gate against the persistent self-hosted SonarQube (private, in-VPC).
+# Runs on the co-located self-hosted runner and scans http://localhost:9000.
+# SonarCloud org private-LOC quota is exhausted; this replaces it for the SDK.
+# New Code = 30 days is set on the server; gate enforces clean-as-you-code.
+#
+# Policy: REQUIRED on `main`, OPTIONAL (informational) on `develop`.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonarqube-local-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarqube-quality-gate:
+    name: SonarQube Quality Gate
+    runs-on: [self-hosted, sonarqube]
+    timeout-minutes: 25
+    env:
+      SONAR_HOST_URL: http://localhost:9000
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.11 (system venv)
+        # self-hosted arm64 runner: actions/setup-python has no 3.11 arm64 build,
+        # so use the box system Python 3.11 via a venv on PATH.
+        run: |
+          python3.11 -m venv "$RUNNER_TEMP/venv"
+          echo "$RUNNER_TEMP/venv/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/venv/bin/python" -m pip install --quiet --upgrade pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests with coverage
+        continue-on-error: true
+        run: pytest tests/ --cov=traigent --cov-report=xml -q
+
+      - name: Analyze and enforce quality gate
+        run: |
+          sonar-scanner \
+            -Dsonar.host.url="${SONAR_HOST_URL}" \
+            -Dsonar.token="${SONAR_TOKEN}" \
+            -Dsonar.organization= \
+            -Dsonar.qualitygate.wait=true \
+            -Dsonar.qualitygate.timeout=300
+
+      - name: Report quality gate conditions
+        if: always()
+        run: |
+          key=$(grep -E '^sonar.projectKey=' sonar-project.properties | cut -d= -f2)
+          echo "Quality gate for project: $key"
+          curl -s -u "${SONAR_TOKEN}:" \
+            "${SONAR_HOST_URL}/api/qualitygates/project_status?projectKey=$key" \
+            | python3 -c "
+          import sys,json
+          d=json.load(sys.stdin).get('projectStatus',{})
+          print('STATUS:', d.get('status'))
+          for c in d.get('conditions',[]):
+              print(f\"  [{c['status']}] {c['metricKey']}: actual={c.get('actualValue')} {c.get('comparator')} {c.get('errorThreshold')}\")
+          " || true


### PR DESCRIPTION
## Summary

Adds the missing `sonarqube-local.yml` workflow to the Python SDK repo, bringing it to parity with TraigentBackend, TraigentFrontend, traigent-js, TraigentSchema, and traigent-smartopt — all of which already have this gate.

**Why:** SonarCloud org LOC quota is exhausted for private repos. The self-hosted SonarQube instance (EC2, `[self-hosted, sonarqube]` runner, `http://localhost:9000`) is the canonical scanner. The SDK was the only core product repo missing this gate.

**Changes:**
- `.github/workflows/sonarqube-local.yml` — adapts the standard smartopt/FE/JS pattern for the Python SDK:
  - `runs-on: [self-hosted, sonarqube]`
  - `SONAR_HOST_URL: http://localhost:9000`
  - Installs `.[dev]`, runs `pytest tests/ --cov=traigent --cov-report=xml`
  - Calls `sonar-scanner -Dsonar.organization=` to clear the SonarCloud org override
  - Reports quality gate conditions after scan

**Policy:** REQUIRED on `main`, OPTIONAL on `develop` (matches other repos).

Spine-Trail: none (CI-only, no product code changed)

## PR checklist
1. **Worst-case prod path:** CI workflow only; no runtime code paths changed.
2. **Production-branch test:** N/A.
3. **Contract regeneration:** none.
4. **Public surface delta:** none.
5. **Review threads:** n/a.
6. **Quality gates:** not relaxed.