### PR TITLE
feat(ci): local pre-push gate (ruff + spine + sonar)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,13 @@
 # Traigent SDK Copilot Instructions
 
+## ✅ Before you push: `make local-gate`
+Run `make local-gate` before every `git push` / `gh pr create`. It mirrors the
+cloud gates locally (ruff check + `ruff format --check` — the required PR gate;
+the `spine-trail present` check; SonarQube for `release/*`/`hotfix/*`) so you
+catch avoidable reds in seconds. Fix ruff reds with `make format-ruff`. One-time
+setup: `make install-hooks`. Add a `Spine-Trail:`/`Spine:` line to the PR body.
+See [../docs/LOCAL_CI_GATE.md](../docs/LOCAL_CI_GATE.md).
+
 ## 🧠 Project Context
 Traigent is a Python SDK for zero-code LLM optimization using decorators (`@traigent.optimize`). It intercepts calls, injects parameters, and optimizes against objectives (accuracy, cost, latency).
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,9 @@
 # Pre-commit hooks for Traigent SDK
 # Install: pip install pre-commit && pre-commit install
+#
+# `make install-hooks` wires BOTH the per-commit hooks and the pre-push gate
+# (the local CI gate that mirrors the cloud gates — see scripts/local_gate.sh).
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 repos:
   # Python import sorting
@@ -111,6 +115,21 @@ repos:
         entry: scripts/hooks/check-ignored-files.sh
         pass_filenames: false
         always_run: true
+
+  # ── Local pre-push gate (mirrors the cloud CI/policy gates) ──────────────
+  # Catches the failures agents/humans otherwise discover only after pushing:
+  # ruff check/format (the required SDK PR gate 'preflight'), the validation-
+  # spine spine-trail breadcrumb, and (for release/hotfix branches) the
+  # SonarQube quality gate. Runs on `git push`, not on every commit.
+  - repo: local
+    hooks:
+      - id: local-gate
+        name: local CI gate (ruff + spine + sonar-if-main-bound)
+        entry: scripts/local_gate.sh
+        language: script
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
 
 # Configuration for detect-secrets
 # Run: detect-secrets scan > .secrets.baseline

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Traigent SDK Development
 # Run 'make help' to see available commands
 
-.PHONY: help install install-dev test test-unit test-integration test-coverage lint format security security-check clean analyze test-validation test-validation-unit test-validation-failures test-validation-traced jaeger-start jaeger-stop analyze-traces sonar-scan sonar-local-start sonar-local-stop sonar-local-down sonar-local-clean sonar-local sonar-local-issues test-quality test-quality-ci test-quality-llm release-review-local release-build release-example-smoke release-check release-real-validation
+.PHONY: help install install-dev test test-unit test-integration test-coverage lint format format-ruff local-gate security security-check clean analyze test-validation test-validation-unit test-validation-failures test-validation-traced jaeger-start jaeger-stop analyze-traces sonar-scan sonar-local-start sonar-local-stop sonar-local-down sonar-local-clean sonar-local sonar-local-issues test-quality test-quality-ci test-quality-llm release-review-local release-build release-example-smoke release-check release-real-validation install-hooks
 
 # Variables
 PYTHON ?= .venv/bin/python
@@ -135,9 +135,19 @@ quick-fix:  ## Quick fix common issues (format, simple lint fixes)
 pre-commit:  ## Run pre-commit hooks on all files
 	pre-commit run --all-files
 
-install-hooks:  ## Install git pre-commit hooks
+local-gate:  ## Run the local pre-push gate (ruff + spine + sonar-if-main-bound) -- RUN THIS BEFORE PUSHING
+	@bash scripts/local_gate.sh
+
+format-ruff:  ## Format + autofix with ruff (matches the REQUIRED 'preflight' CI check)
+	$(RUFF) format $(SRC_DIR) $(VALIDATION_SRC_DIR) $(TEST_DIR)
+	$(RUFF) check --fix $(SRC_DIR) $(VALIDATION_SRC_DIR) $(TEST_DIR)
+
+install-hooks:  ## Install git pre-commit + pre-push hooks (mirrors the cloud gates locally)
+	@command -v pre-commit >/dev/null 2>&1 || { echo "Installing pre-commit..."; $(PIP) install pre-commit; }
 	pre-commit install
 	pre-commit install --hook-type commit-msg
+	pre-commit install --hook-type pre-push
+	@echo "Hooks installed. The pre-push hook runs 'scripts/local_gate.sh' on every push."
 
 update-deps:  ## Update all dependencies to latest versions
 	$(PIP) install --upgrade pip setuptools wheel

--- a/docs/LOCAL_CI_GATE.md
+++ b/docs/LOCAL_CI_GATE.md
@@ -1,0 +1,85 @@
+# Local CI gate — catch policy/CI failures before you push
+
+Coding agents (and humans) repeatedly miss Traigent policy and only discover it
+when the cloud PR goes **red** — a wasted push + a full CI round-trip per miss.
+Most of those checks are runnable **locally in seconds**. This repo ships a
+single local gate that mirrors them so the failure is caught before the push.
+
+## TL;DR
+
+```bash
+make install-hooks   # once per clone: installs pre-commit + commit-msg + pre-push hooks
+make local-gate      # before every push: run the gate manually (agents: do this)
+```
+
+`make local-gate` (a.k.a. `scripts/local_gate.sh`) exits non-zero on anything CI
+would reject. Fix what it reports, then push.
+
+## What it runs
+
+| Step | Mirrors cloud check | Notes |
+|------|---------------------|-------|
+| `ruff check` + `ruff format --check` on **changed `.py` files** | `SDK Required PR Gate` → `preflight` (`.github/workflows/pr-gate.yml`) | The #1 source of avoidable develop reds. Scoped to what your branch changes vs its base (like CI), not the whole tree. Fix with `ruff format <files>`. |
+| `scripts/ci/spine_preflight.py` | `spine-trail present` (`.github/workflows/spine-trail-gate.yml`) | Reminds you to add a `Spine-Trail:`/`Spine:` line to the PR body (CI reads the **body**, so this is a warning, not a hard block). |
+| SonarQube quality gate | `SonarQube Quality Gate` (`.github/workflows/sonarqube-local.yml`, **required on `main`**) | **Only for `release/*` / `hotfix/*` branches** (or `LOCAL_GATE_SONAR=1`). Runs `sonar-scanner -Dsonar.qualitygate.wait=true` against your SonarQube. |
+
+### Why ruff (not black)?
+
+This repo's **pre-commit** formats with `black` + `isort`, but the **required
+cloud check** (`pr-gate.yml` → `preflight`) runs `ruff check` +
+`ruff format --check` on the PR's **changed `.py` files**. That required check
+is what turns a PR red, so the gate mirrors **ruff**, and — crucially — only on
+the files your branch changes vs its base, exactly like CI. (The tree carries
+pre-existing ruff drift; checking the whole tree would block every push on
+unrelated debt and tempt a wide auto-fix sweep, both anti-patterns.) ruff-format
+and black agree on this codebase today; if they ever diverge on a file,
+ruff-format wins in the gate because that's what CI enforces. Fix reds with
+`ruff format <files>` (or `make format-ruff` to format the whole source tree).
+
+## The spine breadcrumb (why CI can fail late)
+
+Every product PR on this core repo needs a validation-spine mark in its **body**
+— CI's `spine-trail present` check fails the PR otherwise. You can't satisfy it
+*after* the fact without re-editing the PR. Create the breadcrumb up front:
+
+```bash
+python3 ../tools/spine-trail/spine_trail.py get-or-create \
+  --repo Traigent --branch "$(git branch --show-current)" --base-branch develop \
+  --kind <bug_fix|feature|change> --source-type <type> --source-ref "<ref>" \
+  --changed-paths "<files>"
+# then add ONE of these lines to the PR body:
+#   Spine-Trail: st_xxxxxxxxxxxx     (a Tier-0 WorkIntent)
+#   Spine: cs_xxxxxxxx               (a promoted ChangeSession)
+#   Spine: none (reason: <why ungoverned>)
+```
+
+> **Note:** unlike TraigentBackend, this repo has **no** `require-spine-session`
+> gate and **no** `.github/spine-policy-surface-globs.txt` policy-surface file
+> (its `validation-spine-pr.yml` security scan is advisory / `continue-on-error`).
+> So the gate does **not** hard-block on a missing `Spine-Session`. If a
+> policy-surface globs file is ever added here, `spine_preflight.py` picks it up
+> automatically and starts enforcing a `Spine-Session:` on policy-surface diffs,
+> matching the TraigentBackend gate — no script change needed.
+
+## SonarQube locally before a main PR
+
+For `release/*` / `hotfix/*` branches the gate runs the SonarQube quality gate
+locally and **blocks the push if it fails** (mirroring the `SonarQube Quality
+Gate` check that is required on `main`). Configure once:
+
+```bash
+export SONAR_HOST_URL="https://<your-persistent-sonarqube>"   # or http://localhost:9000
+export SONAR_TOKEN="<token>"        # or keep a .env.sonar entry
+```
+
+It runs the Dockerized `sonar-scanner` (or a local one) with
+`-Dsonar.qualitygate.wait=true` and the repo's `Traigent_Traigent` project key,
+so you get the same pass/fail verdict the required check produces — before you
+push. If you don't have SonarQube access, run it another way or bypass
+consciously (`git push --no-verify`) and have a reviewer who can run it.
+
+## Bypassing
+
+`git push --no-verify` skips the pre-push hook (leaves a reflog trail). Use only
+when you've verified another way — the gate exists to stop avoidable cloud reds,
+not to block you.

--- a/scripts/ci/spine_preflight.py
+++ b/scripts/ci/spine_preflight.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Local mirror of the validation-spine PR gates, runnable before a push.
+
+CI enforces a spine rule on Traigent (Python SDK) PRs that an agent or human
+only discovers *after* pushing:
+
+* ``spine-trail present`` (``.github/workflows/spine-trail-gate.yml``) — every
+  product PR must carry a validation-spine mark in its body: a
+  ``Spine-Trail: st_<id>`` line (a Tier-0 WorkIntent), a ``Spine: cs_<id>``
+  line (a promoted ChangeSession), or an explicit ``Spine: none (reason: …)``
+  waiver.
+
+Unlike TraigentBackend, this repo currently has **no** ``require-spine-session``
+gate and **no** ``.github/spine-policy-surface-globs.txt`` policy-surface file
+(its only PR-time spine workflow, ``validation-spine-pr.yml``, is advisory /
+``continue-on-error``). So this preflight:
+
+* checks for the spine-trail breadcrumb (WARNING only — the authoritative check
+  reads the PR *body*, which does not exist pre-push, and a standalone clone
+  cannot read the workspace ledger), and
+* if a policy-surface globs file is later added to this repo, automatically
+  picks it up and enforces a ``Spine-Session:`` on policy-surface diffs (hard
+  block), mirroring the TraigentBackend gate — so this stays correct if the
+  repo grows that gate without needing a script change.
+
+It is intentionally dependency-free (stdlib + git) so ``scripts/local_gate.sh``
+and the pre-push hook can block the push with the same verdict CI would reach.
+
+Exit codes: 0 = pass/clean, 1 = a blocking spine requirement is unmet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_NAME = "Traigent"
+# Optional: if this repo ever adds a policy-surface globs file (as
+# TraigentBackend has), this preflight will start enforcing require-spine-session
+# against it automatically. Absent today.
+GLOBS_FILE = REPO_ROOT / ".github" / "spine-policy-surface-globs.txt"
+SPINE_TRAIL = (
+    REPO_ROOT.parent / "tools" / "spine-trail" / "spine_trail.py"
+)  # workspace-level helper; absent in a bare/standalone checkout
+SESSION_RE = re.compile(r"^\s*Spine(?:-Session)?:\s*(cs_[0-9a-z]{6,})\b", re.MULTILINE)
+TRAIL_RE = re.compile(r"^\s*Spine-Trail:\s*(st_[0-9a-f]{6,})\b", re.MULTILINE)
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _load_globs() -> list[str]:
+    if not GLOBS_FILE.exists():
+        return []
+    return [
+        ln.strip()
+        for ln in GLOBS_FILE.read_text().splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+
+
+def _resolve_base(explicit: str | None, branch: str) -> str:
+    if explicit:
+        return explicit
+    # release/hotfix branches target main; everything else targets develop.
+    target = "main" if re.match(r"^(release|hotfix)/", branch) else "develop"
+    for ref in (f"origin/{target}", target):
+        if _git("rev-parse", "--verify", "--quiet", ref):
+            return ref
+    return "origin/develop"
+
+
+def _changed_files(base: str) -> list[str]:
+    merge_base = _git("merge-base", base, "HEAD") or base
+    committed = _git("diff", "--name-only", f"{merge_base}...HEAD")
+    # include staged + unstaged + untracked so an about-to-be-pushed change is
+    # seen even mid-edit or before the first commit (new files in a policy dir).
+    dirty = _git("diff", "--name-only", "HEAD")
+    untracked = _git("ls-files", "--others", "--exclude-standard")
+    files = {f for f in (committed + "\n" + dirty + "\n" + untracked).splitlines() if f}
+    return sorted(files)
+
+
+def _matches_policy(files: list[str], globs: list[str]) -> list[str]:
+    hits = []
+    for f in files:
+        if any(fnmatch.fnmatch(f, g) for g in globs):
+            hits.append(f)
+    return hits
+
+
+def _branch_messages(base: str) -> str:
+    merge_base = _git("merge-base", base, "HEAD") or base
+    return _git("log", f"{merge_base}..HEAD", "--format=%B")
+
+
+def _trail_present(branch: str) -> str | None:
+    """Return the trail id if the workspace ledger has one for this branch."""
+    if not SPINE_TRAIL.exists():
+        return None
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(SPINE_TRAIL),
+            "check",
+            "--repo",
+            REPO_NAME,
+            "--branch",
+            branch,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    m = TRAIL_RE.search(out.stdout) or re.search(r"(st_[0-9a-f]{6,})", out.stdout)
+    return m.group(1) if m else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--base", help="base ref (default: auto from branch name)")
+    args = p.parse_args(argv)
+
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+    base = _resolve_base(args.base, branch)
+    globs = _load_globs()
+    files = _changed_files(base)
+    messages = _branch_messages(base)
+
+    ok = True
+    print(
+        f"🧭 spine preflight — branch={branch} base={base} changed={len(files)} files"
+    )
+
+    # 1) policy surface -> require a Spine-Session signal.
+    # Only active if this repo gains a policy-surface globs file; absent today.
+    if globs:
+        policy_hits = _matches_policy(files, globs)
+        if policy_hits:
+            session = SESSION_RE.search(messages)
+            if session:
+                print(
+                    "   ✅ policy surface touched; Spine-Session "
+                    f"{session.group(1)} found in branch commits"
+                )
+            else:
+                ok = False
+                shown = "\n".join(f"        - {f}" for f in policy_hits[:8])
+                more = (
+                    f"\n        … +{len(policy_hits) - 8} more"
+                    if len(policy_hits) > 8
+                    else ""
+                )
+                print(
+                    "   ❌ POLICY SURFACE touched but no Spine-Session found.\n"
+                    f"      Files:\n{shown}{more}\n"
+                    "      Fix (work the spine way BEFORE pushing):\n"
+                    "        1. Open/relate a ChangeSession (/spine:change).\n"
+                    "        2. Add a trailer to a commit on this branch AND the"
+                    " PR body:\n"
+                    "             Spine: cs_xxxxxxxx\n"
+                    "      (CI reads the PR BODY — keep both in sync.)"
+                )
+        else:
+            print("   ✅ no policy-surface files in diff (no Spine-Session required)")
+    else:
+        print(
+            "   ℹ️  no policy-surface globs file in this repo; "
+            "require-spine-session not enforced (CI has no such gate here)"
+        )
+
+    # 2) spine-trail present (core repo breadcrumb) — WARNING only.
+    # The authoritative check is the PR body (which doesn't exist pre-push), and
+    # the workspace commit hook auto-stamps a trail; a standalone clone also
+    # can't read the workspace ledger. So surface it as a reminder, don't block.
+    trail_in_msg = TRAIL_RE.search(messages) or SESSION_RE.search(messages)
+    trail_in_ledger = _trail_present(branch)
+    if trail_in_msg or trail_in_ledger:
+        tid = trail_in_msg.group(1) if trail_in_msg else trail_in_ledger
+        print(f"   ✅ spine-trail present ({tid})")
+    else:
+        print(
+            "   ⚠️  no Spine-Trail detected for this branch (CI's "
+            "'spine-trail present' requires one in the PR body).\n"
+            "      Create:  python3 tools/spine-trail/spine_trail.py "
+            "get-or-create \\\n"
+            f"                 --repo {REPO_NAME} --branch {branch} "
+            f"--base-branch {base.split('/')[-1]} \\\n"
+            "                 --kind <bug_fix|feature|change> "
+            "--source-type <type> \\\n"
+            '                 --source-ref "<ref>" --changed-paths "<files>"\n'
+            "      then add its  Spine-Trail: st_xxxx  line to the PR body\n"
+            "      (or  Spine: cs_xxxx , or  Spine: none (reason: …) )."
+        )
+
+    print("✅ spine preflight passed" if ok else "❌ spine preflight FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_gate.sh
+++ b/scripts/local_gate.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# local_gate.sh — run the locally-checkable CI/policy gates BEFORE pushing.
+#
+# Why: coding agents (and humans) routinely miss Traigent policy and only find
+# out when the cloud PR goes red — ruff-format reds, the validation-spine
+# spine-trail gate, SonarQube. This mirrors those gates locally so the failure
+# is caught in seconds, not after a push + a full CI round-trip.
+#
+# Runs (fast → slow):
+#   1. ruff check + ruff format --check    (mirrors the SDK Required PR Gate
+#                                            'preflight' job in pr-gate.yml)
+#   2. spine preflight                     (mirrors 'spine-trail present')
+#   3. SonarQube quality gate              (main-bound branches only; see below)
+#
+# NOTE on the linter — CHANGED FILES, not the whole tree. This repo's pre-commit
+# uses black + isort, but the REQUIRED cloud check (pr-gate.yml 'preflight')
+# runs `ruff check` + `ruff format --check` on the PR's CHANGED .py files only
+# (`git diff … -- '*.py' | xargs ruff …`). The tree carries pre-existing ruff
+# drift (hundreds of files); checking the whole tree would block every push on
+# unrelated debt and tempt a wide auto-fix sweep — both anti-patterns. So this
+# gate mirrors CI exactly: it ruff-checks only what THIS branch changes vs its
+# base (develop, or main for release/hotfix), plus staged/unstaged/untracked .py
+# so an about-to-be-pushed edit is seen. Fix reds with `ruff format <files>` (or
+# `make format-ruff`, which formats the whole source tree).
+#
+# Usage:
+#   scripts/local_gate.sh            # auto: ruff+spine always; sonar if main-bound
+#   LOCAL_GATE_SONAR=1 scripts/local_gate.sh   # force the sonar step
+#   LOCAL_GATE_SKIP=sonar scripts/local_gate.sh
+# It is also installed as a git pre-push hook (see `make install-hooks`).
+#
+# SonarQube: required for main-bound branches (release/*, hotfix/*). The cloud
+#   'SonarQube Quality Gate' check (sonarqube-local.yml) is REQUIRED on main and
+#   optional on develop. Set SONAR_HOST_URL (your persistent SonarQube) +
+#   SONAR_TOKEN. Needs Docker (or a local sonar-scanner). It runs with
+#   -Dsonar.qualitygate.wait=true so a failing gate fails the push.
+#
+# Bypass (discouraged, leaves a paper trail in reflog): git push --no-verify
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)"
+FAIL=0
+skip() { [[ ",${LOCAL_GATE_SKIP:-}," == *",$1,"* ]]; }
+
+hr() { printf '─%.0s' {1..64}; echo; }
+section() { hr; echo "▶ $1"; }
+
+# Resolve a ruff entrypoint: PATH ruff, else the venv's, else `python -m ruff`.
+RUFF=""
+if command -v ruff >/dev/null 2>&1; then RUFF="ruff"
+elif [[ -x ".venv/bin/ruff" ]]; then RUFF=".venv/bin/ruff"
+elif python3 -c "import ruff" >/dev/null 2>&1; then RUFF="python3 -m ruff"
+fi
+
+# Base ref for the changed-file diff (mirrors pr-gate.yml's three-dot range):
+# release/hotfix branches target main; everything else targets develop.
+if [[ "$BRANCH" =~ ^(release|hotfix)/ ]]; then base_branch="main"; else base_branch="develop"; fi
+BASE_REF=""
+for ref in "origin/$base_branch" "$base_branch"; do
+  if git rev-parse --verify --quiet "$ref" >/dev/null; then BASE_REF="$ref"; break; fi
+done
+
+# Collect the .py files THIS branch changes (committed vs merge-base) plus
+# staged/unstaged/untracked, so an about-to-be-pushed edit is covered.
+changed_py() {
+  { if [[ -n "$BASE_REF" ]]; then
+      mb="$(git merge-base "$BASE_REF" HEAD 2>/dev/null || echo "$BASE_REF")"
+      git diff --name-only --diff-filter=ACMRT "${mb}...HEAD" -- '*.py'
+    fi
+    git diff --name-only --diff-filter=ACMRT HEAD -- '*.py'
+    git ls-files --others --exclude-standard -- '*.py'
+  } | sort -u
+}
+
+# ── 1. ruff (changed-file format-check + lint) ────────────────────────────
+section "ruff check + format --check on CHANGED files (SDK Required PR Gate: preflight)"
+if [[ -n "$RUFF" ]]; then
+  mapfile -t CHANGED < <(changed_py | while read -r f; do [[ -f "$f" ]] && echo "$f"; done)
+  if [[ "${#CHANGED[@]}" -eq 0 ]]; then
+    echo "  ✅ no changed .py files vs ${BASE_REF:-$base_branch} (nothing to check)"
+  else
+    echo "  • checking ${#CHANGED[@]} changed .py file(s) vs ${BASE_REF:-$base_branch}"
+    if $RUFF format --check "${CHANGED[@]}"; then echo "  ✅ ruff format clean"
+    else echo "  ❌ ruff format would reformat changed files — run 'ruff format <files>'"; FAIL=1; fi
+    if $RUFF check "${CHANGED[@]}"; then echo "  ✅ ruff check clean"
+    else echo "  ❌ ruff check found issues — run 'ruff check --fix <files>'"; FAIL=1; fi
+  fi
+else
+  echo "  ⚠️  ruff not installed (pip install ruff); skipping — CI will still run it"
+fi
+
+# ── 2. spine preflight ────────────────────────────────────────────────────
+section "spine preflight (spine-trail present)"
+if ! python3 scripts/ci/spine_preflight.py; then FAIL=1; fi
+
+# ── 3. SonarQube quality gate (main-bound only) ──────────────────────────
+MAIN_BOUND=0
+[[ "$BRANCH" =~ ^(release|hotfix)/ ]] && MAIN_BOUND=1
+[[ "${LOCAL_GATE_SONAR:-0}" == "1" ]] && MAIN_BOUND=1
+if [[ "$MAIN_BOUND" == "1" ]] && ! skip sonar; then
+  section "SonarQube quality gate (main-bound: $BRANCH)"
+  have_creds=0
+  { [[ -n "${SONAR_TOKEN:-}" ]] || [[ -f .env.sonar ]]; } && have_creds=1
+  if [[ "$have_creds" == "0" ]]; then
+    echo "  ❌ main-bound push requires the SonarQube gate, but no SONAR_TOKEN/.env.sonar found."
+    echo "     Set SONAR_HOST_URL + SONAR_TOKEN (your persistent SonarQube) and re-run,"
+    echo "     or run 'make sonar-scan' manually, then push. (bypass: git push --no-verify)"
+    FAIL=1
+  elif ! command -v docker >/dev/null 2>&1 && ! command -v sonar-scanner >/dev/null 2>&1; then
+    echo "  ❌ need Docker or sonar-scanner for the local SonarQube gate (main-bound)."
+    FAIL=1
+  else
+    host="${SONAR_HOST_URL:-http://localhost:9000}"
+    echo "  🔎 scanning against $host with qualitygate.wait=true …"
+    if command -v docker >/dev/null 2>&1; then
+      net=""; [[ "$host" == *localhost* || "$host" == *127.0.0.1* ]] && net="--network=host"
+      docker run --rm $net -e SONAR_HOST_URL="$host" -e SONAR_TOKEN \
+        -v "$PWD":/usr/src sonarsource/sonar-scanner-cli:latest \
+        -Dsonar.projectKey=Traigent_Traigent \
+        -Dsonar.qualitygate.wait=true -Dsonar.qualitygate.timeout=300
+    else
+      sonar-scanner -Dsonar.host.url="$host" \
+        -Dsonar.projectKey=Traigent_Traigent \
+        -Dsonar.qualitygate.wait=true -Dsonar.qualitygate.timeout=300
+    fi
+    if [[ $? -eq 0 ]]; then echo "  ✅ SonarQube quality gate passed"
+    else echo "  ❌ SonarQube quality gate FAILED — fix locally before the main PR"; FAIL=1; fi
+  fi
+else
+  hr; echo "ℹ️  SonarQube step skipped (not a release/hotfix branch). For main-bound"
+  echo "   work set LOCAL_GATE_SONAR=1 or push a release/* branch."
+fi
+
+hr
+if [[ "$FAIL" == "0" ]]; then
+  echo "✅ local gate PASSED — safe to push"
+else
+  echo "❌ local gate FAILED — fix the items above (or 'git push --no-verify' to bypass)"
+fi
+exit "$FAIL"


### PR DESCRIPTION
## Why
Coding agents (me + codex included) repeatedly ship PRs that go **red in the cloud** on things checkable locally in seconds — `ruff format`/`ruff check`, the validation-spine **`spine-trail present`** gate, SonarQube. Each miss costs a push + a full CI round-trip. This adds a **local gate** that reproduces those decisions **before** the push. Adapted from the TraigentBackend gate ([TraigentBackend#1266](https://github.com/Traigent/TraigentBackend/pull/1266)) to **this** repo's *actual* required checks.

## What
- **`scripts/local_gate.sh`** (`make local-gate`) — runs, fast→slow:
  1. `ruff check` + `ruff format --check` on the branch's **CHANGED `.py` files only** — mirrors the required **`SDK Required PR Gate` → `preflight`** job (`pr-gate.yml`), which scopes to PR-changed files. The tree carries pre-existing ruff drift (hundreds of files); a whole-tree check would block every push on unrelated debt and tempt a wide auto-fix sweep, so this matches CI's changed-file scope exactly.
  2. `scripts/ci/spine_preflight.py` (below).
  3. **SonarQube quality gate** — *only* for `release/*`/`hotfix/*` branches (or `LOCAL_GATE_SONAR=1`): `sonar-scanner -Dsonar.qualitygate.wait=true` against `SONAR_HOST_URL` with the `Traigent_Traigent` key, blocking the push on a failing gate. Mirrors the **`SonarQube Quality Gate`** check (`sonarqube-local.yml`, **required on `main`**).
- **`scripts/ci/spine_preflight.py`** — local mirror of **`spine-trail present`** (`spine-trail-gate.yml`). Unlike TraigentBackend, this repo has **no** `require-spine-session` gate and **no** `.github/spine-policy-surface-globs.txt` policy-surface file (its `validation-spine-pr.yml` scan is advisory / `continue-on-error`), so the spine step is a **warning reminder** to put a `Spine-Trail:`/`Spine:` line in the PR body. If a policy-surface globs file is ever added here, the preflight picks it up automatically and starts enforcing a `Spine-Session:` on policy-surface diffs (hard block), matching the BE gate — no script change needed.
- **`.pre-commit-config.yaml`** — `default_install_hook_types: [pre-commit, commit-msg, pre-push]` + a `repo: local` pre-push hook running the gate (enforcement backstop).
- **`Makefile`** — `make local-gate`, `make format-ruff`, and `install-hooks` now also installs the pre-push hook type.
- **`CLAUDE.md`** (new) + **`docs/LOCAL_CI_GATE.md`** + a short reminder atop `.github/copilot-instructions.md` telling agents to run `make local-gate` before pushing.

### Why ruff, not black?
This repo's **pre-commit** formats with `black` + `isort`, but the **required cloud check** (`pr-gate.yml` preflight) runs **ruff**. The gate mirrors the *required* check, which is what turns a PR red. ruff-format and black agree on this codebase today; if they ever diverge, ruff-format wins in the gate. Fix reds with `ruff format <files>` (or `make format-ruff`).

## Verified (dogfooded)
- **Passes clean** on this PR's own diff (`make local-gate` → exit 0).
- **Blocks** a ruff-format-dirty changed file (the exact avoidable-red this targets): exit **1**, verdict `FAILED`. Reverting → exit 0.
- Changed-file scoping confirmed: checks only the 1–2 files the branch changes, not the whole-tree pre-existing drift.
- `pre-commit validate-config` OK; the `repo: local` **pre-push** hook runs via `pre-commit run local-gate --hook-stage pre-push` → **Passed**.

## Not policy-surface
These are CI/tooling/docs files; this repo has no `require-spine-session` gate, so nothing here requires a `Spine-Session`. Spine-trail breadcrumb below.

## Follow-up
Replicable to the remaining core repos (`traigent-js`, `TraigentFrontend`, `TraigentSchema`, `traigent-smartopt`) — same pattern, swap the linter + reuse each repo's required checks.

Spine-Trail: st_12969092feb6
