### PR TITLE
ci: rationalize SDK PR checks (develop-lean / main-strict / nightly-full)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -11,7 +11,7 @@ on:
       - "scripts/ci/**"
       - ".github/workflows/install-smoke.yml"
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     paths:
       - "pyproject.toml"
       - "uv.lock"
@@ -19,6 +19,10 @@ on:
       - "hello_world.py"
       - "scripts/ci/**"
       - ".github/workflows/install-smoke.yml"
+  # Nightly: run the full OS matrix (ubuntu + macOS + Windows) so the slow
+  # macOS/Windows lanes are caught within ~1 day instead of on every PR.
+  schedule:
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 # Cancel in-flight runs when a new commit lands on the same ref.
@@ -32,13 +36,17 @@ permissions:
   contents: read
 
 jobs:
-  # .[recommended] is the default user-facing bundle — test across all platforms
+  # .[recommended] is the default user-facing bundle.
+  # Per-branch matrix (mirrors the approved CI-rationalization plan):
+  #   develop PR        -> ubuntu / 3.12 only (lean develop gate)
+  #   main PR / push     -> ubuntu / 3.11 + 3.12
+  #   nightly schedule   -> ubuntu + macOS + Windows / 3.11 + 3.12 (full OS matrix)
   install-recommended:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12"]
+        os: ${{ fromJSON( github.event_name == 'schedule' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]' ) }}
+        python-version: ${{ fromJSON( (github.event_name == 'pull_request' && github.base_ref == 'develop') && '["3.12"]' || '["3.11","3.12"]' ) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/skill-contract.yml
+++ b/.github/workflows/skill-contract.yml
@@ -7,14 +7,16 @@ name: Skill Contract
 # (read-only access to Traigent/traigent-skills) is provisioned. Keep advisory (not a
 # required check) until it has been green across a few PRs.
 
+# Moved off `pull_request` to a nightly schedule (CI-rationalization plan):
+# this gate is advisory (not a required check) and secret-gated on
+# SKILLS_REPO_TOKEN — it skips cleanly (green no-op) until the token is
+# provisioned, so it produces no real PR verdict. It now runs nightly + on
+# demand; promote back to PR-time once it has been green and armed across a
+# few PRs.
 on:
-  pull_request:
-    paths:
-      - "traigent/**/*.py"
-      - "pyproject.toml"
-      # Self-test: changes to this workflow re-run the gate so a fix/regression
-      # is caught in-PR (the job otherwise only triggers on SDK-surface changes).
-      - ".github/workflows/skill-contract.yml"
+  schedule:
+    - cron: "40 6 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,6 +21,11 @@ concurrency:
 jobs:
   sonarcloud:
     name: SonarCloud
+    # Public repos only: SonarCloud is quota-blocked (403) on private/internal
+    # repos, and the self-hosted "SonarQube Quality Gate" (sonarqube-local.yml)
+    # is the gate there. Skip cleanly when the repo is private. (Mirrors the
+    # same fix already applied to traigent-smartopt and traigent-js.)
+    if: ${{ github.event.repository.private == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 30  # Job-level timeout
     steps:

--- a/.github/workflows/sonarqube-local.yml
+++ b/.github/workflows/sonarqube-local.yml
@@ -8,11 +8,18 @@ name: SonarQube Local Gate
 #
 # Policy: REQUIRED on `main`, OPTIONAL (informational) on `develop`.
 
+# Develop-PR trigger removed (CI-rationalization plan): this gate scales a
+# single shared in-cluster SonarQube StatefulSet under a GLOBAL lock and is the
+# slowest check (up to ~45m). It is REQUIRED on `main` only; the local pre-push
+# gate already runs it for main-bound work. Keep it on main + release/hotfix PRs
+# + main push + nightly; it no longer runs on develop PRs.
 on:
   pull_request:
-    branches: [develop, main]
+    branches: [main, "release/**", "hotfix/**"]
   push:
     branches: [main]
+  schedule:
+    - cron: "0 7 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validation-spine-pr.yml
+++ b/.github/workflows/validation-spine-pr.yml
@@ -19,14 +19,15 @@
 
 name: validation-spine-pr
 
+# Moved off `pull_request` to a nightly schedule (CI-rationalization plan):
+# this scan is advisory (`continue-on-error: true`), secret-gated on
+# SPINE_RO_TOKEN (skips cleanly when absent), and scans the FULL product repo
+# on every run — so it produces no real PR verdict and only adds PR wall-clock.
+# It now runs nightly + on demand; promote back to PR-time only after it is
+# calibrated to gate (`--gate`) on PR-incremental scope.
 on:
-  pull_request:
-    branches: [develop, main]
-    paths:
-      - "traigent/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/validation-spine-pr.yml"
+  schedule:
+    - cron: "20 6 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## CI rationalization (Traigent Python SDK) — workflow-only

Part of the approved cross-repo CI-rationalization plan (`starry-jingling-fox`). Goal: make **develop PRs fast/lean**, keep **main strict**, push slow/advisory work to **nightly** — without losing real safety. **Workflow-only; no ruleset edits** (owner handles branch protection per the plan's sequencing guardrail).

### Changes
| File | Change | Why |
|------|--------|-----|
| `sonarcloud.yml` | Gate job to public repos (`if: github.event.repository.private == false`) | SonarCloud is quota-blocked (403) on private/internal; self-hosted **SonarQube Quality Gate** stays the gate. Same fix already shipped to smartopt + js. |
| `install-smoke.yml` | Per-branch OS/Python matrix via `fromJSON` branch-switch; add develop-PR + nightly triggers | develop PR → **ubuntu/3.12**; main PR/push → **ubuntu/3.11+3.12**; nightly `schedule` → **ubuntu+macOS+Windows/3.11+3.12**. macOS/Windows lanes no longer run on every PR. |
| `validation-spine-pr.yml` (`spine-pr-scan`) | Moved off `pull_request` → nightly `schedule` + `workflow_dispatch` | Advisory (`continue-on-error: true`), secret-gated on `SPINE_RO_TOKEN`, full-repo scan → no real PR verdict, only PR wall-clock. |
| `skill-contract.yml` (`skill-contract`) | Moved off `pull_request` → nightly `schedule` + `workflow_dispatch` | Advisory (not required), secret-gated on `SKILLS_REPO_TOKEN` (skips green no-op without token) → no real PR verdict. |
| `sonarqube-local.yml` (`SonarQube Quality Gate`) | Removed the **develop**-PR trigger; keeps `main` + `release/**` + `hotfix/**` PRs, `main` push, nightly | Slowest check (≤~45m) under a **global** lock (single shared StatefulSet); required on main only; local pre-push gate covers main-bound work. |

### Matrix branch-switch (install-smoke `install-recommended`)
```yaml
os: ${{ fromJSON( github.event_name == 'schedule' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]' ) }}
python-version: ${{ fromJSON( (github.event_name == 'pull_request' && github.base_ref == 'develop') && '["3.12"]' || '["3.11","3.12"]' ) }}
```
(Reference pattern: TraigentSchema #204.)

### Guardrails honored
- **KEPT on develop (required):** `required-pr-gate` and its `pr-gate.yml` deps (`detect-changes`, `preflight`, `unit`) — untouched. `Spine Trail Gate` (`spine-trail-gate.yml`) untouched.
- No ruleset edits. Job names mirror the real workflow job names.

### Effect on develop PR check count
- **Before:** develop PR ran (matrix-expanded) `SonarQube Quality Gate` + `spine-pr-scan` + (on surface/dep change) `skill-contract` + `validation-spine-pr` + the `required-pr-gate` chain. `install-smoke` did **not** run on develop (it was `main`-only).
- **After:** develop PR runs the lean `required-pr-gate` chain (`detect-changes`, `preflight`, `unit`, `required-pr-gate`) + `Spine Trail Gate`; `install-smoke` runs **ubuntu/3.12 only** when its paths change. SonarQube, spine-pr-scan, and skill-contract no longer run on develop PRs.

---

## ⚠️ Broken **main** ruleset — document only (owner to fix; NOT changed here)

The **main** branch ruleset currently requires these status checks:

```
code-quality, documentation-quality, lint-type, tests-unit, tests-integration,
security, dependency-review, codeql, release-review-consistency,
SonarQube Quality Gate
```

**The problem:** all but one of these point at **`workflow_dispatch`-only** workflows that **never run on a PR**, so they can never report a status on a main PR:

| Required context | Backing workflow | Trigger | Runs on PR? |
|---|---|---|---|
| `lint-type`, `tests-unit`, `tests-integration`, `security`, `dependency-review`, `codeql`, `release-review-consistency` | `release-review.yml` (`name: release-gate`) | `workflow_dispatch` only | ❌ no |
| `code-quality`, `documentation-quality` | `quality.yml` (`name: Code Quality`) | `workflow_dispatch` only | ❌ no |
| `SonarQube Quality Gate` | `sonarqube-local.yml` | PR (main/release/hotfix) + push + nightly | ✅ yes (the only one that fires on a main PR) |

`tests.yml` (`name: Tests`, job `test`) is **also** `workflow_dispatch`-only. There are **no** `pull_request` `continue-on-error` dry-run markers to remove (unlike TraigentBackend's `release-review.yml`) — `release-review.yml` here has **no `pull_request` path at all**, so nothing was deleted.

### Recommended owner fix (ruleset, not in this PR)
Point the main required-status-check list at the **real, PR-time** jobs. Two options:

**Option A (use the existing fast gate, recommended):** require the same chain main already trusts on develop, plus the real Sonar gate:
- `required-pr-gate`  *(from `pr-gate.yml` — but note: `pr-gate.yml` triggers on `pull_request: [develop]` only; **its trigger must add `main`** for this to fire on main PRs)*
- `SonarQube Quality Gate`  *(already correct)*
- `Spine Trail Gate`  *(governance)*

**Option B (give main its own full PR gate):** add a `pull_request: [main]` trigger to `quality.yml` and `tests.yml` (and/or `release-review.yml`) so their jobs actually run on main PRs, then keep requiring `code-quality`, `documentation-quality`, `test (3.11)`, `test (3.12)`, etc. — and **drop** the dead `lint-type`/`tests-unit`/`tests-integration`/`security`/`dependency-review`/`codeql`/`release-review-consistency` contexts (or wire `release-review.yml` to PRs first).

Either way, **remove the dead `workflow_dispatch`-only contexts from the required list** and **add `main` to `pr-gate.yml`'s trigger** if Option A is chosen. Keep `SonarQube Quality Gate` required on main (this PR keeps it firing there). This is a ruleset + (small) trigger change, intentionally **out of scope** for this workflow-only PR.

---

Spine-Trail: st_e6159f581d7a
