### PR TITLE
chore(release): SDK 0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Traigent SDK are documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.14.3] - 2026-06-20
+
+### Changed
+- **Removed the JS bridge from the `@optimize` decorator path** and added a guard for
+  `safety_constraints`. (#1371)
+
+### Security
+- Addressed scoped Aikido security findings. (#1374)
+
+### Fixed
+- Corrected the async context-manager mock in the hybrid degradation test and updated
+  `test_safety.py` integration tests for the `NotImplementedError` guard.
+
 ## [0.14.1] - 2026-06-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.14.2"
+version = "0.14.3"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
Release **0.14.3** of the Traigent Python SDK — ships the unreleased main commits since the v0.14.2 tag (main was 9 ahead at the same version number).

### Included
- Removed the JS bridge from the `@optimize` decorator path + `safety_constraints` guard (#1371)
- Scoped Aikido security findings (#1374)
- Hybrid-degradation + `test_safety.py` test fixes

### Pre-flight (local)
`python -m build` clean → `traigent-0.14.3` wheel **521 files**, package complete (`traigent/__init__.py` + `api/decorators.py`), METADATA `Version: 0.14.3`.

### Publish path
Merge → tag `v0.14.3` on main → `publish.yml` (verifies tag-on-main) builds + uploads to PyPI.

Note: changelog had no `0.14.2` entry (pre-existing gap); this PR adds `0.14.3` only.
Spine-Trail: st_1d1dec0663b8
