### PR TITLE
fix(security): Aikido high33 SDK chromadb + credentials disposition

### DIFF
--- a/.aikidoignore
+++ b/.aikidoignore
@@ -38,3 +38,18 @@ traigent/storage/local_storage.py:path-traversal
 
 # wandb integration: trial filename derived from int(trial_number).
 traigent/integrations/observability/wandb.py:path-traversal
+
+# ============================================================
+# Leaked Secrets - False Positives
+# ============================================================
+
+# SecureString.clear() zeroes in-memory buffers (self._value[i] = 0); not credentials.
+traigent/security/credentials.py:generic
+
+# ============================================================
+# Open Source - Accepted risk (no upstream patch yet)
+# ============================================================
+
+# chromadb 1.5.9 / CVE-2026-45829: only pulled via optional [chroma] extra; no
+# first_patched_version published. Default install excludes chroma (pyproject.toml).
+uv.lock:CVE-2026-45829

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1161,28 +1161,28 @@
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 162
+        "line_number": 183
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 163
+        "line_number": 184
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 164
+        "line_number": 185
       },
       {
         "type": "Secret Keyword",
         "filename": "traigent/security/credentials.py",
         "hashed_secret": "26eae588d0859648be8edcf9cd2cf19bbdfacd43",
         "is_verified": false,
-        "line_number": 167
+        "line_number": 188
       }
     ],
     "traigent/utils/example_id.py": [
@@ -1213,5 +1213,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-18T18:25:48Z"
+  "generated_at": "2026-06-19T21:13:46Z"
 }

--- a/reports/aikido-high33-sdk-result.md
+++ b/reports/aikido-high33-sdk-result.md
@@ -1,0 +1,10 @@
+# Aikido high33 — Traigent SDK (develop)
+
+CSV slice: `aikido-filtered-high33.csv` (5 rows)
+
+| Issue ID | Type | Finding | Disposition |
+|----------|------|---------|-------------|
+| 285161241, 285161101 | open_source | chromadb 1.5.9 CVE-2026-45829 in uv.lock | **Accepted risk** — chromadb is opt-in via `[chroma]` extra only; pyproject documents no patched release; `.aikidoignore` entry added |
+| 113974724, 113974722, 113974723 | leaked_secret | credentials.py generic rule | **False positive** — SecureString memory wipe (`= 0`, memset); `.aikidoignore` + inline `aikido-ignore` comments |
+
+Branch: `codex/aikido-sdk-high33` → `develop`

--- a/traigent/security/credentials.py
+++ b/traigent/security/credentials.py
@@ -237,9 +237,11 @@ class SecureString:
     def clear(self) -> None:
         """Securely overwrite the value in memory."""
         if not self._locked:
-            # Overwrite the buffer with zeros
+            # Overwrite the buffer with zeros (aikido-ignore: false-positive — memory wipe, not a credential)
             for i in range(len(self._value)):
-                self._value[i] = 0
+                self._value[i] = (
+                    0  # aikido-ignore: false-positive — zeroing secure buffer byte
+                )
 
             # Additional platform-specific clearing if possible
             if sys.platform != "win32":
@@ -249,7 +251,7 @@ class SecureString:
 
                     ctypes.memset(
                         ctypes.addressof(ctypes.c_char.from_buffer(self._value)),
-                        0,
+                        0,  # aikido-ignore: false-positive — memset wipe of secure buffer
                         len(self._value),
                     )
                 except (ImportError, AttributeError, Exception):
@@ -259,7 +261,9 @@ class SecureString:
 
     def lock(self) -> None:
         """Prevent further access to the underlying value."""
-        self._locked = True
+        self._locked = (
+            True  # aikido-ignore: false-positive — lock flag, not a secret value
+        )
 
     def unlock(self, value: str | None = None) -> None:
         """Unlock the string for controlled access, optionally updating the value."""


### PR DESCRIPTION
## Summary
- Add `.aikidoignore` entries for chromadb CVE-2026-45829 (opt-in `[chroma]` extra only; no upstream patch) and SecureString memory-wipe false positives in `credentials.py`.
- Inline `aikido-ignore` comments on flagged buffer-zeroing lines.
- Record disposition in `reports/aikido-high33-sdk-result.md`.

## Aikido CSV (33) rows addressed
- 285161241 / 285161101 — chromadb open_source (accepted risk)
- 113974724 / 113974722 / 113974723 — credentials.py leaked_secret (false positive)

## Test plan
- [x] Pre-commit hooks pass locally (bandit, detect-secrets, mypy)
- [ ] Aikido PR scan on this branch

Spine-Trail: st_58b9f086c01f

Made with [Cursor](https://cursor.com)