### PR TITLE
docs: update SDK docs to the algorithm/offline execution model

### DIFF
--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -132,7 +132,7 @@ def my_agent(question: str) -> str:
 | `samples_include_pruned` | `bool` | `True` | Whether pruned trials count toward the sample budget. |
 | `reps_per_trial` | `int` | `1` | Number of repetitions per configuration. OSS SDK accepts only `1`; other values raise `pydantic.ValidationError` and require Traigent Enterprise. |
 | `reps_aggregation` | `str` | `"mean"` | Repetition aggregation method. OSS SDK accepts only `"mean"`; other values raise `pydantic.ValidationError` and require Traigent Enterprise. |
-| `evaluator` | `ExternalServiceEvaluator \| HybridAPIOptions \| dict \| None` | `None` | External service evaluator bundle. Use `ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))` for Hybrid API services. |
+| `evaluator` | `ExternalServiceEvaluator \| HybridAPIOptions \| dict \| None` | `None` | External service evaluator bundle. Use `ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))` for Hybrid API services. The optimizer still runs locally; the evaluator dispatches each trial to the external HTTP or MCP service. |
 
 **Legacy Compatibility**
 
@@ -144,10 +144,12 @@ def my_agent(question: str) -> str:
 **Usage Notes**
 
 - The default path is `algorithm="auto"`: cloud-first optimizer decisions with local trial execution and local fallback on connectivity failures.
+- Set `TRAIGENT_REQUIRE_CLOUD=1` to turn that connectivity fallback into a hard error.
 - Prefer the grouped option classes (`EvaluationOptions`, `InjectionOptions`, `ExecutionOptions`) when you need to adjust several related knobs. Import them from `traigent.api.decorators` and pass either instances or plain dicts. `MockModeOptions` is **deprecated** (all fields inert; see the `mock` row above and issue #874) — do not use it for new code.
 - `parallel_config=ParallelConfig(...)` remains the primary way to control concurrency. Set global defaults via `traigent.configure(parallel_config=...)`, override them in the decorator, and fine-tune per `.optimize()` call. Later scopes override earlier ones field-by-field.
 - `ParallelConfig` lives in `traigent.config.parallel`. You can pass either an instance or a simple `dict` with the same keys.
-- Use `offline=True` when policy requires zero Traigent backend egress.
+- Use `offline=True` when policy requires zero Traigent backend egress. `TRAIGENT_OFFLINE=1` and the legacy `TRAIGENT_OFFLINE_MODE=1` provide the same routing at the environment level.
+- `privacy_enabled` and `cloud_fallback_policy` are deprecated no-ops. `execution_mode` is deprecated compatibility input only; migrate to `algorithm`, `offline`, and `evaluator=ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))`.
 - `config_param` is required whenever you choose `injection_mode="parameter"`; forgetting it leaves your function without injected configs.
 - Provide plain lists for quick starts; Traigent infers orientations (maximize for accuracy-like metrics, minimize for cost/latency) and assigns equal weights. Use an `ObjectiveSchema` when you need explicit control over orientations, weights, or metric metadata.
 - Inline tuned-variable definitions accept `Range`, `IntRange`, `LogRange`, `Choices`, or numeric `(low, high)` tuples. Inline lists are not recognized; use `Choices([...])` instead.
@@ -178,7 +180,8 @@ Later scopes override earlier ones field-by-field. The runtime resolution logs t
         "temperature": (0.0, 1.0)
     },
     evaluation={"eval_dataset": "evals.jsonl"},  # Grouped option bundle
-    execution={"algorithm": "grid", "offline": True},
+    algorithm="grid",
+    offline=True,
 )
 def my_agent(query: str) -> str:
     return process_query(query)
@@ -217,7 +220,7 @@ async def optimize(
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `algorithm` | `str \| None` | Decorator default | Optimizer to use: `"grid"`, `"random"`, `"bayesian"`, `"optuna"`. |
+| `algorithm` | `str \| None` | Decorator default | Optimizer to use. `"auto"` is cloud-first with local fallback on connectivity failures; `"grid"` and `"random"` stay local; explicit smart algorithms such as `"bayesian"`, `"tpe"`, `"optuna_tpe"`, `"optuna_random"`, `"optuna_grid"`, `"optuna_cmaes"`, `"optuna_nsga2"`, `"nsga2"`, `"nsgaii"`, `"nsga_ii"`, `"cmaes"`, and `"cma_es"` require cloud and hard-error when unavailable or offline. |
 | `max_trials` | `int \| None` | Decorator default | Maximum number of trials to execute. `None` means unlimited. |
 | `timeout` | `float \| None` | Decorator default | Wall-clock budget in seconds. |
 | `save_to` | `str \| None` | `None` | Optional path to persist results after completion. |
@@ -523,6 +526,9 @@ class OptimizationResult:
 - `total_trials`: Total number of trials executed
 - `successful_trials`: List of trials that completed successfully
 - `success_rate`: Ratio of successful trials to total trials
+
+`metadata["source"]` records result provenance as one of `cloud_brain`,
+`local_fallback`, `explicit_local`, or `offline`.
 
 ### TrialResult
 

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -505,8 +505,8 @@ from traigent.config.parallel import ParallelConfig
 
 **ExecutionOptions Fields**:
 
-- `algorithm`: optimizer selector. `"auto"` is cloud-first; `"grid"` and `"random"` are explicit local optimizers.
-- `offline`: force local-only operation with zero Traigent backend egress.
+- `algorithm`: optimizer selector. `"auto"` is cloud-first and falls back to local grid/random on connectivity failures; `"grid"` and `"random"` are explicit local optimizers; smart algorithms require cloud and hard-error when unavailable or offline.
+- `offline`: force local-only operation with zero Traigent backend egress. `TRAIGENT_OFFLINE=1` and legacy `TRAIGENT_OFFLINE_MODE=1` provide the same behavior via environment variables.
 - `local_storage_path`: Custom storage directory
 - `minimal_logging`: Reduce log verbosity
 - `parallel_config`: Concurrency configuration
@@ -514,7 +514,7 @@ from traigent.config.parallel import ParallelConfig
 - `samples_include_pruned`: Count pruned trials in budget
 - `reps_per_trial`: Repetitions per configuration. OSS SDK accepts only `1`; non-default values raise `pydantic.ValidationError` and require Traigent Enterprise.
 - `reps_aggregation`: Repetition aggregation method. OSS SDK accepts only `"mean"`; non-default values raise `pydantic.ValidationError` and require Traigent Enterprise.
-- `evaluator`: external evaluator bundle, including `ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))`.
+- `evaluator`: external evaluator bundle, including `ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))`. This does not change optimizer routing; it only changes how each trial is evaluated.
 
 #### `mock`
 
@@ -563,6 +563,12 @@ The `**runtime_overrides` parameter accepts additional settings:
     ...
 )
 ```
+
+Deprecated execution inputs:
+
+- `execution_mode=` is deprecated compatibility input only; migrate to `algorithm=` / `offline=`.
+- `privacy_enabled` is a deprecated no-op. Cloud-brain optimization already avoids dataset-content egress; use `offline=True` for zero Traigent backend egress.
+- `cloud_fallback_policy` is a deprecated no-op. Use `TRAIGENT_REQUIRE_CLOUD=1` to disable `algorithm="auto"` fallback.
 
 Run controls such as `max_trials` and `timeout` are passed to `.optimize()`:
 
@@ -641,11 +647,9 @@ def answer_question(question: str) -> str:
         lambda cfg, metrics: metrics.get("cost", 0) <= 0.10 if metrics else True,
     ],
     evaluation={"eval_dataset": "support_tickets.jsonl"},
-    execution={
-        "algorithm": "grid",
-        "offline": True,
-        "parallel_config": {"thread_workers": 4},
-    },
+    algorithm="grid",
+    offline=True,
+    parallel_config={"thread_workers": 4},
 )
 def process_ticket(ticket: str) -> str:
     return support_chain.run(ticket)
@@ -661,12 +665,10 @@ def process_ticket(ticket: str) -> str:
         "temperature": [0.1, 0.3, 0.5],
     },
     evaluation={"eval_dataset": "medical_qa.jsonl"},
-    execution={
-        "algorithm": "grid",
-        "offline": True,
-        "local_storage_path": "./medical_optimizations",
-        "minimal_logging": True,
-    },
+    algorithm="grid",
+    offline=True,
+    local_storage_path="./medical_optimizations",
+    minimal_logging=True,
 )
 def medical_assistant(query: str) -> str:
     return process_medical_query(query)
@@ -700,7 +702,7 @@ def my_agent(query: str) -> str:
 - [Complete Function Specification](./complete-function-specification.md) - Full API reference
 - [Evaluation Guide](../user-guide/evaluation_guide.md) - Understanding accuracy metrics, evaluation methods, and troubleshooting
 - [Injection Modes Guide](../user-guide/injection_modes.md) - Configuration injection patterns
-- [Execution Modes Guide](../guides/execution-modes.md) - Execution mode details
+- [Choosing the Right Optimization Model](../user-guide/choosing_optimization_model.md) - Cloud-first auto, explicit local, offline, and migration guidance
 - [Thread Pool Examples](./thread-pool-examples.md) - Context propagation with threads
 - [Telemetry Documentation](./telemetry.md) - Data collection and privacy
 - Custom evaluator walkthrough in the repository examples - LLM-as-Judge implementation

--- a/docs/api-reference/telemetry.md
+++ b/docs/api-reference/telemetry.md
@@ -54,10 +54,8 @@ backend egress at all:
 
 ```python
 @traigent.optimize(
-    execution={
-        "algorithm": "grid",
-        "offline": True,
-    },
+    algorithm="grid",
+    offline=True,
     ...
 )
 ```
@@ -65,7 +63,14 @@ backend egress at all:
 Offline runs keep Traigent optimization metadata local while still allowing your
 own function to call LLM providers or other services.
 
-Privacy mode does not disable telemetry; use `TRAIGENT_DISABLE_TELEMETRY=true` for a full opt-out.
+`TRAIGENT_OFFLINE=1` and the legacy `TRAIGENT_OFFLINE_MODE=1` enable the same
+zero-egress routing without changing code. Set `TRAIGENT_REQUIRE_CLOUD=1` when
+`algorithm="auto"` must hard-error instead of falling back locally.
+
+`privacy_enabled` is deprecated and does not disable telemetry or network
+access. The default cloud-brain path is already content-free. Use
+`TRAIGENT_DISABLE_TELEMETRY=true` for telemetry opt-out and `offline=True` for
+zero Traigent backend egress.
 
 ### OpenTelemetry Tracing
 
@@ -252,9 +257,7 @@ You can customize the storage location:
 
 ```python
 @traigent.optimize(
-    execution={
-        "local_storage_path": "./my_optimizations",
-    },
+    local_storage_path="./my_optimizations",
     ...
 )
 ```
@@ -357,7 +360,8 @@ For HIPAA compliance or handling sensitive data:
 1. **Use Offline Mode for Zero Traigent Egress**:
    ```python
    @traigent.optimize(
-       execution={"algorithm": "grid", "offline": True},
+       algorithm="grid",
+       offline=True,
        ...
    )
    ```
@@ -370,11 +374,9 @@ For HIPAA compliance or handling sensitive data:
 3. **Use Local Storage Only**:
    ```python
    @traigent.optimize(
-       execution={
-           "algorithm": "grid",
-           "offline": True,
-           "local_storage_path": "/secure/location",
-       },
+       algorithm="grid",
+       offline=True,
+       local_storage_path="/secure/location",
        ...
    )
    ```
@@ -423,6 +425,6 @@ contain the same trial metadata and metrics emitted to telemetry listeners.
 ## Related Documentation
 
 - [Decorator Reference](./decorator-reference.md) - Configuration options
-- [Execution Model Guide](../guides/execution-modes.md) - cloud-first auto, explicit local, and offline mode
+- [Choosing the Right Optimization Model](../user-guide/choosing_optimization_model.md) - cloud-first auto, explicit local, offline, env vars, and migration guidance
 - [Privacy & Security](../contributing/SECURITY.md) - Security practices
 - [API Reference](./complete-function-specification.md) - Full API documentation

--- a/docs/architecture/execution_mode_follow_up.md
+++ b/docs/architecture/execution_mode_follow_up.md
@@ -1,27 +1,39 @@
-# Execution Mode Follow-Up Plan
+# Execution Model Follow-Up Plan
 
-This note captures the remaining work streams for execution-mode standardization that require broader coordination or non-trivial refactors. It is intended as a living document for post-refactor tracking.
+This note tracks the remaining follow-up work after the execution-mode
+consolidation shipped on `develop`. The public model is now `algorithm` plus
+`offline`; legacy `execution_mode`, `privacy_enabled`, and
+`cloud_fallback_policy` are deprecated compatibility inputs only.
 
 ---
 
 ## 1. Backend Protocol Alignment (Short-Term)
 
-**Goal:** ensure Traigent clients and backend services share the same canonical execution-mode vocabulary.
+**Goal:** ensure Traigent clients and backend services share the same canonical
+execution-policy vocabulary and provenance labels.
 
 - **Owner:** SDK & Backend teams  
-- **Success Criteria:** backend accepts / returns enum-aligned values (`edge_analytics`, `hybrid`, `standard`, `cloud`) without special-casing raw legacy strings.
+- **Success Criteria:** backend contracts align on the current public model:
+  `algorithm`, `offline`, `TRAIGENT_REQUIRE_CLOUD` behavior, and result
+  `source` values (`cloud_brain`, `local_fallback`, `explicit_local`,
+  `offline`).
 
 ### Tasks
 1. **Inventory current payloads**  
-   - Document every endpoint (`trial_operations`, `session_operations`, etc.) returning mode strings.
-   - Capture existing variants (e.g. `"privacy"`, `"private"`).
+   - Document every endpoint (`trial_operations`, `session_operations`, etc.)
+     that still emits or consumes legacy mode strings.
+   - Capture where the backend should instead rely on `algorithm`/`offline`
+     semantics or provenance `source`.
 2. **Draft a migration plan**  
-   - Introduce versioned API fields or graceful fallbacks.
+   - Introduce versioned API fields or graceful fallbacks where backend payloads
+     still expose the old taxonomy.
    - Communicate expected rollout timeline to SDK consumers.
 3. **Implement dual-read / dual-write**  
-   - During transition, accept both old and new values, emitting warnings when legacy strings arrive.
+   - During transition, accept deprecated legacy strings on compatibility paths
+     while writing canonical policy/provenance fields.
 4. **Update SDK**  
-   - Replace the remaining string comparisons in `traigent/cloud/trial_operations.py` with enum-aware handling once backend changes are live.
+   - Replace remaining backend-facing legacy mode assumptions with
+     policy-aware handling once the backend contract is live.
 5. **Monitor & clean up**  
    - Remove legacy fallbacks after sufficient bake time.
 
@@ -29,23 +41,33 @@ This note captures the remaining work streams for execution-mode standardization
 
 ## 2. Concept & Documentation Consolidation (Medium-Term)
 
-**Goal:** clarify the relationship between execution modes, deployment modes, and SLA tiers to avoid future drift.
+**Goal:** clarify the relationship between optimization policy, deployment
+concerns, and SLA tiers so the deprecated mode taxonomy does not drift back into
+docs or contracts.
 
 - **Owner:** SDK Architecture / Docs  
-- **Success Criteria:** single authoritative description of what each mode implies (feature matrix, privacy expectations, storage behaviour).
+- **Success Criteria:** single authoritative description of what
+  `algorithm`, `offline`, external evaluators, privacy guarantees, and backend
+  fallback imply.
 
 ### Tasks
 1. **Review duplicate enums / constants**  
    - Compare `ExecutionMode` with `DeploymentMode` and SLA constants under `traigent/security/`.
    - Decide whether to consolidate or explicitly document their differing scopes.
 2. **Publish a mode capability matrix**  
-   - Highlight supported features (local storage, backend sync, privacy guarantees, offline operation) per mode.
-   - Surface the current limitations of `HYBRID` and the sunset status of the `PRIVACY` alias.
+   - Highlight supported features for the current surface: cloud-first
+     `algorithm="auto"`, explicit local algorithms, `offline=True`, and
+     external evaluator dispatch.
+   - Keep the deprecated mapping table explicit so `execution_mode="privacy"`
+     is not misread as a no-egress guarantee.
 3. **Update API docs & examples**  
-   - Replace raw string defaults with enum references where applicable.
-   - Add guidance on selecting an execution mode based on deployment requirements.
+   - Replace stale `execution_mode`, `privacy_enabled`, `cloud_fallback_policy`,
+     and flat `hybrid_api_*` examples with the current public surface.
+   - Add guidance on selecting `algorithm`/`offline` based on deployment
+     requirements.
 4. **Document migration guidance**  
-   - Provide a clear recipe for teams moving from legacy `privacy` usage to the `HYBRID + privacy_enabled` pattern.
+   - Provide a clear recipe for teams moving from legacy
+     `execution_mode`/`privacy_enabled` usage to `algorithm` plus `offline`.
 
 ---
 
@@ -53,9 +75,11 @@ This note captures the remaining work streams for execution-mode standardization
 
 | Task | Priority | Owner | Status |
 |------|----------|-------|--------|
-| Backend accepts enum payloads | Short-term | Backend Platform | ☐ |
-| SDK switches trial operations to enums | Short-term | SDK | ☐ |
-| Publish execution-mode feature matrix | Medium-term | Docs | ☐ |
-| Align / document deployment vs execution enums | Medium-term | SDK Architecture | ☐ |
+| Backend accepts canonical execution-policy payloads | Short-term | Backend Platform | ☐ |
+| SDK removes backend-facing legacy mode assumptions | Short-term | SDK | ☐ |
+| Publish algorithm/offline capability matrix | Medium-term | Docs | ☐ |
+| Align or document deployment vs execution-policy concepts | Medium-term | SDK Architecture | ☐ |
 
-> **Note:** check this document into version control along with issue tracker links once tickets are created. Update the status table as work completes.
+> **Note:** the public documentation should treat the consolidated
+> `algorithm`/`offline` model as canonical. This note exists only for remaining
+> backend and architecture follow-up work, not as an alternate user model.

--- a/docs/examples/API_PATTERNS.md
+++ b/docs/examples/API_PATTERNS.md
@@ -146,6 +146,7 @@ results = await async_answer.optimize(max_trials=10)
 print(results.best_config)
 print(results.best_score)
 print(results.status)
+print(results.source)
 
 successful = results.successful_trials
 df = results.to_dataframe()
@@ -153,6 +154,9 @@ df = results.to_dataframe()
 
 `successful_trials` is a list of successful `TrialResult` objects. Use
 `len(results.successful_trials)` when you need a count.
+
+`results.source` tells you which execution path ran:
+`cloud_brain`, `local_fallback`, `explicit_local`, or `offline`.
 
 ## Progressive Runs
 
@@ -174,14 +178,20 @@ refined = await answer.optimize(
 ## External Service Evaluator
 
 Use `ExternalServiceEvaluator` when trials are delegated to an external service
-that implements the Traigent Hybrid API contract.
+that implements the Traigent Hybrid API contract. This replaces the removed
+`execution_mode="hybrid_api"` plus flat `hybrid_api_*` arguments; the optimizer
+still runs locally and each trial evaluation is dispatched through the external
+service.
 
 ```python
 from traigent.api.decorators import ExternalServiceEvaluator, HybridAPIOptions
 
 @traigent.optimize(
     evaluator=ExternalServiceEvaluator(
-        hybrid_api=HybridAPIOptions(endpoint="http://localhost:8080")
+        hybrid_api=HybridAPIOptions(
+            endpoint="http://localhost:8080",
+            transport_type="http",
+        )
     ),
     configuration_space={"temperature": [0.0, 0.3]},
     eval_dataset="data/eval.jsonl",
@@ -193,6 +203,9 @@ def external_agent(_query: str) -> str:
 
 results = await external_agent.optimize(max_trials=10)
 ```
+
+Because the optimizer is local in this setup, successful runs report
+`results.source == "explicit_local"`.
 
 ## Multi-Field Evaluation Inputs
 

--- a/docs/examples/QUICK_REFERENCE.md
+++ b/docs/examples/QUICK_REFERENCE.md
@@ -33,7 +33,10 @@ def summarize(text: str) -> str:
 ## Execution model
 - `algorithm="auto"` (default) - cloud-first optimizer decisions, local trials, local fallback on connectivity failures.
 - `algorithm="grid"` / `"random"` - explicit local optimizers with no cloud optimizer round trip.
-- `offline=True` - zero Traigent backend egress.
+- Smart algorithms such as `bayesian`, `tpe`, `optuna_tpe`, `nsga2`, and `cmaes` are cloud-only and hard-error if unavailable.
+- `offline=True`, `TRAIGENT_OFFLINE=1`, or legacy `TRAIGENT_OFFLINE_MODE=1` - zero Traigent backend egress.
+- `TRAIGENT_REQUIRE_CLOUD=1` - disables the automatic local fallback for `algorithm="auto"`.
+- Result provenance: `result.source` is `cloud_brain`, `local_fallback`, `explicit_local`, or `offline`.
 - Mock: call `traigent.testing.enable_mock_mode_for_quickstart()` in local tutorial code.
 
 ## Quick knobs

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -154,11 +154,22 @@ configs and your process runs the trials. If cloud connectivity is unavailable,
 auto falls back locally unless `TRAIGENT_REQUIRE_CLOUD=1` is set.
 
 Explicit `algorithm="grid"` and `"random"` run locally with no cloud optimizer
-round trip. Explicit smart algorithms require cloud and error if offline or
-unavailable.
+round trip. Explicit smart algorithms such as `bayesian`, `tpe`, `optuna_tpe`,
+`nsga2`, and `cmaes` require cloud and hard-error if offline or unavailable.
 
-To run fully local with no Traigent backend communication, set `offline=True` or
-`TRAIGENT_OFFLINE=1`.
+To run fully local with no Traigent backend communication, set `offline=True`,
+`TRAIGENT_OFFLINE=1`, or the legacy `TRAIGENT_OFFLINE_MODE=1`.
+
+If you are migrating older code: `execution_mode="hybrid"` becomes the default
+`@traigent.optimize()` behavior, `execution_mode="edge_analytics"` becomes
+`offline=True`, and `privacy_enabled=True` should be removed.
+
+Optimization results also record how the run resolved:
+
+- `result.source == "cloud_brain"` for the cloud-first path
+- `result.source == "local_fallback"` when `algorithm="auto"` degrades locally
+- `result.source == "explicit_local"` for explicit `grid` / `random`
+- `result.source == "offline"` for `offline=True` or offline env vars
 
 ---
 

--- a/docs/getting-started/minimal-integration.md
+++ b/docs/getting-started/minimal-integration.md
@@ -45,7 +45,7 @@ Minimal checklist:
 
 1. Authentication configured with `traigent auth device-login`, `traigent onboard`, or `TRAIGENT_API_KEY` for CI/non-interactive environments.
 2. `TRAIGENT_API_URL` configured (if not using default backend URL).
-3. For hybrid mode scripts using `requests`, set `User-Agent: Traigent-SDK/1.0`.
+3. For external-service evaluator scripts using `requests`, set `User-Agent: Traigent-SDK/1.0`.
 
 ## 15-Minute Acceptance Test
 

--- a/docs/guides/execution-mode-migration.md
+++ b/docs/guides/execution-mode-migration.md
@@ -1,0 +1,124 @@
+# Execution Mode Migration
+
+Traigent's execution model is now defined by `algorithm` plus `offline`. The
+legacy `execution_mode`, `privacy_enabled`, and `cloud_fallback_policy` inputs
+are deprecated compatibility shims, not the current public model.
+
+## Canonical Model
+
+- `algorithm="auto"`: cloud-first optimizer selection with local trial
+  execution. If the backend is unavailable because of missing credentials,
+  offline connectivity, or backend failure, Traigent warns once and degrades to
+  local grid/random.
+- `algorithm="grid"` or `"random"`: explicit local optimization with no
+  backend round trip.
+- Explicit smart algorithms such as `"bayesian"`, `"tpe"`, `"optuna_tpe"`,
+  `"nsga2"`, or `"cmaes"`: cloud-only. If the cloud is unavailable, the run
+  errors. It does not silently downgrade.
+- `offline=True`: force zero Traigent backend egress. Environment equivalents:
+  `TRAIGENT_OFFLINE=1` and the legacy `TRAIGENT_OFFLINE_MODE=1`.
+- `TRAIGENT_REQUIRE_CLOUD=1`: disable the automatic local fallback for
+  `algorithm="auto"` and hard-error instead.
+
+## Deprecated Mapping Table
+
+| Deprecated input | Current meaning | What to write now |
+| --- | --- | --- |
+| `execution_mode="edge_analytics"` | local-only / no Traigent backend egress | `offline=True` |
+| `execution_mode="local"` | local-only / no Traigent backend egress | `offline=True` |
+| `execution_mode="hybrid"` | cloud-first automatic optimization | omit it, or set `algorithm="auto"` |
+| `execution_mode="standard"` | cloud-first automatic optimization | omit it, or set `algorithm="auto"` |
+| `execution_mode="privacy"` | cloud-first automatic optimization; not no-egress | omit it, or set `algorithm="auto"`; use `offline=True` for no egress |
+| `execution_mode="cloud"` | cloud-first automatic optimization, despite the historical local meaning | omit it, or set `algorithm="auto"` |
+| `execution_mode="hybrid_api"` | external-service evaluation moved off the mode axis | `evaluator=ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))` |
+| `privacy_enabled` | deprecated no-op | remove it; use `offline=True` only when no egress is required |
+| `cloud_fallback_policy` | deprecated no-op | remove it; use `TRAIGENT_REQUIRE_CLOUD=1` when fallback must be disabled |
+
+## Copy-Paste Replacements
+
+```python
+import traigent
+
+# Before
+@traigent.optimize(execution_mode="hybrid")
+def answer(question: str) -> str:
+    return run_agent(question)
+
+# After
+@traigent.optimize()
+def answer(question: str) -> str:
+    return run_agent(question)
+```
+
+```python
+import traigent
+
+# Before
+@traigent.optimize(execution_mode="edge_analytics")
+def answer(question: str) -> str:
+    return run_agent(question)
+
+# After
+@traigent.optimize(offline=True)
+def answer(question: str) -> str:
+    return run_agent(question)
+```
+
+```python
+import traigent
+
+# Before
+@traigent.optimize(
+    execution_mode="hybrid_api",
+    hybrid_api_endpoint="https://svc",
+)
+def my_agent(_query: str) -> str:
+    return ""
+
+# After
+from traigent.api.decorators import ExternalServiceEvaluator, HybridAPIOptions
+
+@traigent.optimize(
+    evaluator=ExternalServiceEvaluator(
+        hybrid_api=HybridAPIOptions(endpoint="https://svc")
+    )
+)
+def my_agent(_query: str) -> str:
+    return ""
+```
+
+```python
+import traigent
+
+# Before
+@traigent.optimize(privacy_enabled=True)
+def answer(question: str) -> str:
+    return run_agent(question)
+
+# After
+@traigent.optimize()
+def answer(question: str) -> str:
+    return run_agent(question)
+```
+
+If the old intent behind `privacy_enabled=True` was "no Traigent network
+egress", the correct replacement is `offline=True`.
+
+## Privacy and No-Egress
+
+The cloud-first path is content-free by design: it sends configuration IDs and
+numeric metrics, not dataset example content. That default privacy boundary is
+not the same as offline operation.
+
+- Use the default cloud-first path when backend egress is allowed.
+- Use `offline=True` when policy requires zero Traigent backend egress.
+
+## Result Provenance
+
+Inspect `result.metadata["source"]` to see how a run actually executed:
+
+- `cloud_brain`: the cloud optimizer selected configurations.
+- `local_fallback`: `algorithm="auto"` degraded to local optimization after a
+  connectivity failure.
+- `explicit_local`: you requested `algorithm="grid"` or `"random"`.
+- `offline`: you forced offline mode.

--- a/docs/guides/execution-modes.md
+++ b/docs/guides/execution-modes.md
@@ -3,10 +3,16 @@
 Traigent no longer exposes an execution-mode selector for normal optimization
 workflows. Configure optimization with these public knobs:
 
-- `algorithm` (default: `"auto"`): `"auto"`, `"grid"`, `"random"`, or a smart
-  optimizer name such as Bayesian/TPE/CMA-ES when enabled by your account.
+- `algorithm` (default: `"auto"`): `"auto"`, `"grid"`, `"random"`, or an
+  explicit smart optimizer name such as `"bayesian"`, `"tpe"`,
+  `"optuna_tpe"`, `"optuna_random"`, `"optuna_grid"`, `"optuna_cmaes"`,
+  `"optuna_nsga2"`, `"nsga2"`, `"nsgaii"`, `"nsga_ii"`, `"cmaes"`, or
+  `"cma_es"` when enabled by your account.
 - `offline` (default: `False`): force local-only operation with zero Traigent
   backend egress.
+
+Unknown algorithm names are rejected instead of silently mapping to another
+mode.
 
 Trials always run in your process. The cloud path supplies optimizer decisions;
 it does not execute your dataset examples remotely.
@@ -32,9 +38,9 @@ downgrade to a local optimizer.
 ## Cloud-First Auto
 
 The default `@optimize(...)` path uses `algorithm="auto"` and `offline=False`.
-When cloud access is configured, the SDK creates a cloud-brain session and asks
-the backend for each next configuration. Each suggested trial still executes
-locally in your Python process.
+When cloud access is configured, the SDK asks the backend for each next
+configuration. Each suggested trial still executes locally in your Python
+process.
 
 ```python
 import traigent
@@ -51,7 +57,7 @@ def answer(question: str) -> str:
     return run_agent(question)
 
 result = answer.optimize(max_trials=8)
-print(result.source)  # "cloud_brain" or "local_fallback"
+print(result.metadata["source"])  # "cloud_brain" or "local_fallback"
 ```
 
 Automatic fallback is limited to `algorithm="auto"`. It exists to keep the
@@ -66,7 +72,7 @@ round trip.
 
 ```python
 result = answer.optimize(algorithm="grid", max_trials=8)
-print(result.source)  # "explicit_local"
+print(result.metadata["source"])  # "explicit_local"
 ```
 
 ## Offline and No Egress
@@ -89,7 +95,7 @@ def answer(question: str) -> str:
     return run_agent(question)
 
 result = answer.optimize(max_trials=3)
-print(result.source)  # "offline"
+print(result.metadata["source"])  # "offline"
 ```
 
 `offline=True`, `TRAIGENT_OFFLINE=1`, and `TRAIGENT_OFFLINE_MODE=1` prevent
@@ -120,7 +126,7 @@ the cloud optimizer to choose configurations.
 
 ```python
 result = answer.optimize(algorithm="bayesian", max_trials=20)
-print(result.source)  # "cloud_brain"
+print(result.metadata["source"])  # "cloud_brain"
 ```
 
 If the cloud is unavailable, or if `offline=True` is set, this run raises an
@@ -129,7 +135,9 @@ fallback.
 
 ## External Service Evaluation
 
-The former `hybrid_api_*` flat options moved into the evaluator bundle.
+The former `hybrid_api_*` flat options moved into the evaluator bundle. The
+optimizer still runs locally; only each trial evaluation is dispatched to the
+external HTTP or MCP service.
 
 ```python
 import traigent
@@ -139,6 +147,7 @@ from traigent.api.decorators import ExternalServiceEvaluator, HybridAPIOptions
     evaluator=ExternalServiceEvaluator(
         hybrid_api=HybridAPIOptions(
             endpoint="http://your-service:8080",
+            transport_type="http",
             tunable_id="my_agent",
             auth_header="Bearer <token>",
             batch_size=10,
@@ -158,7 +167,9 @@ def my_agent(_query: str) -> str:
 
 ## Result Provenance
 
-Optimization results expose one of these `source` values:
+Optimization results expose one of these `source` values in
+`result.metadata["source"]`. The same value is also mirrored on
+`result.source`.
 
 - `cloud_brain`: backend optimizer selected configurations; trials ran locally.
 - `local_fallback`: `algorithm="auto"` fell back to local optimization because
@@ -179,5 +190,10 @@ warnings. They are targeted for removal in a future major release.
 | `execution_mode="privacy"` | cloud-first `algorithm="auto"`; use `offline=True` for no egress |
 | `execution_mode="cloud"` | cloud-first `algorithm="auto"` with a loud warning because historical semantics flipped |
 | `execution_mode="hybrid_api"` | `evaluator=ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))` |
-| `privacy_enabled` | removed no-op with a deprecation warning |
-| `cloud_fallback_policy` | removed no-op with a deprecation warning |
+| `privacy_enabled` | drop it; it is a deprecated no-op. Cloud-first runs already avoid sending dataset example content. Use `offline=True` for zero egress. |
+| `cloud_fallback_policy` | drop it; it is a deprecated no-op. Use `TRAIGENT_REQUIRE_CLOUD=1` to turn auto-fallback into a hard error. |
+
+## Migration Reference
+
+See [Execution Mode Migration](execution-mode-migration.md) for concrete
+old-to-new replacements, deprecated field mapping, and copy-paste examples.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -5,7 +5,7 @@ Comprehensive guides for using Traigent SDK features and capabilities.
 ## Contents
 
 - **[Agent Optimization](agent_optimization.md)** - Optimize AI agents and multi-step workflows
-- **[Choosing Models](choosing_optimization_model.md)** - Select the right optimization model for your use case
+- **[Choosing Models](choosing_optimization_model.md)** - Select the right `algorithm` / `offline` routing model for your use case
 - **[Configuration Spaces](configuration-spaces.md)** - Define tunable variables, parameter ranges, and presets
 - **[Tuned Variables](tuned_variables.md)** - Auto-detect tunable parameters and use the callable discovery API
 - **[Injection Modes](injection_modes.md)** - Different ways to integrate Traigent with your code

--- a/docs/user-guide/agent_optimization.md
+++ b/docs/user-guide/agent_optimization.md
@@ -555,5 +555,5 @@ logger.setLevel(logging.DEBUG)
 ## Next Steps
 
 - Start with `traigent quickstart`, then use `traigent recommend rag` for configuration-space suggestions.
-- Review [Execution Modes](../guides/execution-modes.md) for local/cloud/hybrid context
+- Review [Choosing the Right Optimization Model](./choosing_optimization_model.md) for the current `algorithm` / `offline` routing model
 - Read [Architecture Overview](../architecture/ARCHITECTURE.md) for system design details

--- a/docs/user-guide/choosing_optimization_model.md
+++ b/docs/user-guide/choosing_optimization_model.md
@@ -6,6 +6,12 @@ Traigent optimization has two public routing knobs:
   cloud-backed smart algorithms.
 - `offline`: `False` by default; set `True` for zero Traigent backend egress.
 
+Environment equivalents:
+
+- `TRAIGENT_OFFLINE=1` forces offline mode.
+- `TRAIGENT_OFFLINE_MODE=1` is a legacy alias for offline mode.
+- `TRAIGENT_REQUIRE_CLOUD=1` disables the `algorithm="auto"` local fallback.
+
 Trials run in your process. The cloud-brain path asks Traigent for optimizer
 decisions; it does not execute your dataset examples remotely.
 
@@ -32,7 +38,7 @@ Set `TRAIGENT_REQUIRE_CLOUD=1` when fallback is not acceptable.
 | `algorithm="auto"` | Cloud optimizer chooses configs; trials run locally | `cloud_brain` |
 | `algorithm="auto"` and connectivity failure | Warns and falls back to local search | `local_fallback` |
 | `algorithm="grid"` or `"random"` | Runs locally with no cloud optimizer round trip | `explicit_local` |
-| `offline=True` or `TRAIGENT_OFFLINE=1` | Fully local, zero Traigent backend egress | `offline` |
+| `offline=True`, `TRAIGENT_OFFLINE=1`, or `TRAIGENT_OFFLINE_MODE=1` | Fully local, zero Traigent backend egress | `offline` |
 | Smart algorithm name | Requires cloud; errors if offline or unavailable | `cloud_brain` |
 
 ## Default Cloud-First Auto
@@ -47,7 +53,7 @@ def agent(question: str) -> str:
     return answer_question(question)
 
 result = agent.optimize(max_trials=8)
-print(result.source)
+print(result.metadata["source"])
 ```
 
 Use this when cloud optimizer decisions are acceptable and local fallback is
@@ -57,7 +63,7 @@ acceptable during connectivity failures.
 
 ```python
 result = agent.optimize(algorithm="grid", max_trials=8)
-print(result.source)  # explicit_local
+print(result.metadata["source"])  # explicit_local
 ```
 
 Use this for reproducible local sweeps, CI smoke tests, and simple baselines.
@@ -85,7 +91,7 @@ Smart algorithms are cloud optimizers:
 
 ```python
 result = agent.optimize(algorithm="bayesian", max_trials=20)
-print(result.source)  # cloud_brain
+print(result.metadata["source"])  # cloud_brain
 ```
 
 They hard-error when `offline=True` is set or when the backend is unavailable.
@@ -99,4 +105,48 @@ Traigent backend boundary: no example inputs, expected outputs, prompts,
 responses, or example metadata.
 
 Privacy-on cloud-brain mode is not the same as no-network mode. Use
-`offline=True` or `TRAIGENT_OFFLINE=1` for zero Traigent backend egress.
+`offline=True`, `TRAIGENT_OFFLINE=1`, or `TRAIGENT_OFFLINE_MODE=1` for zero
+Traigent backend egress.
+
+## External Service Evaluation
+
+External-service evaluation is independent of the optimizer routing knobs. The
+optimizer still runs locally; each trial's evaluation is dispatched to your
+HTTP or MCP service through an external evaluator:
+
+```python
+from traigent import optimize
+from traigent.api.decorators import (
+    ExternalServiceEvaluator,
+    HybridAPIOptions,
+)
+
+
+@optimize(
+    configuration_space={"temperature": [0.1, 0.5, 0.9]},
+    objectives=["accuracy"],
+    evaluator=ExternalServiceEvaluator(
+        hybrid_api=HybridAPIOptions(endpoint="https://svc.example.com/evaluate")
+    ),
+)
+def agent(question: str) -> str:
+    return answer_question(question)
+```
+
+Use this in place of the removed `execution_mode="hybrid_api"` plus flat
+`hybrid_api_*` keyword arguments.
+
+## Deprecations and Migration
+
+These legacy execution knobs are deprecated and should not be used in new code:
+
+| Old surface | New surface |
+| --- | --- |
+| `execution_mode="hybrid"` | `@optimize()` |
+| `execution_mode="edge_analytics"` or `"local"` | `@optimize(offline=True)` |
+| `execution_mode="hybrid_api", hybrid_api_endpoint="https://svc"` | `@optimize(evaluator=ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(endpoint="https://svc")))` |
+| `privacy_enabled=True` | Drop it. Cloud-brain mode already avoids dataset content egress; use `offline=True` for zero network egress to Traigent. |
+| `cloud_fallback_policy=...` | Drop it. Use `TRAIGENT_REQUIRE_CLOUD=1` when auto-fallback must be disabled. |
+
+`execution_mode=` is accepted only as a deprecated compatibility keyword with a
+warning. `privacy_enabled` and `cloud_fallback_policy` are deprecated no-ops.

--- a/docs/user-guide/optuna_integration.md
+++ b/docs/user-guide/optuna_integration.md
@@ -1,6 +1,11 @@
 # Optuna Integration in Traigent
 
-> **Cloud-only feature.** Optuna-based optimisers (TPE, CMA-ES, NSGA-II, and others) are **not available in the local SDK**. Calling `get_optimizer("optuna_tpe")` or passing `algorithm="optuna"` / `"tpe"` / `"nsga2"` / `"cmaes"` in a local run raises an `OptimizationError`. To use these algorithms, connect to [Traigent Portal](https://portal.traigent.ai).
+> **Cloud-only feature.** Smart algorithms such as TPE, CMA-ES, and NSGA-II are
+> **not available in the local SDK**. Passing `algorithm="tpe"`,
+> `"optuna_tpe"`, `"optuna_random"`, `"optuna_grid"`, `"optuna_cmaes"`,
+> `"optuna_nsga2"`, `"bayesian"`, `"nsga2"`, `"nsgaii"`, `"nsga_ii"`,
+> `"cmaes"`, or `"cma_es"` without a reachable Traigent backend raises an
+> `OptimizationError`.
 >
 > For local runs, use `algorithm="grid"` (exhaustive, small spaces) or `algorithm="random"` (large spaces, quick exploration).
 
@@ -33,7 +38,7 @@ coordination:
 
 ```python
 # Requires a Traigent backend connection
-result = optimized_fn.optimize(algorithm="tpe", n_trials=100)
+result = optimized_fn.optimize(algorithm="tpe", max_trials=100)
 ```
 
 Local calls with smart algorithm names raise a clear error:
@@ -48,6 +53,10 @@ except OptimizationError as e:
     # "Smart optimization ('tpe') runs in the Traigent cloud..."
     print(e)
 ```
+
+`algorithm="auto"` is different: it is cloud-first, but on connectivity
+failures it warns once and degrades to a local grid/random search unless
+`TRAIGENT_REQUIRE_CLOUD=1` is set.
 
 ## Conditional Parameters
 
@@ -78,6 +87,7 @@ same schema works for `float` and `categorical` definitions, including optional
 ## Availability
 
 Optuna optimisers require a Traigent cloud connection. They are not part of
-the local SDK's registered algorithm set. For local optimization, use `"grid"`
-or `"random"` via `func.optimize(algorithm="grid")` or
+the local SDK's registered algorithm set, and they do not silently downgrade to
+local search when the backend is unavailable. For local optimization, use
+`"grid"` or `"random"` via `func.optimize(algorithm="grid")` or
 `func.optimize(algorithm="random")`.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -31,7 +31,7 @@ The legacy `TRAIGENT_MOCK_LLM=true` env var remains available outside production
 | 5 | `python walkthrough/mock/05_rag_parallel.py` | RAG optimization with parallel evaluation |
 | 6 | `python walkthrough/mock/06_custom_evaluator.py` | Define your own success metrics |
 | 7 | `python walkthrough/mock/07_multi_provider.py` | Compare OpenAI, Anthropic, Google in one run |
-| 8 | `python walkthrough/mock/08_privacy_modes.py` | Local-only privacy-first execution |
+| 8 | `python walkthrough/mock/08_privacy_modes.py` | Cloud-first content-free routing vs `offline=True` zero-egress runs |
 
 ## What to expect
 


### PR DESCRIPTION
## Summary
Documentation pass following the execution-mode consolidation (merged #1380): the SDK has **no `execution_mode` selector** — the knobs are `algorithm` (default `"auto"`, cloud-first with auto-fallback to local) and `offline` (zero backend egress). This reviews and updates the SDK docs to match (3 areas: onboarding, concepts/migration, api-reference/user-guide).

Key corrections across `docs/`:
- Replace the old `execution_mode`/`privacy_enabled`/`cloud_fallback_policy`/flat `hybrid_api_*` surface with `algorithm`/`offline` and `evaluator=ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))` (verified runnable form).
- Document cloud-first + auto-fallback, smart-algos-are-cloud-only, env vars (`TRAIGENT_OFFLINE`/`TRAIGENT_REQUIRE_CLOUD`), and result provenance `source ∈ {cloud_brain, local_fallback, explicit_local, offline}`.
- **Honest privacy wording**: the cloud path sends config IDs + numeric metrics only (never example content); privacy ≠ no-network (use `offline=True`).
- New `docs/guides/execution-mode-migration.md` (legacy→new mapping); legacy surface now appears only as migration context.

Reviewed-and-left-unchanged docs are listed in the worker reports (many were already compatible).

## Notes
- Verified the external-evaluator constructor is `ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...))` (positional raises TypeError).
- Docs-only change; no SDK source touched.

## Related
SDK consolidation #1380 (merged); Phase-2 hardening (egress guard + cleanup, in flight); skills update (traigent-skills #55).

Spine-Trail: st_b6e4f73d0d13
Spine-Session: cs_6ca80e2e02805fe3

🤖 Generated with [Claude Code](https://claude.com/claude-code)