### PR TITLE
chore(release): SDK 0.15.0 — execution-mode consolidation + Phase-2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.14.3"
+version = "0.15.0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
Minor release bump to 0.15.0. main already carries the execution-mode consolidation (algorithm=auto + offline, no execution_mode selector) + Phase-2 universal offline egress guard + ExternalServiceEvaluator (via #1382/#1383). This bumps the version so the v0.15.0 tag publishes to PyPI. 0.14.3 is already published with the pre-consolidation content, so a new minor is required.

After merge: tag v0.15.0 -> publish.yml publishes to PyPI; then develop bumps to 0.16.0.dev0.

Spine-Trail: st_c9cb64326ffe
Spine: none (reason: release version bump)