### PR TITLE
chore: develop → 0.16.0.dev0 (open next cycle after 0.15.0 release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.14.2"
+version = "0.16.0.dev0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
Version bump only: opens the next dev cycle after the 0.15.0 PyPI release.

Spine-Trail: st_c0ef60967df0
Spine: none (reason: dev version bump)