### PR TITLE
fix(sync): sync results to the cloud for all modes except offline

### DIFF
--- a/tests/unit/core/test_execution_policy_execution.py
+++ b/tests/unit/core/test_execution_policy_execution.py
@@ -8,11 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 import traigent
-from traigent.api.decorators import (
-    ExternalServiceEvaluator,
-    HybridAPIOptions,
-    optimize,
-)
+from traigent.api.decorators import ExternalServiceEvaluator, HybridAPIOptions, optimize
 from traigent.cloud.models import (
     DatasetSubsetIndices,
     NextTrialResponse,
@@ -127,6 +123,66 @@ async def test_offline_env_makes_zero_backend_calls_even_with_key(
         result = await agent.optimize(max_trials=1)
 
     create_backend_client.assert_not_called()
+    next_trial.assert_not_called()
+    assert result.source == "offline"
+    assert result.metadata["source"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_offline_mode_env_makes_zero_backend_calls_even_with_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "1")
+    monkeypatch.setenv("TRAIGENT_API_KEY", "tg_test_key")
+    backend = FakeBackendClient()
+    agent = _make_agent(algorithm="grid")
+
+    with (
+        patch(
+            "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client",
+            return_value=backend,
+        ) as create_backend_client,
+        patch("traigent.cloud.client.TraigentCloudClient.get_next_trial") as next_trial,
+    ):
+        result = await agent.optimize(max_trials=1)
+
+    create_backend_client.assert_not_called()
+    backend.create_session.assert_not_called()
+    backend.submit_result.assert_not_called()
+    backend.request_trial_slot.assert_not_called()
+    backend._submit_trial_result_via_session.assert_not_called()
+    backend.finalize_session_sync.assert_not_called()
+    next_trial.assert_not_called()
+    assert result.source == "offline"
+    assert result.metadata["source"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_offline_option_makes_zero_backend_calls_even_with_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
+    monkeypatch.delenv("TRAIGENT_OFFLINE_MODE", raising=False)
+    monkeypatch.setenv("TRAIGENT_API_KEY", "tg_test_key")
+    backend = FakeBackendClient()
+    agent = _make_agent(algorithm="grid", offline=True)
+
+    with (
+        patch(
+            "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client",
+            return_value=backend,
+        ) as create_backend_client,
+        patch("traigent.cloud.client.TraigentCloudClient.get_next_trial") as next_trial,
+    ):
+        result = await agent.optimize(max_trials=1)
+
+    create_backend_client.assert_not_called()
+    backend.create_session.assert_not_called()
+    backend.submit_result.assert_not_called()
+    backend.request_trial_slot.assert_not_called()
+    backend._submit_trial_result_via_session.assert_not_called()
+    backend.finalize_session_sync.assert_not_called()
     next_trial.assert_not_called()
     assert result.source == "offline"
     assert result.metadata["source"] == "offline"
@@ -305,23 +361,32 @@ async def test_explicit_smart_backend_down_hard_errors(
 
 
 @pytest.mark.asyncio
-async def test_explicit_grid_runs_local_without_next_trial_or_backend(
+@pytest.mark.parametrize("algorithm", ["grid", "random"])
+async def test_explicit_local_algorithms_run_locally_and_sync_results(
     monkeypatch: pytest.MonkeyPatch,
+    algorithm: str,
 ) -> None:
     monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
     monkeypatch.delenv("TRAIGENT_OFFLINE_MODE", raising=False)
     monkeypatch.setenv("TRAIGENT_API_KEY", "tg_test_key")
-    agent = _make_agent(algorithm="grid")
+    backend = FakeBackendClient()
+    agent = _make_agent(algorithm=algorithm)
 
     with (
         patch(
-            "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client"
+            "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client",
+            return_value=backend,
         ) as create_backend_client,
         patch("traigent.cloud.client.TraigentCloudClient.get_next_trial") as next_trial,
     ):
         result = await agent.optimize(max_trials=1)
 
-    create_backend_client.assert_not_called()
+    create_backend_client.assert_called_once()
+    backend.create_session.assert_called_once()
+    backend.submit_result.assert_called_once()
+    backend.request_trial_slot.assert_awaited_once()
+    backend._submit_trial_result_via_session.assert_awaited_once()
+    backend.finalize_session_sync.assert_called_once()
     next_trial.assert_not_called()
     assert result.source == "explicit_local"
 
@@ -374,6 +439,7 @@ async def test_hybrid_api_options_dispatch_through_external_transport(
     monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
     monkeypatch.delenv("TRAIGENT_OFFLINE_MODE", raising=False)
     monkeypatch.setenv("TRAIGENT_API_KEY", "tg_test_key")
+    backend = FakeBackendClient()
     transport = FakeHybridTransport()
 
     @optimize(
@@ -389,13 +455,19 @@ async def test_hybrid_api_options_dispatch_through_external_transport(
 
     with (
         patch(
-            "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client"
+            "traigent.core.backend_session_manager.BackendSessionManager.create_backend_client",
+            return_value=backend,
         ) as create_backend_client,
         patch("traigent.cloud.client.TraigentCloudClient.get_next_trial") as next_trial,
     ):
         result = await external_agent.optimize(max_trials=1)
 
-    create_backend_client.assert_not_called()
+    create_backend_client.assert_called_once()
+    backend.create_session.assert_called_once()
+    assert backend.submit_result.call_count >= 1
+    backend.request_trial_slot.assert_awaited_once()
+    backend._submit_trial_result_via_session.assert_awaited_once()
+    backend.finalize_session_sync.assert_called_once()
     next_trial.assert_not_called()
     transport.execute.assert_awaited_once()
     transport.evaluate.assert_awaited_once()

--- a/traigent/core/execution_policy_runtime.py
+++ b/traigent/core/execution_policy_runtime.py
@@ -171,8 +171,6 @@ def backend_egress_disabled(config: TraigentConfig | None) -> bool:
         return True
     if bool(getattr(config, "no_egress", False)):
         return True
-    if policy is not None and policy.intent is ExecutionIntent.LOCAL_ONLY:
-        return True
     return False
 
 

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -2222,10 +2222,7 @@ Remediation:
             execution_policy,
             external_evaluator=external_evaluator,
         )
-        no_egress = result_source in {
-            SOURCE_OFFLINE,
-            SOURCE_EXPLICIT_LOCAL,
-        }
+        no_egress = result_source == SOURCE_OFFLINE
 
         # Phase 2: Create TraigentConfig and check CI approval
         traigent_config = create_traigent_config(


### PR DESCRIPTION
## What & why
Owner directive: optimization results should sync to the portal in **all** modes except when the user explicitly sets `offline`. Today `grid`/`random` run locally **and** are silently treated as no-egress, so those runs never appear in the portal (compounds the "no results" reports).

## Change
- `backend_egress_disabled()` no longer treats `policy.intent is LOCAL_ONLY` as no-egress.
- `optimized_function` no longer sets `no_egress` for explicit-local; only `SOURCE_OFFLINE` does.
- Net: `grid`/`random` (offline=False) run the search locally but **create session, submit trials, finalize** to the portal. `auto`/smart unchanged (cloud).

## Privacy guarantee (preserved)
`offline=True` and `TRAIGENT_OFFLINE` / `TRAIGENT_OFFLINE_MODE` still produce **zero** backend egress — covered by canary tests. Only the local-search-but-not-offline case was changed.

## Tests
- Canary: offline → no backend client/session/trial/finalize calls.
- New: grid/random + offline=False + key → session/trial/finalize sync occurs (pre-fix: 0 calls).
- codex gpt-5.5 review: **GO** (remaining egress gates are offline-based; smart/cloud path unchanged).

## PR checklist
1. Worst-case prod path: changes when results egress to the portal. `offline=True` still fails closed (zero egress, canary-tested).
2. Production-branch test: offline zero-egress canary at `tests/unit/core/test_execution_policy_execution.py`.
3. Contract regen: none.
4. Public surface delta: none (behavioral — local algos now sync unless offline).
5. Review threads: codex GO; bot FPs resolved on PR.
6. Quality gates: unchanged.

Note: privacy-relevant behavior change — flagging for promotion to a spine ChangeSession before merge.

Spine-Trail: st_e71644211e35

🤖 Generated with [Claude Code](https://claude.com/claude-code)