### PR TITLE
fix(sdk): experiment URL path + results-list/check/whoami/sync bugs

### DIFF
--- a/tests/cloud/test_sync_manager.py
+++ b/tests/cloud/test_sync_manager.py
@@ -230,7 +230,7 @@ class TestSyncManager:
         "method_name,resource_path,payload_key",
         [
             ("_sync_agent", "agents", "agent_id"),
-            ("_sync_benchmark", "benchmarks", "benchmark_id"),
+            ("_sync_benchmark", "datasets", "benchmark_id"),
             ("_sync_experiment", "experiments", "experiment_id"),
             ("_sync_experiment_run", "experiment-runs", "run_id"),
         ],
@@ -295,7 +295,7 @@ class TestSyncManager:
             assert result["dataset_id"] == "benchmark-123"
             assert result["benchmark_id"] == "benchmark-123"
             sync_manager._session.post.assert_called_once_with(
-                f"{sync_manager.base_url}/benchmarks",
+                f"{sync_manager.base_url}/datasets",
                 json=payload,
                 timeout=sync_manager._request_timeout,
             )
@@ -499,7 +499,7 @@ class TestSyncManager:
         calls = post_mock.call_args_list
         assert [call.args[0] for call in calls] == [
             f"{self.sync_manager.base_url}/agents",
-            f"{self.sync_manager.base_url}/benchmarks",
+            f"{self.sync_manager.base_url}/datasets",
             f"{self.sync_manager.base_url}/experiments",
             f"{self.sync_manager.base_url}/experiment-runs/experiment-id/runs",
             f"{self.sync_manager.base_url}/configuration-runs/runs/"

--- a/tests/unit/cli/test_auth_whoami_command.py
+++ b/tests/unit/cli/test_auth_whoami_command.py
@@ -97,14 +97,17 @@ def _install_fake_aiohttp(
     return fake_module
 
 
-def _run_whoami(monkeypatch: pytest.MonkeyPatch, api_key: str = "tg_test_key") -> Any:
+def _run_whoami(
+    monkeypatch: pytest.MonkeyPatch, api_key: str | None = "tg_test_key"
+) -> Any:
     monkeypatch.setattr(
         auth_commands.BackendConfig,
-        "get_backend_api_url",
+        "get_cloud_api_url",
         staticmethod(lambda: "http://localhost:5000/api/v1"),
     )
     runner = CliRunner()
-    return runner.invoke(auth_commands.auth, ["whoami", api_key])
+    args = ["whoami"] if api_key is None else ["whoami", api_key]
+    return runner.invoke(auth_commands.auth, args)
 
 
 def test_whoami_valid_key_200(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -148,6 +151,23 @@ def test_whoami_posts_json_payload_to_validate_endpoint(
         _FakeSession.last_post_kwargs["headers"]["Content-Type"]
         == "application/json"
     )
+
+
+def test_whoami_uses_traigent_api_key_env_when_no_positional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_key = "tg_" + "b" * 43  # pragma: allowlist secret
+    monkeypatch.setenv("TRAIGENT_API_KEY", api_key)
+    _install_fake_aiohttp(
+        monkeypatch,
+        response=_FakeResponse(status=200, json_payload={"valid": True, "data": {}}),
+    )
+
+    result = _run_whoami(monkeypatch, api_key=None)
+
+    assert result.exit_code == 0
+    assert _FakeSession.last_post_kwargs is not None
+    assert _FakeSession.last_post_kwargs["json"] == {"api_key": api_key}
 
 
 @pytest.mark.parametrize("prefix", ["tg_", "uk_", "sk_", "ak_", "tk_"])

--- a/tests/unit/cli/test_auth_whoami_command.py
+++ b/tests/unit/cli/test_auth_whoami_command.py
@@ -148,8 +148,7 @@ def test_whoami_posts_json_payload_to_validate_endpoint(
     assert _FakeSession.last_post_kwargs is not None
     assert _FakeSession.last_post_kwargs["json"] == {"api_key": api_key}
     assert (
-        _FakeSession.last_post_kwargs["headers"]["Content-Type"]
-        == "application/json"
+        _FakeSession.last_post_kwargs["headers"]["Content-Type"] == "application/json"
     )
 
 

--- a/tests/unit/cli/test_main_cli_user_paths.py
+++ b/tests/unit/cli/test_main_cli_user_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -68,3 +69,32 @@ def test_validate_strict_exits_zero_for_valid_dataset(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert "Dataset content validation passed" in result.output
+
+
+def test_check_dry_run_accepts_user_module_outside_package_dir(tmp_path: Path) -> None:
+    module_path = tmp_path / "user_module.py"
+    module_path.write_text(
+        """
+def tuned_function(value: str = "default"):
+    return value
+
+
+async def _optimize_stub(**kwargs):
+    return None
+
+
+tuned_function.optimize = _optimize_stub
+tuned_function.eval_dataset = "dataset.jsonl"
+tuned_function.objectives = ["accuracy"]
+tuned_function.configuration_space = {"value": ["default", "optimized"]}
+""",
+        encoding="utf-8",
+    )
+
+    try:
+        result = CliRunner().invoke(cli, ["check", str(module_path), "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert "Dry run completed" in result.output
+        assert "workspace" not in result.output.lower()
+    finally:
+        sys.modules.pop("user_module", None)

--- a/tests/unit/cli/test_validation_edge_cases.py
+++ b/tests/unit/cli/test_validation_edge_cases.py
@@ -322,7 +322,6 @@ class TestErrorScenarios:
                 side_effect=Exception("Optimization failed"),
             ),
         ):
-
             result = await validator.validate_optimization(func_info)
 
             assert result.is_superior is False
@@ -522,7 +521,6 @@ class TestConcurrencyAndPerformance:
             patch.object(validator, "_run_baseline", side_effect=mock_baseline),
             patch.object(validator, "_run_optimization", side_effect=mock_optimization),
         ):
-
             # Run validations concurrently
             import asyncio
 

--- a/tests/unit/cli/test_validation_edge_cases.py
+++ b/tests/unit/cli/test_validation_edge_cases.py
@@ -211,14 +211,13 @@ class TestErrorScenarios:
             discover_optimized_functions("completely_nonexistent_file.py")
 
     def test_discover_functions_outside_workspace(self):
-        """Path traversal outside the workspace should be rejected."""
+        """User modules outside the installed SDK tree should be importable."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write("# temporary external module")
             external_file = f.name
 
         try:
-            with pytest.raises(ValueError):
-                discover_optimized_functions(external_file)
+            assert discover_optimized_functions(external_file) == []
         finally:
             os.chmod(external_file, 0o600)
             os.unlink(external_file)

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -14,7 +14,11 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import requests
 
-from traigent.cloud.sync_manager import DEFAULT_SYNC_AGENT_TYPE_ID, SyncManager
+from traigent.cloud.sync_manager import (
+    DEFAULT_SYNC_AGENT_TYPE_ID,
+    SyncManager,
+    build_experiment_url,
+)
 from traigent.config.types import TraigentConfig
 from traigent.storage.local_storage import OptimizationSession, TrialResult
 from traigent.utils.exceptions import TraigentStorageError
@@ -30,6 +34,12 @@ def backend_response(status_code=201, payload=None, text="Created"):
 
 class TestSyncManager:
     """Tests for SyncManager class."""
+
+    def test_build_experiment_url_uses_portal_view_route(self) -> None:
+        assert (
+            build_experiment_url("https://portal.example/", "exp_123")
+            == "https://portal.example/experiments/view/exp_123"
+        )
 
     @pytest.fixture
     def mock_config(self, tmp_path: Path) -> TraigentConfig:
@@ -646,7 +656,7 @@ class TestSyncManager:
         post_calls = sync_manager._session.post.call_args_list
         assert [call.args[0] for call in post_calls] == [
             f"{sync_manager.base_url}/agents",
-            f"{sync_manager.base_url}/benchmarks",
+            f"{sync_manager.base_url}/datasets",
             f"{sync_manager.base_url}/experiments",
             f"{sync_manager.base_url}/experiment-runs/experiment-id/runs",
             f"{sync_manager.base_url}/configuration-runs/runs/"
@@ -710,7 +720,7 @@ class TestSyncManager:
             backend_response(
                 200,
                 payload={
-                    "benchmarks": [
+                    "datasets": [
                         {
                             "id": "existing-benchmark-id",
                             "name": "Local Dataset idem_fn",
@@ -732,10 +742,40 @@ class TestSyncManager:
         assert result["status"] == "success"
         post_calls = sync_manager._session.post.call_args_list
         assert post_calls[0].args[0] == f"{sync_manager.base_url}/agents"
-        assert post_calls[1].args[0] == f"{sync_manager.base_url}/benchmarks"
+        assert post_calls[1].args[0] == f"{sync_manager.base_url}/datasets"
         experiment_payload = post_calls[2].kwargs["json"]
         assert experiment_payload["agent_id"] == "existing-agent-id"
         assert experiment_payload["dataset_id"] == "existing-benchmark-id"
+
+    def test_sync_experiment_run_uses_project_scoped_current_endpoint(
+        self, monkeypatch: pytest.MonkeyPatch, sync_manager: SyncManager
+    ) -> None:
+        """Project-scoped sync uses the current v1beta experiment_runs route."""
+        monkeypatch.setenv("TRAIGENT_PROJECT_ID", "project 123")
+        run_data = {
+            "experiment_data": {
+                "agent_id": "agent-id",
+                "benchmark_id": "dataset-id",
+                "measures": ["score"],
+                "configurations": {},
+            }
+        }
+        sync_manager._session.post.return_value = backend_response(
+            payload={"id": "run-id"}
+        )
+
+        result = sync_manager._sync_experiment_run("experiment-id", run_data)
+
+        assert result["success"] is True
+        expected_url = (
+            sync_manager.base_url.removesuffix("/api/v1")
+            + "/api/v1beta/projects/project%20123/experiment_runs"
+        )
+        sync_manager._session.post.assert_called_once_with(
+            expected_url,
+            json={**run_data, "experiment_id": "experiment-id"},
+            timeout=sync_manager._request_timeout,
+        )
 
     def test_sync_session_to_cloud_configuration_failure_is_partial(
         self, sync_manager: SyncManager, sample_session: OptimizationSession
@@ -767,7 +807,7 @@ class TestSyncManager:
 
         # Mock mixed responses (some succeed, some fail)
         def mock_post(url: str, *args, **kwargs):
-            if "agents" in url or "benchmarks" in url:
+            if "agents" in url or "datasets" in url:
                 return backend_response()
             return backend_response(status_code=500, text="Internal Server Error")
 
@@ -1001,7 +1041,7 @@ class TestSyncManager:
         }
 
         sync_manager._session.get.return_value = backend_response(
-            200, payload={"benchmarks": [{"id": "bench_123", "name": "Test Benchmark"}]}
+            200, payload={"datasets": [{"id": "bench_123", "name": "Test Benchmark"}]}
         )
 
         result = sync_manager._sync_benchmark(benchmark_data)

--- a/tests/unit/utils/test_persistence.py
+++ b/tests/unit/utils/test_persistence.py
@@ -7,6 +7,7 @@ import json
 from datetime import UTC, datetime
 
 from traigent.api.types import OptimizationResult, OptimizationStatus
+from traigent.storage.local_storage import LocalStorageManager
 from traigent.utils.persistence import PersistenceManager, ResumableOptimization
 
 
@@ -51,6 +52,33 @@ def test_get_result_hash_uses_metadata(tmp_path) -> None:
     ).hexdigest()[:12]
 
     assert generated_hash == expected_hash
+
+
+def test_list_results_includes_current_local_storage_sessions(tmp_path) -> None:
+    """results list should discover current .traigent/local_storage sessions."""
+    traigent_dir = tmp_path / ".traigent"
+    storage = LocalStorageManager(str(traigent_dir / "local_storage"))
+    session_id = storage.create_session(
+        "demo_function",
+        optimization_config={
+            "algorithm": "grid_search",
+            "objectives": ["accuracy"],
+            "search_space": {"param": [0, 1]},
+        },
+    )
+    storage.add_trial_result(session_id, {"param": 1}, 0.91)
+    storage.finalize_session(session_id, "completed")
+
+    persistence = PersistenceManager(base_dir=traigent_dir)
+    results = persistence.list_results()
+
+    result = next(item for item in results if item["name"] == session_id)
+    assert result["source"] == "local_storage"
+    assert result["function_name"] == "demo_function"
+    assert result["algorithm"] == "grid_search"
+    assert result["best_score"] == 0.91
+    assert result["total_trials"] == 1
+    assert result["success_rate"] == 1.0
 
 
 def test_resumable_load_checkpoint_roundtrip(tmp_path) -> None:

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -1757,8 +1757,8 @@ def configure() -> None:
 
 
 @auth.command()
-@click.argument("key")
-def whoami(key: str) -> None:
+@click.argument("key", required=False)
+def whoami(key: str | None) -> None:
     """Show information about an API key.
 
     This command will validate an API key and show associated user information.
@@ -1768,12 +1768,21 @@ def whoami(key: str) -> None:
 
     Examples:
         traigent auth whoami tg_1234567890abcdef
+        TRAIGENT_API_KEY=tg_1234567890abcdef traigent auth whoami
     """
     console.print("\n[bold blue]🔍 API Key Information[/bold blue]\n")
 
+    resolved_key = key or BackendConfig.get_api_key()
+    if not resolved_key:
+        console.print("[red]❌ No API key provided[/red]")
+        console.print(
+            "Pass a key or set TRAIGENT_API_KEY / stored CLI credentials.\n"
+        )
+        sys.exit(1)
+
     # Validate format
     valid_prefixes = ("tg_", "uk_", "sk_", "ak_", "tk_")
-    if not any(key.startswith(prefix) for prefix in valid_prefixes):
+    if not any(resolved_key.startswith(prefix) for prefix in valid_prefixes):
         console.print("[red]❌ Invalid API key format[/red]")
         console.print(
             "API keys should start with 'tg_', 'uk_', 'sk_', 'ak_', or 'tk_'\n"
@@ -1784,7 +1793,7 @@ def whoami(key: str) -> None:
     backend_api_url = BackendConfig.get_cloud_api_url()
     console.print(f"[dim]Backend: {backend_api_url}[/dim]")
 
-    success = asyncio.run(_check_api_key(backend_api_url, key))
+    success = asyncio.run(_check_api_key(backend_api_url, resolved_key))
     sys.exit(0 if success else 1)
 
 

--- a/traigent/cli/auth_commands.py
+++ b/traigent/cli/auth_commands.py
@@ -1775,9 +1775,7 @@ def whoami(key: str | None) -> None:
     resolved_key = key or BackendConfig.get_api_key()
     if not resolved_key:
         console.print("[red]❌ No API key provided[/red]")
-        console.print(
-            "Pass a key or set TRAIGENT_API_KEY / stored CLI credentials.\n"
-        )
+        console.print("Pass a key or set TRAIGENT_API_KEY / stored CLI credentials.\n")
         sys.exit(1)
 
     # Validate format

--- a/traigent/cli/function_discovery.py
+++ b/traigent/cli/function_discovery.py
@@ -17,7 +17,6 @@ from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 console = Console()
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 def discover_optimized_functions(
@@ -41,15 +40,10 @@ def discover_optimized_functions(
     # Validate and resolve module path
     module_path_obj = Path(module_path).expanduser().resolve()
 
-    # Security check for path traversal
-    if ".." in str(module_path_obj) or str(module_path_obj).startswith("/etc"):
+    # Avoid importing system configuration files; user project modules may live
+    # outside the installed SDK tree.
+    if str(module_path_obj).startswith("/etc"):
         raise ValueError(f"Invalid module path: {module_path_obj}")
-    try:
-        module_path_obj.relative_to(PROJECT_ROOT)
-    except ValueError as exc:
-        raise ValueError(
-            f"Module path must reside inside the Traigent workspace ({PROJECT_ROOT}): {module_path_obj}"
-        ) from exc
 
     if not module_path_obj.exists():
         raise FileNotFoundError(f"Module file not found: {module_path_obj}")

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -12,6 +12,7 @@ import re
 from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote, urlparse, urlunparse
 
 import requests  # Always needed for synchronous operations
 
@@ -25,6 +26,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
 
 from ..config.backend_config import BackendConfig, get_no_credentials_hint
+from ..config.project import read_optional_project_env
 from ..config.types import TraigentConfig
 from ..storage.local_storage import (
     TRIAL_COST_FIELDS,
@@ -51,7 +53,24 @@ def build_experiment_url(base_url: str, experiment_id: str) -> str:
     Single source of truth for experiment URL construction —
     used by both SyncManager and the orchestrator.
     """
-    return f"{base_url.rstrip('/')}/experiments/{experiment_id}"
+    return f"{base_url.rstrip('/')}/experiments/view/{experiment_id}"
+
+
+def _replace_api_path(base_url: str, api_path: str) -> str:
+    """Return ``base_url`` origin with an explicit API path."""
+    parsed = urlparse(base_url)
+    if parsed.scheme and parsed.netloc:
+        return urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                api_path,
+                "",
+                "",
+                "",
+            )
+        )
+    return f"{base_url.rstrip('/')}/{api_path.strip('/')}"
 
 
 def sanitize_backend_name(value: str, fallback: str = "Local Dataset") -> str:
@@ -824,7 +843,7 @@ class SyncManager:
         self._raise_if_backend_egress_disabled("sync benchmark")
         try:
             existing_benchmark = self._find_existing_by_name(
-                "benchmarks", benchmark_data["name"], "benchmarks"
+                "datasets", benchmark_data["name"], "datasets"
             )
             if existing_benchmark:
                 benchmark_id = self._extract_resource_id(existing_benchmark)
@@ -837,14 +856,14 @@ class SyncManager:
                     }
 
             response = self._session.post(
-                f"{self.base_url}/benchmarks",
+                f"{self.base_url}/datasets",
                 json=benchmark_data,
                 timeout=self._request_timeout,
             )
 
             if response.status_code in [409, 500]:
                 existing_benchmark = self._find_existing_by_name(
-                    "benchmarks", benchmark_data["name"], "benchmarks"
+                    "datasets", benchmark_data["name"], "datasets"
                 )
                 if existing_benchmark:
                     benchmark_id = self._extract_resource_id(existing_benchmark)
@@ -901,6 +920,20 @@ class SyncManager:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    def _experiment_run_create_target(self, experiment_id: str) -> tuple[str, bool]:
+        """Return experiment-run create endpoint and whether it is collection-scoped."""
+        project_id = read_optional_project_env()
+        if project_id:
+            project_segment = quote(project_id, safe="")
+            return (
+                _replace_api_path(
+                    self.base_url,
+                    f"/api/v1beta/projects/{project_segment}/experiment_runs",
+                ),
+                True,
+            )
+        return f"{self.base_url}/experiment-runs/{experiment_id}/runs", False
+
     def _sync_experiment_run(
         self, experiment_id: str, run_data: dict[str, Any]
     ) -> dict[str, Any]:
@@ -913,9 +946,15 @@ class SyncManager:
                     "error": "Experiment run sync requires experiment_id",
                 }
 
+            url, collection_scoped = self._experiment_run_create_target(experiment_id)
+            payload = (
+                {**run_data, "experiment_id": experiment_id}
+                if collection_scoped
+                else run_data
+            )
             response = self._session.post(
-                f"{self.base_url}/experiment-runs/{experiment_id}/runs",
-                json=run_data,
+                url,
+                json=payload,
                 timeout=self._request_timeout,
             )
             if response.status_code in [200, 201]:

--- a/traigent/utils/persistence.py
+++ b/traigent/utils/persistence.py
@@ -149,6 +149,103 @@ def _rehydrate_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     return {key: _rehydrate_value(key, value) for key, value in metadata.items()}
 
 
+def _safe_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _successful_local_trial_count(trials: Any) -> int:
+    if not isinstance(trials, list):
+        return 0
+    successful = 0
+    for trial in trials:
+        if isinstance(trial, dict) and not trial.get("error"):
+            successful += 1
+    return successful
+
+
+def _first_string_value(
+    *sources: Any, keys: tuple[str, ...]
+) -> str | None:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _extract_local_objectives(config: Any) -> list[str]:
+    if not isinstance(config, dict):
+        return ["score"]
+
+    objective_schema = config.get("objective_schema")
+    if isinstance(objective_schema, dict):
+        objectives = objective_schema.get("objectives")
+        if isinstance(objectives, list):
+            names = [
+                obj.get("name") if isinstance(obj, dict) else obj
+                for obj in objectives
+            ]
+            return [str(name) for name in names if name]
+
+    objectives = config.get("objectives")
+    if isinstance(objectives, list):
+        names = [
+            obj.get("name") if isinstance(obj, dict) else obj for obj in objectives
+        ]
+        return [str(name) for name in names if name]
+
+    return ["score"]
+
+
+def _extract_local_configuration_space(config: Any) -> dict[str, Any]:
+    if not isinstance(config, dict):
+        return {}
+    for key in ("configuration_space", "search_space", "config_space"):
+        value = config.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _extract_log_objectives(objectives: Any) -> list[str]:
+    if not isinstance(objectives, dict):
+        return ["score"]
+    summary = objectives.get("summary")
+    if isinstance(summary, dict) and isinstance(summary.get("names"), list):
+        return [str(name) for name in summary["names"] if name]
+    raw_objectives = objectives.get("objectives")
+    if isinstance(raw_objectives, list):
+        names = [
+            obj.get("name") if isinstance(obj, dict) else obj
+            for obj in raw_objectives
+        ]
+        return [str(name) for name in names if name]
+    return ["score"]
+
+
+def _read_latest_json(directory: Path, pattern: str) -> dict[str, Any]:
+    if not directory.exists():
+        return {}
+    files = sorted(directory.glob(pattern), key=lambda path: path.name, reverse=True)
+    for file_path in files:
+        try:
+            with file_path.open(encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(data, dict):
+            return data
+    return {}
+
+
 class PersistenceManager:
     """Manages saving and loading optimization results to/from disk."""
 
@@ -453,6 +550,9 @@ class PersistenceManager:
         """
         results = []
 
+        results.extend(self._list_current_local_storage_results())
+        results.extend(self._list_optimization_log_results())
+
         for result_dir in self.base_dir.iterdir():
             if result_dir.is_dir():
                 metadata_file = self._resolve_path(result_dir / METADATA_FILE)
@@ -468,6 +568,199 @@ class PersistenceManager:
         # Sort by creation time, newest first
         results.sort(key=lambda x: x.get("created_at", ""), reverse=True)
         return results
+
+    def _iter_existing_child_roots(self, child_name: str) -> list[Path]:
+        """Return base_dir and base_dir/child_name when they contain child data."""
+        candidates = [self.base_dir]
+        nested = self.base_dir / child_name
+        if nested != self.base_dir:
+            candidates.append(nested)
+
+        roots: list[Path] = []
+        seen: set[Path] = set()
+        for candidate in candidates:
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                continue
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            if resolved.exists():
+                roots.append(resolved)
+        return roots
+
+    def _list_current_local_storage_results(self) -> list[dict[str, Any]]:
+        """Read LocalStorageManager session files from current storage roots."""
+        results: list[dict[str, Any]] = []
+        for storage_root in self._iter_existing_child_roots("local_storage"):
+            sessions_dir = storage_root / "sessions"
+            if not sessions_dir.exists():
+                continue
+
+            for session_file in sessions_dir.glob("*.json"):
+                try:
+                    metadata = self._metadata_from_local_storage_session(
+                        session_file, storage_root
+                    )
+                except (OSError, json.JSONDecodeError, ValueError):
+                    continue
+                if metadata:
+                    results.append(metadata)
+        return results
+
+    def _metadata_from_local_storage_session(
+        self, session_file: Path, storage_root: Path
+    ) -> dict[str, Any] | None:
+        validated_file = validate_path(session_file, storage_root, must_exist=True)
+        with safe_open(validated_file, storage_root, mode="r") as f:
+            session = json.load(f)
+        if not isinstance(session, dict):
+            return None
+
+        trials = session.get("trials")
+        trial_count = len(trials) if isinstance(trials, list) else 0
+        completed_trials = _safe_int(session.get("completed_trials"), trial_count)
+        if completed_trials <= 0:
+            completed_trials = trial_count
+        total_trials = _safe_int(session.get("total_trials"), completed_trials)
+        if total_trials <= 0:
+            total_trials = completed_trials or trial_count
+        successful_trials = _successful_local_trial_count(trials)
+        denominator = completed_trials or trial_count or total_trials
+        success_rate = successful_trials / denominator if denominator else 0.0
+
+        optimization_config = session.get("optimization_config")
+        metadata = session.get("metadata")
+        algorithm = _first_string_value(
+            optimization_config,
+            metadata,
+            keys=("algorithm", "search_algorithm", "optimizer", "strategy"),
+        )
+
+        session_id = str(session.get("session_id") or session_file.stem)
+        function_name = str(session.get("function_name") or "unknown")
+        return {
+            "name": session_id,
+            "function_identifier": function_name,
+            "function_name": function_name,
+            "algorithm": algorithm or "local_storage",
+            "objectives": _extract_local_objectives(optimization_config),
+            "configuration_space": _extract_local_configuration_space(
+                optimization_config
+            ),
+            "best_score": session.get("best_score"),
+            "best_config": session.get("best_config"),
+            "success_rate": success_rate,
+            "duration": None,
+            "convergence_info": {},
+            "created_at": session.get("created_at", ""),
+            "total_trials": total_trials,
+            "successful_trials": successful_trials,
+            "status": session.get("status"),
+            "source": "local_storage",
+            "path": str(session_file),
+        }
+
+    def _list_optimization_log_results(self) -> list[dict[str, Any]]:
+        """Read OptimizationLogger v2 run directories."""
+        results: list[dict[str, Any]] = []
+        for logs_root in self._iter_existing_child_roots("optimization_logs"):
+            experiments_dir = logs_root / "experiments"
+            if not experiments_dir.exists():
+                continue
+            for run_dir in experiments_dir.glob("*/runs/*"):
+                if not run_dir.is_dir():
+                    continue
+                try:
+                    metadata = self._metadata_from_optimization_log_run(
+                        run_dir, logs_root
+                    )
+                except (OSError, json.JSONDecodeError, ValueError):
+                    continue
+                if metadata:
+                    results.append(metadata)
+        return results
+
+    def _metadata_from_optimization_log_run(
+        self, run_dir: Path, logs_root: Path
+    ) -> dict[str, Any] | None:
+        validated_run_dir = validate_path(run_dir, logs_root, must_exist=True)
+        session = _read_latest_json(validated_run_dir / "meta", "session*.json")
+        metrics = _read_latest_json(validated_run_dir / "metrics", "metrics_summary*.json")
+        best_config = _read_latest_json(
+            validated_run_dir / "artifacts", "best_config*.json"
+        )
+        config = _read_latest_json(validated_run_dir / "meta", "config*.json")
+        objectives = _read_latest_json(validated_run_dir / "meta", "objectives*.json")
+
+        if not any((session, metrics, best_config, config, objectives)):
+            return None
+
+        experiment_name = (
+            session.get("experiment_name")
+            if isinstance(session, dict)
+            else validated_run_dir.parents[1].name
+        )
+        run_id = (
+            session.get("run_id") if isinstance(session, dict) else validated_run_dir.name
+        )
+        function_name = str(experiment_name or validated_run_dir.parents[1].name)
+        algorithm = _first_string_value(
+            metrics,
+            objectives.get("metadata") if isinstance(objectives, dict) else None,
+            objectives,
+            config,
+            keys=("algorithm", "search_algorithm", "optimizer", "strategy"),
+        )
+
+        total_trials = _safe_int(
+            metrics.get("total_trials") if isinstance(metrics, dict) else None,
+            0,
+        )
+        successful_trials = _safe_int(
+            metrics.get("successful_trials") if isinstance(metrics, dict) else None,
+            0,
+        )
+        success_rate = (
+            metrics.get("success_rate")
+            if isinstance(metrics, dict)
+            and isinstance(metrics.get("success_rate"), (int, float))
+            else (successful_trials / total_trials if total_trials else 0.0)
+        )
+        created_at = (
+            session.get("start_time")
+            if isinstance(session, dict) and session.get("start_time")
+            else (
+                metrics.get("timestamp")
+                if isinstance(metrics, dict) and metrics.get("timestamp")
+                else ""
+            )
+        )
+
+        return {
+            "name": str(run_id or validated_run_dir.name),
+            "function_identifier": function_name,
+            "function_name": function_name,
+            "algorithm": algorithm or "optimization_log",
+            "objectives": _extract_log_objectives(objectives),
+            "configuration_space": _extract_local_configuration_space(config),
+            "best_score": (
+                best_config.get("score") if isinstance(best_config, dict) else None
+            ),
+            "best_config": (
+                best_config.get("config") if isinstance(best_config, dict) else None
+            ),
+            "success_rate": float(success_rate),
+            "duration": metrics.get("duration") if isinstance(metrics, dict) else None,
+            "convergence_info": {},
+            "created_at": str(created_at),
+            "total_trials": total_trials,
+            "successful_trials": successful_trials,
+            "status": session.get("status") if isinstance(session, dict) else None,
+            "source": "optimization_log",
+            "path": str(validated_run_dir),
+        }
 
     def delete_result(self, name: str) -> bool:
         """Delete a saved optimization result.

--- a/traigent/utils/persistence.py
+++ b/traigent/utils/persistence.py
@@ -168,9 +168,7 @@ def _successful_local_trial_count(trials: Any) -> int:
     return successful
 
 
-def _first_string_value(
-    *sources: Any, keys: tuple[str, ...]
-) -> str | None:
+def _first_string_value(*sources: Any, keys: tuple[str, ...]) -> str | None:
     for source in sources:
         if not isinstance(source, dict):
             continue
@@ -190,8 +188,7 @@ def _extract_local_objectives(config: Any) -> list[str]:
         objectives = objective_schema.get("objectives")
         if isinstance(objectives, list):
             names = [
-                obj.get("name") if isinstance(obj, dict) else obj
-                for obj in objectives
+                obj.get("name") if isinstance(obj, dict) else obj for obj in objectives
             ]
             return [str(name) for name in names if name]
 
@@ -224,8 +221,7 @@ def _extract_log_objectives(objectives: Any) -> list[str]:
     raw_objectives = objectives.get("objectives")
     if isinstance(raw_objectives, list):
         names = [
-            obj.get("name") if isinstance(obj, dict) else obj
-            for obj in raw_objectives
+            obj.get("name") if isinstance(obj, dict) else obj for obj in raw_objectives
         ]
         return [str(name) for name in names if name]
     return ["score"]
@@ -687,7 +683,9 @@ class PersistenceManager:
     ) -> dict[str, Any] | None:
         validated_run_dir = validate_path(run_dir, logs_root, must_exist=True)
         session = _read_latest_json(validated_run_dir / "meta", "session*.json")
-        metrics = _read_latest_json(validated_run_dir / "metrics", "metrics_summary*.json")
+        metrics = _read_latest_json(
+            validated_run_dir / "metrics", "metrics_summary*.json"
+        )
         best_config = _read_latest_json(
             validated_run_dir / "artifacts", "best_config*.json"
         )
@@ -703,7 +701,9 @@ class PersistenceManager:
             else validated_run_dir.parents[1].name
         )
         run_id = (
-            session.get("run_id") if isinstance(session, dict) else validated_run_dir.name
+            session.get("run_id")
+            if isinstance(session, dict)
+            else validated_run_dir.name
         )
         function_name = str(experiment_name or validated_run_dir.parents[1].name)
         algorithm = _first_string_value(


### PR DESCRIPTION
Fixes surfaced by installing 0.15.0: portal URL path (build_experiment_url -> /experiments/view/{id}), results list reads current local_storage layout, check --dry-run works outside the SDK tree, auth whoami honors TRAIGENT_API_KEY, sync uses /api/v1/datasets + project-scoped experiment_runs. Targeted tests pass; broad failures verified pre-existing (185==185, +4). 0.15.1 backport is a separate release decision.

Spine-Trail: st_2309a3279b32
Spine: none (reason: SDK bug-fix)