### PR TITLE
refactor(api): expose only algorithm + offline (deprecate legacy execution-mode surface)

### DIFF
--- a/tests/integration/test_cost_enforcement_mode_matrix.py
+++ b/tests/integration/test_cost_enforcement_mode_matrix.py
@@ -239,7 +239,7 @@ EXECUTION_MODES = [
 UNSUPPORTED_EXECUTION_MODES = [
     (
         "totally_unknown_mode",
-        "execution_mode must be one of|No such mode",
+        "Unsupported execution selector",
     ),
 ]
 

--- a/tests/integration/test_execution_modes.py
+++ b/tests/integration/test_execution_modes.py
@@ -232,7 +232,7 @@ class TestExecutionModes:
 
     def test_invalid_mode_raises_configuration_error(self, mock_agent_builder):
         """Test that invalid modes raise ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="No such mode"):
+        with pytest.raises(ConfigurationError, match="Unsupported execution selector"):
             TraigentClient(
                 execution_mode="invalid_mode",
                 agent_builder=mock_agent_builder,

--- a/tests/unit/api/test_execution_policy_resolution.py
+++ b/tests/unit/api/test_execution_policy_resolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import warnings
 
 import pytest
@@ -68,7 +69,9 @@ def test_legacy_cloud_maps_to_cloud_first_with_edge_analytics_compat_mode() -> N
 
 
 def test_legacy_auto_execution_mode_is_rejected() -> None:
-    with pytest.raises(ConfigurationError, match="No such mode 'auto'"):
+    with pytest.raises(
+        ConfigurationError, match="Unsupported execution selector 'auto'"
+    ):
 
         @optimize(configuration_space={"x": [1, 2]}, execution_mode="auto")
         def sample(x: int) -> int:
@@ -122,6 +125,27 @@ def test_legacy_flat_hybrid_api_kwargs_translate_to_options() -> None:
     )
 
 
+def test_legacy_hybrid_api_options_evaluator_warns_but_works() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        @optimize(
+            configuration_space={"x": [1, 2]},
+            evaluator=HybridAPIOptions(endpoint="https://evaluator.example.test"),
+        )
+        def sample(x: int) -> int:
+            return x
+
+    assert isinstance(sample.hybrid_api_options, HybridAPIOptions)
+    assert sample.hybrid_api_options.endpoint == "https://evaluator.example.test"
+    assert sample.execution_mode == "hybrid_api"
+    assert any(
+        issubclass(w.category, DeprecationWarning)
+        and "HybridAPIOptions as an evaluator is deprecated" in str(w.message)
+        for w in caught
+    )
+
+
 def test_execution_options_public_fields_exclude_removed_surface() -> None:
     assert "algorithm" in ExecutionOptions.model_fields
     assert "offline" in ExecutionOptions.model_fields
@@ -131,8 +155,23 @@ def test_execution_options_public_fields_exclude_removed_surface() -> None:
     assert "hybrid_api_endpoint" not in ExecutionOptions.model_fields
 
 
+def test_optimize_public_signature_exposes_algorithm_offline_only() -> None:
+    public_signature = str(inspect.signature(optimize))
+
+    assert "algorithm" in public_signature
+    assert "offline" in public_signature
+    for legacy_name in (
+        "execution_mode",
+        "privacy_enabled",
+        "cloud_fallback_policy",
+        "HybridAPIOptions",
+        "hybrid_api_endpoint",
+    ):
+        assert legacy_name not in public_signature
+
+
 def test_offline_smart_algorithm_hard_errors() -> None:
-    with pytest.raises(ConfigurationError, match="requires cloud execution"):
+    with pytest.raises(ConfigurationError, match="requires managed optimization"):
 
         @optimize(
             configuration_space={"x": [1, 2]},

--- a/tests/unit/config/test_types.py
+++ b/tests/unit/config/test_types.py
@@ -1,5 +1,7 @@
 """Tests for TraigentConfig type and execution mode helpers."""
 
+import inspect
+
 import pytest
 
 from traigent.config.types import (
@@ -116,6 +118,42 @@ class TestTraigentConfig:
         assert TraigentConfig().to_dict() == {}
         assert TraigentConfig(model="GPT-4o").to_dict() == {"model": "GPT-4o"}
 
+    def test_to_dict_omits_legacy_execution_surface(self):
+        """Public serialization should expose algorithm/offline, not legacy knobs."""
+        with pytest.warns(DeprecationWarning):
+            config = TraigentConfig(
+                algorithm="grid",
+                offline=True,
+                execution_mode="hybrid",
+                privacy_enabled=True,
+                custom_params={
+                    "custom_key": "custom_value",
+                    "execution_mode": "custom",
+                    "privacy_enabled": "custom",
+                },
+            )
+
+        assert config.to_dict() == {
+            "algorithm": "grid",
+            "offline": True,
+            "custom_key": "custom_value",
+        }
+
+    def test_public_signature_uses_algorithm_offline_surface(self):
+        """TraigentConfig help/inspect output should not advertise legacy knobs."""
+        public_signature = str(inspect.signature(TraigentConfig))
+
+        assert "algorithm" in public_signature
+        assert "offline" in public_signature
+        for legacy_name in (
+            "execution_mode",
+            "privacy_enabled",
+            "edge_analytics",
+            "hybrid_api",
+            "cloud_fallback_policy",
+        ):
+            assert legacy_name not in public_signature
+
     def test_from_dict(self):
         """Test creating config from dictionary."""
         config_dict = {
@@ -180,6 +218,25 @@ class TestTraigentConfig:
         assert "TraigentConfig" in repr_str
         assert "model='GPT-4o'" in repr_str
         assert "temperature=0.7" in repr_str
+        assert "execution_mode" not in repr_str
+        assert "privacy_enabled" not in repr_str
+
+    def test_repr_omits_legacy_execution_surface(self):
+        """Public repr should expose algorithm/offline, not legacy knobs."""
+        with pytest.warns(DeprecationWarning):
+            config = TraigentConfig(
+                algorithm="grid",
+                offline=True,
+                execution_mode="hybrid",
+                privacy_enabled=True,
+            )
+
+        repr_str = repr(config)
+
+        assert "algorithm='grid'" in repr_str
+        assert "offline=True" in repr_str
+        assert "execution_mode" not in repr_str
+        assert "privacy_enabled" not in repr_str
 
     def test_custom_params(self):
         """Test handling of custom parameters."""
@@ -205,10 +262,69 @@ class TestValidateExecutionMode:
         """Validation should accept the omitted-mode public default."""
         assert validate_execution_mode(None) is ExecutionMode.EDGE_ANALYTICS
 
+    @pytest.mark.parametrize(
+        ("mode", "expected"),
+        [
+            ("edge_analytics", "edge_analytics"),
+            ("hybrid", "hybrid"),
+            ("hybrid_api", "hybrid_api"),
+        ],
+    )
+    def test_config_direct_legacy_execution_mode_warns_but_works(
+        self, mode: str, expected: str
+    ) -> None:
+        with pytest.warns(DeprecationWarning) as caught:
+            config = TraigentConfig(execution_mode=mode)
+
+        messages = [str(w.message) for w in caught]
+        assert config.execution_mode == expected
+        assert any("algorithm" in message for message in messages)
+        assert any("offline=True" in message for message in messages)
+
+    def test_config_direct_privacy_enabled_warns_but_works(self) -> None:
+        with pytest.warns(DeprecationWarning) as caught:
+            config = TraigentConfig(privacy_enabled=True)
+
+        messages = [str(w.message) for w in caught]
+        assert config.privacy_enabled is True
+        assert any("privacy_enabled is deprecated" in message for message in messages)
+        assert any("offline=True" in message for message in messages)
+
+    def test_legacy_config_attribute_assignments_warn_but_work(self) -> None:
+        config = TraigentConfig()
+
+        with pytest.warns(DeprecationWarning) as mode_warnings:
+            config.execution_mode = "hybrid"
+        with pytest.warns(DeprecationWarning) as privacy_warnings:
+            config.privacy_enabled = True
+
+        assert config.execution_mode == "hybrid"
+        assert config.privacy_enabled is True
+        assert any("algorithm" in str(w.message) for w in mode_warnings)
+        assert any("offline=True" in str(w.message) for w in privacy_warnings)
+
     def test_invalid_mode_string_raises_configuration_error(self) -> None:
-        """Invalid mode string should raise ConfigurationError, not ValueError."""
-        with pytest.raises(ConfigurationError, match="No such mode 'nonexistent_mode'"):
+        """Invalid compatibility selectors should guide to algorithm/offline."""
+        with pytest.raises(ConfigurationError) as exc_info:
             validate_execution_mode("nonexistent_mode")
+
+        message = str(exc_info.value)
+        assert "algorithm='auto', 'grid', or 'random'" in message
+        assert "offline=True" in message
+        assert "execution_mode" not in message
+        assert "edge_analytics" not in message
+        assert "hybrid" not in message
+
+    def test_resolve_execution_mode_invalid_message_uses_public_knobs(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            resolve_execution_mode("nonexistent_mode")
+
+        message = str(exc_info.value)
+        assert "algorithm='auto', 'grid', or 'random'" in message
+        assert "offline=True" in message
+        assert "execution_mode" not in message
+        assert "edge_analytics" not in message
+        assert "hybrid" not in message
 
     def test_privacy_alias_validates_as_hybrid(self) -> None:
         """Privacy remains a legacy alias for hybrid."""

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -239,9 +239,12 @@ class TestContextualErrorInfo:
         error_msg = str(exc_info.value)
         assert "invalid_mode" in error_msg
         assert "execution_mode" in error_msg
-        assert (
-            "edge_analytics" in error_msg or "cloud" in error_msg
-        )  # Valid options mentioned
+        # New error contract: the message points users at the supported
+        # algorithm selectors and the offline flag, not legacy mode names.
+        assert "algorithm=" in error_msg
+        assert "grid" in error_msg
+        assert "random" in error_msg
+        assert "offline" in error_msg
 
     def test_configuration_error_context(self):
         """Test that configuration errors include parameter context."""
@@ -270,10 +273,16 @@ class TestErrorHandlingIntegration:
         with pytest.raises(ValidationError) as exc_info:
             validate_optimize_parameters(execution_mode="definitely_invalid_mode")
 
-        # Error should have proper context
+        # Error should have proper context. The purged execution-mode
+        # vocabulary is replaced by guidance toward the execution selector
+        # (algorithm) and the offline flag.
         error_msg = str(exc_info.value)
-        assert "execution_mode" in error_msg
+        assert "execution selector" in error_msg
         assert "definitely_invalid_mode" in error_msg
+        assert "algorithm=" in error_msg
+        assert "grid" in error_msg
+        assert "random" in error_msg
+        assert "offline" in error_msg
 
     def test_removed_parameters_raise_validation_error(self):
         """Removed decorator parameters should raise a validation error."""

--- a/tests/unit/test_init_imports.py
+++ b/tests/unit/test_init_imports.py
@@ -137,10 +137,57 @@ class TestTraigentInit:
         assert hasattr(traigent, "__all__")
         assert isinstance(traigent.__all__, list)
         assert len(traigent.__all__) > 0
+        for deprecated_name in (
+            "ExecutionIntent",
+            "ExecutionMode",
+            "ResolvedExecutionPolicy",
+            "HybridAPIOptions",
+        ):
+            assert deprecated_name not in traigent.__all__
 
         # All items in __all__ should be accessible
         for name in traigent.__all__:
             assert hasattr(traigent, name), f"{name} in __all__ but not accessible"
+
+    def test_deprecated_execution_surface_imports_warn_but_work(self) -> None:
+        """Legacy root/package imports remain available as warning aliases."""
+        script = textwrap.dedent(
+            """
+            import warnings
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always", DeprecationWarning)
+                from traigent import ExecutionMode, HybridAPIOptions, ResolvedExecutionPolicy
+                from traigent.api import HybridAPIOptions as ApiHybridAPIOptions
+                from traigent.config import ExecutionMode as ConfigExecutionMode
+                import traigent
+                import traigent.api as api
+                import traigent.config as config
+
+            messages = [str(w.message) for w in caught]
+            assert ExecutionMode is ConfigExecutionMode
+            assert HybridAPIOptions is ApiHybridAPIOptions
+            assert ResolvedExecutionPolicy.__name__ == "ResolvedExecutionPolicy"
+            assert "HybridAPIOptions" not in api.__all__
+            assert "ExecutionMode" not in config.__all__
+            assert "ResolvedExecutionPolicy" not in config.__all__
+            assert "ExecutionMode" not in traigent.__all__
+            assert "HybridAPIOptions" not in traigent.__all__
+            compatibility_messages = [
+                message for message in messages if "deprecated compatibility alias" in message
+            ]
+            assert len(compatibility_messages) >= 5, messages
+            """
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
 
     def test_main_module_imports_without_optional_cloud_modules(self) -> None:
         """Test that traigent still imports when cloud-only modules are absent."""

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -446,6 +446,13 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "validate_and_suggest": ("traigent.utils.validation", "validate_and_suggest"),
 }
 
+_DEPRECATED_LAZY_EXPORTS = {
+    "ExecutionIntent",
+    "ExecutionMode",
+    "ResolvedExecutionPolicy",
+    "HybridAPIOptions",
+}
+
 
 def _load_lazy_export(name: str):
     module_name, attr_name = _LAZY_EXPORTS[name]
@@ -460,6 +467,14 @@ def _load_lazy_export(name: str):
         raise
 
     globals()[name] = value
+    if name in _DEPRECATED_LAZY_EXPORTS:
+        warnings.warn(
+            f"traigent.{name} is a deprecated compatibility alias and is no "
+            "longer part of the public root export surface. Import the internal "
+            "compatibility symbol from its defining submodule only when needed.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
     return value
 
 
@@ -511,12 +526,8 @@ __all__ = [
     "set_strategy",
     "with_usage",  # New: wrap multi-agent workflow responses with usage metadata
     # Configuration types
-    "ExecutionIntent",
-    "ExecutionMode",
-    "ResolvedExecutionPolicy",
     "TraigentConfig",
     "ExternalServiceEvaluator",
-    "HybridAPIOptions",
     # Lifecycle and state
     "OptimizationState",
     # Thread context helpers

--- a/traigent/api/__init__.py
+++ b/traigent/api/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from typing import Any
+import warnings
 
 __all__ = [
     "optimize",
@@ -55,7 +56,6 @@ __all__ = [
     "get_available_safety_presets",
     "TextDocument",
     "ExternalServiceEvaluator",
-    "HybridAPIOptions",
 ]
 
 _EXPORT_MAP = {
@@ -137,6 +137,8 @@ _EXPORT_MAP = {
     "HybridAPIOptions": ("traigent.api.decorators", "HybridAPIOptions"),
 }
 
+_DEPRECATED_EXPORTS = {"HybridAPIOptions"}
+
 
 def __getattr__(name: str) -> Any:
     if name not in _EXPORT_MAP:
@@ -145,6 +147,13 @@ def __getattr__(name: str) -> Any:
     module = import_module(module_name)
     value = getattr(module, attr_name)
     globals()[name] = value
+    if name in _DEPRECATED_EXPORTS:
+        warnings.warn(
+            f"traigent.api.{name} is a deprecated compatibility alias and is "
+            "no longer part of the public API export surface.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     return value
 
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -157,7 +157,7 @@ class InjectionOptions(BaseModel):
 
 
 class HybridAPIOptions(BaseModel):
-    """External Hybrid API evaluator configuration."""
+    """Deprecated compatibility bundle for external-service evaluators."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
@@ -193,8 +193,8 @@ class ExecutionOptions(BaseModel):
 
     Attributes:
         algorithm: Optimizer selector. ``auto`` (default) resolves to the
-            cloud-brain policy, ``grid``/``random`` stay local, and known smart
-            algorithms require cloud.
+            managed optimizer policy, ``grid``/``random`` stay local, and known
+            smart algorithms require managed orchestration.
         offline: Force local-only, zero-egress resolution.
         local_storage_path: Path for local result storage.
         minimal_logging: Whether to minimize logging output.
@@ -228,9 +228,7 @@ class ExecutionOptions(BaseModel):
 
     algorithm: str = "auto"
     offline: bool = False
-    evaluator: ExternalServiceEvaluator | HybridAPIOptions | dict[str, Any] | None = (
-        None
-    )
+    evaluator: ExternalServiceEvaluator | dict[str, Any] | None = None
     local_storage_path: str | None = None
     minimal_logging: bool = True
     parallel_config: ParallelConfig | dict[str, Any] | None = None
@@ -244,6 +242,19 @@ class ExecutionOptions(BaseModel):
     def _warn_legacy_execution_fields(cls, data: Any) -> Any:
         if isinstance(data, Mapping):
             _warn_for_legacy_execution_options(set(data))
+            if isinstance(data.get("evaluator"), HybridAPIOptions):
+                import warnings
+
+                warnings.warn(
+                    "HybridAPIOptions as an evaluator is deprecated. Pass an "
+                    "ExternalServiceEvaluator or evaluator options dict instead.",
+                    DeprecationWarning,
+                    stacklevel=4,
+                )
+                data = {
+                    **data,
+                    "evaluator": ExternalServiceEvaluator(hybrid_api=data["evaluator"]),
+                }
             legacy_hybrid_values = {
                 option_key: data[legacy_key]
                 for legacy_key, option_key in _LEGACY_HYBRID_API_OPTION_MAP.items()
@@ -578,9 +589,8 @@ def _warn_for_legacy_execution_options(keys: set[str]) -> None:
         )
     if keys & set(_LEGACY_HYBRID_API_OPTION_MAP):
         warnings.warn(
-            "Flat hybrid_api_* optimize options are deprecated. Pass "
-            "evaluator=ExternalServiceEvaluator(hybrid_api=HybridAPIOptions(...)) "
-            "instead.",
+            "Flat hybrid_api_* optimize options are deprecated. Pass an "
+            "ExternalServiceEvaluator or evaluator options dict instead.",
             DeprecationWarning,
             stacklevel=4,
         )
@@ -663,9 +673,7 @@ class LegacyOptimizeArgs:
     evaluation: EvaluationOptions | dict[str, Any] | None = None
     injection: InjectionOptions | dict[str, Any] | None = None
     execution: ExecutionOptions | dict[str, Any] | None = None
-    evaluator: ExternalServiceEvaluator | HybridAPIOptions | dict[str, Any] | None = (
-        None
-    )
+    evaluator: ExternalServiceEvaluator | dict[str, Any] | None = None
     mock: MockModeOptions | dict[str, Any] | None = None
     algorithm: str | None = None
     offline: bool | None = None
@@ -1307,7 +1315,7 @@ def _resolve_execution_policy_from_options(
 
 
 def _coerce_external_service_evaluator(
-    value: ExternalServiceEvaluator | HybridAPIOptions | dict[str, Any] | None,
+    value: Any,
 ) -> ExternalServiceEvaluator | None:
     """Normalize evaluator/external-service config to a typed bundle."""
 
@@ -1316,6 +1324,14 @@ def _coerce_external_service_evaluator(
     if isinstance(value, ExternalServiceEvaluator):
         return value
     if isinstance(value, HybridAPIOptions):
+        import warnings
+
+        warnings.warn(
+            "HybridAPIOptions as an evaluator is deprecated. Pass an "
+            "ExternalServiceEvaluator or evaluator options dict instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         return ExternalServiceEvaluator(hybrid_api=value)
     if isinstance(value, dict):
         if "hybrid_api" in value or "kind" in value:
@@ -1369,7 +1385,7 @@ def _coerce_external_service_evaluator(
         )
 
     raise TypeError(
-        "evaluator must be an ExternalServiceEvaluator, HybridAPIOptions, dict, or None"
+        "evaluator must be an ExternalServiceEvaluator, external-service options dict, or None"
     )
 
 
@@ -1377,7 +1393,7 @@ def _merge_hybrid_api_options(
     current: HybridAPIOptions | None,
     legacy_values: dict[str, Any],
 ) -> HybridAPIOptions | None:
-    """Merge deprecated flat Hybrid API kwargs into a typed option bundle."""
+    """Merge deprecated flat evaluator kwargs into a typed option bundle."""
 
     if not legacy_values:
         return current
@@ -1385,8 +1401,8 @@ def _merge_hybrid_api_options(
     import warnings
 
     warnings.warn(
-        "Flat hybrid_api_* optimize options are deprecated. Use "
-        "HybridAPIOptions via evaluator=ExternalServiceEvaluator(...).",
+        "Flat hybrid_api_* optimize options are deprecated. Pass an "
+        "ExternalServiceEvaluator or evaluator options dict instead.",
         DeprecationWarning,
         stacklevel=3,
     )
@@ -1402,18 +1418,18 @@ def _merge_hybrid_api_options(
         default = HybridAPIOptions.model_fields[option_key].default
         if existing not in (None, default) and existing != value:
             raise TypeError(
-                f"Conflicting values for HybridAPIOptions.{option_key!r} supplied "
-                "via both evaluator and legacy flat hybrid_api_* arguments."
+                f"Conflicting values for external-service option {option_key!r} "
+                "supplied via both evaluator and deprecated flat arguments."
             )
         merged[option_key] = value
     return cast(HybridAPIOptions, HybridAPIOptions.model_validate(merged))
 
 
 def _resolve_external_service_evaluator(
-    evaluator: ExternalServiceEvaluator | HybridAPIOptions | dict[str, Any] | None,
+    evaluator: Any,
     legacy_options: Mapping[str, Any],
 ) -> ExternalServiceEvaluator | None:
-    """Resolve new evaluator config plus deprecated flat Hybrid API kwargs."""
+    """Resolve evaluator config plus deprecated flat external-service kwargs."""
 
     resolved = _coerce_external_service_evaluator(evaluator)
     legacy_hybrid_values = {
@@ -1520,11 +1536,11 @@ def _log_execution_mode_warnings(
     local_storage_path: str | None,
     minimal_logging: bool,
 ) -> None:
-    """Log warnings for incompatible execution mode settings."""
+    """Log warnings for incompatible runtime settings."""
     if minimal_logging and execution_mode_enum is not ExecutionMode.EDGE_ANALYTICS:
         logger.warning(
-            "minimal_logging is only effective in Edge Analytics mode. "
-            f"It will be ignored in {actual_execution_mode} mode."
+            "minimal_logging is only effective for offline local runs. "
+            "It will be ignored for the selected managed execution path."
         )
 
 
@@ -1921,9 +1937,7 @@ def optimize(  # NOSONAR(S107)
     injection: InjectionOptions | dict[str, Any] | None = None,
     effectuation: bool = False,
     execution: ExecutionOptions | dict[str, Any] | None = None,
-    evaluator: ExternalServiceEvaluator | HybridAPIOptions | dict[str, Any] | None = (
-        None
-    ),
+    evaluator: ExternalServiceEvaluator | dict[str, Any] | None = None,
     mock: MockModeOptions | dict[str, Any] | None = None,
     algorithm: str = "auto",
     offline: bool = False,
@@ -2046,13 +2060,13 @@ def optimize(  # NOSONAR(S107)
         Execution options:
             execution: Grouped execution settings (ExecutionOptions or dict) spanning
                 orchestration, storage, and parallelism.
-            algorithm: Optimizer selector. ``auto`` (default) uses cloud-brain
+            algorithm: Optimizer selector. ``auto`` (default) uses managed
                 orchestration with local fallback, ``grid``/``random`` stay
-                local, and known smart optimizers require cloud orchestration.
+                local, and known smart optimizers require managed orchestration.
             offline: Force local-only, zero-egress resolution.
-            local_storage_path: Location for Edge Analytics storage. Falls back
+            local_storage_path: Location for local result storage. Falls back
                 to ``TRAIGENT_RESULTS_FOLDER`` or ``~/.traigent/`` when omitted.
-            minimal_logging: Toggle for reduced logging noise in Edge mode.
+            minimal_logging: Toggle for reduced logging noise in offline local runs.
             parallel_config: Consolidated parallel configuration (ParallelConfig
                 or dict). Preferred path for controlling concurrency.
             max_total_examples: Global sample budget across all trials.

--- a/traigent/config/__init__.py
+++ b/traigent/config/__init__.py
@@ -7,6 +7,10 @@ This module provides flexible configuration injection strategies for optimized f
 
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any
+import warnings
+
 from traigent.config.context import (
     TrialContext,
     config_context,
@@ -21,12 +25,13 @@ from traigent.config.providers import (
     SeamlessParameterProvider,
     get_provider,
 )
-from traigent.config.types import (
-    ExecutionIntent,
-    ExecutionMode,
-    ResolvedExecutionPolicy,
-    TraigentConfig,
-)
+from traigent.config.types import TraigentConfig
+
+_DEPRECATED_EXPORT_MAP = {
+    "ExecutionIntent": ("traigent.config.types", "ExecutionIntent"),
+    "ExecutionMode": ("traigent.config.types", "ExecutionMode"),
+    "ResolvedExecutionPolicy": ("traigent.config.types", "ResolvedExecutionPolicy"),
+}
 
 __all__ = [
     # Context management
@@ -42,8 +47,24 @@ __all__ = [
     "SeamlessParameterProvider",
     "get_provider",
     # Types
-    "ExecutionIntent",
-    "ExecutionMode",
-    "ResolvedExecutionPolicy",
     "TraigentConfig",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _DEPRECATED_EXPORT_MAP:
+        raise AttributeError(f"module 'traigent.config' has no attribute {name!r}")
+    module_name, attr_name = _DEPRECATED_EXPORT_MAP[name]
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    warnings.warn(
+        f"traigent.config.{name} is a deprecated compatibility alias and is "
+        "no longer part of the public config export surface.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from enum import StrEnum
+from inspect import Parameter, Signature
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -14,14 +15,9 @@ from traigent.utils.validation import Validators, validate_or_raise
 
 
 class ExecutionMode(StrEnum):
-    """Execution modes for Traigent optimization.
+    """Deprecated internal compatibility enum for runtime routing.
 
-    - EDGE_ANALYTICS: Optimization and LLM calls execute on the client.
-      Non-sensitive telemetry syncs to the backend when available for analytics.
-    - HYBRID: Smart algorithm (Optuna-based) with backend-provided next-trial suggestions
-      and client-side execution.
-    - HYBRID_API: External API-based optimization where trials execute via HTTP endpoints
-      implementing the Traigent Hybrid Mode API contract.
+    Public SDK code should use ``algorithm`` plus ``offline``.
     """
 
     EDGE_ANALYTICS = "edge_analytics"
@@ -55,7 +51,7 @@ class ResolvedExecutionPolicy:
 
     @property
     def allows_cloud_fallback(self) -> bool:
-        """Whether cloud-brain resolution may fall back to local execution."""
+        """Whether managed optimization may fall back to local execution."""
 
         return self.intent is ExecutionIntent.CLOUD_BRAIN and not self.require_cloud
 
@@ -72,11 +68,23 @@ _SUPPORTED_MODES = (
     ExecutionMode.HYBRID,
     ExecutionMode.HYBRID_API,
 )
+_LEGACY_CONFIG_EXECUTION_MODE_VALUES = frozenset(
+    mode.value for mode in _SUPPORTED_MODES
+)
 _EXECUTION_MODE_ALIASES: dict[str, ExecutionMode] = {
     "local": ExecutionMode.EDGE_ANALYTICS,
 }
 _NOT_YET_SUPPORTED_MODES: set[ExecutionMode] = set()
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_CONFIG_VALUE_UNSET = object()
+_PURGED_PUBLIC_CONFIG_KEYS = frozenset(
+    {
+        "execution_mode",
+        "privacy_enabled",
+        "cloud_fallback_policy",
+        "hybrid_api_endpoint",
+    }
+)
 _LOCAL_ALGORITHMS = frozenset({"grid", "random"})
 _SMART_ALGORITHMS = frozenset(
     {
@@ -131,7 +139,7 @@ def is_local_algorithm(algorithm: str | None) -> bool:
 
 
 def is_smart_algorithm(algorithm: str | None) -> bool:
-    """Return True for cloud-required smart optimizer names."""
+    """Return True for managed-service optimizer names."""
 
     normalized = normalize_algorithm_name(algorithm)
     return normalized in _SMART_ALGORITHMS or normalized.startswith("optuna_")
@@ -164,7 +172,7 @@ def validate_algorithm_name(algorithm: str | None) -> str:
 
 
 def accepted_execution_mode_values() -> tuple[str, ...]:
-    """Return accepted execution_mode strings for all public validators."""
+    """Return deprecated compatibility selector strings for internal validators."""
 
     values = {mode.value for mode in _SUPPORTED_MODES}
     values.update(_EXECUTION_MODE_ALIASES)
@@ -172,7 +180,10 @@ def accepted_execution_mode_values() -> tuple[str, ...]:
 
 
 def _accepted_execution_mode_message() -> str:
-    return f"accepted values are {list(accepted_execution_mode_values())}"
+    return (
+        "use algorithm='auto', 'grid', or 'random'; set offline=True for "
+        "local-only, zero-egress optimization"
+    )
 
 
 def _warn_deprecated_execution_mode_alias(mode: str, message: str) -> None:
@@ -182,6 +193,54 @@ def _warn_deprecated_execution_mode_alias(mode: str, message: str) -> None:
         f"execution_mode={mode!r} is deprecated. {message}",
         DeprecationWarning,
         stacklevel=4,
+    )
+
+
+def _warn_deprecated_config_execution_mode(
+    mode: ExecutionMode | str,
+    *,
+    stacklevel: int = 4,
+) -> None:
+    raw_mode = mode.value if isinstance(mode, ExecutionMode) else str(mode)
+    normalized = raw_mode.strip().lower()
+    if normalized not in _LEGACY_CONFIG_EXECUTION_MODE_VALUES:
+        return
+
+    import warnings
+
+    if normalized == ExecutionMode.EDGE_ANALYTICS.value:
+        guidance = (
+            "Use offline=True for local-only, zero-egress optimization; use "
+            "algorithm='grid' or 'random' to force local search."
+        )
+    elif normalized == ExecutionMode.HYBRID.value:
+        guidance = (
+            "Omit execution_mode and use algorithm='auto' for managed "
+            "optimization; set offline=True only when no egress is required."
+        )
+    else:
+        guidance = (
+            "Omit execution_mode and use algorithm='auto', 'grid', or 'random' "
+            "with offline=True when no egress is required. Configure an "
+            "external-service evaluator bundle separately."
+        )
+
+    warnings.warn(
+        f"execution_mode={raw_mode!r} is deprecated for TraigentConfig. {guidance}",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
+
+
+def _warn_deprecated_config_privacy_enabled(*, stacklevel: int = 4) -> None:
+    import warnings
+
+    warnings.warn(
+        "privacy_enabled is deprecated for TraigentConfig and has no effect in "
+        "execution policy resolution. Use offline=True for no-egress local "
+        "optimization.",
+        DeprecationWarning,
+        stacklevel=stacklevel,
     )
 
 
@@ -235,35 +294,31 @@ def resolve_execution_mode(
             return ExecutionMode(normalized)
         except ValueError as exc:  # pragma: no cover - defensive
             raise ValueError(
-                f"execution_mode must be one of {list(accepted_execution_mode_values())}, got '{mode}'"
+                f"Unsupported execution selector {mode!r}; "
+                f"{_accepted_execution_mode_message()}."
             ) from exc
     raise TypeError(
-        f"execution_mode must be a string or ExecutionMode, got {type(mode).__name__}"
+        "Execution selector must be a string or compatibility enum, "
+        f"got {type(mode).__name__}; {_accepted_execution_mode_message()}."
     )
 
 
 def validate_execution_mode(mode: ExecutionMode | str | None) -> ExecutionMode:
-    """Resolve *and* validate that an execution mode is currently supported.
-
-    Legacy string values (``local``, ``privacy``, ``cloud``, ``standard``) emit a
-    DeprecationWarning and are mapped to a canonical mode.
-    Raises :class:`~traigent.utils.exceptions.ConfigurationError` for
-    unknown mode strings.
-    Use :func:`resolve_execution_mode` when you only need
-    string-to-enum conversion without support validation.
-    """
+    """Resolve and validate a deprecated compatibility selector."""
     from traigent.utils.exceptions import ConfigurationError
 
     try:
         resolved = resolve_execution_mode(mode)
     except ValueError:
         raise ConfigurationError(
-            f"No such mode '{mode}'; {_accepted_execution_mode_message()}"
+            f"Unsupported execution selector {mode!r}; "
+            f"{_accepted_execution_mode_message()}."
         ) from None
 
     if resolved not in _SUPPORTED_MODES:
         raise ConfigurationError(
-            f"No such mode '{resolved.value}'; {_accepted_execution_mode_message()}"
+            f"Unsupported execution selector {resolved.value!r}; "
+            f"{_accepted_execution_mode_message()}."
         )
 
     return resolved
@@ -282,13 +337,12 @@ def resolve_execution_policy(
     """Resolve public execution controls into a policy object.
 
     Semantics:
-    - ``algorithm='auto'`` with egress allowed resolves to cloud-brain mode.
+    - ``algorithm='auto'`` with egress allowed uses managed optimization when available.
     - ``grid``/``random`` resolve to local-only mode.
-    - smart algorithms resolve to cloud-required mode.
+    - smart algorithms require managed optimization.
     - ``offline=True`` or ``TRAIGENT_OFFLINE=1`` forces local-only mode and
       rejects smart algorithms.
-    - ``TRAIGENT_REQUIRE_CLOUD=1`` disables cloud-brain fallback.
-    - legacy ``execution_mode`` values warn and map into this policy surface.
+    - ``TRAIGENT_REQUIRE_CLOUD=1`` disables managed-to-local fallback.
     """
     import warnings
 
@@ -352,15 +406,15 @@ def resolve_execution_policy(
         elif normalized_mode == "hybrid_api":
             warnings.warn(
                 "execution_mode='hybrid_api' is deprecated as a public execution "
-                "selector. Configure HybridAPIOptions via the evaluator bundle.",
+                "selector. Configure an external-service evaluator bundle.",
                 DeprecationWarning,
                 stacklevel=3,
             )
         else:
             raise ConfigurationError(
-                f"No such mode '{raw_mode}'; legacy execution_mode is no longer "
-                "a public selector. Use algorithm='auto'|'grid'|'random' and "
-                "offline=True when no egress is required."
+                f"Unsupported execution selector {raw_mode!r}; use "
+                "algorithm='auto', 'grid', or 'random'; set offline=True when "
+                "no egress is required."
             )
 
     if privacy_enabled is not None:
@@ -383,7 +437,7 @@ def resolve_execution_policy(
 
     if offline_requested and is_smart_algorithm(normalized_algorithm):
         raise ConfigurationError(
-            f"algorithm={normalized_algorithm!r} requires cloud execution and "
+            f"algorithm={normalized_algorithm!r} requires managed optimization and "
             "cannot be used with offline=True or TRAIGENT_OFFLINE=1."
         )
 
@@ -474,6 +528,12 @@ class TraigentConfig:
         presence_penalty: Penalty for new topics
         stop_sequences: List of sequences that stop generation
         seed: Random seed for reproducibility
+        algorithm: Optimizer selector. Public values are ``auto``, ``grid``, and
+            ``random``; smart optimizer names are accepted where supported.
+        offline: Force local-only, zero-egress optimization.
+        local_storage_path: Path for local result storage.
+        auto_sync: Whether local results may sync to the backend/portal when
+            credentials are configured.
         custom_params: Additional custom parameters
 
     Example:
@@ -501,19 +561,17 @@ class TraigentConfig:
     # Custom parameters
     custom_params: dict[str, Any] = field(default_factory=dict)
 
-    # Execution mode and storage configuration
-    execution_mode: Literal[
-        "edge_analytics",
-        "local",
-        "privacy",
-        "hybrid",
-        "hybrid_api",
-    ] = "edge_analytics"
+    # Public execution controls.
+    algorithm: str = "auto"
+    offline: bool = False
+
+    # Deprecated compatibility state retained for existing config dictionaries.
+    execution_mode: str | ExecutionMode | None | object = _CONFIG_VALUE_UNSET
     local_storage_path: str | None = None
     minimal_logging: bool = True
     auto_sync: bool = False  # Auto-sync to backend/portal when API key is available
-    # Privacy toggle: when True, do not log or transmit input/output/prompts (local/hybrid)
-    privacy_enabled: bool = False
+    # Deprecated content-redaction compatibility flag; prefer offline/sync controls.
+    privacy_enabled: bool | object = _CONFIG_VALUE_UNSET
 
     # Metrics configuration
     strict_metrics_nulls: bool = (
@@ -565,15 +623,28 @@ class TraigentConfig:
                 )
                 validate_or_raise(result)
 
-        # Validate execution mode against the public support contract.
+        supplied_execution_mode = getattr(
+            self, "_supplied_execution_mode_value", _CONFIG_VALUE_UNSET
+        )
+        if self.execution_mode is _CONFIG_VALUE_UNSET:
+            object.__setattr__(
+                self, "execution_mode", ExecutionMode.EDGE_ANALYTICS.value
+            )
+        elif supplied_execution_mode is not None:
+            _warn_deprecated_config_execution_mode(supplied_execution_mode)
+
+        if self.privacy_enabled is _CONFIG_VALUE_UNSET:
+            object.__setattr__(self, "privacy_enabled", False)
+        if getattr(self, "_supplied_privacy_enabled", False):
+            _warn_deprecated_config_privacy_enabled()
+
+        # Validate deprecated compatibility selector against supported runtime modes.
         requested_mode = resolve_execution_mode(self.execution_mode)
         mode_enum = validate_execution_mode(requested_mode)
         if isinstance(self.execution_mode, str) and self.execution_mode == "privacy":
-            self.privacy_enabled = True
-        self.execution_mode = cast(
-            Literal["edge_analytics", "local", "privacy", "hybrid", "hybrid_api"],
-            mode_enum.value,
-        )
+            object.__setattr__(self, "privacy_enabled", True)
+        object.__setattr__(self, "execution_mode", cast(str, mode_enum.value))
+        object.__setattr__(self, "_warn_legacy_config_assignments", True)
 
         # Handle local storage path
         if self.is_edge_analytics_mode() and self.local_storage_path:
@@ -588,20 +659,30 @@ class TraigentConfig:
         Returns:
             Dictionary representation of configuration, excluding None values and defaults.
         """
+        return self._to_dict(include_legacy=False)
+
+    def _to_dict(self, *, include_legacy: bool) -> dict[str, Any]:
         result = {}
 
         # Define default values to exclude
         defaults = {
-            "execution_mode": "edge_analytics",
+            "algorithm": "auto",
+            "offline": False,
             "minimal_logging": True,
             "auto_sync": False,
-            "privacy_enabled": False,
             "strict_metrics_nulls": False,
             "comparability_mode": "warn",
         }
+        if include_legacy:
+            defaults.update(
+                {
+                    "execution_mode": "edge_analytics",
+                    "privacy_enabled": False,
+                }
+            )
 
         # Add defined parameters (only if not None and not default)
-        for field_name in [
+        field_names = [
             "model",
             "temperature",
             "max_tokens",
@@ -610,20 +691,26 @@ class TraigentConfig:
             "presence_penalty",
             "stop_sequences",
             "seed",
-            "execution_mode",
+            "algorithm",
+            "offline",
             "local_storage_path",
             "minimal_logging",
             "auto_sync",
-            "privacy_enabled",
             "strict_metrics_nulls",
             "comparability_mode",
-        ]:
+        ]
+        if include_legacy:
+            field_names.extend(["execution_mode", "privacy_enabled"])
+
+        for field_name in field_names:
             value = getattr(self, field_name)
             if value is not None and value != defaults.get(field_name):
                 result[field_name] = value
 
         # Add custom parameters
-        result.update(self.custom_params)
+        for key, value in self.custom_params.items():
+            if include_legacy or key not in _PURGED_PUBLIC_CONFIG_KEYS:
+                result[key] = value
 
         return result
 
@@ -647,6 +734,8 @@ class TraigentConfig:
             "presence_penalty",
             "stop_sequences",
             "seed",
+            "algorithm",
+            "offline",
             "execution_mode",
             "local_storage_path",
             "minimal_logging",
@@ -676,13 +765,13 @@ class TraigentConfig:
             other = self.from_dict(other)
 
         # Start with current values.
-        merged_dict = self.to_dict()
+        merged_dict = self._to_dict(include_legacy=True)
 
         # Override with non-default values from the other config. For dict
         # inputs, preserve explicitly supplied defaults such as
         # {"execution_mode": "edge_analytics"} so callers can intentionally
         # reset a value without default leakage from TraigentConfig().
-        override_dict = other.to_dict()
+        override_dict = other._to_dict(include_legacy=True)
         dataclass_fields = getattr(self, "__dataclass_fields__", {})
         for key in explicit_override_keys:
             if key in dataclass_fields and key != "custom_params":
@@ -763,18 +852,18 @@ class TraigentConfig:
 
     @property
     def execution_mode_enum(self) -> ExecutionMode:
-        """Return execution mode as an ExecutionMode enum."""
+        """Return internal compatibility selector as an enum."""
         return resolve_execution_mode(self.execution_mode)
 
     def is_edge_analytics_mode(self) -> bool:
-        """Check if configuration uses Edge Analytics mode."""
+        """Return whether the compatibility selector maps to local-only runtime."""
         return self.execution_mode_enum is ExecutionMode.EDGE_ANALYTICS
 
     def is_cloud_mode(self) -> bool:
         return False
 
     def is_privacy_enabled(self) -> bool:
-        """Whether privacy mode is enabled (content never logged or transmitted)."""
+        """Whether deprecated content-redaction compatibility is enabled."""
         return bool(self.privacy_enabled)
 
     def is_strict_metrics_nulls_enabled(self) -> bool:
@@ -801,7 +890,7 @@ class TraigentConfig:
         if env_path:
             return str(Path(env_path).expanduser().resolve())
 
-        # Default to ~/.traigent/ for Edge Analytics mode
+        # Default to ~/.traigent/ for local-only storage.
         if self.is_edge_analytics_mode():
             return str(Path.home() / ".traigent")
 
@@ -809,6 +898,19 @@ class TraigentConfig:
 
     def _validated_assignment(self, key: str, value: Any) -> Any:
         """Apply per-field validation when assigning configuration values."""
+        warn_legacy_assignment = getattr(self, "_warn_legacy_config_assignments", False)
+        if key == "execution_mode":
+            if not warn_legacy_assignment and value is not _CONFIG_VALUE_UNSET:
+                object.__setattr__(self, "_supplied_execution_mode_value", value)
+            elif warn_legacy_assignment and value is not None:
+                _warn_deprecated_config_execution_mode(value)
+        elif (
+            key == "privacy_enabled"
+            and not warn_legacy_assignment
+            and value is not _CONFIG_VALUE_UNSET
+        ):
+            object.__setattr__(self, "_supplied_privacy_enabled", True)
+
         if key == "temperature" and value is not None:
             validate_or_raise(
                 Validators.validate_number(value, "temperature", 0.0, 2.0)
@@ -819,10 +921,19 @@ class TraigentConfig:
             validate_or_raise(Validators.validate_probability(value, "top_p"))
         elif key in {"frequency_penalty", "presence_penalty"} and value is not None:
             validate_or_raise(Validators.validate_number(value, key, -2.0, 2.0))
+        elif key == "algorithm":
+            value = validate_algorithm_name(value)
+        elif key == "offline":
+            if not isinstance(value, bool):
+                raise TypeError(f"offline must be a bool, got {type(value).__name__}")
         elif key == "stop_sequences" and value is not None:
             if not isinstance(value, list):
                 raise TypeError("stop_sequences must be a list of strings")
-        elif key == "execution_mode" and value is not None:
+        elif (
+            key == "execution_mode"
+            and value is not None
+            and value is not _CONFIG_VALUE_UNSET
+        ):
             requested_mode = resolve_execution_mode(value)
             resolved_mode = validate_execution_mode(requested_mode)
             if isinstance(value, str) and value.strip().lower() == "privacy":
@@ -843,7 +954,11 @@ class TraigentConfig:
             ):
                 value = True
                 object.__setattr__(self, "_privacy_enforced_by_execution_mode", False)
+            elif value is _CONFIG_VALUE_UNSET:
+                return value
             else:
+                if key == "privacy_enabled" and warn_legacy_assignment:
+                    _warn_deprecated_config_privacy_enabled()
                 value = bool(value)
         elif key == "comparability_mode":
             mode = str(value or "warn").strip().lower()
@@ -865,7 +980,7 @@ class TraigentConfig:
         auto_sync: bool = False,
         **kwargs,
     ) -> TraigentConfig:
-        """Create a configuration for Edge Analytics execution.
+        """Deprecated compatibility constructor for offline local execution.
 
         Args:
             storage_path: Custom storage path for local data
@@ -874,9 +989,10 @@ class TraigentConfig:
             **kwargs: Additional configuration parameters
 
         Returns:
-            TraigentConfig configured for Edge Analytics mode
+            TraigentConfig configured for local-only execution
         """
         return cls(
+            offline=True,
             execution_mode=ExecutionMode.EDGE_ANALYTICS.value,
             local_storage_path=storage_path,
             minimal_logging=minimal_logging,
@@ -889,11 +1005,12 @@ class TraigentConfig:
         """Create configuration from environment variables.
 
         Checks for:
-        - TRAIGENT_EDGE_ANALYTICS_MODE: Sets execution mode to edge_analytics if true
+        - TRAIGENT_OFFLINE: Sets offline local-only execution if true
         - TRAIGENT_RESULTS_FOLDER: Sets local storage path
         - TRAIGENT_MINIMAL_LOGGING: Sets minimal logging preference
         - TRAIGENT_AUTO_SYNC: Sets auto-sync preference
-        - TRAIGENT_PRIVACY_MODE: Sets privacy mode preference
+        - TRAIGENT_EDGE_ANALYTICS_MODE: Deprecated compatibility alias for offline
+        - TRAIGENT_PRIVACY_MODE: Deprecated compatibility content-redaction flag
         - TRAIGENT_STRICT_METRICS_NULLS: Use None instead of 0.0 for missing metrics
         - TRAIGENT_COMPARABILITY_MODE: one of legacy|warn|strict
 
@@ -902,13 +1019,30 @@ class TraigentConfig:
         """
         config = cls()
 
-        # Check for Edge Analytics mode
+        if is_traigent_offline_requested():
+            config.offline = True
+            object.__setattr__(
+                config, "execution_mode", ExecutionMode.EDGE_ANALYTICS.value
+            )
+
+        # Deprecated local-only compatibility env var.
         if os.getenv("TRAIGENT_EDGE_ANALYTICS_MODE", "").lower() in (
             "true",
             "1",
             "yes",
         ):
-            config.execution_mode = ExecutionMode.EDGE_ANALYTICS.value
+            import warnings
+
+            warnings.warn(
+                "TRAIGENT_EDGE_ANALYTICS_MODE is deprecated. Use "
+                "TRAIGENT_OFFLINE=1 for local-only, zero-egress optimization.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            config.offline = True
+            object.__setattr__(
+                config, "execution_mode", ExecutionMode.EDGE_ANALYTICS.value
+            )
 
         # Set storage path from environment
         env_path = os.getenv("TRAIGENT_RESULTS_FOLDER")
@@ -923,9 +1057,17 @@ class TraigentConfig:
         if os.getenv("TRAIGENT_AUTO_SYNC", "").lower() in ("true", "1", "yes"):
             config.auto_sync = True
 
-        # Privacy mode toggle
+        # Deprecated content-redaction compatibility toggle.
         if os.getenv("TRAIGENT_PRIVACY_MODE", "").lower() in ("true", "1", "yes"):
-            config.privacy_enabled = True
+            import warnings
+
+            warnings.warn(
+                "TRAIGENT_PRIVACY_MODE is deprecated. Use offline=True or "
+                "TRAIGENT_OFFLINE=1 for no-egress local optimization.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            object.__setattr__(config, "privacy_enabled", True)
 
         # Strict metrics nulls toggle
         if os.getenv("TRAIGENT_STRICT_METRICS_NULLS", "").lower() in (
@@ -940,3 +1082,36 @@ class TraigentConfig:
             config.comparability_mode = mode  # type: ignore[assignment]
 
         return config
+
+
+def _public_config_param(name: str, default: Any, annotation: Any) -> Parameter:
+    return Parameter(
+        name,
+        kind=Parameter.KEYWORD_ONLY,
+        default=default,
+        annotation=annotation,
+    )
+
+
+TraigentConfig.__signature__ = Signature(
+    parameters=[
+        _public_config_param("model", None, str | None),
+        _public_config_param("temperature", None, float | None),
+        _public_config_param("max_tokens", None, int | None),
+        _public_config_param("top_p", None, float | None),
+        _public_config_param("frequency_penalty", None, float | None),
+        _public_config_param("presence_penalty", None, float | None),
+        _public_config_param("stop_sequences", None, list[str] | None),
+        _public_config_param("seed", None, int | None),
+        _public_config_param("algorithm", "auto", str),
+        _public_config_param("offline", False, bool),
+        _public_config_param("local_storage_path", None, str | None),
+        _public_config_param("minimal_logging", True, bool),
+        _public_config_param("auto_sync", False, bool),
+        _public_config_param("strict_metrics_nulls", False, bool),
+        _public_config_param(
+            "comparability_mode", "warn", Literal["legacy", "warn", "strict"]
+        ),
+        _public_config_param("custom_params", None, dict[str, Any] | None),
+    ]
+)


### PR DESCRIPTION
## What & why
Owner directive: keep the SDK execution model simple — users see **only** `algorithm` and `offline`, and most users touch neither (`algorithm="auto"` = cloud smart by default). This removes the half-finished, contradictory `execution_mode` vocabulary from the public surface.

## Changes
- Public `optimize()` / `TraigentConfig` advertise only `algorithm` + `offline`.
- Legacy inputs (`execution_mode`, `privacy_enabled`, `cloud_fallback_policy`, flat `hybrid_api_*`) and legacy imports (`ExecutionMode`, `HybridAPIOptions`) remain **accepted but emit `DeprecationWarning`** (incl. direct `TraigentConfig(...)` construction) — nothing hard-breaks.
- Removed from public docstrings, the `TraigentConfig` signature, `to_dict()`/`repr()`, and top-level exports.
- Smart algorithm names (`bayesian`/`optuna*`/…) stay valid (cloud-routed); optimizers registry and Optuna files untouched.

## Tests
- 74 pass (`-n0`): legacy kwargs/imports warn + still work; `to_dict()`/`repr()` exclude legacy keys; smart names still accepted. codex gpt-5.5 review applied (2 blockers fixed: construction-time warning, `to_dict`/`repr` leakage).

## PR checklist
1. Worst-case prod path: API-surface change only; legacy inputs still function (fail-safe via deprecation).
2. Production-branch test: deprecation + compat asserted in `tests/unit/config/test_types.py`.
3. Contract regen: none (legacy still accepted).
4. **Public surface delta:** `optimize`/`TraigentConfig` now expose only `algorithm`+`offline`; legacy names deprecated (warn) and dropped from docs/exports/serialization.
5. Review threads: codex GO after fixes.
6. Quality gates: unchanged.

Companion PRs purge the same vocabulary from the CLI, docs/onboarding, and skills.

Spine-Trail: st_4eec3a3b2d8a

🤖 Generated with [Claude Code](https://claude.com/claude-code)