### PR TITLE
feat(smart-pruning): SDK surface + per-trial intermediate-report wiring

### DIFF
--- a/tests/unit/core/test_smart_pruning_wiring.py
+++ b/tests/unit/core/test_smart_pruning_wiring.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from traigent.config.types import TraigentConfig
+from traigent.core.trial_lifecycle import TrialLifecycle
+from traigent.core.types import TrialResult, TrialStatus
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
+from traigent.optimizers.base import BaseOptimizer
+
+
+class QueueOptimizer(BaseOptimizer):
+    def __init__(self, configs: list[dict[str, Any]]) -> None:
+        super().__init__({"answer": ["ok"]}, ["accuracy"])
+        self._configs = list(configs)
+
+    def suggest_next_trial(self, history: list[TrialResult]) -> dict[str, Any]:
+        return dict(self._configs[len(history)])
+
+    def should_stop(self, history: list[TrialResult]) -> bool:
+        return len(history) >= len(self._configs)
+
+
+class SmartPruningOrchestrator:
+    def __init__(self, client: Any, configs: list[dict[str, Any]]) -> None:
+        self.optimizer = QueueOptimizer(configs)
+        self.evaluator = LocalEvaluator(metrics=["accuracy"], max_workers=1, detailed=True)
+        self.knob_resolver = None
+        self._optimization_id = "smart-pruning-test"
+        self._sample_budget_manager = None
+        self._consumed_examples = 0
+        self._examples_capped = 0
+        self._stop_reason = None
+        self._constraints_pre_eval: list[Any] = []
+        self._constraints_post_eval: list[Any] = []
+        self._trials: list[TrialResult] = []
+        self.max_trials = len(configs)
+        self.config = {
+            "cache_policy": "allow_repeats",
+            "smart_pruning": {"label": "balanced"},
+        }
+        self.traigent_config = TraigentConfig(
+            custom_params={"smart_pruning": {"label": "balanced"}}
+        )
+        self.cache_policy_handler = MagicMock()
+        self.callback_manager = MagicMock()
+        self.cost_enforcer = None
+        self._default_config = None
+        self._default_config_used = False
+        self.objective_schema = None
+        self.objectives = ["accuracy"]
+        self.backend_client = client
+        self.backend_session_manager = SimpleNamespace(backend_tracking_enabled=True)
+        self._cloud_guidance_client = None
+        self._workflow_traces_tracker = None
+
+    def _apply_knob_resolution(self, config: dict[str, Any]) -> dict[str, Any]:
+        return config
+
+    def _consume_default_config(self) -> None:
+        return None
+
+    def _is_cloud_brain_run(self) -> bool:
+        return True
+
+    def _smart_pruning_config(self) -> dict[str, Any]:
+        return {"label": "balanced"}
+
+    async def _handle_trial_result(self, **kwargs: Any) -> int:
+        trial_result = kwargs["trial_result"]
+        self._trials.append(trial_result)
+        return int(kwargs.get("current_trial_index", 0)) + 1
+
+
+def _dataset() -> Dataset:
+    return Dataset(
+        [
+            EvaluationExample({"question": "q1"}, "ok"),
+            EvaluationExample({"question": "q2"}, "ok"),
+        ],
+        name="smart_pruning_eval",
+    )
+
+
+def _candidate(question: str) -> str:
+    return "ok"
+
+
+def test_smart_pruning_true_records_pruned_trial_and_run_continues() -> None:
+    asyncio.run(_run_smart_pruning_true_records_pruned_trial_and_continues())
+
+
+async def _run_smart_pruning_true_records_pruned_trial_and_continues() -> None:
+    client = MagicMock()
+    client.report_intermediate_trial.side_effect = [
+        {"prune": True, "prune_reason": "score_below_band"},
+        {"prune": False, "prune_reason": None},
+        {"prune": False, "prune_reason": None},
+    ]
+    orchestrator = SmartPruningOrchestrator(
+        client,
+        configs=[{"answer": "bad"}, {"answer": "ok"}],
+    )
+    lifecycle = TrialLifecycle(orchestrator)
+
+    trial_count, action = await lifecycle.run_sequential_trial(
+        func=_candidate,
+        dataset=_dataset(),
+        session_id="session-smart",
+        function_name="candidate",
+        trial_count=0,
+    )
+
+    assert action == "continue"
+    assert trial_count == 1
+    assert orchestrator._trials[0].status == TrialStatus.PRUNED
+    assert orchestrator._trials[0].metadata["stop_reason"] == "smart_prune"
+    assert orchestrator._trials[0].metadata["prune_reason"] == "score_below_band"
+
+    trial_count, action = await lifecycle.run_sequential_trial(
+        func=_candidate,
+        dataset=_dataset(),
+        session_id="session-smart",
+        function_name="candidate",
+        trial_count=trial_count,
+    )
+
+    assert action == "continue"
+    assert trial_count == 2
+    assert [trial.status for trial in orchestrator._trials] == [
+        TrialStatus.PRUNED,
+        TrialStatus.COMPLETED,
+    ]
+    assert orchestrator._stop_reason is None
+
+
+def test_smart_pruning_false_runs_trial_normally() -> None:
+    asyncio.run(_run_smart_pruning_false_runs_trial_normally())
+
+
+async def _run_smart_pruning_false_runs_trial_normally() -> None:
+    client = MagicMock()
+    client.report_intermediate_trial.return_value = {
+        "prune": False,
+        "prune_reason": None,
+    }
+    orchestrator = SmartPruningOrchestrator(client, configs=[{"answer": "ok"}])
+    lifecycle = TrialLifecycle(orchestrator)
+
+    trial_count, action = await lifecycle.run_sequential_trial(
+        func=_candidate,
+        dataset=_dataset(),
+        session_id="session-smart",
+        function_name="candidate",
+        trial_count=0,
+    )
+
+    assert action == "continue"
+    assert trial_count == 1
+    assert orchestrator._trials[0].status == TrialStatus.COMPLETED
+    assert client.report_intermediate_trial.call_count == 2

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -246,6 +246,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
         "traigent.api.decorators",
         "ExternalServiceEvaluator",
     ),
+    "SmartPruningConfig": ("traigent.api.decorators", "SmartPruningConfig"),
     "HybridAPIOptions": ("traigent.api.decorators", "HybridAPIOptions"),
     "ConstraintValidator": (
         "traigent.api.validation_protocol",
@@ -528,6 +529,7 @@ __all__ = [
     # Configuration types
     "TraigentConfig",
     "ExternalServiceEvaluator",
+    "SmartPruningConfig",
     # Lifecycle and state
     "OptimizationState",
     # Thread context helpers

--- a/traigent/api/__init__.py
+++ b/traigent/api/__init__.py
@@ -6,9 +6,9 @@ This package intentionally uses lazy exports so submodule imports such as
 
 from __future__ import annotations
 
+import warnings
 from importlib import import_module
 from typing import Any
-import warnings
 
 __all__ = [
     "optimize",
@@ -56,6 +56,7 @@ __all__ = [
     "get_available_safety_presets",
     "TextDocument",
     "ExternalServiceEvaluator",
+    "SmartPruningConfig",
 ]
 
 _EXPORT_MAP = {
@@ -134,6 +135,7 @@ _EXPORT_MAP = {
         "traigent.api.decorators",
         "ExternalServiceEvaluator",
     ),
+    "SmartPruningConfig": ("traigent.api.decorators", "SmartPruningConfig"),
     "HybridAPIOptions": ("traigent.api.decorators", "HybridAPIOptions"),
 }
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -183,6 +183,45 @@ class ExternalServiceEvaluator(BaseModel):
     hybrid_api: HybridAPIOptions = Field(default_factory=HybridAPIOptions)
 
 
+SmartPruningLabel = Literal["aggressive", "balanced", "conservative"]
+
+
+class SmartPruningConfig(BaseModel):
+    """Cloud-side per-trial pruning policy for managed optimization runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: SmartPruningLabel
+    min_completed_trials: int | None = Field(default=None, ge=1)
+    warmup_steps: int | None = Field(default=None, ge=0)
+    epsilon: float | None = Field(default=None, ge=0)
+    cost_threshold: float | None = Field(default=None, ge=0)
+    confidence: float | None = Field(default=None, gt=0, lt=1)
+    min_samples_per_config: int | None = Field(default=None, ge=1)
+    warmup_trials: int | None = Field(default=None, ge=0)
+
+
+def _normalize_smart_pruning(
+    value: SmartPruningConfig | Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate and return the smart-pruning payload in schema wire shape."""
+    if value is None:
+        return None
+    if isinstance(value, SmartPruningConfig):
+        return cast(dict[str, Any], value.model_dump(exclude_none=True))
+    if isinstance(value, Mapping):
+        try:
+            config = SmartPruningConfig.model_validate(dict(value))
+        except Exception as exc:
+            raise ValueError(
+                "smart_pruning must include label in "
+                "{'aggressive', 'balanced', 'conservative'} and only supported "
+                "optional parameter overrides"
+            ) from exc
+        return cast(dict[str, Any], config.model_dump(exclude_none=True))
+    raise TypeError("smart_pruning must be a SmartPruningConfig, dict, or None")
+
+
 class ExecutionOptions(BaseModel):
     """Execution and orchestration preferences for optimization runs.
 
@@ -201,6 +240,7 @@ class ExecutionOptions(BaseModel):
         parallel_config: Configuration for parallel execution.
         max_total_examples: Maximum total examples across all trials.
         samples_include_pruned: Whether to include pruned trials in sample count.
+        smart_pruning: Optional cloud-side per-trial pruning policy.
         reps_per_trial: Number of repetitions per configuration for statistical
             stability. Only the default ``1`` (no repetition) is available in the
             OSS SDK; passing any other value raises ``pydantic.ValidationError`` at
@@ -234,6 +274,7 @@ class ExecutionOptions(BaseModel):
     parallel_config: ParallelConfig | dict[str, Any] | None = None
     max_total_examples: int | None = None
     samples_include_pruned: bool = True
+    smart_pruning: SmartPruningConfig | dict[str, Any] | None = None
     reps_per_trial: int = 1
     reps_aggregation: str = "mean"
 
@@ -464,6 +505,7 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "parallel_config": None,
     "max_total_examples": None,
     "samples_include_pruned": True,
+    "smart_pruning": None,
     "mock_mode_config": None,
     "custom_evaluator": None,
     "scoring_function": None,
@@ -1168,6 +1210,7 @@ class ResolvedExecutionOptions:
     parallel_config: Any
     max_total_examples: Any
     samples_include_pruned: Any
+    smart_pruning: Any
     legacy_options: dict[str, Any] = field(default_factory=dict)
 
 
@@ -1260,6 +1303,12 @@ def _resolve_execution_bundle_options(
             "samples_include_pruned",
             base_options.samples_include_pruned,
             execution_bundle.samples_include_pruned,
+            defaults,
+        ),
+        smart_pruning=_resolve_option(
+            "smart_pruning",
+            base_options.smart_pruning,
+            execution_bundle.smart_pruning,
             defaults,
         ),
         legacy_options=legacy_options,
@@ -1938,6 +1987,7 @@ def optimize(  # NOSONAR(S107)
     effectuation: bool = False,
     execution: ExecutionOptions | dict[str, Any] | None = None,
     evaluator: ExternalServiceEvaluator | dict[str, Any] | None = None,
+    smart_pruning: SmartPruningConfig | dict[str, Any] | None = None,
     mock: MockModeOptions | dict[str, Any] | None = None,
     algorithm: str = "auto",
     offline: bool = False,
@@ -2260,6 +2310,7 @@ def optimize(  # NOSONAR(S107)
         "effectuation": effectuation,
         "execution": execution,
         "evaluator": evaluator,
+        "smart_pruning": smart_pruning,
         "mock": mock,
         "algorithm": algorithm,
         "offline": offline,
@@ -2354,6 +2405,7 @@ def optimize(  # NOSONAR(S107)
     parallel_config = combined_settings["parallel_config"]
     max_total_examples = combined_settings["max_total_examples"]
     samples_include_pruned = combined_settings["samples_include_pruned"]
+    smart_pruning_value = combined_settings["smart_pruning"]
     mock_mode_config = combined_settings["mock_mode_config"]
     custom_evaluator = combined_settings["custom_evaluator"]
     scoring_function = combined_settings["scoring_function"]
@@ -2462,6 +2514,7 @@ def optimize(  # NOSONAR(S107)
         parallel_config=parallel_config,
         max_total_examples=max_total_examples,
         samples_include_pruned=samples_include_pruned,
+        smart_pruning=smart_pruning_value,
         legacy_options=legacy_execution_options,
     )
     resolved_execution = _resolve_execution_bundle_options(
@@ -2479,6 +2532,7 @@ def optimize(  # NOSONAR(S107)
     parallel_config = resolved_execution.parallel_config
     max_total_examples = resolved_execution.max_total_examples
     samples_include_pruned = resolved_execution.samples_include_pruned
+    smart_pruning_value = _normalize_smart_pruning(resolved_execution.smart_pruning)
     legacy_execution_options = resolved_execution.legacy_options
     external_service_evaluator = _resolve_external_service_evaluator(
         evaluator_value,
@@ -2678,6 +2732,7 @@ def optimize(  # NOSONAR(S107)
             minimal_logging=minimal_logging,
             max_total_examples=max_total_examples,
             samples_include_pruned=samples_include_pruned,
+            smart_pruning=smart_pruning_value,
             parallel_config=combined_parallel_config,
             mock_mode_config=mock_mode_config,
             custom_evaluator=custom_evaluator,

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -128,6 +128,7 @@ StopReason = Literal[
     "error",  # Optimization failed due to an exception
     "vendor_error",  # Provider error (rate limit/quota/service)
     "network_error",  # Connectivity failure
+    "smart_prune",  # Backend smart-pruning policy stopped the run
 ]
 
 TrialDatetimeFormat = Literal["iso", "epoch"]
@@ -661,6 +662,7 @@ class OptimizationResult:
             - "user_cancelled": User cancelled or declined cost approval
             - "condition": Generic stop condition was triggered
             - "error": Optimization failed due to an exception
+            - "smart_prune": Backend smart-pruning policy stopped the run
             - None: Unknown or not set
         experiment_id: Backend experiment identifier (None if offline/not synced).
         cloud_url: Direct link to the experiment on the cloud portal (None if offline).

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -588,6 +588,8 @@ class ApiOperations:
         wire_governance = tvl_governance_to_wire(session_request.tvl_governance)
         if wire_governance:
             payload["tvl_governance"] = wire_governance
+        if session_request.smart_pruning is not None:
+            payload["smart_pruning"] = dict(session_request.smart_pruning)
         return payload
 
     def _build_legacy_session_payload(

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -42,6 +42,7 @@ from traigent.cloud.models import (
     AgentOptimizationRequest,
     AgentOptimizationResponse,
     AgentSpecification,
+    IntermediateReportResponse,
     NextTrialRequest,
     NextTrialResponse,
     OptimizationFinalizationResponse,
@@ -662,6 +663,7 @@ class BackendIntegratedClient:
         objectives: list[Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
+        smart_pruning: dict[str, Any] | None = None,
     ) -> SessionCreationResult:
         """Synchronous wrapper for creating a session.
         Delegates to session_operations module. Phase 8: objectives are
@@ -675,6 +677,7 @@ class BackendIntegratedClient:
             objectives=objectives,
             promotion_policy=promotion_policy,
             tvl_governance=tvl_governance,
+            smart_pruning=smart_pruning,
         )
 
     async def create_hybrid_session(
@@ -1139,6 +1142,26 @@ class BackendIntegratedClient:
             declined). ``None`` never means "use a client id".
         """
         return cast(str | None, await self._trial_ops.request_trial_slot(session_id))
+
+    async def report_intermediate_trial(
+        self,
+        *,
+        session_id: str,
+        trial_id: str,
+        running_score: float,
+        examples_attempted: int,
+        partial_cost_usd: float | None = None,
+        objective_name: str | None = None,
+    ) -> IntermediateReportResponse:
+        """Send per-trial smart-pruning progress to the backend."""
+        return await self._trial_ops.report_intermediate_trial(
+            session_id=session_id,
+            trial_id=trial_id,
+            running_score=running_score,
+            examples_attempted=examples_attempted,
+            partial_cost_usd=partial_cost_usd,
+            objective_name=objective_name,
+        )
 
     def _generate_trial_id(
         self,

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -35,6 +35,7 @@ from .models import (
     AgentOptimizationResponse,
     AgentOptimizationStatus,
     AgentSpecification,
+    IntermediateReportResponse,
     NextTrialRequest,
     NextTrialResponse,
     OptimizationFinalizationRequest,
@@ -1221,6 +1222,7 @@ class TraigentCloudClient(BaseTraigentClient):
         default_config: dict[str, Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         optimization_strategy: dict[str, Any] | None = None,
+        smart_pruning: dict[str, Any] | None = None,
         user_id: str | None = None,
         billing_tier: str = "standard",
     ) -> SessionCreationResponse:
@@ -1262,6 +1264,7 @@ class TraigentCloudClient(BaseTraigentClient):
                 default_config=default_config,
                 promotion_policy=promotion_policy,
                 optimization_strategy=optimization_strategy,
+                smart_pruning=smart_pruning,
                 user_id=user_id,
                 billing_tier=billing_tier,
             )
@@ -1477,6 +1480,64 @@ class TraigentCloudClient(BaseTraigentClient):
             await self._reset_http_session("finalize_session network error")
             raise CloudServiceError(f"Network error finalizing session: {e}") from None
 
+    async def report_intermediate_trial(
+        self,
+        *,
+        session_id: str,
+        trial_id: str,
+        running_score: float,
+        examples_attempted: int,
+        partial_cost_usd: float | None = None,
+        objective_name: str | None = None,
+    ) -> IntermediateReportResponse:
+        """Send per-trial progress to the backend smart-pruning endpoint."""
+        self._raise_if_backend_egress_disabled("intermediate trial report")
+        await self._ensure_session()
+
+        if self._aio_session is None:
+            raise CloudServiceError(_CLIENT_SESSION_NOT_INITIALIZED)
+
+        payload: dict[str, Any] = {
+            "session_id": session_id,
+            "trial_id": trial_id,
+            "running_score": float(running_score),
+            "examples_attempted": int(examples_attempted),
+        }
+        if partial_cost_usd is not None:
+            payload["partial_cost_usd"] = float(partial_cost_usd)
+        if objective_name:
+            payload["objective_name"] = str(objective_name)
+
+        try:
+            url = f"{self.api_base_url}/sessions/{session_id}/intermediate-report"
+            async with self._aio_session.post(
+                url, json=payload, headers=await self._get_headers()
+            ) as response:
+                if response.status == 403:
+                    error_text = await response.text()
+                    self._raise_ownership_error(
+                        session_id,
+                        "Sending intermediate trial report",
+                        response.status,
+                        error_text,
+                    )
+                if response.status not in [200, 201]:
+                    error_text = await response.text()
+                    raise CloudServiceError(
+                        "Failed to submit intermediate report: "
+                        f"HTTP {response.status}: {error_text}"
+                    )
+                data = await response.json()
+                return IntermediateReportResponse(
+                    prune=bool(data.get("prune", False)),
+                    prune_reason=data.get("prune_reason"),
+                )
+        except aiohttp.ClientError as e:
+            await self._reset_http_session("intermediate_report network error")
+            raise CloudServiceError(
+                f"Network error submitting intermediate report: {e}"
+            ) from None
+
     # Serialization/deserialization helpers
 
     def _serialize_session_request(
@@ -1499,6 +1560,8 @@ class TraigentCloudClient(BaseTraigentClient):
             "billing_tier": request.billing_tier,
             "metadata": metadata,
         }
+        if request.smart_pruning is not None:
+            payload["smart_pruning"] = dict(request.smart_pruning)
         if request.budget is not None:
             payload["budget"] = request.budget
         if request.constraints is not None:

--- a/traigent/cloud/models.py
+++ b/traigent/cloud/models.py
@@ -180,6 +180,26 @@ class TrialResultSubmission:
 
 
 @dataclass
+class IntermediateReportRequest:
+    """Per-trial intermediate progress report for cloud smart pruning."""
+
+    session_id: str
+    trial_id: str
+    running_score: float
+    examples_attempted: int
+    partial_cost_usd: float | None = None
+    objective_name: str | None = None
+
+
+@dataclass
+class IntermediateReportResponse:
+    """Cloud pruning decision returned for an intermediate report."""
+
+    prune: bool
+    prune_reason: str | None = None
+
+
+@dataclass
 class SessionCreationRequest:
     """Request to create a new optimization session."""
 
@@ -198,6 +218,7 @@ class SessionCreationRequest:
     # governed flags only — built by traigent.cloud.governance, never ad hoc.
     tvl_governance: dict[str, Any] | None = None
     optimization_strategy: dict[str, Any] | None = None
+    smart_pruning: dict[str, Any] | None = None
     user_id: str | None = None
     billing_tier: str = "standard"
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -328,6 +328,7 @@ class SessionOperations:
         objectives: list[Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
+        smart_pruning: dict[str, Any] | None = None,
     ) -> SessionCreationResult:
         """Create a session with backend metadata submission.
 
@@ -438,6 +439,7 @@ class SessionOperations:
                 promotion_policy=promotion_policy,
                 tvl_governance=tvl_governance,
                 optimization_strategy={"mode": "local_execution"},
+                smart_pruning=smart_pruning,
                 user_id=None,  # Privacy preserving
                 billing_tier="privacy",
                 metadata=metadata or {},

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -223,6 +223,7 @@ class SyncManager:
                 "error",
                 "vendor_error",
                 "network_error",
+                "smart_prune",
                 # Legacy alias retained for backward-compat with pre-1.0 sessions
                 "budget_exhausted",
             ):

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from traigent._version import get_version
 from traigent.cloud.client import raise_if_cloud_egress_disabled
 from traigent.cloud.dtos import MeasuresDict
+from traigent.cloud.models import IntermediateReportResponse
 from traigent.cloud.validators import validate_configuration_run_submission
 from traigent.config.backend_config import BackendConfig
 from traigent.utils.env_config import is_backend_offline, resolve_environment_label
@@ -481,6 +482,103 @@ class TrialOperations:
                 self._describe_backend(),
             )
             return None
+
+    async def report_intermediate_trial(
+        self,
+        *,
+        session_id: str,
+        trial_id: str,
+        running_score: float,
+        examples_attempted: int,
+        partial_cost_usd: float | None = None,
+        objective_name: str | None = None,
+    ) -> IntermediateReportResponse:
+        """Submit per-trial progress to the smart-pruning endpoint."""
+        no_prune = IntermediateReportResponse(prune=False, prune_reason=None)
+        if is_backend_offline():
+            logger.debug(
+                "Offline mode: skipping intermediate report for session %s trial %s",
+                session_id,
+                trial_id,
+            )
+            return no_prune
+        self._raise_if_backend_egress_disabled("intermediate trial report")
+
+        if not AIOHTTP_AVAILABLE:
+            logger.warning("aiohttp not available, skipping intermediate report")
+            return no_prune
+
+        payload: dict[str, Any] = {
+            "session_id": session_id,
+            "trial_id": trial_id,
+            "running_score": float(running_score),
+            "examples_attempted": int(examples_attempted),
+        }
+        if partial_cost_usd is not None:
+            payload["partial_cost_usd"] = float(partial_cost_usd)
+        if objective_name:
+            payload["objective_name"] = str(objective_name)
+
+        try:
+            headers = await self.client.auth_manager.augment_headers(
+                _JSON_CONTENT_TYPE_HEADER
+            )
+            connector = self._create_localhost_connector()
+            async with aiohttp.ClientSession(connector=connector) as session:
+                api_base = (
+                    self.client.backend_config.api_base_url
+                    or BackendConfig.get_backend_api_url()
+                )
+                url = f"{api_base}/sessions/{session_id}/intermediate-report"
+                async with session.post(
+                    url,
+                    json=self._sanitize_for_json(payload),
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as response:
+                    if response.status in [200, 201]:
+                        data = await response.json()
+                        if not isinstance(data, dict):
+                            return no_prune
+                        return IntermediateReportResponse(
+                            prune=bool(data.get("prune", False)),
+                            prune_reason=data.get("prune_reason"),
+                        )
+                    if response.status == 403:
+                        error_msg = await response.text()
+                        self._log_ownership_forbidden(
+                            session_id,
+                            "Submitting intermediate report",
+                            response.status,
+                            error_msg,
+                        )
+                        return no_prune
+                    error_text = self._first_error_line(await response.text())
+                    logger.warning(
+                        "Intermediate report rejected for session %s trial %s: "
+                        "HTTP %s %s",
+                        session_id,
+                        trial_id,
+                        response.status,
+                        error_text,
+                    )
+                    return no_prune
+
+        except Exception as exc:
+            if is_backend_offline():
+                logger.debug(
+                    "Offline mode: intermediate report encountered %s; skipping",
+                    exc,
+                )
+                return no_prune
+            logger.warning(
+                "Intermediate report failed for session %s trial %s (%s): %s",
+                session_id,
+                trial_id,
+                self._describe_backend(),
+                exc,
+            )
+            return no_prune
 
     def _extract_measures_from_metrics(
         self, metrics: dict[str, Any]

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from traigent._version import get_version
 from traigent.api.types import (
     AgentConfiguration,
     OptimizationResult,
     OptimizationStatus,
+    StopReason,
     TrialResult,
     TrialStatus,
 )
@@ -634,6 +635,7 @@ class BackendSessionManager:
         objectives: list[Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
+        smart_pruning: dict[str, Any] | None = None,
         experiment_display_name: str | None = None,
     ) -> SessionContext:
         """Create backend session and return context.
@@ -721,6 +723,7 @@ class BackendSessionManager:
                 objectives=objectives,
                 promotion_policy=promotion_policy,
                 tvl_governance=tvl_governance,
+                smart_pruning=smart_pruning,
             )
             result = self.normalize_session_creation_result(raw_result)
             session_id = self.handle_session_creation_result(result)
@@ -1396,9 +1399,9 @@ class BackendSessionManager:
             result.metadata.get("statistical_significance") if result.metadata else None
         )
         if stat_sig:
-            summary_stats_with_aggregation["metadata"]["statistical_significance"] = (
-                stat_sig
-            )
+            summary_stats_with_aggregation["metadata"][
+                "statistical_significance"
+            ] = stat_sig
 
         try:
             successful_trials = len([t for t in result.trials if t.is_successful])
@@ -1495,7 +1498,7 @@ class BackendSessionManager:
         self,
         result: OptimizationResult,
         session_id: str | None,
-        session_summary: dict[str, Any] | None,
+        session_summary: Any | None,
     ) -> None:
         """Attach session identifiers and summary to result metadata.
 
@@ -1516,6 +1519,13 @@ class BackendSessionManager:
         update_payload: dict[str, Any] = {"local_session_id": session_id}
         if session_summary is not None:
             update_payload["local_session_summary"] = session_summary
+            stop_reason = self._summary_value(session_summary, "stop_reason")
+            if isinstance(stop_reason, str) and stop_reason:
+                result.stop_reason = cast(StopReason, stop_reason)
+                update_payload["stop_reason"] = stop_reason
+            prune_reason = self._summary_value(session_summary, "prune_reason")
+            if isinstance(prune_reason, str) and prune_reason:
+                update_payload["prune_reason"] = prune_reason
         if owning_context := self._session_owning_context.get(session_id):
             update_payload.update(owning_context)
 
@@ -1530,3 +1540,18 @@ class BackendSessionManager:
                 pass  # Silently ignore if mapping not available
 
         result.metadata.update(update_payload)
+
+    @staticmethod
+    def _summary_value(session_summary: Any, key: str) -> Any:
+        """Read a top-level or metadata field from dict/dataclass-style summaries."""
+        if isinstance(session_summary, dict):
+            value = session_summary.get(key)
+            metadata = session_summary.get("metadata")
+        else:
+            value = getattr(session_summary, key, None)
+            metadata = getattr(session_summary, "metadata", None)
+        if value is not None:
+            return value
+        if isinstance(metadata, dict):
+            return metadata.get(key)
+        return None

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -26,8 +26,8 @@ from traigent.config.types import (
     TraigentConfig,
     resolve_execution_mode,
 )
-from traigent.core.execution_policy_runtime import backend_egress_disabled
 from traigent.core.evaluator_wrapper import CustomEvaluatorWrapper
+from traigent.core.execution_policy_runtime import backend_egress_disabled
 from traigent.core.trace_env import is_trace_enabled
 from traigent.evaluators.base import BaseEvaluator, Dataset
 from traigent.evaluators.local import LocalEvaluator
@@ -107,6 +107,7 @@ def create_traigent_config(
     result_source: str | None = None,
     fallback_reason: str | None = None,
     persistence_status: str | None = None,
+    smart_pruning: dict[str, Any] | None = None,
 ) -> TraigentConfig:
     """Create TraigentConfig for the optimization run.
 
@@ -119,6 +120,10 @@ def create_traigent_config(
     Returns:
         Configured TraigentConfig instance
     """
+    custom_params: dict[str, Any] = {}
+    if smart_pruning is not None:
+        custom_params["smart_pruning"] = dict(smart_pruning)
+
     return TraigentConfig(
         execution_mode=cast(
             Literal[
@@ -137,6 +142,7 @@ def create_traigent_config(
         result_source=result_source,
         fallback_reason=fallback_reason,
         persistence_status=persistence_status,
+        custom_params=custom_params,
     )
 
 
@@ -611,6 +617,7 @@ def collect_orchestrator_kwargs(
     promotion_gate: Any | None,
     safety_constraints: list[Any] | None = None,
     invocations_per_example: int = 1,
+    smart_pruning: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Collect optional kwargs for orchestrator from algorithm_kwargs and attrs.
 
@@ -626,6 +633,7 @@ def collect_orchestrator_kwargs(
         promotion_gate: Promotion gate configuration
         safety_constraints: Post-evaluation safety constraints
         invocations_per_example: Number of invocations per example (default: 1)
+        smart_pruning: Optional cloud-side per-trial pruning policy.
 
     Returns:
         Dict of orchestrator keyword arguments.
@@ -671,6 +679,7 @@ def collect_orchestrator_kwargs(
         ("global_measures", global_measures, None),
         ("promotion_gate", promotion_gate, None),
         ("safety_constraints", safety_constraints, None),
+        ("smart_pruning", smart_pruning, lambda v: dict(v)),
     ]
     for attr_name, value, transform in optional_attrs:
         if value is not None:

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -686,6 +686,9 @@ class OptimizedFunction:
         self.samples_include_pruned = self._store_optional_param(
             kwargs, sentinel, "samples_include_pruned", True, as_bool=True
         )
+        self.smart_pruning = self._store_optional_param(
+            kwargs, sentinel, "smart_pruning", None
+        )
         self.optimization_history_limit = kwargs.pop("optimization_history_limit", 100)
         if (
             not isinstance(self.optimization_history_limit, int)
@@ -736,6 +739,7 @@ class OptimizedFunction:
             "mock_mode_config",
             "max_total_examples",
             "samples_include_pruned",
+            "smart_pruning",
             # Multi-agent configuration
             "agents",
             "agent_prefixes",
@@ -1781,6 +1785,7 @@ class OptimizedFunction:
             global_measures=getattr(self, "global_measures", None),
             promotion_gate=getattr(self, "promotion_gate", None),
             safety_constraints=getattr(self, "safety_constraints", None),
+            smart_pruning=getattr(self, "smart_pruning", None),
         )
 
         # Auto-initialize workflow traces tracker if backend is configured
@@ -2236,6 +2241,7 @@ Remediation:
             execution_policy=execution_policy,
             no_egress=no_egress,
             result_source=result_source,
+            smart_pruning=getattr(self, "smart_pruning", None),
         )
         self.traigent_config = traigent_config
         self._check_ci_approval()

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -54,15 +54,14 @@ from traigent.core.cost_enforcement import (
 from traigent.core.cost_estimator import CostEstimator
 from traigent.core.exception_handler import VendorErrorCategory
 from traigent.core.execution_policy_runtime import (
-    CloudBrainUnavailableError,
     SOURCE_CLOUD_BRAIN,
     SOURCE_LOCAL_FALLBACK,
+    CloudBrainUnavailableError,
     backend_egress_disabled,
     is_offline_requested,
     policy_from_config,
     policy_is_cloud_brain,
 )
-from traigent.utils.env_config import is_backend_offline as is_backend_offline  # noqa: F401
 from traigent.core.logger_facade import LoggerFacade
 from traigent.core.metadata_helpers import merge_run_metrics_into_session_summary
 from traigent.core.metric_registry import MetricRegistry, MetricSpec
@@ -103,6 +102,9 @@ from traigent.metrics.registry import clone_registry
 from traigent.optimizers.base import BaseOptimizer
 from traigent.tvl.promotion_gate import PromotionGate
 from traigent.utils.callbacks import CallbackManager, OptimizationCallback, ProgressInfo
+from traigent.utils.env_config import (  # noqa: F401
+    is_backend_offline as is_backend_offline,
+)
 from traigent.utils.exceptions import OptimizationError, VendorPauseError
 from traigent.utils.function_identity import (
     FunctionDescriptor,
@@ -670,6 +672,15 @@ class OptimizationOrchestrator:
             == SOURCE_CLOUD_BRAIN
             and not backend_egress_disabled(self.traigent_config)
         )
+
+    def _smart_pruning_config(self) -> dict[str, Any] | None:
+        """Return the normalized smart-pruning policy for this run, if any."""
+        raw = self.config.get("smart_pruning")
+        if raw is None:
+            custom_params = getattr(self.traigent_config, "custom_params", None) or {}
+            if isinstance(custom_params, dict):
+                raw = custom_params.get("smart_pruning")
+        return dict(raw) if isinstance(raw, dict) else None
 
     def _optimizer_uses_remote_guidance(self) -> bool:
         """Whether the active optimizer would call remote next-trial guidance."""
@@ -2170,6 +2181,7 @@ class OptimizationOrchestrator:
             objectives=list(self.optimizer.objectives or []),
             promotion_policy=wire_policy,
             tvl_governance=wire_governance,
+            smart_pruning=self._smart_pruning_config(),
             experiment_display_name=experiment_display_name,
         )
         session_id: str | None = session_context.session_id
@@ -2338,6 +2350,7 @@ class OptimizationOrchestrator:
                 search_space=getattr(self.optimizer, "config_space", {}),
                 optimization_goal="maximize",  # Default assumption
                 metadata=metadata,
+                smart_pruning=self._smart_pruning_config(),
             )
             session_id = self.backend_session_manager.handle_session_creation_result(
                 self.backend_session_manager.normalize_session_creation_result(

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -13,6 +13,8 @@ Classes:
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import inspect
 import math
 import time
 import uuid
@@ -291,7 +293,7 @@ class TrialLifecycle:
 
         # Phase 2: Setup progress tracking and budget
         progress_callback, progress_state = self._create_progress_tracking(
-            optuna_trial_id, dataset, trial_id
+            optuna_trial_id, dataset, trial_id, session_id
         )
         lease = self._setup_trial_budget_lease(dataset, trial_id, sample_ceiling)
 
@@ -589,14 +591,260 @@ class TrialLifecycle:
         optuna_trial_id: int | None,
         dataset: Dataset,
         trial_id: str,
+        session_id: str | None = None,
     ) -> tuple[Callable[[int, dict[str, Any]], None] | None, dict[str, Any] | None]:
         """Return progress callback state.
 
-        Local Optuna-backed intermediate reporting has been evicted. Generic
-        pruned-trial result handling remains in the lifecycle for future callers
-        that raise :class:`TrialPrunedError` directly.
+        Local Optuna-backed intermediate reporting has been evicted. Cloud smart
+        pruning reuses the generic pruned-trial path: when the backend returns a
+        prune decision, the callback raises :class:`TrialPrunedError` so
+        ``build_pruned_result`` records ``TrialStatus.PRUNED`` for this trial
+        without stopping the whole optimization run.
         """
-        return None, None
+        _ = optuna_trial_id
+        orchestrator = self._orchestrator
+        smart_pruning = self._smart_pruning_config()
+        if smart_pruning is None or not session_id:
+            return None, None
+
+        is_cloud_brain_run = getattr(orchestrator, "_is_cloud_brain_run", None)
+        if not callable(is_cloud_brain_run) or not is_cloud_brain_run():
+            return None, None
+
+        backend_manager = getattr(orchestrator, "backend_session_manager", None)
+        if not bool(getattr(backend_manager, "backend_tracking_enabled", False)):
+            return None, None
+
+        client = getattr(orchestrator, "backend_client", None) or getattr(
+            orchestrator, "_cloud_guidance_client", None
+        )
+        reporter = getattr(client, "report_intermediate_trial", None)
+        if not callable(reporter):
+            return None, None
+
+        objective_name = self._primary_objective_name()
+        total_examples = len(dataset)
+        progress_state: dict[str, Any] = {
+            "total_examples": total_examples,
+            "evaluated": 0,
+            "correct_sum": 0.0,
+            "total_cost": 0.0,
+            "smart_pruning": True,
+            "smart_pruning_label": smart_pruning.get("label"),
+            "stop_reason": "smart_prune",
+        }
+        if objective_name:
+            progress_state["objective_name"] = objective_name
+
+        scores_by_index: dict[int, float] = {}
+        costs_by_index: dict[int, float] = {}
+        reported_indices: set[int] = set()
+
+        def progress_callback(example_index: int, payload: dict[str, Any]) -> None:
+            if not isinstance(payload, dict):
+                return
+            score = self._extract_progress_score(payload, objective_name)
+            if score is None:
+                return
+            if example_index in reported_indices:
+                return
+
+            scores_by_index[int(example_index)] = score
+            cost = self._extract_progress_cost(payload)
+            if cost is not None:
+                costs_by_index[int(example_index)] = cost
+
+            examples_attempted = max(max(scores_by_index) + 1, len(scores_by_index))
+            payload_attempted = payload.get("examples_attempted")
+            if isinstance(payload_attempted, int) and not isinstance(
+                payload_attempted, bool
+            ):
+                examples_attempted = max(examples_attempted, payload_attempted)
+            running_score = sum(scores_by_index.values()) / len(scores_by_index)
+            partial_cost_usd = sum(costs_by_index.values()) if costs_by_index else 0.0
+            reported_indices.add(int(example_index))
+
+            progress_state.update(
+                {
+                    "evaluated": len(scores_by_index),
+                    "examples_attempted": examples_attempted,
+                    "running_score": running_score,
+                    "correct_sum": sum(scores_by_index.values()),
+                    "total_cost": partial_cost_usd,
+                }
+            )
+
+            try:
+                response = self._call_intermediate_report(
+                    reporter=reporter,
+                    session_id=session_id,
+                    trial_id=trial_id,
+                    running_score=running_score,
+                    examples_attempted=examples_attempted,
+                    partial_cost_usd=partial_cost_usd,
+                    objective_name=objective_name,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Skipping smart-pruning decision for trial %s after "
+                    "intermediate-report failure: %s",
+                    trial_id,
+                    exc,
+                )
+                return
+            if self._response_prune(response):
+                prune_reason = self._response_prune_reason(response)
+                if prune_reason:
+                    progress_state["prune_reason"] = prune_reason
+                raise TrialPrunedError(
+                    prune_reason or "smart_prune",
+                    step=examples_attempted,
+                )
+
+        return progress_callback, progress_state
+
+    def _smart_pruning_config(self) -> dict[str, Any] | None:
+        """Read the normalized smart-pruning config from the orchestrator."""
+        orchestrator = self._orchestrator
+        getter = getattr(orchestrator, "_smart_pruning_config", None)
+        if callable(getter):
+            value = getter()
+            return dict(value) if isinstance(value, dict) else None
+        raw = getattr(orchestrator, "config", {}).get("smart_pruning")
+        if raw is None:
+            custom_params = getattr(
+                getattr(orchestrator, "traigent_config", None),
+                "custom_params",
+                {},
+            )
+            if isinstance(custom_params, dict):
+                raw = custom_params.get("smart_pruning")
+        return dict(raw) if isinstance(raw, dict) else None
+
+    def _primary_objective_name(self) -> str | None:
+        """Return the objective name to use for running-score reports."""
+        orchestrator = self._orchestrator
+        objective_schema = getattr(orchestrator, "objective_schema", None)
+        schema_objectives = getattr(objective_schema, "objectives", None)
+        if schema_objectives:
+            first = schema_objectives[0]
+            name = getattr(first, "name", None)
+            if isinstance(name, str) and name:
+                return name
+
+        for source in (
+            getattr(getattr(orchestrator, "optimizer", None), "objectives", None),
+            getattr(orchestrator, "objectives", None),
+        ):
+            if source:
+                first = source[0]
+                if isinstance(first, str) and first:
+                    return first
+        return None
+
+    @staticmethod
+    def _extract_numeric(value: Any) -> float | None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value)
+
+    @classmethod
+    def _extract_progress_score(
+        cls,
+        payload: dict[str, Any],
+        objective_name: str | None,
+    ) -> float | None:
+        metrics = payload.get("metrics")
+        if isinstance(metrics, dict):
+            if objective_name and objective_name in metrics:
+                value = cls._extract_numeric(metrics.get(objective_name))
+                if value is not None:
+                    return value
+            for key in ("score", "accuracy", "f1", "quality"):
+                value = cls._extract_numeric(metrics.get(key))
+                if value is not None:
+                    return value
+            for key, raw_value in metrics.items():
+                if key in {"examples_attempted", "total_cost", "cost"}:
+                    continue
+                value = cls._extract_numeric(raw_value)
+                if value is not None:
+                    return value
+
+        if objective_name:
+            value = cls._extract_numeric(payload.get(objective_name))
+            if value is not None:
+                return value
+        return cls._extract_numeric(payload.get("score"))
+
+    @classmethod
+    def _extract_progress_cost(cls, payload: dict[str, Any]) -> float | None:
+        for source in (payload.get("metrics"), payload.get("llm_metrics"), payload):
+            if not isinstance(source, dict):
+                continue
+            for key in (
+                "partial_cost_usd",
+                "total_cost_usd",
+                "total_cost",
+                "cost_usd",
+                "cost",
+            ):
+                value = cls._extract_numeric(source.get(key))
+                if value is not None:
+                    return max(value, 0.0)
+        return None
+
+    @staticmethod
+    def _await_if_needed(value: Any) -> Any:
+        if not inspect.isawaitable(value):
+            return value
+
+        async def _await_value() -> Any:
+            return await value
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(_await_value())
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(lambda: asyncio.run(_await_value())).result()
+
+    def _call_intermediate_report(
+        self,
+        *,
+        reporter: Callable[..., Any],
+        session_id: str,
+        trial_id: str,
+        running_score: float,
+        examples_attempted: int,
+        partial_cost_usd: float,
+        objective_name: str | None,
+    ) -> Any:
+        response = reporter(
+            session_id=session_id,
+            trial_id=trial_id,
+            running_score=running_score,
+            examples_attempted=examples_attempted,
+            partial_cost_usd=partial_cost_usd,
+            objective_name=objective_name,
+        )
+        return self._await_if_needed(response)
+
+    @staticmethod
+    def _response_prune(response: Any) -> bool:
+        if isinstance(response, dict):
+            return bool(response.get("prune"))
+        return bool(getattr(response, "prune", False))
+
+    @staticmethod
+    def _response_prune_reason(response: Any) -> str | None:
+        value = (
+            response.get("prune_reason")
+            if isinstance(response, dict)
+            else getattr(response, "prune_reason", None)
+        )
+        return value if isinstance(value, str) and value else None
 
     # =========================================================================
     # Budget Management

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import copy
 from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 from traigent.api.types import (
     ComparabilityInfo,
@@ -553,6 +553,26 @@ def build_pruned_result(
             metadata["examples_attempted"] = evaluated
             # Also add to metrics for backend submission
             metrics["examples_attempted"] = float(evaluated)
+
+        running_score_value = progress_state.get("running_score")
+        objective_name = progress_state.get("objective_name")
+        if isinstance(objective_name, str) and objective_name:
+            try:
+                running_score = float(cast(Any, running_score_value))
+                metrics[objective_name] = running_score
+                metadata["running_score"] = running_score
+                metadata["objective_name"] = objective_name
+            except (TypeError, ValueError):
+                logger.debug(
+                    "Unable to preserve running_score for pruned trial %s: %s",
+                    trial_id,
+                    running_score_value,
+                )
+
+        for key in ("stop_reason", "prune_reason", "smart_pruning_label"):
+            value = progress_state.get(key)
+            if value is not None:
+                metadata[key] = value
 
         total_cost_value = progress_state.get("total_cost")
         if total_cost_value is not None:

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -733,6 +733,7 @@ class LocalEvaluator(BaseEvaluator):
         example_metric: ExampleMetrics,
         example_result: Any,
         output: Any,
+        example_index: int,
     ) -> dict[str, Any]:
         """Build payload for progress callback in local evaluation mode.
 
@@ -743,6 +744,7 @@ class LocalEvaluator(BaseEvaluator):
             example_metric: Current example metrics
             example_result: Example result (if in detailed mode)
             output: Function output
+            example_index: Zero-based dataset example index.
 
         Returns:
             Payload dictionary for progress callback
@@ -760,12 +762,16 @@ class LocalEvaluator(BaseEvaluator):
                     continue
                 payload_metrics.setdefault(key, value)
 
-        return {
+        payload: dict[str, Any] = {
             "success": example_metric.success,
             "error": example_metric.error,
             "metrics": payload_metrics,
             "output": output,
+            "examples_attempted": example_index + 1,
         }
+        if total_cost_value is not None:
+            payload["partial_cost_usd"] = float(total_cost_value)
+        return payload
 
     def _extract_llm_metrics_for_output(
         self,
@@ -1140,7 +1146,7 @@ class LocalEvaluator(BaseEvaluator):
                 else None
             )
             payload = self._build_local_progress_payload(
-                example_metric, example_result_for_progress, output
+                example_metric, example_result_for_progress, output, index
             )
             progress_callback(index, payload)
 


### PR DESCRIPTION
## What
SDK side of **smart pruning** (stacked on the optuna-eviction branch). Public `smart_pruning`
(label + optional params) on `optimize()`/`ExecutionOptions`, forwarded in session-create;
`StopReason += "smart_prune"`; per-trial mid-execution wiring.

- During a cloud-guided trial the kept intermediate hook POSTs `/sessions/{id}/intermediate-report`;
  `prune=True` → raises `TrialPrunedError` → existing `build_pruned_result` records
  `TrialStatus.PRUNED` (reuses the generic machinery the eviction deliberately kept).
- Backend `stop_reason`/`prune_reason` surfaced into `OptimizationResult.stop_reason`.

## Evidence
Unit test at the mocked client boundary 2/2 (independently re-verified): `prune=True`→PRUNED,
`prune=False`→trial runs. `trial_lifecycle.py:426` catch path confirmed.

## Notes
- **Base = `chore/sdk-optuna-eviction-finish`** (PR #1411) so this diff shows only the wiring;
  retarget to `develop` after #1411 merges. **Depends on** TraigentSchema#213.
- Limitation: `LocalEvaluator(detailed=True)` batch path prunes at batch boundary, not mid-batch;
  the per-example/custom-evaluator path is true mid-execution.

Spine-Trail: st_35d9a62fdd6a
Spine: none (reason: additive surface; reuses existing pruned-trial machinery)
