### PR TITLE
chore: open 0.17.0 dev cycle (develop -> 0.17.0.dev0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.16.0.dev0"
+version = "0.17.0.dev0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## What

Bump SDK develop version `0.16.0.dev0` -> `0.17.0.dev0` to open the next dev cycle.

## Why

The `0.16.0` GA has shipped (tag `v0.16.0`, on PyPI), but develop still carried the stale `0.16.0.dev0` marker despite having newer content (#1411 optuna-eviction, etc.). Bumping to `0.17.0.dev0` lets the latest develop code be pip-installed as a pre-release (`pip install --pre traigent`). Mirrors the prior "open next dev cycle" chore (#1390 set `0.16.0.dev0` after the 0.15.0 release).

## Scope

Single-line change. `pyproject.toml` is the single source of truth: `traigent/_version.py` reads it dynamically and `traigent/__init__.py` exposes `__version__` via `get_version()`. Verified `get_version()` -> `0.17.0.dev0`; no remaining `0.16.0.dev0` literals anywhere in the tree.

After merge, the pre-release is published to PyPI via `publish.yml` workflow_dispatch (`environment=pypi`, `confirm_publish=true`), same path used for `0.16.0.dev0`.

### PR checklist
1. **Worst-case prod path** — none. Version-string-only chore; no policy surface, no runtime branch changes.
2. **Production-branch test** — n/a (no policy code).
3. **Contract regeneration** — none. No schema/DTO changes.
4. **Public surface delta** — only `__version__` string value changes (expected); no `__all__`/route/optimizer changes.
5. **Review threads resolved** — n/a at open; will resolve any before merge.
6. **Quality gates not relaxed** — none touched.

Spine-Trail: st_745306ebb0f7

🤖 Generated with [Claude Code](https://claude.com/claude-code)