### PR TITLE
ci(spine-pr-scan): fix SPINE_REF drift + token fallback (root cause)

### DIFF
--- a/.github/workflows/validation-spine-pr.yml
+++ b/.github/workflows/validation-spine-pr.yml
@@ -44,9 +44,16 @@ jobs:
     timeout-minutes: 15
     continue-on-error: true  # advisory mode — promote to blocking after calibration
     env:
-      SPINE_REF: 0dc2d057e7e33e71acc882388b546e5808e4002b  # pragma: allowlist secret
+      # MUST point at a spine commit that has the `validation security-ledger` CLI
+      # (added 2026-05-14, commit 42bbba8). The old pin 0dc2d057 (2026-05-13)
+      # predated it, so the scan exited "invalid choice: security-ledger" and
+      # failed with "no gap report emitted". Matches TraigentSchema develop's pin.
+      # When changing the scan command below, bump this ref in lockstep.
+      SPINE_REF: 7766f10589b24971696c63d0235763a743cd9cd3  # pragma: allowlist secret
       SPINE_FILE_LIMIT: "5000"
-      SPINE_RO_TOKEN: ${{ secrets.SPINE_RO_TOKEN }}
+      # Prefer a dedicated read-only spine token; fall back to this repo's existing
+      # VALIDATION_CI_PAT so the scan runs instead of failing closed when unset.
+      SPINE_RO_TOKEN: ${{ secrets.SPINE_RO_TOKEN || secrets.VALIDATION_CI_PAT }}
 
     steps:
       # Checkout the product repo as $GITHUB_WORKSPACE/Traigent/ so the


### PR DESCRIPTION
## Root cause
`validation-spine-pr.yml` (the `spine-pr-scan` check) runs `validation security-ledger run`,
but its pinned `SPINE_REF 0dc2d057` (2026-05-13) predated the `security-ledger` CLI subcommand,
added to the spine on **2026-05-14** (commit `42bbba8`). So the scanner exited
`invalid choice: security-ledger` (exit 2), wrote no gaps file, and the gate failed closed with
the misleading "no gap report emitted." Separately, the workflow referenced an unset
`SPINE_RO_TOKEN` while the repo has `VALIDATION_CI_PAT`.

## Fix (mirrors TraigentSchema develop)
1. Bump `SPINE_REF` `0dc2d057` → `7766f105` (spine `develop` HEAD — has `security-ledger run` with
   the exact `--workspace-root/--health-dir/--file-limit` args this workflow passes), with a comment
   requiring the pin to stay >= the command so it can't silently drift again.
2. `SPINE_RO_TOKEN || VALIDATION_CI_PAT` fallback so the scan runs instead of failing closed.

The equivalent fix already works on TraigentSchema (spine scan runs end-to-end; security_ledger +
summarize both green). This is the only other product repo whose `develop` still carried the stale
workflow (BE/FE/js/smartopt don't have it).

Spine-Trail: st_81fe2ea382fa
Spine: none (reason: CI workflow config fix; no policy surface)
