### PR TITLE
fix(sync): post-hoc sync of completed sessions — 409 EXPERIMENT_HAS_NO_RUNS + dry-run/exit + idempotent resume (#1420)

### DIFF
--- a/tests/unit/cli/test_sync_command.py
+++ b/tests/unit/cli/test_sync_command.py
@@ -94,3 +94,63 @@ def test_sync_requires_api_key_when_not_dry_run():
 
     assert result.exit_code == 1
     assert "API key required" in result.output
+
+
+def test_sync_single_session_failure_exits_nonzero():
+    """A failed real sync (non dry-run) must exit non-zero so CI detects it.
+
+    Regression test for issue #1420 sub-bug (b): `traigent sync` was exiting 0
+    on failure, causing CI/scripts to believe the session was uploaded.
+    """
+    manager = _patched_manager()
+    manager.sync_session_to_cloud.return_value = {
+        "session_id": "s1",
+        "status": "error",
+        "errors": ["Experiment sync failed: HTTP 409: EXPERIMENT_HAS_NO_RUNS"],
+    }
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "s1", "--api-key", "k"])
+
+    assert result.exit_code == 1, (
+        f"Expected exit code 1 on sync failure but got {result.exit_code}"
+    )
+
+
+def test_sync_all_failure_exits_nonzero():
+    """sync --all with any error exits non-zero."""
+    manager = _patched_manager()
+    manager.sync_all_sessions.return_value = {
+        "total_sessions": 2,
+        "eligible_sessions": 2,
+        "synced_successfully": 0,
+        "skipped": 0,
+        "sync_errors": 2,
+        "dry_run": False,
+        "session_results": [
+            {"session_id": "s1", "status": "error", "errors": ["409"]},
+            {"session_id": "s2", "status": "error", "errors": ["409"]},
+        ],
+        "overall_status": "failed",
+    }
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "--all", "--api-key", "k"])
+
+    assert result.exit_code == 1, (
+        f"Expected exit code 1 when all syncs fail but got {result.exit_code}"
+    )
+
+
+def test_sync_failure_in_dry_run_exits_zero():
+    """--dry-run is non-destructive; failures in dry mode don't set exit code 1."""
+    manager = _patched_manager()
+    manager.sync_session_to_cloud.return_value = {
+        "session_id": "s1",
+        "status": "error",
+        "errors": ["Dry-run detected ordering issue"],
+        "dry_run": True,
+    }
+    with patch("traigent.cli.sync_commands.SyncManager", return_value=manager):
+        result = CliRunner().invoke(cli, ["sync", "s1", "--dry-run"])
+
+    # Dry-run exit code is 0 even when it predicts failure (it's informational).
+    assert result.exit_code == 0

--- a/tests/unit/cloud/test_sync_idempotency.py
+++ b/tests/unit/cloud/test_sync_idempotency.py
@@ -56,10 +56,22 @@ def _stub_backend_success(sync_manager: SyncManager) -> dict[str, Mock]:
         "_sync_experiment_run": Mock(
             return_value={"success": True, "experiment_run_id": "run1"}
         ),
+        # The post-hoc sync now finalizes the experiment to COMPLETED via
+        # PUT /experiments/{id} after all runs upload (issue #1420); stub it so
+        # the no-HTTP success path reaches finalization without a real request.
+        "_finalize_experiment": Mock(return_value={"success": True}),
     }
 
-    def _runs(_run_id, configuration_runs):
-        return {"success": True, "synced": len(configuration_runs), "errors": []}
+    # ``_sync_configuration_runs`` gained ``already_synced_keys`` / ``on_synced``
+    # kwargs and now returns a ``skipped`` count (resume idempotency, #1420).
+    # Mirror the real contract: accept the kwargs and report 0 skipped.
+    def _runs(_run_id, configuration_runs, **_kwargs):
+        return {
+            "success": True,
+            "synced": len(configuration_runs),
+            "skipped": 0,
+            "errors": [],
+        }
 
     mocks["_sync_configuration_runs"] = Mock(side_effect=_runs)
     for name, mock in mocks.items():

--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -445,7 +445,11 @@ class TestSyncManager:
 
         # Check experiment template
         assert result["experiment"]["name"] == "Local Import: test_function"
-        assert result["experiment"]["status"] == "COMPLETED"
+        # Experiment is created with PENDING (non-run-requiring) so the backend
+        # accepts it before runs exist.  Both RUNNING and COMPLETED are rejected at
+        # create time with 409 EXPERIMENT_HAS_NO_RUNS (#1420).
+        # _finalize_experiment transitions it to COMPLETED via PUT after all runs.
+        assert result["experiment"]["status"] == "PENDING"
         assert result["experiment"]["measures"]
         assert "agent_id" not in result["experiment"]
         assert "dataset_id" not in result["experiment"]
@@ -549,7 +553,9 @@ class TestSyncManager:
         assert experiment_payload["agent_id"] == "agent-id"
         assert experiment_payload["dataset_id"] == "benchmark-id"
         assert experiment_payload["measures"]
-        assert experiment_payload["status"] == "COMPLETED"
+        # Experiment is POSTed with PENDING; _finalize_experiment PUTs to COMPLETED.
+        # RUNNING and COMPLETED are both rejected at create time (#1420).
+        assert experiment_payload["status"] == "PENDING"
 
         experiment_run_payload = sync_manager._build_experiment_run_payload(
             result["experiment_run"], "agent-id", "benchmark-id"
@@ -650,9 +656,10 @@ class TestSyncManager:
         """Test successful sync of session to cloud."""
         sync_manager.storage.load_session.return_value = sample_session
 
-        # Mock successful responses
+        # Mock successful responses; PUT is used for experiment finalization.
         sync_manager._session.get.return_value = backend_response(404)
         sync_manager._session.post.return_value = backend_response()
+        sync_manager._session.put.return_value = backend_response(status_code=200)
 
         result = sync_manager.sync_session_to_cloud("test_session_123")
 
@@ -665,7 +672,18 @@ class TestSyncManager:
     def test_sync_session_to_cloud_posts_current_sequence_and_threads_ids(
         self, sync_manager: SyncManager, sample_session: OptimizationSession
     ) -> None:
-        """Full mocked flow posts current endpoints and returned IDs."""
+        """Full mocked flow posts current endpoints and returned IDs.
+
+        Verifies the ordering contract required by issue #1420:
+          1. POST /experiments with status=PENDING (non-run-requiring)
+          2. POST /experiment-runs/{id}/runs
+          3. POST /configuration-runs/... (N times)
+          4. PUT  /experiments/{id} with status=COMPLETED
+
+        The backend rejects both RUNNING and COMPLETED at create time with
+        409 EXPERIMENT_HAS_NO_RUNS.  The finalization route is PUT, not PATCH
+        (TraigentBackend src/routes/experiment_routes.py:1058).
+        """
         sync_manager.storage.load_session.return_value = sample_session
         sync_manager._session.get.return_value = backend_response(404)
         sync_manager._session.post.side_effect = [
@@ -683,6 +701,8 @@ class TestSyncManager:
             backend_response(payload={"id": "configuration-run-2"}),
             backend_response(payload={"id": "configuration-run-3"}),
         ]
+        # PUT /experiments/{id} finalizes to COMPLETED after all runs are uploaded.
+        sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
             "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
@@ -711,11 +731,18 @@ class TestSyncManager:
             "experiment-run-id/configurations",
         ]
 
+        # Verify experiment is created with PENDING (non-run-requiring) — the
+        # fix for issue #1420: both RUNNING and COMPLETED before runs exist
+        # cause 409 EXPERIMENT_HAS_NO_RUNS on the real backend.
         experiment_payload = post_calls[2].kwargs["json"]
         assert experiment_payload["agent_id"] == "agent-id"
         assert experiment_payload["dataset_id"] == "benchmark-id"
         assert experiment_payload["measures"]
-        assert experiment_payload["status"] == "COMPLETED"
+        assert experiment_payload["status"] == "PENDING", (
+            "Experiment must be created with status=PENDING (non-run-requiring) "
+            "so the backend accepts it before any experiment_run exists (#1420). "
+            "Both RUNNING and COMPLETED are rejected at create time."
+        )
 
         experiment_run_payload = post_calls[3].kwargs["json"]
         assert set(experiment_run_payload) == {"experiment_data"}
@@ -726,13 +753,62 @@ class TestSyncManager:
             "configurations": experiment_payload["configurations"],
         }
 
+        # Verify PUT /experiments/{id} with status=COMPLETED was called last.
+        # The backend exposes only PUT (not PATCH) for experiment updates
+        # (TraigentBackend src/routes/experiment_routes.py:1058).
+        put_calls = sync_manager._session.put.call_args_list
+        assert len(put_calls) == 1, "Expected exactly one PUT to finalize experiment"
+        assert put_calls[0].args[0] == (
+            f"{sync_manager.base_url}/experiments/experiment-id"
+        )
+        assert put_calls[0].kwargs["json"] == {"status": "COMPLETED"}
+
+    @staticmethod
+    def _wire_persisting_sync_state(
+        sync_manager: SyncManager, session: OptimizationSession
+    ) -> None:
+        """Make the mocked storage actually mutate ``session.sync_state``.
+
+        The default MagicMock ``update_sync_state`` is a no-op, so a resume
+        would never see the incremental per-config-run progress that the SUT
+        persists. This side_effect mirrors the real LocalStorageManager merge
+        (shallow top-level patch + per-trial merge under ``sync_state["trials"]``)
+        so the no-duplicate-on-resume behavior is exercised end-to-end instead
+        of being mocked away.
+        """
+
+        def _persist(session_id, patch, *, trial_updates=None):
+            state = dict(session.sync_state or {})
+            state.update(patch)
+            if trial_updates:
+                trials_state = dict(state.get("trials") or {})
+                for trial_key, trial_patch in trial_updates.items():
+                    merged = dict(trials_state.get(trial_key) or {})
+                    merged.update(trial_patch)
+                    trials_state[trial_key] = merged
+                state["trials"] = trials_state
+            session.sync_state = state
+            return session
+
+        sync_manager.storage.update_sync_state.side_effect = _persist
+
     def test_sync_session_to_cloud_resume_partial_uses_persisted_context_url(
         self, sync_manager: SyncManager, sample_session: OptimizationSession
     ) -> None:
-        """A partial-sync retry preserves project/tenant context in success URL."""
+        """A partial-sync retry preserves context AND skips already-synced runs.
+
+        Regression guard for the data-integrity BLOCKER (#1420): the prior weak
+        version of this test asserted ALL three config-runs were re-POSTed on
+        resume — which is exactly the duplicate-on-retry bug, because the
+        backend does NOT dedup config-run creates (backend issue #1330). The
+        SDK must be idempotent itself: a resume re-POSTs only the config-runs
+        not yet recorded as synced.
+        """
         payload_hash = sync_manager._compute_payload_hash(
             sync_manager.convert_session_to_traigent_format(sample_session)
         )
+        # Prior attempt already uploaded config-runs cfg_0 and cfg_1 (2 of 3);
+        # cfg_2 is the only one left to upload on resume.
         sample_session.sync_state = {
             "status": "partial",
             "payload_hash": payload_hash,
@@ -743,13 +819,25 @@ class TestSyncManager:
             "project_id": "project/alpha",
             "tenant_id": "tenant acme",
             "attempts": 1,
+            "trials": {
+                "cfg_0": {
+                    "status": "synced",
+                    "cloud_configuration_run_id": "configuration-run-0",
+                },
+                "cfg_1": {
+                    "status": "synced",
+                    "cloud_configuration_run_id": "configuration-run-1",
+                },
+            },
         }
         sync_manager.storage.load_session.return_value = sample_session
+        self._wire_persisting_sync_state(sync_manager, sample_session)
+        # Only the single remaining config-run (cfg_2) should be POSTed.
         sync_manager._session.post.side_effect = [
-            backend_response(payload={"id": "configuration-run-1"}),
             backend_response(payload={"id": "configuration-run-2"}),
-            backend_response(payload={"id": "configuration-run-3"}),
         ]
+        # PUT finalizes the experiment to COMPLETED after all runs upload.
+        sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
             "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
@@ -765,20 +853,148 @@ class TestSyncManager:
             == "https://portal.traigent.ai/experiments/view/experiment-id"
             "?project_id=project%2Falpha&tenant_id=tenant%20acme"
         )
-        assert [call.args[0] for call in sync_manager._session.post.call_args_list] == [
-            f"{sync_manager.base_url}/configuration-runs/runs/"
-            "experiment-run-id/configurations",
-            f"{sync_manager.base_url}/configuration-runs/runs/"
-            "experiment-run-id/configurations",
-            f"{sync_manager.base_url}/configuration-runs/runs/"
-            "experiment-run-id/configurations",
+        # No-duplicate guard: exactly ONE config-run POST (the remaining cfg_2),
+        # NOT three. The already-synced cfg_0 / cfg_1 are skipped.
+        config_post_urls = [
+            call.args[0]
+            for call in sync_manager._session.post.call_args_list
+            if "configurations" in call.args[0]
         ]
+        assert config_post_urls == [
+            f"{sync_manager.base_url}/configuration-runs/runs/"
+            "experiment-run-id/configurations",
+        ], (
+            "resume must POST only the not-yet-synced config-run, never re-post synced ones"
+        )
 
-        sync_state_patch = sync_manager.storage.update_sync_state.call_args.args[1]
+        # Finalized to COMPLETED exactly once.
+        put_calls = sync_manager._session.put.call_args_list
+        assert len(put_calls) == 1
+        assert put_calls[0].kwargs["json"] == {"status": "COMPLETED"}
+
+        # cfg_2 now recorded as synced so a further resume is a clean no-op.
+        assert sample_session.sync_state["trials"]["cfg_2"] == {
+            "status": "synced",
+            "cloud_configuration_run_id": "configuration-run-2",
+        }
+
+        # Top-level outcome patch still carries context + attempt bookkeeping.
+        outcome_calls = [
+            call
+            for call in sync_manager.storage.update_sync_state.call_args_list
+            if call.kwargs.get("trial_updates") is None
+        ]
+        sync_state_patch = outcome_calls[-1].args[1]
         assert sync_state_patch["project_id"] == "project/alpha"
         assert sync_state_patch["tenant_id"] == "tenant acme"
         assert sync_state_patch["cloud_url"] == result["cloud_url"]
         assert sync_state_patch["attempts"] == 2
+
+    def test_sync_resume_does_not_duplicate_config_runs_after_midbatch_failure(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """End-to-end no-duplicate-on-retry guard for the #1420 data-integrity fix.
+
+        Scenario (matches the codex BLOCKER reproduction):
+          - sample_session has 3 config-runs (cfg_0, cfg_1, cfg_2).
+          - Attempt 1: config-run #2 (cfg_1) FAILS with a 500; cfg_0 and cfg_2
+            succeed. The attempt records itself as ``partial``.
+          - Attempt 2 (resume, same payload_hash): cfg_0 and cfg_2 are recorded
+            as synced and MUST NOT be re-POSTed (the backend does not dedup —
+            backend issue #1330). Only cfg_1 is re-POSTed.
+          - After the resume the experiment is finalized to COMPLETED exactly
+            once and every config-run is POSTed exactly once across the two
+            attempts (no duplicates).
+        """
+        sample_session.sync_state = None
+        sync_manager.storage.load_session.return_value = sample_session
+        self._wire_persisting_sync_state(sync_manager, sample_session)
+
+        # --- Attempt 1: cfg_1 (the 2nd config-run POST) fails with 500. ---
+        # Order of POSTs: agent, benchmark, experiment, experiment-run,
+        # then config-runs cfg_0, cfg_1, cfg_2.
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.side_effect = [
+            backend_response(payload={"id": "agent-id"}),
+            backend_response(payload={"id": "benchmark-id"}),
+            backend_response(payload={"id": "experiment-id"}),
+            backend_response(payload={"id": "experiment-run-id"}),
+            backend_response(payload={"id": "configuration-run-0"}),  # cfg_0 OK
+            backend_response(status_code=500, text="config 2 failed"),  # cfg_1 FAIL
+            backend_response(payload={"id": "configuration-run-2"}),  # cfg_2 OK
+        ]
+        # Finalization is gated on a clean upload, so it is not reached here.
+        sync_manager._session.put.return_value = backend_response(status_code=200)
+
+        with patch(
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            return_value="https://portal.traigent.ai/",
+        ):
+            first = sync_manager.sync_session_to_cloud("test_session_123")
+
+        assert first["status"] == "partial"
+        # cfg_0 and cfg_2 persisted as synced; cfg_1 NOT (it failed).
+        trials_state = sample_session.sync_state["trials"]
+        assert trials_state["cfg_0"]["status"] == "synced"
+        assert trials_state["cfg_2"]["status"] == "synced"
+        assert "cfg_1" not in trials_state
+        # No finalize on a partial upload — the experiment stays un-completed so
+        # the resume can finish it.
+        assert sync_manager._session.put.call_count == 0
+
+        # --- Attempt 2: resume. Only cfg_1 must be re-POSTed. ---
+        sync_manager._session.post.reset_mock()
+        sync_manager._session.put.reset_mock()
+        sync_manager._session.get.reset_mock()
+        # Resume reuses saved agent/benchmark/experiment/run ids, so the ONLY
+        # POST in attempt 2 is the single retried config-run cfg_1.
+        sync_manager._session.post.side_effect = [
+            backend_response(payload={"id": "configuration-run-1"}),  # cfg_1 retry
+        ]
+        sync_manager._session.put.return_value = backend_response(status_code=200)
+
+        with patch(
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            return_value="https://portal.traigent.ai/",
+        ):
+            second = sync_manager.sync_session_to_cloud("test_session_123")
+
+        assert second["status"] == "success"
+
+        # CORE ASSERTION — no duplicate config-run POSTs on resume.
+        config_posts = [
+            call
+            for call in sync_manager._session.post.call_args_list
+            if "configurations" in call.args[0]
+        ]
+        # Exactly one config-run POST on resume: the previously-failed cfg_1.
+        assert len(config_posts) == 1, (
+            "resume must NOT re-post the already-synced config-runs (cfg_0/cfg_2); "
+            f"got {len(config_posts)} config-run POSTs"
+        )
+        # And it carried cfg_1's payload — the trial that actually failed before.
+        # Derive the expected per-config-run payloads from the SUT's own
+        # conversion so the assertion is grounded in real behavior, not a
+        # hand-mirrored copy.
+        expected_config_runs = sync_manager.convert_session_to_traigent_format(
+            sample_session
+        )["configuration_runs"]
+        retried_payload = config_posts[0].kwargs["json"]
+        assert retried_payload == expected_config_runs[1]  # cfg_1 == index 1
+
+        # Every config-run uploaded exactly once across the two attempts.
+        assert set(sample_session.sync_state["trials"]) == {"cfg_0", "cfg_1", "cfg_2"}
+        for key in ("cfg_0", "cfg_1", "cfg_2"):
+            assert sample_session.sync_state["trials"][key]["status"] == "synced"
+
+        # Experiment finalized to COMPLETED exactly once (only after the clean
+        # resume), never on the failed first attempt.
+        put_calls = sync_manager._session.put.call_args_list
+        assert len(put_calls) == 1, "experiment must be finalized exactly once"
+        assert put_calls[0].args[0] == (
+            f"{sync_manager.base_url}/experiments/experiment-id"
+        )
+        assert put_calls[0].kwargs["json"] == {"status": "COMPLETED"}
 
     def test_sync_session_to_cloud_reuses_agent_and_benchmark_for_idempotency(
         self, sync_manager: SyncManager
@@ -834,6 +1050,8 @@ class TestSyncManager:
             backend_response(payload={"id": "experiment-run-id"}),
             backend_response(payload={"id": "configuration-run-id"}),
         ]
+        # PUT finalizes experiment after all config runs are uploaded.
+        sync_manager._session.put.return_value = backend_response(status_code=200)
 
         result = sync_manager.sync_session_to_cloud("idem-session")
 
@@ -1374,3 +1592,191 @@ class TestSyncManager:
         # The base_url should have trailing slash removed
         assert not sync_manager.base_url.endswith("/")
         assert "http" in sync_manager.base_url
+
+    # Regression tests for issue #1420 — sync ordering and exit code
+
+    def test_sync_run_ordering_experiment_created_pending_then_finalized(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """Completed local session syncs without 409: experiment created PENDING,
+        runs uploaded, then experiment transitioned to COMPLETED via PUT.
+
+        Regression test for issue #1420: the backend rejects
+        POST /experiments with status=RUNNING or COMPLETED when no experiment_run
+        exists (HTTP 409 EXPERIMENT_HAS_NO_RUNS, _RUN_REQUIRING_EXPERIMENT_STATUSES
+        = {RUNNING, COMPLETED}, TraigentBackend src/models/status_enums.py:333).
+        The fix: create with PENDING (non-run-requiring) and PUT to COMPLETED after
+        all runs are uploaded (PUT /experiments/{id}, not PATCH).
+        """
+        sync_manager.storage.load_session.return_value = sample_session
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.side_effect = [
+            backend_response(payload={"id": "agent-id"}),
+            backend_response(payload={"id": "benchmark-id"}),
+            backend_response(payload={"id": "experiment-id"}),
+            backend_response(payload={"id": "experiment-run-id"}),
+            backend_response(payload={"id": "cfg-run-1"}),
+            backend_response(payload={"id": "cfg-run-2"}),
+            backend_response(payload={"id": "cfg-run-3"}),
+        ]
+        sync_manager._session.put.return_value = backend_response(status_code=200)
+
+        with patch(
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            return_value="https://portal.traigent.ai/",
+        ):
+            result = sync_manager.sync_session_to_cloud("test_session_123")
+
+        assert result["status"] == "success", (
+            f"Expected success but got {result['status']}: {result.get('errors')}"
+        )
+
+        # ASSERT ORDERING: experiment POSTed with status=PENDING (non-run-requiring).
+        # Both RUNNING and COMPLETED are rejected at create time with
+        # 409 EXPERIMENT_HAS_NO_RUNS (#1420).
+        post_calls = sync_manager._session.post.call_args_list
+        experiment_post_payload = post_calls[2].kwargs["json"]
+        assert experiment_post_payload["status"] == "PENDING", (
+            "Experiment must be created with status=PENDING (non-run-requiring); "
+            "both RUNNING and COMPLETED before runs exist cause HTTP 409 "
+            "EXPERIMENT_HAS_NO_RUNS (#1420)"
+        )
+
+        # ASSERT ORDERING: runs uploaded BEFORE finalization.
+        # The 4th POST is experiment_run, 5th-7th are configuration_runs.
+        assert post_calls[3].args[0].endswith("/experiment-runs/experiment-id/runs")
+        for cfg_call in post_calls[4:]:
+            assert "configuration-runs" in cfg_call.args[0]
+
+        # ASSERT ORDERING: PUT to COMPLETED is the LAST call, after all runs.
+        # The backend exposes PUT (not PATCH) for experiment updates (#1420 fix).
+        put_calls = sync_manager._session.put.call_args_list
+        assert len(put_calls) == 1, "Expected exactly one PUT to finalize"
+        assert put_calls[0].args[0].endswith("/experiments/experiment-id")
+        assert put_calls[0].kwargs["json"] == {"status": "COMPLETED"}
+
+        # Confirm the final experiment state is COMPLETED in the result.
+        assert result["cloud_experiment_id"] == "experiment-id"
+
+    def test_dry_run_outcome_matches_real_sync_outcome(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """--dry-run predicts the same outcome as the real sync.
+
+        For a session with correct ordering (RUNNING create status), dry-run
+        must report success.  If the ordering regresses to COMPLETED on create,
+        dry-run must report error — not silently claim success while the real
+        sync would 409.
+        """
+        sync_manager.storage.load_session.return_value = sample_session
+
+        # Dry-run on a valid session (RUNNING create status) -> success.
+        dry_result = sync_manager.sync_session_to_cloud(
+            "test_session_123", dry_run=True
+        )
+        assert dry_result["status"] == "success", (
+            f"Dry-run reported {dry_result['status']} for a valid session"
+        )
+        assert dry_result["dry_run"] is True
+        assert "preview" in dry_result
+        assert dry_result["preview"]["ordering_valid"] is True
+        assert dry_result["preview"]["experiment_create_status"] == "PENDING"
+
+        # Simulate the regression: temporarily make the payload use COMPLETED.
+        # Dry-run must detect this and report error, not success.
+        with patch.object(
+            sync_manager,
+            "convert_session_to_traigent_format",
+            return_value={
+                "agent": {"name": "agent", "agent_type_id": "completion"},
+                "benchmark": {"name": "bench", "type": "input-output", "label": "l"},
+                "experiment": {
+                    "name": "exp",
+                    "measures": ["score"],
+                    "configurations": {},
+                    "status": "COMPLETED",  # regression: run-requiring status at create
+                },
+                "experiment_run": {"measures": ["score"], "configurations": {}},
+                "configuration_runs": [],
+            },
+        ):
+            regressed_result = sync_manager.sync_session_to_cloud(
+                "test_session_123", dry_run=True
+            )
+
+        assert regressed_result["status"] == "error", (
+            "Dry-run must report error when experiment would be created with "
+            "status=COMPLETED before any runs (would 409 on real sync)"
+        )
+        assert any(
+            "409" in err or "COMPLETED" in err or "run-requiring" in err
+            for err in regressed_result.get("errors", [])
+        ), (
+            f"Expected a 409/COMPLETED/run-requiring error, got {regressed_result.get('errors')}"
+        )
+
+    def test_dry_run_rejects_running_create_status(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """Dry-run must also flag RUNNING as a run-requiring create-status error.
+
+        The backend rejects both RUNNING and COMPLETED at create time with
+        409 EXPERIMENT_HAS_NO_RUNS.  Dry-run must predict failure for either.
+        """
+        sync_manager.storage.load_session.return_value = sample_session
+
+        with patch.object(
+            sync_manager,
+            "convert_session_to_traigent_format",
+            return_value={
+                "agent": {"name": "agent", "agent_type_id": "completion"},
+                "benchmark": {"name": "bench", "type": "input-output", "label": "l"},
+                "experiment": {
+                    "name": "exp",
+                    "measures": ["score"],
+                    "configurations": {},
+                    "status": "RUNNING",  # run-requiring: backend rejects this too
+                },
+                "experiment_run": {"measures": ["score"], "configurations": {}},
+                "configuration_runs": [],
+            },
+        ):
+            result = sync_manager.sync_session_to_cloud(
+                "test_session_123", dry_run=True
+            )
+
+        assert result["status"] == "error", (
+            "Dry-run must report error when experiment would be created with "
+            "status=RUNNING (also run-requiring, also causes 409 on real sync)"
+        )
+        assert result["preview"]["ordering_valid"] is False
+        assert any(
+            "run-requiring" in err or "RUNNING" in err or "409" in err
+            for err in result.get("errors", [])
+        ), f"Expected a run-requiring/RUNNING/409 error, got {result.get('errors')}"
+
+    def test_sync_experiment_failure_sets_error_status_in_result(
+        self, sync_manager: SyncManager, sample_session: OptimizationSession
+    ) -> None:
+        """A failed experiment POST leaves status as 'partial' (error before runs)."""
+        sync_manager.storage.load_session.return_value = sample_session
+        sync_manager._session.get.return_value = backend_response(404)
+        sync_manager._session.post.side_effect = [
+            backend_response(payload={"id": "agent-id"}),
+            backend_response(payload={"id": "benchmark-id"}),
+            # Experiment POST fails — simulates the 409 that existed before fix.
+            backend_response(
+                status_code=409,
+                text='{"error": "EXPERIMENT_HAS_NO_RUNS"}',
+            ),
+        ]
+
+        result = sync_manager.sync_session_to_cloud("test_session_123")
+
+        # Verify failure is surfaced correctly.
+        assert result["status"] in {"partial", "error"}, (
+            f"Expected partial/error, got {result['status']}"
+        )
+        assert any("Experiment sync failed" in err for err in result.get("errors", []))
+        # _finalize_experiment must NOT be called when experiment creation fails.
+        sync_manager._session.put.assert_not_called()

--- a/traigent/cli/sync_commands.py
+++ b/traigent/cli/sync_commands.py
@@ -121,6 +121,7 @@ def sync_command(
             sys.exit(1)
 
         synced_ids: list[str] = []
+        had_errors = False
         if session_id:
             result = sync_manager.sync_session_to_cloud(
                 session_id, dry_run=dry_run, force=force
@@ -131,6 +132,10 @@ def sync_command(
                 _emit_session_result(result, dry_run=dry_run)
             if result.get("status") in {"success", "already_synced"}:
                 synced_ids.append(session_id)
+            elif not dry_run:
+                # A real sync that did not succeed is a failure — exit non-zero
+                # so callers (CI, scripts) do not assume the session was uploaded.
+                had_errors = True
         else:
             result = sync_manager.sync_all_sessions(dry_run, force=force)
             if as_json:
@@ -149,6 +154,8 @@ def sync_command(
                 for r in result["session_results"]
                 if r.get("status") in {"success", "already_synced"}
             ]
+            if not dry_run and result.get("sync_errors", 0) > 0:
+                had_errors = True
 
         # --clean: delete local copies only for runs verified synced, with backup.
         if clean and not dry_run and synced_ids:
@@ -159,6 +166,9 @@ def sync_command(
                     f"🧹 Cleaned {cleanup['sessions_deleted']} synced run(s) "
                     "(backed up first)."
                 )
+
+        if had_errors:
+            sys.exit(1)
 
     except Exception as e:  # noqa: BLE001 - CLI boundary surfaces a clean message
         click.echo(f"Error syncing to portal: {e}", err=True)

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -9,7 +9,7 @@ import hashlib
 import json
 import os
 import re
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote, urlencode
@@ -329,11 +329,18 @@ class SyncManager:
         }
 
         # agent_id and dataset_id are filled with returned backend IDs at sync time.
+        # Status is PENDING (a non-run-requiring status) so the backend accepts the
+        # POST before any experiment_run exists.  The backend rejects RUNNING and
+        # COMPLETED at create time with 409 EXPERIMENT_HAS_NO_RUNS when no runs
+        # exist yet (_RUN_REQUIRING_EXPERIMENT_STATUSES = {RUNNING, COMPLETED},
+        # TraigentBackend src/models/status_enums.py:333, issue #1420).
+        # After all runs are uploaded, _upload_session transitions the experiment
+        # to COMPLETED via PUT /experiments/{id} {"status":"COMPLETED"}.
         experiment_data = {
             "name": f"Local Import: {session.function_name}",
             "measures": measures,
             "configurations": configurations,
-            "status": "COMPLETED",
+            "status": "PENDING",
         }
 
         # experiment_data is filled with returned backend IDs at sync time.
@@ -469,6 +476,20 @@ class SyncManager:
         canonical = json.dumps(traigent_data, sort_keys=True, default=str)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
 
+    @staticmethod
+    def _config_run_key(index: int) -> str:
+        """Stable key identifying a configuration-run within a session's batch.
+
+        Configuration runs are derived deterministically from
+        ``session.trials`` in order (see
+        ``_convert_trials_to_configuration_runs``), so the zero-based position
+        in that list is a stable identity across sync attempts of the SAME
+        content. We record which config-runs already uploaded under this key so
+        a resume never re-POSTs them — the backend does NOT dedup config-run
+        creates (backend issue #1330), so the SDK must be idempotent itself.
+        """
+        return f"cfg_{index}"
+
     def sync_session_to_cloud(
         self, session_id: str, dry_run: bool = False, force: bool = False
     ) -> dict[str, Any]:
@@ -527,18 +548,44 @@ class SyncManager:
                 return sync_result
 
             if dry_run:
-                # Preserve the legacy "success" status for an un-synced
-                # validation run; only flag the already-synced case distinctly.
-                sync_result["status"] = (
-                    "already_synced" if already_synced else "success"
-                )
+                # Dry-run mirrors the real sync ordering so it predicts the same
+                # outcome.  The experiment is now created with status=PENDING (a
+                # non-run-requiring status).  The backend rejects RUNNING and
+                # COMPLETED at create time with 409 EXPERIMENT_HAS_NO_RUNS when no
+                # runs exist yet (_RUN_REQUIRING_EXPERIMENT_STATUSES = {RUNNING,
+                # COMPLETED}, issue #1420).  Validate the converted payload and flag
+                # any status that would cause the real sync to fail.
+                trial_count = len(traigent_data["configuration_runs"])
+                experiment_create_status = traigent_data["experiment"].get("status")
+                # Catch regressions where the create status is run-requiring
+                # (RUNNING or COMPLETED) — both would 409 on a real sync.
+                _RUN_REQUIRING = {"RUNNING", "COMPLETED"}
+                ordering_valid = (
+                    experiment_create_status or ""
+                ).upper() not in _RUN_REQUIRING
+
+                if already_synced:
+                    sync_result["status"] = "already_synced"
+                elif not ordering_valid:
+                    # The payload would 409 — flag as predictable failure.
+                    sync_result["status"] = "error"
+                    sync_result["errors"].append(
+                        f"Dry-run detected experiment would be created with "
+                        f"status={experiment_create_status!r} which is run-requiring "
+                        "(RUNNING or COMPLETED); this would 409 EXPERIMENT_HAS_NO_RUNS "
+                        "on the real sync — use a non-run-requiring status (e.g. PENDING)"
+                    )
+                else:
+                    sync_result["status"] = "success"
                 sync_result["preview"] = {
                     "experiment_name": traigent_data["experiment"]["name"],
                     "agent_name": traigent_data["agent"]["name"],
                     "benchmark_name": traigent_data["benchmark"]["name"],
-                    "trial_count": len(traigent_data["configuration_runs"]),
+                    "trial_count": trial_count,
                     "best_score": session.best_score,
                     "already_synced": already_synced,
+                    "experiment_create_status": experiment_create_status,
+                    "ordering_valid": ordering_valid,
                 }
                 return sync_result
 
@@ -562,7 +609,11 @@ class SyncManager:
             )
             try:
                 self._upload_session(
-                    traigent_data, sync_result, prior_state, resume=resume
+                    session_id,
+                    traigent_data,
+                    sync_result,
+                    prior_state,
+                    resume=resume,
                 )
             except Exception as e:
                 sync_result["status"] = "error"
@@ -577,6 +628,7 @@ class SyncManager:
 
     def _upload_session(
         self,
+        session_id: str,
         traigent_data: dict[str, Any],
         sync_result: dict[str, Any],
         prior_state: dict[str, Any],
@@ -665,19 +717,89 @@ class SyncManager:
         sync_result["cloud_experiment_run_id"] = experiment_run_id
         successful_steps += 1
 
+        # Resume idempotency (BLOCKER fix): on a retry of the SAME content we
+        # must NOT re-POST configuration-runs a prior attempt already created —
+        # the backend does not dedup config-run creates (backend issue #1330),
+        # so a re-POST silently duplicates rows. We persist each config-run as
+        # synced (keyed by its stable position) immediately after its POST
+        # succeeds, and on resume we skip the ones already recorded.
+        already_synced_keys: set[str] = set()
+        if reuse:
+            prior_trials = prior_state.get("trials")
+            if isinstance(prior_trials, dict):
+                already_synced_keys = {
+                    key
+                    for key, record in prior_trials.items()
+                    if isinstance(record, dict) and record.get("status") == "synced"
+                }
+
+        def _record_config_run_synced(
+            key: str, configuration_run_id: str | None
+        ) -> None:
+            """Persist one config-run as synced right after its POST succeeds.
+
+            Crash-safe: written incrementally (not batched at the end) so a
+            crash/failure mid-batch still leaves a durable marker that lets the
+            next resume skip the already-uploaded rows.
+            """
+            try:
+                self.storage.update_sync_state(
+                    session_id,
+                    {},
+                    trial_updates={
+                        key: {
+                            "status": "synced",
+                            "cloud_configuration_run_id": configuration_run_id,
+                        }
+                    },
+                )
+            except (
+                Exception
+            ) as exc:  # pragma: no cover - bookkeeping must not break sync
+                logger.warning(
+                    "Failed to persist config-run progress (%s) for session %s: %s",
+                    key,
+                    session_id,
+                    exc,
+                )
+
         configuration_result = self._sync_configuration_runs(
-            experiment_run_id, configuration_runs
+            experiment_run_id,
+            configuration_runs,
+            already_synced_keys=already_synced_keys,
+            on_synced=_record_config_run_synced,
         )
+        # Both freshly-synced AND already-synced (skipped) config-runs count as
+        # done, so a fully-resumed session can still reach total_steps and be
+        # finalized to COMPLETED.
         successful_steps += configuration_result["synced"]
+        successful_steps += configuration_result["skipped"]
         if not configuration_result["success"]:
             sync_result["errors"].extend(
                 f"Configuration run sync failed: {error}"
                 for error in configuration_result["errors"]
             )
 
+        # Transition the experiment from RUNNING to COMPLETED now that all runs
+        # are uploaded.  This ordering is required: the backend rejects the
+        # POST /experiments payload when status=COMPLETED and no runs exist yet
+        # (HTTP 409 EXPERIMENT_HAS_NO_RUNS).  We finalize only on a clean upload
+        # (all config-runs synced); a partial upload stays RUNNING so a retry
+        # can resume and finish it.
+        if configuration_result["success"]:
+            finalize_result = self._finalize_experiment(experiment_id)
+            if not finalize_result["success"]:
+                sync_result["errors"].append(
+                    f"Experiment finalization failed: {finalize_result['error']}"
+                )
+                # Successful configuration uploads but failed finalization is partial.
+                if successful_steps == total_steps:
+                    sync_result["status"] = "partial"
+                    return
+
         if successful_steps == 0:
             sync_result["status"] = "error"  # Complete failure
-        elif successful_steps == total_steps:
+        elif successful_steps == total_steps and not sync_result.get("errors"):
             sync_result["status"] = "success"
             sync_result["cloud_url"] = build_experiment_url(
                 BackendConfig.get_cloud_backend_url(),
@@ -941,6 +1063,38 @@ class SyncManager:
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    def _finalize_experiment(self, experiment_id: str) -> dict[str, Any]:
+        """Transition a synced experiment to COMPLETED via PUT /experiments/{id}.
+
+        Must be called after all experiment_run and configuration_run rows have
+        been uploaded.  The backend rejects experiment creation with a
+        run-requiring status (RUNNING or COMPLETED) when no runs exist yet
+        (#1420), and exposes only PUT (not PATCH) for experiment updates
+        (TraigentBackend src/routes/experiment_routes.py:1058).  The correct
+        sync protocol is therefore:
+          1. POST /experiments  (status="PENDING")
+          2. POST /experiment-runs/{id}/runs
+          3. POST /configuration-runs/runs/{run_id}/configurations  (N times)
+          4. PUT  /experiments/{id}  {"status":"COMPLETED"}   <-- this method
+        The PUT COMPLETED guard passes once >=1 experiment_run exists
+        (experiment_routes.py ~1108-1126).
+        """
+        self._raise_if_backend_egress_disabled("finalize experiment")
+        try:
+            response = self._session.put(
+                f"{self.base_url}/experiments/{experiment_id}",
+                json={"status": "COMPLETED"},
+                timeout=self._request_timeout,
+            )
+            if response.status_code in [200, 204]:
+                return {"success": True}
+            return {
+                "success": False,
+                "error": f"HTTP {response.status_code}: {response.text}",
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
     def _sync_experiment_run(
         self, experiment_id: str, run_data: dict[str, Any]
     ) -> dict[str, Any]:
@@ -978,15 +1132,40 @@ class SyncManager:
             return {"success": False, "error": str(e)}
 
     def _sync_configuration_runs(
-        self, experiment_run_id: str, trials: list[dict[str, Any]]
+        self,
+        experiment_run_id: str,
+        trials: list[dict[str, Any]],
+        *,
+        already_synced_keys: set[str] | None = None,
+        on_synced: Callable[[str, str | None], None] | None = None,
     ) -> dict[str, Any]:
-        """Create the cost-bearing configuration rows for an experiment run."""
+        """Create the cost-bearing configuration rows for an experiment run.
+
+        Idempotent across resumes: each config-run carries a stable key
+        (``_config_run_key`` of its zero-based position). Runs whose key is in
+        ``already_synced_keys`` are SKIPPED (not re-POSTed) — the backend does
+        not dedup config-run creates (backend issue #1330), so re-POSTing would
+        duplicate rows. ``on_synced(key, configuration_run_id)`` is invoked
+        immediately after each successful POST so progress is persisted
+        incrementally (crash-safe), not only at the end of the batch.
+        """
         self._raise_if_backend_egress_disabled("sync configuration runs")
+        already_synced_keys = already_synced_keys or set()
         errors: list[str] = []
         configuration_run_ids: list[str] = []
         synced = 0
+        skipped = 0
 
-        for index, trial in enumerate(trials, start=1):
+        for index, trial in enumerate(trials):
+            key = self._config_run_key(index)
+            # Skip config-runs a prior attempt already uploaded so a resume
+            # never creates duplicate rows.
+            if key in already_synced_keys:
+                skipped += 1
+                continue
+
+            # 1-based ordinal for human-readable error messages.
+            ordinal = index + 1
             try:
                 response = self._session.post(
                     f"{self.base_url}/configuration-runs/runs/"
@@ -995,7 +1174,7 @@ class SyncManager:
                     timeout=self._request_timeout,
                 )
             except Exception as exc:
-                errors.append(f"trial {index}: {exc}")
+                errors.append(f"trial {ordinal}: {exc}")
                 continue
 
             if response.status_code == 201:
@@ -1003,15 +1182,21 @@ class SyncManager:
                 configuration_run_id = self._extract_response_id(response)
                 if configuration_run_id:
                     configuration_run_ids.append(configuration_run_id)
+                # Persist this config-run as synced RIGHT NOW (before the next
+                # POST) so a crash/failure on a later row leaves a durable
+                # marker the next resume can skip past.
+                if on_synced is not None:
+                    on_synced(key, configuration_run_id)
                 continue
 
             errors.append(
-                f"trial {index}: HTTP {response.status_code}: {response.text}"
+                f"trial {ordinal}: HTTP {response.status_code}: {response.text}"
             )
 
         return {
             "success": not errors,
             "synced": synced,
+            "skipped": skipped,
             "errors": errors,
             "configuration_run_ids": configuration_run_ids,
         }


### PR DESCRIPTION
## What & why

`traigent sync <id>` and `traigent local sync --session-id <id>` failed on **every** completed local session with `HTTP 409 EXPERIMENT_HAS_NO_RUNS`, so the advertised "optimize locally, then sync to the portal" workflow was unusable. Two aggravating sub-bugs hid it: `--dry-run` reported success for a session that then 409'd, and `traigent sync` exited `0` on failure (CI/scripts believed it worked). Fixes #1420.

## Root cause & fix

The sync created the experiment in a **run-requiring status before any run existed**. Verified against `TraigentBackend@origin/develop`: the create-guard rejects the run-requiring set `{RUNNING, COMPLETED}` (`src/models/status_enums.py` `_RUN_REQUIRING_EXPERIMENT_STATUSES`), and the only experiment-update route is `PUT /experiments/{id}` (no PATCH).

- **Correct ordering:** create experiment `PENDING` → upload `experiment_run` + `configuration_runs` → finalize to `COMPLETED` via `PUT /experiments/{id}`.
- **Dry-run parity:** `--dry-run` now runs the same validation and predicts the real outcome (rejects `RUNNING` and `COMPLETED` on create).
- **Honest exit code:** `traigent sync` returns non-zero on any failed session.
- **Idempotent resume (data-integrity):** the backend does **not** dedup config-run creates (open BE #1330), so the SDK records each config-run as synced (with its backend id) immediately after a successful POST and **skips already-uploaded config-runs on retry**. Without this, a retry after a mid-batch failure duplicated config-runs.

Out of scope: live cloud logging during a run (already works; untouched).

## Tests

76 passing (`tests/unit/cloud/test_sync_manager.py` + `tests/unit/cli/test_sync_command.py`), including:
- ordering test (POST `PENDING` → POST runs → `PUT {"status":"COMPLETED"}`),
- dry-run-matches-real for syncable and non-syncable sessions,
- non-zero exit on real-sync failure,
- **negative-control** resume test: a mid-batch config-run failure then resume posts **only** the failed/remaining runs and finalizes exactly once — the assertion **fails if the skip logic is disabled** (not tautological).

Reviewed by a codex gpt-5.5 gate, which caught the duplicate-on-retry data-integrity bug now fixed here.

## PR checklist

1. **Worst-case prod path** — a failed sync now fails **loud** (non-zero exit, honest error) and never duplicates runs; no fail-open path.
2. **Production-branch test** — negative-control resume test (`test_sync_resume_does_not_duplicate_config_runs_after_midbatch_failure`), dry-run parity, exit-code tests.
3. **Contract regeneration** — none. SDK-only; no `TraigentSchema` change. Depends only on existing BE endpoints (`POST`/`PUT /experiments`, run/config-run uploads) verified on `origin/develop`. JS-SDK sync parity is a separate follow-up (not blocking).
4. **Public surface delta** — no new public API; `traigent sync` exit code is now non-zero on failure (intended behavior fix).
5. **Review threads** — codex gate addressed; will resolve any Aikido/Greptile/Sonar threads before merge.
6. **Quality gates** — none relaxed.

Spine-Trail: st_9e1c0930ca1d
