### PR TITLE
fix(cost): per-config cost wiring + unpriced-runtime surfacing (#1423, #1407)

### DIFF
--- a/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round4.py
+++ b/tests/unit/evaluators/test_tuple_metrics_channel_hardening_round4.py
@@ -170,16 +170,17 @@ def _eval_result_with_metrics(metrics: dict[str, float]) -> Mock:
 def test_final_cap_keeps_evaluator_computed_name_drops_user_key() -> None:
     """H3 (captain repro): 49 composite_metric_* user keys + ``f1`` arrive at the
     ceiling from the lane, then assembly writes ``examples_attempted`` and
-    ``total_cost`` AFTER the lane caps ran — pushing the final union to 52. The
-    cap must fire, KEEP ``f1`` (the primary objective, via ``extra_reserved``)
-    and drop composite user keys instead.
+    ``total_cost`` AFTER the lane caps ran. Assembly ALSO materializes the reserved
+    ``cost`` metric from ``total_cost`` when it is otherwise absent (#1423), so the
+    final union is 53. The cap must fire, KEEP ``f1`` (the primary objective, via
+    ``extra_reserved``) and the reserved assembly keys, and drop composite user
+    keys instead.
 
     Pre-fix: ``build_success_result`` passed no ``extra_reserved``, so ``f1`` was
     seen as a droppable user key and (sorting after the composites) the cap
     removed it — the objective vanished from ``TrialResult.metrics``. The
-    non-``None`` ``examples_attempted``/``total_cost`` are essential: with both
-    ``None`` the union is exactly 50 and the cap returns early without testing
-    anything (codex round-4 MINOR).
+    non-``None`` ``examples_attempted``/``total_cost`` are essential: they (plus
+    the derived ``cost``) push the union past the ceiling so the cap is exercised.
     """
     metrics = {f"composite_metric_{i:03d}": 1.0 for i in range(49)}
     metrics["f1"] = 0.93
@@ -196,23 +197,27 @@ def test_final_cap_keeps_evaluator_computed_name_drops_user_key() -> None:
         extra_reserved=frozenset({"f1"}),
     )
 
-    # The cap actually fired: 52-key union clamped back to the ceiling.
+    # The cap actually fired: 53-key union (49 composites + f1 + examples_attempted
+    # + total_cost + the derived ``cost``) clamped back to the ceiling.
     assert len(result.metrics) == 50
     # The evaluator-computed objective survived...
     assert result.metrics["f1"] == pytest.approx(0.93)
     # ...as did the reserved assembly keys written after the lane caps...
     assert "examples_attempted" in result.metrics
     assert "total_cost" in result.metrics
-    # ...and exactly TWO composite user keys were dropped to make room.
+    # ...including the per-config ``cost`` derived from ``total_cost`` (#1423)...
+    assert result.metrics["cost"] == pytest.approx(0.01)
+    # ...and exactly THREE composite user keys were dropped to make room.
     composite_kept = [k for k in result.metrics if k.startswith("composite_metric_")]
-    assert len(composite_kept) == 47
+    assert len(composite_kept) == 46
 
 
 def test_final_cap_without_extra_reserved_would_drop_objective() -> None:
-    """H3 counterfactual guard: the same 52-key union WITHOUT ``extra_reserved``
+    """H3 counterfactual guard: the same 53-key union WITHOUT ``extra_reserved``
     drops ``f1`` — proving the threaded set is what protects the objective (if a
     refactor silently stops threading it, the positive test above could go
-    vacuous; this pins the mechanism).
+    vacuous; this pins the mechanism). The union is 53 because assembly also
+    derives the reserved ``cost`` metric from ``total_cost`` (#1423).
     """
     metrics = {f"composite_metric_{i:03d}": 1.0 for i in range(49)}
     metrics["f1"] = 0.93

--- a/tests/unit/utils/test_cost_metric_wiring_1423_1407.py
+++ b/tests/unit/utils/test_cost_metric_wiring_1423_1407.py
@@ -1,0 +1,338 @@
+"""Regression tests for cost-metric wiring (#1423) and runtime cost-coverage (#1407).
+
+#1423: the per-config ``cost`` metric / objective and the input_cost/output_cost
+breakdown must be wired to the SDK's already-correct ``total_cost`` (non-zero,
+model-differentiated), the OpenRouter-prefix pricing helper must price via the
+normalized id, and ``cost_efficiency`` must not divide by zero.
+
+#1407: a model HARD-CODED in the optimized function body that no pricing table
+covers must surface to the USER and the result object at runtime (non-strict) and
+must fail closed under strict accounting.
+
+These tests assert externally-observable behavior on a real (mocked-LLM) pipeline;
+they never assert ``== 0`` or trivially-true conditions.
+"""
+
+from __future__ import annotations
+
+import warnings
+from datetime import UTC, datetime
+
+import pytest
+
+import traigent.utils.cost_calculator as cost_calculator
+from traigent.api.decorators import optimize
+from traigent.api.types import TrialResult, TrialStatus
+from traigent.evaluators.base import Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
+from traigent.evaluators.metrics_tracker import extract_llm_metrics
+from traigent.utils.cost_calculator import (
+    UnknownModelError,
+    completion_cost,
+    prompt_cost,
+)
+from traigent.utils.insights import _calculate_cost_efficiency
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles: minimal litellm-style response objects                        #
+# --------------------------------------------------------------------------- #
+class _Msg:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _Choice:
+    def __init__(self, content: str) -> None:
+        self.message = _Msg(content)
+
+
+class _Usage:
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.prompt_tokens = input_tokens
+        self.completion_tokens = output_tokens
+        self.total_tokens = input_tokens + output_tokens
+
+
+class _LLMResponse:
+    """OpenAI/litellm-style response with usage and optional provider cost."""
+
+    def __init__(
+        self,
+        content: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        provider_cost: float | None = None,
+    ) -> None:
+        self.choices = [_Choice(content)]
+        self.usage = _Usage(input_tokens, output_tokens)
+        self.model = model
+        if provider_cost is not None:
+            # OpenRouter / litellm report per-call cost here when the model is
+            # missing from the pricing table.
+            self._hidden_params = {"response_cost": provider_cost}
+
+
+@pytest.fixture(autouse=True)
+def _reset_unpriced_registry():
+    cost_calculator.reset_unpriced_runtime_models()
+    yield
+    cost_calculator.reset_unpriced_runtime_models()
+
+
+@pytest.fixture(autouse=True)
+def _non_prod_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("TRAIGENT_ENV", "test")
+    monkeypatch.delenv("TRAIGENT_STRICT_COST_ACCOUNTING", raising=False)
+    monkeypatch.delenv("TRAIGENT_GENERATE_MOCKS", raising=False)
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# #1423 (a): OpenRouter-prefix pricing helper                                 #
+# --------------------------------------------------------------------------- #
+def test_completion_cost_prices_openrouter_prefix_nonzero():
+    """completion_cost('openrouter/openai/gpt-4o-mini') returns non-zero.
+
+    litellm.completion_cost raises 'This model isn't mapped yet' for this id even
+    though litellm.model_cost HAS the underlying gpt-4o-mini entry. The SDK helper
+    must price via the normalized id.
+    """
+    mini = completion_cost(model="openrouter/openai/gpt-4o-mini", output_tokens=1000)
+    assert mini > 0.0
+
+    # And it is model-differentiated: gpt-4o output costs strictly more than mini.
+    big = completion_cost(model="openrouter/openai/gpt-4o", output_tokens=1000)
+    assert big > mini
+
+    # Prompt side too.
+    assert prompt_cost(model="openrouter/openai/gpt-4o-mini", input_tokens=1000) > 0.0
+
+
+def test_completion_cost_still_zero_for_genuinely_unpriced():
+    """An id with no pricing anywhere returns 0.0 (query-mode, not a raise)."""
+    assert completion_cost(model="acme/private-unmapped-v9", output_tokens=1000) == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# #1423 (b): input_cost / output_cost breakdown back-filled                   #
+# --------------------------------------------------------------------------- #
+def test_breakdown_backfilled_when_only_total_cost_reported():
+    """OpenRouter path: total_cost authoritative, breakdown reconstructed.
+
+    The provider reports total_cost via _hidden_params['response_cost'] but no
+    input/output split. The breakdown must be re-derived from the calculator
+    while total_cost stays exactly as reported.
+    """
+    reported_total = 0.0144275
+    metrics = extract_llm_metrics(
+        _LLMResponse("AI", "openrouter/openai/gpt-4o", 700, 300, reported_total),
+        model_name="openrouter/openai/gpt-4o",
+    )
+    assert metrics.cost.total_cost == pytest.approx(reported_total)
+    assert metrics.cost.input_cost > 0.0
+    assert metrics.cost.output_cost > 0.0
+    # Output tokens are cheaper-priced per-token but there are fewer of them;
+    # the key invariant is the split sums to the authoritative total.
+    assert metrics.cost.input_cost + metrics.cost.output_cost == pytest.approx(
+        reported_total
+    )
+
+
+# --------------------------------------------------------------------------- #
+# #1423 (c): cost_efficiency divide-by-zero guard                             #
+# --------------------------------------------------------------------------- #
+def _trial(metrics: dict[str, float]) -> TrialResult:
+    return TrialResult(
+        trial_id="t",
+        config={"model": "gpt-4o"},
+        metrics=metrics,
+        status=TrialStatus.COMPLETED,
+        duration=0.0,
+        timestamp=datetime.now(UTC),
+    )
+
+
+def test_cost_efficiency_not_inf_when_cost_zero():
+    """cost_efficiency returns a finite 0.0 (not inf) when cost is missing/zero."""
+    eff = _calculate_cost_efficiency(_trial({"accuracy": 0.6, "cost": 0.0}), "accuracy")
+    assert eff == 0.0
+
+
+def test_cost_efficiency_falls_back_to_total_cost_and_ranks():
+    """With total_cost present, efficiency is finite and ranks cheaper config higher."""
+    cheap = _calculate_cost_efficiency(
+        _trial({"accuracy": 0.5, "total_cost": 0.0007}), "accuracy"
+    )
+    pricey = _calculate_cost_efficiency(
+        _trial({"accuracy": 0.6, "total_cost": 0.0125}), "accuracy"
+    )
+    assert cheap != float("inf") and pricey != float("inf")
+    # 0.5/0.0007 ~= 714 vs 0.6/0.0125 = 48 -> cheaper config is more efficient.
+    assert cheap > pricey
+
+
+# --------------------------------------------------------------------------- #
+# #1423 (1): per-config cost metric / objective wired to total_cost           #
+# real, mocked-LLM optimize run, model-differentiated, ordered                #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_per_config_cost_nonzero_and_objective_prefers_cheaper():
+    """A real local optimize run reports non-zero per-config cost ordered by model.
+
+    Both models score identically (accuracy tie) so the minimize-cost objective is
+    the only differentiator. The optimizer must (a) report a non-zero, model-
+    differentiated per-config cost and (b) prefer the cheaper model on the tie.
+    """
+    dataset = [{"input": {"question": "q"}, "expected_output": "A"} for _ in range(2)]
+
+    @optimize(
+        eval_dataset=dataset,
+        objectives=["accuracy", "cost"],
+        configuration_space={"model": ["gpt-4o", "gpt-4o-mini"]},
+        offline=True,
+    )
+    def fn(question: str = "", model: str = "gpt-4o", **_cfg):
+        return {"text": "A", "raw_response": _LLMResponse("A", model, 700, 300)}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = await fn.optimize(progress_bar=False)
+
+    costs = {t.config["model"]: t.metrics["cost"] for t in result.trials}
+    assert costs["gpt-4o"] > 0.0
+    assert costs["gpt-4o-mini"] > 0.0
+    # gpt-4o is materially (>5x) more expensive than gpt-4o-mini for equal tokens.
+    assert costs["gpt-4o"] > costs["gpt-4o-mini"] * 5
+    # Aggregate total_cost stays correct (sum of per-trial totals), unchanged.
+    assert result.total_cost == pytest.approx(
+        sum(t.metrics["total_cost"] for t in result.trials)
+    )
+    # The cost objective is live: on the accuracy tie the cheaper model wins.
+    assert result.best_config["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_per_config_cost_wired_from_provider_reported_total():
+    """OpenRouter-style provider-reported total still yields a non-zero per-config cost."""
+    dataset = [{"input": {"question": "q"}, "expected_output": "A"}]
+
+    @optimize(
+        eval_dataset=dataset,
+        objectives=["accuracy", "cost"],
+        configuration_space={"temperature": [0.1, 0.5]},
+        offline=True,
+    )
+    def fn(question: str = "", temperature: float = 0.1, **_cfg):
+        return {
+            "text": "A",
+            "raw_response": _LLMResponse(
+                "A", "openrouter/openai/gpt-4o", 700, 300, provider_cost=0.0144275
+            ),
+        }
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = await fn.optimize(progress_bar=False)
+
+    for trial in result.trials:
+        # Per-config cost is wired to the provider-reported total (a small
+        # pre-existing 6-decimal rounding applies to stored trial metrics).
+        assert trial.metrics["cost"] == pytest.approx(0.0144275, abs=1e-5)
+        assert trial.metrics["cost"] > 0.0
+        assert trial.metrics["total_cost"] == pytest.approx(0.0144275, abs=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# #1407: unpriced fixed-in-code model — runtime warning + strict fail-closed  #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_unpriced_fixed_in_code_model_surfaces_warning(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Non-strict: an unpriced model fixed in the function body warns the user.
+
+    The model is NOT in the configuration space (preflight cannot see it), so the
+    only signal is the runtime collection lifted onto the OptimizationResult.
+    """
+    monkeypatch.setenv("TRAIGENT_COST_APPROVED", "true")  # no interactive prompt
+    dataset = [{"input": {"question": "q"}, "expected_output": "A"}]
+
+    @optimize(
+        eval_dataset=dataset,
+        objectives=["accuracy", "cost"],
+        configuration_space={"temperature": [0.1]},
+        offline=True,
+    )
+    def fn(question: str = "", temperature: float = 0.1, **_cfg):
+        # Model hard-coded in body, unpriced, discoverable on the response object.
+        return _LLMResponse("A", "acme/private-llm-v9", 700, 300)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = await fn.optimize(progress_bar=False)
+
+    assert result.warnings, "expected a user-visible unpriced-model warning"
+    assert any("acme/private-llm-v9" in w for w in result.warnings)
+    assert "UNPRICED_MODEL_RUNTIME" in result.warning_codes
+    assert "acme/private-llm-v9" in result.metadata.get("unpriced_models_runtime", [])
+    assert any(
+        "acme/private-llm-v9" in str(w.message)
+        for w in caught
+        if issubclass(w.category, UserWarning)
+    )
+
+
+@pytest.mark.asyncio
+async def test_unpriced_fixed_in_code_model_fails_closed_under_strict(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Strict accounting: an unpriced fixed-in-code model fails the run, never $0."""
+    monkeypatch.setenv("TRAIGENT_STRICT_COST_ACCOUNTING", "true")
+    dataset = [{"input": {"question": "q"}, "expected_output": "A"}]
+
+    @optimize(
+        eval_dataset=dataset,
+        objectives=["accuracy", "cost"],
+        configuration_space={"temperature": [0.1]},
+        offline=True,
+    )
+    def fn(question: str = "", temperature: float = 0.1, **_cfg):
+        return _LLMResponse("A", "acme/private-llm-v9", 700, 300)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(Exception) as exc_info:  # noqa: B017 - run must fail closed
+            await fn.optimize(progress_bar=False)
+
+    # The run failed closed instead of silently recording $0. The failure must be
+    # cost-related: either the UnknownModelError itself (in the __cause__ chain) or
+    # an OptimizationError whose message reports the cost-extraction failure.
+    chain: list[BaseException] = []
+    err: BaseException | None = exc_info.value
+    while err is not None:
+        chain.append(err)
+        err = err.__cause__
+    messages = " | ".join(str(e).lower() for e in chain)
+    assert any(isinstance(e, UnknownModelError) for e in chain) or (
+        "private-llm-v9" in messages
+        or "no known pricing" in messages
+        or "cost extraction failed" in messages
+    )
+
+
+def test_unpriced_runtime_model_recorded_at_evaluator_level():
+    """The LocalEvaluator records an unpriced runtime model id (non-strict)."""
+    import asyncio
+
+    evaluator = LocalEvaluator(metrics=["accuracy", "cost"])
+
+    async def fn(question: str = "", **_cfg):
+        return _LLMResponse("A", "acme/private-llm-v9", 700, 300)
+
+    dataset = Dataset(
+        examples=[EvaluationExample(input_data={"question": "q"}, expected_output="A")]
+    )
+    asyncio.run(evaluator.evaluate(fn, {"temperature": 0.1}, dataset))
+    assert cost_calculator.get_unpriced_runtime_models() == ["acme/private-llm-v9"]

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -693,6 +693,15 @@ class OptimizationResult:
     cloud_url: str | None = None
     run_label: str | None = None
 
+    # User-facing, non-fatal warnings about this run (issue #1407). Populated
+    # when the run hit a money-correctness gap that the user should see — e.g.
+    # one or more models priced to $0 at runtime (a model hard-coded in the
+    # optimized function body that no pricing table covers), which silently
+    # under-reports spend. Empty by default. Each entry is a human-readable
+    # remediation message; structured codes live in ``warning_codes``.
+    warnings: list[str] = field(default_factory=list)
+    warning_codes: list[str] = field(default_factory=list)
+
     # Provenance of this result (issue #1265): "backend" when the run was
     # tracked end-to-end on the cloud backend, "local" when it was computed
     # locally — either an intentionally local mode or a hybrid/cloud run that

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -1825,6 +1825,15 @@ class OptimizedFunction:
 
         trial_func = self._trial_callable_for_config_space(effective_config_space)
 
+        # Reset the unpriced-at-runtime model registry so this run starts clean.
+        # The runtime cost path records models that priced to $0 despite non-zero
+        # tokens (e.g. a model hard-coded in the optimized function body that no
+        # pricing table covers, invisible to the config-space preflight); we drain
+        # it onto the result below to surface a user-visible warning (#1407).
+        from traigent.utils.cost_calculator import reset_unpriced_runtime_models
+
+        reset_unpriced_runtime_models()
+
         # Set state to OPTIMIZING before starting
         self._state = OptimizationState.OPTIMIZING
 
@@ -1859,6 +1868,13 @@ class OptimizedFunction:
             # Set state to ERROR on failure
             self._state = OptimizationState.ERROR
             raise
+        # Surface any models that priced to $0 at runtime despite non-zero tokens
+        # (#1407). Strict accounting already raised mid-run via
+        # ``cost_from_tokens(strict=True)`` (fail-closed), so anything collected
+        # here is the non-strict warn-and-continue case — make it visible on the
+        # result instead of leaving only a buried log.
+        self._attach_unpriced_model_warning(result)
+
         # Save results if requested
         if save_to:
             self.save_optimization_results(save_to)
@@ -1880,6 +1896,44 @@ class OptimizedFunction:
                 logger.debug(f"Failed to show upgrade hint: {e}")
 
         return result  # type: ignore[no-any-return]
+
+    def _attach_unpriced_model_warning(self, result: OptimizationResult) -> None:
+        """Attach a user-visible warning for models that priced to $0 at runtime.
+
+        Closes the runtime half of the cost-coverage gap (#1407): the pre-run
+        preflight only inspects config-space model ids, so a model HARD-CODED in
+        the optimized function body is invisible to it. When such a model is
+        unpriced, the non-strict runtime cost path records $0 with only a buried
+        log. Here we lift the collected ids onto the result (``warnings`` /
+        ``warning_codes`` and ``metadata``) using the SAME remediation surface as
+        the preflight, so the user can opt into custom pricing or acknowledge the
+        gap. Strict accounting never reaches this surface — it fails closed
+        mid-run via ``cost_from_tokens(strict=True)``.
+        """
+        try:
+            from traigent.utils.cost_calculator import get_unpriced_runtime_models
+
+            unpriced = get_unpriced_runtime_models()
+        except Exception:  # pragma: no cover - defensive; never break a run
+            return
+
+        if not unpriced:
+            return
+
+        message = _format_unpriced_model_warning(unpriced)
+        if message not in result.warnings:
+            result.warnings.append(message)
+        if "UNPRICED_MODEL_RUNTIME" not in result.warning_codes:
+            result.warning_codes.append("UNPRICED_MODEL_RUNTIME")
+        if isinstance(result.metadata, dict):
+            result.metadata.setdefault("unpriced_models_runtime", list(unpriced))
+
+        warnings.warn(message, UserWarning, stacklevel=2)
+        logger.warning(
+            "Models priced at $0 at runtime (real spend under-reported): %s. %s",
+            ", ".join(unpriced),
+            message,
+        )
 
     async def _try_cloud_execution(
         self,

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2928,6 +2928,16 @@ class OptimizationOrchestrator:
             # Fallback for common objective aliases
             if metric_value is None and objective in {"accuracy", "success_rate"}:
                 metric_value = metrics.get("accuracy") or metrics.get("success_rate")
+            # The per-config ``cost`` metric can be decoupled from the real spend
+            # (provider/meta-reported total) and arrive missing or 0.0 while
+            # ``total_cost`` is correct. A ``minimize cost`` objective pinned at 0
+            # is inert — every config looks free — so prefer ``total_cost`` when
+            # the ``cost`` metric is absent or zero (#1423). ``total_cost`` is the
+            # SDK's authoritative aggregate cost and is never wrongly zeroed.
+            if objective == "cost" and not metric_value:
+                total_cost = metrics.get("total_cost")
+                if total_cost:
+                    metric_value = total_cost
             if metric_value is None and objective in {"cost", "latency", "error"}:
                 metric_value = metrics.get(objective, 0.0)
             values.append(float(metric_value if metric_value is not None else 0.0))

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -328,6 +328,43 @@ def _set_metric_if_convertible(
         )
 
 
+def _reconcile_cost_with_total_cost(metrics: dict[str, Any], trial_id: str) -> None:
+    """Wire the per-config ``cost`` metric to ``total_cost`` when decoupled (#1423).
+
+    The per-config ``cost`` metric is what the optimizer minimizes and the portal
+    displays. On several real paths (provider-reported cost via OpenRouter, cost
+    injected via ``__traigent_meta__``) it can arrive missing or 0.0 even though
+    the SDK computed the correct ``total_cost`` for the same trial. Left
+    decoupled, the ``minimize cost`` objective is inert and the portal shows $0
+    per config for a real paid run. ``total_cost`` is authoritative and is never
+    wrongly zeroed, so back-fill ``cost`` from it. The authoritative ``total_cost``
+    is never modified.
+    """
+    raw_total = metrics.get("total_cost")
+    try:
+        total_cost = float(raw_total) if raw_total is not None else 0.0
+    except (TypeError, ValueError):
+        return
+    if total_cost <= 0.0:
+        return
+
+    raw_cost = metrics.get("cost")
+    try:
+        current_cost = float(raw_cost) if raw_cost is not None else 0.0
+    except (TypeError, ValueError):
+        current_cost = 0.0
+
+    if current_cost > 0.0:
+        return
+
+    metrics["cost"] = total_cost
+    logger.debug(
+        "Reconciled per-config cost from total_cost for trial %s: $%.6f",
+        trial_id,
+        total_cost,
+    )
+
+
 def _extract_success_comparability(eval_result: Any) -> dict[str, Any]:
     """Resolve comparability metadata from evaluator output or fallback synthesis."""
     comparability_payload = _validated_comparability_payload(
@@ -434,6 +471,14 @@ def build_success_result(
             float,
             trial_id,
         )
+
+    # Wire the per-config ``cost`` metric to the authoritative ``total_cost``
+    # whenever ``cost`` is absent or 0.0 while ``total_cost`` is non-zero (#1423).
+    # The ``cost`` metric is what the optimizer minimizes and the portal displays;
+    # leaving it decoupled at 0 makes the cost objective inert and shows $0 per
+    # config for a real paid run. ``total_cost`` is the SDK's authoritative spend
+    # and is never wrongly zeroed, so it is the correct source here.
+    _reconcile_cost_with_total_cost(trial_result.metrics, trial_id)
 
     # Authoritative final-union ceiling — the SINGLE cap that bounds what every
     # lane actually ships on a successful trial. Both evaluator lanes already cap

--- a/traigent/evaluators/metrics_tracker.py
+++ b/traigent/evaluators/metrics_tracker.py
@@ -1333,6 +1333,13 @@ def _calculate_cost_for_metrics(
         return
 
     if metrics.cost.total_cost > 0.0:
+        # total_cost is authoritative (e.g. provider-reported via OpenRouter
+        # ``_hidden_params['response_cost']`` or user-injected via
+        # ``__traigent_meta__``), but the per-trial input_cost/output_cost
+        # breakdown is dropped on those paths and persists as 0.0 even though
+        # spend is real (#1423). Re-derive the breakdown from the canonical
+        # calculator without ever changing the authoritative total_cost.
+        _backfill_cost_breakdown(metrics, model_name)
         return
 
     if not model_name:
@@ -1381,6 +1388,58 @@ def _calculate_cost_for_metrics(
             or os.environ.get("TRAIGENT_DEBUG", "").lower() == "true"
         ):
             raise
+
+
+def _backfill_cost_breakdown(metrics: ExampleMetrics, model_name: str | None) -> None:
+    """Populate input_cost/output_cost when only total_cost is known (#1423).
+
+    Provider-reported and user-injected cost paths set ``total_cost`` directly
+    and leave the per-trial breakdown at 0.0. When tokens are available, derive
+    the breakdown from the canonical calculator so it is not dropped. The
+    authoritative ``total_cost`` is NEVER modified here; only the split is
+    reconstructed (and only when it is currently zero and tokens are present).
+    """
+    if not model_name:
+        return
+    if metrics.cost.input_cost > 0.0 or metrics.cost.output_cost > 0.0:
+        return
+    in_tokens = metrics.tokens.input_tokens
+    out_tokens = metrics.tokens.output_tokens
+    if in_tokens <= 0 and out_tokens <= 0:
+        return
+
+    from traigent.utils.cost_calculator import cost_from_tokens
+
+    try:
+        input_cost, output_cost = cost_from_tokens(
+            in_tokens, out_tokens, model_name, strict=False
+        )
+    except Exception:  # pragma: no cover - defensive; never break the trial
+        logger.debug(
+            "Cost breakdown backfill failed for model %r", model_name, exc_info=True
+        )
+        return
+
+    derived_total = input_cost + output_cost
+    if derived_total <= 0.0:
+        # Calculator could not price this id (would be 0/0); leave the
+        # authoritative total_cost untouched and the breakdown at zero.
+        return
+
+    authoritative_total = metrics.cost.total_cost
+    # Scale the derived split to match the authoritative total so the two stay
+    # consistent (provider-reported totals can differ slightly from token math).
+    scale = authoritative_total / derived_total
+    metrics.cost.input_cost = input_cost * scale
+    metrics.cost.output_cost = output_cost * scale
+    metrics.cost.total_cost = authoritative_total
+    logger.debug(
+        "Backfilled cost breakdown for %s: in=$%.6f out=$%.6f (total=$%.6f)",
+        model_name,
+        metrics.cost.input_cost,
+        metrics.cost.output_cost,
+        metrics.cost.total_cost,
+    )
 
 
 def _handle_mock_mode(
@@ -1436,6 +1495,15 @@ def _compute_cost(
                 model_name,
                 metrics.cost.total_cost,
             )
+        else:
+            # Non-strict path: the model priced to $0 despite non-zero tokens
+            # (litellm + custom + built-in tables all miss). Record it so the
+            # optimizer can surface a result-level warning to the USER instead
+            # of leaving only a buried log (#1407). Strict accounting never
+            # reaches here — ``cost_from_tokens(strict=True)`` raises above.
+            from traigent.utils.cost_calculator import record_unpriced_runtime_model
+
+            record_unpriced_runtime_model(model_name)
     else:
         logger.debug(
             "No token usage extracted for model %s; "

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -381,13 +381,16 @@ def _try_litellm_prompt_cost(
             tokens = litellm.token_counter(model=model, messages=prompt)
         else:
             tokens = litellm.token_counter(model=model, text=prompt)
-    prompt_cost, _ = litellm.cost_per_token(
-        model=model, prompt_tokens=tokens, completion_tokens=0
-    )
-    if prompt_cost > 0:
-        return float(prompt_cost), tokens
-    if model_known:
-        return 0.0, tokens
+    # Price via the canonical candidate ladder (normalized id + aliases) so that
+    # provider-prefixed ids litellm cannot price directly (e.g.
+    # "openrouter/openai/gpt-4o-mini", which raises "This model isn't mapped yet"
+    # from ``litellm.cost_per_token``/``completion_cost`` even though
+    # ``litellm.model_cost`` HAS the underlying "gpt-4o-mini" entry) still resolve.
+    litellm_rates = _try_litellm_cost(_build_model_candidates(model), tokens, 0)
+    if litellm_rates is not None:
+        prompt_cost = litellm_rates[0]
+        if prompt_cost > 0 or model_known:
+            return float(prompt_cost), tokens
     return None, tokens
 
 
@@ -455,13 +458,14 @@ def _try_litellm_completion_cost(
     model_known = _is_model_known_to_litellm(model)
     if completion is not None:
         tokens = litellm.token_counter(model=model, text=completion)
-    _, completion_cost = litellm.cost_per_token(
-        model=model, prompt_tokens=0, completion_tokens=tokens
-    )
-    if completion_cost > 0:
-        return float(completion_cost), tokens
-    if model_known:
-        return 0.0, tokens
+    # Price via the canonical candidate ladder so provider-prefixed ids litellm
+    # cannot price directly (e.g. "openrouter/openai/gpt-4o-mini") still resolve
+    # against the underlying entry in ``litellm.model_cost``. (See #1423.)
+    litellm_rates = _try_litellm_cost(_build_model_candidates(model), 0, tokens)
+    if litellm_rates is not None:
+        completion_cost = litellm_rates[1]
+        if completion_cost > 0 or model_known:
+            return float(completion_cost), tokens
     return None, tokens
 
 
@@ -1229,3 +1233,112 @@ def get_model_pricing_per_1k(model_name: str) -> tuple[float, float]:
     input_per_1k, _ = cost_from_tokens(1000, 0, model_name, strict=False)
     _, output_per_1k = cost_from_tokens(0, 1000, model_name, strict=False)
     return float(input_per_1k), float(output_per_1k)
+
+
+def completion_cost(
+    completion: str | None = None,
+    model: str | None = None,
+    *,
+    output_tokens: int | None = None,
+) -> float:
+    """Output (completion) cost in USD via the canonical pricing pipeline.
+
+    Unlike ``litellm.completion_cost``, this prices provider-prefixed ids that
+    litellm cannot map directly (e.g. ``"openrouter/openai/gpt-4o-mini"``, which
+    raises ``"This model isn't mapped yet"`` from litellm even though
+    ``litellm.model_cost`` HAS the underlying ``"gpt-4o-mini"`` entry) by routing
+    through :func:`_build_model_candidates` / :func:`cost_from_tokens`. (See #1423.)
+
+    Provide either ``completion`` text (tokens are counted with litellm) or a
+    pre-computed ``output_tokens`` count.
+
+    Args:
+        completion: Completion text whose tokens should be priced.
+        model: Model identifier (with or without provider prefix).
+        output_tokens: Pre-computed completion token count (overrides ``completion``).
+
+    Returns:
+        Cost in USD for the output tokens. ``0.0`` for an unpriced model.
+    """
+    if not model:
+        return 0.0
+    tokens = output_tokens
+    if tokens is None:
+        if completion is None:
+            return 0.0
+        tokens = (
+            litellm.token_counter(model=model, text=completion)
+            if LITELLM_AVAILABLE
+            else max(1, len(completion) // 4)
+        )
+    _, out_cost = cost_from_tokens(0, max(int(tokens), 0), model, strict=False)
+    return float(out_cost)
+
+
+def prompt_cost(
+    prompt: str | list[dict[str, Any]] | None = None,
+    model: str | None = None,
+    *,
+    input_tokens: int | None = None,
+) -> float:
+    """Input (prompt) cost in USD via the canonical pricing pipeline.
+
+    Counterpart to :func:`completion_cost`; prices provider-prefixed ids the same
+    way. Provide either ``prompt`` text/messages or a pre-computed ``input_tokens``.
+
+    Returns:
+        Cost in USD for the input tokens. ``0.0`` for an unpriced model.
+    """
+    if not model:
+        return 0.0
+    tokens = input_tokens
+    if tokens is None:
+        if prompt is None:
+            return 0.0
+        if LITELLM_AVAILABLE:
+            tokens = (
+                litellm.token_counter(model=model, messages=prompt)
+                if isinstance(prompt, list)
+                else litellm.token_counter(model=model, text=prompt)
+            )
+        else:
+            tokens = max(1, len(str(prompt)) // 4)
+    in_cost, _ = cost_from_tokens(max(int(tokens), 0), 0, model, strict=False)
+    return float(in_cost)
+
+
+# ---------------------------------------------------------------------------
+# Unpriced-at-runtime model registry (issue #1407)
+# ---------------------------------------------------------------------------
+#
+# The pre-run cost-coverage preflight only inspects model ids declared in the
+# configuration space; it cannot see a model HARD-CODED inside the user's
+# @optimize function body. When such a model is unpriced, the non-strict runtime
+# cost path records $0 with only a buried log, silently under-reporting spend.
+# This registry lets the runtime cost path record those ids so the optimizer can
+# surface them on the OptimizationResult (a user-visible warning), reusing the
+# same remediation surface as the preflight. (Strict accounting still RAISES via
+# ``cost_from_tokens(strict=True)`` — fail-closed — so the registry only carries
+# the non-strict, warn-and-continue case.)
+_unpriced_runtime_models: set[str] = set()
+_unpriced_runtime_lock = threading.Lock()
+
+
+def record_unpriced_runtime_model(model: str) -> None:
+    """Record a model id that priced to $0 at runtime despite non-zero tokens."""
+    if not model or not str(model).strip():
+        return
+    with _unpriced_runtime_lock:
+        _unpriced_runtime_models.add(str(model).strip())
+
+
+def get_unpriced_runtime_models() -> list[str]:
+    """Return a snapshot of model ids that priced to $0 at runtime (sorted)."""
+    with _unpriced_runtime_lock:
+        return sorted(_unpriced_runtime_models)
+
+
+def reset_unpriced_runtime_models() -> None:
+    """Clear the unpriced-at-runtime model registry (call before a fresh run)."""
+    with _unpriced_runtime_lock:
+        _unpriced_runtime_models.clear()

--- a/traigent/utils/insights.py
+++ b/traigent/utils/insights.py
@@ -110,11 +110,19 @@ def _analyze_top_configurations(
             ),
         }
 
-        # Add cost analysis if cost metric is available
-        if "cost" in trial.metrics or "cost_per_1k" in trial.metrics:
-            cost_key = "cost_per_1k" if "cost_per_1k" in trial.metrics else "cost"
+        # Add cost analysis if any cost metric is available. Prefer cost_per_1k,
+        # then the per-config ``cost`` metric, then ``total_cost`` so that a run
+        # whose per-config ``cost`` was decoupled from the real spend still
+        # reports a non-zero cost-per-query (#1423).
+        if any(k in trial.metrics for k in ("cost", "cost_per_1k", "total_cost")):
+            cost_per_query = (
+                trial.metrics.get("cost_per_1k")
+                or trial.metrics.get("cost")
+                or trial.metrics.get("total_cost")
+                or 0.0
+            )
             config_analysis["cost_analysis"] = {
-                "cost_per_query": trial.metrics.get(cost_key, 0.0),
+                "cost_per_query": cost_per_query,
                 "cost_efficiency": _calculate_cost_efficiency(trial, primary_objective),
             }
 
@@ -219,7 +227,9 @@ def _analyze_parameter_importance(
                 "optimization_priority": (
                     "high"
                     if performance_impact > 0.1
-                    else "medium" if performance_impact > 0.05 else "low"
+                    else "medium"
+                    if performance_impact > 0.05
+                    else "low"
                 ),
             }
 
@@ -307,12 +317,24 @@ def _calculate_relative_performance(
 
 
 def _calculate_cost_efficiency(trial: TrialResult, primary_objective: str) -> float:
-    """Calculate cost efficiency score."""
-    score = trial.metrics.get(primary_objective, 0.0)
-    cost = trial.metrics.get("cost_per_1k", trial.metrics.get("cost", 1.0))
+    """Calculate cost efficiency score (quality per unit cost).
 
-    if cost == 0:
-        return float("inf")
+    Falls back to ``total_cost`` when the per-config ``cost`` metric is missing,
+    and guards against a zero/missing cost. Returning ``inf`` for cost==0 (the
+    old behavior) corrupted every downstream ranking/aggregation that consumed
+    this value, because a real run whose per-config ``cost`` was wrongly $0
+    produced ``inf`` efficiency for EVERY config (#1423). A non-finite efficiency
+    is not actionable, so we return ``0.0`` when cost is unavailable.
+    """
+    score = trial.metrics.get(primary_objective, 0.0)
+    cost = trial.metrics.get("cost_per_1k")
+    if cost is None:
+        cost = trial.metrics.get("cost")
+    if cost is None:
+        cost = trial.metrics.get("total_cost")
+
+    if not cost:  # None or 0.0
+        return 0.0
 
     return score / cost
 


### PR DESCRIPTION
## What & why

Two cost-correctness defects on the paying-customer path. Fixes #1423, Fixes #1407.

**#1423** — the per-configuration `cost` metric the optimizer minimizes (and the portal displays) was **always `0.0`** even though the SDK computed the real `total_cost` correctly. Result: the `minimize cost` objective was **inert** (every config looked free, so the optimizer could pick the most expensive model on an accuracy tie) and the portal showed `$0` per config.

**#1407** — a model **hard-coded in the optimized function body** (not in the config space) bypassed the cost-coverage preflight; if unpriced it ran as a **silent `$0`** with only a buried log, corrupting the cost objective / Pareto frontier / cost stop-condition.

## Fix

- Per-config `cost` is materialized from the authoritative `total_cost` only when `cost` is absent/≤0 and `total_cost>0` (a legitimately positive or zero cost is preserved — no clobbering). The `minimize cost` objective falls back to `total_cost`. `result.total_cost` is unchanged (it was already correct).
- `input_cost`/`output_cost` are back-filled from the canonical calculator, scaled to the authoritative total (the split is the non-authoritative approximation; the total is the billed number).
- OpenRouter-prefix pricing fixed via a model-candidate ladder (`completion_cost("openrouter/openai/gpt-4o-mini")` now prices non-zero; genuinely-unpriced models still return `0.0` — no false pricing). New public `completion_cost()`/`prompt_cost()` helpers.
- **#1407**: an unpriced-at-runtime model (non-zero tokens, $0 price) is collected and surfaced to the **user and the result object** (`OptimizationResult.warnings` / `warning_codes` / metadata) — not just a log. Under `TRAIGENT_STRICT_COST_ACCOUNTING=true` the run **fails closed**.
- `cost_efficiency` divide-by-zero guarded (finite `0.0`, not `inf`).

## Tests

10 new regression tests (`tests/unit/utils/test_cost_metric_wiring_1423_1407.py`), real discriminators: non-zero model-differentiated cost (gpt-4o ≈ $0.00475 vs mini ≈ $0.000285), objective prefers cheaper on a tie, unpriced-fixed-in-code model → result warning (non-strict) and raise (strict), OpenRouter prefix non-zero, genuinely-unpriced stays $0. 375 surrounding cost tests pass; broad sweeps `tests/unit/core/` 1956, `api`+`utils` 2408, `evaluators` 404 pass. Reviewed by a codex gpt-5.5 gate (GO-with-nits).

## Known limitation / follow-up

The unpriced-runtime-model registry is process-global (reset per run). Sequential runs are correctly attributed; **concurrent** `optimize()` calls in one process could cross-attribute an unpriced-model warning. Tracked as a follow-up (run-scoped registry); not a correctness blocker for the primary cost fix.

## Cross-leg coupling note

This makes the SDK emit a **real non-zero per-config cost** — which is what makes the sibling backend read-back precision fix (BE #1333) observable. The backend must not re-zero a present non-zero cost (consistent with #1407's note that the BE faithfully echoes the SDK number).

## PR checklist

1. **Worst-case prod path** — a wrong/zero cost corrupts the cost objective & "cheapest config"; now cost is real, and an unpriced model is surfaced (non-strict) or **fails closed** (strict). No fail-open.
2. **Production-branch test** — `test_unpriced_fixed_in_code_model_fails_closed_under_strict` + `..._surfaces_warning` + the wiring/objective tests.
3. **Contract regeneration** — none. `OptimizationResult` is the SDK return object, not a wire DTO (no `to_dict`, not in any cloud request body). JS-SDK cost-warning parity is a separate non-blocking follow-up.
4. **Public surface delta** — new public `completion_cost()`/`prompt_cost()`; `OptimizationResult` gains `warnings`/`warning_codes` (backward-compatible defaults).
5. **Review threads** — codex gate addressed (1 nit documented above); will resolve Aikido/Greptile/Sonar before merge.
6. **Quality gates** — none relaxed; the metric-union ceiling stays 50 (codex confirmed `cost` reservation is correct eviction priority, not cap inflation).

Spine-Trail: st_73ac50c6e6ef
