### PR TITLE
fix(objectives): fail-closed on unimplemented normalization strategies

### DIFF
--- a/tests/unit/core/test_objectives.py
+++ b/tests/unit/core/test_objectives.py
@@ -74,14 +74,65 @@ class TestObjectiveDefinition:
             )
 
     def test_invalid_normalization(self):
-        """Test that invalid normalization strategies are rejected."""
-        with pytest.raises(ValueError, match="Normalization must be one of"):
+        """Test that an unknown normalization strategy raises ValueError."""
+        with pytest.raises(ValueError, match="not a recognised strategy"):
             ObjectiveDefinition(
                 name="accuracy",
                 orientation="maximize",
                 weight=1.0,
                 normalization="invalid",
             )
+
+    def test_z_score_normalization_raises_not_implemented(self):
+        """Test that z_score raises NotImplementedError (reserved, not implemented)."""
+        with pytest.raises(NotImplementedError, match="z_score.*not implemented"):
+            ObjectiveDefinition(
+                name="accuracy",
+                orientation="maximize",
+                weight=1.0,
+                normalization="z_score",
+            )
+
+    def test_robust_normalization_raises_not_implemented(self):
+        """Test that robust raises NotImplementedError (reserved, not implemented)."""
+        with pytest.raises(NotImplementedError, match="robust.*not implemented"):
+            ObjectiveDefinition(
+                name="cost",
+                orientation="minimize",
+                weight=1.0,
+                normalization="robust",
+            )
+
+    def test_min_max_normalization_is_valid(self):
+        """Test that min_max is the only valid normalization and constructs without error."""
+        obj = ObjectiveDefinition(
+            name="accuracy",
+            orientation="maximize",
+            weight=1.0,
+            normalization="min_max",
+        )
+        assert obj.normalization == "min_max"
+
+    def test_default_normalization_is_min_max(self):
+        """Test that default normalization (no argument) is min_max."""
+        obj = ObjectiveDefinition(name="accuracy", orientation="maximize", weight=1.0)
+        assert obj.normalization == "min_max"
+
+    def test_min_max_roundtrip_via_dict(self):
+        """Test that a min_max objective round-trips correctly through to_dict/from_dict."""
+        original = ObjectiveDefinition(
+            name="accuracy",
+            orientation="maximize",
+            weight=0.8,
+            normalization="min_max",
+            bounds=(0.0, 1.0),
+            unit="ratio",
+        )
+        restored = ObjectiveDefinition.from_dict(original.to_dict())
+        assert restored.name == original.name
+        assert restored.normalization == "min_max"
+        assert restored.bounds == original.bounds
+        assert restored.unit == original.unit
 
     def test_to_dict(self):
         """Test conversion to dictionary."""
@@ -109,7 +160,7 @@ class TestObjectiveDefinition:
             "name": "latency",
             "orientation": "minimize",
             "weight": 0.2,
-            "normalization": "z_score",
+            "normalization": "min_max",
             "bounds": [0.0, 5.0],
             "unit": "seconds",
         }
@@ -118,9 +169,32 @@ class TestObjectiveDefinition:
         assert obj.name == "latency"
         assert obj.orientation == "minimize"
         assert obj.weight == 0.2
-        assert obj.normalization == "z_score"
+        assert obj.normalization == "min_max"
         assert obj.bounds == (0.0, 5.0)
         assert obj.unit == "seconds"
+
+    def test_from_dict_z_score_raises(self):
+        """Test that from_dict with z_score normalization raises NotImplementedError."""
+        data = {
+            "name": "latency",
+            "orientation": "minimize",
+            "weight": 0.2,
+            "normalization": "z_score",
+            "bounds": [0.0, 5.0],
+        }
+        with pytest.raises(NotImplementedError, match="z_score.*not implemented"):
+            ObjectiveDefinition.from_dict(data)
+
+    def test_from_dict_robust_raises(self):
+        """Test that from_dict with robust normalization raises NotImplementedError."""
+        data = {
+            "name": "latency",
+            "orientation": "minimize",
+            "weight": 0.2,
+            "normalization": "robust",
+        }
+        with pytest.raises(NotImplementedError, match="robust.*not implemented"):
+            ObjectiveDefinition.from_dict(data)
 
 
 class TestObjectiveSchema:

--- a/tests/unit/core/test_objectives_edge_cases.py
+++ b/tests/unit/core/test_objectives_edge_cases.py
@@ -180,7 +180,8 @@ class TestProvidedBoundsVsObservedRanges:
         # Accuracy uses provided bounds
         metrics = {"accuracy": 0.8, "latency": 50}
         normalized = schema.normalize_metrics(
-            metrics, ranges={"latency": (10, 100)}  # Observed range for latency
+            metrics,
+            ranges={"latency": (10, 100)},  # Observed range for latency
         )
 
         assert normalized["accuracy"] == 0.8  # Direct with 0-1 bounds
@@ -449,7 +450,7 @@ class TestSerializationRoundTrips:
             name="f1_score",
             orientation="maximize",
             weight=0.7,
-            normalization="z_score",
+            normalization="min_max",
             bounds=(0.0, 1.0),
             unit="ratio",
         )
@@ -471,7 +472,7 @@ class TestSerializationRoundTrips:
         objectives = [
             ObjectiveDefinition("accuracy", "maximize", 0.5, bounds=(0, 1)),
             ObjectiveDefinition("cost", "minimize", 0.3, unit="USD"),
-            ObjectiveDefinition("latency", "minimize", 0.2, normalization="robust"),
+            ObjectiveDefinition("latency", "minimize", 0.2, normalization="min_max"),
         ]
         original = ObjectiveSchema.from_objectives(objectives, schema_version="1.2.3")
 
@@ -503,7 +504,7 @@ class TestSerializationRoundTrips:
                 name=f"metric_{i}",
                 orientation="maximize" if i % 2 == 0 else "minimize",
                 weight=1.0 / 10,  # Equal weights
-                normalization=["min_max", "z_score", "robust"][i % 3],
+                normalization="min_max",
                 bounds=(0, 100 * (i + 1)) if i % 2 == 0 else None,
                 unit=["percentage", "ms", "MB", None][i % 4],
             )

--- a/tests/unit/utils/test_optimization_logger_objectives.py
+++ b/tests/unit/utils/test_optimization_logger_objectives.py
@@ -257,7 +257,7 @@ class TestOptimizationLoggerObjectives:
                 name="latency",
                 orientation="minimize",
                 weight=0.2,
-                normalization="z_score",
+                normalization="min_max",
                 bounds=(0, 1000),
                 unit="ms",
             ),
@@ -287,7 +287,7 @@ class TestOptimizationLoggerObjectives:
         assert objectives_by_name["cost"]["bounds"] == [0.0, 0.1]
         assert objectives_by_name["cost"]["unit"] == "USD"
 
-        assert objectives_by_name["latency"]["normalization"] == "z_score"
+        assert objectives_by_name["latency"]["normalization"] == "min_max"
         assert objectives_by_name["latency"]["bounds"] == [0, 1000]
         assert objectives_by_name["latency"]["unit"] == "ms"
 

--- a/traigent/core/objectives.py
+++ b/traigent/core/objectives.py
@@ -113,12 +113,19 @@ class ObjectiveDefinition:
                     f"Invalid bounds: min ({self.bounds[0]}) must be less than max ({self.bounds[1]})"
                 )
 
-        # Validate normalization
-        valid_normalizations = ["min_max", "z_score", "robust"]
-        if self.normalization not in valid_normalizations:
+        # Validate normalization — only "min_max" is implemented.
+        # "z_score" and "robust" are reserved and will be supported in a future
+        # version; accepting them silently would produce incorrect results.
+        if self.normalization in ("z_score", "robust"):
+            raise NotImplementedError(
+                f"normalization='{self.normalization}' is not implemented; "
+                f"only 'min_max' is available in this version. "
+                f"Remove the normalization argument or set normalization='min_max'."
+            )
+        if self.normalization != "min_max":
             raise ValueError(
-                f"Normalization must be one of {valid_normalizations}, "
-                f"got '{self.normalization}' for objective '{self.name}'"
+                f"normalization='{self.normalization}' is not a recognised strategy "
+                f"for objective '{self.name}'. Only 'min_max' is supported."
             )
 
         # Validate band_alpha


### PR DESCRIPTION
## Summary

Makes `ObjectiveDefinition` **fail closed** on unimplemented normalization strategies. `z_score`/`robust` were accepted but only `min_max` is implemented — they silently behaved like the default (a no-op that looks like success, CLAUDE.md Rule 2). They now raise `NotImplementedError`. Paired with the TraigentSchema enum-narrow PR.

## Why

`normalize_value` / `_normalize_value_for_aggregation` never branch on `obj.normalization`; codex (gpt-5.4) + sonnet confirmed no SDK consumer honors `z_score`/`robust`. Selecting them silently produced `min_max`-style behavior.

## Changes

- `traigent/core/objectives.py`: `ObjectiveDefinition.__post_init__` raises `NotImplementedError` for `z_score`/`robust` (unknown values → `ValueError`); honored at `from_dict` too (it routes through `__post_init__`), so previously-serialized configs fail loudly at load. `min_max` behavior unchanged.
- Regression tests in `tests/unit/core/test_objectives.py`: `z_score`/`robust` raise at construction and via `from_dict`; `min_max` constructs + round-trips; default is `min_max`. Aligned 4 pre-existing tests that used `z_score`/`robust` as valid values.

## PR checklist

1. **Worst-case prod path** — a config requesting `z_score`/`robust` now raises at construction/load instead of silently mis-normalizing scores. ✅ fails closed.
2. **Production-branch test** — `tests/unit/core/test_objectives.py::test_z_score_normalization_raises_not_implemented`, `::test_robust_normalization_raises_not_implemented`, `::test_from_dict_z_score_raises`, `::test_from_dict_robust_raises`.
3. **Contract regeneration** — pairs with the TraigentSchema PR (enum narrow). No further regen; blast radius SDK+Schema-contained.
4. **Public surface delta** — behavior change: `z_score`/`robust` now raise; error message points users to `min_max`; documented in the schema.
5. **Review threads** — codex 5.4 cross-review verdict: SHIP-WITH-NITS.
6. **Quality gates not relaxed** — none widened; `make local-gate` PASSED (230 tests). NOTE: the local pre-commit `mypy` hook flags **10 pre-existing errors in 4 unrelated files** (`config/types.py`, `analytics/intelligence.py`, `core/metadata_helpers.py`, `core/backend_session_manager.py`, `core/orchestrator.py`) — develop debt, not introduced here; the changed file `objectives.py` is mypy-clean. Flagged for separate cleanup, not relaxed.

Depends on: TraigentSchema PR (`NormalizationStrategy` → `["min_max"]`).
Spine-Trail: st_6d900417c46c
Spine: cs_1d84cacb3ff38ffe (bug-fix ChangeSession; trail promoted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
