### PR TITLE
test(coverage): backfill parameter/enum coverage gaps from optimize-interface audit

### DIFF
--- a/tests/unit/api/test_auto_detect_tvars_decorator.py
+++ b/tests/unit/api/test_auto_detect_tvars_decorator.py
@@ -63,6 +63,53 @@ def test_auto_detect_tvars_apply_exclude_filter() -> None:
     assert "model" in sample_agent.configuration_space
 
 
+def test_auto_detect_tvars_mode_off_respects_explicit_configuration_space() -> None:
+    @optimize(
+        configuration_space={"manual_param": [1, 2, 3]},
+        auto_detect_tvars_mode="off",
+    )
+    def sample_agent(query: str) -> str:
+        temperature = 0.7  # noqa: F841
+        config = {"model": "gpt-4o-mini"}  # noqa: F841
+        return f"answer: {query}"
+
+    assert isinstance(sample_agent, OptimizedFunction)
+    assert sample_agent.configuration_space == {"manual_param": [1, 2, 3]}
+
+
+@pytest.mark.parametrize(
+    ("min_confidence", "expected_space"),
+    [
+        pytest.param("high", {"temperature": (0.0, 2.0)}, id="high"),
+        pytest.param(
+            "medium",
+            {"temperature": (0.0, 2.0), "model": ["gpt-4o-mini"]},
+            id="medium",
+        ),
+        pytest.param(
+            "low",
+            {"temperature": (0.0, 2.0), "model": ["gpt-4o-mini"]},
+            id="low",
+        ),
+    ],
+)
+def test_auto_detect_tvars_min_confidence_filters_candidates(
+    min_confidence: str,
+    expected_space: dict[str, object],
+) -> None:
+    @optimize(
+        auto_detect_tvars_mode="apply",
+        auto_detect_tvars_min_confidence=min_confidence,
+    )
+    def sample_agent(query: str) -> str:
+        temperature = 0.7  # noqa: F841
+        config = {"model": "gpt-4o-mini"}  # noqa: F841
+        return f"answer: {query}"
+
+    assert isinstance(sample_agent, OptimizedFunction)
+    assert sample_agent.configuration_space == expected_space
+
+
 def test_auto_detect_tvars_bool_remains_suggest_only() -> None:
     with pytest.raises(ValueError, match="Configuration space cannot be empty"):
 

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -10,11 +10,40 @@ import pytest
 from traigent.api.decorators import optimize
 from traigent.api.strategy_presets import (
     MAX_ACCURACY_THEN_CHEAPEST,
+    PARETO_FRONTIER,
     QUALITY_FLOOR_MIN_COST,
 )
 from traigent.api.types import ExampleResult
 from traigent.core.optimized_function import OptimizedFunction
 from traigent.evaluators.base import Dataset
+
+
+def _write_environment_tvl_spec(tmp_path: Path) -> Path:
+    spec_path = tmp_path / "environment_overlay.tvl.yml"
+    spec_path.write_text(
+        """tvl:
+  module: test.environment
+tvl_version: "0.9"
+tvars:
+  - name: retrieval_depth
+    type: int
+    domain:
+      range: [2, 6]
+objectives:
+  - name: accuracy
+    direction: maximize
+environments:
+  finals_week:
+    overrides:
+      tvars:
+        - name: retrieval_depth
+          type: int
+          domain:
+            range: [3, 8]
+""",
+        encoding="utf-8",
+    )
+    return spec_path
 
 
 class TestOptimizeDecorator:
@@ -225,6 +254,39 @@ class TestOptimizeDecorator:
                 "Selected the lowest-cost completed trial within the preset accuracy band."
             ),
         }
+
+    def test_decorator_accepts_pareto_frontier_strategy_preset(self):
+        """Pareto frontier preset should resolve objectives without extra params."""
+
+        @optimize(
+            configuration_space={"model": ["cheap", "accurate"]},
+            strategy=PARETO_FRONTIER,
+            strategy_params={},
+        )
+        def sample_function() -> str:
+            return "ok"
+
+        assert isinstance(sample_function, OptimizedFunction)
+        assert sample_function.objectives == ["accuracy", "cost"]
+        assert sample_function.strategy_preset.to_metadata() == {
+            "preset_name": PARETO_FRONTIER,
+            "params": {},
+            "selection_grade": "advisory",
+            "selection_rationale": (
+                "Selected all completed trials on the advisory accuracy-cost Pareto frontier."
+            ),
+        }
+
+    def test_decorator_rejects_pareto_frontier_unexpected_params(self):
+        with pytest.raises(ValueError, match="does not accept strategy_params"):
+
+            @optimize(
+                configuration_space={"model": ["cheap", "accurate"]},
+                strategy=PARETO_FRONTIER,
+                strategy_params={"epsilon": 0.1},
+            )
+            def sample_function() -> str:
+                return "ok"
 
     def test_decorator_rejects_strategy_preset_with_objectives(self):
         """Preset business goals should not silently override hand-set objectives."""
@@ -538,6 +600,88 @@ objectives:
 
         assert isinstance(tvl_wrapped, OptimizedFunction)
         assert tvl_wrapped.eval_dataset == "user.jsonl"
+
+    def test_decorator_applies_tvl_environment_overlay(self, tmp_path):
+        spec_path = _write_environment_tvl_spec(tmp_path)
+
+        @optimize(tvl_spec=spec_path, tvl_environment="finals_week")
+        def tvl_wrapped(question: str) -> str:
+            return question
+
+        assert isinstance(tvl_wrapped, OptimizedFunction)
+        assert tvl_wrapped.configuration_space["retrieval_depth"] == (3, 8)
+
+    def test_decorator_accepts_structured_tvl_options_model(self, tmp_path):
+        from traigent.tvl.options import TVLOptions
+
+        spec_path = _write_environment_tvl_spec(tmp_path)
+
+        @optimize(tvl=TVLOptions(spec_path=str(spec_path), environment="finals_week"))
+        def tvl_wrapped(question: str) -> str:
+            return question
+
+        assert isinstance(tvl_wrapped, OptimizedFunction)
+        assert tvl_wrapped.configuration_space["retrieval_depth"] == (3, 8)
+
+    def test_decorator_accepts_structured_tvl_options_dict(self, tmp_path):
+        spec_path = _write_environment_tvl_spec(tmp_path)
+
+        @optimize(tvl={"spec_path": str(spec_path), "environment": "finals_week"})
+        def tvl_wrapped(question: str) -> str:
+            return question
+
+        assert isinstance(tvl_wrapped, OptimizedFunction)
+        assert tvl_wrapped.configuration_space["retrieval_depth"] == (3, 8)
+
+    def test_mock_mode_options_round_trip_base_accuracy_and_variance(self):
+        from traigent.api.decorators import MockModeOptions
+
+        @optimize(
+            configuration_space={"x": [1, 2, 3]},
+            mock=MockModeOptions(base_accuracy=0.9, variance=0.05),
+        )
+        def func_with_mock_round_trip(x):
+            return x
+
+        # base_accuracy and variance are inert; this only confirms they survive
+        # decorator construction / round-trip into mock_mode_config.
+        assert isinstance(func_with_mock_round_trip, OptimizedFunction)
+        assert func_with_mock_round_trip.mock_mode_config["base_accuracy"] == 0.9
+        assert func_with_mock_round_trip.mock_mode_config["variance"] == 0.05
+
+    def test_decorator_wires_agent_configuration_parameters(self):
+        from traigent.api.types import AgentDefinition
+
+        @optimize(
+            configuration_space={
+                "router_model": ["gpt-4o"],
+                "draft_model": ["gpt-4o-mini"],
+            },
+            agents={
+                "router": AgentDefinition(
+                    display_name="Router",
+                    parameter_keys=["router_model"],
+                    measure_ids=["routing_accuracy"],
+                )
+            },
+            agent_prefixes=["draft"],
+            agent_measures={
+                "router": ["routing_accuracy"],
+                "draft": ["draft_accuracy"],
+            },
+            global_measures=["total_cost"],
+        )
+        def sample_function() -> str:
+            return "ok"
+
+        assert isinstance(sample_function, OptimizedFunction)
+        assert sample_function.agents["router"].parameter_keys == ["router_model"]
+        assert sample_function.agent_prefixes == ["draft"]
+        assert sample_function.agent_measures == {
+            "router": ["routing_accuracy"],
+            "draft": ["draft_accuracy"],
+        }
+        assert sample_function.global_measures == ["total_cost"]
 
 
 class TestOptimizedFunctionIntegration:

--- a/tests/unit/api/test_execution_policy_resolution.py
+++ b/tests/unit/api/test_execution_policy_resolution.py
@@ -8,7 +8,7 @@ import warnings
 import pytest
 
 from traigent.api.decorators import ExecutionOptions, HybridAPIOptions, optimize
-from traigent.config.types import ExecutionIntent
+from traigent.config.types import ExecutionIntent, resolve_execution_policy
 from traigent.core.optimized_function import OptimizedFunction
 from traigent.utils.exceptions import ConfigurationError
 
@@ -200,3 +200,12 @@ def test_known_smart_algorithm_names_accepted() -> None:
             return x
 
         assert sample.execution_policy.algorithm == name
+
+
+def test_smart_algorithm_resolves_cloud_required_policy() -> None:
+    policy = resolve_execution_policy(algorithm="tpe", offline=False)
+
+    assert policy.intent is ExecutionIntent.CLOUD_REQUIRED
+    assert policy.algorithm == "tpe"
+    assert policy.offline is False
+    assert policy.allows_cloud_fallback is False

--- a/tests/unit/api/test_types.py
+++ b/tests/unit/api/test_types.py
@@ -39,6 +39,7 @@ class TestEnums:
         assert OptimizationStatus.COMPLETED == "completed"
         assert OptimizationStatus.FAILED == "failed"
         assert OptimizationStatus.CANCELLED == "cancelled"
+        assert OptimizationStatus.UNKNOWN == "unknown"
 
     def test_trial_status_values(self):
         """Test TrialStatus enum values."""

--- a/tests/unit/core/test_best_config_runtime_integration.py
+++ b/tests/unit/core/test_best_config_runtime_integration.py
@@ -20,11 +20,13 @@ from traigent.api.types import (
     TrialStatus,
 )
 from traigent.core.best_config_runtime import (
+    BEST_CONFIG_SCHEMA_VERSION,
     BestConfigSnapshot,
     BestConfigSource,
     CloudPublishUnavailable,
     CloudPublishUnavailableReason,
     function_ref_for,
+    write_cloud_cache_best_config,
     write_repo_best_config,
 )
 from traigent.core.optimized_function import OptimizedFunction
@@ -40,6 +42,22 @@ def plain_answer(text: str, **kwargs):
 def context_answer(text: str):
     config = traigent.get_config()
     return f"{text}:{config.get('temperature')}"
+
+
+def _build_canonical_best_config_spec(
+    tmp_path: Path,
+    *,
+    config_id: str,
+    config: dict[str, float],
+    func,
+) -> dict[str, object]:
+    spec_path = write_repo_best_config(
+        tmp_path / ".spec-seed" / config_id,
+        config_id=config_id,
+        config=config,
+        function_ref=function_ref_for(func),
+    )
+    return json.loads(spec_path.read_text(encoding="utf-8"))
 
 
 def test_load_from_beats_env_path(tmp_path, monkeypatch):
@@ -506,6 +524,136 @@ def test_decorator_passes_cloud_cache_ttl_options(tmp_path):
 
     assert wrapped.current_config["temperature"] == 0.4
     assert wrapped.best_config_snapshot.source == BestConfigSource.CLOUD_CACHE.value
+
+
+def test_decorator_best_config_strict_rejects_invalid_repo_spec(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec_path = write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id="strict-answerer",
+        config={"temperature": 0.4},
+        function_ref=function_ref_for(context_answer),
+    )
+    spec_path.write_text(
+        json.dumps({"schema_version": BEST_CONFIG_SCHEMA_VERSION}),
+        encoding="utf-8",
+    )
+
+    relaxed = optimize(
+        configuration_space={"temperature": [0.1, 0.4]},
+        config_id="strict-answerer",
+        best_config_source="repo",
+        best_config_strict=False,
+        default_config={"temperature": 0.1},
+    )(context_answer)
+
+    assert relaxed.current_config["temperature"] == 0.1
+    assert relaxed.best_config_snapshot.source == BestConfigSource.DEFAULT.value
+
+    with pytest.raises(ConfigurationError, match="missing fields"):
+        optimize(
+            configuration_space={"temperature": [0.1, 0.4]},
+            config_id="strict-answerer",
+            best_config_source="repo",
+            best_config_strict=True,
+            default_config={"temperature": 0.1},
+        )(context_answer)
+
+
+def test_decorator_enable_auto_load_dev_logs_reads_latest_config(tmp_path):
+    artifacts_dir = (
+        tmp_path
+        / "optimization_logs"
+        / "experiments"
+        / "context_answer"
+        / "runs"
+        / "run-001"
+        / "artifacts"
+    )
+    artifacts_dir.mkdir(parents=True)
+    (artifacts_dir / "best_config.json").write_text(
+        json.dumps({"config": {"temperature": 0.6}}),
+        encoding="utf-8",
+    )
+
+    wrapped = optimize(
+        configuration_space={"temperature": [0.1, 0.6]},
+        local_storage_path=str(tmp_path),
+        enable_auto_load_dev_logs=True,
+        default_config={"temperature": 0.1},
+    )(context_answer)
+
+    assert wrapped.current_config["temperature"] == 0.6
+    assert wrapped.best_config_snapshot.source == BestConfigSource.DEV_LOG.value
+    assert wrapped("ok") == "ok:0.6"
+
+
+def test_decorator_repo_then_cloud_prefers_repo_before_cloud_cache(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_id = "waterfall-answerer"
+    cache_dir = tmp_path / "cache"
+
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id=config_id,
+        config={"temperature": 0.4},
+        function_ref=function_ref_for(context_answer),
+    )
+    cloud_spec = _build_canonical_best_config_spec(
+        tmp_path,
+        config_id=config_id,
+        config={"temperature": 0.8},
+        func=context_answer,
+    )
+    write_cloud_cache_best_config(cache_dir, cloud_spec, version=1)
+
+    wrapped = optimize(
+        configuration_space={"temperature": [0.1, 0.4, 0.8]},
+        config_id=config_id,
+        best_config_source="repo_then_cloud",
+        best_config_cache_dir=str(cache_dir),
+        default_config={"temperature": 0.1},
+    )(context_answer)
+
+    assert wrapped.current_config["temperature"] == 0.4
+    assert wrapped.best_config_snapshot.source == BestConfigSource.REPO.value
+    assert wrapped("ok") == "ok:0.4"
+
+
+def test_decorator_cloud_then_repo_prefers_cloud_cache_before_repo(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    config_id = "waterfall-answerer"
+    cache_dir = tmp_path / "cache"
+
+    write_repo_best_config(
+        tmp_path / ".traigent" / "best-configs",
+        config_id=config_id,
+        config={"temperature": 0.4},
+        function_ref=function_ref_for(context_answer),
+    )
+    cloud_spec = _build_canonical_best_config_spec(
+        tmp_path,
+        config_id=config_id,
+        config={"temperature": 0.8},
+        func=context_answer,
+    )
+    write_cloud_cache_best_config(cache_dir, cloud_spec, version=1)
+
+    wrapped = optimize(
+        configuration_space={"temperature": [0.1, 0.4, 0.8]},
+        config_id=config_id,
+        best_config_source="cloud_then_repo",
+        best_config_cache_dir=str(cache_dir),
+        default_config={"temperature": 0.1},
+    )(context_answer)
+
+    assert wrapped.current_config["temperature"] == 0.8
+    assert wrapped.best_config_snapshot.source == BestConfigSource.CLOUD_CACHE.value
+    assert wrapped("ok") == "ok:0.8"
 
 
 def streaming_context_answer(text: str):

--- a/tests/unit/core/test_objectives.py
+++ b/tests/unit/core/test_objectives.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from traigent.core.objectives import (
+    AggregationMode,
     ObjectiveDefinition,
     ObjectiveSchema,
     create_default_objectives,
@@ -242,6 +243,28 @@ class TestObjectiveSchema:
         assert schema2.weights_normalized["cost"] == 0.4
         assert schema2.objectives[0].bounds == (0.0, 1.0)
         assert schema2.objectives[0].unit == "percentage"
+
+    @pytest.mark.parametrize(
+        ("mode", "expected"),
+        [
+            pytest.param(AggregationMode.WEIGHTED_SUM, 23 / 30, id="weighted-sum"),
+            pytest.param(AggregationMode.HARMONIC, 16 / 21, id="harmonic"),
+            pytest.param(AggregationMode.CHEBYSHEV, -0.15, id="chebyshev"),
+        ],
+    )
+    def test_compute_aggregated_score_supports_all_modes(self, mode, expected):
+        """Each public aggregation mode should produce its documented score."""
+        schema = ObjectiveSchema.from_objectives(
+            [
+                ObjectiveDefinition("accuracy", "maximize", 0.75),
+                ObjectiveDefinition("cost", "minimize", 0.25),
+            ]
+        )
+        metrics = {"accuracy": 0.8, "cost": 0.5}
+
+        assert schema.compute_aggregated_score(metrics, mode) == pytest.approx(expected)
+        if mode is AggregationMode.WEIGHTED_SUM:
+            assert schema.compute_weighted_score(metrics) == pytest.approx(expected)
 
     def test_get_objective(self):
         """Test getting objective by name."""

--- a/tests/unit/generation/test_decorator_guidance.py
+++ b/tests/unit/generation/test_decorator_guidance.py
@@ -55,6 +55,38 @@ def test_decorator_stores_guidance_options() -> None:
     assert fn.grow_dataset_options is None
 
 
+def test_decorator_stores_grow_dataset_options() -> None:
+    @optimize(
+        eval_dataset=Dataset(
+            examples=[EvaluationExample(input_data={"q": "x"}, expected_output="y")]
+        ),
+        objectives=["accuracy"],
+        configuration_space={"prompt": Choices(["base prompt"])},
+        grow_dataset={"rounds": 2, "target_examples": 4},
+    )
+    def fn(**kwargs):  # noqa: ANN003, ANN202
+        return "ok"
+
+    assert fn.grow_dataset_options == {"rounds": 2, "target_examples": 4}
+    assert fn.skill_train_options is None
+
+
+def test_decorator_stores_skill_train_options() -> None:
+    @optimize(
+        eval_dataset=Dataset(
+            examples=[EvaluationExample(input_data={"q": "x"}, expected_output="y")]
+        ),
+        objectives=["accuracy"],
+        configuration_space={"prompt": Choices(["base prompt"])},
+        skill_train={"epochs": 1, "rollout_batch": 4},
+    )
+    def fn(**kwargs):  # noqa: ANN003, ANN202
+        return "ok"
+
+    assert fn.skill_train_options == {"epochs": 1, "rollout_batch": 4}
+    assert fn.grow_dataset_options is None
+
+
 def test_optimize_with_guidance_uses_stored_options() -> None:
     fn = _decorate()
     plan = GuidancePlan(

--- a/tests/unit/optimizers/test_grid.py
+++ b/tests/unit/optimizers/test_grid.py
@@ -468,6 +468,34 @@ class TestGridSearchOptimizer:
             "prompt",
         ]
 
+    def test_order_alias_matches_parameter_order_behavior(self):
+        """The public order alias should behave like parameter_order."""
+        config_space = {
+            "temperature": [0.0, 0.5],
+            "embedding_model": ["embed-a"],
+            "model": ["gpt-4o"],
+            "prompt": ["cot", "zero_shot"],
+        }
+
+        optimizer = GridSearchOptimizer(
+            config_space,
+            ["accuracy"],
+            order={"temperature": 0, "model": 2},
+        )
+
+        assert optimizer._ordered_param_names == [
+            "temperature",
+            "model",
+            "embedding_model",
+            "prompt",
+        ]
+        assert list(optimizer._grid_points[0].keys()) == [
+            "temperature",
+            "model",
+            "embedding_model",
+            "prompt",
+        ]
+
     def test_parameter_order_invalid_type_raises(self):
         """Reject non-mapping parameter order specifications."""
         config_space = {"model": ["gpt-4o"], "temperature": [0.0, 0.5]}


### PR DESCRIPTION
## Summary

Backfills parameter- and enum-level **test coverage** gaps in the `optimize()` surface, surfaced by a captain-led coverage audit (codex gpt-5.4 implemented, claude-sonnet reviewed). **Tests-only — no product code.**

## Context

A multi-agent audit of the post-refactor `optimize()` interface found params/enum-values with no exercising test. This PR closes the actionable, reachable gaps. Two "gaps" from the first audit pass were dropped after codex verification — call-time `optimize(configuration_space=...)` and `optimize(algorithm="random")` are already tested.

## Coverage added (23 tests across 8 files)

- `AggregationMode`: `sum` / `harmonic` / `chebyshev` (distinct per-mode results independently verified)
- `ExecutionIntent.CLOUD_REQUIRED`; `OptimizationStatus.UNKNOWN`
- `strategy="pareto_frontier"` through `@optimize` (happy + rejection path)
- `auto_detect_tvars_mode="off"`; `auto_detect_tvars_min_confidence` high/medium/low
- `best_config_source` `repo_then_cloud` / `cloud_then_repo` (end-to-end waterfall)
- `best_config_strict`; `enable_auto_load_dev_logs`
- `tvl_environment` overlay; structured `tvl=` (model + dict)
- `grow_dataset` / `skill_train`; `MockModeOptions` base_accuracy/variance round-trip
- grid `order` alias; multi-agent decorator wiring (agents/agent_prefixes/agent_measures/global_measures)

## Not covered (honest gaps, not faked)

`StopReason` `"error"` / `"network_error"` / `"user_cancelled"`: no local producer sets these (confirmed independently by codex + sonnet) — only the backend returns them. A local unit test would be a tautological constructor test, so none was added. **Product follow-up:** `"error"` is documented as "failed due to an exception" but no local exception handler ever sets it (left as `None`) — worth a separate fix; out of scope for a test-only PR.

## Checklist

- Tests-only; no public surface / schema / contract change.
- Cross-model reviewed: codex 5.4 implemented; sonnet review = SHIP-WITH-NITS, all 3 nits fixed (removed a duplicate `UNKNOWN` test, added a symmetry assert to the `skill_train` test, added an inert-field comment to the mock round-trip test).
- Quality gates not relaxed: `make local-gate` PASSED (230 tests).

Spine-Trail: st_b3f1459f77e8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
