### PR TITLE
feat(sdk): traigent_get_plan — thin client + MCP tool + CLI (backend pass-through)

### DIFF
--- a/tests/cli/test_plan_command.py
+++ b/tests/cli/test_plan_command.py
@@ -1,0 +1,128 @@
+"""CLI smoke tests for traigent plan."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from traigent.cli.main import cli
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def plan_payload() -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "phase": "P1_STATIC",
+        "plan": {
+            "objectives": [
+                {"name": "accuracy", "weight": 1.0, "orientation": "maximize"}
+            ],
+            "models": ["gpt-4o-mini"],
+            "knobs": [{"name": "temperature", "values": ["0.0", "0.3"]}],
+            "algorithm": "auto",
+            "max_trials": 4,
+            "cost_limit_usd": 5.0,
+            "offline": False,
+        },
+        "steps": [
+            {
+                "id": "review_plan",
+                "label": "Review plan",
+                "command_template": "traigent optimize agent.py --max-trials 4",
+            }
+        ],
+        "evidence_level": "medium",
+        "caveat": "Plans are advisory until a run starts.",
+        "advisory": True,
+    }
+
+
+class _FakeOptimizationPlanClient:
+    def __init__(self, backend_url: str) -> None:
+        self.backend_url = backend_url
+
+    async def __aenter__(self) -> _FakeOptimizationPlanClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        return None
+
+    async def get_optimization_plan(self, **kwargs) -> dict[str, object]:
+        assert kwargs == {
+            "task_description": "Tune a support chatbot.",
+            "dataset_size": 20,
+            "dataset_has_holdout": True,
+            "objectives": ("accuracy", "latency"),
+            "max_trials": 4,
+            "cost_limit_usd": 5.0,
+            "task_type": "chatbot",
+        }
+        return _FakeOptimizationPlanClient.payload
+
+
+def _plan_args(*extra: str) -> list[str]:
+    return [
+        "plan",
+        "--task-description",
+        "Tune a support chatbot.",
+        "--dataset-size",
+        "20",
+        "--has-holdout",
+        "--objective",
+        "accuracy",
+        "--objective",
+        "latency",
+        "--max-trials",
+        "4",
+        "--cost-limit",
+        "5.0",
+        "--task-type",
+        "chatbot",
+        *extra,
+    ]
+
+
+def test_plan_table_mode(
+    runner: CliRunner,
+    plan_payload: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeOptimizationPlanClient.payload = plan_payload
+    monkeypatch.setattr(
+        "traigent.cli.plan_command.OptimizationPlanClient",
+        _FakeOptimizationPlanClient,
+    )
+
+    result = runner.invoke(cli, _plan_args())
+
+    assert result.exit_code == 0
+    assert "Optimization Plan" in result.output
+    assert "P1_STATIC" in result.output
+    assert "gpt-4o-mini" in result.output
+    assert "temperature" in result.output
+    assert "traigent optimize agent.py --max-trials 4" in result.output
+    assert "Plans are advisory" in result.output
+
+
+def test_plan_json_mode(
+    runner: CliRunner,
+    plan_payload: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeOptimizationPlanClient.payload = plan_payload
+    monkeypatch.setattr(
+        "traigent.cli.plan_command.OptimizationPlanClient",
+        _FakeOptimizationPlanClient,
+    )
+
+    result = runner.invoke(cli, _plan_args("--json"))
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == plan_payload

--- a/tests/unit/analytics/test_optimization_plan.py
+++ b/tests/unit/analytics/test_optimization_plan.py
@@ -1,0 +1,265 @@
+"""Unit tests for OptimizationPlanClient."""
+
+from __future__ import annotations
+
+import importlib.util
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from traigent.analytics import optimization_plan as op_module
+
+HTTPX_AVAILABLE = importlib.util.find_spec("httpx") is not None
+
+
+@pytest.fixture(autouse=True)
+def _online_backend(jwt_development_mode, monkeypatch):
+    """These tests mock transport but exercise the online request path."""
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+
+
+@pytest.fixture()
+def valid_plan_payload() -> dict[str, object]:
+    return {
+        "schema_version": "1.0.0",
+        "phase": "P1_STATIC",
+        "plan": {
+            "objectives": [
+                {"name": "accuracy", "weight": 1.0, "orientation": "maximize"}
+            ],
+            "models": ["gpt-4o-mini"],
+            "knobs": [{"name": "temperature", "values": ["0.0", "0.3"]}],
+            "algorithm": "auto",
+            "max_trials": 4,
+            "cost_limit_usd": 5.0,
+            "offline": False,
+        },
+        "steps": [
+            {
+                "id": "review_plan",
+                "label": "Review plan",
+                "command_template": "traigent plan --task-description ...",
+            }
+        ],
+        "evidence_level": "medium",
+        "caveat": "Plans are advisory until a run starts.",
+        "advisory": True,
+    }
+
+
+class TestOptimizationPlanClientInit:
+    """Tests for OptimizationPlanClient initialization."""
+
+    @pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+    def test_init_defaults(self) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        with patch(
+            "traigent.utils.env_config.get_api_key",
+            return_value="test_key",  # pragma: allowlist secret
+        ):
+            client = OptimizationPlanClient()
+
+            assert client.backend_url == "http://localhost:5000"
+            assert client.timeout == 30.0
+            assert client.api_key == "test_key"  # pragma: allowlist secret
+            assert client._client is None
+
+    @pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+    def test_init_with_custom_values(self) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(
+            backend_url="https://custom.api.com",
+            api_key="custom_key",  # pragma: allowlist secret
+            timeout=60.0,
+        )
+
+        assert client.backend_url == "https://custom.api.com"
+        assert client.api_key == "custom_key"  # pragma: allowlist secret
+        assert client.timeout == 60.0
+
+    @pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+    def test_init_strips_trailing_slash(self) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(
+            backend_url="http://localhost:5000/",
+            api_key="key",  # pragma: allowlist secret
+        )
+
+        assert client.backend_url == "http://localhost:5000"
+
+    @pytest.mark.skipif(HTTPX_AVAILABLE, reason="Test for httpx not available")
+    def test_init_raises_without_httpx(self) -> None:
+        with pytest.raises(ImportError, match="httpx is required"):
+            op_module.OptimizationPlanClient()
+
+
+@pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+class TestOptimizationPlanClientGetClient:
+    """Tests for _get_client method."""
+
+    def test_get_client_creates_client_with_auth_header(self) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(api_key="test_token")
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_instance = MagicMock()
+            mock_async_client.return_value = mock_instance
+
+            result = client._get_client()
+
+            assert result == mock_instance
+            mock_async_client.assert_called_once()
+            call_kwargs = mock_async_client.call_args.kwargs
+            assert call_kwargs["headers"]["Authorization"] == "Bearer test_token"
+
+    def test_get_client_without_api_key(self) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(api_key=None)
+        client.api_key = None
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            client._get_client()
+
+            call_kwargs = mock_async_client.call_args.kwargs
+            assert "Authorization" not in call_kwargs["headers"]
+
+
+@pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+class TestGetOptimizationPlan:
+    """Tests for get_optimization_plan method."""
+
+    @pytest.mark.asyncio
+    async def test_get_optimization_plan_success(
+        self,
+        valid_plan_payload: dict[str, object],
+    ) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(api_key="test")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = valid_plan_payload
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = mock_response
+        client._client = mock_http
+
+        result = await client.get_optimization_plan(
+            task_description="Tune a support chatbot.",
+            dataset_size=20,
+            dataset_has_holdout=True,
+            objectives=["accuracy", "latency"],
+            max_trials=8,
+            cost_limit_usd=12.5,
+            task_type="chatbot",
+            agent_shape="tool_agent",
+            weights={"accuracy": 0.8, "latency": 0.2},
+            offline=False,
+        )
+
+        assert result == valid_plan_payload
+        mock_http.post.assert_called_once_with(
+            "/api/v1/optimization/plan",
+            json={
+                "task_description": "Tune a support chatbot.",
+                "dataset": {"size": 20, "has_holdout": True},
+                "objectives": ["accuracy", "latency"],
+                "budget": {"max_trials": 8, "cost_limit_usd": 12.5},
+                "task_type": "chatbot",
+                "agent_shape": "tool_agent",
+                "weights": {"accuracy": 0.8, "latency": 0.2},
+                "offline": False,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_optimization_plan_omits_absent_optional_fields(
+        self,
+        valid_plan_payload: dict[str, object],
+    ) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(api_key="test")
+        mock_response = MagicMock()
+        mock_response.json.return_value = valid_plan_payload
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = mock_response
+        client._client = mock_http
+
+        await client.get_optimization_plan(
+            task_description="Tune a support chatbot.",
+            dataset_size=20,
+            dataset_has_holdout=False,
+            objectives=["accuracy"],
+            max_trials=4,
+            cost_limit_usd=5.0,
+        )
+
+        kwargs = mock_http.post.call_args.kwargs
+        assert kwargs["json"] == {
+            "task_description": "Tune a support chatbot.",
+            "dataset": {"size": 20, "has_holdout": False},
+            "objectives": ["accuracy"],
+            "budget": {"max_trials": 4, "cost_limit_usd": 5.0},
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_optimization_plan_requires_json_object(self) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(api_key="test")
+        mock_response = MagicMock()
+        mock_response.json.return_value = ["not", "an", "object"]
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = mock_response
+        client._client = mock_http
+
+        with pytest.raises(ValueError, match="expected a JSON object"):
+            await client.get_optimization_plan(
+                task_description="Tune a support chatbot.",
+                dataset_size=20,
+                dataset_has_holdout=False,
+                objectives=["accuracy"],
+                max_trials=4,
+                cost_limit_usd=5.0,
+            )
+
+    @pytest.mark.parametrize("missing_key", ["plan", "steps", "advisory"])
+    async def test_get_optimization_plan_requires_full_contract_keys(
+        self,
+        valid_plan_payload: dict[str, object],
+        missing_key: str,
+    ) -> None:
+        from traigent.analytics.optimization_plan import OptimizationPlanClient
+
+        client = OptimizationPlanClient(api_key="test")
+        malformed = dict(valid_plan_payload)
+        malformed.pop(missing_key)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = malformed
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = mock_response
+        client._client = mock_http
+
+        with pytest.raises(ValueError, match="missing required key"):
+            await client.get_optimization_plan(
+                task_description="Tune a support chatbot.",
+                dataset_size=20,
+                dataset_has_holdout=False,
+                objectives=["accuracy"],
+                max_trials=4,
+                cost_limit_usd=5.0,
+            )

--- a/tests/unit/mcp/test_local_server.py
+++ b/tests/unit/mcp/test_local_server.py
@@ -83,6 +83,7 @@ async def test_tool_listing_matches_v1_set() -> None:
 
     assert [tool.name for tool in result.tools] == list(V1_TOOL_NAMES)
     assert "scaffold_eval" in {tool.name for tool in result.tools}
+    assert "get_optimization_plan" in {tool.name for tool in result.tools}
     assert "export_evidence" in {tool.name for tool in result.tools}
     assert "significant_variables" not in {tool.name for tool in result.tools}
     assert "generate_examples" not in {tool.name for tool in result.tools}
@@ -102,6 +103,87 @@ async def test_catalog_and_recommend_happy_path() -> None:
     assert recommendation["ok"] is True
     assert recommendation["recommendation"]["agent_type"] == "rag"
     assert "configuration_space" in recommendation["recommendation"]
+
+
+async def test_get_optimization_plan_delegates_to_backend_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "schema_version": "1.0.0",
+        "phase": "P1_STATIC",
+        "plan": {
+            "objectives": [
+                {"name": "accuracy", "weight": 1.0, "orientation": "maximize"}
+            ],
+            "models": ["gpt-4o-mini"],
+            "knobs": [{"name": "temperature", "values": ["0.0", "0.3"]}],
+            "algorithm": "auto",
+            "max_trials": 4,
+            "cost_limit_usd": 5.0,
+            "offline": False,
+        },
+        "steps": [
+            {
+                "id": "review_plan",
+                "label": "Review plan",
+                "command_template": "traigent optimize agent.py --max-trials 4",
+            }
+        ],
+        "evidence_level": "medium",
+        "caveat": "Plans are advisory until a run starts.",
+        "advisory": True,
+    }
+    calls: list[dict[str, Any]] = []
+
+    class FakeOptimizationPlanClient:
+        async def __aenter__(self) -> FakeOptimizationPlanClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+            return None
+
+        async def get_optimization_plan(self, **kwargs: Any) -> dict[str, Any]:
+            calls.append(kwargs)
+            return payload
+
+    monkeypatch.setattr(
+        "traigent.mcp.tools.OptimizationPlanClient",
+        FakeOptimizationPlanClient,
+    )
+
+    async with mcp_session() as session:
+        result = await call_tool(
+            session,
+            "get_optimization_plan",
+            {
+                "task_description": "Tune a support chatbot.",
+                "dataset_size": 20,
+                "dataset_has_holdout": True,
+                "objectives": ["accuracy", "latency"],
+                "max_trials": 4,
+                "cost_limit_usd": 5.0,
+                "task_type": "chatbot",
+                "agent_shape": "tool_agent",
+                "weights": {"accuracy": 0.8, "latency": 0.2},
+                "offline": False,
+            },
+        )
+
+    assert result == payload
+    assert calls == [
+        {
+            "task_description": "Tune a support chatbot.",
+            "dataset_size": 20,
+            "dataset_has_holdout": True,
+            "objectives": ["accuracy", "latency"],
+            "max_trials": 4,
+            "cost_limit_usd": 5.0,
+            "task_type": "chatbot",
+            "agent_shape": "tool_agent",
+            "weights": {"accuracy": 0.8, "latency": 0.2},
+            "offline": False,
+        }
+    ]
 
 
 async def test_detect_validate_and_estimate_happy_paths(

--- a/tests/unit/mcp/test_local_server.py
+++ b/tests/unit/mcp/test_local_server.py
@@ -375,7 +375,9 @@ async def test_run_optimization_real_allows_user_approved_eval_manifest(
         manifest["approved_by"] = "pytest"
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-        def fake_run(*args: Any, **kwargs: Any) -> tuple[list[dict[str, Any]], str, str]:
+        def fake_run(
+            *args: Any, **kwargs: Any
+        ) -> tuple[list[dict[str, Any]], str, str]:
             return (
                 [
                     {

--- a/traigent/analytics/__init__.py
+++ b/traigent/analytics/__init__.py
@@ -92,6 +92,7 @@ except ImportError:
         PerformancePredictor,
     )
     from .next_steps import NextStepsClient
+    from .optimization_plan import OptimizationPlanClient
 
     # Predictive analytics
     from .predictive import (
@@ -130,6 +131,7 @@ __all__ = [
     # Example Insights
     "ExampleInsightsClient",
     "NextStepsClient",
+    "OptimizationPlanClient",
     # Historical analytics
     "HistoricalAnalyticsEngine",
     "OptimizationHistory",

--- a/traigent/analytics/optimization_plan.py
+++ b/traigent/analytics/optimization_plan.py
@@ -1,0 +1,202 @@
+"""Client for retrieving backend-provided pre-run optimization plans.
+
+This module provides an async-first thin client for:
+``POST /api/v1/optimization/plan``.
+
+The backend owns all planning intelligence. The SDK only sends the request
+context, validates the response has the required top-level contract keys, and
+returns the allowlisted payload unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+from traigent.config.backend_config import DEFAULT_LOCAL_URL
+from traigent.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore
+
+
+_REQUIRED_RESPONSE_KEYS = {
+    "schema_version",
+    "phase",
+    "plan",
+    "steps",
+    "evidence_level",
+    "caveat",
+    "advisory",
+}
+
+
+class OptimizationPlanClient:
+    """Client for retrieving allowlisted pre-run optimization plans.
+
+    Thread Safety: Safe for concurrent use (httpx.AsyncClient is thread-safe).
+    """
+
+    def __init__(
+        self,
+        backend_url: str = DEFAULT_LOCAL_URL,
+        api_key: str | None = None,
+        timeout: float = 30.0,
+    ):
+        """Initialize OptimizationPlanClient.
+
+        Args:
+            backend_url: Backend API base URL. The backend must expose the
+                optimization plan endpoint.
+            api_key: API key for authentication (None uses env var
+                TRAIGENT_API_KEY)
+            timeout: Default timeout for HTTP requests in seconds
+
+        Raises:
+            ImportError: If httpx is not installed
+        """
+        if not HTTPX_AVAILABLE:
+            raise ImportError(
+                "httpx is required for OptimizationPlanClient. "
+                "Install with: pip install traigent[hybrid]"
+            )
+
+        self.backend_url = backend_url.rstrip("/")
+        self.timeout = timeout
+
+        # Import here to avoid circular dependency
+        from traigent.config.backend_config import get_no_credentials_hint
+        from traigent.utils.env_config import get_api_key
+
+        self.api_key = api_key or get_api_key("traigent")
+        if not self.api_key:
+            logger.warning(
+                "No API key found for OptimizationPlanClient. %s",
+                get_no_credentials_hint(),
+            )
+
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Get or create async HTTP client.
+
+        Returns:
+            Configured httpx.AsyncClient instance
+        """
+        from traigent.utils.env_config import raise_if_backend_offline
+
+        raise_if_backend_offline("OptimizationPlanClient request")
+        if self._client is None:
+            headers = {}
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
+
+            self._client = httpx.AsyncClient(
+                base_url=self.backend_url,
+                headers=headers,
+                timeout=self.timeout,
+            )
+
+        return self._client
+
+    async def close(self) -> None:
+        """Close HTTP client and release resources."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> OptimizationPlanClient:
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Async context manager exit."""
+        await self.close()
+
+    async def get_optimization_plan(
+        self,
+        *,
+        task_description: str,
+        dataset_size: int,
+        dataset_has_holdout: bool,
+        objectives: Sequence[str],
+        max_trials: int,
+        cost_limit_usd: float,
+        task_type: str | None = None,
+        agent_shape: str | None = None,
+        weights: dict[str, float] | None = None,
+        offline: bool | None = None,
+    ) -> dict[str, Any]:
+        """Retrieve a backend-provided pre-run optimization plan.
+
+        The backend must expose ``POST /api/v1/optimization/plan`` and returns
+        the bare allowlisted optimization plan contract payload.
+
+        Args:
+            task_description: Natural-language description of the optimization
+                task.
+            dataset_size: Number of available examples.
+            dataset_has_holdout: Whether the dataset already has a holdout split.
+            objectives: Objective metric names to plan against.
+            max_trials: Maximum trial count requested for the planned run.
+            cost_limit_usd: Maximum approved spend for the planned run, in USD.
+            task_type: Optional safe task category.
+            agent_shape: Optional safe label for the agent shape.
+            weights: Optional objective-name to relative-weight map.
+            offline: Optional request for a fully offline plan.
+
+        Returns:
+            Dict with the backend optimization plan contract payload.
+
+        Raises:
+            httpx.HTTPError: If request fails.
+            ValueError: If the backend returns a non-object JSON payload or an
+                object missing required optimization-plan contract keys.
+        """
+        body: dict[str, Any] = {
+            "task_description": task_description,
+            "dataset": {
+                "size": dataset_size,
+                "has_holdout": dataset_has_holdout,
+            },
+            "objectives": list(objectives),
+            "budget": {
+                "max_trials": max_trials,
+                "cost_limit_usd": cost_limit_usd,
+            },
+        }
+        if task_type is not None:
+            body["task_type"] = task_type
+        if agent_shape is not None:
+            body["agent_shape"] = agent_shape
+        if weights is not None:
+            body["weights"] = dict(weights)
+        if offline is not None:
+            body["offline"] = offline
+
+        client = self._get_client()
+        response = await client.post("/api/v1/optimization/plan", json=body)
+        response.raise_for_status()
+
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError(
+                "Malformed optimization-plan response: expected a JSON object "
+                "matching the optimization-plan contract."
+            )
+
+        missing = sorted(_REQUIRED_RESPONSE_KEYS - payload.keys())
+        if missing:
+            raise ValueError(
+                "Malformed optimization-plan response: missing required key(s): "
+                f"{', '.join(missing)}."
+            )
+
+        return cast(dict[str, Any], payload)

--- a/traigent/cli/main.py
+++ b/traigent/cli/main.py
@@ -2730,6 +2730,10 @@ from traigent.cli.next_steps_command import next_steps  # noqa: E402
 
 cli.add_command(next_steps)
 
+from traigent.cli.plan_command import plan  # noqa: E402
+
+cli.add_command(plan)
+
 from traigent.cli.playbook_commands import playbook  # noqa: E402
 
 cli.add_command(playbook)

--- a/traigent/cli/plan_command.py
+++ b/traigent/cli/plan_command.py
@@ -1,0 +1,221 @@
+"""CLI command: traigent plan.
+
+Fetches a backend-provided, client-safe pre-run optimization plan. Requires a
+backend version that exposes POST /api/v1/optimization/plan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from traigent.analytics.optimization_plan import OptimizationPlanClient
+from traigent.config.backend_config import DEFAULT_LOCAL_URL
+
+console = Console(width=120)
+
+
+@click.command("plan")
+@click.option(
+    "--task-description",
+    required=True,
+    help="Short natural-language description of the optimization task.",
+)
+@click.option(
+    "--dataset-size",
+    required=True,
+    type=int,
+    help="Number of examples available for optimization planning.",
+)
+@click.option(
+    "--has-holdout/--no-holdout",
+    default=False,
+    show_default=True,
+    help="Whether the dataset already has a holdout split.",
+)
+@click.option(
+    "--objective",
+    "objectives",
+    required=True,
+    multiple=True,
+    help="Objective metric name. Can be repeated.",
+)
+@click.option(
+    "--max-trials",
+    required=True,
+    type=int,
+    help="Maximum trial count requested for the planned run.",
+)
+@click.option(
+    "--cost-limit",
+    "cost_limit_usd",
+    required=True,
+    type=float,
+    help="Maximum approved spend for the planned run, in USD.",
+)
+@click.option(
+    "--task-type",
+    default=None,
+    help="Optional safe task category supplied to the backend.",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Output the raw backend payload as JSON.",
+)
+@click.option(
+    "--backend-url",
+    default=DEFAULT_LOCAL_URL,
+    show_default=True,
+    help=("Backend API base URL. Requires the optimization plan endpoint."),
+)
+def plan(
+    task_description: str,
+    dataset_size: int,
+    has_holdout: bool,
+    objectives: tuple[str, ...],
+    max_trials: int,
+    cost_limit_usd: float,
+    task_type: str | None,
+    output_json: bool,
+    backend_url: str,
+) -> None:
+    """Show a backend-provided pre-run optimization plan."""
+    try:
+        payload = asyncio.run(
+            _fetch_optimization_plan(
+                task_description=task_description,
+                dataset_size=dataset_size,
+                dataset_has_holdout=has_holdout,
+                objectives=objectives,
+                max_trials=max_trials,
+                cost_limit_usd=cost_limit_usd,
+                task_type=task_type,
+                backend_url=backend_url,
+            )
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_json:
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    _print_plan_table(payload)
+
+
+async def _fetch_optimization_plan(
+    *,
+    task_description: str,
+    dataset_size: int,
+    dataset_has_holdout: bool,
+    objectives: tuple[str, ...],
+    max_trials: int,
+    cost_limit_usd: float,
+    task_type: str | None,
+    backend_url: str,
+) -> dict[str, Any]:
+    async with OptimizationPlanClient(backend_url=backend_url) as client:
+        return await client.get_optimization_plan(
+            task_description=task_description,
+            dataset_size=dataset_size,
+            dataset_has_holdout=dataset_has_holdout,
+            objectives=objectives,
+            max_trials=max_trials,
+            cost_limit_usd=cost_limit_usd,
+            task_type=task_type,
+        )
+
+
+def _print_plan_table(payload: dict[str, Any]) -> None:
+    plan_payload = payload.get("plan") or {}
+    console.print("\n[bold blue]Optimization Plan[/bold blue]\n")
+    console.print(f"[bold]Phase:[/bold] {payload.get('phase', '')}")
+    console.print(f"[bold]Evidence:[/bold] {payload.get('evidence_level', '')}")
+    console.print(f"[bold]Advisory:[/bold] {payload.get('advisory', '')}")
+
+    if isinstance(plan_payload, dict):
+        console.print(
+            "[bold]Budget:[/bold] "
+            f"{plan_payload.get('max_trials', '')} trials, "
+            f"${plan_payload.get('cost_limit_usd', '')} limit"
+        )
+        console.print(f"[bold]Algorithm:[/bold] {plan_payload.get('algorithm', '')}")
+        console.print(f"[bold]Offline:[/bold] {plan_payload.get('offline', '')}")
+
+        _print_objectives_table(plan_payload.get("objectives") or [])
+        _print_models_table(plan_payload.get("models") or [])
+        _print_knobs_table(plan_payload.get("knobs") or [])
+
+    _print_steps_table(payload.get("steps") or [])
+    console.print(f"\n[bold]Caveat:[/bold] {payload.get('caveat', '')}")
+
+
+def _print_objectives_table(objectives: list[dict[str, Any]]) -> None:
+    if not objectives:
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Objective", style="cyan", no_wrap=True)
+    table.add_column("Weight", justify="right", no_wrap=True)
+    table.add_column("Orientation", no_wrap=True)
+    for objective in objectives:
+        table.add_row(
+            str(objective.get("name", "")),
+            str(objective.get("weight", "")),
+            str(objective.get("orientation", "")),
+        )
+    console.print("\n[bold]Objectives[/bold]")
+    console.print(table)
+
+
+def _print_models_table(models: list[str]) -> None:
+    if not models:
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Models", style="cyan")
+    for model in models:
+        table.add_row(str(model))
+    console.print("\n[bold]Models[/bold]")
+    console.print(table)
+
+
+def _print_knobs_table(knobs: list[dict[str, Any]]) -> None:
+    if not knobs:
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Knob", style="cyan", no_wrap=True)
+    table.add_column("Values", overflow="fold")
+    for knob in knobs:
+        values = knob.get("values") or []
+        table.add_row(str(knob.get("name", "")), ", ".join(map(str, values)))
+    console.print("\n[bold]Knobs[/bold]")
+    console.print(table)
+
+
+def _print_steps_table(steps: list[dict[str, Any]]) -> None:
+    if not steps:
+        console.print("\n[yellow]No steps were returned by the backend.[/yellow]")
+        return
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Step", style="cyan", no_wrap=True)
+    table.add_column("Label", overflow="fold")
+    table.add_column("Command", overflow="fold")
+    for step in steps:
+        table.add_row(
+            str(step.get("id", "")),
+            str(step.get("label", "")),
+            str(step.get("command_template", "")),
+        )
+    console.print("\n[bold]Steps[/bold]")
+    console.print(table)

--- a/traigent/mcp/server.py
+++ b/traigent/mcp/server.py
@@ -9,6 +9,7 @@ from traigent.mcp.tools import (
     detect_tvars_tool,
     estimate_cost_tool,
     export_evidence_tool,
+    get_optimization_plan_tool,
     get_results_tool,
     list_recommendation_agent_types_tool,
     recommend_configuration_space_tool,
@@ -139,6 +140,37 @@ def create_server() -> Any:
             dataset_path=dataset_path,
             max_trials=max_trials,
             model=model,
+        )
+
+    @server.tool(
+        description=(
+            "fetch an aggregated pre-run optimization plan from the Traigent "
+            "backend; requires backend auth"
+        )
+    )
+    async def get_optimization_plan(
+        task_description: str,
+        dataset_size: int,
+        dataset_has_holdout: bool,
+        objectives: list[str],
+        max_trials: int,
+        cost_limit_usd: float,
+        task_type: str | None = None,
+        agent_shape: str | None = None,
+        weights: dict[str, float] | None = None,
+        offline: bool | None = None,
+    ) -> dict[str, Any]:
+        return await get_optimization_plan_tool(
+            task_description=task_description,
+            dataset_size=dataset_size,
+            dataset_has_holdout=dataset_has_holdout,
+            objectives=objectives,
+            max_trials=max_trials,
+            cost_limit_usd=cost_limit_usd,
+            task_type=task_type,
+            agent_shape=agent_shape,
+            weights=weights,
+            offline=offline,
         )
 
     @server.tool(

--- a/traigent/mcp/tools.py
+++ b/traigent/mcp/tools.py
@@ -22,6 +22,7 @@ from traigent.api.functions import (
 from traigent.api.functions import (
     recommend_configuration_space as public_recommend_configuration_space,
 )
+from traigent.analytics.optimization_plan import OptimizationPlanClient
 from traigent.cloud.credential_manager import CredentialManager
 from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env
@@ -44,6 +45,7 @@ V1_TOOL_NAMES: tuple[str, ...] = (
     "scaffold_eval",
     "validate_dataset",
     "estimate_cost",
+    "get_optimization_plan",
     "run_optimization",
     "get_results",
     "export_evidence",
@@ -542,6 +544,35 @@ def estimate_cost_tool(
         "pricing_source": pricing_source,
         "assumptions": assumptions,
     }
+
+
+async def get_optimization_plan_tool(
+    *,
+    task_description: str,
+    dataset_size: int,
+    dataset_has_holdout: bool,
+    objectives: list[str],
+    max_trials: int,
+    cost_limit_usd: float,
+    task_type: str | None = None,
+    agent_shape: str | None = None,
+    weights: dict[str, float] | None = None,
+    offline: bool | None = None,
+) -> dict[str, Any]:
+    """Fetch a backend-provided optimization plan without local planning."""
+    async with OptimizationPlanClient() as client:
+        return await client.get_optimization_plan(
+            task_description=task_description,
+            dataset_size=dataset_size,
+            dataset_has_holdout=dataset_has_holdout,
+            objectives=objectives,
+            max_trials=max_trials,
+            cost_limit_usd=cost_limit_usd,
+            task_type=task_type,
+            agent_shape=agent_shape,
+            weights=weights,
+            offline=offline,
+        )
 
 
 def _is_optimizable_function(obj: Any) -> bool:


### PR DESCRIPTION
Thin-client path so a coding agent fetches a pre-run **optimization plan** from the backend and presents it. **IP boundary: pure pass-through** — the SDK holds NO plan logic, no scoring/thresholds, and **errors (never synthesizes)** when the backend is offline.

- `OptimizationPlanClient` (mirrors `NextStepsClient`) → POST /api/v1/optimization/plan, validates required keys.
- Backend-backed MCP tool `get_optimization_plan` (in `traigent mcp serve`); CLI `traigent plan`.
- Calls TraigentBackend#1355; contract = TraigentSchema optimization_plan PR.

## Opus 4.8 review: SHIP (no must-fix)
Byte-for-byte NextStepsClient mirror; request/response match the schema; MCP tool listed; 29 tests pass; ruff clean. Point at dev via `TRAIGENT_BACKEND_URL=https://api-dev.traigent.ai`.

Spine-Trail: st_8b8dda4efd28