### PR TITLE
fix(sdk): build experiment view URL from portal/web origin (dev 404 fix)

### DIFF
--- a/tests/unit/cloud/test_sync_manager.py
+++ b/tests/unit/cloud/test_sync_manager.py
@@ -705,7 +705,7 @@ class TestSyncManager:
         sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
-            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_web_url",
             return_value="https://portal.traigent.ai/",
         ):
             result = sync_manager.sync_session_to_cloud("test_session_123")
@@ -840,7 +840,7 @@ class TestSyncManager:
         sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
-            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_web_url",
             return_value="https://portal.traigent.ai/",
         ):
             result = sync_manager.sync_session_to_cloud("test_session_123")
@@ -927,7 +927,7 @@ class TestSyncManager:
         sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
-            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_web_url",
             return_value="https://portal.traigent.ai/",
         ):
             first = sync_manager.sync_session_to_cloud("test_session_123")
@@ -954,7 +954,7 @@ class TestSyncManager:
         sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
-            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_web_url",
             return_value="https://portal.traigent.ai/",
         ):
             second = sync_manager.sync_session_to_cloud("test_session_123")
@@ -1622,7 +1622,7 @@ class TestSyncManager:
         sync_manager._session.put.return_value = backend_response(status_code=200)
 
         with patch(
-            "traigent.cloud.sync_manager.BackendConfig.get_cloud_backend_url",
+            "traigent.cloud.sync_manager.BackendConfig.get_cloud_web_url",
             return_value="https://portal.traigent.ai/",
         ):
             result = sync_manager.sync_session_to_cloud("test_session_123")

--- a/tests/unit/config/test_backend_config_web_url.py
+++ b/tests/unit/config/test_backend_config_web_url.py
@@ -1,0 +1,142 @@
+"""Tests for BackendConfig.get_cloud_web_url() portal/web URL resolution.
+
+Covers the dev split-host fix: experiment view URLs must target the portal
+frontend origin, not the API backend origin.
+"""
+
+# Traceability: CONC-CloudService FUNC-CLOUD-HYBRID REQ-CLOUD-009
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from traigent.config.backend_config import BackendConfig
+
+
+class TestGetCloudWebUrl:
+    """BackendConfig.get_cloud_web_url() returns the portal/web frontend origin."""
+
+    def test_no_env_returns_default_prod_url(self) -> None:
+        """With no env vars or stored creds the default prod portal URL is returned."""
+        with (
+            patch.dict(
+                "os.environ",
+                {},
+                clear=True,
+            ),
+            patch(
+                "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+                return_value=None,
+            ),
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://portal.traigent.ai"
+
+    def test_traigent_web_url_env_takes_priority(self) -> None:
+        """TRAIGENT_WEB_URL overrides everything else."""
+        with patch.dict(
+            "os.environ",
+            {
+                "TRAIGENT_WEB_URL": "https://my-portal.example.com",
+                "TRAIGENT_BACKEND_URL": "https://api.traigent.ai",
+            },
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://my-portal.example.com"
+
+    def test_traigent_portal_url_env_used_when_web_url_absent(self) -> None:
+        """TRAIGENT_PORTAL_URL is used when TRAIGENT_WEB_URL is not set."""
+        with patch.dict(
+            "os.environ",
+            {
+                "TRAIGENT_PORTAL_URL": "https://portal-staging.example.com",
+                "TRAIGENT_BACKEND_URL": "https://api-staging.example.com",
+            },
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://portal-staging.example.com"
+
+    def test_api_dev_host_derives_to_portal_dev(self) -> None:
+        """api-dev.traigent.ai -> portal-dev.traigent.ai (split-host dev env)."""
+        with patch.dict(
+            "os.environ",
+            {"TRAIGENT_BACKEND_URL": "https://api-dev.traigent.ai"},
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://portal-dev.traigent.ai"
+
+    def test_api_dot_host_derives_to_portal_dot(self) -> None:
+        """api.traigent.ai -> portal.traigent.ai (dot-separated api subdomain)."""
+        with patch.dict(
+            "os.environ",
+            {"TRAIGENT_BACKEND_URL": "https://api.traigent.ai"},
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://portal.traigent.ai"
+
+    def test_prod_portal_origin_unchanged(self) -> None:
+        """https://portal.traigent.ai does not start with 'api' — returned as-is."""
+        with patch.dict(
+            "os.environ",
+            {"TRAIGENT_BACKEND_URL": "https://portal.traigent.ai"},
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://portal.traigent.ai"
+
+    def test_non_api_custom_origin_returned_unchanged(self) -> None:
+        """A custom origin without an 'api' prefix is returned without rewriting."""
+        with patch.dict(
+            "os.environ",
+            {"TRAIGENT_BACKEND_URL": "https://backend.internal.example.com"},
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://backend.internal.example.com"
+
+    def test_derive_web_origin_bare_api_host(self) -> None:
+        """Host exactly equal to 'api' is rewritten to 'portal'."""
+        result = BackendConfig._derive_web_origin_from_api_origin("https://api")
+        # urlunparse will not include a trailing slash for empty path
+        assert result is not None
+        assert "portal" in result
+        assert "api" not in result.split("://", 1)[1]
+
+    def test_derive_web_origin_none_returns_none(self) -> None:
+        """None input returns None — no crash."""
+        assert BackendConfig._derive_web_origin_from_api_origin(None) is None
+
+    def test_uppercase_api_dot_host_derives_to_portal(self) -> None:
+        """API.traigent.ai (uppercase) -> portal.traigent.ai (case-insensitive host)."""
+        result = BackendConfig._derive_web_origin_from_api_origin(
+            "https://API.traigent.ai"
+        )
+        assert result == "https://portal.traigent.ai"
+
+    def test_uppercase_api_dev_host_derives_to_portal_dev(self) -> None:
+        """API-DEV.traigent.ai (uppercase) -> portal-dev.traigent.ai."""
+        result = BackendConfig._derive_web_origin_from_api_origin(
+            "https://API-DEV.traigent.ai"
+        )
+        assert result == "https://portal-dev.traigent.ai"
+
+    def test_api_host_with_port_preserves_port(self) -> None:
+        """A port on the api host is preserved on the derived portal host."""
+        result = BackendConfig._derive_web_origin_from_api_origin(
+            "https://api-dev.traigent.ai:8443"
+        )
+        assert result == "https://portal-dev.traigent.ai:8443"
+
+    def test_traigent_api_url_origin_also_derives_portal(self) -> None:
+        """TRAIGENT_API_URL host origin is used for derivation when BACKEND_URL absent."""
+        with (
+            patch.dict(
+                "os.environ",
+                {"TRAIGENT_API_URL": "https://api-staging.traigent.ai/api/v1"},
+                clear=True,
+            ),
+            patch(
+                "traigent.cloud.credential_manager.CredentialManager.get_stored_backend_url",
+                return_value=None,
+            ),
+        ):
+            result = BackendConfig.get_cloud_web_url()
+        assert result == "https://portal-staging.traigent.ai"

--- a/tests/unit/core/test_orchestrator_cloud_url.py
+++ b/tests/unit/core/test_orchestrator_cloud_url.py
@@ -8,7 +8,7 @@ def test_orchestrator_cloud_url_includes_session_context(monkeypatch) -> None:
     """Cloud URL construction passes owning project/tenant context."""
     monkeypatch.setattr(
         BackendConfig,
-        "get_cloud_backend_url",
+        "get_cloud_web_url",
         lambda: "https://portal.traigent.ai/",
     )
     result = SimpleNamespace(

--- a/traigent/cloud/sync_manager.py
+++ b/traigent/cloud/sync_manager.py
@@ -802,7 +802,7 @@ class SyncManager:
         elif successful_steps == total_steps and not sync_result.get("errors"):
             sync_result["status"] = "success"
             sync_result["cloud_url"] = build_experiment_url(
-                BackendConfig.get_cloud_backend_url(),
+                BackendConfig.get_cloud_web_url(),
                 experiment_id,
                 project_id=project_id,
                 tenant_id=tenant_id,

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -194,6 +194,68 @@ class BackendConfig:
         return f"{backend_origin}{cls._DEFAULT_API_PATH}"
 
     @classmethod
+    def _derive_web_origin_from_api_origin(cls, origin: str | None) -> str | None:
+        """Derive the portal/web origin from a backend API origin.
+
+        In split-host deployments the API lives on ``api-*.traigent.ai`` while
+        the portal SPA lives on ``portal-*.traigent.ai``.  This helper rewrites
+        the ``api``/``api.``/``api-`` prefix to ``portal`` so that experiment
+        view URLs resolve to the correct frontend host.
+
+        Falls back to the original origin when no ``api`` prefix is found (e.g.
+        single-origin dev stacks or prod where DEFAULT_PROD_URL already starts
+        with ``portal``).
+        """
+        parsed_origin = cls._normalize_origin(origin)
+        if not parsed_origin:
+            return None
+        parsed = urlparse(parsed_origin)
+        host = parsed.hostname or ""
+        if host == "api" or host.startswith("api.") or host.startswith("api-"):
+            web_host = f"portal{host[3:]}"
+            # Rebuild the authority from parsed parts (preserving any userinfo and
+            # port) instead of string-replacing in the original-case netloc — the
+            # latter misses uppercase hosts because ``parsed.hostname`` is
+            # lowercased (e.g. ``API-DEV.traigent.ai`` would not be rewritten).
+            userinfo = ""
+            if parsed.username:
+                userinfo = parsed.username
+                if parsed.password:
+                    userinfo += f":{parsed.password}"
+                userinfo += "@"
+            port = f":{parsed.port}" if parsed.port else ""
+            netloc = f"{userinfo}{web_host}{port}"
+            return urlunparse((parsed.scheme, netloc, "", "", "", "")).rstrip("/")
+        return parsed_origin
+
+    @classmethod
+    def get_cloud_web_url(cls) -> str:
+        """Return the portal/web origin used for user-facing experiment view URLs.
+
+        Priority:
+            1. ``TRAIGENT_WEB_URL`` environment variable (explicit override)
+            2. ``TRAIGENT_PORTAL_URL`` environment variable (explicit override)
+            3. Derive portal origin from the configured backend API origin by
+               rewriting the ``api``/``api.``/``api-`` host prefix to ``portal``
+               (handles split-host dev environments transparently).
+            4. ``DEFAULT_PROD_URL`` (``https://portal.traigent.ai``)
+
+        Prod installations have no ``api`` prefix in their configured origin so
+        the derivation step is a no-op and the default is returned unchanged.
+        """
+        for env_var in ("TRAIGENT_WEB_URL", "TRAIGENT_PORTAL_URL"):
+            origin = cls._normalize_origin(os.environ.get(env_var))
+            if origin:
+                return origin
+        configured_origin = cls._get_configured_backend_origin()
+        if configured_origin:
+            return (
+                cls._derive_web_origin_from_api_origin(configured_origin)
+                or configured_origin
+            )
+        return cls.DEFAULT_PROD_URL
+
+    @classmethod
     def get_backend_api_url(cls) -> str:
         """Return the base API URL (including version path)."""
 

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2097,7 +2097,7 @@ class OptimizationOrchestrator:
             from traigent.config.backend_config import BackendConfig
 
             result.cloud_url = build_experiment_url(
-                BackendConfig.get_cloud_backend_url(),
+                BackendConfig.get_cloud_web_url(),
                 exp_id,
                 project_id=metadata.get("project_id"),
                 tenant_id=metadata.get("tenant_id"),


### PR DESCRIPTION
## Problem

In split-host dev environments (e.g. `api-dev.traigent.ai` for the backend, `portal-dev.traigent.ai` for the SPA), both `SyncManager.sync_session_to_cloud()` and `OptimizationOrchestrator._populate_experiment_cloud_url()` were calling `BackendConfig.get_cloud_backend_url()` to construct the experiment view URL passed back as `cloud_url`. This produces a URL on the API host (`https://api-dev.traigent.ai/experiments/view/<id>`) which returns 404 because the FE route `/experiments/view/:id` is mounted on the portal frontend, not the API server.

## Fix

Add `BackendConfig.get_cloud_web_url()` that resolves the portal/web frontend origin separately from the API origin:

1. `TRAIGENT_WEB_URL` env var (highest priority explicit override)
2. `TRAIGENT_PORTAL_URL` env var (second explicit override)
3. Derive portal origin from the configured backend origin by rewriting the `api`/`api.`/`api-` host prefix to `portal` (e.g. `api-dev.traigent.ai` → `portal-dev.traigent.ai`)
4. `DEFAULT_PROD_URL` (`https://portal.traigent.ai`) when no origin is configured

Switch both `build_experiment_url()` call sites in `sync_manager.py` and `orchestrator.py` to use `get_cloud_web_url()`.

**Prod is unchanged**: `DEFAULT_PROD_URL` is already `https://portal.traigent.ai` (no `api` prefix), so the derivation step is a no-op and the default is returned as-is. `get_cloud_backend_url()` is untouched.

## Files changed

- `traigent/config/backend_config.py` — add `_derive_web_origin_from_api_origin()` + `get_cloud_web_url()`
- `traigent/cloud/sync_manager.py` — swap `get_cloud_backend_url()` → `get_cloud_web_url()` at the `cloud_url` assignment
- `traigent/core/orchestrator.py` — same swap at `result.cloud_url` assignment
- `tests/unit/config/test_backend_config_web_url.py` — 10 new tests covering all resolver branches
- `tests/unit/core/test_orchestrator_cloud_url.py` — updated patch target
- `tests/unit/cloud/test_sync_manager.py` — 5 patch targets updated

## Immediate workaround (before this lands)

Set `TRAIGENT_WEB_URL=https://portal-dev.traigent.ai` in your dev environment.

## Test evidence

78 unit tests pass (`-n0`):

```
tests/unit/config/test_backend_config_web_url.py ..........   10 new
tests/unit/core/test_orchestrator_cloud_url.py .              updated
tests/unit/cloud/test_sync_manager.py ....................     67 existing
78 passed in 1.53s
```

ruff check + format: all clean.

## PR checklist

1. **Worst-case prod path**: prod with no env → `DEFAULT_PROD_URL` (`https://portal.traigent.ai`), identical to before. No regression.
2. **Production-branch test**: `test_no_env_returns_default_prod_url` in `test_backend_config_web_url.py` — clears all env vars + mocks stored creds to None, asserts `https://portal.traigent.ai`.
3. **Contract regeneration**: no schema or API contract changes.
4. **Public surface delta**: new `get_cloud_web_url()` classmethod added; `get_cloud_backend_url()` unchanged.
5. **Review threads resolved**: n/a (new PR).
6. **Quality gates not relaxed**: ruff clean, no thresholds touched.

Spine-Trail: st_46f3e2cbce4e