### PR TITLE
fix(sdk): send dataset label in connected session-create metadata (portal Dataset column)

### DIFF
--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -432,6 +432,9 @@ class SessionOperations:
                 objectives=list(objectives) if objectives else [optimization_goal],
                 dataset_metadata={
                     "size": metadata.get("dataset_size", 0) if metadata else 0,
+                    # Carry the dataset label (content is not submitted) so the
+                    # portal "Dataset" column is populated instead of blank.
+                    "name": metadata.get("evaluation_set") if metadata else None,
                     "privacy_mode": True,
                 },
                 max_trials=max_trials_from_metadata,

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -662,18 +662,14 @@ class BackendSessionManager:
         if self._egress_disabled():
             return SessionContext(
                 session_id=None,
-                dataset_name=(
-                    getattr(dataset, "name", None) or "default_evaluation"
-                ),
+                dataset_name=(getattr(dataset, "name", None) or "default_evaluation"),
                 function_name=function_identifier,
                 optimization_id=self._optimization_id,
                 start_time=start_time,
             )
 
         if self._backend_client:
-            evaluation_set_name = (
-                getattr(dataset, "name", None) or "default_evaluation"
-            )
+            evaluation_set_name = getattr(dataset, "name", None) or "default_evaluation"
 
             max_trials_value = max_trials if max_trials is not None else 10
             max_samples_value = (
@@ -759,9 +755,7 @@ class BackendSessionManager:
                         ),
                     )
 
-        dataset_name = (
-            getattr(dataset, "name", None) or "default_evaluation"
-        )
+        dataset_name = getattr(dataset, "name", None) or "default_evaluation"
 
         return SessionContext(
             session_id=session_id,

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -663,7 +663,7 @@ class BackendSessionManager:
             return SessionContext(
                 session_id=None,
                 dataset_name=(
-                    dataset.name if hasattr(dataset, "name") else "default_evaluation"
+                    getattr(dataset, "name", None) or "default_evaluation"
                 ),
                 function_name=function_identifier,
                 optimization_id=self._optimization_id,
@@ -672,7 +672,7 @@ class BackendSessionManager:
 
         if self._backend_client:
             evaluation_set_name = (
-                dataset.name if hasattr(dataset, "name") else "default_evaluation"
+                getattr(dataset, "name", None) or "default_evaluation"
             )
 
             max_trials_value = max_trials if max_trials is not None else 10
@@ -760,7 +760,7 @@ class BackendSessionManager:
                     )
 
         dataset_name = (
-            dataset.name if hasattr(dataset, "name") else "default_evaluation"
+            getattr(dataset, "name", None) or "default_evaluation"
         )
 
         return SessionContext(


### PR DESCRIPTION
The portal **Dataset** column showed blank for connected/typed optimization runs.

**Root cause:** the connected session-create path (`session_operations.create_session`) built `dataset_metadata={size, privacy_mode}` — **no name** — so the backend stored no dataset label. The label was already computed (`evaluation_set` in `backend_session_manager`) but never carried into the session-create metadata. Also, `dataset.name if hasattr(dataset, "name") else "default_evaluation"` returns `None` when the attribute exists but is `None` (e.g. a path-loaded `Dataset`).

**Fix:**
- `session_operations.create_session`: add `"name": metadata.get("evaluation_set")` to `dataset_metadata` (content-free label; dataset content is not submitted).
- `backend_session_manager`: `getattr(dataset, "name", None) or "default_evaluation"` at the 3 sites (robust to name-is-None).

Pairs with TraigentBackend #1374 (which stores + surfaces the label). Verified live on api-dev: experiment now has `experiment_parameters.dataset_name = "eval"`.

Spine-Trail: st_fdbc4f2e939e