### PR TITLE
fix(auth): X-API-Key for ExampleInsightsClient and NextStepsClient (#1437 sibling fix)

### DIFF
--- a/tests/unit/analytics/test_example_insights.py
+++ b/tests/unit/analytics/test_example_insights.py
@@ -131,10 +131,10 @@ class TestExampleInsightsClientGetClient:
 
             assert result == mock_instance
             mock_async_client.assert_called_once()
-            # Check headers include auth
+            # API keys must travel via X-API-Key, not Authorization: Bearer
             call_kwargs = mock_async_client.call_args.kwargs
-            assert "Authorization" in call_kwargs["headers"]
-            assert call_kwargs["headers"]["Authorization"] == "Bearer test_token"
+            assert call_kwargs["headers"]["X-API-Key"] == "test_token"
+            assert "Authorization" not in call_kwargs["headers"]
 
     @pytest.mark.asyncio
     async def test_get_client_reuses_existing(self) -> None:
@@ -167,6 +167,42 @@ class TestExampleInsightsClientGetClient:
 
             call_kwargs = mock_async_client.call_args.kwargs
             # Authorization header should not be present without key
+            assert "Authorization" not in call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_get_client_uk_api_key_uses_x_api_key_header(self) -> None:
+        """uk_-style API keys must use X-API-Key only, never Authorization: Bearer."""
+        from traigent.analytics.example_insights import ExampleInsightsClient
+
+        api_key = "uk_testkey1234567890"  # pragma: allowlist secret
+        client = ExampleInsightsClient(api_key=api_key)
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_instance = MagicMock()
+            mock_async_client.return_value = mock_instance
+
+            client._get_client()
+
+            call_kwargs = mock_async_client.call_args.kwargs
+            assert call_kwargs["headers"]["X-API-Key"] == api_key
+            assert "Authorization" not in call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_get_client_jwt_string_uses_x_api_key_header(self) -> None:
+        """JWT-shaped API-key strings must not be inferred as Bearer tokens."""
+        from traigent.analytics.example_insights import ExampleInsightsClient
+
+        api_key = "eyJnotjwt.with.dots"  # pragma: allowlist secret
+        client = ExampleInsightsClient(api_key=api_key)
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_instance = MagicMock()
+            mock_async_client.return_value = mock_instance
+
+            client._get_client()
+
+            call_kwargs = mock_async_client.call_args.kwargs
+            assert call_kwargs["headers"] == {"X-API-Key": api_key}
             assert "Authorization" not in call_kwargs["headers"]
 
 
@@ -569,4 +605,6 @@ class TestNoSignalTaxonomyInSource:
             "score_distributions",
         ]
         leaked = [name for name in forbidden if name in source]
-        assert not leaked, f"Signal taxonomy leaked into example_insights source: {leaked}"
+        assert not leaked, (
+            f"Signal taxonomy leaked into example_insights source: {leaked}"
+        )

--- a/tests/unit/analytics/test_next_steps.py
+++ b/tests/unit/analytics/test_next_steps.py
@@ -120,7 +120,8 @@ class TestNextStepsClientInit:
 class TestNextStepsClientGetClient:
     """Tests for _get_client method."""
 
-    def test_get_client_creates_client_with_auth_header(self) -> None:
+    def test_get_client_creates_client_with_x_api_key_header(self) -> None:
+        """API keys must travel via X-API-Key, not Authorization: Bearer."""
         from traigent.analytics.next_steps import NextStepsClient
 
         client = NextStepsClient(api_key="test_token")
@@ -134,7 +135,8 @@ class TestNextStepsClientGetClient:
             assert result == mock_instance
             mock_async_client.assert_called_once()
             call_kwargs = mock_async_client.call_args.kwargs
-            assert call_kwargs["headers"]["Authorization"] == "Bearer test_token"
+            assert call_kwargs["headers"]["X-API-Key"] == "test_token"
+            assert "Authorization" not in call_kwargs["headers"]
 
     def test_get_client_without_api_key(self) -> None:
         from traigent.analytics.next_steps import NextStepsClient
@@ -146,6 +148,40 @@ class TestNextStepsClientGetClient:
             client._get_client()
 
             call_kwargs = mock_async_client.call_args.kwargs
+            assert "Authorization" not in call_kwargs["headers"]
+
+    def test_get_client_uk_api_key_uses_x_api_key_header(self) -> None:
+        """uk_-style API keys must use X-API-Key only, never Authorization: Bearer."""
+        from traigent.analytics.next_steps import NextStepsClient
+
+        api_key = "uk_testkey1234567890"  # pragma: allowlist secret
+        client = NextStepsClient(api_key=api_key)
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_instance = MagicMock()
+            mock_async_client.return_value = mock_instance
+
+            client._get_client()
+
+            call_kwargs = mock_async_client.call_args.kwargs
+            assert call_kwargs["headers"]["X-API-Key"] == api_key
+            assert "Authorization" not in call_kwargs["headers"]
+
+    def test_get_client_jwt_string_uses_x_api_key_header(self) -> None:
+        """JWT-shaped API-key strings must not be inferred as Bearer tokens."""
+        from traigent.analytics.next_steps import NextStepsClient
+
+        api_key = "eyJnotjwt.with.dots"  # pragma: allowlist secret
+        client = NextStepsClient(api_key=api_key)
+
+        with patch("httpx.AsyncClient") as mock_async_client:
+            mock_instance = MagicMock()
+            mock_async_client.return_value = mock_instance
+
+            client._get_client()
+
+            call_kwargs = mock_async_client.call_args.kwargs
+            assert call_kwargs["headers"] == {"X-API-Key": api_key}
             assert "Authorization" not in call_kwargs["headers"]
 
 

--- a/traigent/analytics/example_insights.py
+++ b/traigent/analytics/example_insights.py
@@ -30,6 +30,7 @@ import asyncio
 import time
 from typing import Any, cast
 
+from traigent.cloud.auth import _build_api_key_auth_headers
 from traigent.config.backend_config import DEFAULT_LOCAL_URL
 from traigent.utils.logging import get_logger
 
@@ -100,9 +101,9 @@ class ExampleInsightsClient:
 
         raise_if_backend_offline("ExampleInsightsClient request")
         if self._client is None:
-            headers = {}
+            headers: dict[str, str] = {}
             if self.api_key:
-                headers["Authorization"] = f"Bearer {self.api_key}"
+                headers.update(_build_api_key_auth_headers(self.api_key))
 
             self._client = httpx.AsyncClient(
                 base_url=self.backend_url,

--- a/traigent/analytics/next_steps.py
+++ b/traigent/analytics/next_steps.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from traigent.cloud.auth import _build_api_key_auth_headers
 from traigent.config.backend_config import DEFAULT_LOCAL_URL
 from traigent.utils.logging import get_logger
 
@@ -102,9 +103,9 @@ class NextStepsClient:
 
         raise_if_backend_offline("NextStepsClient request")
         if self._client is None:
-            headers = {}
+            headers: dict[str, str] = {}
             if self.api_key:
-                headers["Authorization"] = f"Bearer {self.api_key}"
+                headers.update(_build_api_key_auth_headers(self.api_key))
 
             self._client = httpx.AsyncClient(
                 base_url=self.backend_url,


### PR DESCRIPTION
## Summary

Applies the same API-key auth fix from #1437 (`OptimizationPlanClient`) to the two sibling analytics clients that had the identical `Authorization: Bearer <api_key>` bug:

- `traigent/analytics/example_insights.py` — `ExampleInsightsClient._get_client`
- `traigent/analytics/next_steps.py` — `NextStepsClient._get_client`

Both now import and call `_build_api_key_auth_headers()` from `traigent.cloud.auth`, emitting `X-API-Key` only. Auth-header tests updated/added for `uk_`-style keys, JWT-shaped keys, and no-key cases.

## Diff stat (auth lines only, no reformatting)

```
traigent/analytics/example_insights.py  |  5 lines changed (import + header call)
traigent/analytics/next_steps.py        |  5 lines changed (import + header call)
tests/unit/analytics/test_example_insights.py | +2 new tests, 1 assertion updated
tests/unit/analytics/test_next_steps.py       | +2 new tests, 1 assertion updated
```

## Test plan

- `pytest tests/unit/analytics/test_example_insights.py tests/unit/analytics/test_next_steps.py -q -n0` → 36 passed, 2 skipped
- `ruff check` + `ruff format --check` → clean on all 4 changed files

Spine: none (reason: SDK API-key auth fix for sibling analytics clients (next_steps/example_insights), same pattern as #1437; no contract/schema/migration change)