### PR TITLE
fix(sdk): actionable error on permanent 4xx trial-submission (e.g. invalid objective) + correct 4xx classification

### DIFF
--- a/tests/unit/core/test_connectivity_classification.py
+++ b/tests/unit/core/test_connectivity_classification.py
@@ -1,0 +1,47 @@
+"""A 4xx client error must not be treated as a transient connectivity failure.
+
+Regression (found in a live demo): a trial-result submission rejected with
+HTTP 400 (e.g. an unknown objective metric like ``cost_usd``) was wrapped in
+``CloudBrainUnavailableError`` and classified as connectivity, silently
+degrading the run to local-only and leaving a PENDING experiment on the
+backend. A permanent 4xx is now surfaced loudly (no fallback); transient
+5xx/network still fall back.
+"""
+
+import pytest
+
+from traigent.core.execution_policy_runtime import (
+    CloudBrainUnavailableError,
+    exception_is_connectivity,
+)
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        # permanent client errors -> NOT connectivity (surface loudly)
+        (
+            CloudBrainUnavailableError(
+                "next-trial",
+                "Failed to submit trial result: HTTP 400 - Invalid request data",
+            ),
+            False,
+        ),
+        (CloudBrainUnavailableError("next-trial", "HTTP 404 not found"), False),
+        (CloudBrainUnavailableError("next-trial", "HTTP 422 unprocessable"), False),
+        (CloudBrainUnavailableError("next-trial", "HTTP 429 too many requests"), False),
+        # transient -> connectivity (allow local fallback)
+        (
+            CloudBrainUnavailableError(
+                "session-create", "backend unavailable: HTTP 503"
+            ),
+            True,
+        ),
+        (CloudBrainUnavailableError("next-trial", "HTTP 500 internal error"), True),
+        (CloudBrainUnavailableError("session-create", "connection refused"), True),
+        (ConnectionError("connection refused"), True),
+        (TimeoutError("timed out"), True),
+    ],
+)
+def test_connectivity_classification(exc, expected):
+    assert exception_is_connectivity(exc) is expected

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -709,8 +709,27 @@ class TrialOperations:
             )
             return True
 
+        # A non-transient 4xx is a PERMANENT rejection -- commonly an invalid or
+        # uncomputable optimization objective/metric name (e.g. "cost_usd" instead
+        # of "cost"). Label it explicitly so it is not mistaken for a transient
+        # backend outage; the run continues but is tracked LOCALLY ONLY.
+        if isinstance(status, int) and 400 <= status < 500:
+            logger.error(
+                "\u274c Trial submission REJECTED by the backend: HTTP %s \u2014 %s. "
+                "This is a PERMANENT error (commonly an invalid optimization "
+                "objective/metric name, e.g. 'cost_usd' instead of 'cost'), NOT a "
+                "transient outage. The run will be tracked LOCALLY ONLY "
+                "(source='local_fallback'); fix the request to track it on the "
+                "backend.  Trial %s  Session %s  URL %s",
+                status,
+                detail or "(no response body)",
+                trial_id,
+                session_id,
+                url,
+            )
+            return False
         logger.warning(
-            "❌ Failed to submit trial result: HTTP %s — %s",
+            "\u274c Failed to submit trial result: HTTP %s \u2014 %s",
             status,
             detail or "(no response body)",
         )

--- a/traigent/core/execution_policy_runtime.py
+++ b/traigent/core/execution_policy_runtime.py
@@ -251,6 +251,11 @@ def exception_status(exc: BaseException) -> int | None:
         value = getattr(exc, name, None)
         if isinstance(value, int):
             return value
+    # httpx.HTTPStatusError and similar carry the code on .response.status_code
+    response = getattr(exc, "response", None)
+    response_status = getattr(response, "status_code", None)
+    if isinstance(response_status, int):
+        return response_status
     match = re.search(r"\bHTTP\s+(\d{3})\b", str(exc), flags=re.IGNORECASE)
     if match:
         return int(match.group(1))

--- a/traigent/core/execution_policy_runtime.py
+++ b/traigent/core/execution_policy_runtime.py
@@ -33,7 +33,7 @@ RESULT_SOURCES = frozenset(
 )
 
 CONNECTIVITY_STATUSES = frozenset({500, 502, 503, 504})
-HARD_FAILURE_STATUSES = frozenset({401, 402, 403, 409, 422, 429})
+HARD_FAILURE_STATUSES = frozenset({400, 401, 402, 403, 404, 405, 409, 415, 422, 429})
 
 CONNECTIVITY_PATTERNS = (
     "backend unavailable",
@@ -264,14 +264,18 @@ def exception_is_connectivity(exc: BaseException) -> bool:
     visited: set[int] = set()
     while current is not None and id(current) not in visited:
         visited.add(id(current))
-        if isinstance(current, CloudBrainUnavailableError):
-            return True
         status = exception_status(current)
         text = str(current).lower()
+        # A permanent client error (4xx) is NOT a connectivity failure and must
+        # not trigger a silent local fallback -- even when wrapped in a
+        # CloudBrainUnavailableError (e.g. a trial-result submission rejected
+        # with HTTP 400 for an unknown objective metric). Surface it loudly.
         if status in HARD_FAILURE_STATUSES or _contains_any(
             text, HARD_FAILURE_PATTERNS
         ):
             return False
+        if isinstance(current, CloudBrainUnavailableError):
+            return True
         if status in CONNECTIVITY_STATUSES or _contains_any(
             text, CONNECTIVITY_PATTERNS
         ):


### PR DESCRIPTION
## Problem (found in a live demo)
A run with an invalid objective (`cost_usd` — the metric is named `cost`) got **stuck**: a single config sat PENDING on the portal and never completed. The trial-result submission was rejected with **HTTP 400** (unknown metric), but the SDK logged it generically and **silently degraded to local-only** with the message *"backend tracking became unavailable"* — mislabelling a **permanent config error** as a transient outage, with no actionable guidance.

## Fix (safe — no submission-contract change)
- **trial_operations**: a non-transient **4xx** now logs a prominent, actionable error that names the likely cause and states the run is tracked LOCALLY ONLY:
  > ❌ Trial submission REJECTED by the backend: HTTP 400 — … This is a PERMANENT error (commonly an invalid optimization objective/metric name, e.g. 'cost_usd' instead of 'cost'), NOT a transient outage. … fix the request to track it on the backend.
- **execution_policy_runtime**: treat 4xx (`400/404/405/415`) as HARD failures, check the status **before** the `CloudBrainUnavailableError` short-circuit, and read `.response.status_code` too — so a 4xx is never misclassified as transient connectivity (fixes silent local-fallback wherever `exception_is_connectivity` gates the fallback).

## Why not a hard raise?
The trial-submission path is **deliberately resilient** — ~6 nested degrade-and-continue layers. Forcing a hard raise would change the contract across all of them and risk breaking legitimate transient-degradation behavior. This keeps the resilience design intact while making the cause **unmistakable and actionable** (the demo prompt's `cost_usd`→`cost` typo is now spelled out to the user).

## Tests
`tests/unit/core/test_connectivity_classification.py` (4xx→not-connectivity, 5xx/network→connectivity). 96 unit tests across connectivity/execution-policy/trial-ops green; no regressions.

Spine-Trail: st_6eef6196d128
