### PR TITLE
fix(sdk): #1466 honor objective orientation in batch/grid composite score

### DIFF
--- a/tests/unit/optimizers/test_batch_optimizers.py
+++ b/tests/unit/optimizers/test_batch_optimizers.py
@@ -14,6 +14,8 @@ from traigent.optimizers.batch_optimizers import (
 from traigent.optimizers.grid import GridSearchOptimizer
 from traigent.optimizers.random import RandomSearchOptimizer
 from traigent.optimizers.registry import get_optimizer
+from traigent.optimizers.results import Trial
+from traigent.utils.multi_objective import scalarize_objectives
 
 
 class MockInvoker:
@@ -482,9 +484,7 @@ class TestLegacyPositionalConstructors:
         self.config_space = {"param1": [1, 2], "param2": [0.1, 0.2]}
         self.objectives = ["accuracy"]
         self.base_optimizer = GridSearchOptimizer(self.config_space, self.objectives)
-        self.batch_config = BatchOptimizationConfig(
-            max_parallel_trials=3, batch_size=7
-        )
+        self.batch_config = BatchOptimizationConfig(max_parallel_trials=3, batch_size=7)
 
     def test_parallel_batch_legacy_positional(self):
         """ParallelBatchOptimizer(base_optimizer, batch_config) still works."""
@@ -672,3 +672,113 @@ class TestBaseOptimizerKwargForwarding:
 
         assert equal_score != skewed_score
         assert skewed_score > equal_score
+
+
+class TestObjectiveOrientationInCompositeScore:
+    """Regression tests for #1466.
+
+    Batch/grid optimizers scalarized every objective as ``maximize``, so a
+    declared ``minimize`` objective (cost/latency/error) contributed
+    *positively* to the composite. Best-pick is ``max(score)``, so the most
+    expensive / slowest config was returned as ``best_config``. These tests
+    assert orientation is honored: for two configs with identical accuracy, the
+    cheaper config must score strictly higher and be selected as best.
+
+    All scoring is computed directly from in-memory metrics — no LLM calls.
+    """
+
+    config_space = {"param1": [1, 2]}
+    objectives = ["accuracy", "cost"]
+
+    def _cheap_and_expensive_metrics(self):
+        """Equal accuracy, different cost. Cheaper config should win."""
+        cheap = {"accuracy": 0.9, "cost": 0.1}
+        expensive = {"accuracy": 0.9, "cost": 0.9}
+        return cheap, expensive
+
+    def test_grid_composite_prefers_cheaper(self):
+        """GridSearchOptimizer composite ranks lower cost above higher cost."""
+        optimizer = get_optimizer("grid", self.config_space, self.objectives)
+        cheap, expensive = self._cheap_and_expensive_metrics()
+
+        cheap_score = optimizer._calculate_composite_score(cheap)
+        expensive_score = optimizer._calculate_composite_score(expensive)
+
+        # Pre-fix this was reversed (cost added positively → expensive higher).
+        assert cheap_score > expensive_score
+
+    def test_parallel_batch_composite_prefers_cheaper(self):
+        """ParallelBatchOptimizer composite ranks lower cost above higher cost."""
+        optimizer = get_optimizer("parallel_batch", self.config_space, self.objectives)
+        cheap, expensive = self._cheap_and_expensive_metrics()
+
+        assert optimizer._calculate_composite_score(
+            cheap
+        ) > optimizer._calculate_composite_score(expensive)
+
+    def test_adaptive_batch_composite_prefers_cheaper(self):
+        """AdaptiveBatchOptimizer composite ranks lower cost above higher cost."""
+        optimizer = get_optimizer("adaptive_batch", self.config_space, self.objectives)
+        cheap, expensive = self._cheap_and_expensive_metrics()
+
+        assert optimizer._calculate_composite_score(
+            cheap
+        ) > optimizer._calculate_composite_score(expensive)
+
+    def test_multi_objective_select_best_from_pareto_prefers_cheaper(self):
+        """_select_best_from_pareto returns the orientation-correct optimum.
+
+        Two configs sit on an accuracy/cost frontier with equal accuracy. Both
+        are non-dominated only if accuracy differs; with equal accuracy the
+        cheaper one dominates. Either way, the selected best must be the cheaper
+        config, never the orientation-blind ``max(score)`` (the expensive one).
+        """
+        optimizer = MultiObjectiveBatchOptimizer(
+            configuration_space=self.config_space,
+            objectives=self.objectives,
+        )
+
+        # cost is a minimize objective: direction must be False (minimize).
+        assert optimizer.objective_directions["cost"] is False
+        assert optimizer.objective_directions["accuracy"] is True
+
+        cheap_metrics = {"accuracy": 0.9, "cost": 0.1}
+        expensive_metrics = {"accuracy": 0.9, "cost": 0.9}
+
+        # Mirror the per-trial scoring path in ``_run_batch_trial`` (which uses
+        # scalarize_objectives over objective_weights, honoring orientation).
+        def _composite(metrics):
+            return scalarize_objectives(
+                metrics,
+                optimizer.objective_weights,
+                minimize_objectives=optimizer._minimize_objectives,
+            )
+
+        cheap_trial = Trial(
+            configuration={"param1": 1},
+            score=_composite(cheap_metrics),
+            duration=0.0,
+            metadata={"objective_scores": cheap_metrics},
+        )
+        expensive_trial = Trial(
+            configuration={"param1": 2},
+            score=_composite(expensive_metrics),
+            duration=0.0,
+            metadata={"objective_scores": expensive_metrics},
+        )
+
+        optimizer._update_pareto_frontier(cheap_trial)
+        optimizer._update_pareto_frontier(expensive_trial)
+
+        best = optimizer._select_best_from_pareto()
+        assert best is not None
+        # Pre-fix: expensive config selected (max of orientation-blind score).
+        assert best.configuration == {"param1": 1}
+
+    def test_minimize_objectives_resolved_on_base(self):
+        """Optimizers expose the resolved minimize-objective list (#1466)."""
+        optimizer = get_optimizer(
+            "grid", self.config_space, ["accuracy", "cost", "latency", "error"]
+        )
+        assert set(optimizer._minimize_objectives) == {"cost", "latency", "error"}
+        assert "accuracy" not in optimizer._minimize_objectives

--- a/traigent/optimizers/base.py
+++ b/traigent/optimizers/base.py
@@ -86,6 +86,16 @@ class BaseOptimizer(ABC):
                 if obj in self.objectives
             }
 
+        # Resolve objective orientation once so composite/scalarized scoring
+        # respects ``minimize`` objectives (cost/latency/error) instead of
+        # treating every objective as ``maximize`` (#1466). Name-pattern
+        # heuristics are used here because optimizers receive string objective
+        # names; callers with an ``ObjectiveSchema`` should pass it through to
+        # ``scalarize_objectives`` directly for exact orientation.
+        self._minimize_objectives: list[str] = [
+            obj for obj in self.objectives if is_minimization_objective(obj)
+        ]
+
         # Initialize internal state
         self._trial_count = 0
         self._best_score: float | None = None

--- a/traigent/optimizers/batch_optimizers.py
+++ b/traigent/optimizers/batch_optimizers.py
@@ -23,6 +23,7 @@ from traigent.optimizers.random import RandomSearchOptimizer
 from traigent.optimizers.results import OptimizationResult, Trial
 from traigent.utils.batch_processing import AdaptiveBatchSizer
 from traigent.utils.logging import get_logger
+from traigent.utils.objectives import is_minimization_objective
 
 logger = get_logger(__name__)
 
@@ -330,10 +331,18 @@ class ParallelBatchOptimizer(BaseOptimizer):
         if not metrics:
             return 0.0
 
-        # Use scalarize_objectives for weighted scoring
+        # Use scalarize_objectives for weighted scoring, honoring objective
+        # orientation so minimize objectives (cost/latency/error) lower the
+        # composite instead of raising it (#1466).
         from traigent.utils.multi_objective import scalarize_objectives
 
-        return float(scalarize_objectives(metrics, self.objective_weights))
+        return float(
+            scalarize_objectives(
+                metrics,
+                self.objective_weights,
+                minimize_objectives=self._minimize_objectives,
+            )
+        )
 
 
 class MultiObjectiveBatchOptimizer(BaseOptimizer):
@@ -377,19 +386,14 @@ class MultiObjectiveBatchOptimizer(BaseOptimizer):
         self.pareto_frontier: list[Trial] = []
         self._current_trial_count = 0
 
-        # Define objective directions (True = maximize, False = minimize)
-        # Cost should be minimized, accuracy should be maximized
+        # Define objective directions (True = maximize, False = minimize).
+        # Derive from the canonical orientation helper (#1466) so Pareto
+        # dominance in ``_dominates`` uses the same orientation as the
+        # composite/scalarized score (cost/latency/error/loss/... → minimize).
         resolved_objectives = objectives or []
-        self.objective_directions: dict[str, Any] = {}
-        for obj in resolved_objectives:
-            if (
-                "cost" in obj.lower()
-                or "latency" in obj.lower()
-                or "error" in obj.lower()
-            ):
-                self.objective_directions[obj] = False  # minimize
-            else:
-                self.objective_directions[obj] = True  # maximize
+        self.objective_directions: dict[str, Any] = {
+            obj: not is_minimization_objective(obj) for obj in resolved_objectives
+        }
 
         # Use random search for multi-objective exploration
         self._base_optimizer = RandomSearchOptimizer(
@@ -531,8 +535,17 @@ class MultiObjectiveBatchOptimizer(BaseOptimizer):
                 # Equal weights for all objectives if not specified
                 objective_weights = dict.fromkeys(self.objectives, 1.0)
 
-            # Use the scalarize_objectives function for proper weighted averaging
-            composite_score = scalarize_objectives(objective_scores, objective_weights)
+            # Use the scalarize_objectives function for proper weighted
+            # averaging, honoring objective orientation so minimize objectives
+            # (cost/latency/error) lower the composite instead of raising it
+            # (#1466). This keeps the composite consistent with the
+            # orientation-aware Pareto dominance in ``_dominates`` and the
+            # ``max(score)`` pick in ``_select_best_from_pareto``.
+            composite_score = scalarize_objectives(
+                objective_scores,
+                objective_weights,
+                minimize_objectives=self._minimize_objectives,
+            )
 
             trial_duration = time.time() - trial_start
 
@@ -874,7 +887,15 @@ class AdaptiveBatchOptimizer(BaseOptimizer):
         if not metrics:
             return 0.0
 
-        # Use scalarize_objectives for weighted scoring
+        # Use scalarize_objectives for weighted scoring, honoring objective
+        # orientation so minimize objectives (cost/latency/error) lower the
+        # composite instead of raising it (#1466).
         from traigent.utils.multi_objective import scalarize_objectives
 
-        return float(scalarize_objectives(metrics, self.objective_weights))
+        return float(
+            scalarize_objectives(
+                metrics,
+                self.objective_weights,
+                minimize_objectives=self._minimize_objectives,
+            )
+        )

--- a/traigent/optimizers/grid.py
+++ b/traigent/optimizers/grid.py
@@ -242,10 +242,18 @@ class GridSearchOptimizer(BaseOptimizer):
         if not metrics:
             return 0.0
 
-        # Use scalarize_objectives for weighted scoring
+        # Use scalarize_objectives for weighted scoring, honoring objective
+        # orientation so minimize objectives (cost/latency/error) lower the
+        # composite instead of raising it (#1466).
         from traigent.utils.multi_objective import scalarize_objectives
 
-        return scalarize_objectives(metrics, self.objective_weights)
+        return float(
+            scalarize_objectives(
+                metrics,
+                self.objective_weights,
+                minimize_objectives=self._minimize_objectives,
+            )
+        )
 
     def suggest_next_trial(self, history: list[TrialResult]) -> dict[str, Any]:
         """Suggest next configuration to evaluate.


### PR DESCRIPTION
Fixes #1466.

## Root cause

`GridSearchOptimizer` (`grid`), `ParallelBatchOptimizer` (`parallel_batch`),
`MultiObjectiveBatchOptimizer` (`multi_objective_batch`) and `AdaptiveBatchOptimizer`
(`adaptive_batch`) computed each trial's composite score via
`scalarize_objectives(metrics, self.objective_weights)` with **no** `minimize_objectives`
and **no** `objective_schema`. When orientation is absent, `scalarize_objectives` treats
every objective as **maximize** (`traigent/utils/multi_objective.py:427-447`). Since best-pick
is `max(score)`, a declared minimize objective (`cost`/`latency`/`error`) contributed
*positively*, so the **most expensive / slowest** config was returned as
`OptimizationResult.best_config`. `MultiObjectiveBatchOptimizer` was self-inconsistent: it
built `objective_directions` and honored it in `_dominates` (Pareto membership) but discarded
it in `_select_best_from_pareto`, which picked the orientation-blind `max(score)`.

## The fix (minimal, scoped to the composite/selection orientation)

- `traigent/optimizers/base.py:89-95` — resolve `self._minimize_objectives` once in
  `BaseOptimizer.__init__` using the canonical
  `traigent.utils.objectives.is_minimization_objective` helper (already imported).
- `traigent/optimizers/grid.py:250-256` — pass `minimize_objectives=self._minimize_objectives`
  into `scalarize_objectives` (and `float(...)`-wrap to match sibling style / clear a
  pre-existing `no-any-return`).
- `traigent/optimizers/batch_optimizers.py:336-344` (ParallelBatchOptimizer),
  `:539-548` (MultiObjectiveBatchOptimizer per-trial), `:891-899` (AdaptiveBatchOptimizer) —
  same orientation thread-through.
- `traigent/optimizers/batch_optimizers.py:389-396` — derive
  `MultiObjectiveBatchOptimizer.objective_directions` from the same canonical helper, so
  `_dominates` and the composite/`_select_best_from_pareto` now use one consistent orientation
  source (also picks up `loss`/`time`/`duration`, previously only `cost`/`latency`/`error`).

`_select_best_from_pareto`'s `max(score)` becomes correct because the composite it ranks on is
now orientation-aware. No public surface, no schema, no contract change.

## Scope note (issue fix-item 3 deferred)

The issue also proposes making `scalarize_objectives` itself **raise** when a known-minimize
name is present but no orientation is supplied. That would break the documented
backward-compatibility contract of this public utility and ~10 existing tests
(`tests/unit/optimizers/test_weighted_objectives.py` explicitly asserts no-orientation =
maximize, e.g. `test_scalarize_basic_weighted_average`). Kept out of this PR to stay minimal
and non-breaking; tracked as a follow-up (see "Sibling/follow-ups" below).

## PR checklist

1. **Worst-case prod path** — N/A to policy surfaces (no auth/tenant/billing/privacy). The
   worst case the bug caused was returning the *most expensive* config as "best"; this fix
   corrects selection so the truly-best config wins. No fail-open concern.
2. **Production-branch / regression test** — `TestObjectiveOrientationInCompositeScore` in
   `tests/unit/optimizers/test_batch_optimizers.py` (grid / parallel_batch / adaptive_batch
   composite prefers cheaper; `_select_best_from_pareto` returns the cheaper config;
   `_minimize_objectives` resolution). Verified to **fail before** this change (worst config
   picked) and **pass after** (5 new tests + 174 related tests green). No LLM calls
   (`TRAIGENT_MOCK_LLM` not even required; pure in-memory scoring).
3. **Contract regeneration** — None. No `TraigentSchema` / OpenAPI / cross-SDK parity change;
   this is SDK-internal optimizer scoring.
4. **Public surface delta** — None. `__all__`, `list_optimizers()`, registered algorithm names,
   and documented routes are unchanged. `_minimize_objectives` / `objective_directions` are
   private.
5. **Review threads resolved** — N/A at open; will resolve any human/Greptile/Aikido/SonarCloud
   threads before merge.
6. **Quality gates not relaxed** — No thresholds touched. Cleared one pre-existing
   `no-any-return` on the grid line being edited (gate tightened, not loosened).

## Sibling / follow-ups (out of scope here)

- **Defensive `scalarize_objectives`** (issue fix-item 3): consider an opt-in strict mode or a
  deprecation path so a future caller cannot silently sum a minimize objective as maximize,
  without breaking the documented backward-compat default. Needs its own issue.
- Orientation here uses **name-pattern heuristics** (string objective names reach the
  optimizers). Callers holding an `ObjectiveSchema` should thread it through to
  `scalarize_objectives` for exact orientation; compound names like `accuracy_cost_ratio` can
  still misclassify (documented in `is_minimization_objective`).

Spine-Trail: st_d736342846a8