### PR TITLE
fix(sdk): #1448/#1460 non-finite best-config guard + #1467 pareto orientation

### DIFF
--- a/tests/unit/core/test_promotion_gate_integration.py
+++ b/tests/unit/core/test_promotion_gate_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime
 from unittest.mock import patch
 
@@ -201,6 +202,53 @@ class TestPromotionGateIntegration:
         )
 
         orchestrator._best_trial_cached = incumbent
+
+        assert orchestrator._simple_is_better(candidate) is True
+
+    @staticmethod
+    def _trial_with_accuracy(
+        trial_id: str, config: dict[str, int], accuracy: float
+    ) -> TrialResult:
+        return TrialResult(
+            trial_id=trial_id,
+            config=config,
+            metrics={"accuracy": accuracy},
+            status=TrialStatus.COMPLETED,
+            duration=0.1,
+            timestamp=datetime.now(UTC),
+        )
+
+    def test_best_trial_cache_skips_non_finite_first_score(self) -> None:
+        """A NaN first trial must not become the cached incumbent."""
+        orchestrator = OptimizationOrchestrator(
+            optimizer=_MockOptimizer(),
+            evaluator=_MockEvaluator(),
+            max_trials=3,
+        )
+        nan_trial = self._trial_with_accuracy("trial_nan", {"x": 1}, math.nan)
+        finite_trial = self._trial_with_accuracy("trial_finite", {"x": 2}, 0.9)
+
+        orchestrator._update_best_trial_cache(nan_trial)
+        assert orchestrator._best_trial_cached is None
+        assert orchestrator._incumbent_config_hash is None
+
+        orchestrator._update_best_trial_cache(finite_trial)
+
+        assert orchestrator._best_trial_cached is finite_trial
+        assert orchestrator._incumbent_config_hash is not None
+
+    def test_simple_is_better_replaces_non_finite_incumbent(self) -> None:
+        """A finite candidate should displace any legacy non-finite incumbent."""
+        orchestrator = OptimizationOrchestrator(
+            optimizer=_MockOptimizer(),
+            evaluator=_MockEvaluator(),
+            max_trials=3,
+        )
+        orchestrator._best_trial_cached = self._trial_with_accuracy(
+            "trial_nan", {"x": 1}, math.nan
+        )
+
+        candidate = self._trial_with_accuracy("trial_finite", {"x": 2}, 0.9)
 
         assert orchestrator._simple_is_better(candidate) is True
 

--- a/tests/unit/core/test_result_selection.py
+++ b/tests/unit/core/test_result_selection.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from traigent.core.result_selection import (
@@ -139,6 +141,47 @@ def test_selects_best_trial_without_aggregation():
     assert result.session_summary["ranking"]["eligible_count"] == 2
 
 
+@pytest.mark.parametrize(
+    ("primary_objective", "finite_score", "worse_score", "winner_config"),
+    [
+        ("accuracy", 0.9, 0.7, {"model": "finite"}),
+        ("cost", 0.1, 0.5, {"model": "finite"}),
+    ],
+)
+@pytest.mark.parametrize("nan_position", ["first", "last"])
+def test_single_trial_selection_ignores_nan_scores(
+    primary_objective, finite_score, worse_score, winner_config, nan_position
+):
+    nan_trial = FakeTrial(
+        metrics={primary_objective: math.nan},
+        config={"model": "nan"},
+    )
+    finite_trial = FakeTrial(
+        metrics={primary_objective: finite_score},
+        config=winner_config,
+    )
+    worse_trial = FakeTrial(
+        metrics={primary_objective: worse_score},
+        config={"model": "worse"},
+    )
+    trials = (
+        [nan_trial, finite_trial, worse_trial]
+        if nan_position == "first"
+        else [finite_trial, worse_trial, nan_trial]
+    )
+
+    result = select_best_configuration(
+        trials=trials,
+        primary_objective=primary_objective,
+        config_space_keys={"model"},
+        aggregate_configs=False,
+        comparability_mode="legacy",
+    )
+
+    assert result.best_config == winner_config
+    assert result.best_score == pytest.approx(finite_score)
+
+
 def test_minimization_objective_is_respected():
     trials = [
         FakeTrial(metrics={"cost_per_call": 0.5}, config={"model": "cheap"}),
@@ -175,6 +218,26 @@ def test_banded_primary_objective_selects_closest_single_trial():
     assert result.best_score == pytest.approx(500.0)
 
 
+def test_banded_primary_objective_ignores_nan_score():
+    trials = [
+        FakeTrial(metrics={"accuracy": math.nan}, config={"model": "nan"}),
+        FakeTrial(metrics={"accuracy": 0.81}, config={"model": "center"}),
+        FakeTrial(metrics={"accuracy": 0.50}, config={"model": "far"}),
+    ]
+
+    result = select_best_configuration(
+        trials=trials,
+        primary_objective="accuracy",
+        config_space_keys={"model"},
+        aggregate_configs=False,
+        band_target=0.80,
+        comparability_mode="legacy",
+    )
+
+    assert result.best_config == {"model": "center"}
+    assert result.best_score == pytest.approx(0.81)
+
+
 def test_banded_primary_objective_selects_closest_aggregated_config():
     trials = [
         FakeTrial(metrics={"accuracy": 0.95}, config={"model": "high"}),
@@ -193,6 +256,64 @@ def test_banded_primary_objective_selects_closest_aggregated_config():
 
     assert result.best_config == {"model": "center"}
     assert result.best_score == pytest.approx(0.695)
+
+
+@pytest.mark.parametrize(
+    ("primary_objective", "finite_score", "worse_score", "winner_config"),
+    [
+        ("accuracy", 0.9, 0.7, {"model": "finite"}),
+        ("cost", 0.1, 0.5, {"model": "finite"}),
+    ],
+)
+@pytest.mark.parametrize("nan_position", ["first", "last"])
+def test_aggregated_selection_ignores_nan_scores(
+    primary_objective, finite_score, worse_score, winner_config, nan_position
+):
+    nan_trial = FakeTrial(
+        metrics={primary_objective: math.nan},
+        config={"model": "nan"},
+    )
+    finite_trial = FakeTrial(
+        metrics={primary_objective: finite_score},
+        config=winner_config,
+    )
+    worse_trial = FakeTrial(
+        metrics={primary_objective: worse_score},
+        config={"model": "worse"},
+    )
+    trials = (
+        [nan_trial, finite_trial, worse_trial]
+        if nan_position == "first"
+        else [finite_trial, worse_trial, nan_trial]
+    )
+
+    result = select_best_configuration(
+        trials=trials,
+        primary_objective=primary_objective,
+        config_space_keys={"model"},
+        aggregate_configs=True,
+        comparability_mode="legacy",
+    )
+
+    assert result.best_config == winner_config
+    assert result.best_score == pytest.approx(finite_score)
+
+
+def test_aggregated_selection_all_nan_returns_no_eligible_reason():
+    result = select_best_configuration(
+        trials=[
+            FakeTrial(metrics={"accuracy": math.nan}, config={"model": "nan-a"}),
+            FakeTrial(metrics={"accuracy": math.nan}, config={"model": "nan-b"}),
+        ],
+        primary_objective="accuracy",
+        config_space_keys={"model"},
+        aggregate_configs=True,
+        comparability_mode="legacy",
+    )
+
+    assert result.best_config == {}
+    assert result.best_score is None
+    assert result.reason_code == NO_RANKING_ELIGIBLE_TRIALS
 
 
 def test_aggregated_selection_computes_means_and_metadata():

--- a/tests/unit/optimizers/test_base_optimizer.py
+++ b/tests/unit/optimizers/test_base_optimizer.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for base optimizer class."""
 
+import math
 from datetime import datetime
 from typing import Any
 from unittest.mock import Mock
@@ -393,6 +394,64 @@ class TestBaseOptimizer:
         # Best should remain None
         assert optimizer.best_score is None
         assert optimizer.best_config is None
+
+    @pytest.mark.parametrize("bad_score", [math.nan, math.inf, -math.inf])
+    def test_update_best_skips_non_finite_first_trial(self, bad_score):
+        """A non-finite first score must not poison the incumbent."""
+        optimizer = ConcreteOptimizer({"x": [0, 1]}, ["accuracy"])
+
+        optimizer.update_best(
+            TrialResult(
+                trial_id="trial-non-finite",
+                config={"x": 0},
+                metrics={"accuracy": bad_score},
+                status=TrialStatus.COMPLETED,
+                duration=1.0,
+                timestamp=datetime.now(),
+            )
+        )
+        optimizer.update_best(
+            TrialResult(
+                trial_id="trial-finite",
+                config={"x": 1},
+                metrics={"accuracy": 0.9},
+                status=TrialStatus.COMPLETED,
+                duration=1.0,
+                timestamp=datetime.now(),
+            )
+        )
+
+        assert optimizer.best_score == pytest.approx(0.9)
+        assert optimizer.best_config == {"x": 1}
+
+    @pytest.mark.parametrize("bad_score", [math.nan, math.inf, -math.inf])
+    def test_update_best_non_finite_trial_does_not_displace_incumbent(self, bad_score):
+        """A finite incumbent must survive later non-finite scores."""
+        optimizer = ConcreteOptimizer({"x": [0, 1]}, ["accuracy"])
+        optimizer.update_best(
+            TrialResult(
+                trial_id="trial-finite",
+                config={"x": 1},
+                metrics={"accuracy": 0.8},
+                status=TrialStatus.COMPLETED,
+                duration=1.0,
+                timestamp=datetime.now(),
+            )
+        )
+
+        optimizer.update_best(
+            TrialResult(
+                trial_id="trial-non-finite",
+                config={"x": 0},
+                metrics={"accuracy": bad_score},
+                status=TrialStatus.COMPLETED,
+                duration=1.0,
+                timestamp=datetime.now(),
+            )
+        )
+
+        assert optimizer.best_score == pytest.approx(0.8)
+        assert optimizer.best_config == {"x": 1}
 
     def test_properties(self):
         """Test optimizer properties."""

--- a/tests/unit/utils/test_optimization_logger.py
+++ b/tests/unit/utils/test_optimization_logger.py
@@ -747,6 +747,37 @@ class TestLogSessionEnd:
         pareto_files = list((log.run_path / "artifacts").glob("pareto_front_v*.json"))
         assert len(pareto_files) == 1
 
+    def test_session_end_pareto_front_respects_minimize_objectives(
+        self, tmp_path: Path
+    ) -> None:
+        log = _make_logger(tmp_path)
+        cheap = TrialResult(
+            trial_id="cheap",
+            config={"model": "cheap"},
+            metrics={"accuracy": 0.9, "cost": 0.1},
+            status=TrialStatus.COMPLETED,
+            duration=1.0,
+            timestamp=datetime.now(UTC),
+        )
+        expensive = TrialResult(
+            trial_id="expensive",
+            config={"model": "expensive"},
+            metrics={"accuracy": 0.8, "cost": 0.9},
+            status=TrialStatus.COMPLETED,
+            duration=1.0,
+            timestamp=datetime.now(UTC),
+        )
+        result = _make_opt_result(
+            trials=[cheap, expensive],
+            objectives=["accuracy", "cost"],
+        )
+
+        log.log_session_end(result)
+
+        pareto_file = next((log.run_path / "artifacts").glob("pareto_front_v*.json"))
+        pareto_data = json.loads(pareto_file.read_text())
+        assert pareto_data["configurations"] == [{"model": "cheap"}]
+
     def test_session_end_creates_manifest(self, tmp_path: Path) -> None:
         log = _make_logger(tmp_path)
         result = _make_opt_result()

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -112,7 +112,10 @@ from traigent.utils.function_identity import (
 )
 from traigent.utils.hashing import generate_run_label
 from traigent.utils.logging import get_logger
-from traigent.utils.objectives import is_minimization_objective
+from traigent.utils.objectives import (
+    coerce_finite_objective_score,
+    is_minimization_objective,
+)
 from traigent.utils.optimization_logger import OptimizationLogger
 
 from .tracing import optimization_session_span, record_optimization_complete
@@ -768,16 +771,22 @@ class OptimizationOrchestrator:
         if self.optimizer.objectives:
             primary_objective = self.optimizer.objectives[0]
             minimization = is_minimization_objective(primary_objective)
+            scored_trials = [
+                (trial, score)
+                for trial in rankable_trials
+                if (
+                    score := coerce_finite_objective_score(
+                        trial.metrics.get(primary_objective)
+                    )
+                )
+                is not None
+            ]
+            if not scored_trials:
+                return None
             if minimization:
-                best_trial = min(
-                    rankable_trials,
-                    key=lambda t: t.metrics.get(primary_objective, float("inf")),
-                )
+                best_trial = min(scored_trials, key=lambda item: item[1])[0]
             else:
-                best_trial = max(
-                    rankable_trials,
-                    key=lambda t: t.metrics.get(primary_objective, float("-inf")),
-                )
+                best_trial = max(scored_trials, key=lambda item: item[1])[0]
             self._best_trial_cached = best_trial
             return best_trial
 
@@ -1101,32 +1110,30 @@ class OptimizationOrchestrator:
 
     def _simple_is_better(self, trial_result: TrialResult) -> bool:
         """Check if trial_result is better than current best using simple comparison."""
-        if self._best_trial_cached is None:
-            return True
-
         if not self.optimizer.objectives:
             return True
 
         primary_objective = self.optimizer.objectives[0]
-        new_score = (
+        new_score_value = coerce_finite_objective_score(
             trial_result.get_metric(primary_objective)
             if hasattr(trial_result, "get_metric")
-            else ((trial_result.metrics or {}).get(primary_objective))
+            else (trial_result.metrics or {}).get(primary_objective)
         )
-        if new_score is None:
+        if new_score_value is None:
             return False
 
-        current_score = (
+        if self._best_trial_cached is None:
+            return True
+
+        current_score_value = coerce_finite_objective_score(
             self._best_trial_cached.get_metric(primary_objective)
             if hasattr(self._best_trial_cached, "get_metric")
             else (self._best_trial_cached.metrics or {}).get(primary_objective)
         )
-        if current_score is None:
+        if current_score_value is None:
             return True
 
         minimization = is_minimization_objective(primary_objective)
-        new_score_value = cast(float, new_score)
-        current_score_value = cast(float, current_score)
         if _primary_scores_tied(new_score_value, current_score_value):
             return self._secondary_tie_breaks_incumbent(trial_result, primary_objective)
         if minimization:
@@ -1157,6 +1164,13 @@ class OptimizationOrchestrator:
     def _update_best_trial_cache(self, trial_result: TrialResult) -> None:
         if not self.optimizer.objectives:
             self._best_trial_cached = trial_result
+            return
+
+        primary_objective = self.optimizer.objectives[0]
+        if (
+            coerce_finite_objective_score(trial_result.get_metric(primary_objective))
+            is None
+        ):
             return
 
         # Track metrics for this trial

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -7,10 +7,14 @@ from __future__ import annotations
 import math
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from traigent.api.types import TrialResult
-from traigent.utils.objectives import classify_objective, is_minimization_objective
+from traigent.utils.objectives import (
+    classify_objective,
+    coerce_finite_objective_score,
+    is_minimization_objective,
+)
 
 __all__ = [
     "SelectionResult",
@@ -211,14 +215,14 @@ def _is_ranking_eligible(
         return False, False, ["MCI-007"]
 
     if comparability_mode == "legacy":
-        metric = trial.get_metric(primary_objective)
+        metric = coerce_finite_objective_score(trial.get_metric(primary_objective))
         return metric is not None, False, (["MCI-004"] if metric is None else [])
 
     comparability = _extract_trial_comparability(trial)
     if comparability is None:
         return False, True, ["UNKNOWN_COMPARABILITY"]
 
-    objective_value = trial.get_metric(primary_objective)
+    objective_value = coerce_finite_objective_score(trial.get_metric(primary_objective))
     if objective_value is None:
         return False, False, ["MCI-004"]
 
@@ -370,7 +374,7 @@ def _apply_min_abs_deviation(
     if band_target is not None:
 
         def deviation(t: TrialResult) -> float:
-            value = t.get_metric(objective)
+            value = coerce_finite_objective_score(t.get_metric(objective))
             return float("inf") if value is None else abs(value - band_target)
 
         return min(trials, key=deviation)
@@ -400,11 +404,11 @@ def _select_best_single_trial(
     )
     chooser = min if minimization else max
 
-    scored_trials = [
-        (t, cast(float, _coerce_float(t.get_metric(primary_objective))))
-        for t in successful_trials
-        if _coerce_float(t.get_metric(primary_objective)) is not None
-    ]
+    scored_trials = []
+    for trial in successful_trials:
+        score = coerce_finite_objective_score(trial.get_metric(primary_objective))
+        if score is not None:
+            scored_trials.append((trial, score))
     if not scored_trials:
         return SelectionResult(
             best_config={},
@@ -451,7 +455,9 @@ def _select_best_single_trial(
 
     return SelectionResult(
         best_config=best_trial.config or {},
-        best_score=best_trial.get_metric(primary_objective),
+        best_score=coerce_finite_objective_score(
+            best_trial.get_metric(primary_objective)
+        ),
         session_summary={"ranking": ranking_summary},
         best_trial_id=best_trial.trial_id,
     )
@@ -577,14 +583,16 @@ def _select_best_aggregated(
     )
 
     def score(entry: dict[str, Any]) -> float:
-        value = _compute_mean_metrics(entry).get(primary_objective)
+        value = coerce_finite_objective_score(
+            _compute_mean_metrics(entry).get(primary_objective)
+        )
         if value is None:
             return float("inf") if minimization else float("-inf")
         return value
 
     # Find the best score
     all_scores = [score(entry) for entry in aggregated.values()]
-    all_scores = [s for s in all_scores if s not in (float("inf"), float("-inf"))]
+    all_scores = [s for s in all_scores if math.isfinite(s)]
     if not all_scores:
         return SelectionResult(
             best_config={},
@@ -602,7 +610,7 @@ def _select_best_aggregated(
         tied_entries = [
             entry
             for entry in aggregated.values()
-            if (score_value := score(entry)) not in (float("inf"), float("-inf"))
+            if math.isfinite(score_value := score(entry))
             and _primary_scores_tied(abs(score_value - band_target), best_deviation)
         ]
     else:
@@ -616,7 +624,7 @@ def _select_best_aggregated(
                 score_value := score(entry),
                 best_score_val,
             )
-            and score_value not in (float("inf"), float("-inf"))
+            and math.isfinite(score_value)
         ]
 
     # Apply tie-breaking for aggregated entries
@@ -658,7 +666,7 @@ def _select_best_aggregated(
 
     return SelectionResult(
         best_config=best_entry["config"] or {},
-        best_score=best_metrics.get(primary_objective),
+        best_score=coerce_finite_objective_score(best_metrics.get(primary_objective)),
         session_summary=session_summary,
         best_trial_id=(best_entry.get("trial_ids") or [None])[0],
     )

--- a/traigent/optimizers/base.py
+++ b/traigent/optimizers/base.py
@@ -10,7 +10,10 @@ from typing import Any
 from traigent.api.types import TrialResult
 from traigent.config.types import TraigentConfig
 from traigent.utils.logging import get_logger
-from traigent.utils.objectives import is_minimization_objective
+from traigent.utils.objectives import (
+    coerce_finite_objective_score,
+    is_minimization_objective,
+)
 from traigent.utils.validation import validate_objectives
 
 logger = get_logger(__name__)
@@ -233,19 +236,18 @@ class BaseOptimizer(ABC):
 
         # Get primary objective score
         primary_objective = self.objectives[0]
-        score = trial.get_metric(primary_objective)
+        score = coerce_finite_objective_score(trial.get_metric(primary_objective))
         if score is None:
             return
 
-        if self._best_score is None:
+        best_score = coerce_finite_objective_score(self._best_score)
+        if best_score is None:
             self._best_score = score
             self._best_config = trial.config.copy()
             return
 
         minimization = is_minimization_objective(primary_objective)
-        is_better = (
-            score < self._best_score if minimization else score > self._best_score
-        )
+        is_better = score < best_score if minimization else score > best_score
         if is_better:
             self._best_score = score
             self._best_config = trial.config.copy()

--- a/traigent/utils/objectives.py
+++ b/traigent/utils/objectives.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from typing import Literal
+import math
+from typing import Any, Literal
 
 _MINIMIZE_OBJECTIVE_PATTERNS = (
     "cost",
@@ -53,6 +54,17 @@ def is_minimization_objective(
     return any(pattern in lowered for pattern in _MINIMIZE_OBJECTIVE_PATTERNS)
 
 
+def coerce_finite_objective_score(value: Any) -> float | None:
+    """Return a finite numeric objective score, or None when unrankable."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    return score if math.isfinite(score) else None
+
+
 def classify_objective(
     objective_name: str,
 ) -> Literal["quality", "operational", "other"]:
@@ -77,6 +89,7 @@ def is_operational_objective(objective_name: str) -> bool:
 
 __all__ = [
     "classify_objective",
+    "coerce_finite_objective_score",
     "is_minimization_objective",
     "is_operational_objective",
     "is_quality_objective",

--- a/traigent/utils/optimization_logger.py
+++ b/traigent/utils/optimization_logger.py
@@ -23,6 +23,7 @@ from traigent.config.types import ExecutionMode, resolve_execution_mode
 from traigent.core.objectives import ObjectiveSchema, normalize_objectives
 from traigent.utils.file_versioning import FileVersionManager, RunVersionInfo
 from traigent.utils.logging import get_logger
+from traigent.utils.objectives import is_minimization_objective
 from traigent.utils.secure_path import PathTraversalError, validate_path
 
 logger = get_logger(__name__)
@@ -744,7 +745,11 @@ class OptimizationLogger:
         if len(optimization_result.objectives) > 1:
             from traigent.utils.multi_objective import ParetoFrontCalculator
 
-            calculator = ParetoFrontCalculator()
+            maximize = {
+                objective: not is_minimization_objective(objective)
+                for objective in optimization_result.objectives
+            }
+            calculator = ParetoFrontCalculator(maximize=maximize)
             pareto_front = calculator.calculate_pareto_front(
                 optimization_result.trials, optimization_result.objectives
             )


### PR DESCRIPTION
Fixes result-layer correctness P1s. codex 5.5 authored + reviewed (**GO**); captain agrees.

- **#1448** — a single NaN-metric trial permanently poisoned best-config tracking (optimizer reported a NaN config as best).
- **#1460** — `select_best_configuration` returned a NaN-scored / arbitrary config (or crashed) when a primary-objective metric was NaN.
- **#1467** — persisted `pareto_front` was inverted for minimize objectives (default maximize-all `ParetoFrontCalculator`).

Shared `coerce_finite_objective_score` guard applied across eligibility/single/banded/aggregate ranking + incumbent tracking; persisted Pareto now threads `is_minimization_objective` (consistent with merged #1466).

**Tests:** 191 passed (behavioral regressions that fail on revert). **ruff** clean. mypy: only pre-existing strict-mode errors in untouched files (CI's mypy config does not fire them); no new errors. No public-surface / contract change.

Spine-Trail: st_bcc58b439668
