### PR TITLE
fix(sdk): #1452/#1453/#1463/#1464/#1454/#1455/#1462/#1468 evaluator accuracy + cost metering

### DIFF
--- a/tests/unit/adapters/test_execution_adapter.py
+++ b/tests/unit/adapters/test_execution_adapter.py
@@ -101,6 +101,31 @@ async def test_local_adapter_preserves_evaluation_type_and_reports_per_type_accu
 
 
 @pytest.mark.asyncio
+async def test_local_adapter_unknown_evaluation_type_fails_closed():
+    agent = _SimpleAgent()
+    adapter = LocalExecutionAdapter(_AgentBuilder(agent))
+
+    dataset = {
+        "examples": [
+            {
+                "input": {"text": "a"},
+                "expected_output": "OK",
+                "metadata": {"evaluation_type": "bogus"},
+            },
+        ]
+    }
+
+    result = await adapter.execute_configuration(
+        agent_spec={}, dataset=dataset, trial_id="unknown-eval"
+    )
+
+    assert result["metrics"]["accuracy"] == 0.0
+    assert result["metrics"]["success_rate"] == 0.0
+    assert result["metrics"]["accuracy_bogus"] == 0.0
+    assert result["metadata"]["failures"] == 1
+
+
+@pytest.mark.asyncio
 async def test_local_adapter_accepts_dataset_object_from_core_types():
     agent = _SimpleAgent()
     adapter = LocalExecutionAdapter(_AgentBuilder(agent))

--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -85,9 +85,7 @@ class _StopConditionSink:
 def _setup_orchestrator_cost_enforcer(cost_approved: object) -> CostEnforcer:
     from traigent.core.orchestrator import OptimizationOrchestrator
 
-    orchestrator = cast(
-        Any, OptimizationOrchestrator.__new__(OptimizationOrchestrator)
-    )
+    orchestrator = cast(Any, OptimizationOrchestrator.__new__(OptimizationOrchestrator))
     orchestrator.config = {"cost_limit": 1.0, "cost_approved": cost_approved}
     orchestrator.parallel_execution_manager = _CostEnforcerSink()
     orchestrator._stop_condition_manager = _StopConditionSink()
@@ -191,6 +189,14 @@ class TestCostEnforcerBasic:
         enforcer = CostEnforcer(config=CostEnforcerConfig(limit=10.0))
         with pytest.raises(ValueError, match="non-negative"):
             enforcer.track_cost(-0.5, permit=_create_mock_permit())
+
+    @pytest.mark.parametrize("cost", [float("nan"), float("inf"), -float("inf")])
+    def test_track_cost_rejects_non_finite(self, cost: float) -> None:
+        """track_cost rejects non-finite costs before accumulation."""
+        enforcer = CostEnforcer(config=CostEnforcerConfig(limit=10.0))
+        with pytest.raises(ValueError, match="finite"):
+            enforcer.track_cost(cost, permit=_create_mock_permit())
+        assert enforcer.accumulated_cost == 0.0
 
     def test_limit_reached_detection(self) -> None:
         """is_limit_reached returns True when limit exceeded."""
@@ -580,6 +586,15 @@ class TestCostEnforcerAsync:
 
         assert enforcer.accumulated_cost == 3.0
         assert enforcer.trial_count == 2
+
+    @pytest.mark.parametrize("cost", [float("nan"), float("inf"), -float("inf")])
+    @pytest.mark.asyncio
+    async def test_track_cost_async_rejects_non_finite(self, cost: float) -> None:
+        """track_cost_async rejects non-finite costs before accumulation."""
+        enforcer = CostEnforcer()
+        with pytest.raises(ValueError, match="finite"):
+            await enforcer.track_cost_async(cost, permit=_create_mock_permit())
+        assert enforcer.accumulated_cost == 0.0
 
     @pytest.mark.asyncio
     async def test_concurrent_async_tracking(self) -> None:

--- a/tests/unit/core/test_mandatory_metrics.py
+++ b/tests/unit/core/test_mandatory_metrics.py
@@ -162,8 +162,10 @@ class TestMandatoryMetricsCollectorBasics:
         assert totals.total_duration == 1.5
         assert totals.total_examples_attempted == 10
 
-    def test_accumulate_failed_trial_ignored(self, failed_trial):
-        """Test that failed trials are ignored."""
+    def test_accumulate_failed_trial_without_metrics_contributes_zero(
+        self, failed_trial
+    ):
+        """Test that failed trials without spend metrics contribute zero."""
         collector = MandatoryMetricsCollector()
 
         collector.accumulate(failed_trial)
@@ -171,7 +173,7 @@ class TestMandatoryMetricsCollectorBasics:
         totals = collector.totals()
         assert totals.total_cost == 0.0
         assert totals.total_tokens == 0
-        assert totals.total_duration == 0.0
+        assert totals.total_duration == 0.5
 
     def test_accumulate_multiple_trials(self, completed_trial):
         """Test accumulating multiple trials."""
@@ -383,6 +385,59 @@ class TestMandatoryMetricsCollectorCostAndTokens:
 
         assert collector.totals().total_cost == 0.0
 
+    def test_pruned_and_failed_trials_with_spend_are_accumulated(self):
+        """Mid-execution PRUNED/FAILED trials should count real provider spend."""
+        collector = MandatoryMetricsCollector()
+
+        completed = Mock(spec=TrialResult)
+        completed.trial_id = "completed"
+        completed.status = TrialStatus.COMPLETED
+        completed.duration = 1.0
+        completed.metrics = {
+            "total_cost": 0.10,
+            "total_tokens": 100,
+            "examples_attempted": 10,
+        }
+        completed.metadata = {}
+
+        pruned = Mock(spec=TrialResult)
+        pruned.trial_id = "pruned"
+        pruned.status = TrialStatus.PRUNED
+        pruned.duration = 0.5
+        pruned.metrics = {
+            "total_cost": 0.20,
+            "total_tokens": 50,
+            "examples_attempted": 3,
+        }
+        pruned.metadata = {}
+
+        failed = Mock(spec=TrialResult)
+        failed.trial_id = "failed"
+        failed.status = TrialStatus.FAILED
+        failed.duration = 0.25
+        failed.metrics = {
+            "total_cost": 0.30,
+            "total_tokens": 25,
+            "examples_attempted": 2,
+        }
+        failed.metadata = {}
+
+        abandoned = Mock(spec=TrialResult)
+        abandoned.trial_id = "abandoned"
+        abandoned.status = TrialStatus.PRUNED
+        abandoned.duration = 0.0
+        abandoned.metrics = {}
+        abandoned.metadata = {}
+
+        for trial in (completed, pruned, failed, abandoned):
+            collector.accumulate(trial)
+
+        totals = collector.totals()
+        assert totals.total_cost == pytest.approx(0.60)
+        assert totals.total_tokens == 175
+        assert totals.total_duration == pytest.approx(1.75)
+        assert totals.total_examples_attempted == 15
+
 
 class TestMandatoryMetricsCollectorAggregatedMetrics:
     """Test extraction from aggregated metrics."""
@@ -500,8 +555,8 @@ class TestMandatoryMetricsCollectorEdgeCases:
 
         assert collector.totals().total_examples_attempted == 0
 
-    def test_pruned_trial_ignored(self):
-        """Test pruned trials are ignored."""
+    def test_pruned_trial_spend_is_accumulated(self):
+        """Test pruned trials with spend metrics are accumulated."""
         collector = MandatoryMetricsCollector()
         trial = Mock(spec=TrialResult)
         trial.trial_id = "trial_123"
@@ -512,7 +567,9 @@ class TestMandatoryMetricsCollectorEdgeCases:
 
         collector.accumulate(trial)
 
-        assert collector.totals().total_cost == 0.0
+        totals = collector.totals()
+        assert totals.total_cost == 0.5
+        assert totals.total_duration == 1.0
 
     def test_accumulate_preserves_previous_totals(self, completed_trial):
         """Test that accumulate adds to existing totals."""
@@ -554,7 +611,7 @@ class TestMandatoryMetricsCollectorIntegration:
         trial2.trial_id = "trial_2"
         trial2.status = TrialStatus.FAILED
         trial2.duration = 0.5
-        trial2.metrics = {"total_cost": 0.20}  # Should be ignored
+        trial2.metrics = {"total_cost": 0.20}
         trial2.metadata = {}
 
         trial3 = Mock(spec=TrialResult)
@@ -571,9 +628,9 @@ class TestMandatoryMetricsCollectorIntegration:
         totals = collector.totals()
         metrics = totals.as_metrics_dict()
 
-        assert totals.total_cost == 0.10
+        assert totals.total_cost == pytest.approx(0.30)
         assert totals.total_tokens == 100
-        assert totals.total_duration == 3.0  # 1.0 + 2.0 (failed ignored)
+        assert totals.total_duration == 3.5
         assert totals.total_examples_attempted == 15  # 10 + 5
 
         assert "total_cost" in metrics

--- a/tests/unit/evaluators/test_accuracy_comparison_regressions.py
+++ b/tests/unit/evaluators/test_accuracy_comparison_regressions.py
@@ -1,0 +1,66 @@
+"""Regression tests for evaluator exact-match comparison semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.evaluators.base import BaseEvaluator, Dataset, EvaluationExample
+from traigent.evaluators.local import LocalEvaluator
+from traigent.evaluators.metrics import MetricsComputer
+from traigent.invokers.base import InvocationResult
+
+
+class _DummyBaseEvaluator(BaseEvaluator):
+    async def evaluate(self, func, config, dataset, **kwargs):  # noqa: D401, ANN001
+        raise NotImplementedError
+
+
+def test_exact_match_coerces_string_output_for_typed_expected(caplog) -> None:
+    """String outputs matching typed scalar expected values should score correctly."""
+    caplog.set_level("WARNING", logger="traigent.evaluators.base")
+    base = _DummyBaseEvaluator()
+    local = LocalEvaluator(metrics=["accuracy"])
+    dataset = Dataset(
+        [
+            EvaluationExample({"q": "int"}, 42),
+            EvaluationExample({"q": "bool"}, True),
+            EvaluationExample({"q": "float"}, 3.5),
+        ]
+    )
+    outputs = ["42", "true", "3.5"]
+    expected = [example.expected_output for example in dataset.examples]
+    errors = [None, None, None]
+
+    assert base._compute_accuracy(outputs, expected, errors) == pytest.approx(1.0)
+    assert local._calculate_example_accuracy("42", 42) == pytest.approx(1.0)
+    assert local._compute_accuracy_aggregated(outputs, dataset)[0] == pytest.approx(1.0)
+    assert local._compute_real_accuracy("true", True) == pytest.approx(1.0)
+
+    metrics_result = MetricsComputer(metrics=["accuracy"]).compute_metrics(
+        [InvocationResult(result=value, is_successful=True) for value in outputs],
+        expected,
+    )
+    assert metrics_result.metrics["accuracy"] == pytest.approx(1.0)
+    assert "Coercing string output" in caplog.text
+
+
+def test_numeric_accuracy_uses_float_tolerance_across_paths() -> None:
+    """Float representation noise should not make numeric accuracy miss."""
+    actual = 0.1 + 0.2
+    expected = 0.3
+    base = _DummyBaseEvaluator()
+    local = LocalEvaluator(metrics=["accuracy"])
+    dataset = Dataset([EvaluationExample({"q": "float"}, expected)])
+
+    assert base._compute_accuracy([actual], [expected], [None]) == pytest.approx(1.0)
+    assert local._calculate_example_accuracy(actual, expected) == pytest.approx(1.0)
+    assert local._compute_accuracy_aggregated([actual], dataset)[0] == pytest.approx(
+        1.0
+    )
+    assert local._compute_real_accuracy(actual, expected) == pytest.approx(1.0)
+
+    metrics_result = MetricsComputer(metrics=["accuracy"]).compute_metrics(
+        [InvocationResult(result=actual, is_successful=True)],
+        [expected],
+    )
+    assert metrics_result.metrics["accuracy"] == pytest.approx(1.0)

--- a/tests/unit/evaluators/test_base.py
+++ b/tests/unit/evaluators/test_base.py
@@ -502,6 +502,51 @@ class TestLoadDatasetFromFile:
         assert dataset[1].input_data["text"] == "Goodbye"
         assert dataset[2].input_data["text"] == "Test"
 
+    def test_load_jsonl_warns_when_all_inputs_empty(self, tmp_path, caplog):
+        """Empty input values should warn without rejecting the dataset."""
+        jsonl_content = [
+            '{"input": "", "output": "empty"}',
+            '{"input": null, "output": "none"}',
+        ]
+        temp_path = tmp_path / "empty_inputs.jsonl"
+        temp_path.write_text("\n".join(jsonl_content), encoding="utf-8")
+
+        caplog.set_level("WARNING", logger="traigent.evaluators.base")
+        dataset = load_dataset_from_file(str(temp_path))
+
+        assert len(dataset) == 2
+        assert "has no input values" in caplog.text
+
+    def test_load_jsonl_warns_when_some_inputs_empty(self, tmp_path, caplog):
+        """Partially empty input values should report the count."""
+        jsonl_content = [
+            '{"input": "", "output": "empty"}',
+            '{"input": {"text": "Hello"}, "output": "Hi"}',
+        ]
+        temp_path = tmp_path / "partial_empty_inputs.jsonl"
+        temp_path.write_text("\n".join(jsonl_content), encoding="utf-8")
+
+        caplog.set_level("WARNING", logger="traigent.evaluators.base")
+        dataset = load_dataset_from_file(str(temp_path))
+
+        assert len(dataset) == 2
+        assert "has 1/2 examples with missing or empty input values" in caplog.text
+
+    def test_load_jsonl_does_not_warn_for_valid_inputs(self, tmp_path, caplog):
+        """Non-empty inputs should not emit the empty-input warning."""
+        jsonl_content = [
+            '{"input": {"text": "Hello"}, "output": "Hi"}',
+            '{"input": "Question", "output": "Answer"}',
+        ]
+        temp_path = tmp_path / "valid_inputs.jsonl"
+        temp_path.write_text("\n".join(jsonl_content), encoding="utf-8")
+
+        caplog.set_level("WARNING", logger="traigent.evaluators.base")
+        dataset = load_dataset_from_file(str(temp_path))
+
+        assert len(dataset) == 2
+        assert "missing or empty input values" not in caplog.text
+
 
 class MockEvaluator(BaseEvaluator):
     """Mock evaluator for testing BaseEvaluator interface."""

--- a/tests/unit/evaluators/test_litellm_integration.py
+++ b/tests/unit/evaluators/test_litellm_integration.py
@@ -1,5 +1,6 @@
 """Unit tests for litellm integration in evaluators."""
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
@@ -86,6 +87,27 @@ class MockAnthropicResponseAlias:
         self.content = [ContentBlock()]
 
 
+def test_aggregated_responses_reads_litellm_usage_shape() -> None:
+    """Multi-call aggregation should count litellm/OpenAI-SDK usage objects."""
+    from traigent.evaluators.local import _AggregatedResponses
+
+    response = SimpleNamespace(
+        usage=SimpleNamespace(
+            prompt_tokens=10,
+            completion_tokens=5,
+            total_tokens=15,
+        )
+    )
+
+    aggregated = _AggregatedResponses([response, response])
+
+    assert aggregated.usage_metadata == {
+        "input_tokens": 20,
+        "output_tokens": 10,
+        "total_tokens": 30,
+    }
+
+
 class TestTokencostIntegration:
     """Test litellm integration in metrics extraction."""
 
@@ -115,9 +137,11 @@ class TestTokencostIntegration:
         with (
             patch("traigent.evaluators.metrics_tracker.TOKENCOST_AVAILABLE", True),
             patch("os.environ.get") as mock_env,
-            patch("traigent.evaluators.metrics_tracker._calculate_cost_for_metrics", mock_calculate_cost),
+            patch(
+                "traigent.evaluators.metrics_tracker._calculate_cost_for_metrics",
+                mock_calculate_cost,
+            ),
         ):
-
             # Make os.environ.get return False for mock mode checks
             mock_env.side_effect = lambda key, default="": (
                 ""
@@ -168,7 +192,10 @@ class TestTokencostIntegration:
 
         with (
             patch("traigent.evaluators.metrics_tracker.TOKENCOST_AVAILABLE", False),
-            patch("traigent.evaluators.metrics_tracker._calculate_cost_for_metrics", mock_calculate_cost),
+            patch(
+                "traigent.evaluators.metrics_tracker._calculate_cost_for_metrics",
+                mock_calculate_cost,
+            ),
         ):
             metrics = extract_llm_metrics(response=response, model_name=model_name)
 
@@ -201,7 +228,10 @@ class TestTokencostIntegration:
 
         with (
             patch("traigent.evaluators.metrics_tracker.TOKENCOST_AVAILABLE", False),
-            patch("traigent.evaluators.metrics_tracker._calculate_cost_for_metrics", mock_calculate_cost),
+            patch(
+                "traigent.evaluators.metrics_tracker._calculate_cost_for_metrics",
+                mock_calculate_cost,
+            ),
         ):
             metrics = extract_llm_metrics(response=response)
 
@@ -233,9 +263,11 @@ class TestTokencostIntegration:
         with (
             patch("traigent.evaluators.metrics_tracker.TOKENCOST_AVAILABLE", True),
             patch("os.environ.get") as mock_env,
-            patch("traigent.evaluators.metrics_tracker._calculate_cost_for_metrics", mock_calculate_cost),
+            patch(
+                "traigent.evaluators.metrics_tracker._calculate_cost_for_metrics",
+                mock_calculate_cost,
+            ),
         ):
-
             # Make os.environ.get return False for mock mode checks
             mock_env.side_effect = lambda key, default="": (
                 ""
@@ -272,7 +304,6 @@ class TestTokencostIntegration:
                 "traigent.evaluators.metrics_tracker.calculate_prompt_cost"
             ) as mock_prompt_cost,
         ):
-
             # Make litellm raise an exception
             mock_prompt_cost.side_effect = Exception("litellm API error")
 
@@ -343,9 +374,11 @@ class TestLocalEvaluatorWithTokencost:
         with (
             patch("traigent.evaluators.metrics_tracker.TOKENCOST_AVAILABLE", True),
             patch("os.environ.get") as mock_env,
-            patch("traigent.evaluators.metrics_tracker._calculate_cost_for_metrics", mock_calculate_cost),
+            patch(
+                "traigent.evaluators.metrics_tracker._calculate_cost_for_metrics",
+                mock_calculate_cost,
+            ),
         ):
-
             # Make os.environ.get return False for mock mode checks
             mock_env.side_effect = lambda key, default="": (
                 ""
@@ -358,9 +391,9 @@ class TestLocalEvaluatorWithTokencost:
 
             # Verify cost information is present in aggregated metrics
             assert "cost" in result.aggregated_metrics
-            assert (
-                result.aggregated_metrics["cost"] > 0
-            ), "Total cost should be greater than 0"
+            assert result.aggregated_metrics["cost"] > 0, (
+                "Total cost should be greater than 0"
+            )
 
     @pytest.mark.asyncio
     async def test_local_evaluator_fallback_without_litellm(
@@ -449,7 +482,6 @@ class TestCostTrackingEdgeCases:
                 "traigent.evaluators.metrics_tracker.calculate_completion_cost"
             ) as mock_completion_cost,
         ):
-
             mock_completion_cost.return_value = 0.000002
 
             metrics = extract_llm_metrics(

--- a/tests/unit/integrations/langchain/test_langchain_handler.py
+++ b/tests/unit/integrations/langchain/test_langchain_handler.py
@@ -7,6 +7,7 @@ Run with: TRAIGENT_MOCK_LLM=true pytest tests/unit/integrations/langchain/ -v
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -475,6 +476,67 @@ class TestTraigentHandlerChatModelCallbacks:
         assert call.total_tokens == 150
         assert call.model == "gpt-4o"
 
+    def test_on_chat_model_end_reads_generation_usage_metadata(self, handler):
+        """Anthropic/Gemini chat usage_metadata should populate tokens and cost."""
+        run_id = str(uuid4())
+        handler.on_chat_model_start(
+            serialized={"kwargs": {"model": "claude-3-haiku-20240307"}},
+            messages=[[]],
+            run_id=run_id,
+        )
+
+        message = SimpleNamespace(
+            usage_metadata={
+                "input_tokens": 12,
+                "output_tokens": 7,
+                "total_tokens": 19,
+            },
+            response_metadata={"model_name": "claude-3-haiku-20240307"},
+        )
+        response = SimpleNamespace(
+            llm_output={},
+            generations=[[SimpleNamespace(message=message)]],
+        )
+
+        with patch.object(handler, "_estimate_cost", return_value=0.000123):
+            handler.on_chat_model_end(response=response, run_id=run_id)
+
+        call = handler._completed_llm_calls[0]
+        assert call.input_tokens == 12
+        assert call.output_tokens == 7
+        assert call.total_tokens == 19
+        assert call.cost == pytest.approx(0.000123)
+
+    def test_on_chat_model_end_reads_gemini_usage_metadata(self, handler):
+        """Gemini prompt/candidate token count fields should be counted."""
+        run_id = str(uuid4())
+        handler.on_chat_model_start(
+            serialized={"kwargs": {"model": "gemini-1.5-flash"}},
+            messages=[[]],
+            run_id=run_id,
+        )
+
+        message = SimpleNamespace(
+            usage_metadata={
+                "prompt_token_count": 20,
+                "candidates_token_count": 8,
+                "total_token_count": 28,
+            }
+        )
+        response = SimpleNamespace(
+            llm_output={},
+            generations=[[SimpleNamespace(message=message)]],
+        )
+
+        with patch.object(handler, "_estimate_cost", return_value=0.000456):
+            handler.on_chat_model_end(response=response, run_id=run_id)
+
+        call = handler._completed_llm_calls[0]
+        assert call.input_tokens == 20
+        assert call.output_tokens == 8
+        assert call.total_tokens == 28
+        assert call.cost == pytest.approx(0.000456)
+
     def test_on_chat_model_error(self, handler):
         """Test on_chat_model_error callback."""
         run_id = str(uuid4())
@@ -827,9 +889,9 @@ class TestCostEstimation:
     def test_estimate_cost_unknown_model_returns_zero(self, handler):
         """Test _estimate_cost returns 0.0 for unknown model (strict=False)."""
         cost = handler._estimate_cost("unknown-model-xyz-123", 1000, 500)
-        assert cost == pytest.approx(
-            0.0
-        ), "Unknown model should return 0.0 with strict=False"
+        assert cost == pytest.approx(0.0), (
+            "Unknown model should return 0.0 with strict=False"
+        )
 
     def test_estimate_cost_unknown_model_raises_in_strict_mode(self):
         """Strict cost accounting raises for unknown model pricing."""

--- a/tests/unit/utils/test_cost_calculator.py
+++ b/tests/unit/utils/test_cost_calculator.py
@@ -219,6 +219,34 @@ class TestCustomPricingAndValidation:
         assert result["not_found"] is True
         assert "invalid JSON" in result["error"]
 
+    @pytest.mark.parametrize("rate", [float("nan"), float("inf"), -float("inf")])
+    def test_custom_pricing_rejects_non_finite_rates(self, rate) -> None:
+        with pytest.raises(ValueError, match="non-finite pricing"):
+            cc._parse_custom_pricing_entry(
+                "bad-model",
+                {
+                    "input_cost_per_token": rate,
+                    "output_cost_per_token": 1e-6,
+                },
+                "test",
+            )
+
+    @pytest.mark.parametrize("literal", ["NaN", "Infinity", "-Infinity"])
+    def test_custom_pricing_json_rejects_non_finite_literals(
+        self, monkeypatch, literal
+    ) -> None:
+        monkeypatch.setenv(
+            "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",
+            (
+                '{"bad-model":{"input_cost_per_token":'
+                f'{literal},"output_cost_per_token":1e-6}}'
+            ),
+        )
+        monkeypatch.delenv("TRAIGENT_CUSTOM_MODEL_PRICING_FILE", raising=False)
+
+        with pytest.raises(ValueError, match="invalid JSON"):
+            cc._get_custom_pricing_index()
+
     def test_clear_cache_resets_custom_pricing_cache(self, monkeypatch) -> None:
         monkeypatch.setenv(
             "TRAIGENT_CUSTOM_MODEL_PRICING_JSON",

--- a/traigent/adapters/execution_adapter.py
+++ b/traigent/adapters/execution_adapter.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from typing import Any, cast
 
 from traigent.config.types import ExecutionMode
+from traigent.evaluators.base import _accuracy_values_match
 
 logger = logging.getLogger(__name__)
 
@@ -192,7 +193,7 @@ class LocalExecutionAdapter(ExecutionAdapter):
             # Exact / case-insensitive match — must stay aligned with
             # LocalEvaluator and the public docs (the tracked fix). Diverging
             # here was how "Paris" vs "paris" silently scored 0.0.
-            is_correct = str(output).strip().lower() == str(expected).strip().lower()
+            is_correct = _accuracy_values_match(output, expected)
             result["correct"] = is_correct
 
         elif eval_type == "contains":
@@ -245,8 +246,21 @@ class LocalExecutionAdapter(ExecutionAdapter):
 
         else:
             # Unknown evaluation type
-            result["correct"] = None
+            result["correct"] = False
+            result["success"] = False
             result["unknown_eval_type"] = eval_type
+            result["error"] = (
+                f"Unsupported evaluation_type '{eval_type}'. "
+                "Use exact_match, contains, numeric, semantic with a custom evaluator, "
+                "or provide a scoring_function."
+            )
+            logger.error(
+                "Unsupported evaluation_type %r for LocalExecutionAdapter; marking "
+                "example as failed. trial_id=%s example_index=%s",
+                eval_type,
+                trial_id or "<unknown>",
+                example_index if example_index is not None else "<unknown>",
+            )
 
         return result
 

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -667,12 +667,15 @@ Options:
             CostTrackingRequiredError: If cost is None and
                 TRAIGENT_REQUIRE_COST_TRACKING=true or
                 TRAIGENT_STRICT_COST_ACCOUNTING=true.
-            ValueError: If a negative cost is provided.
+            ValueError: If a negative or non-finite cost is provided.
         """
         self._check_mixing(is_async=False)
 
-        if cost is not None and cost < 0:
-            raise ValueError(f"Cost must be non-negative, got {cost}")
+        if cost is not None:
+            if not math.isfinite(cost):
+                raise ValueError(f"Cost must be finite, got {cost}")
+            if cost < 0:
+                raise ValueError(f"Cost must be non-negative, got {cost}")
 
         # Read environment-driven strictness once per call.
         # Keep this outside the lock to minimize lock hold time.
@@ -875,12 +878,15 @@ Options:
             CostTrackingRequiredError: If cost is None and
                 TRAIGENT_REQUIRE_COST_TRACKING=true or
                 TRAIGENT_STRICT_COST_ACCOUNTING=true.
-            ValueError: If a negative cost is provided.
+            ValueError: If a negative or non-finite cost is provided.
         """
         self._check_mixing(is_async=True)
 
-        if cost is not None and cost < 0:
-            raise ValueError(f"Cost must be non-negative, got {cost}")
+        if cost is not None:
+            if not math.isfinite(cost):
+                raise ValueError(f"Cost must be finite, got {cost}")
+            if cost < 0:
+                raise ValueError(f"Cost must be non-negative, got {cost}")
 
         # Read environment-driven strictness once per call.
         # Keep this outside the lock to minimize lock hold time.

--- a/traigent/core/mandatory_metrics.py
+++ b/traigent/core/mandatory_metrics.py
@@ -13,6 +13,12 @@ from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+_SPEND_ACCUMULATING_STATUSES = {
+    TrialStatus.COMPLETED,
+    TrialStatus.PRUNED,
+    TrialStatus.FAILED,
+}
+
 
 @dataclass(slots=True)
 class MandatoryMetricsTotals:
@@ -43,7 +49,7 @@ class MandatoryMetricsCollector:
         self._totals = MandatoryMetricsTotals()
 
     def accumulate(self, trial: TrialResult) -> None:
-        if trial.status != TrialStatus.COMPLETED:
+        if trial.status not in _SPEND_ACCUMULATING_STATUSES:
             return
 
         try:

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -84,6 +84,72 @@ record_example_result = None  # type: ignore
 
 logger = get_logger(__name__)
 
+_ACCURACY_REL_TOL = 1e-9
+_ACCURACY_ABS_TOL = 1e-12
+
+
+def _coerce_string_to_expected_type(actual: str, expected: Any) -> tuple[Any, bool]:
+    """Coerce string outputs for scalar typed expected values."""
+    stripped = actual.strip()
+    if isinstance(expected, bool):
+        lowered = stripped.lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true", True
+        return actual, False
+
+    if isinstance(expected, int) and not isinstance(expected, bool):
+        try:
+            return float(stripped), True
+        except ValueError:
+            return actual, False
+
+    if isinstance(expected, float):
+        try:
+            return float(stripped), True
+        except ValueError:
+            return actual, False
+
+    return actual, False
+
+
+def _typed_accuracy_equality(actual: Any, expected: Any) -> bool:
+    """Return direct equality for accuracy comparisons with an explicit bool type."""
+    return cast(bool, actual == expected)
+
+
+def _accuracy_values_match(actual: Any, expected: Any) -> bool:
+    """Return whether two accuracy values match under SDK exact-match semantics."""
+    original_actual = actual
+    if isinstance(actual, str) and not isinstance(expected, str):
+        actual, coerced = _coerce_string_to_expected_type(actual, expected)
+        if coerced:
+            logger.warning(
+                "Coercing string output %r to %s for exact-match accuracy comparison",
+                original_actual,
+                type(expected).__name__,
+            )
+
+    if isinstance(actual, str) and isinstance(expected, str):
+        return actual.strip().lower() == expected.strip().lower()
+
+    if (
+        (isinstance(actual, float) or isinstance(expected, float))
+        and not isinstance(actual, bool)
+        and not isinstance(expected, bool)
+    ):
+        try:
+            return math.isclose(
+                float(actual),
+                float(expected),
+                rel_tol=_ACCURACY_REL_TOL,
+                abs_tol=_ACCURACY_ABS_TOL,
+            )
+        except (TypeError, ValueError):
+            return _typed_accuracy_equality(actual, expected)
+
+    return _typed_accuracy_equality(actual, expected)
+
+
 try:  # pragma: no cover - import guard for optional dependency
     from traigent.metrics.ragas_metrics import (
         POPULAR_RAGAS_METRICS,
@@ -199,6 +265,40 @@ def _is_empty_expected_output(value: Any) -> bool:
     return False
 
 
+def _is_empty_input(value: Any) -> bool:
+    """Check if an input value is effectively empty."""
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    if isinstance(value, CollectionsMapping) and not value:
+        return True
+    return False
+
+
+def _warn_if_inputs_missing(examples: list[EvaluationExample], source: str) -> None:
+    """Warn when examples have empty inputs."""
+    missing_count = sum(1 for ex in examples if _is_empty_input(ex.input_data))
+    if missing_count <= 0:
+        return
+
+    if missing_count == len(examples):
+        logger.warning(
+            "Dataset '%s' has no input values (input field missing or empty in all "
+            "%d examples). Evaluation prompts may not be meaningful.",
+            source,
+            len(examples),
+        )
+        return
+
+    logger.warning(
+        "Dataset '%s' has %d/%d examples with missing or empty input values.",
+        source,
+        missing_count,
+        len(examples),
+    )
+
+
 def _warn_if_expected_outputs_missing(
     examples: list[EvaluationExample], source: str
 ) -> None:
@@ -263,6 +363,7 @@ def _build_dataset(
     if not examples:
         raise ValidationError(f"No valid examples found in {source}")
 
+    _warn_if_inputs_missing(examples, source)
     _warn_if_expected_outputs_missing(examples, source)
     metadata_out = _build_dataset_metadata(
         resolved_path,
@@ -944,7 +1045,7 @@ class BaseEvaluator(ABC):
         for output, exp, error in zip(outputs, expected, errors, strict=False):
             # Skip if error occurred or expected output is missing/empty
             if error is None and not _is_empty_expected_output(exp):
-                if output == exp:
+                if _accuracy_values_match(output, exp):
                     correct += 1
                 total += 1
 

--- a/traigent/evaluators/local.py
+++ b/traigent/evaluators/local.py
@@ -19,6 +19,7 @@ from traigent.evaluators.base import (
     BaseEvaluator,
     Dataset,
     EvaluationResult,
+    _accuracy_values_match,
     _example_correlation_key,
 )
 from traigent.evaluators.metrics_tracker import (
@@ -89,6 +90,22 @@ class _AggregatedResponses:
                 usage.get("output_tokens", 0),
                 usage.get("total_tokens", 0),
             )
+
+        usage_obj = getattr(resp, "usage", None)
+        if usage_obj is not None:
+            input_tokens = getattr(usage_obj, "prompt_tokens", 0) or 0
+            output_tokens = getattr(usage_obj, "completion_tokens", 0) or 0
+            total_tokens = getattr(usage_obj, "total_tokens", None)
+            if isinstance(input_tokens, (int, float)) and isinstance(
+                output_tokens, (int, float)
+            ):
+                if isinstance(total_tokens, (int, float)):
+                    return (int(input_tokens), int(output_tokens), int(total_tokens))
+                return (
+                    int(input_tokens),
+                    int(output_tokens),
+                    int(input_tokens + output_tokens),
+                )
 
         resp_meta = getattr(resp, "response_metadata", None)
         if not resp_meta or not isinstance(resp_meta, dict):
@@ -528,12 +545,8 @@ class LocalEvaluator(BaseEvaluator):
             return None
 
         if isinstance(actual_value, str) and isinstance(expected_output, str):
-            return (
-                1.0
-                if actual_value.strip().lower() == expected_output.strip().lower()
-                else 0.0
-            )
-        return 1.0 if actual_value == expected_output else 0.0
+            return 1.0 if _accuracy_values_match(actual_value, expected_output) else 0.0
+        return 1.0 if _accuracy_values_match(actual_value, expected_output) else 0.0
 
     def _transfer_token_metrics_to_example_result(
         self,
@@ -1175,10 +1188,7 @@ class LocalEvaluator(BaseEvaluator):
                 continue
 
             total += 1
-            if isinstance(value, str) and isinstance(expected, str):
-                if value.strip().lower() == expected.strip().lower():
-                    correct += 1
-            elif value == expected:
+            if _accuracy_values_match(value, expected):
                 correct += 1
 
         if total > 0:
@@ -1536,14 +1546,8 @@ class LocalEvaluator(BaseEvaluator):
             else actual_output
         )
 
-        # Exact match
-        if actual_to_compare == expected_output:
+        if _accuracy_values_match(actual_to_compare, expected_output):
             return 1.0
-
-        # Try case-insensitive comparison for string outputs
-        if isinstance(actual_to_compare, str) and isinstance(expected_output, str):
-            if actual_to_compare.lower().strip() == expected_output.lower().strip():
-                return 1.0
 
         return 0.0
 

--- a/traigent/evaluators/metrics.py
+++ b/traigent/evaluators/metrics.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from traigent.evaluators.base import _accuracy_values_match
 from traigent.invokers.base import InvocationResult
 from traigent.utils.logging import get_logger
 
@@ -117,7 +118,9 @@ class MetricsComputer:
         # Accuracy (exact match)
         if "accuracy" in self.metrics and successful_pairs:
             correct = sum(
-                1 for output, expected in successful_pairs if output == expected
+                1
+                for output, expected in successful_pairs
+                if _accuracy_values_match(output, expected)
             )
             computed_metrics["accuracy"] = correct / len(successful_pairs)
         elif "accuracy" in self.metrics:

--- a/traigent/integrations/langchain/handler.py
+++ b/traigent/integrations/langchain/handler.py
@@ -119,6 +119,139 @@ def get_current_node_name() -> str | None:
     return _current_node_name.get()
 
 
+def _token_value(source: Any, *names: str) -> int | None:
+    for name in names:
+        if isinstance(source, dict):
+            value = source.get(name)
+        else:
+            value = getattr(source, name, None)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return int(value)
+    return None
+
+
+def _tokens_from_usage(source: Any) -> tuple[int, int, int] | None:
+    if source is None:
+        return None
+
+    input_tokens = _token_value(
+        source,
+        "prompt_tokens",
+        "input_tokens",
+        "input_token_count",
+        "prompt_token_count",
+        "num_input_tokens",
+        "inputTokens",
+    )
+    output_tokens = _token_value(
+        source,
+        "completion_tokens",
+        "output_tokens",
+        "output_token_count",
+        "candidates_token_count",
+        "num_output_tokens",
+        "outputTokens",
+    )
+    total_tokens = _token_value(source, "total_tokens", "total_token_count")
+
+    input_count = input_tokens or 0
+    output_count = output_tokens or 0
+    total_count = (
+        total_tokens if total_tokens is not None else input_count + output_count
+    )
+    if input_count > 0 or output_count > 0 or total_count > 0:
+        return input_count, output_count, total_count
+    return None
+
+
+def _iter_generation_payloads(response: Any) -> list[Any]:
+    generations = getattr(response, "generations", None)
+    if not isinstance(generations, list):
+        return []
+
+    payloads: list[Any] = []
+    for row in generations:
+        if isinstance(row, list):
+            payloads.extend(row)
+        else:
+            payloads.append(row)
+    return payloads
+
+
+def _extract_response_token_usage(response: Any) -> tuple[int, int, int]:
+    llm_output = getattr(response, "llm_output", None)
+    if isinstance(llm_output, dict):
+        for key in ("token_usage", "usage", "usage_metadata"):
+            tokens = _tokens_from_usage(llm_output.get(key))
+            if tokens is not None:
+                return tokens
+
+    for source in (
+        getattr(response, "usage_metadata", None),
+        getattr(response, "usage", None),
+    ):
+        tokens = _tokens_from_usage(source)
+        if tokens is not None:
+            return tokens
+
+    response_metadata = getattr(response, "response_metadata", None)
+    if isinstance(response_metadata, dict):
+        for key in ("token_usage", "usage", "usage_metadata"):
+            tokens = _tokens_from_usage(response_metadata.get(key))
+            if tokens is not None:
+                return tokens
+
+    for generation in _iter_generation_payloads(response):
+        for candidate in (getattr(generation, "message", None), generation):
+            for source in (
+                getattr(candidate, "usage_metadata", None),
+                getattr(candidate, "usage", None),
+            ):
+                tokens = _tokens_from_usage(source)
+                if tokens is not None:
+                    return tokens
+
+            metadata = getattr(candidate, "response_metadata", None)
+            if isinstance(metadata, dict):
+                for key in ("token_usage", "usage", "usage_metadata"):
+                    tokens = _tokens_from_usage(metadata.get(key))
+                    if tokens is not None:
+                        return tokens
+
+    return 0, 0, 0
+
+
+def _extract_response_model(response: Any) -> str | None:
+    llm_output = getattr(response, "llm_output", None)
+    if isinstance(llm_output, dict):
+        model = llm_output.get("model_name") or llm_output.get("model")
+        if isinstance(model, str) and model:
+            return model
+
+    response_metadata = getattr(response, "response_metadata", None)
+    if isinstance(response_metadata, dict):
+        model = response_metadata.get("model_name") or response_metadata.get("model")
+        if isinstance(model, str) and model:
+            return model
+
+    model = getattr(response, "model", None)
+    if isinstance(model, str) and model:
+        return model
+
+    for generation in _iter_generation_payloads(response):
+        for candidate in (getattr(generation, "message", None), generation):
+            metadata = getattr(candidate, "response_metadata", None)
+            if isinstance(metadata, dict):
+                model = metadata.get("model_name") or metadata.get("model")
+                if isinstance(model, str) and model:
+                    return model
+            model = getattr(candidate, "model", None)
+            if isinstance(model, str) and model:
+                return model
+
+    return None
+
+
 # =============================================================================
 # Data Models
 # =============================================================================
@@ -398,15 +531,13 @@ class TraigentHandler(BaseCallbackHandler):
             call.end_time = time.time()
 
             # Extract token usage from response
-            if response.llm_output:
-                token_usage = response.llm_output.get("token_usage", {})
-                call.input_tokens = token_usage.get("prompt_tokens", 0)
-                call.output_tokens = token_usage.get("completion_tokens", 0)
-                call.total_tokens = token_usage.get("total_tokens", 0)
+            call.input_tokens, call.output_tokens, call.total_tokens = (
+                _extract_response_token_usage(response)
+            )
 
-                # Try to get model info if not already set
-                if call.model is None:
-                    call.model = response.llm_output.get("model_name")
+            # Try to get model info if not already set
+            if call.model is None:
+                call.model = _extract_response_model(response)
 
             # Calculate cost (uses litellm if available)
             if call.total_tokens > 0 and call.model:
@@ -467,15 +598,13 @@ class TraigentHandler(BaseCallbackHandler):
             call.end_time = time.time()
 
             # Extract token usage
-            if response.llm_output:
-                token_usage = response.llm_output.get("token_usage", {})
-                call.input_tokens = token_usage.get("prompt_tokens", 0)
-                call.output_tokens = token_usage.get("completion_tokens", 0)
-                call.total_tokens = token_usage.get("total_tokens", 0)
+            call.input_tokens, call.output_tokens, call.total_tokens = (
+                _extract_response_token_usage(response)
+            )
 
-                # Try to get model info if not already set
-                if call.model is None:
-                    call.model = response.llm_output.get("model_name")
+            # Try to get model info if not already set
+            if call.model is None:
+                call.model = _extract_response_model(response)
 
             # Calculate cost (simplified - uses litellm if available)
             if call.total_tokens > 0 and call.model:

--- a/traigent/utils/cost_calculator.py
+++ b/traigent/utils/cost_calculator.py
@@ -11,6 +11,7 @@ Cost resolution is intentionally fail-fast:
 
 import json
 import logging
+import math
 import os
 import re
 import threading
@@ -262,10 +263,17 @@ def _parse_custom_pricing_entry(
             f"Invalid numeric pricing for model '{model}' in {source}"
         ) from exc
 
+    if not math.isfinite(input_cost) or not math.isfinite(output_cost):
+        raise ValueError(f"Invalid non-finite pricing for model '{model}' in {source}")
+
     if input_cost < 0 or output_cost < 0:
         raise ValueError(f"Invalid negative pricing for model '{model}' in {source}")
 
     return input_cost, output_cost
+
+
+def _reject_non_finite_json_constant(token: str) -> None:
+    raise ValueError(f"Non-finite literal '{token}' not allowed in custom pricing")
 
 
 def _normalize_custom_pricing_map(
@@ -293,7 +301,9 @@ def _load_custom_pricing_from_sources() -> dict[str, tuple[float, float]]:
     if file_path:
         try:
             with open(file_path, encoding="utf-8") as f:
-                file_payload = json.load(f)
+                file_payload = json.load(
+                    f, parse_constant=_reject_non_finite_json_constant
+                )
         except Exception as exc:
             raise ValueError(
                 f"Failed to parse custom pricing file '{file_path}'."
@@ -307,7 +317,9 @@ def _load_custom_pricing_from_sources() -> dict[str, tuple[float, float]]:
     env_json = os.environ.get(_CUSTOM_PRICING_JSON_ENV, "").strip()
     if env_json:
         try:
-            env_payload = json.loads(env_json)
+            env_payload = json.loads(
+                env_json, parse_constant=_reject_non_finite_json_constant
+            )
         except Exception as exc:
             raise ValueError(
                 f"Failed to parse {_CUSTOM_PRICING_JSON_ENV}: invalid JSON"


### PR DESCRIPTION
Evaluator accuracy + cost metering. codex 5.5 authored + reviewed (**GO**, 2 rounds); captain agrees.

- **#1452** unknown `evaluation_type` fails loud (no silent 0% polluting the denominator) - **#1453** dataset loaders warn on empty/None input values - **#1463** exact-match coerces string-vs-typed (int/float/bool) with a warning - **#1464** numeric accuracy uses tolerance, not bare `==`.
- **#1454** LangChain handler reads provider-correct token usage (Anthropic/Gemini, not OpenAI-only) - **#1455** `_AggregatedResponses` handles litellm multi-call usage - **#1462** `total_cost` includes PRUNED/FAILED trial spend.
- **#1468** custom pricing rejects NaN/Infinity (fail-closed) - restores the cost-limit guard.

**Tests:** behavioral regressions across evaluators/metering/pricing. ruff + mypy clean (no-any-return fixed).

Spine-Trail: st_30a1982af076
