### PR TITLE
fix(sdk): #1465/#1449/#1450/#1457/#1458/#1459/#1451/#1456 search-safety + stepped-ranges + silent-noop

### DIFF
--- a/tests/unit/api/test_constraints.py
+++ b/tests/unit/api/test_constraints.py
@@ -529,6 +529,38 @@ class TestPythonConstraintValidator:
         assert result.status == SatStatus.UNSAT
         assert result.unsat_core == [0, 1]
 
+    def test_check_satisfiability_stepped_int_includes_high(self) -> None:
+        """Stepped IntRange satisfiability includes the inclusive high endpoint."""
+        count = IntRange(0, 5, step=2, name="count")
+        constraints = [require(count.equals(5))]
+
+        validator = PythonConstraintValidator()
+        result = validator.check_satisfiability({"count": count}, constraints)
+
+        assert result.status == SatStatus.SAT
+        assert result.example_config == {"count": 5}
+
+    def test_check_satisfiability_stepped_float_unsat(self) -> None:
+        """Stepped float ranges are finite and can prove contradictions UNSAT."""
+        temp = Range(0.0, 1.0, step=0.5, name="temp")
+        constraints = [require(temp.equals(0.5)), require(temp.equals(1.0))]
+
+        validator = PythonConstraintValidator()
+        result = validator.check_satisfiability({"temp": temp}, constraints)
+
+        assert result.status == SatStatus.UNSAT
+
+    def test_check_satisfiability_stepped_float_sat_example(self) -> None:
+        """Stepped float satisfiable examples come from the snapped grid."""
+        temp = Range(0.0, 1.0, step=0.5, name="temp")
+        constraints = [require(temp.gte(0.5))]
+
+        validator = PythonConstraintValidator()
+        result = validator.check_satisfiability({"temp": temp}, constraints)
+
+        assert result.status == SatStatus.SAT
+        assert result.example_config in ({"temp": 0.5}, {"temp": 1.0})
+
 
 class TestSATConstraintValidator:
     """Tests for SATConstraintValidator compatibility adapter."""

--- a/tests/unit/config/test_seamless_runtime_shim.py
+++ b/tests/unit/config/test_seamless_runtime_shim.py
@@ -90,6 +90,46 @@ def test_seamless_runtime_shim_keeps_assignment_path() -> None:
     assert wrapped("What is 2+2?") == "claude-3-sonnet"
 
 
+def test_seamless_warns_when_config_has_no_injectable_target(caplog) -> None:
+    provider = _reset_provider()
+
+    def fn(question: str) -> str:
+        model_name = "claude-3-haiku"
+        return model_name
+
+    wrapped = provider.inject_config(fn, {"model": "claude-3-sonnet"})
+
+    with caplog.at_level("WARNING", logger="traigent.config.providers"):
+        assert wrapped("What is 2+2?") == "claude-3-haiku"
+
+    assert "found no injectable targets" in caplog.text
+    assert provider.get_stats()["fallback_triggers"]["no_injection"] == [["model"]]
+
+
+def test_seamless_does_not_warn_for_assignment_or_parameter_injection(caplog) -> None:
+    provider = _reset_provider()
+
+    def assignment_fn(question: str) -> str:
+        model = "claude-3-haiku"
+        return model
+
+    def parameter_fn(question: str, model: str = "claude-3-haiku") -> str:
+        return model
+
+    assignment_wrapped = provider.inject_config(
+        assignment_fn, {"model": "claude-3-sonnet"}
+    )
+    parameter_wrapped = provider.inject_config(
+        parameter_fn, {"model": "claude-3-sonnet"}
+    )
+
+    with caplog.at_level("WARNING", logger="traigent.config.providers"):
+        assert assignment_wrapped("What is 2+2?") == "claude-3-sonnet"
+        assert parameter_wrapped("What is 2+2?") == "claude-3-sonnet"
+
+    assert "found no injectable targets" not in caplog.text
+
+
 def test_seamless_runtime_shim_caches_per_config() -> None:
     provider = _reset_provider()
 

--- a/tests/unit/integrations/test_framework_override_extended.py
+++ b/tests/unit/integrations/test_framework_override_extended.py
@@ -14,6 +14,8 @@ This test module focuses on the uncovered areas:
 from __future__ import annotations
 
 import asyncio
+import logging
+from functools import cached_property
 from unittest.mock import patch
 
 import pytest
@@ -69,6 +71,44 @@ class MockChatCompletions:
 
     def create(self, **kwargs):
         return {"choices": [{"message": {"content": "Chat result"}}]}
+
+
+class CachedPropertyMessagesForOverride:
+    """Resource class used to exercise cached_property method resolution."""
+
+    def create(self, **kwargs):
+        return kwargs
+
+
+class CachedPropertyClientForOverride:
+    """Client class with SDK-like cached resource accessors."""
+
+    @cached_property
+    def messages(self) -> CachedPropertyMessagesForOverride:
+        return CachedPropertyMessagesForOverride()
+
+
+class CachedPropertyChatCompletionsForOverride:
+    """SDK-shaped chat completions resource."""
+
+    def create(self, **kwargs: object) -> dict[str, object]:
+        return kwargs
+
+
+class CachedPropertyChatForOverride:
+    """SDK-shaped chat resource."""
+
+    @cached_property
+    def completions(self) -> CachedPropertyChatCompletionsForOverride:
+        return CachedPropertyChatCompletionsForOverride()
+
+
+class CachedPropertyOpenAIClientForOverride:
+    """Client class with OpenAI-style cached chat resource accessor."""
+
+    @cached_property
+    def chat(self) -> CachedPropertyChatForOverride:
+        return CachedPropertyChatForOverride()
 
 
 class MockAsyncOpenAI:
@@ -1081,6 +1121,100 @@ class TestEdgeCases:
         # Should complete without error - verify class still works
         client = MockClient()
         assert isinstance(client, MockClient)
+
+    def test_apply_method_override_resolves_cached_property_resource(
+        self, override_manager, sample_config
+    ):
+        """Dotted SDK resource paths patch the lazily-created resource class."""
+
+        override_manager._parameter_mappings["test.Client"] = {"model": "model"}
+        override_manager._method_mappings["test.Client"] = {
+            "messages.create": ["model"]
+        }
+        original_create = CachedPropertyMessagesForOverride.create
+
+        override_manager._apply_method_override(
+            CachedPropertyClientForOverride, "test.Client", "messages.create"
+        )
+
+        assert CachedPropertyMessagesForOverride.create is not original_create
+        assert hasattr(CachedPropertyMessagesForOverride.create, "__wrapped__")
+        assert "test.Client.messages.create" in override_manager._original_methods
+
+        token = set_config(sample_config)
+        override_manager._override_active.enabled = True
+        try:
+            assert (
+                CachedPropertyClientForOverride().messages.create(model="original")[
+                    "model"
+                ]
+                == "gpt-4o-mini"
+            )
+        finally:
+            config_context.reset(token)
+
+    def test_apply_method_override_resolves_cached_property_string_resource(
+        self,
+        override_manager,
+        sample_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """OpenAI-style string annotations patch chat.completions.create."""
+
+        def fail_type_hints(_func: object) -> dict[str, object]:
+            raise NameError("Chat")
+
+        monkeypatch.setattr(
+            "traigent.integrations.framework_override.get_type_hints",
+            fail_type_hints,
+        )
+        override_manager._parameter_mappings["openai.OpenAI"] = {"model": "model"}
+        override_manager._method_mappings["openai.OpenAI"] = {
+            "chat.completions.create": ["model"]
+        }
+        original_create = CachedPropertyChatCompletionsForOverride.create
+
+        override_manager._apply_method_override(
+            CachedPropertyOpenAIClientForOverride,
+            "openai.OpenAI",
+            "chat.completions.create",
+        )
+
+        assert CachedPropertyChatCompletionsForOverride.create is not original_create
+        assert hasattr(CachedPropertyChatCompletionsForOverride.create, "__wrapped__")
+
+        token = set_config(sample_config)
+        override_manager._override_active.enabled = True
+        try:
+            assert (
+                CachedPropertyOpenAIClientForOverride().chat.completions.create(
+                    model="original"
+                )["model"]
+                == "gpt-4o-mini"
+            )
+        finally:
+            config_context.reset(token)
+
+    def test_apply_method_override_warns_when_cached_property_unresolved(
+        self, override_manager, caplog
+    ):
+        """Registered method targets that cannot be patched are warning-visible."""
+
+        class Client:
+            @cached_property
+            def messages(self):
+                return object()
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="traigent.integrations.framework_override",
+        ):
+            override_manager._apply_method_override(
+                Client, "test.Client", "messages.create"
+            )
+
+        assert "Skipping override" in caplog.text
+        assert "messages.create" in caplog.text
 
     def test_create_override_constructor_with_dict_config(
         self, override_manager, dict_config

--- a/tests/unit/optimizers/test_search_safety_ranges.py
+++ b/tests/unit/optimizers/test_search_safety_ranges.py
@@ -1,0 +1,282 @@
+"""Regression coverage for finite range semantics and search safety."""
+
+from __future__ import annotations
+
+import pytest
+
+from traigent.api.config_space import ConfigSpace
+from traigent.api.constraints import require
+from traigent.api.parameter_ranges import Range
+from traigent.api.validation_protocol import SatStatus
+from traigent.core.trial_lifecycle import TrialLifecycle
+from traigent.optimizers.grid import GridSearchOptimizer
+from traigent.optimizers.random import RandomSearchOptimizer
+from traigent.utils.discrete_domains import discrete_cardinality_for_config_param
+from traigent.utils.exceptions import OptimizationError
+
+
+def test_grid_search_rejects_large_space_before_product_materialization(monkeypatch):
+    """Large finite grids fail before cartesian product allocation."""
+
+    def fail_product(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("grid product should not be materialized")
+
+    monkeypatch.setattr("traigent.optimizers.grid.itertools.product", fail_product)
+
+    with pytest.raises(OptimizationError, match="exceeding the safety cap"):
+        GridSearchOptimizer(
+            {f"p{i}": list(range(3)) for i in range(4)},
+            ["accuracy"],
+            max_grid_combinations=10,
+        )
+
+
+def test_grid_search_rejects_large_stepped_range_before_value_materialization(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Large stepped range dicts fail on cardinality before tuple allocation."""
+
+    def fail_stepped_float_values(
+        _low: float, _high: float, _step: float
+    ) -> tuple[float, ...]:
+        raise AssertionError("stepped values should not be materialized before cap")
+
+    monkeypatch.setattr(
+        "traigent.utils.discrete_domains.stepped_float_values",
+        fail_stepped_float_values,
+    )
+
+    with pytest.raises(OptimizationError, match="exceeding the safety cap"):
+        GridSearchOptimizer(
+            {"temperature": {"type": "float", "low": 0.0, "high": 20.0, "step": 0.001}},
+            ["accuracy"],
+            max_grid_combinations=10_000,
+        )
+
+
+def test_grid_search_enumerates_stepped_float_range_below_cap():
+    optimizer = GridSearchOptimizer(
+        {"temperature": Range(0.0, 1.0, step=0.5).to_config_value()},
+        ["accuracy"],
+    )
+
+    assert optimizer.total_combinations == 3
+    assert optimizer._grid_points == [
+        {"temperature": 0.0},
+        {"temperature": 0.5},
+        {"temperature": 1.0},
+    ]
+
+
+def test_satisfiability_returns_unknown_for_large_stepped_range_without_values(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Large finite SAT spaces return UNKNOWN before value materialization."""
+
+    def fail_stepped_float_values(
+        _low: float, _high: float, _step: float
+    ) -> tuple[float, ...]:
+        raise AssertionError("SAT domain values should not be materialized before cap")
+
+    monkeypatch.setattr(
+        "traigent_validation.validators.stepped_float_values",
+        fail_stepped_float_values,
+    )
+    temperature = Range(0.0, 20.0, step=0.001, name="temperature")
+    space = ConfigSpace(
+        tvars={"temperature": temperature},
+        constraints=(require(temperature.gte(0.0)),),
+    )
+
+    result = space.check_satisfiability()
+
+    assert result.status == SatStatus.UNKNOWN
+    assert "more than 10000" in result.message
+
+
+def test_random_search_stepped_float_cardinality_and_exhaustion():
+    optimizer = RandomSearchOptimizer(
+        {"temperature": Range(0.0, 1.0, step=0.5).to_config_value()},
+        ["accuracy"],
+        max_trials=10,
+        random_seed=7,
+    )
+
+    values = {optimizer.suggest_next_trial([])["temperature"] for _ in range(3)}
+
+    assert optimizer.config_space_cardinality == 3
+    assert values == {0.0, 0.5, 1.0}
+    with pytest.raises(OptimizationError, match="Config space exhausted"):
+        optimizer.suggest_next_trial([])
+
+
+def test_untyped_categorical_dicts_report_choice_cardinality():
+    assert discrete_cardinality_for_config_param({"values": ["a", "b"]}) == 2
+    assert discrete_cardinality_for_config_param({"choices": ["a", "b"]}) == 2
+
+
+def test_random_search_falls_back_to_untried_config_after_collision_streak(
+    monkeypatch,
+):
+    optimizer = RandomSearchOptimizer({"x": [0, 1]}, ["accuracy"], max_trials=2)
+    optimizer.register_tried_config({"x": 0})
+
+    monkeypatch.setattr(optimizer, "_sample_parameter", lambda *_args: 0)
+
+    assert optimizer.suggest_next_trial([]) == {"x": 1}
+
+
+def test_random_search_large_stepped_collision_fails_without_materializing_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    optimizer = RandomSearchOptimizer(
+        {"x": {"type": "float", "low": 0.0, "high": 200.0, "step": 0.001}},
+        ["accuracy"],
+        max_trials=2,
+    )
+
+    def always_zero(_param_name: str, _param_def: object) -> float:
+        return 0.0
+
+    def two_attempts(_cardinality: int | None) -> int:
+        return 2
+
+    def fail_discrete_values(_definition: object) -> tuple[object, ...] | None:
+        raise AssertionError("large range fallback should not materialize values")
+
+    monkeypatch.setattr(optimizer, "_sample_parameter", always_zero)
+    monkeypatch.setattr(optimizer, "_max_unique_sampling_attempts", two_attempts)
+    monkeypatch.setattr(
+        "traigent.optimizers.random.discrete_values_for_config_param",
+        fail_discrete_values,
+    )
+
+    assert optimizer.suggest_next_trial([]) == {"x": 0.0}
+    with pytest.raises(OptimizationError, match="Failed to find unique config"):
+        optimizer.suggest_next_trial([])
+
+
+@pytest.mark.asyncio
+async def test_sequential_lifecycle_treats_optimizer_exhaustion_as_clean_break():
+    class ExhaustedOptimizer:
+        _trial_count = 0
+        _tried_config_hashes: set[str] = set()
+
+        def suggest_next_trial(self, history):
+            raise OptimizationError("Config space exhausted")
+
+    class DummyOrchestrator:
+        max_trials = None
+        _trials = []
+        _stop_reason = None
+        optimizer = ExhaustedOptimizer()
+
+        def _consume_default_config(self):
+            return None
+
+    orchestrator = DummyOrchestrator()
+    lifecycle = TrialLifecycle(orchestrator)  # type: ignore[arg-type]
+
+    trial_count, action = await lifecycle.run_sequential_trial(
+        func=lambda: None,
+        dataset=object(),  # type: ignore[arg-type]
+        session_id=None,
+        function_name="target",
+        trial_count=0,
+    )
+
+    assert (trial_count, action) == (0, "break")
+    assert orchestrator._stop_reason == "space_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_sequential_lifecycle_propagates_non_terminal_optimizer_errors():
+    class InvalidOptimizer:
+        _trial_count = 0
+        _tried_config_hashes: set[str] = set()
+
+        def suggest_next_trial(self, _history: list[object]) -> dict[str, object]:
+            raise OptimizationError("Invalid step for float parameter 'x': 0")
+
+    class DummyOrchestrator:
+        max_trials = None
+        _trials: list[object] = []
+        _stop_reason = None
+        optimizer = InvalidOptimizer()
+
+        def _consume_default_config(self) -> None:
+            return None
+
+    orchestrator = DummyOrchestrator()
+    lifecycle = TrialLifecycle(orchestrator)  # type: ignore[arg-type]
+
+    with pytest.raises(OptimizationError, match="Invalid step"):
+        await lifecycle.run_sequential_trial(
+            func=lambda: None,
+            dataset=object(),  # type: ignore[arg-type]
+            session_id=None,
+            function_name="target",
+            trial_count=0,
+        )
+    assert orchestrator._stop_reason is None
+
+
+@pytest.mark.asyncio
+async def test_random_search_invalid_float_step_raises_through_lifecycle():
+    class DummyOrchestrator:
+        max_trials = None
+        _trials: list[object] = []
+        _stop_reason = None
+        optimizer = RandomSearchOptimizer(
+            {"x": {"type": "float", "low": 0.0, "high": 1.0, "step": 0.0}},
+            ["accuracy"],
+            max_trials=2,
+        )
+
+        def _consume_default_config(self) -> None:
+            return None
+
+    orchestrator = DummyOrchestrator()
+    lifecycle = TrialLifecycle(orchestrator)  # type: ignore[arg-type]
+
+    with pytest.raises(OptimizationError, match="Invalid step for float parameter 'x'"):
+        await lifecycle.run_sequential_trial(
+            func=lambda: None,
+            dataset=object(),  # type: ignore[arg-type]
+            session_id=None,
+            function_name="target",
+            trial_count=0,
+        )
+
+    assert orchestrator._stop_reason is None
+
+
+def test_random_search_stepped_float_sampling_includes_high_for_uneven_step():
+    with pytest.warns(UserWarning, match="does not evenly divide span"):
+        range_def = Range(0.0, 1.0, step=0.4).to_config_value()
+    optimizer = RandomSearchOptimizer({"x": range_def}, ["accuracy"], max_trials=4)
+
+    values = {optimizer.suggest_next_trial([])["x"] for _ in range(4)}
+
+    assert values == {0.0, 0.4, 0.8, 1.0}
+
+
+def test_constraint_rejected_config_restore_removes_tried_hash():
+    optimizer = RandomSearchOptimizer({"x": [0, 1]}, ["accuracy"], random_seed=1)
+
+    class DummyOrchestrator:
+        pass
+
+    orchestrator = DummyOrchestrator()
+    orchestrator.optimizer = optimizer
+    lifecycle = TrialLifecycle(orchestrator)  # type: ignore[arg-type]
+
+    state = lifecycle._snapshot_optimizer_state()
+    optimizer.suggest_next_trial([])
+    assert optimizer.trial_count == 1
+    assert optimizer.unique_configs_tried == 1
+
+    lifecycle._restore_optimizer_state(state)
+
+    assert optimizer.trial_count == 0
+    assert optimizer.unique_configs_tried == 0

--- a/traigent/api/parameter_ranges.py
+++ b/traigent/api/parameter_ranges.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -58,6 +59,7 @@ from traigent.api.constraint_builders import (
     CategoricalConstraintBuilderMixin,
     NumericConstraintBuilderMixin,
 )
+from traigent.utils.discrete_domains import float_step_divides_span
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +193,16 @@ class Range(NumericConstraintBuilderMixin, ParameterRange):
             )
         if self.step is not None and self.step <= 0:
             raise ValueError(f"Range step must be positive, got {self.step}")
+        if self.step is not None and not float_step_divides_span(
+            float(self.low), float(self.high), float(self.step)
+        ):
+            warnings.warn(
+                f"Range step {self.step} does not evenly divide span "
+                f"[{self.low}, {self.high}]; upper bound {self.high} will be "
+                "included as an extra discrete point with uneven spacing.",
+                UserWarning,
+                stacklevel=2,
+            )
         if self.log and self.low <= 0:
             raise ValueError(f"log=True requires positive bounds, got low={self.low}")
         if self.log and self.step is not None:

--- a/traigent/config/providers.py
+++ b/traigent/config/providers.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from functools import wraps
 from threading import Lock
-from typing import Any
+from typing import Any, cast
 
 from traigent.config.ast_transformer import ConfigTransformer, SafeASTCompiler
 from traigent.config.context import (
@@ -80,8 +80,8 @@ class ConfigurationProvider:
 
         config = ctx_get_config()
         if isinstance(config, TraigentConfig):
-            return config.to_dict()
-        return config if config else None
+            return cast(dict[str, Any], config.to_dict())
+        return cast(dict[str, Any], config) if config else None
 
     def supports_function(self, func: Callable[..., Any]) -> bool:
         """Check if provider can handle this function.
@@ -220,9 +220,9 @@ class ContextBasedProvider(ConfigurationProvider):
         """Extract configuration from context."""
         config: TraigentConfig | dict[str, Any] = get_config()
         if isinstance(config, TraigentConfig):
-            return config.to_dict()
+            return cast(dict[str, Any], config.to_dict())
         # config is dict[str, Any] after isinstance narrowing
-        return config
+        return dict(config)
 
     def supports_function(self, func: Callable[..., Any]) -> bool:
         """Context injection works with any function."""
@@ -641,11 +641,20 @@ class SeamlessParameterProvider(ConfigurationProvider):
             self._stats["fallback_triggers"]["no_injection"].append(
                 sorted(active_config.keys())
             )
-        logger.debug(
-            f"Seamless provider found no injectable targets for {func.__name__}; "
-            "configuration keys were %s",
-            sorted(active_config.keys()),
-        )
+        if active_config:
+            logger.warning(
+                "Seamless provider found no injectable targets for %s; no local "
+                "assignment or parameter matched configuration keys %s, so the "
+                "function ran with original values.",
+                func.__name__,
+                sorted(active_config.keys()),
+            )
+        else:
+            logger.debug(
+                "Seamless provider found no injectable targets for %s with empty "
+                "configuration",
+                func.__name__,
+            )
         return func(*args, **kwargs)
 
     def _seamless_fallback(
@@ -988,8 +997,8 @@ class SeamlessParameterProvider(ConfigurationProvider):
         """
         config: TraigentConfig | dict[str, Any] = get_config()
         if isinstance(config, TraigentConfig):
-            return config.to_dict()
-        return config
+            return cast(dict[str, Any], config.to_dict())
+        return dict(config)
 
     def supports_function(self, func: Callable[..., Any]) -> bool:
         """Check if function source is available for transformation.

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -106,7 +106,7 @@ class TrialLifecycle:
             Tuple of (updated_trial_count, action) where action is "continue" or "break"
         """
         orchestrator = self._orchestrator
-        optimizer_trial_count_before_suggest = self._snapshot_optimizer_trial_count()
+        optimizer_state_before_suggest = self._snapshot_optimizer_state()
 
         if (
             orchestrator.max_trials is not None
@@ -130,8 +130,16 @@ class TrialLifecycle:
                         orchestrator._trials
                     )
                     config = orchestrator._apply_knob_resolution(config)
-            except OptimizationError:
-                raise
+            except OptimizationError as e:
+                stop_reason = self._terminal_optimizer_stop_reason(e)
+                if stop_reason is None:
+                    logger.exception(
+                        "Optimizer failed to suggest the next trial: %s", e
+                    )
+                    raise
+                logger.info("Optimizer could not suggest another trial: %s", e)
+                orchestrator._stop_reason = stop_reason
+                return trial_count, "break"
             except (ValueError, TypeError, KeyError, AttributeError) as e:
                 logger.exception("Optimizer failed to suggest the next trial: %s", e)
                 return trial_count, "break"
@@ -191,9 +199,7 @@ class TrialLifecycle:
                     error=e,
                 )
             finally:
-                self._restore_optimizer_trial_count(
-                    optimizer_trial_count_before_suggest
-                )
+                self._restore_optimizer_state(optimizer_state_before_suggest)
             return trial_count, "continue"
 
         # Phase 2.1: Acquire cost permit before sequential trial execution
@@ -245,6 +251,18 @@ class TrialLifecycle:
             raise
 
         return trial_count, "continue"
+
+    def _terminal_optimizer_stop_reason(self, error: OptimizationError) -> str | None:
+        """Classify explicit optimizer terminal states without swallowing defects."""
+
+        message = str(error)
+        if "Maximum trials" in message:
+            return "max_trials_reached"
+        if message.startswith("Config space exhausted"):
+            return "space_exhausted"
+        if message == "All grid combinations have been evaluated":
+            return "space_exhausted"
+        return None
 
     # =========================================================================
     # Core Trial Execution
@@ -597,6 +615,18 @@ class TrialLifecycle:
             return trial_count
         return None
 
+    def _snapshot_optimizer_state(self) -> tuple[int | None, set[str] | None]:
+        """Snapshot optimizer counters that suggestion may consume."""
+
+        tried_hashes = getattr(
+            self._orchestrator.optimizer, "_tried_config_hashes", None
+        )
+        if isinstance(tried_hashes, set):
+            tried_snapshot = set(tried_hashes)
+        else:
+            tried_snapshot = None
+        return self._snapshot_optimizer_trial_count(), tried_snapshot
+
     def _restore_optimizer_trial_count(self, previous_trial_count: int | None) -> None:
         """Restore the optimizer's consumed slot for a rejected pre-constraint."""
         if previous_trial_count is None:
@@ -610,6 +640,18 @@ class TrialLifecycle:
             and current_trial_count > previous_trial_count
         ):
             self._orchestrator.optimizer._trial_count = previous_trial_count
+
+    def _restore_optimizer_state(
+        self, previous_state: tuple[int | None, set[str] | None]
+    ) -> None:
+        """Restore optimizer state for a rejected pre-constraint."""
+
+        previous_trial_count, previous_tried_hashes = previous_state
+        self._restore_optimizer_trial_count(previous_trial_count)
+        if previous_tried_hashes is not None and hasattr(
+            self._orchestrator.optimizer, "_tried_config_hashes"
+        ):
+            self._orchestrator.optimizer._tried_config_hashes = previous_tried_hashes
 
     def _generate_constraint_rejection_trial_id(
         self,

--- a/traigent/integrations/framework_override.py
+++ b/traigent/integrations/framework_override.py
@@ -20,11 +20,13 @@ Key Features:
 
 from __future__ import annotations
 
+import ast
 import functools
+import importlib
 import inspect
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager, contextmanager
-from typing import Any, cast
+from typing import Any, cast, get_type_hints
 
 from ..config.context import get_config
 from ..config.types import TraigentConfig
@@ -326,14 +328,8 @@ class FrameworkOverrideManager(BaseOverrideManager):
             method_path: Dot-separated path to the method (e.g., "messages.create")
         """
         try:
-            # Navigate to the method location
-            current_obj = target_class
             path_parts = method_path.split(".")
-
-            # Navigate to the parent object containing the method
-            for part in path_parts[:-1]:
-                current_obj = getattr(current_obj, part)
-
+            current_obj = self._resolve_method_parent(target_class, path_parts[:-1])
             method_name = path_parts[-1]
             original_method = getattr(current_obj, method_name)
 
@@ -350,20 +346,118 @@ class FrameworkOverrideManager(BaseOverrideManager):
 
             # Track for cleanup
             method_key = f"{class_name}.{method_path}"
-            self._original_methods[method_key] = (
-                current_obj,
-                method_name,
+            self.store_original_method(
+                method_key,
                 original_method,
+                target=current_obj,
+                attribute=method_name,
             )
 
-        except (AttributeError, TypeError):
-            # Method not found or not accessible, skip silently
-            logger.debug(
-                "Skipping override for %s because %s.%s is unavailable",
+        except (AttributeError, TypeError) as exc:
+            logger.warning(
+                "Skipping override for %s because %s.%s is unavailable: %s",
                 method_path,
                 class_name,
                 method_path,
+                exc,
             )
+
+    def _resolve_method_parent(self, target_class: type, path_parts: list[str]) -> Any:
+        """Resolve a dotted method parent, including cached-property resources."""
+
+        current_obj: Any = target_class
+        for part in path_parts:
+            descriptor = inspect.getattr_static(current_obj, part, None)
+            if isinstance(descriptor, functools.cached_property):
+                resource_class = self._cached_property_return_class(descriptor)
+                if resource_class is None:
+                    raise AttributeError(
+                        f"cached property '{part}' has no resolvable return class"
+                    )
+                current_obj = resource_class
+                continue
+            current_obj = getattr(current_obj, part)
+        return current_obj
+
+    def _cached_property_return_class(
+        self, descriptor: functools.cached_property[Any]
+    ) -> type | None:
+        """Resolve a cached_property resource accessor's annotated return class."""
+
+        func = getattr(descriptor, "func", None)
+        if func is None:
+            return None
+        try:
+            return_type = get_type_hints(func).get("return")
+        except (NameError, TypeError, AttributeError):
+            return_type = getattr(func, "__annotations__", {}).get("return")
+        return self._annotation_to_class(return_type, func)
+
+    def _annotation_to_class(
+        self, annotation: Any, func: Callable[..., Any]
+    ) -> type | None:
+        """Resolve a direct class annotation, including SDK string annotations."""
+
+        if isinstance(annotation, type):
+            return annotation
+        if not isinstance(annotation, str):
+            return None
+
+        annotation_name = self._normalize_annotation_string(annotation)
+        if not annotation_name:
+            return None
+
+        raw_globalns = getattr(func, "__globals__", {})
+        globalns = (
+            cast(dict[str, Any], raw_globalns) if isinstance(raw_globalns, dict) else {}
+        )
+        resolved = self._resolve_annotation_name(annotation_name, globalns)
+        if isinstance(resolved, type):
+            return cast(type, resolved)
+        return None
+
+    def _normalize_annotation_string(self, annotation: str) -> str:
+        """Normalize quoted forward-reference annotation strings."""
+
+        annotation = annotation.strip()
+        try:
+            literal_value = ast.literal_eval(annotation)
+        except (SyntaxError, ValueError):
+            return annotation
+        if isinstance(literal_value, str):
+            return literal_value.strip()
+        return annotation
+
+    def _resolve_annotation_name(
+        self, annotation_name: str, globalns: dict[str, Any]
+    ) -> Any:
+        """Resolve an identifier or dotted annotation name without broad eval."""
+
+        parts = annotation_name.split(".")
+        if not parts or not all(part.isidentifier() for part in parts):
+            return None
+
+        if parts[0] in globalns:
+            resolved = globalns[parts[0]]
+            for part in parts[1:]:
+                resolved = getattr(resolved, part, None)
+                if resolved is None:
+                    return None
+            return resolved
+
+        for module_end in range(len(parts) - 1, 0, -1):
+            module_name = ".".join(parts[:module_end])
+            try:
+                resolved = importlib.import_module(module_name)
+            except (ImportError, ValueError):
+                continue
+            for part in parts[module_end:]:
+                resolved = getattr(resolved, part, None)
+                if resolved is None:
+                    break
+            else:
+                return resolved
+        return None
 
     def activate_overrides(self, framework_targets: list[str]) -> None:
         """Activate framework overrides for specified targets.
@@ -613,7 +707,7 @@ class FrameworkOverrideManager(BaseOverrideManager):
                 package, version
             )
             if version_mapping:
-                return version_mapping
+                return cast(dict[str, str], version_mapping)
 
         # Discover parameters dynamically
         if self.discovery is not None:

--- a/traigent/optimizers/base.py
+++ b/traigent/optimizers/base.py
@@ -14,6 +14,7 @@ from traigent.utils.objectives import (
     coerce_finite_objective_score,
     is_minimization_objective,
 )
+from traigent.utils.discrete_domains import discrete_cardinality_for_config_param
 from traigent.utils.validation import validate_objectives
 
 logger = get_logger(__name__)
@@ -280,34 +281,7 @@ class BaseOptimizer(ABC):
         Returns:
             Cardinality count, 0 for empty, or None for continuous types.
         """
-        # Detect range dicts from hybrid discovery ({"low": x, "high": y})
-        # before falling back to "categorical" default
-        has_range = "low" in definition and "high" in definition
-        param_type = (definition.get("type") or "").lower()
-
-        if not param_type and has_range:
-            # No explicit type but has low/high → continuous float range
-            return None
-
-        if not param_type:
-            param_type = "categorical"
-
-        if param_type in {"fixed", "constant"}:
-            return 1
-
-        if param_type in {"categorical", "choice"}:
-            choices = definition.get("choices") or definition.get("values") or []
-            return len(choices) if choices else 0
-
-        if param_type in {"int", "integer"}:
-            low, high = definition.get("low"), definition.get("high")
-            if low is not None and high is not None:
-                step = definition.get("step", 1)
-                return max(((int(high) - int(low)) // int(step)) + 1, 1)
-            return None
-
-        # Float or other continuous types
-        return None
+        return discrete_cardinality_for_config_param(definition)
 
     def _get_param_cardinality(self, definition: Any) -> int | None:
         """Get cardinality for a single parameter definition.

--- a/traigent/optimizers/grid.py
+++ b/traigent/optimizers/grid.py
@@ -5,15 +5,18 @@
 from __future__ import annotations
 
 import itertools
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from traigent.api.types import TrialResult
 from traigent.optimizers.base import BaseOptimizer
+from traigent.utils.discrete_domains import discrete_values_for_config_param
 from traigent.utils.exceptions import OptimizationError
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+DEFAULT_MAX_GRID_COMBINATIONS = 100_000
 
 
 class GridSearchOptimizer(BaseOptimizer):
@@ -99,11 +102,15 @@ class GridSearchOptimizer(BaseOptimizer):
         order_spec = kwargs.get("parameter_order")
         if order_spec is None:
             order_spec = kwargs.get("order")
+        self._max_grid_combinations = int(
+            kwargs.get("max_grid_combinations", DEFAULT_MAX_GRID_COMBINATIONS)
+        )
 
         super().__init__(config_space, objectives, context, objective_weights, **kwargs)
 
         self._parameter_order = self._normalize_parameter_order(order_spec)
         self._ordered_param_names = self._resolve_parameter_names()
+        self._guard_grid_cardinality()
 
         # Generate all parameter combinations
         self._grid_points = self._generate_grid()
@@ -124,13 +131,24 @@ class GridSearchOptimizer(BaseOptimizer):
             raise OptimizationError("No valid parameter combinations found")
 
         param_names = self._ordered_param_names.copy()
-        param_values = []
+        param_values: list[Sequence[Any]] = []
         for param_name in param_names:
             param_def = self.config_space[param_name]
 
             if isinstance(param_def, list):
                 # Categorical parameter
                 param_values.append(param_def)
+            elif isinstance(param_def, dict):
+                values = discrete_values_for_config_param(param_def)
+                if values is None:
+                    raise OptimizationError(
+                        f"Grid search cannot optimize continuous parameter '{param_name}' "
+                        f"with range {param_def}. Grid search requires discrete values "
+                        "to enumerate. Options: (1) provide a step for the range, "
+                        "(2) use a list of discrete values, (3) use 'random' optimizer "
+                        "instead for continuous ranges"
+                    )
+                param_values.append(values)
             elif isinstance(param_def, tuple) and len(param_def) == 2:
                 # Continuous parameter - not directly supported in basic grid search
                 low, high = param_def
@@ -151,12 +169,10 @@ class GridSearchOptimizer(BaseOptimizer):
                 # Single value (fixed parameter)
                 param_values.append([param_def])
 
-        # Generate cartesian product
-        combinations = list(itertools.product(*param_values))
-
-        # Convert to list of dictionaries
+        # Convert cartesian product to dictionaries without materializing a second
+        # list of raw tuples.
         grid_points = []
-        for combination in combinations:
+        for combination in itertools.product(*param_values):
             config = dict(zip(param_names, combination, strict=False))
             grid_points.append(config)
 
@@ -164,6 +180,25 @@ class GridSearchOptimizer(BaseOptimizer):
             raise OptimizationError("No valid parameter combinations found")
 
         return grid_points
+
+    def _guard_grid_cardinality(self) -> None:
+        """Fail fast before constructing an unsafe grid."""
+
+        if self._max_grid_combinations <= 0:
+            raise OptimizationError(
+                "max_grid_combinations must be a positive integer for grid search"
+            )
+
+        cardinality = self.config_space_cardinality
+        if cardinality is None or cardinality <= self._max_grid_combinations:
+            return
+
+        raise OptimizationError(
+            "Grid search would enumerate "
+            f"{cardinality} combinations, exceeding the safety cap of "
+            f"{self._max_grid_combinations}. Reduce the configuration space or "
+            "use algorithm='random' with max_trials for large discrete spaces."
+        )
 
     def _normalize_parameter_order(
         self, order_spec: Mapping[str, Any] | None

--- a/traigent/optimizers/random.py
+++ b/traigent/optimizers/random.py
@@ -5,15 +5,22 @@
 from __future__ import annotations
 
 import random
+from itertools import product
 from typing import Any
 
 from traigent.api.types import TrialResult
 from traigent.optimizers.base import BaseOptimizer
+from traigent.utils.discrete_domains import (
+    discrete_values_for_config_param,
+    stepped_float_values,
+    stepped_int_values,
+)
 from traigent.utils.exceptions import OptimizationError
 from traigent.utils.logging import get_logger
 from traigent.utils.validation import Validators
 
 logger = get_logger(__name__)
+MAX_COMPLEMENT_SCAN_CONFIGS = 100_000
 
 
 class RandomSearchOptimizer(BaseOptimizer):
@@ -99,9 +106,10 @@ class RandomSearchOptimizer(BaseOptimizer):
                 "unique configurations have been tried"
             )
 
-        # For discrete spaces, avoid duplicates by retrying
-        max_attempts = 100  # Prevent infinite loops
+        # For discrete spaces, avoid duplicates by retrying, then fall back to a
+        # lazy complement scan so collision streaks do not masquerade as exhaustion.
         cardinality = self.config_space_cardinality
+        max_attempts = self._max_unique_sampling_attempts(cardinality)
 
         for _attempt in range(max_attempts):
             config = {}
@@ -124,27 +132,78 @@ class RandomSearchOptimizer(BaseOptimizer):
                 self.register_tried_config(config)
                 break
         else:
-            # Exhausted retry attempts (shouldn't happen with proper cardinality)
-            raise OptimizationError(
-                f"Failed to find unique config after {max_attempts} attempts"
-            )
-
+            fallback_config = self._find_untried_discrete_config()
+            if fallback_config is None:
+                # Exhausted retry attempts (shouldn't happen with proper cardinality)
+                raise OptimizationError(
+                    f"Failed to find unique config after {max_attempts} attempts"
+                )
+            config = fallback_config
         self._trial_count += 1
 
         logger.debug(f"Suggesting random trial {self._trial_count}: {config}")
 
         return config
 
+    def _max_unique_sampling_attempts(self, cardinality: int | None) -> int:
+        """Scale retry effort with finite search-space size."""
+
+        if cardinality is None:
+            return 100
+        return min(max(cardinality * 2, 100), 10_000)
+
+    def _find_untried_discrete_config(self) -> dict[str, Any] | None:
+        """Lazily scan a finite discrete space for an untried configuration."""
+
+        cardinality = self.config_space_cardinality
+        if cardinality is None or cardinality > MAX_COMPLEMENT_SCAN_CONFIGS:
+            return None
+
+        value_domains: list[tuple[Any, ...]] = []
+        param_names = list(self.config_space)
+        for param_name in param_names:
+            values = discrete_values_for_config_param(self.config_space[param_name])
+            if values is None:
+                return None
+            if not values:
+                raise OptimizationError("Config space exhausted: no values to sample")
+            value_domains.append(values)
+
+        for combination in product(*value_domains):
+            config = dict(zip(param_names, combination, strict=True))
+            if self.register_tried_config(config):
+                return config
+
+        if cardinality is not None:
+            raise OptimizationError(
+                f"Config space exhausted: all {cardinality} "
+                "unique configurations have been tried"
+            )
+        return None
+
     def _sample_range_int(self, param_name: str, param_def: dict) -> int:
         """Sample an integer value from a range-dict definition."""
-        low_f, high_f = float(param_def["low"]), float(param_def["high"])
+        try:
+            low_f, high_f = float(param_def["low"]), float(param_def["high"])
+        except (TypeError, ValueError) as exc:
+            raise OptimizationError(
+                f"Invalid integer range for parameter '{param_name}': "
+                "low/high must be numeric"
+            ) from exc
         if not low_f.is_integer() or not high_f.is_integer():
             raise OptimizationError(
                 f"Integer parameter '{param_name}' requires integral low/high bounds"
             )
 
-        step_raw = param_def.get("step", 1) or 1
-        step_f = float(step_raw)
+        step_raw = param_def.get("step", 1)
+        if step_raw is None:
+            step_raw = 1
+        try:
+            step_f = float(step_raw)
+        except (TypeError, ValueError) as exc:
+            raise OptimizationError(
+                f"Invalid step for integer parameter '{param_name}': {step_raw}"
+            ) from exc
         if step_f <= 0 or not step_f.is_integer():
             raise OptimizationError(
                 f"Invalid step for integer parameter '{param_name}': {step_raw}"
@@ -157,26 +216,46 @@ class RandomSearchOptimizer(BaseOptimizer):
                 f"low ({low_i}) must be <= high ({high_i})"
             )
 
-        values = list(range(low_i, high_i + 1, int_step))
+        values = stepped_int_values(low_i, high_i, int_step)
         if not values:
-            values = [low_i]
-        elif values[-1] != high_i:
-            values.append(high_i)
+            raise OptimizationError(
+                f"Invalid integer range for parameter '{param_name}': no values"
+            )
         return self._random.choice(values)
 
     def _sample_range_float(self, param_name: str, param_def: dict) -> float:
         """Sample a float value from a range-dict definition."""
-        low_f, high_f = float(param_def["low"]), float(param_def["high"])
-        val = self._random.uniform(low_f, high_f)
+        try:
+            low_f, high_f = float(param_def["low"]), float(param_def["high"])
+        except (TypeError, ValueError) as exc:
+            raise OptimizationError(
+                f"Invalid float range for parameter '{param_name}': "
+                "low/high must be numeric"
+            ) from exc
+        if low_f > high_f:
+            raise OptimizationError(
+                f"Invalid float range for parameter '{param_name}': "
+                f"low ({low_f}) must be <= high ({high_f})"
+            )
         step_raw = param_def.get("step")
         if step_raw is not None:
-            step = float(step_raw)
+            try:
+                step = float(step_raw)
+            except (TypeError, ValueError) as exc:
+                raise OptimizationError(
+                    f"Invalid step for float parameter '{param_name}': {step_raw}"
+                ) from exc
             if step <= 0:
                 raise OptimizationError(
                     f"Invalid step for float parameter '{param_name}': {step}"
                 )
-            snapped = round((val - low_f) / step) * step + low_f
-            val = min(max(snapped, low_f), high_f)
+            values = stepped_float_values(low_f, high_f, step)
+            if not values:
+                raise OptimizationError(
+                    f"Invalid float range for parameter '{param_name}': no values"
+                )
+            return self._random.choice(values)
+        val = self._random.uniform(low_f, high_f)
         return round(val, 6)
 
     def _sample_parameter(self, param_name: str, param_def: Any) -> Any:
@@ -250,7 +329,7 @@ class RandomSearchOptimizer(BaseOptimizer):
     @property
     def progress(self) -> float:
         """Get optimization progress as a fraction (0.0 to 1.0)."""
-        return min(self._trial_count / self.max_trials, 1.0)
+        return float(min(self._trial_count / self.max_trials, 1.0))
 
     def set_max_trials(self, max_trials: int) -> None:
         """Update maximum number of trials.
@@ -269,7 +348,7 @@ class RandomSearchOptimizer(BaseOptimizer):
 
     def get_algorithm_info(self) -> dict[str, Any]:
         """Get information about this optimization algorithm."""
-        info = super().get_algorithm_info()
+        info: dict[str, Any] = super().get_algorithm_info()
         info.update(
             {
                 "max_trials": self.max_trials,

--- a/traigent/utils/discrete_domains.py
+++ b/traigent/utils/discrete_domains.py
@@ -1,0 +1,232 @@
+"""Shared finite-domain helpers for stepped search ranges."""
+
+from __future__ import annotations
+
+import math
+import sys
+from typing import Any
+
+FLOAT_GRID_ROUND_DIGITS = 6
+_FLOAT_STEP_TOLERANCE = 1e-9
+
+
+def float_step_divides_span(low: float, high: float, step: float) -> bool:
+    """Return True when ``step`` lands exactly on ``high`` within tolerance."""
+
+    if step <= 0:
+        return False
+    span = high - low
+    if span < 0:
+        return False
+    intervals = span / step
+    nearest = round(intervals)
+    tolerance = _FLOAT_STEP_TOLERANCE * max(1.0, abs(intervals))
+    return abs(intervals - nearest) <= tolerance
+
+
+def stepped_int_values(low: int, high: int, step: int) -> tuple[int, ...]:
+    """Build the integer grid, preserving the inclusive high endpoint."""
+
+    if step <= 0 or low > high:
+        return ()
+    values = tuple(range(low, high + 1, step))
+    if not values:
+        return (low,)
+    if values[-1] != high:
+        return (*values, high)
+    return values
+
+
+def stepped_int_cardinality(low: int, high: int, step: int) -> int:
+    """Count integer grid points without materializing them."""
+
+    if step <= 0 or low > high:
+        return 0
+
+    count = ((high - low) // step) + 1
+    last_value = low + ((count - 1) * step)
+    if last_value != high:
+        count += 1
+    return count
+
+
+def stepped_float_values(low: float, high: float, step: float) -> tuple[float, ...]:
+    """Build the stepped float grid, preserving the inclusive high endpoint."""
+
+    if step <= 0 or low > high:
+        return ()
+
+    values: list[float] = []
+    epsilon = _FLOAT_STEP_TOLERANCE * max(1.0, abs(high - low), abs(step))
+    index = 0
+    while True:
+        value = low + (index * step)
+        if value > high + epsilon:
+            break
+        value = min(max(value, low), high)
+        rounded = round(value, FLOAT_GRID_ROUND_DIGITS)
+        if not values or values[-1] != rounded:
+            values.append(rounded)
+        index += 1
+
+    high_value = round(high, FLOAT_GRID_ROUND_DIGITS)
+    if not values or values[-1] != high_value:
+        values.append(high_value)
+    return tuple(values)
+
+
+def stepped_float_cardinality(low: float, high: float, step: float) -> int:
+    """Count stepped float grid points without materializing them."""
+
+    if step <= 0 or low > high:
+        return 0
+
+    epsilon = _FLOAT_STEP_TOLERANCE * max(1.0, abs(high - low), abs(step))
+    interval_count = (high - low + epsilon) / step
+    if not math.isfinite(interval_count):
+        return sys.maxsize
+
+    count = max(math.floor(interval_count) + 1, 1)
+    value = low + ((count - 1) * step)
+    rounded = round(min(max(value, low), high), FLOAT_GRID_ROUND_DIGITS)
+    high_value = round(high, FLOAT_GRID_ROUND_DIGITS)
+    if rounded != high_value:
+        count += 1
+    return count
+
+
+def discrete_cardinality_for_config_param(definition: Any) -> int | None:
+    """Return finite cardinality for a config-space parameter, or None if continuous."""
+
+    if isinstance(definition, list):
+        return len(definition)
+
+    if isinstance(definition, tuple) and len(definition) == 2:
+        return None
+
+    if isinstance(definition, dict):
+        param_type = str(definition.get("type") or "").lower()
+        has_range = "low" in definition and "high" in definition
+        has_categorical_values = "choices" in definition or "values" in definition
+
+        if param_type in {"categorical", "choice"} or (
+            not param_type and not has_range and has_categorical_values
+        ):
+            choices = (
+                definition["choices"]
+                if "choices" in definition
+                else definition.get("values", ())
+            )
+            try:
+                return len(choices)
+            except TypeError:
+                return None
+
+        if param_type in {"fixed", "constant"}:
+            return 1
+
+        if has_range:
+            low = definition.get("low")
+            high = definition.get("high")
+            if low is None or high is None:
+                return None
+
+            if param_type in {"int", "integer"}:
+                step = definition.get("step", 1)
+                if step is None:
+                    step = 1
+                try:
+                    low_i = int(low)
+                    high_i = int(high)
+                    step_i = int(step)
+                except (TypeError, ValueError):
+                    return None
+                if step_i <= 0 or low_i > high_i:
+                    return None
+                return stepped_int_cardinality(low_i, high_i, step_i)
+
+            step = definition.get("step")
+            if step is None:
+                return None
+            try:
+                low_f = float(low)
+                high_f = float(high)
+                step_f = float(step)
+            except (TypeError, ValueError):
+                return None
+            if step_f <= 0 or low_f > high_f:
+                return None
+            return stepped_float_cardinality(low_f, high_f, step_f)
+
+        return 1
+
+    return 1
+
+
+def discrete_values_for_config_param(definition: Any) -> tuple[Any, ...] | None:
+    """Return finite values for a config-space parameter, or None if continuous."""
+
+    if isinstance(definition, list):
+        return tuple(definition)
+
+    if isinstance(definition, tuple) and len(definition) == 2:
+        return None
+
+    if isinstance(definition, dict):
+        param_type = str(definition.get("type") or "").lower()
+        has_range = "low" in definition and "high" in definition
+        has_categorical_values = "choices" in definition or "values" in definition
+
+        if param_type in {"categorical", "choice"} or (
+            not param_type and not has_range and has_categorical_values
+        ):
+            choices = (
+                definition["choices"]
+                if "choices" in definition
+                else definition.get("values", ())
+            )
+            return tuple(choices)
+
+        if param_type in {"fixed", "constant"}:
+            if "value" in definition:
+                return (definition["value"],)
+            if "default" in definition:
+                return (definition["default"],)
+            return (definition,)
+
+        if has_range:
+            low = definition.get("low")
+            high = definition.get("high")
+            if low is None or high is None:
+                return None
+
+            if param_type in {"int", "integer"}:
+                step = definition.get("step", 1)
+                if step is None:
+                    step = 1
+                try:
+                    low_i = int(low)
+                    high_i = int(high)
+                    step_i = int(step)
+                except (TypeError, ValueError):
+                    return None
+                if step_i <= 0 or low_i > high_i:
+                    return ()
+                return stepped_int_values(low_i, high_i, step_i)
+
+            step = definition.get("step")
+            if step is None:
+                return None
+            try:
+                low_f = float(low)
+                high_f = float(high)
+                step_f = float(step)
+            except (TypeError, ValueError):
+                return None
+            if step_f <= 0 or low_f > high_f:
+                return ()
+            return stepped_float_values(low_f, high_f, step_f)
+
+        return (definition,)
+
+    return (definition,)

--- a/traigent_validation/validators.py
+++ b/traigent_validation/validators.py
@@ -12,6 +12,12 @@ from traigent_validation.base import (
     SatStatus,
     ValidationResult,
 )
+from traigent.utils.discrete_domains import (
+    stepped_float_cardinality,
+    stepped_float_values,
+    stepped_int_cardinality,
+    stepped_int_values,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -87,12 +93,11 @@ class PythonConstraintValidator:
         if not tvars:
             return SatResult(status=SatStatus.UNSAT, message="No parameters defined")
 
-        domains = self._finite_domains(tvars)
-        if domains is not None:
-            names = list(domains)
+        cardinalities = self._finite_domain_cardinalities(tvars)
+        if cardinalities is not None:
             total_configs = 1
-            for values in domains.values():
-                total_configs *= len(values)
+            for cardinality in cardinalities.values():
+                total_configs *= cardinality
                 if total_configs > _MAX_SAT_ENUMERATION_CONFIGS:
                     return SatResult(
                         status=SatStatus.UNKNOWN,
@@ -103,6 +108,17 @@ class PythonConstraintValidator:
                         ),
                     )
 
+            domains = self._finite_domains(tvars)
+            if domains is None:
+                return SatResult(
+                    status=SatStatus.UNKNOWN,
+                    message=(
+                        "Python validator cannot prove satisfiability. "
+                        "Consider a SAT/SMT validator for complex constraints."
+                    ),
+                )
+
+            names = list(domains)
             var_names = {id(tvar): name for name, tvar in tvars.items()}
             for values in product(*(domains[name] for name in names)):
                 config = dict(zip(names, values, strict=True))
@@ -128,6 +144,42 @@ class PythonConstraintValidator:
             ),
         )
 
+    def _finite_domain_cardinalities(
+        self, tvars: Mapping[str, ParameterRange]
+    ) -> dict[str, int] | None:
+        cardinalities: dict[str, int] = {}
+        for name, tvar in tvars.items():
+            cardinality = self._finite_domain_cardinality(tvar)
+            if cardinality is None:
+                return None
+            cardinalities[name] = cardinality
+        return cardinalities
+
+    def _finite_domain_cardinality(self, tvar: ParameterRange) -> int | None:
+        values = getattr(tvar, "values", None)
+        if values is not None:
+            try:
+                return len(values)
+            except TypeError:
+                return None
+
+        low = getattr(tvar, "low", None)
+        high = getattr(tvar, "high", None)
+        if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
+            return None
+
+        if type(tvar).__name__ == "IntRange":
+            step = getattr(tvar, "step", None) or 1
+            if not isinstance(step, int) or step <= 0:
+                return None
+            return stepped_int_cardinality(int(low), int(high), step)
+
+        step = getattr(tvar, "step", None)
+        if step is None or not isinstance(step, (int, float)) or step <= 0:
+            return None
+
+        return stepped_float_cardinality(float(low), float(high), float(step))
+
     def _finite_domains(
         self, tvars: Mapping[str, ParameterRange]
     ) -> dict[str, tuple[Any, ...]] | None:
@@ -146,14 +198,20 @@ class PythonConstraintValidator:
 
         low = getattr(tvar, "low", None)
         high = getattr(tvar, "high", None)
-        if not isinstance(low, int) or not isinstance(high, int):
+        if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
             return None
 
-        step = getattr(tvar, "step", None) or 1
-        if not isinstance(step, int) or step <= 0:
+        if type(tvar).__name__ == "IntRange":
+            step = getattr(tvar, "step", None) or 1
+            if not isinstance(step, int) or step <= 0:
+                return None
+            return stepped_int_values(int(low), int(high), step)
+
+        step = getattr(tvar, "step", None)
+        if step is None or not isinstance(step, (int, float)) or step <= 0:
             return None
 
-        return tuple(range(low, high + 1, step))
+        return stepped_float_values(float(low), float(high), float(step))
 
     def validate_structural_constraints(
         self,


### PR DESCRIPTION
Search-safety + stepped-range semantics + silent-noop fail-loud. codex 5.5 authored + reviewed (**GO**, 3 rounds); captain agrees.

- **#1465** grid counts cardinality before materializing (no full-cartesian OOM) - **#1449** random false-exhaustion fixed; an invalid range/step now **RAISES** (fail-loud) instead of clean-stopping as exhausted - **#1450** stepped-float cardinality correct - **#1457/#1458** stepped IntRange/float satisfiability keeps the inclusive high, no UNKNOWN escape - **#1459** non-dividing step warns.
- **#1451** seamless injection no-op fails loud (positive proof) - **#1456** framework override resolves cached-property parents incl raw string annotations (real OpenAI SDK shape). Categorical {values}/{choices} cardinality preserved.

**Tests:** revert-sensitive regressions (incl invalid-step RAISE, large-grid no-blowup). mypy + ruff clean.

Spine-Trail: st_8334ac414c0e
