### PR TITLE
feat(analytics): Wave-2 single-run client tools + MCP

### DIFF
--- a/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
+++ b/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
@@ -191,6 +191,167 @@ class TestDecisionBriefTool:
         reader.get_run_decision_brief.assert_not_called()
 
 
+class TestWave2AnalyticsTools:
+    @pytest.mark.asyncio
+    async def test_pareto_tool_calls_client(self, monkeypatch) -> None:
+        from traigent.analytics_mcp.tools import analytics_get_single_run_pareto_tool
+
+        reader = AsyncMock()
+        reader.get_single_run_pareto.return_value = {"run_id": "run_123"}
+        _install_fake_client(monkeypatch, reader)
+
+        result = await analytics_get_single_run_pareto_tool(
+            "proj_abc",
+            "run_123",
+            x_measure="cost",
+            y_measure="quality",
+            request_count=5,
+        )
+
+        assert result["ok"] is True
+        assert result["single_run_pareto"] == {"run_id": "run_123"}
+        reader.get_single_run_pareto.assert_awaited_once_with(
+            "proj_abc",
+            "run_123",
+            x_measure="cost",
+            y_measure="quality",
+            request_count=5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_correlation_tool_calls_client(self, monkeypatch) -> None:
+        from traigent.analytics_mcp.tools import analytics_get_correlation_matrix_tool
+
+        reader = AsyncMock()
+        reader.get_correlation_matrix.return_value = {"run_id": "run_123"}
+        _install_fake_client(monkeypatch, reader)
+
+        result = await analytics_get_correlation_matrix_tool(
+            "proj_abc", "run_123", method="spearman", min_sample=4
+        )
+
+        assert result["ok"] is True
+        assert result["correlation_matrix"] == {"run_id": "run_123"}
+        reader.get_correlation_matrix.assert_awaited_once_with(
+            "proj_abc", "run_123", method="spearman", min_sample=4
+        )
+
+    @pytest.mark.asyncio
+    async def test_leaderboard_tool_calls_client(self, monkeypatch) -> None:
+        from traigent.analytics_mcp.tools import analytics_get_run_leaderboard_tool
+
+        reader = AsyncMock()
+        reader.get_run_leaderboard.return_value = {"run_id": "run_123"}
+        _install_fake_client(monkeypatch, reader)
+
+        result = await analytics_get_run_leaderboard_tool(
+            "proj_abc",
+            "run_123",
+            objective="weighted",
+            weights={"quality": 0.8},
+            constraints='{"cost":1.0}',
+            request_count=7,
+            limit=10,
+        )
+
+        assert result["ok"] is True
+        assert result["run_leaderboard"] == {"run_id": "run_123"}
+        reader.get_run_leaderboard.assert_awaited_once_with(
+            "proj_abc",
+            "run_123",
+            objective="weighted",
+            weights={"quality": 0.8},
+            constraints='{"cost":1.0}',
+            request_count=7,
+            limit=10,
+        )
+
+    @pytest.mark.asyncio
+    async def test_parameter_insights_tool_calls_client(self, monkeypatch) -> None:
+        from traigent.analytics_mcp.tools import analytics_get_parameter_insights_tool
+
+        reader = AsyncMock()
+        reader.get_parameter_insights.return_value = {"run_id": "run_123"}
+        _install_fake_client(monkeypatch, reader)
+
+        result = await analytics_get_parameter_insights_tool(
+            "proj_abc",
+            "run_123",
+            target_measure="accuracy",
+            min_trials=12,
+            top_k=5,
+        )
+
+        assert result["ok"] is True
+        assert result["parameter_insights"] == {"run_id": "run_123"}
+        reader.get_parameter_insights.assert_awaited_once_with(
+            "proj_abc",
+            "run_123",
+            target_measure="accuracy",
+            min_trials=12,
+            top_k=5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_project_id_is_rejected_for_new_tools(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+
+        reader = AsyncMock()
+        _install_fake_client(monkeypatch, reader)
+        calls = [
+            tools_mod.analytics_get_single_run_pareto_tool("", "run_123"),
+            tools_mod.analytics_get_correlation_matrix_tool("", "run_123"),
+            tools_mod.analytics_get_run_leaderboard_tool("", "run_123"),
+            tools_mod.analytics_get_parameter_insights_tool("", "run_123"),
+        ]
+
+        for call in calls:
+            result = await call
+            assert result["ok"] is False
+            assert "project_id" in result["message"]
+
+        reader.get_single_run_pareto.assert_not_called()
+        reader.get_correlation_matrix.assert_not_called()
+        reader.get_run_leaderboard.assert_not_called()
+        reader.get_parameter_insights.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backend_failures_are_structured_for_new_tools(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+
+        reader = AsyncMock()
+        reader.get_single_run_pareto.side_effect = RuntimeError(
+            "https://secret-host/internal leaked"
+        )
+        reader.get_correlation_matrix.side_effect = RuntimeError(
+            "https://secret-host/internal leaked"
+        )
+        reader.get_run_leaderboard.side_effect = RuntimeError(
+            "https://secret-host/internal leaked"
+        )
+        reader.get_parameter_insights.side_effect = RuntimeError(
+            "https://secret-host/internal leaked"
+        )
+        _install_fake_client(monkeypatch, reader)
+
+        calls = [
+            tools_mod.analytics_get_single_run_pareto_tool("proj_abc", "run_123"),
+            tools_mod.analytics_get_correlation_matrix_tool("proj_abc", "run_123"),
+            tools_mod.analytics_get_run_leaderboard_tool("proj_abc", "run_123"),
+            tools_mod.analytics_get_parameter_insights_tool("proj_abc", "run_123"),
+        ]
+
+        for call in calls:
+            result = await call
+            assert result["ok"] is False
+            assert result["code"] == "backend_unavailable"
+            assert "secret-host" not in result["message"]
+
+
 class TestRenderChartTool:
     def test_renders_and_returns_path(self, tmp_path) -> None:
         from traigent.analytics_mcp.tools import analytics_render_chart_tool
@@ -276,6 +437,10 @@ class TestNoTenantArgument:
             tools_mod.analytics_get_project_overview_tool,
             tools_mod.analytics_compare_runs_tool,
             tools_mod.analytics_get_run_decision_brief_tool,
+            tools_mod.analytics_get_single_run_pareto_tool,
+            tools_mod.analytics_get_correlation_matrix_tool,
+            tools_mod.analytics_get_run_leaderboard_tool,
+            tools_mod.analytics_get_parameter_insights_tool,
             tools_mod.analytics_render_chart_tool,
         ]
         for fn in tool_callables:

--- a/tests/unit/cloud/test_analytics_client.py
+++ b/tests/unit/cloud/test_analytics_client.py
@@ -55,6 +55,16 @@ def _success_envelope(data: object) -> dict[str, object]:
     return {"success": True, "message": "ok", "data": data}
 
 
+def _mock_get_response(client, data: object):
+    mock_response = MagicMock()
+    mock_response.json.return_value = _success_envelope(data)
+    mock_response.raise_for_status = MagicMock()
+    mock_http = AsyncMock()
+    mock_http.get.return_value = mock_response
+    client._client = mock_http
+    return mock_http, mock_response
+
+
 class TestInit:
     def test_defaults_resolve_backend_url_and_key(self) -> None:
         from traigent.cloud.analytics_client import BackendAnalyticsClient
@@ -312,3 +322,272 @@ class TestGetRunDecisionBrief:
             await client.get_run_decision_brief("proj_abc", "run_123", intent="promote")
 
         mock_http.get.assert_not_called()
+
+
+class TestWave2SingleRunAnalytics:
+    @pytest.fixture()
+    def pareto_payload(self) -> dict[str, object]:
+        return {
+            "run_id": "run_123",
+            "project_id": "proj_abc",
+            "measures": {
+                "quality": "quality",
+                "cost": "cost",
+                "latency": "latency",
+            },
+            "frontier": [],
+            "dominated": [],
+            "shape": "flat",
+            "warnings": [],
+        }
+
+    @pytest.fixture()
+    def correlations_payload(self) -> dict[str, object]:
+        return {
+            "run_id": "run_123",
+            "method": "spearman",
+            "sample_size": 12,
+            "measure_correlations": [],
+            "parameter_correlations": [],
+            "warnings": [],
+        }
+
+    @pytest.fixture()
+    def leaderboard_payload(self) -> dict[str, object]:
+        return {
+            "run_id": "run_123",
+            "ranking_basis": {
+                "objective": "weighted",
+                "weights": {"quality": 0.8},
+                "constraints": {"cost": 1.0},
+            },
+            "configs": [],
+        }
+
+    @pytest.fixture()
+    def parameter_insights_payload(self) -> dict[str, object]:
+        return {
+            "run_id": "run_123",
+            "target_measure": "quality",
+            "min_trials": 10,
+            "drivers": [],
+            "interactions": [],
+            "warnings": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_single_run_pareto_calls_endpoint(
+        self, pareto_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        mock_http, mock_response = _mock_get_response(client, pareto_payload)
+
+        result = await client.get_single_run_pareto(
+            "proj_abc",
+            "run 123",
+            x_measure="cost",
+            y_measure="quality",
+            request_count=5,
+        )
+
+        assert result == pareto_payload
+        mock_response.raise_for_status.assert_called_once()
+        mock_http.get.assert_called_once_with(
+            "/api/v1/analytics/runs/run%20123/pareto",
+            headers={"X-Project-Id": "proj_abc"},
+            params={
+                "x_measure": "cost",
+                "y_measure": "quality",
+                "request_count": "5",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_correlation_matrix_calls_endpoint(
+        self, correlations_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        mock_http, mock_response = _mock_get_response(client, correlations_payload)
+
+        result = await client.get_correlation_matrix(
+            "proj_abc", "run_123", method="spearman", min_sample=4
+        )
+
+        assert result == correlations_payload
+        mock_response.raise_for_status.assert_called_once()
+        mock_http.get.assert_called_once_with(
+            "/api/v1/analytics/runs/run_123/correlations",
+            headers={"X-Project-Id": "proj_abc"},
+            params={"method": "spearman", "min_sample": "4"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_run_leaderboard_calls_endpoint_with_json_query(
+        self, leaderboard_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        mock_http, mock_response = _mock_get_response(client, leaderboard_payload)
+
+        result = await client.get_run_leaderboard(
+            "proj_abc",
+            "run_123",
+            objective="weighted",
+            weights={"quality": 0.8},
+            constraints='{"cost":1.0}',
+            request_count=7,
+            limit=10,
+        )
+
+        assert result == leaderboard_payload
+        mock_response.raise_for_status.assert_called_once()
+        mock_http.get.assert_called_once_with(
+            "/api/v1/analytics/runs/run_123/leaderboard",
+            headers={"X-Project-Id": "proj_abc"},
+            params={
+                "objective": "weighted",
+                "weights": '{"quality":0.8}',
+                "constraints": '{"cost":1.0}',
+                "request_count": "7",
+                "limit": "10",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_parameter_insights_calls_endpoint(
+        self, parameter_insights_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        mock_http, mock_response = _mock_get_response(
+            client, parameter_insights_payload
+        )
+
+        result = await client.get_parameter_insights(
+            "proj_abc",
+            "run_123",
+            target_measure="accuracy",
+            min_trials=12,
+            top_k=5,
+        )
+
+        assert result == parameter_insights_payload
+        mock_response.raise_for_status.assert_called_once()
+        mock_http.get.assert_called_once_with(
+            "/api/v1/analytics/runs/run_123/parameter-insights",
+            headers={"X-Project-Id": "proj_abc"},
+            params={
+                "target_measure": "accuracy",
+                "min_trials": "12",
+                "top_k": "5",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_defaults_match_backend_query_schema(
+        self,
+        pareto_payload: dict[str, object],
+        correlations_payload: dict[str, object],
+        leaderboard_payload: dict[str, object],
+        parameter_insights_payload: dict[str, object],
+    ) -> None:
+        cases = [
+            (
+                lambda client: client.get_single_run_pareto("proj_abc", "run_123"),
+                pareto_payload,
+                {
+                    "x_measure": "cost",
+                    "y_measure": "quality",
+                    "request_count": "1",
+                },
+            ),
+            (
+                lambda client: client.get_correlation_matrix("proj_abc", "run_123"),
+                correlations_payload,
+                {"method": "pearson", "min_sample": "3"},
+            ),
+            (
+                lambda client: client.get_run_leaderboard("proj_abc", "run_123"),
+                leaderboard_payload,
+                {"objective": "weighted", "request_count": "1", "limit": "50"},
+            ),
+            (
+                lambda client: client.get_parameter_insights("proj_abc", "run_123"),
+                parameter_insights_payload,
+                {"target_measure": "quality", "min_trials": "10", "top_k": "10"},
+            ),
+        ]
+
+        for call, payload, expected_params in cases:
+            client = _make_client()
+            mock_http, _ = _mock_get_response(client, payload)
+
+            await call(client)
+
+            assert mock_http.get.call_args.kwargs["params"] == expected_params
+
+    @pytest.mark.asyncio
+    async def test_missing_required_dto_keys_fail_closed(
+        self,
+        pareto_payload: dict[str, object],
+        correlations_payload: dict[str, object],
+        leaderboard_payload: dict[str, object],
+        parameter_insights_payload: dict[str, object],
+    ) -> None:
+        from traigent.cloud.analytics_client import AnalyticsClientError
+
+        cases = [
+            (
+                "shape",
+                pareto_payload,
+                lambda client: client.get_single_run_pareto("proj_abc", "run_123"),
+            ),
+            (
+                "sample_size",
+                correlations_payload,
+                lambda client: client.get_correlation_matrix("proj_abc", "run_123"),
+            ),
+            (
+                "ranking_basis",
+                leaderboard_payload,
+                lambda client: client.get_run_leaderboard("proj_abc", "run_123"),
+            ),
+            (
+                "drivers",
+                parameter_insights_payload,
+                lambda client: client.get_parameter_insights("proj_abc", "run_123"),
+            ),
+        ]
+
+        for missing_key, payload, call in cases:
+            malformed = dict(payload)
+            malformed.pop(missing_key)
+            client = _make_client()
+            _mock_get_response(client, malformed)
+
+            with pytest.raises(AnalyticsClientError, match=missing_key):
+                await call(client)
+
+    @pytest.mark.asyncio
+    async def test_malformed_envelope_fails_closed(self) -> None:
+        from traigent.cloud.analytics_client import AnalyticsClientError
+
+        client = _make_client()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"success": True}
+        mock_response.raise_for_status = MagicMock()
+        mock_http = AsyncMock()
+        mock_http.get.return_value = mock_response
+        client._client = mock_http
+
+        with pytest.raises(AnalyticsClientError, match="success envelope"):
+            await client.get_parameter_insights("proj_abc", "run_123")
+
+    @pytest.mark.asyncio
+    async def test_transport_error_surfaces_before_unwrap(
+        self, pareto_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        _, mock_response = _mock_get_response(client, pareto_payload)
+        mock_response.raise_for_status.side_effect = RuntimeError("http error")
+
+        with pytest.raises(RuntimeError, match="http error"):
+            await client.get_single_run_pareto("proj_abc", "run_123")

--- a/traigent/analytics_mcp/server.py
+++ b/traigent/analytics_mcp/server.py
@@ -26,9 +26,13 @@ from typing import Any
 
 from traigent.analytics_mcp.tools import (
     analytics_compare_runs_tool,
+    analytics_get_correlation_matrix_tool,
+    analytics_get_parameter_insights_tool,
     analytics_get_project_overview_tool,
     analytics_get_run_decision_brief_tool,
+    analytics_get_run_leaderboard_tool,
     analytics_get_run_report_tool,
+    analytics_get_single_run_pareto_tool,
     analytics_render_chart_tool,
     auth_status_tool,
     health_check_tool,
@@ -127,6 +131,101 @@ def create_server() -> Any:
         intent: str = "iterate",
     ) -> dict[str, Any]:
         return await analytics_get_run_decision_brief_tool(project_id, run_id, intent)
+
+    @server.tool(
+        description=(
+            "Fetch the backend's Pareto frontier (run_pareto v0) for one "
+            "optimization run. Requires explicit project_id and run_id; "
+            "optional x_measure, y_measure, and request_count query params. "
+            "Backend auth required."
+        )
+    )
+    async def analytics_get_single_run_pareto(
+        project_id: str,
+        run_id: str,
+        x_measure: str = "cost",
+        y_measure: str = "quality",
+        request_count: int = 1,
+    ) -> dict[str, Any]:
+        return await analytics_get_single_run_pareto_tool(
+            project_id,
+            run_id,
+            x_measure,
+            y_measure,
+            request_count,
+        )
+
+    @server.tool(
+        description=(
+            "Fetch the backend's correlation matrix (run_correlations v0) for "
+            "one optimization run. Requires explicit project_id and run_id; "
+            "optional method (pearson/spearman) and min_sample query params. "
+            "Backend auth required."
+        )
+    )
+    async def analytics_get_correlation_matrix(
+        project_id: str,
+        run_id: str,
+        method: str = "pearson",
+        min_sample: int = 3,
+    ) -> dict[str, Any]:
+        return await analytics_get_correlation_matrix_tool(
+            project_id,
+            run_id,
+            method,
+            min_sample,
+        )
+
+    @server.tool(
+        description=(
+            "Fetch the backend's ranked configuration leaderboard "
+            "(run_leaderboard v0) for one optimization run. Requires explicit "
+            "project_id and run_id; optional objective, weights, constraints, "
+            "request_count, and limit query params. weights/constraints are "
+            "JSON-object values on the wire. Backend auth required."
+        )
+    )
+    async def analytics_get_run_leaderboard(
+        project_id: str,
+        run_id: str,
+        objective: str = "weighted",
+        weights: dict[str, object] | str | None = None,
+        constraints: dict[str, object] | str | None = None,
+        request_count: int = 1,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        return await analytics_get_run_leaderboard_tool(
+            project_id,
+            run_id,
+            objective,
+            weights,
+            constraints,
+            request_count,
+            limit,
+        )
+
+    @server.tool(
+        description=(
+            "Fetch the backend's parameter-importance insights "
+            "(run_parameter_insights v0) for one optimization run. Requires "
+            "explicit project_id and run_id; optional target_measure, "
+            "min_trials, and top_k query params. Backend auth required."
+        )
+    )
+    async def analytics_get_parameter_insights(
+        project_id: str,
+        run_id: str,
+        target_measure: str = "quality",
+        min_trials: int = 10,
+        top_k: int = 10,
+    ) -> dict[str, Any]:
+        return await analytics_get_parameter_insights_tool(
+            project_id,
+            run_id,
+            target_measure,
+            min_trials,
+            top_k,
+        )
 
     @server.tool(
         description=(

--- a/traigent/analytics_mcp/tools.py
+++ b/traigent/analytics_mcp/tools.py
@@ -37,6 +37,10 @@ ANALYTICS_TOOL_NAMES: tuple[str, ...] = (
     "analytics_get_project_overview",
     "analytics_compare_runs",
     "analytics_get_run_decision_brief",
+    "analytics_get_single_run_pareto",
+    "analytics_get_correlation_matrix",
+    "analytics_get_run_leaderboard",
+    "analytics_get_parameter_insights",
     "analytics_render_chart",
 )
 
@@ -252,6 +256,108 @@ async def analytics_get_run_decision_brief_tool(
     return await _call_backend(
         lambda reader: reader.get_run_decision_brief(pid, rid, normalized_intent),
         what="decision brief",
+    )
+
+
+async def analytics_get_single_run_pareto_tool(
+    project_id: str,
+    run_id: str,
+    x_measure: str = "cost",
+    y_measure: str = "quality",
+    request_count: int = 1,
+) -> dict[str, Any]:
+    """Fetch the backend's Pareto frontier (run_pareto v0) for one run."""
+    try:
+        pid = _require_identifier(project_id, field="project_id")
+        rid = _require_identifier(run_id, field="run_id")
+    except _ToolInputError as exc:
+        return _failure(str(exc))
+    return await _call_backend(
+        lambda reader: reader.get_single_run_pareto(
+            pid,
+            rid,
+            x_measure=x_measure,
+            y_measure=y_measure,
+            request_count=request_count,
+        ),
+        what="single run pareto",
+    )
+
+
+async def analytics_get_correlation_matrix_tool(
+    project_id: str,
+    run_id: str,
+    method: str = "pearson",
+    min_sample: int = 3,
+) -> dict[str, Any]:
+    """Fetch the backend's correlation matrix (run_correlations v0)."""
+    try:
+        pid = _require_identifier(project_id, field="project_id")
+        rid = _require_identifier(run_id, field="run_id")
+    except _ToolInputError as exc:
+        return _failure(str(exc))
+    return await _call_backend(
+        lambda reader: reader.get_correlation_matrix(
+            pid,
+            rid,
+            method=method,
+            min_sample=min_sample,
+        ),
+        what="correlation matrix",
+    )
+
+
+async def analytics_get_run_leaderboard_tool(
+    project_id: str,
+    run_id: str,
+    objective: str = "weighted",
+    weights: dict[str, object] | str | None = None,
+    constraints: dict[str, object] | str | None = None,
+    request_count: int = 1,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Fetch the backend's ranked configuration leaderboard for one run."""
+    try:
+        pid = _require_identifier(project_id, field="project_id")
+        rid = _require_identifier(run_id, field="run_id")
+    except _ToolInputError as exc:
+        return _failure(str(exc))
+    return await _call_backend(
+        lambda reader: reader.get_run_leaderboard(
+            pid,
+            rid,
+            objective=objective,
+            weights=weights,
+            constraints=constraints,
+            request_count=request_count,
+            limit=limit,
+        ),
+        what="run leaderboard",
+    )
+
+
+async def analytics_get_parameter_insights_tool(
+    project_id: str,
+    run_id: str,
+    target_measure: str = "quality",
+    min_trials: int = 10,
+    top_k: int = 10,
+) -> dict[str, Any]:
+    """Fetch the backend's parameter-importance insights for one run."""
+    try:
+        pid = _require_identifier(project_id, field="project_id")
+        rid = _require_identifier(run_id, field="run_id")
+    except _ToolInputError as exc:
+        return _failure(str(exc))
+    return await _call_backend(
+        lambda reader: reader.get_parameter_insights(
+            pid,
+            rid,
+            target_measure=target_measure,
+            min_trials=min_trials,
+            top_k=top_k,
+        ),
+        what="parameter insights",
     )
 
 

--- a/traigent/cloud/analytics_client.py
+++ b/traigent/cloud/analytics_client.py
@@ -18,19 +18,24 @@ than adding a second auth path. Tenancy is owned by the backend and derived
 from the authenticated principal; this client never sends a caller-supplied
 ``tenant_id``.
 
-Today's wired endpoints (Wave-1):
+Wired analytics endpoints:
 
 * ``GET /api/v1/analytics/runs/{run_id}/report``
 * ``GET /api/v1/analytics/dashboards/optimization-overview``
 * ``POST /api/v1/optimization-comparisons``
 * ``GET /api/v1/analytics/runs/{run_id}/decision-payload``
+* ``GET /api/v1/analytics/runs/{run_id}/pareto``
+* ``GET /api/v1/analytics/runs/{run_id}/correlations``
+* ``GET /api/v1/analytics/runs/{run_id}/leaderboard``
+* ``GET /api/v1/analytics/runs/{run_id}/parameter-insights``
 """
 
 # Traceability: CONC-Layer-Infra CONC-Security FUNC-CLOUD-HYBRID FUNC-ANALYTICS REQ-CLOUD-009
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import json
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
 from urllib.parse import quote
 
@@ -63,6 +68,38 @@ _DECISION_PAYLOAD_REQUIRED_KEYS = frozenset(
         "recommended_action",
         "evidence",
         "drilldowns",
+        "warnings",
+    }
+)
+_RUN_PARETO_REQUIRED_KEYS = frozenset(
+    {
+        "run_id",
+        "project_id",
+        "measures",
+        "frontier",
+        "dominated",
+        "shape",
+        "warnings",
+    }
+)
+_RUN_CORRELATIONS_REQUIRED_KEYS = frozenset(
+    {
+        "run_id",
+        "method",
+        "sample_size",
+        "measure_correlations",
+        "parameter_correlations",
+        "warnings",
+    }
+)
+_RUN_LEADERBOARD_REQUIRED_KEYS = frozenset({"run_id", "ranking_basis", "configs"})
+_RUN_PARAMETER_INSIGHTS_REQUIRED_KEYS = frozenset(
+    {
+        "run_id",
+        "target_measure",
+        "min_trials",
+        "drivers",
+        "interactions",
         "warnings",
     }
 )
@@ -116,6 +153,25 @@ def _quote_segment(value: str, *, field: str) -> str:
     if not text:
         raise ValueError(f"{field} must be a non-empty string.")
     return quote(text, safe="")
+
+
+def _json_object_query_value(
+    value: Mapping[str, object] | str | None, *, field: str
+) -> str | None:
+    """Serialize a leaderboard JSON-object query value."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    try:
+        return json.dumps(value, separators=(",", ":"), sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be JSON-object serializable.") from exc
+
+
+def _without_none(params: dict[str, str | None]) -> dict[str, str]:
+    return {key: value for key, value in params.items() if value is not None}
 
 
 def normalize_decision_intent(intent: str | None = None) -> str:
@@ -341,6 +397,120 @@ class BackendAnalyticsClient:
             params={"intent": normalized_intent},
         )
         _require_keys(payload, _DECISION_PAYLOAD_REQUIRED_KEYS, what="decision brief")
+        return payload
+
+    async def get_single_run_pareto(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        x_measure: str = "cost",
+        y_measure: str = "quality",
+        request_count: int = 1,
+    ) -> dict[str, Any]:
+        """Return the backend's run_pareto v0 payload for one run."""
+        path = f"/api/v1/analytics/runs/{_quote_segment(run_id, field='run_id')}/pareto"
+        payload = await self._get_json(
+            path,
+            what="single-run Pareto",
+            headers=self._project_headers(project_id),
+            params={
+                "x_measure": str(x_measure),
+                "y_measure": str(y_measure),
+                "request_count": str(request_count),
+            },
+        )
+        _require_keys(payload, _RUN_PARETO_REQUIRED_KEYS, what="single-run Pareto")
+        return payload
+
+    async def get_correlation_matrix(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        method: str = "pearson",
+        min_sample: int = 3,
+    ) -> dict[str, Any]:
+        """Return the backend's run_correlations v0 payload for one run."""
+        path = (
+            "/api/v1/analytics/runs/"
+            f"{_quote_segment(run_id, field='run_id')}/correlations"
+        )
+        payload = await self._get_json(
+            path,
+            what="correlation matrix",
+            headers=self._project_headers(project_id),
+            params={"method": str(method), "min_sample": str(min_sample)},
+        )
+        _require_keys(
+            payload, _RUN_CORRELATIONS_REQUIRED_KEYS, what="correlation matrix"
+        )
+        return payload
+
+    async def get_run_leaderboard(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        objective: str = "weighted",
+        weights: Mapping[str, object] | str | None = None,
+        constraints: Mapping[str, object] | str | None = None,
+        request_count: int = 1,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Return the backend's run_leaderboard v0 payload for one run."""
+        path = (
+            "/api/v1/analytics/runs/"
+            f"{_quote_segment(run_id, field='run_id')}/leaderboard"
+        )
+        payload = await self._get_json(
+            path,
+            what="run leaderboard",
+            headers=self._project_headers(project_id),
+            params=_without_none(
+                {
+                    "objective": str(objective),
+                    "weights": _json_object_query_value(weights, field="weights"),
+                    "constraints": _json_object_query_value(
+                        constraints, field="constraints"
+                    ),
+                    "request_count": str(request_count),
+                    "limit": str(limit),
+                }
+            ),
+        )
+        _require_keys(payload, _RUN_LEADERBOARD_REQUIRED_KEYS, what="run leaderboard")
+        return payload
+
+    async def get_parameter_insights(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        target_measure: str = "quality",
+        min_trials: int = 10,
+        top_k: int = 10,
+    ) -> dict[str, Any]:
+        """Return the backend's run_parameter_insights v0 payload for one run."""
+        path = (
+            "/api/v1/analytics/runs/"
+            f"{_quote_segment(run_id, field='run_id')}/parameter-insights"
+        )
+        payload = await self._get_json(
+            path,
+            what="parameter insights",
+            headers=self._project_headers(project_id),
+            params={
+                "target_measure": str(target_measure),
+                "min_trials": str(min_trials),
+                "top_k": str(top_k),
+            },
+        )
+        _require_keys(
+            payload,
+            _RUN_PARAMETER_INSIGHTS_REQUIRED_KEYS,
+            what="parameter insights",
+        )
         return payload
 
 

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -12,6 +12,7 @@ import os
 import secrets
 import sys
 import time
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
@@ -172,6 +173,96 @@ class AnalyticsNamespace:
             return cast(
                 dict[str, Any],
                 await reader.get_run_decision_brief(project_id, run_id, intent),
+            )
+
+    async def get_single_run_pareto(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        x_measure: str = "cost",
+        y_measure: str = "quality",
+        request_count: int = 1,
+    ) -> dict[str, Any]:
+        """Return the backend's Pareto frontier for one run."""
+        async with self._new_read_client() as reader:
+            return cast(
+                dict[str, Any],
+                await reader.get_single_run_pareto(
+                    project_id,
+                    run_id,
+                    x_measure=x_measure,
+                    y_measure=y_measure,
+                    request_count=request_count,
+                ),
+            )
+
+    async def get_correlation_matrix(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        method: str = "pearson",
+        min_sample: int = 3,
+    ) -> dict[str, Any]:
+        """Return the backend's correlation matrix for one run."""
+        async with self._new_read_client() as reader:
+            return cast(
+                dict[str, Any],
+                await reader.get_correlation_matrix(
+                    project_id,
+                    run_id,
+                    method=method,
+                    min_sample=min_sample,
+                ),
+            )
+
+    async def get_run_leaderboard(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        objective: str = "weighted",
+        weights: Mapping[str, object] | str | None = None,
+        constraints: Mapping[str, object] | str | None = None,
+        request_count: int = 1,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        """Return the backend's ranked configuration leaderboard for one run."""
+        async with self._new_read_client() as reader:
+            return cast(
+                dict[str, Any],
+                await reader.get_run_leaderboard(
+                    project_id,
+                    run_id,
+                    objective=objective,
+                    weights=weights,
+                    constraints=constraints,
+                    request_count=request_count,
+                    limit=limit,
+                ),
+            )
+
+    async def get_parameter_insights(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        target_measure: str = "quality",
+        min_trials: int = 10,
+        top_k: int = 10,
+    ) -> dict[str, Any]:
+        """Return the backend's parameter-importance insights for one run."""
+        async with self._new_read_client() as reader:
+            return cast(
+                dict[str, Any],
+                await reader.get_parameter_insights(
+                    project_id,
+                    run_id,
+                    target_measure=target_measure,
+                    min_trials=min_trials,
+                    top_k=top_k,
+                ),
             )
 
 


### PR DESCRIPTION
Wave-2 single-run analytics **client tools** — wires the SDK to the BE single-run endpoints (merged in #1630) so the terminal skill can drill into Pareto / correlations / leaderboard / parameter-insights through the MCP.

- `client.analytics`: `get_single_run_pareto` / `get_correlation_matrix` / `get_run_leaderboard` / `get_parameter_insights` → `GET /api/v1/analytics/runs/{run_id}/{pareto,correlations,leaderboard,parameter-insights}`
- MCP tools: `analytics_get_single_run_pareto` / `_correlation_matrix` / `_run_leaderboard` / `_parameter_insights` (registered; explicit `project_id`; structured `ok=False` errors)
- Reuses established conventions: platform-envelope unwrap, `X-Project-Id` header, required-DTO-key validation, `scope_api_path` bypass for `/api/v1/analytics`.
- Tests: mocked-HTTP unit tests (client + MCP). `make local-gate` green (230 tests).
- Reviewed via dual-model gate (codex 5.5 xhigh + opus): MERGEABLE.

Spine-Trail: st_dbb683e021a1
Spine: cs_b82c2fa335430aeb
Spine-Session: cs_b82c2fa335430aeb