### PR TITLE
fix(analytics): resolve render Pareto axes via measures mapping (real BE payload)

### DIFF
--- a/tests/unit/analytics/test_render.py
+++ b/tests/unit/analytics/test_render.py
@@ -19,27 +19,27 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture()
 def pareto_payload() -> dict[str, object]:
-    """A frozen-v0 run_pareto contract instance."""
+    """A backend-realistic run_pareto contract instance."""
     return {
         "run_id": "run_123",
         "project_id": "proj_abc",
         "measures": {
-            "quality": {"label": "Accuracy", "unit": "%"},
-            "cost": {"label": "Cost", "unit": "USD"},
-            "latency": {"label": "Latency", "unit": "ms"},
+            "quality": "accuracy_score",
+            "cost": "cost",
+            "latency": "latency_ms",
         },
         "frontier": [
             {
                 "config_id": "cfg_1",
                 "rank_on_frontier": 1,
-                "metrics": {"quality": 0.9, "cost": 0.02, "latency": 800},
+                "metrics": {"accuracy_score": 0.9, "cost": 0.02, "latency_ms": 800},
                 "is_knee": True,
                 "tradeoff_summary": "Best balance.",
             },
             {
                 "config_id": "cfg_2",
                 "rank_on_frontier": 2,
-                "metrics": {"quality": 0.95, "cost": 0.05, "latency": 1200},
+                "metrics": {"accuracy_score": 0.95, "cost": 0.05, "latency_ms": 1200},
                 "is_knee": False,
                 "tradeoff_summary": "Highest quality.",
             },
@@ -49,7 +49,7 @@ def pareto_payload() -> dict[str, object]:
                 "config_id": "cfg_3",
                 "dominated_by": "cfg_1",
                 "reason": "Worse on both axes.",
-                "metrics": {"quality": 0.8, "cost": 0.04, "latency": 1500},
+                "metrics": {"accuracy_score": 0.8, "cost": 0.04, "latency_ms": 1500},
             }
         ],
         "shape": "convex",
@@ -87,10 +87,13 @@ def correlations_payload() -> dict[str, object]:
 
 class TestRenderPareto:
     def test_writes_png_file(self, pareto_payload, tmp_path) -> None:
-        from traigent.analytics.render import render_chart
+        from traigent.analytics.render import ChartRenderError, render_chart
 
         out = tmp_path / "pareto.png"
-        path = render_chart(pareto_payload, "run_pareto", str(out))
+        try:
+            path = render_chart(pareto_payload, "run_pareto", str(out))
+        except ChartRenderError as exc:  # pragma: no cover - assertion aid
+            pytest.fail(f"realistic backend pareto payload should render: {exc}")
 
         assert path == str(out.resolve())
         assert out.exists()
@@ -135,10 +138,21 @@ class TestRenderPareto:
 
         payload = {
             "run_id": "r",
-            "measures": {},
+            "measures": {
+                "quality": "accuracy_score",
+                "cost": "cost",
+                "latency": "latency_ms",
+            },
             "frontier": [
-                {"config_id": "good", "metrics": {"quality": 0.9, "cost": 0.01}},
-                {"config_id": "bad", "metrics": {"quality": None}},
+                {
+                    "config_id": "good",
+                    "metrics": {
+                        "accuracy_score": 0.9,
+                        "cost": 0.01,
+                        "latency_ms": 100,
+                    },
+                },
+                {"config_id": "bad", "metrics": {"cost": 0.02, "latency_ms": 110}},
             ],
             "dominated": [],
         }

--- a/traigent/analytics/render.py
+++ b/traigent/analytics/render.py
@@ -103,6 +103,16 @@ def _require_mapping(payload: Any) -> dict[str, Any]:
     return payload
 
 
+def _resolve_axis_metric_key(measures: Any, axis: str) -> str:
+    """Resolve a canonical axis name to the payload's actual metric key."""
+    if not isinstance(measures, dict):
+        return axis
+    resolved = measures.get(axis)
+    if isinstance(resolved, str) and resolved:
+        return resolved
+    return axis
+
+
 def _render_pareto(plt: Any, payload: dict[str, Any]) -> Any:
     """Plot a cost/quality scatter from a ``run_pareto`` payload.
 
@@ -111,8 +121,8 @@ def _render_pareto(plt: Any, payload: dict[str, Any]) -> Any:
     is recomputed.
     """
     measures = payload.get("measures") or {}
-    quality_key = "quality"
-    cost_key = "cost"
+    quality_key = _resolve_axis_metric_key(measures, "quality")
+    cost_key = _resolve_axis_metric_key(measures, "cost")
 
     fig, ax = plt.subplots(figsize=(7, 5))
 
@@ -187,7 +197,8 @@ def _render_pareto(plt: Any, payload: dict[str, Any]) -> Any:
     if not plotted_any:
         raise ChartRenderError(
             "run_pareto payload had no plottable points "
-            "(need frontier/dominated entries with metrics.cost and metrics.quality)."
+            f"(need frontier/dominated entries with metrics.{cost_key} "
+            f"and metrics.{quality_key})."
         )
 
     quality_meta = measures.get(quality_key) if isinstance(measures, dict) else None


### PR DESCRIPTION
Fix a real (pre-existing, from the original render helper) bug that broke the **Pareto chart on real backend data**.

**Bug:** `render.py:_render_pareto` hardcoded `quality_key="quality"` / `cost_key="cost"` and read those literal keys from `frontier[].metrics`. But the BE `run_pareto` payload keys `metrics` by the **actual** metric names (e.g. `accuracy_score`, `cost`) and uses the `measures` map (`{quality:"accuracy_score", cost:"cost"}`) to label axes — so on real data the render found no `"quality"` key and raised `no plottable points`.

**Fix:** resolve the axis keys *through* the `measures` mapping (`_resolve_axis_metric_key`), with a literal fallback. `_render_correlations` checked — already correct (uses `measure_correlations[].x/y/r`).

**Verification:** render unit tests updated to a backend-realistic payload (10/10 pass); empirically rendered a realistic payload → valid PNG **and confirmed it displays inline in Claude Code** (closes the terminal-visuals question).

Spine-Trail: st_54dfef4ad7a5
Spine: cs_b82c2fa335430aeb
Spine-Session: cs_b82c2fa335430aeb