### PR TITLE
feat(analytics): Phase-3 example-insights client + MCP tool

### DIFF
--- a/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
+++ b/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
@@ -293,6 +293,26 @@ class TestWave2AnalyticsTools:
         )
 
     @pytest.mark.asyncio
+    async def test_example_insights_tool_calls_client(self, monkeypatch) -> None:
+        from traigent.analytics_mcp.tools import analytics_get_example_insights_tool
+
+        reader = AsyncMock()
+        reader.get_example_insights.return_value = {
+            "run_id": "run_123",
+            "privacy_mode": "safe_agent_projection",
+        }
+        _install_fake_client(monkeypatch, reader)
+
+        result = await analytics_get_example_insights_tool("proj_abc", "run_123")
+
+        assert result["ok"] is True
+        assert result["example_insights"] == {
+            "run_id": "run_123",
+            "privacy_mode": "safe_agent_projection",
+        }
+        reader.get_example_insights.assert_awaited_once_with("proj_abc", "run_123")
+
+    @pytest.mark.asyncio
     async def test_missing_project_id_is_rejected_for_new_tools(
         self, monkeypatch
     ) -> None:
@@ -305,6 +325,7 @@ class TestWave2AnalyticsTools:
             tools_mod.analytics_get_correlation_matrix_tool("", "run_123"),
             tools_mod.analytics_get_run_leaderboard_tool("", "run_123"),
             tools_mod.analytics_get_parameter_insights_tool("", "run_123"),
+            tools_mod.analytics_get_example_insights_tool("", "run_123"),
         ]
 
         for call in calls:
@@ -316,6 +337,20 @@ class TestWave2AnalyticsTools:
         reader.get_correlation_matrix.assert_not_called()
         reader.get_run_leaderboard.assert_not_called()
         reader.get_parameter_insights.assert_not_called()
+        reader.get_example_insights.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_example_insights_requires_run_id(self, monkeypatch) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+
+        reader = AsyncMock()
+        _install_fake_client(monkeypatch, reader)
+
+        result = await tools_mod.analytics_get_example_insights_tool("proj_abc", "")
+
+        assert result["ok"] is False
+        assert "run_id" in result["message"]
+        reader.get_example_insights.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_backend_failures_are_structured_for_new_tools(
@@ -336,6 +371,9 @@ class TestWave2AnalyticsTools:
         reader.get_parameter_insights.side_effect = RuntimeError(
             "https://secret-host/internal leaked"
         )
+        reader.get_example_insights.side_effect = RuntimeError(
+            "https://secret-host/internal leaked"
+        )
         _install_fake_client(monkeypatch, reader)
 
         calls = [
@@ -343,6 +381,7 @@ class TestWave2AnalyticsTools:
             tools_mod.analytics_get_correlation_matrix_tool("proj_abc", "run_123"),
             tools_mod.analytics_get_run_leaderboard_tool("proj_abc", "run_123"),
             tools_mod.analytics_get_parameter_insights_tool("proj_abc", "run_123"),
+            tools_mod.analytics_get_example_insights_tool("proj_abc", "run_123"),
         ]
 
         for call in calls:
@@ -441,6 +480,7 @@ class TestNoTenantArgument:
             tools_mod.analytics_get_correlation_matrix_tool,
             tools_mod.analytics_get_run_leaderboard_tool,
             tools_mod.analytics_get_parameter_insights_tool,
+            tools_mod.analytics_get_example_insights_tool,
             tools_mod.analytics_render_chart_tool,
         ]
         for fn in tool_callables:

--- a/tests/unit/cloud/test_analytics_client.py
+++ b/tests/unit/cloud/test_analytics_client.py
@@ -375,6 +375,38 @@ class TestWave2SingleRunAnalytics:
             "warnings": [],
         }
 
+    @pytest.fixture()
+    def example_insights_payload(self) -> dict[str, object]:
+        return {
+            "run_id": "run_123",
+            "privacy_mode": "safe_agent_projection",
+            "summary": {
+                "example_count": 10,
+                "weak_example_count": 2,
+                "unstable_example_count": 1,
+                "dataset_quality": "medium",
+            },
+            "cohorts": [
+                {
+                    "kind": "weak_examples",
+                    "count": 2,
+                    "impact": "quality_risk",
+                    "safe_example_refs": ["exref_abc123"],
+                    "recommendation": "Review weak examples before promotion.",
+                }
+            ],
+            "recommendations": [
+                {
+                    "action": "rebalance_dataset",
+                    "reason": "Weak example cohort is non-empty.",
+                }
+            ],
+            "redactions": {
+                "raw_proprietary_signals_hidden": True,
+                "raw_prompt_text_hidden_by_default": True,
+            },
+        }
+
     @pytest.mark.asyncio
     async def test_get_single_run_pareto_calls_endpoint(
         self, pareto_payload: dict[str, object]
@@ -482,6 +514,37 @@ class TestWave2SingleRunAnalytics:
         )
 
     @pytest.mark.asyncio
+    async def test_get_example_insights_calls_endpoint(
+        self, example_insights_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        mock_http, mock_response = _mock_get_response(client, example_insights_payload)
+
+        result = await client.get_example_insights("proj_abc", "run 123")
+
+        assert result == example_insights_payload
+        mock_response.raise_for_status.assert_called_once()
+        mock_http.get.assert_called_once_with(
+            "/api/v1/analytics/runs/run%20123/example-insights",
+            headers={"X-Project-Id": "proj_abc"},
+            params=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_example_insights_rejects_empty_ids(
+        self, example_insights_payload: dict[str, object]
+    ) -> None:
+        client = _make_client()
+        mock_http, _ = _mock_get_response(client, example_insights_payload)
+
+        with pytest.raises(ValueError, match="project_id"):
+            await client.get_example_insights("", "run_123")
+        with pytest.raises(ValueError, match="run_id"):
+            await client.get_example_insights("proj_abc", " ")
+
+        mock_http.get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_defaults_match_backend_query_schema(
         self,
         pareto_payload: dict[str, object],
@@ -531,6 +594,7 @@ class TestWave2SingleRunAnalytics:
         correlations_payload: dict[str, object],
         leaderboard_payload: dict[str, object],
         parameter_insights_payload: dict[str, object],
+        example_insights_payload: dict[str, object],
     ) -> None:
         from traigent.cloud.analytics_client import AnalyticsClientError
 
@@ -554,6 +618,11 @@ class TestWave2SingleRunAnalytics:
                 "drivers",
                 parameter_insights_payload,
                 lambda client: client.get_parameter_insights("proj_abc", "run_123"),
+            ),
+            (
+                "redactions",
+                example_insights_payload,
+                lambda client: client.get_example_insights("proj_abc", "run_123"),
             ),
         ]
 

--- a/tests/unit/config/test_tenant_headers.py
+++ b/tests/unit/config/test_tenant_headers.py
@@ -133,6 +133,12 @@ def test_project_scope_helpers_normalize_paths_and_blank_env(monkeypatch) -> Non
         == "/api/v1/analytics/dashboards/optimization-overview"
     )
     assert (
+        scope_api_path(
+            "/api/v1/analytics/runs/run_123/example-insights", "project_alpha"
+        )
+        == "/api/v1/analytics/runs/run_123/example-insights"
+    )
+    assert (
         scope_api_path("/api/v1/optimization-comparisons", "project_alpha")
         == "/api/v1/optimization-comparisons"
     )

--- a/traigent/analytics_mcp/server.py
+++ b/traigent/analytics_mcp/server.py
@@ -27,6 +27,7 @@ from typing import Any
 from traigent.analytics_mcp.tools import (
     analytics_compare_runs_tool,
     analytics_get_correlation_matrix_tool,
+    analytics_get_example_insights_tool,
     analytics_get_parameter_insights_tool,
     analytics_get_project_overview_tool,
     analytics_get_run_decision_brief_tool,
@@ -226,6 +227,21 @@ def create_server() -> Any:
             min_trials,
             top_k,
         )
+
+    @server.tool(
+        description=(
+            "Fetch privacy-bounded example insights for one optimization run. "
+            "Requires explicit project_id and run_id. The backend returns only "
+            "safe-agent-projection data: coarse counts, dataset-quality "
+            "buckets, safe example refs, templated recommendations, and "
+            "redaction metadata. Backend auth required."
+        )
+    )
+    async def analytics_get_example_insights(
+        project_id: str,
+        run_id: str,
+    ) -> dict[str, Any]:
+        return await analytics_get_example_insights_tool(project_id, run_id)
 
     @server.tool(
         description=(

--- a/traigent/analytics_mcp/tools.py
+++ b/traigent/analytics_mcp/tools.py
@@ -41,6 +41,7 @@ ANALYTICS_TOOL_NAMES: tuple[str, ...] = (
     "analytics_get_correlation_matrix",
     "analytics_get_run_leaderboard",
     "analytics_get_parameter_insights",
+    "analytics_get_example_insights",
     "analytics_render_chart",
 )
 
@@ -358,6 +359,22 @@ async def analytics_get_parameter_insights_tool(
             top_k=top_k,
         ),
         what="parameter insights",
+    )
+
+
+async def analytics_get_example_insights_tool(
+    project_id: str,
+    run_id: str,
+) -> dict[str, Any]:
+    """Fetch the backend's privacy-bounded example insights for one run."""
+    try:
+        pid = _require_identifier(project_id, field="project_id")
+        rid = _require_identifier(run_id, field="run_id")
+    except _ToolInputError as exc:
+        return _failure(str(exc))
+    return await _call_backend(
+        lambda reader: reader.get_example_insights(pid, rid),
+        what="example insights",
     )
 
 

--- a/traigent/cloud/analytics_client.py
+++ b/traigent/cloud/analytics_client.py
@@ -28,6 +28,7 @@ Wired analytics endpoints:
 * ``GET /api/v1/analytics/runs/{run_id}/correlations``
 * ``GET /api/v1/analytics/runs/{run_id}/leaderboard``
 * ``GET /api/v1/analytics/runs/{run_id}/parameter-insights``
+* ``GET /api/v1/analytics/runs/{run_id}/example-insights``
 """
 
 # Traceability: CONC-Layer-Infra CONC-Security FUNC-CLOUD-HYBRID FUNC-ANALYTICS REQ-CLOUD-009
@@ -101,6 +102,16 @@ _RUN_PARAMETER_INSIGHTS_REQUIRED_KEYS = frozenset(
         "drivers",
         "interactions",
         "warnings",
+    }
+)
+_RUN_EXAMPLE_INSIGHTS_REQUIRED_KEYS = frozenset(
+    {
+        "run_id",
+        "privacy_mode",
+        "summary",
+        "cohorts",
+        "recommendations",
+        "redactions",
     }
 )
 
@@ -510,6 +521,28 @@ class BackendAnalyticsClient:
             payload,
             _RUN_PARAMETER_INSIGHTS_REQUIRED_KEYS,
             what="parameter insights",
+        )
+        return payload
+
+    async def get_example_insights(
+        self,
+        project_id: str,
+        run_id: str,
+    ) -> dict[str, Any]:
+        """Return the backend's privacy-bounded example insights for one run."""
+        path = (
+            "/api/v1/analytics/runs/"
+            f"{_quote_segment(run_id, field='run_id')}/example-insights"
+        )
+        payload = await self._get_json(
+            path,
+            what="example insights",
+            headers=self._project_headers(project_id),
+        )
+        _require_keys(
+            payload,
+            _RUN_EXAMPLE_INSIGHTS_REQUIRED_KEYS,
+            what="example insights",
         )
         return payload
 

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -265,6 +265,16 @@ class AnalyticsNamespace:
                 ),
             )
 
+    async def get_example_insights(
+        self, project_id: str, run_id: str
+    ) -> dict[str, Any]:
+        """Return the backend's privacy-bounded example insights for one run."""
+        async with self._new_read_client() as reader:
+            return cast(
+                dict[str, Any],
+                await reader.get_example_insights(project_id, run_id),
+            )
+
 
 # Backwards compatibility: expose shared bridge instance at this module scope so
 # existing tests patching ``traigent.cloud.backend_client.bridge`` continue to


### PR DESCRIPTION
Phase-3 example-insights client wiring (privacy-bounded run_example_insights). Calls GET /api/v1/analytics/runs/{run_id}/example-insights with the established conventions (envelope unwrap, X-Project-Id, validation). Dual-model gate (codex 5.5 + opus): MERGEABLE.

Spine-Trail: st_98b5f4507c90
Spine: cs_b82c2fa335430aeb
Spine-Session: cs_b82c2fa335430aeb