### PR TITLE
fix(sdk/analytics): canonical credential doctrine across analytics clients + MCP (cross-session reconciliation)

### DIFF
--- a/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
+++ b/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
@@ -20,7 +20,7 @@ HTTPX_AVAILABLE = importlib.util.find_spec("httpx") is not None
 def _install_fake_client(monkeypatch, reader: AsyncMock):
     """Patch ``_new_analytics_client`` to yield ``reader`` as an async ctx mgr.
 
-    The tools open the client with ``async with _new_analytics_client() as
+    The tools open the client with ``async with await _new_analytics_client() as
     reader``; this returns an object whose async context manager yields the
     provided mock ``reader`` so each tool's real call path is exercised.
     """
@@ -33,7 +33,10 @@ def _install_fake_client(monkeypatch, reader: AsyncMock):
         async def __aexit__(self, *exc):
             return False
 
-    monkeypatch.setattr(tools_mod, "_new_analytics_client", lambda: _FakeClient())
+    async def _fake_new_analytics_client():
+        return _FakeClient()
+
+    monkeypatch.setattr(tools_mod, "_new_analytics_client", _fake_new_analytics_client)
     return reader
 
 
@@ -95,6 +98,26 @@ class TestRunReportTool:
 
         assert result["ok"] is False
         assert result["code"] == "malformed_response"
+
+    @pytest.mark.asyncio
+    async def test_client_construction_auth_failure_is_structured(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+        from traigent.cloud.auth import InvalidCredentialsError
+
+        async def _raise_invalid_credentials():
+            raise InvalidCredentialsError("https://secret-host rejected the token")
+
+        monkeypatch.setattr(
+            tools_mod, "_new_analytics_client", _raise_invalid_credentials
+        )
+
+        result = await tools_mod.analytics_get_run_report_tool("proj_abc", "run_123")
+
+        assert result["ok"] is False
+        assert result["code"] == "authentication_failed"
+        assert "secret-host" not in result["message"]
 
 
 class TestProjectOverviewTool:
@@ -424,6 +447,172 @@ class TestHealthAndAuthTools:
         assert result["api_key"]["prefix"] == "uk_a"
         assert result["api_key"]["last4"] == "3456"
         assert "uk_abcdef123456" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_auth_status_rejects_malformed_jwt_only_credential(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            classmethod(
+                lambda cls: {
+                    "jwt_token": "not-a-jwt",
+                    "backend_url": "http://localhost:5000",
+                    "source": "cli",
+                }
+            ),
+        )
+        validation_result = type(
+            "ValidationResult",
+            (),
+            {
+                "valid": False,
+                "claims": {},
+                "warnings": [],
+                "expires_at": None,
+                "error": "malformed JWT",
+            },
+        )()
+        monkeypatch.setattr(
+            "traigent.security.jwt_validator.get_secure_jwt_validator",
+            lambda mode: type(
+                "Validator",
+                (),
+                {"validate_token": lambda self, token: validation_result},
+            )(),
+        )
+
+        result = await tools_mod.auth_status_tool()
+
+        assert result["ok"] is True
+        assert result["credential_present"] is True
+        assert result["authenticated"] is False
+        assert result["auth_type"] == "jwt"
+        assert "malformed JWT" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_auth_status_accepts_valid_jwt_only_credential(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            classmethod(
+                lambda cls: {
+                    "jwt_token": "header.payload.signature",
+                    "backend_url": "http://localhost:5000",
+                    "source": "cli",
+                }
+            ),
+        )
+        validation_result = type(
+            "ValidationResult",
+            (),
+            {
+                "valid": True,
+                "claims": {"sub": "user_123"},
+                "warnings": [],
+                "expires_at": None,
+                "error": None,
+            },
+        )()
+        monkeypatch.setattr(
+            "traigent.security.jwt_validator.get_secure_jwt_validator",
+            lambda mode: type(
+                "Validator",
+                (),
+                {"validate_token": lambda self, token: validation_result},
+            )(),
+        )
+
+        result = await tools_mod.auth_status_tool()
+
+        assert result["ok"] is True
+        assert result["credential_present"] is True
+        assert result["authenticated"] is True
+        assert result["auth_type"] == "jwt"
+
+    @pytest.mark.asyncio
+    async def test_new_client_uses_bearer_header_for_jwt_only_credential(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            classmethod(
+                lambda cls: {
+                    "jwt_token": "header.payload.signature",
+                    "backend_url": "http://localhost:5000",
+                    "source": "cli",
+                }
+            ),
+        )
+
+        validation_result = type(
+            "ValidationResult",
+            (),
+            {
+                "valid": True,
+                "claims": {"sub": "user_123"},
+                "warnings": [],
+                "expires_at": None,
+                "error": None,
+            },
+        )()
+        monkeypatch.setattr(
+            "traigent.security.jwt_validator.get_secure_jwt_validator",
+            lambda mode: type(
+                "Validator",
+                (),
+                {"validate_token": lambda self, token: validation_result},
+            )(),
+        )
+
+        client = await tools_mod._new_analytics_client()
+
+        assert client._auth_headers() == {
+            "Authorization": "Bearer header.payload.signature"
+        }
+
+    @pytest.mark.asyncio
+    async def test_new_client_uses_x_api_key_header_for_api_key(
+        self, monkeypatch
+    ) -> None:
+        from traigent.analytics_mcp import tools as tools_mod
+        from traigent.cloud.auth import AuthManager
+
+        async def _ok(self, api_key):  # noqa: ARG001
+            return None
+
+        api_key = "uk_" + "a" * 43
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            classmethod(
+                lambda cls: {
+                    "api_key": api_key,
+                    "backend_url": "http://localhost:5000",
+                    "source": "cli",
+                }
+            ),
+        )
+        monkeypatch.setattr(AuthManager, "_validate_api_key_with_backend", _ok)
+
+        client = await tools_mod._new_analytics_client()
+
+        assert client._auth_headers() == {"X-API-Key": api_key}
+        assert "Authorization" not in client._auth_headers()
 
 
 class TestNoTenantArgument:

--- a/tests/unit/cloud/test_analytics_client.py
+++ b/tests/unit/cloud/test_analytics_client.py
@@ -45,10 +45,14 @@ def run_report_payload() -> dict[str, object]:
     return {"run_id": "run_123", "project_id": "proj_abc", "measures": {}}
 
 
-def _make_client(api_key: str = "uk_test_key"):
+def _make_client(api_key: str | None = "uk_test_key", jwt_token: str | None = None):
     from traigent.cloud.analytics_client import BackendAnalyticsClient
 
-    return BackendAnalyticsClient(backend_url="http://localhost:5000", api_key=api_key)
+    return BackendAnalyticsClient(
+        backend_url="http://localhost:5000",
+        api_key=api_key,
+        jwt_token=jwt_token,
+    )
 
 
 def _success_envelope(data: object) -> dict[str, object]:
@@ -95,10 +99,29 @@ class TestInit:
         headers = client._auth_headers()
         assert headers == {"X-API-Key": "uk_abcdef"}
 
+    def test_dotted_api_key_uses_x_api_key_header(self) -> None:
+        """Regression: a three-segment API key is still an API key, not a JWT."""
+        client = _make_client(api_key="uk_test.segment.withdots")
+        headers = client._auth_headers()
+        assert headers == {"X-API-Key": "uk_test.segment.withdots"}
+        assert "Authorization" not in headers
+
     def test_jwt_uses_bearer_header(self) -> None:
-        client = _make_client(api_key="aaa.bbb.ccc")
+        client = _make_client(api_key=None, jwt_token="aaa.bbb.ccc")
         headers = client._auth_headers()
         assert headers == {"Authorization": "Bearer aaa.bbb.ccc"}
+
+    def test_api_key_wins_when_api_key_and_jwt_are_both_set(self) -> None:
+        """Match JS buildTraigentHeaders: apiKey wins over jwtToken."""
+        client = _make_client(
+            api_key="uk_abcdef",
+            jwt_token="aaa.bbb.ccc",
+        )
+
+        headers = client._auth_headers()
+
+        assert headers == {"X-API-Key": "uk_abcdef"}
+        assert "Authorization" not in headers
 
 
 @pytest.mark.skipif(HTTPX_AVAILABLE, reason="only when httpx missing")

--- a/tests/unit/cloud/test_backend_client.py
+++ b/tests/unit/cloud/test_backend_client.py
@@ -135,6 +135,155 @@ class TestBackendIntegratedClient:
         assert client._session is None
         assert len(client._active_sessions) == 0
 
+    @pytest.mark.asyncio
+    async def test_analytics_facade_passes_jwt_token_from_auth_manager(
+        self, backend_client, monkeypatch
+    ):
+        """JWT-configured clients must send analytics Authorization: Bearer."""
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        backend_client.auth_manager.auth.get_headers = AsyncMock(
+            return_value={"Authorization": "Bearer aaa.bbb.ccc"}
+        )
+
+        with patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            return_value={},
+        ):
+            reader = await backend_client.analytics._new_read_client()
+
+        assert reader._auth_headers() == {"Authorization": "Bearer aaa.bbb.ccc"}
+        backend_client.auth_manager.auth.get_headers.assert_awaited_once_with(
+            target="backend"
+        )
+
+    @pytest.mark.asyncio
+    async def test_analytics_facade_passes_api_key_from_auth_manager(
+        self, backend_client, monkeypatch
+    ):
+        """API-key-configured clients must send analytics X-API-Key."""
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        backend_client.auth_manager.auth.get_headers = AsyncMock(
+            return_value={"X-API-Key": "uk_facade_key"}
+        )
+
+        with patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            return_value={},
+        ):
+            reader = await backend_client.analytics._new_read_client()
+
+        assert reader._auth_headers() == {"X-API-Key": "uk_facade_key"}
+        backend_client.auth_manager.auth.get_headers.assert_awaited_once_with(
+            target="backend"
+        )
+
+    @pytest.mark.asyncio
+    async def test_analytics_facade_uses_jwt_mode_for_stored_jwt_only(
+        self, backend_client, monkeypatch
+    ):
+        """Stored JWT-only credentials must not be resolved as API keys."""
+        from traigent.cloud.auth import AuthMode
+
+        monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+        monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
+        backend_client._api_key_fallback = None
+        backend_client.auth_manager.auth.authenticate = AsyncMock(
+            return_value=MagicMock(success=True)
+        )
+        backend_client.auth_manager.auth.get_headers = AsyncMock(
+            return_value={"Authorization": "Bearer stored.header.sig"}
+        )
+
+        with patch(
+            "traigent.cloud.credential_manager.CredentialManager.get_credentials",
+            return_value={"jwt_token": "stored.header.sig", "source": "cli"},
+        ):
+            reader = await backend_client.analytics._new_read_client()
+
+        backend_client.auth_manager.auth.authenticate.assert_awaited_once_with(
+            mode=AuthMode.JWT_TOKEN
+        )
+        assert reader._auth_headers() == {"Authorization": "Bearer stored.header.sig"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("facade_method", "reader_method", "kwargs"),
+        [
+            (
+                "get_single_run_pareto",
+                "get_single_run_pareto",
+                {
+                    "x_measure": "latency",
+                    "y_measure": "quality",
+                    "request_count": 2,
+                },
+            ),
+            (
+                "get_correlation_matrix",
+                "get_correlation_matrix",
+                {"method": "spearman", "min_sample": 4},
+            ),
+            (
+                "get_run_leaderboard",
+                "get_run_leaderboard",
+                {
+                    "objective": "weighted",
+                    "weights": {"quality": 0.8},
+                    "constraints": {"cost": 1.0},
+                    "request_count": 3,
+                    "limit": 7,
+                },
+            ),
+            (
+                "get_parameter_insights",
+                "get_parameter_insights",
+                {"target_measure": "accuracy", "min_trials": 12, "top_k": 5},
+            ),
+        ],
+    )
+    async def test_wave2_analytics_facade_methods_enter_async_context(
+        self,
+        backend_client,
+        monkeypatch,
+        facade_method,
+        reader_method,
+        kwargs,
+    ):
+        """Regression: async _new_read_client() must be awaited before async with."""
+        reader = MagicMock()
+        setattr(reader, reader_method, AsyncMock(return_value={"ok": True}))
+
+        class _FakeReadClient:
+            async def __aenter__(self):
+                return reader
+
+            async def __aexit__(self, *exc):
+                return False
+
+        async def _new_read_client():
+            return _FakeReadClient()
+
+        monkeypatch.setattr(
+            backend_client.analytics,
+            "_new_read_client",
+            _new_read_client,
+        )
+
+        result = await getattr(backend_client.analytics, facade_method)(
+            "proj_abc",
+            "run_123",
+            **kwargs,
+        )
+
+        assert result == {"ok": True}
+        getattr(reader, reader_method).assert_awaited_once_with(
+            "proj_abc",
+            "run_123",
+            **kwargs,
+        )
+
     def test_client_default_initialization(self, monkeypatch):
         """Test client with default configuration."""
         # Ensure consistent environment for test

--- a/traigent/analytics_mcp/tools.py
+++ b/traigent/analytics_mcp/tools.py
@@ -51,6 +51,13 @@ def _failure(message: str, *, code: str = "invalid_input") -> dict[str, Any]:
     return {"ok": False, "code": code, "message": message}
 
 
+def _auth_failure() -> dict[str, Any]:
+    return _failure(
+        "Analytics authentication failed; configure valid Traigent credentials.",
+        code="authentication_failed",
+    )
+
+
 def _require_identifier(value: str | None, *, field: str) -> str:
     text = (value or "").strip()
     if not text:
@@ -62,15 +69,17 @@ class _ToolInputError(ValueError):
     """Raised for user-correctable analytics MCP tool input errors."""
 
 
-def _new_analytics_client() -> Any:
+async def _new_analytics_client() -> Any:
     """Construct a backend analytics read client using SDK credentials.
 
-    Reuses :class:`BackendAnalyticsClient`, which resolves the backend URL and
-    API key through the SDK's existing credential plumbing.
+    Reuses the same AuthManager-backed analytics credential resolver as
+    ``client.analytics`` before constructing the low-level read client.
     """
+    from traigent.cloud.analytics_auth import resolve_analytics_read_client_credentials
     from traigent.cloud.analytics_client import BackendAnalyticsClient
 
-    return BackendAnalyticsClient()
+    credential_kwargs = await resolve_analytics_read_client_credentials()
+    return BackendAnalyticsClient(**credential_kwargs)
 
 
 async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
@@ -82,11 +91,15 @@ async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
     response bodies) never reaches the caller.
     """
     from traigent.cloud.analytics_client import AnalyticsClientError
+    from traigent.cloud.auth import InvalidCredentialsError
 
     try:
-        client = _new_analytics_client()
+        client = await _new_analytics_client()
     except ImportError as exc:
         return _failure(str(exc), code="dependency_missing")
+    except InvalidCredentialsError as exc:
+        logger.debug("Analytics %s authentication failed: %s", what, exc)
+        return _auth_failure()
 
     try:
         async with client as reader:
@@ -96,6 +109,9 @@ async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
             f"The backend returned a malformed {what} response.",
             code="malformed_response",
         )
+    except InvalidCredentialsError as exc:
+        logger.debug("Analytics %s authentication failed: %s", what, exc)
+        return _auth_failure()
     except Exception as exc:  # noqa: BLE001 - normalize all transport failures
         # Do not surface raw exception text: it can contain the backend URL,
         # auth header echoes, or response bodies. Log at debug for operators.
@@ -174,22 +190,49 @@ async def auth_status_tool() -> dict[str, Any]:
 
     API key material is masked to prefix and last4 only.
     """
+    import os
+
     from traigent.cloud.credential_manager import CredentialManager
 
     credentials = CredentialManager.get_credentials()
     api_key = credentials.get("api_key")
     if api_key is not None and not isinstance(api_key, str):
         api_key = None
-    authenticated = bool(api_key or credentials.get("jwt_token"))
+    jwt_token = credentials.get("jwt_token")
+    if jwt_token is not None and not isinstance(jwt_token, str):
+        jwt_token = None
+    if isinstance(jwt_token, str) and not jwt_token.strip():
+        jwt_token = None
+
+    credential_source = credentials.get("source") or "none"
+    if not api_key and not jwt_token:
+        env_jwt_token = os.getenv("TRAIGENT_JWT_TOKEN")
+        if env_jwt_token:
+            jwt_token = env_jwt_token
+            credential_source = "environment"
+
+    credential_present = bool(api_key or jwt_token)
+    authenticated = bool(api_key)
+    if jwt_token and not api_key:
+        from traigent.cloud.analytics_auth import (
+            resolve_analytics_read_client_credentials,
+        )
+        from traigent.cloud.auth import InvalidCredentialsError
+
+        try:
+            credential_kwargs = await resolve_analytics_read_client_credentials()
+        except InvalidCredentialsError as exc:
+            logger.debug("Analytics JWT credential validation failed: %s", exc)
+            authenticated = False
+        else:
+            authenticated = bool(credential_kwargs.get("jwt_token"))
+
     return {
         "ok": True,
         "authenticated": authenticated,
-        "credential_source": credentials.get("source") or "none",
-        "auth_type": (
-            "api_key"
-            if api_key
-            else ("jwt" if credentials.get("jwt_token") else "none")
-        ),
+        "credential_present": credential_present,
+        "credential_source": credential_source if credential_present else "none",
+        "auth_type": "api_key" if api_key else ("jwt" if jwt_token else "none"),
         "api_key": _mask_api_key(api_key),
         "backend_url": _sanitize_url(credentials.get("backend_url")),
     }

--- a/traigent/cloud/analytics_auth.py
+++ b/traigent/cloud/analytics_auth.py
@@ -1,0 +1,73 @@
+"""Shared credential resolution for analytics read clients."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from traigent.cloud.auth import AuthManager, AuthMode, InvalidCredentialsError
+
+
+def analytics_credential_kwargs_from_auth_headers(
+    auth_headers: dict[str, str],
+) -> dict[str, str]:
+    """Translate canonical auth headers into BackendAnalyticsClient kwargs."""
+    api_key = auth_headers.get("X-API-Key")
+    if api_key:
+        return {"api_key": api_key}
+
+    auth_header = auth_headers.get("Authorization", "")
+    scheme, separator, token = auth_header.partition(" ")
+    if separator and scheme.lower() == "bearer":
+        jwt_token = token.strip()
+        if jwt_token:
+            return {"jwt_token": jwt_token}
+
+    return {}
+
+
+def _configured_jwt_without_api_key(api_key_fallback: str | None = None) -> bool:
+    if api_key_fallback or os.getenv("TRAIGENT_API_KEY"):
+        return False
+    if os.getenv("TRAIGENT_JWT_TOKEN"):
+        return True
+
+    from traigent.cloud.credential_manager import CredentialManager
+
+    credentials = CredentialManager.get_credentials()
+    if credentials.get("api_key"):
+        return False
+    jwt_token = credentials.get("jwt_token")
+    return isinstance(jwt_token, str) and bool(jwt_token.strip())
+
+
+async def resolve_analytics_read_client_credentials(
+    auth: AuthManager | Any | None = None,
+    *,
+    api_key_fallback: str | None = None,
+) -> dict[str, str]:
+    """Resolve analytics read-client credentials through AuthManager.
+
+    Returns kwargs for :class:`traigent.cloud.analytics_client.BackendAnalyticsClient`.
+    The auth manager remains the authority for credential precedence and header
+    construction; this helper only converts its emitted headers back into the
+    explicit constructor shape required by the low-level analytics HTTP client.
+    """
+    if auth is None:
+        auth = AuthManager(api_key=api_key_fallback)
+
+    if _configured_jwt_without_api_key(api_key_fallback):
+        auth_result = await auth.authenticate(mode=AuthMode.JWT_TOKEN)
+        if not auth_result.success:
+            raise InvalidCredentialsError(
+                auth_result.error_message
+                or "JWT authentication failed; refusing to create analytics client."
+            )
+
+    auth_headers = await auth.get_headers(target="backend")
+    credential_kwargs = analytics_credential_kwargs_from_auth_headers(auth_headers)
+    if not credential_kwargs:
+        raise InvalidCredentialsError(
+            "No usable analytics credential resolved; refusing to create analytics client."
+        )
+    return credential_kwargs

--- a/traigent/cloud/analytics_client.py
+++ b/traigent/cloud/analytics_client.py
@@ -11,12 +11,11 @@ the backend owns all analytics intelligence, so the SDK only
 * returns the allowlisted payload unchanged.
 
 It deliberately reuses the SDK's existing credential plumbing
-(:func:`traigent.utils.env_config.get_api_key`,
-:meth:`traigent.cloud.credential_manager.CredentialManager.get_auth_headers`,
+(:func:`traigent.cloud.auth._build_api_key_auth_headers`,
 :meth:`traigent.config.backend_config.BackendConfig.get_backend_url`) rather
-than adding a second auth path. Tenancy is owned by the backend and derived
-from the authenticated principal; this client never sends a caller-supplied
-``tenant_id``.
+than adding a second API-key auth path. Tenancy is owned by the backend and
+derived from the authenticated principal; this client never sends a
+caller-supplied ``tenant_id``.
 
 Wired analytics endpoints:
 
@@ -194,6 +193,7 @@ class BackendAnalyticsClient:
         self,
         backend_url: str | None = None,
         api_key: str | None = None,
+        jwt_token: str | None = None,
         timeout: float = 30.0,
     ) -> None:
         """Initialize the analytics read client.
@@ -204,6 +204,9 @@ class BackendAnalyticsClient:
             api_key: Explicit API key. When ``None`` the SDK's existing
                 credential resolution is used (``TRAIGENT_API_KEY`` /
                 stored CLI credentials / dev-mode key).
+            jwt_token: Explicit JWT bearer token. If ``api_key`` is also
+                provided, ``api_key`` wins to match the JS SDK header builder.
+                API-key values are never treated as JWTs based on string shape.
             timeout: Per-request timeout in seconds.
 
         Raises:
@@ -225,10 +228,13 @@ class BackendAnalyticsClient:
         self.backend_url = resolved_url.rstrip("/")
         self.timeout = timeout
 
-        self.api_key = api_key if api_key is not None else self._resolve_api_key()
-        if not self.api_key:
+        self.api_key = api_key if api_key is not None else None
+        self.jwt_token = jwt_token
+        if self.api_key is None and self.jwt_token is None:
+            self.api_key = self._resolve_api_key()
+        if not self.api_key and not self.jwt_token:
             logger.warning(
-                "No API key found for BackendAnalyticsClient. %s",
+                "No API key or JWT found for BackendAnalyticsClient. %s",
                 get_no_credentials_hint(),
             )
 
@@ -246,15 +252,20 @@ class BackendAnalyticsClient:
     def _auth_headers(self) -> dict[str, str]:
         """Build auth headers using the canonical credential helper.
 
-        Reuses :meth:`CredentialManager.get_auth_headers`, which correctly
-        routes API keys to ``X-API-Key`` and JWTs to ``Authorization: Bearer``
-        (an API key sent as a bearer token is rejected by the backend).
+        Reuses :func:`traigent.cloud.auth._build_api_key_auth_headers`, the same
+        API-key header builder used by ``AuthManager`` and other analytics
+        clients. API keys always route to ``X-API-Key`` and win when both
+        credential types are present; JWTs are explicit and route to
+        ``Authorization: Bearer``.
         """
-        if not self.api_key:
-            return {}
-        if "." in self.api_key and len(self.api_key.split(".")) == 3:
-            return {"Authorization": f"Bearer {self.api_key}"}
-        return {"X-API-Key": self.api_key}
+        from traigent.cloud.auth import _build_api_key_auth_headers
+
+        api_key_headers = _build_api_key_auth_headers(self.api_key)
+        if api_key_headers:
+            return api_key_headers
+        if self.jwt_token:
+            return {"Authorization": f"Bearer {self.jwt_token}"}
+        return {}
 
     def _get_client(self) -> httpx.AsyncClient:
         """Get or create the async HTTP client, failing closed when offline."""

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -138,28 +138,35 @@ class AnalyticsNamespace:
     def __init__(self, client: "BackendIntegratedClient") -> None:
         self._client = client
 
-    def _new_read_client(self) -> Any:
+    async def _new_read_client(self) -> Any:
+        from traigent.cloud.analytics_auth import (
+            resolve_analytics_read_client_credentials,
+        )
         from traigent.cloud.analytics_client import BackendAnalyticsClient
 
+        credential_kwargs = await resolve_analytics_read_client_credentials(
+            self._client.auth_manager.auth,
+            api_key_fallback=self._client._api_key_fallback,
+        )
         return BackendAnalyticsClient(
             backend_url=self._client.base_url,
-            api_key=self._client._api_key_fallback,
             timeout=self._client.timeout,
+            **credential_kwargs,
         )
 
     async def get_run_report(self, project_id: str, run_id: str) -> dict[str, Any]:
         """Return the backend's full analytics report for one run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(dict[str, Any], await reader.get_run_report(project_id, run_id))
 
     async def get_project_overview(self, project_id: str) -> dict[str, Any]:
         """Return the backend's cross-run overview for a project."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(dict[str, Any], await reader.get_project_overview(project_id))
 
     async def compare_runs(self, project_id: str, run_ids: list[str]) -> dict[str, Any]:
         """Compare two or more runs within a project."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(dict[str, Any], await reader.compare_runs(project_id, run_ids))
 
     async def get_run_decision_brief(
@@ -169,7 +176,7 @@ class AnalyticsNamespace:
         intent: str = "iterate",
     ) -> dict[str, Any]:
         """Return the backend's decision brief (decision_payload v0) for a run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(
                 dict[str, Any],
                 await reader.get_run_decision_brief(project_id, run_id, intent),
@@ -185,7 +192,7 @@ class AnalyticsNamespace:
         request_count: int = 1,
     ) -> dict[str, Any]:
         """Return the backend's Pareto frontier for one run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(
                 dict[str, Any],
                 await reader.get_single_run_pareto(
@@ -206,7 +213,7 @@ class AnalyticsNamespace:
         min_sample: int = 3,
     ) -> dict[str, Any]:
         """Return the backend's correlation matrix for one run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(
                 dict[str, Any],
                 await reader.get_correlation_matrix(
@@ -229,7 +236,7 @@ class AnalyticsNamespace:
         limit: int = 50,
     ) -> dict[str, Any]:
         """Return the backend's ranked configuration leaderboard for one run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(
                 dict[str, Any],
                 await reader.get_run_leaderboard(
@@ -253,7 +260,7 @@ class AnalyticsNamespace:
         top_k: int = 10,
     ) -> dict[str, Any]:
         """Return the backend's parameter-importance insights for one run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(
                 dict[str, Any],
                 await reader.get_parameter_insights(


### PR DESCRIPTION
SDK analytics credential-doctrine reconciliation (surfaced by the 3-session collision audit vs the analytics session's #1475 wave-2). codex 5.5 authored + independently reviewed across rounds: **GO**; captain agrees.

**Worst-case prod path:** before this, the analytics clients diverged from the SDK credential doctrine (#1439/#1469): `BackendAnalyticsClient` inferred `Authorization: Bearer` from a dotted **api key** (which the backend rejects), `analytics_mcp` constructed the client **directly** bypassing auth resolution (a JWT-only CLI credential reported authenticated but sent empty headers), and 4 wave-2 facade methods **crashed at runtime** (missing `await`). All now fail closed / authenticate correctly.

- **New shared `traigent/cloud/analytics_auth.py`** (AuthManager-backed) consumed by **both** `client.analytics` and `analytics_mcp`: api key->`X-API-Key`, JWT-only->`Bearer`, both-set->prefer api key (**JS parity**), dotted api key->`X-API-Key`, **fail-closed** on no usable credential.
- `jwt_token` plumbed through the `client.analytics` facade (JWT-configured SDKs authenticate analytics).
- **#1475 runtime crash fixed**: 4 wave-2 facade methods now `async with await self._new_read_client()`.
- `analytics_mcp` returns a sanitized `ok:false` envelope (no unhandled raise); `auth_status` is truthful (validates JWT-only; malformed JWT->`authenticated:false`; reports `credential_present` separately; no raw-credential leak).

**Production-branch test:** dotted-key->X-API-Key, both-set->api key, JWT->Bearer, facade async-context entry, MCP unauthenticated->ok:false, malformed-JWT->authenticated:false. 120+ pass; fail on revert. ruff 0.15.19 clean.
**Cross-SDK parity:** matches the JS reconciliation (PR #163, merged) and #1439/#1469.

Spine-Trail: st_1063385bec6f
Spine-Session: cs_5284b6d7f117f588
