### PR TITLE
chore(release): bump to 0.18.0.dev0 (terminal-analytics prerelease)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.17.0.dev0"
+version = "0.18.0.dev0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
Bump SDK `0.17.0.dev0` → `0.18.0.dev0` to publish the merged terminal-analytics surface (analytics client + `traigent-analytics-mcp` + chart rendering + example-insights) as a **PyPI prerelease**.

`0.17.0.dev0` is already on PyPI (pre-analytics) and the `0.17.0` stable is published, so this is the next prerelease ahead of stable. After merge I'll tag `v0.18.0.dev0` → `publish.yml` auto-publishes to PyPI; users install with `pip install --pre 'traigent[analytics]'`.

No code change — version string only.

Spine-Trail: st_2b66bfc88065