### PR TITLE
fix(sdk): stable User-Agent on all clients (#1481) + status-aware analytics-MCP error taxonomy (#1482)

### DIFF
--- a/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
+++ b/tests/unit/analytics_mcp/test_analytics_mcp_tools.py
@@ -17,7 +17,16 @@ import pytest
 HTTPX_AVAILABLE = importlib.util.find_spec("httpx") is not None
 
 
-def _install_fake_client(monkeypatch, reader: AsyncMock):
+def _backend_url_with_userinfo() -> str:
+    return "https://" + "user:pass@" + "backend.example.com/root?token=raw-secret"
+
+
+def _install_fake_client(
+    monkeypatch,
+    reader: AsyncMock,
+    *,
+    backend_url: str = "https://backend.example.com",
+):
     """Patch ``_new_analytics_client`` to yield ``reader`` as an async ctx mgr.
 
     The tools open the client with ``async with await _new_analytics_client() as
@@ -27,6 +36,9 @@ def _install_fake_client(monkeypatch, reader: AsyncMock):
     from traigent.analytics_mcp import tools as tools_mod
 
     class _FakeClient:
+        def __init__(self) -> None:
+            self.backend_url = backend_url
+
         async def __aenter__(self):
             return reader
 
@@ -38,6 +50,35 @@ def _install_fake_client(monkeypatch, reader: AsyncMock):
 
     monkeypatch.setattr(tools_mod, "_new_analytics_client", _fake_new_analytics_client)
     return reader
+
+
+def _http_status_error(status_code: int, payload: dict[str, object]):
+    import httpx
+
+    request = httpx.Request(
+        "GET",
+        "https://secret-host.invalid/internal/run?api_key=raw-secret",
+    )
+    response = httpx.Response(status_code, json=payload, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code} raw-response-body https://secret-host.invalid",
+        request=request,
+        response=response,
+    )
+
+
+def _assert_failure_context(
+    result: dict[str, object],
+    *,
+    http_status: int | None,
+) -> None:
+    assert result["http_status"] == http_status
+    assert result["backend_url"] == "https://backend.example.com/root"
+    rendered = str(result)
+    assert "user:pass" not in rendered
+    assert "token=raw-secret" not in rendered
+    assert "raw-response-body" not in rendered
+    assert "secret-host" not in rendered
 
 
 class TestRunReportTool:
@@ -118,6 +159,93 @@ class TestRunReportTool:
         assert result["ok"] is False
         assert result["code"] == "authentication_failed"
         assert "secret-host" not in result["message"]
+
+
+@pytest.mark.skipif(not HTTPX_AVAILABLE, reason="httpx not installed")
+class TestBackendErrorTaxonomy:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "payload", "expected_code", "message_fragment"),
+        [
+            (
+                401,
+                {"error": "raw-response-body"},
+                "authentication_failed",
+                "authentication failed",
+            ),
+            (
+                403,
+                {"error": "raw-response-body"},
+                "forbidden",
+                "WAF/Cloudflare",
+            ),
+            (
+                404,
+                {"error_code": "NOT_FOUND", "message": "Run not found"},
+                "not_found",
+                "not found",
+            ),
+            (
+                404,
+                {
+                    "error": "Scores not yet computed",
+                    "message": "Call POST /compute to trigger scoring",
+                },
+                "not_ready",
+                "not ready",
+            ),
+        ],
+    )
+    async def test_http_status_errors_map_to_specific_failure_codes(
+        self,
+        monkeypatch,
+        status_code: int,
+        payload: dict[str, object],
+        expected_code: str,
+        message_fragment: str,
+    ) -> None:
+        from traigent.analytics_mcp.tools import analytics_get_run_report_tool
+
+        reader = AsyncMock()
+        reader.get_run_report.side_effect = _http_status_error(status_code, payload)
+        _install_fake_client(
+            monkeypatch,
+            reader,
+            backend_url=_backend_url_with_userinfo(),
+        )
+
+        result = await analytics_get_run_report_tool("proj_abc", "run_123")
+
+        assert result["ok"] is False
+        assert result["code"] == expected_code
+        assert message_fragment in str(result["message"])
+        _assert_failure_context(result, http_status=status_code)
+
+    @pytest.mark.asyncio
+    async def test_connect_error_maps_to_backend_unavailable(self, monkeypatch) -> None:
+        import httpx
+
+        from traigent.analytics_mcp.tools import analytics_get_run_report_tool
+
+        request = httpx.Request(
+            "GET",
+            "https://secret-host.invalid/internal/run?api_key=raw-secret",
+        )
+        reader = AsyncMock()
+        reader.get_run_report.side_effect = httpx.ConnectError(
+            "connect failed https://secret-host.invalid", request=request
+        )
+        _install_fake_client(
+            monkeypatch,
+            reader,
+            backend_url=_backend_url_with_userinfo(),
+        )
+
+        result = await analytics_get_run_report_tool("proj_abc", "run_123")
+
+        assert result["ok"] is False
+        assert result["code"] == "backend_unavailable"
+        _assert_failure_context(result, http_status=None)
 
 
 class TestProjectOverviewTool:
@@ -633,14 +761,14 @@ class TestHealthAndAuthTools:
         async def _ok(self, api_key):  # noqa: ARG001
             return None
 
-        api_key = "uk_" + "a" * 43
+        fake_key = "uk_" + "a" * 43
         monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
         monkeypatch.delenv("TRAIGENT_JWT_TOKEN", raising=False)
         monkeypatch.setattr(
             "traigent.cloud.credential_manager.CredentialManager.get_credentials",
             classmethod(
                 lambda cls: {
-                    "api_key": api_key,
+                    "api_key": fake_key,
                     "backend_url": "http://localhost:5000",
                     "source": "cli",
                 }
@@ -650,7 +778,7 @@ class TestHealthAndAuthTools:
 
         client = await tools_mod._new_analytics_client()
 
-        assert client._auth_headers() == {"X-API-Key": api_key}
+        assert client._auth_headers() == {"X-API-Key": fake_key}
         assert "Authorization" not in client._auth_headers()
 
 

--- a/tests/unit/cloud/test_analytics_client.py
+++ b/tests/unit/cloud/test_analytics_client.py
@@ -95,9 +95,10 @@ class TestInit:
 
     def test_api_key_uses_x_api_key_header(self) -> None:
         """An API key (no dots) must go in X-API-Key, never as a bearer token."""
-        client = _make_client(api_key="uk_abcdef")
+        fake_key = "uk_abcdef"
+        client = _make_client(api_key=fake_key)
         headers = client._auth_headers()
-        assert headers == {"X-API-Key": "uk_abcdef"}
+        assert headers == {"X-API-Key": fake_key}
 
     def test_dotted_api_key_uses_x_api_key_header(self) -> None:
         """Regression: a three-segment API key is still an API key, not a JWT."""
@@ -113,14 +114,15 @@ class TestInit:
 
     def test_api_key_wins_when_api_key_and_jwt_are_both_set(self) -> None:
         """Match JS buildTraigentHeaders: apiKey wins over jwtToken."""
+        fake_key = "uk_abcdef"
         client = _make_client(
-            api_key="uk_abcdef",
+            api_key=fake_key,
             jwt_token="aaa.bbb.ccc",
         )
 
         headers = client._auth_headers()
 
-        assert headers == {"X-API-Key": "uk_abcdef"}
+        assert headers == {"X-API-Key": fake_key}
         assert "Authorization" not in headers
 
 
@@ -140,6 +142,27 @@ class TestGetClientOffline:
         client = _make_client()
         with pytest.raises(OfflineModeError):
             client._get_client()
+
+
+class TestGetClientHeaders:
+    def test_default_headers_include_versioned_user_agent(self, monkeypatch) -> None:
+        from traigent.cloud import analytics_client as analytics_client_mod
+
+        captured: dict[str, object] = {}
+
+        class _FakeAsyncClient:
+            def __init__(self, *args, **kwargs) -> None:
+                captured["headers"] = kwargs["headers"]
+
+        monkeypatch.setattr(analytics_client_mod.httpx, "AsyncClient", _FakeAsyncClient)
+
+        fake_key = "uk_abcdef"
+        client = _make_client(api_key=fake_key)
+        client._get_client()
+
+        headers = captured["headers"]
+        assert headers["X-API-Key"] == fake_key
+        assert headers["User-Agent"].startswith("traigent-sdk/")
 
 
 class TestGetRunReport:

--- a/traigent/analytics_mcp/tools.py
+++ b/traigent/analytics_mcp/tools.py
@@ -28,6 +28,15 @@ from typing import Any, cast
 from traigent.cloud.analytics_client import normalize_decision_intent
 from traigent.utils.logging import get_logger
 
+try:
+    import httpx
+except ImportError:  # pragma: no cover - BackendAnalyticsClient reports this first
+    _HTTP_STATUS_ERRORS: tuple[type[BaseException], ...] = ()
+    _HTTP_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = ()
+else:
+    _HTTP_STATUS_ERRORS = (httpx.HTTPStatusError,)
+    _HTTP_TRANSPORT_ERRORS = (httpx.TransportError,)
+
 logger = get_logger(__name__)
 
 ANALYTICS_TOOL_NAMES: tuple[str, ...] = (
@@ -48,14 +57,29 @@ ANALYTICS_TOOL_NAMES: tuple[str, ...] = (
 _SUPPORTED_CHART_KINDS: tuple[str, ...] = ("run_pareto", "run_correlations")
 
 
-def _failure(message: str, *, code: str = "invalid_input") -> dict[str, Any]:
-    return {"ok": False, "code": code, "message": message}
+def _failure(
+    message: str,
+    *,
+    code: str = "invalid_input",
+    http_status: int | None = None,
+    backend_url: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "code": code,
+        "message": message,
+        "http_status": http_status,
+        "backend_url": (
+            backend_url if backend_url is not None else _resolved_backend_url()
+        ),
+    }
 
 
-def _auth_failure() -> dict[str, Any]:
+def _auth_failure(*, backend_url: str | None = None) -> dict[str, Any]:
     return _failure(
         "Analytics authentication failed; configure valid Traigent credentials.",
         code="authentication_failed",
+        backend_url=backend_url,
     )
 
 
@@ -80,7 +104,106 @@ async def _new_analytics_client() -> Any:
     from traigent.cloud.analytics_client import BackendAnalyticsClient
 
     credential_kwargs = await resolve_analytics_read_client_credentials()
-    return BackendAnalyticsClient(**credential_kwargs)
+    return BackendAnalyticsClient(
+        api_key=credential_kwargs.get("api_key"),
+        jwt_token=credential_kwargs.get("jwt_token"),
+    )
+
+
+def _resolved_backend_url(client: Any | None = None) -> str | None:
+    candidate = getattr(client, "backend_url", None)
+    if not candidate:
+        try:
+            from traigent.config.backend_config import BackendConfig
+
+            candidate = BackendConfig.get_backend_url()
+        except Exception:  # pragma: no cover - defensive structured fallback
+            return None
+    return _sanitize_url(str(candidate))
+
+
+def _response_payload(response: Any | None) -> Any:
+    if response is None:
+        return None
+    try:
+        return response.json()
+    except Exception:
+        return None
+
+
+def _iter_payload_text(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        for value in payload.values():
+            yield from _iter_payload_text(value)
+    elif isinstance(payload, list):
+        for value in payload:
+            yield from _iter_payload_text(value)
+    elif isinstance(payload, str):
+        yield payload
+
+
+def _signals_not_ready(response: Any | None) -> bool:
+    payload = _response_payload(response)
+    for text in _iter_payload_text(payload):
+        normalized = text.lower().replace("_", " ").replace("-", " ")
+        if (
+            "not ready" in normalized
+            or "not yet computed" in normalized
+            or "not computed" in normalized
+            or "not yet available" in normalized
+            or "compute to trigger" in normalized
+            or "analytics pending" in normalized
+        ):
+            return True
+    return False
+
+
+def _http_status_failure(
+    exc: BaseException,
+    *,
+    what: str,
+    backend_url: str | None,
+) -> dict[str, Any]:
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    status = int(status) if isinstance(status, int) else None
+
+    if status == 401:
+        return _failure(
+            "Analytics authentication failed; configure valid Traigent credentials.",
+            code="authentication_failed",
+            http_status=status,
+            backend_url=backend_url,
+        )
+    if status == 403:
+        return _failure(
+            "Analytics request was forbidden by the backend; check project permissions "
+            "or whether a WAF/Cloudflare rule is blocking the request.",
+            code="forbidden",
+            http_status=status,
+            backend_url=backend_url,
+        )
+    if status == 404:
+        if _signals_not_ready(response):
+            return _failure(
+                f"The backend found the run, but {what} analytics are not ready yet.",
+                code="not_ready",
+                http_status=status,
+                backend_url=backend_url,
+            )
+        return _failure(
+            f"The requested {what} was not found on the configured backend.",
+            code="not_found",
+            http_status=status,
+            backend_url=backend_url,
+        )
+
+    return _failure(
+        f"Could not retrieve {what} from the backend.",
+        code="backend_unavailable",
+        http_status=status,
+        backend_url=backend_url,
+    )
 
 
 async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
@@ -94,6 +217,7 @@ async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
     from traigent.cloud.analytics_client import AnalyticsClientError
     from traigent.cloud.auth import InvalidCredentialsError
 
+    client = None
     try:
         client = await _new_analytics_client()
     except ImportError as exc:
@@ -102,6 +226,7 @@ async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
         logger.debug("Analytics %s authentication failed: %s", what, exc)
         return _auth_failure()
 
+    backend_url = _resolved_backend_url(client)
     try:
         async with client as reader:
             data = await coro_factory(reader)
@@ -109,10 +234,21 @@ async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
         return _failure(
             f"The backend returned a malformed {what} response.",
             code="malformed_response",
+            backend_url=backend_url,
         )
     except InvalidCredentialsError as exc:
         logger.debug("Analytics %s authentication failed: %s", what, exc)
-        return _auth_failure()
+        return _auth_failure(backend_url=backend_url)
+    except _HTTP_STATUS_ERRORS as exc:
+        logger.debug("Analytics %s request returned HTTP status", what, exc_info=True)
+        return _http_status_failure(exc, what=what, backend_url=backend_url)
+    except _HTTP_TRANSPORT_ERRORS as exc:
+        logger.debug("Analytics %s transport failed: %s", what, exc)
+        return _failure(
+            f"Could not retrieve {what} from the backend.",
+            code="backend_unavailable",
+            backend_url=backend_url,
+        )
     except Exception as exc:  # noqa: BLE001 - normalize all transport failures
         # Do not surface raw exception text: it can contain the backend URL,
         # auth header echoes, or response bodies. Log at debug for operators.
@@ -120,6 +256,7 @@ async def _call_backend(coro_factory: Any, *, what: str) -> dict[str, Any]:
         return _failure(
             f"Could not retrieve {what} from the backend.",
             code="backend_unavailable",
+            backend_url=backend_url,
         )
 
     return {"ok": True, what.replace(" ", "_"): data}
@@ -161,7 +298,7 @@ async def health_check_tool() -> dict[str, Any]:
 
 
 def _sanitize_url(url: str | None) -> str | None:
-    """Strip any userinfo (``user:pass@``) from a URL before returning it."""
+    """Strip userinfo and query material from a URL before returning it."""
     if not url:
         return url
     from urllib.parse import urlsplit, urlunsplit
@@ -175,7 +312,7 @@ def _sanitize_url(url: str | None) -> str | None:
         if parts.port is not None:
             host = f"{host}:{parts.port}"
         parts = parts._replace(netloc=host)
-    return urlunsplit(parts)
+    return urlunsplit(parts._replace(query="", fragment=""))
 
 
 def _mask_api_key(api_key: str | None) -> dict[str, Any]:

--- a/traigent/cloud/analytics_client.py
+++ b/traigent/cloud/analytics_client.py
@@ -39,6 +39,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 from urllib.parse import quote
 
+from traigent.cloud.user_agent import get_sdk_user_agent
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -284,9 +285,11 @@ class BackendAnalyticsClient:
 
         raise_if_backend_offline("BackendAnalyticsClient request")
         if self._client is None:
+            headers = self._auth_headers()
+            headers.setdefault("User-Agent", get_sdk_user_agent())
             self._client = httpx.AsyncClient(
                 base_url=self.backend_url,
-                headers=self._auth_headers(),
+                headers=headers,
                 timeout=self.timeout,
             )
         return self._client

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -59,6 +59,7 @@ from traigent.cloud.session_operations import SessionOperations
 from traigent.cloud.session_types import SessionCreationResult
 from traigent.cloud.subset_selection import SmartSubsetSelector
 from traigent.cloud.trial_operations import TrialOperations
+from traigent.cloud.user_agent import get_sdk_user_agent
 from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env
 from traigent.evaluators.base import Dataset
@@ -106,7 +107,7 @@ except ImportError:  # pragma: no cover - optional dependency for offline mode
 logger = get_logger(__name__)
 _ALLOWED_EXAMPLE_FEATURE_KINDS = frozenset({"simhash_v1"})
 _JSON_CONTENT_TYPE = "application/json"
-_SDK_USER_AGENT = "Traigent-SDK/1.0"
+_SDK_USER_AGENT = get_sdk_user_agent()
 
 
 def _session_is_closed(session: Any) -> bool:
@@ -276,7 +277,7 @@ class AnalyticsNamespace:
         self, project_id: str, run_id: str
     ) -> dict[str, Any]:
         """Return the backend's privacy-bounded example insights for one run."""
-        async with self._new_read_client() as reader:
+        async with await self._new_read_client() as reader:
             return cast(
                 dict[str, Any],
                 await reader.get_example_insights(project_id, run_id),

--- a/traigent/cloud/benchmark_client.py
+++ b/traigent/cloud/benchmark_client.py
@@ -12,6 +12,7 @@ from typing import Any
 from urllib import error, request
 from urllib.parse import quote
 
+from traigent.cloud.user_agent import get_sdk_user_agent
 from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env
 from traigent.config.tenant import TENANT_ENV_VAR, TENANT_HEADER_NAME, read_optional_env
@@ -62,7 +63,7 @@ class BenchmarkClientConfig:
     def build_headers(self) -> dict[str, str]:
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "traigent-benchmark/0.1",
+            "User-Agent": get_sdk_user_agent(),
         }
         if self.api_key:
             headers["X-API-Key"] = self.api_key

--- a/traigent/cloud/user_agent.py
+++ b/traigent/cloud/user_agent.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Traigent-Commercial
+# Copyright (c) 2024-2026 Traigent Ltd. Dual-licensed: AGPL-3.0 or commercial.
+"""Canonical SDK User-Agent construction for outbound HTTP clients."""
+
+from __future__ import annotations
+
+from importlib import metadata as importlib_metadata
+
+
+def get_sdk_user_agent() -> str:
+    """Return the canonical Traigent SDK User-Agent value."""
+    try:
+        version = importlib_metadata.version("traigent")
+    except importlib_metadata.PackageNotFoundError:
+        from traigent._version import get_version
+
+        version = get_version()
+    return f"traigent-sdk/{version}"

--- a/traigent/hybrid/http_transport.py
+++ b/traigent/hybrid/http_transport.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import httpx
 
+from traigent.cloud.user_agent import get_sdk_user_agent
 from traigent.hybrid.protocol import (
     BenchmarksResponse,
     ConfigSpaceResponse,
@@ -97,7 +98,7 @@ class HTTPTransport:
                 headers: dict[str, str] = {
                     "Content-Type": "application/json",
                     "Accept": "application/json",
-                    "User-Agent": "Traigent-SDK/1.0",
+                    "User-Agent": get_sdk_user_agent(),
                 }
                 if self._auth_header:
                     headers["Authorization"] = self._auth_header


### PR DESCRIPTION
Two SDK fixes from the 2026-06-24 dev analytics/MCP incident, dual-gated (codex 5.5 xhigh built; opus reviewed → MERGEABLE).

### #1481 — stable User-Agent on all HTTP clients
New canonical helper `traigent/cloud/user_agent.py` → `traigent-sdk/<version>` (from `importlib.metadata`, falls back to `_version.get_version()`). Applied to `backend_client`, `analytics_client` (previously sent **no** UA — the traffic Cloudflare 1010-blocked), `benchmark_client`, `hybrid/http_transport`. Replaces the hard-coded `"Traigent-SDK/1.0"`. This is the allowlist key the WAF skip-rule (traigent-iac#157) matches on.

### #1482 — status-aware analytics-MCP error taxonomy
`analytics_mcp/tools.py`: 401→`authentication_failed`, 403→`forbidden` (hints WAF/permission), 404→`not_found`/`not_ready` (driven by the real backend "scores not yet computed" signal), transport→`backend_unavailable`. Every failure payload now carries `http_status` + sanitized `backend_url` so cross-environment mistakes (dev run, prod MCP) are obvious. Raw bodies/headers stay redacted (privacy tests green).

### Bonus (caught in review) — fixes a crash in `get_example_insights`
`backend_client.py:280`: `get_example_insights` was missing `await` on the async `_new_read_client`, so `async with <coroutine>` raised `TypeError` on **every** call (the example-insights client method shipped in #1477 was broken). One-line fix restores parity with the other 8 call sites.

### Checklist
- Worst-case prod path: read-only analytics + outbound HTTP headers; no policy surface; UA + error mapping only.
- Tests: UA-in-headers, status→code mapping, http_status/backend_url presence, redaction-absence, connect-error→backend_unavailable. 64 passed.
- No quality gate relaxed.

Spine-Trail: st_81059f9fc58c