### PR TITLE
fix(sdk): auto degrades to local on session-create 400 (#1483) + execution_mode=cloud consistency (#1484) + cred env-precedence visibility (#1485)

### DIFF
--- a/tests/integration/test_execution_modes.py
+++ b/tests/integration/test_execution_modes.py
@@ -133,14 +133,14 @@ class TestExecutionModes:
 
         assert client.execution_mode == ExecutionMode.HYBRID
 
-    def test_cloud_mode_deprecated_resolves_to_edge_analytics(self):
-        """Test that 'cloud' mode (deprecated) emits DeprecationWarning and resolves to edge_analytics."""
+    def test_cloud_mode_deprecated_resolves_to_hybrid(self):
+        """Test that 'cloud' mode emits DeprecationWarning and resolves to hybrid."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             client = TraigentClient(execution_mode="cloud", api_key="test_key")
-        assert client.execution_mode == ExecutionMode.EDGE_ANALYTICS
+        assert client.execution_mode == ExecutionMode.HYBRID
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
     def test_execution_mode_auto_detection(self):
@@ -185,8 +185,10 @@ class TestExecutionModes:
         assert mode == "edge_analytics"
 
     @pytest.mark.asyncio
-    async def test_metric_submission_batching(self):
+    async def test_metric_submission_batching(self, monkeypatch):
         """Test metric submission batching in optimizer client."""
+        monkeypatch.delenv("TRAIGENT_OFFLINE", raising=False)
+        monkeypatch.delenv("TRAIGENT_OFFLINE_MODE", raising=False)
         with patch("aiohttp.ClientSession") as MockSession:
             # Setup mock session
             mock_session = AsyncMock()

--- a/tests/integration/test_summary_stats_integration.py
+++ b/tests/integration/test_summary_stats_integration.py
@@ -299,7 +299,7 @@ class TestExecutionModeHandling:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             result = validate_execution_mode("cloud")
-        assert result.value == "edge_analytics"
+        assert result.value == "hybrid"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
         assert validate_execution_mode("hybrid").value == "hybrid"
@@ -314,7 +314,7 @@ class TestExecutionModeHandling:
     def test_traigent_config_invalid_execution_mode(self):
         """Test that TraigentConfig rejects truly invalid execution mode strings."""
         for invalid_mode in ["invalid_mode"]:
-            with pytest.raises(ValueError, match="execution_mode must be one of"):
+            with pytest.raises(ValueError, match="Unsupported execution selector"):
                 TraigentConfig(execution_mode=invalid_mode)
 
         # "local" is a valid alias for edge_analytics

--- a/tests/integration/test_traigent_decorator_cloud_integration.py
+++ b/tests/integration/test_traigent_decorator_cloud_integration.py
@@ -21,10 +21,10 @@ def _dataset() -> Dataset:
 
 
 class TestTraigentDecoratorCloudIntegration:
-    """Deprecated cloud mode resolves to edge_analytics; standard mode resolves to hybrid."""
+    """Deprecated cloud and standard modes resolve to hybrid."""
 
     def test_basic_decorator_with_cloud_mode_deprecated(self):
-        """A cloud request emits DeprecationWarning and resolves to edge_analytics."""
+        """A cloud request emits DeprecationWarning and resolves to cloud-first hybrid."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
@@ -38,11 +38,11 @@ class TestTraigentDecoratorCloudIntegration:
                 return question
 
         assert isinstance(answer, OptimizedFunction)
-        assert answer.execution_mode == ExecutionMode.EDGE_ANALYTICS.value
+        assert answer.execution_mode == ExecutionMode.HYBRID.value
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
     def test_execution_bundle_with_cloud_mode_deprecated(self):
-        """ExecutionOptions with cloud emits DeprecationWarning and resolves to edge_analytics."""
+        """ExecutionOptions with cloud emits DeprecationWarning and resolves to hybrid."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
@@ -59,7 +59,7 @@ class TestTraigentDecoratorCloudIntegration:
                 return question
 
         assert isinstance(answer, OptimizedFunction)
-        assert answer.execution_mode == ExecutionMode.EDGE_ANALYTICS.value
+        assert answer.execution_mode == ExecutionMode.HYBRID.value
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
     def test_standard_mode_deprecated_resolves_to_hybrid(self):

--- a/tests/unit/api/decorator_tests/test_decorator_advanced.py
+++ b/tests/unit/api/decorator_tests/test_decorator_advanced.py
@@ -241,7 +241,7 @@ class TestOptimizationScenarios(DecoratorTestBase):
         assert callable(test_func)
         assert test_func("hello") == "Response: hello"
 
-    def test_cloud_execution_mode_deprecated_resolves_to_edge_analytics(self):
+    def test_cloud_execution_mode_deprecated_resolves_to_hybrid(self):
         """Deprecated cloud execution mode is accepted with DeprecationWarning."""
         import warnings
 
@@ -255,7 +255,7 @@ class TestOptimizationScenarios(DecoratorTestBase):
             def test_func(text: str) -> str:
                 return f"Commercial response: {text}"
 
-        assert test_func.execution_mode == "edge_analytics"
+        assert test_func.execution_mode == "hybrid"
         assert test_func.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -113,8 +113,8 @@ class TestOptimizeDecorator:
         assert sample_function.execution_mode == "hybrid_api"
         assert sample_function.hybrid_api_transport is transport
 
-    def test_execution_bundle_deprecated_cloud_resolves_to_edge_analytics_mode(self):
-        """Deprecated cloud keeps cloud-first policy with edge_analytics compat mode."""
+    def test_execution_bundle_deprecated_cloud_resolves_to_hybrid_mode(self):
+        """Deprecated cloud keeps cloud-first policy with hybrid compat mode."""
         import warnings
 
         from traigent.api.decorators import ExecutionOptions
@@ -133,7 +133,7 @@ class TestOptimizeDecorator:
                 return x
 
         assert isinstance(sample_function, OptimizedFunction)
-        assert sample_function.execution_mode == "edge_analytics"
+        assert sample_function.execution_mode == "hybrid"
         assert sample_function.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
@@ -443,7 +443,7 @@ class TestOptimizeDecorator:
         assert "test-10-1-1" in result
 
     def test_decorator_with_cloud_execution_mode_deprecated(self):
-        """Deprecated cloud mode warns and keeps edge_analytics compat mode."""
+        """Deprecated cloud mode warns and keeps hybrid compat mode."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
@@ -457,7 +457,7 @@ class TestOptimizeDecorator:
                 return f"Using {model}"
 
         assert isinstance(ai_function, OptimizedFunction)
-        assert ai_function.execution_mode == "edge_analytics"
+        assert ai_function.execution_mode == "hybrid"
         assert ai_function.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 

--- a/tests/unit/api/test_execution_policy_resolution.py
+++ b/tests/unit/api/test_execution_policy_resolution.py
@@ -51,7 +51,7 @@ def test_legacy_edge_analytics_maps_to_offline_with_warning() -> None:
     assert any("preserve the legacy no-egress guarantee" in msg for msg in messages)
 
 
-def test_legacy_cloud_maps_to_cloud_first_with_edge_analytics_compat_mode() -> None:
+def test_legacy_cloud_maps_to_cloud_first_with_hybrid_compat_mode() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
 
@@ -64,8 +64,31 @@ def test_legacy_cloud_maps_to_cloud_first_with_edge_analytics_compat_mode() -> N
     ]
     assert sample.execution_policy.intent is ExecutionIntent.CLOUD_BRAIN
     assert sample.execution_policy.offline is False
-    assert sample.execution_mode == "edge_analytics"
+    assert sample.execution_mode == "hybrid"
     assert any("semantic flip" in msg for msg in messages)
+
+
+def test_initialize_cloud_global_default_matches_decorator_cloud_policy() -> None:
+    from traigent.api.functions import _GLOBAL_CONFIG, initialize
+
+    original_config = _GLOBAL_CONFIG.copy()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            initialize(execution_mode="cloud")
+            initialized_mode = _GLOBAL_CONFIG.get("execution_mode")
+
+            @optimize(configuration_space={"x": [1, 2]})
+            def sample(x: int) -> int:
+                return x
+    finally:
+        _GLOBAL_CONFIG.clear()
+        _GLOBAL_CONFIG.update(original_config)
+
+    assert sample.execution_policy.intent is ExecutionIntent.CLOUD_BRAIN
+    assert sample.execution_mode == "hybrid"
+    assert initialized_mode == "hybrid"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 
 def test_legacy_auto_execution_mode_is_rejected() -> None:

--- a/tests/unit/api/test_traigent_client_execution_policy.py
+++ b/tests/unit/api/test_traigent_client_execution_policy.py
@@ -77,7 +77,7 @@ def test_traigent_client_deprecated_execution_mode_warns_and_maps_local(
     backend_client_factory.assert_not_called()
 
 
-def test_traigent_client_deprecated_cloud_warns_and_maps_edge_analytics_mode(
+def test_traigent_client_deprecated_cloud_warns_and_maps_hybrid_mode(
     backend_client_factory: Mock,
 ) -> None:
     with pytest.warns(DeprecationWarning, match="semantic flip"):
@@ -85,9 +85,8 @@ def test_traigent_client_deprecated_cloud_warns_and_maps_edge_analytics_mode(
 
     assert client.execution_policy.intent is ExecutionIntent.CLOUD_BRAIN
     assert client.execution_policy.offline is False
-    assert client.execution_mode is ExecutionMode.EDGE_ANALYTICS
-    assert client.backend_client is None
-    backend_client_factory.assert_not_called()
+    assert client.execution_mode is ExecutionMode.HYBRID
+    backend_client_factory.assert_called_once()
 
 
 def test_traigent_client_deprecated_execution_mode_auto_maps_edge_analytics(

--- a/tests/unit/cloud/test_credential_manager.py
+++ b/tests/unit/cloud/test_credential_manager.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import patch
 
+import pytest
+
+import traigent.cloud.credential_manager as credential_manager_module
 from traigent.cloud.credential_manager import CredentialManager
 
 
@@ -48,10 +52,14 @@ def test_dev_mode_with_dev_api_key_returns_value(monkeypatch) -> None:
     """When TRAIGENT_DEV_API_KEY is set alongside dev mode, return that value."""
     _clear_env(monkeypatch)
     monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
-    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "dev-key-xyz")  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "TRAIGENT_DEV_API_KEY", "dev-key-xyz"
+    )  # pragma: allowlist secret
 
     with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
-        assert CredentialManager.get_api_key() == "dev-key-xyz"  # pragma: allowlist secret
+        assert (
+            CredentialManager.get_api_key() == "dev-key-xyz"
+        )  # pragma: allowlist secret
         creds = CredentialManager.get_credentials()
 
     assert creds["api_key"] == "dev-key-xyz"  # pragma: allowlist secret
@@ -78,7 +86,9 @@ def test_dev_api_key_alone_does_not_activate_dev_fallback(monkeypatch) -> None:
     if no credentials are configured.
     """
     _clear_env(monkeypatch)
-    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "leaked-dev-key")  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "TRAIGENT_DEV_API_KEY", "leaked-dev-key"
+    )  # pragma: allowlist secret
 
     with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
         assert CredentialManager.get_api_key() is None
@@ -91,7 +101,9 @@ def test_get_auth_headers_jwt_shaped_dev_key_uses_bearer(monkeypatch) -> None:
     `get_auth_headers` for the env-driven dev path."""
     _clear_env(monkeypatch)
     monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
-    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "header.payload.signature")  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "TRAIGENT_DEV_API_KEY", "header.payload.signature"
+    )  # pragma: allowlist secret
 
     with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
         headers = CredentialManager.get_auth_headers()
@@ -103,7 +115,9 @@ def test_get_auth_headers_opaque_dev_key_uses_x_api_key(monkeypatch) -> None:
     """An opaque (non-JWT-shaped) dev key uses the X-API-Key header."""
     _clear_env(monkeypatch)
     monkeypatch.setenv("TRAIGENT_DEV_MODE", "true")
-    monkeypatch.setenv("TRAIGENT_DEV_API_KEY", "tg_opaque_token_value")  # pragma: allowlist secret
+    monkeypatch.setenv(
+        "TRAIGENT_DEV_API_KEY", "tg_opaque_token_value"
+    )  # pragma: allowlist secret
 
     with patch.object(CredentialManager, "_load_cli_credentials", return_value=None):
         headers = CredentialManager.get_auth_headers()
@@ -135,7 +149,9 @@ def test_load_cli_credentials_prefers_secure_store(monkeypatch) -> None:
         lambda: _FakeSecureStore(payload),
     )
 
-    assert CredentialManager.get_api_key() == "secure-api-key"  # pragma: allowlist secret
+    assert (
+        CredentialManager.get_api_key() == "secure-api-key"
+    )  # pragma: allowlist secret
     assert CredentialManager.get_stored_backend_url() == "https://api.example.test"
 
 
@@ -161,4 +177,74 @@ def test_legacy_plaintext_cli_credentials_are_ignored_without_opt_in(
 
     monkeypatch.setenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", "true")
 
-    assert CredentialManager.get_api_key() == "plaintext-api-key"  # pragma: allowlist secret
+    assert (
+        CredentialManager.get_api_key() == "plaintext-api-key"
+    )  # pragma: allowlist secret
+
+
+@pytest.mark.parametrize(
+    ("url_env_name", "url_env_value", "expected_backend_url"),
+    [
+        (
+            "TRAIGENT_BACKEND_URL",
+            "https://env-backend.example.test",
+            "https://env-backend.example.test",
+        ),
+        (
+            "TRAIGENT_API_URL",
+            "https://env-api.example.test/api/v1",
+            "https://env-api.example.test",
+        ),
+    ],
+)
+def test_get_credentials_env_url_and_key_override_stale_stored_credentials(
+    monkeypatch,
+    tmp_path,
+    caplog,
+    url_env_name,
+    url_env_value,
+    expected_backend_url,
+) -> None:
+    """Full CredentialManager path must prefer env over stale CLI credentials."""
+    _clear_env(monkeypatch)
+    monkeypatch.delenv("TRAIGENT_BACKEND_URL", raising=False)
+    monkeypatch.delenv("TRAIGENT_API_URL", raising=False)
+    monkeypatch.delenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", raising=False)
+
+    config_dir = tmp_path / ".traigent"
+    config_dir.mkdir()
+    credentials_file = config_dir / "credentials.json"
+    credentials_file.write_text(
+        json.dumps(
+            {
+                "api_key": "stale-stored-key",  # pragma: allowlist secret
+                "backend_url": "http://stale-localhost.example.test",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(credential_manager_module, "TRAIGENT_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(credential_manager_module, "CREDENTIALS_FILE", credentials_file)
+    monkeypatch.setattr(
+        "traigent.cloud.credential_manager.get_secure_credential_store",
+        lambda: _FakeSecureStore(None),
+    )
+
+    monkeypatch.setenv("TRAIGENT_ALLOW_PLAINTEXT_CREDENTIALS", "true")
+    monkeypatch.setenv("TRAIGENT_API_KEY", "env-api-key")  # pragma: allowlist secret
+    monkeypatch.setenv(url_env_name, url_env_value)
+
+    with caplog.at_level(logging.INFO, logger="traigent.config.backend_config"):
+        credentials = CredentialManager.get_credentials()
+
+    assert credentials == {
+        "api_key": "env-api-key",  # pragma: allowlist secret
+        "backend_url": expected_backend_url,
+        "source": "environment",
+    }
+    assert any(
+        f"{url_env_name} overrides stored CLI backend_url" in record.message
+        and "http://stale-localhost.example.test" in record.message
+        and expected_backend_url in record.message
+        for record in caplog.records
+    )

--- a/tests/unit/cloud/test_credential_manager.py
+++ b/tests/unit/cloud/test_credential_manager.py
@@ -206,6 +206,10 @@ def test_get_credentials_env_url_and_key_override_stale_stored_credentials(
     expected_backend_url,
 ) -> None:
     """Full CredentialManager path must prefer env over stale CLI credentials."""
+    # Held in a variable (not a URL literal in the membership assertion below) so
+    # the log-message check does not trip CodeQL py/incomplete-url-substring-sanitization;
+    # this is a log assertion, not URL validation.
+    stale_stored_url = "http://stale-localhost.example.test"
     _clear_env(monkeypatch)
     monkeypatch.delenv("TRAIGENT_BACKEND_URL", raising=False)
     monkeypatch.delenv("TRAIGENT_API_URL", raising=False)
@@ -218,7 +222,7 @@ def test_get_credentials_env_url_and_key_override_stale_stored_credentials(
         json.dumps(
             {
                 "api_key": "stale-stored-key",  # pragma: allowlist secret
-                "backend_url": "http://stale-localhost.example.test",
+                "backend_url": stale_stored_url,
             }
         ),
         encoding="utf-8",
@@ -244,7 +248,7 @@ def test_get_credentials_env_url_and_key_override_stale_stored_credentials(
     }
     assert any(
         f"{url_env_name} overrides stored CLI backend_url" in record.message
-        and "http://stale-localhost.example.test" in record.message
+        and stale_stored_url in record.message
         and expected_backend_url in record.message
         for record in caplog.records
     )

--- a/tests/unit/cloud/test_typed_session_contract.py
+++ b/tests/unit/cloud/test_typed_session_contract.py
@@ -20,6 +20,7 @@ from traigent.cloud.api_operations import ApiOperations
 from traigent.cloud.client import CloudServiceError
 from traigent.cloud.governance import build_tvl_governance, promotion_policy_to_wire
 from traigent.cloud.models import SessionCreationRequest
+from traigent.core.session_types import SessionCreationFailureDetail
 
 STRICT_POLICY = {
     "dominance": "epsilon_pareto",
@@ -143,6 +144,33 @@ class TestAutoFallback:
                 _request(promotion_policy=STRICT_POLICY)
             )
         assert len(attempts) == 1  # NO legacy retry for governed sessions
+
+    @pytest.mark.asyncio
+    async def test_typed_and_legacy_400_marks_auto_retry_failure(self, monkeypatch):
+        monkeypatch.delenv("TRAIGENT_SESSION_CONTRACT", raising=False)
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        ops = _ops()
+        ops.client.auth_manager.augment_headers = AsyncMock(return_value={})
+        statuses = [400, 400]
+
+        async def fake_post(payload, headers, connector):
+            status = statuses.pop(0)
+            exc = CloudServiceError(f"session create rejected {status}")
+            exc.session_creation_failure = (
+                SessionCreationFailureDetail.from_http_response(
+                    status, "Bad request from session endpoint"
+                )
+            )
+            raise exc
+
+        monkeypatch.setattr(ops, "_post_session_creation", fake_post)
+        monkeypatch.setattr(ops, "_build_connector", lambda: None)
+
+        with pytest.raises(CloudServiceError) as exc_info:
+            await ops.create_traigent_session_via_api(_request())
+
+        assert getattr(exc_info.value, "typed_legacy_session_create_400", False) is True
+        assert statuses == []
 
 
 class TestPayloadChokePoint:

--- a/tests/unit/config/test_config_validation_property.py
+++ b/tests/unit/config/test_config_validation_property.py
@@ -143,7 +143,7 @@ def test_execution_mode_deprecated_values_warn_and_resolve(mode):
         warnings.simplefilter("always")
         config = TraigentConfig(execution_mode=mode)
 
-    expected = "edge_analytics" if mode in {"local", "cloud"} else "hybrid"
+    expected = "edge_analytics" if mode == "local" else "hybrid"
     assert config.execution_mode == expected
     assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 

--- a/tests/unit/config/test_types.py
+++ b/tests/unit/config/test_types.py
@@ -370,14 +370,14 @@ class TestValidateExecutionMode:
                 ExecutionMode.HYBRID_API,
             }
 
-    def test_deprecated_cloud_mode_warns_and_resolves_to_edge_analytics(self) -> None:
-        """The removed cloud mode emits DeprecationWarning and maps to edge_analytics."""
+    def test_deprecated_cloud_mode_warns_and_resolves_to_hybrid(self) -> None:
+        """The deprecated cloud mode emits DeprecationWarning and maps to hybrid."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             result = validate_execution_mode("cloud")
-        assert result is ExecutionMode.EDGE_ANALYTICS
+        assert result is ExecutionMode.HYBRID
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
     def test_config_privacy_alias_normalizes_to_hybrid(self) -> None:
@@ -401,5 +401,5 @@ class TestValidateExecutionMode:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             config = TraigentConfig(execution_mode="cloud")
-        assert config.execution_mode == "edge_analytics"
+        assert config.execution_mode == "hybrid"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/unit/core/optimized_function_tests/test_cloud_integration.py
+++ b/tests/unit/core/optimized_function_tests/test_cloud_integration.py
@@ -2,18 +2,17 @@
 
 import warnings
 
-
 from traigent.config.types import ExecutionMode
 from traigent.core.optimized_function import OptimizedFunction
 
 
 class TestCloudIntegration:
-    """Cloud mode is deprecated; it resolves to edge_analytics with a DeprecationWarning."""
+    """Cloud mode is deprecated; it resolves to hybrid with a DeprecationWarning."""
 
-    def test_cloud_mode_deprecated_resolves_to_edge_analytics(
+    def test_cloud_mode_deprecated_resolves_to_hybrid(
         self, simple_function, sample_config_space, sample_objectives, sample_dataset
     ):
-        """Deprecated cloud mode resolves to edge_analytics with DeprecationWarning."""
+        """Deprecated cloud mode resolves to cloud-first hybrid with DeprecationWarning."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             opt_func = OptimizedFunction(
@@ -23,8 +22,8 @@ class TestCloudIntegration:
                 eval_dataset=sample_dataset,
                 execution_mode="cloud",
             )
-        assert opt_func.execution_mode == ExecutionMode.EDGE_ANALYTICS.value
-        assert opt_func._effective_execution_mode is ExecutionMode.EDGE_ANALYTICS
+        assert opt_func.execution_mode == ExecutionMode.HYBRID.value
+        assert opt_func._effective_execution_mode is ExecutionMode.HYBRID
         assert opt_func.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 

--- a/tests/unit/core/optimized_function_tests/test_optimization.py
+++ b/tests/unit/core/optimized_function_tests/test_optimization.py
@@ -828,10 +828,10 @@ class TestOptimization:
             opt_func.apply_best_config()
 
     @pytest.mark.asyncio
-    async def test_optimization_with_deprecated_cloud_resolves_to_edge_analytics(
+    async def test_optimization_with_deprecated_cloud_resolves_to_hybrid(
         self, simple_function, sample_config_space, sample_objectives, sample_dataset
     ):
-        """Deprecated cloud mode resolves to edge_analytics with DeprecationWarning."""
+        """Deprecated cloud mode resolves to cloud-first hybrid with DeprecationWarning."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
@@ -843,7 +843,7 @@ class TestOptimization:
                 eval_dataset=sample_dataset,
                 execution_mode="cloud",
             )
-        assert opt_func.execution_mode == "edge_analytics"
+        assert opt_func.execution_mode == "hybrid"
         assert opt_func.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -1551,6 +1551,147 @@ class TestHandleSessionCreationResult:
             "Bad request from session endpoint" in msg for msg in caplog.messages
         )
 
+    def test_cloud_brain_session_create_400_warns_and_marks_local_fallback(
+        self, traigent_config, objective_schema, mock_optimizer, caplog
+    ):
+        """Non-governed auto runs degrade locally when typed+legacy session create 400."""
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+        from traigent.config.types import resolve_execution_policy
+
+        traigent_config.execution_mode = "hybrid"
+        traigent_config.execution_policy = resolve_execution_policy(algorithm="auto")
+        manager = BackendSessionManager(
+            backend_client=Mock(),
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        result = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.SESSION_FAILED,
+            detail="Typed and legacy session-create returned HTTP 400",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                400, "Bad request from session endpoint"
+            ),
+            typed_legacy_session_create_400=True,
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="traigent.core.backend_session_manager"
+        ):
+            session_id = manager.handle_session_creation_result(result)
+
+        assert session_id == "local_test"
+        assert manager.result_source(trial_count=0) == "local_fallback"
+        assert traigent_config.result_source == "local_fallback"
+        assert traigent_config.no_egress is True
+        assert any("traigent.cloud_brain_fallback" in msg for msg in caplog.messages)
+        assert any("HTTP 400" in msg for msg in caplog.messages)
+
+    @pytest.mark.parametrize(
+        "policy_kwargs,require_cloud_env,governed_session",
+        [
+            ({"algorithm": "bayesian"}, None, False),
+            ({"algorithm": "auto", "require_cloud": True}, None, False),
+            ({"algorithm": "auto"}, "1", False),
+            ({"algorithm": "auto"}, None, True),
+        ],
+    )
+    def test_cloud_brain_session_create_400_still_raises_when_cloud_required(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_optimizer,
+        monkeypatch,
+        policy_kwargs,
+        require_cloud_env,
+        governed_session,
+    ):
+        """Strict/governed-style cloud-required runs do not absorb session-create 400."""
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+        from traigent.config.types import resolve_execution_policy
+        from traigent.utils.exceptions import ConfigurationError
+
+        if require_cloud_env:
+            monkeypatch.setenv("TRAIGENT_REQUIRE_CLOUD", require_cloud_env)
+        else:
+            monkeypatch.delenv("TRAIGENT_REQUIRE_CLOUD", raising=False)
+
+        traigent_config.execution_mode = "hybrid"
+        traigent_config.execution_policy = resolve_execution_policy(**policy_kwargs)
+        manager = BackendSessionManager(
+            backend_client=Mock(),
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        result = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.SESSION_FAILED,
+            detail="Typed and legacy session-create returned HTTP 400",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                400, "Bad request from session endpoint"
+            ),
+            typed_legacy_session_create_400=True,
+        )
+
+        with pytest.raises(ConfigurationError):
+            manager.handle_session_creation_result(
+                result, governed_session=governed_session
+            )
+
+    def test_cloud_brain_typed_only_session_create_400_still_raises(
+        self, traigent_config, objective_schema, mock_optimizer, monkeypatch
+    ):
+        """The 400 downgrade is limited to typed+legacy auto-contract failure."""
+        from traigent.cloud.session_types import (
+            SessionCreationFailureDetail,
+            SessionCreationFailureReason,
+            SessionCreationResult,
+        )
+        from traigent.config.types import resolve_execution_policy
+        from traigent.utils.exceptions import ConfigurationError
+
+        monkeypatch.delenv("TRAIGENT_REQUIRE_CLOUD", raising=False)
+        traigent_config.execution_mode = "hybrid"
+        traigent_config.execution_policy = resolve_execution_policy(algorithm="auto")
+        manager = BackendSessionManager(
+            backend_client=Mock(),
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-id",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+        result = SessionCreationResult.fallback(
+            session_id="local_test",
+            reason=SessionCreationFailureReason.SESSION_FAILED,
+            detail="Typed session-create returned HTTP 400",
+            failure_response=SessionCreationFailureDetail.from_http_response(
+                400, "Bad request from session endpoint"
+            ),
+        )
+
+        with pytest.raises(ConfigurationError):
+            manager.handle_session_creation_result(result)
+
     def test_idempotent_warns_only_once(
         self, traigent_config, objective_schema, mock_optimizer, caplog
     ):

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -659,10 +659,10 @@ class TestOptimizedFunction:
             assert evaluator_arg.custom_evaluator is mock_custom_evaluator
 
     @pytest.mark.asyncio
-    async def test_optimize_with_deprecated_cloud_resolves_to_edge_analytics(
+    async def test_optimize_with_deprecated_cloud_resolves_to_hybrid(
         self, mock_function, sample_config_space, sample_objectives, sample_dataset
     ):
-        """Deprecated cloud mode keeps cloud-first policy with edge_analytics compat mode."""
+        """Deprecated cloud mode keeps cloud-first policy with hybrid compat mode."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
@@ -675,7 +675,7 @@ class TestOptimizedFunction:
                 max_trials=5,
                 eval_dataset=sample_dataset,
             )
-        assert opt_func.execution_mode == "edge_analytics"
+        assert opt_func.execution_mode == "hybrid"
         assert opt_func.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
@@ -823,10 +823,10 @@ class TestOptimizedFunction:
             # This would happen during actual optimization call
             assert opt_func.algorithm == "random"  # Original value
 
-    def test_cloud_mode_deprecated_resolves_to_edge_analytics(
+    def test_cloud_mode_deprecated_resolves_to_hybrid(
         self, mock_function, sample_config_space, sample_objectives
     ):
-        """Deprecated cloud mode is accepted and resolves to edge_analytics."""
+        """Deprecated cloud mode is accepted and resolves to cloud-first hybrid."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
@@ -837,7 +837,7 @@ class TestOptimizedFunction:
                 objectives=sample_objectives,
                 execution_mode="cloud",
             )
-        assert opt_func.execution_mode == "edge_analytics"
+        assert opt_func.execution_mode == "hybrid"
         assert opt_func.execution_policy.intent.value == "cloud_brain"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 

--- a/tests/unit/plugins/test_plugin_architecture.py
+++ b/tests/unit/plugins/test_plugin_architecture.py
@@ -850,11 +850,11 @@ class TestTraigentClientEdgeAnalyticsMode:
                 if module_obj is not None:
                     sys.modules[mod] = module_obj
 
-    def test_traigent_client_cloud_mode_deprecated_resolves_to_edge_analytics(self):
+    def test_traigent_client_cloud_mode_deprecated_resolves_to_hybrid(self):
         """TraigentClient accepts deprecated cloud mode with DeprecationWarning.
 
         Cloud mode is no longer reserved — it emits DeprecationWarning and
-        resolves to edge_analytics.
+        resolves to hybrid.
         """
         import warnings
 
@@ -864,5 +864,5 @@ class TestTraigentClientEdgeAnalyticsMode:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             client = TraigentClient(execution_mode="cloud", agent_builder=None)
-        assert client.execution_mode == ExecutionMode.EDGE_ANALYTICS
+        assert client.execution_mode == ExecutionMode.HYBRID
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/unit/test_commercial_mode.py
+++ b/tests/unit/test_commercial_mode.py
@@ -22,10 +22,10 @@ def sample_dataset():
 
 
 class TestDeprecatedCloudMode:
-    """Public cloud mode is deprecated and emits DeprecationWarning, resolving to edge_analytics."""
+    """Public cloud mode is deprecated and emits DeprecationWarning, resolving to hybrid."""
 
     def test_decorator_with_cloud_execution_deprecated(self):
-        """The deprecated cloud mode emits DeprecationWarning and resolves to edge_analytics."""
+        """The deprecated cloud mode emits DeprecationWarning and resolves to hybrid."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
@@ -61,10 +61,10 @@ class TestDeprecatedCloudMode:
 
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
-    def test_optimized_function_cloud_deprecated_resolves_to_edge_analytics(
+    def test_optimized_function_cloud_deprecated_resolves_to_hybrid(
         self, sample_dataset
     ):
-        """Direct OptimizedFunction with cloud mode resolves to edge_analytics."""
+        """Direct OptimizedFunction with cloud mode resolves to hybrid."""
         import warnings
 
         def test_func(x: str) -> str:
@@ -79,7 +79,7 @@ class TestDeprecatedCloudMode:
                 configuration_space={"param": [1, 2, 3]},
                 execution_mode="cloud",
             )
-        assert opt_func.execution_mode == "edge_analytics"
+        assert opt_func.execution_mode == "hybrid"
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
 

--- a/tests/unit/test_traigent_client.py
+++ b/tests/unit/test_traigent_client.py
@@ -108,14 +108,14 @@ class TestDetermineExecutionMode:
         assert client.execution_mode == ExecutionMode.HYBRID
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
-    def test_explicit_cloud_mode_deprecated_resolves_to_edge_analytics(self) -> None:
-        """Deprecated cloud mode warns and resolves to edge_analytics."""
+    def test_explicit_cloud_mode_deprecated_resolves_to_hybrid(self) -> None:
+        """Deprecated cloud mode warns and resolves to hybrid."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             client = TraigentClient(execution_mode="cloud")
-        assert client.execution_mode == ExecutionMode.EDGE_ANALYTICS
+        assert client.execution_mode == ExecutionMode.HYBRID
         assert any(issubclass(w.category, DeprecationWarning) for w in caught)
 
     @patch("traigent.traigent_client.BackendIntegratedClient")

--- a/tests/unit/utils/test_optimization_logger.py
+++ b/tests/unit/utils/test_optimization_logger.py
@@ -465,7 +465,7 @@ class TestLogTrialResult:
         assert len(log._trial_buffer) == 0
 
     def test_deprecated_cloud_mode_still_buffers(self, tmp_path: Path) -> None:
-        """Deprecated cloud mode resolves to edge_analytics and buffers trials normally."""
+        """Deprecated cloud mode resolves to a supported runtime and buffers trials normally."""
         import warnings
 
         with warnings.catch_warnings(record=True) as caught:

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -2227,6 +2227,8 @@ def optimize(  # NOSONAR(S107)
     legacy_args = _parse_legacy_args(legacy)
 
     combined_settings = dict(_OPTIMIZE_DEFAULTS)
+    if "execution_mode" in _GLOBAL_CONFIG:
+        combined_settings["execution_mode"] = _GLOBAL_CONFIG["execution_mode"]
     provided_sources: dict[str, str] = {}
     record_option = _build_settings_recorder(combined_settings, provided_sources)
 

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -19,7 +19,7 @@ from traigent.config.parallel import (
     coerce_parallel_config,
     merge_parallel_configs,
 )
-from traigent.config.types import TraigentConfig
+from traigent.config.types import TraigentConfig, validate_execution_mode
 from traigent.optimizers import list_optimizers
 from traigent.optimizers.registry import _is_smart_algorithm
 from traigent.utils.exceptions import (
@@ -283,6 +283,8 @@ def _apply_additional_overrides(overrides: dict[str, Any]) -> None:
     """Merge arbitrary keyword overrides into the global configuration."""
 
     for key, value in overrides.items():
+        if key == "execution_mode" and value is not None:
+            value = validate_execution_mode(value).value
         _GLOBAL_CONFIG[key] = value
 
 

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -445,7 +445,7 @@ class ApiOperations:
                 return await self._post_session_creation(
                     session_payload, headers, connector
                 )
-            except CloudServiceError:
+            except CloudServiceError as typed_exc:
                 # auto-contract fallback: a failed TYPED create may retry the
                 # legacy shape ONCE — and only for NON-governed sessions
                 # (governed sessions must fail loudly; the legacy contract
@@ -463,9 +463,20 @@ class ApiOperations:
                 legacy_payload = self._build_legacy_session_payload(
                     session_request, max_trials_value
                 )
-                return await self._post_session_creation(
-                    legacy_payload, headers, connector
-                )
+                try:
+                    return await self._post_session_creation(
+                        legacy_payload, headers, connector
+                    )
+                except CloudServiceError as legacy_exc:
+                    typed_detail = getattr(typed_exc, "session_creation_failure", None)
+                    legacy_detail = getattr(
+                        legacy_exc, "session_creation_failure", None
+                    )
+                    typed_status = getattr(typed_detail, "status_code", None)
+                    legacy_status = getattr(legacy_detail, "status_code", None)
+                    if typed_status == 400 and legacy_status == 400:
+                        cast(Any, legacy_exc).typed_legacy_session_create_400 = True
+                    raise
         except SessionContractError:
             # Review round 3: contract failures must reach the caller AS
             # THEMSELVES — the generic wrap below would demote them to a
@@ -481,6 +492,10 @@ class ApiOperations:
             # BACKEND_UNREACHABLE ("check your network/URL") instead of an
             # auth/permission error (MISSING_PERMISSION / INVALID_OR_REVOKED_KEY).
             raise
+        except CloudServiceError as e:
+            if getattr(e, "typed_legacy_session_create_400", False):
+                raise
+            self._handle_generic_session_exception(e)
         except aiohttp.ClientConnectorError as e:
             self._handle_connector_error(e)
         except aiohttp.ClientError as e:

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -605,6 +605,9 @@ class SessionOperations:
                     reason=SessionCreationFailureReason.SESSION_FAILED,
                     detail=detail,
                     failure_response=failure_response,
+                    typed_legacy_session_create_400=bool(
+                        getattr(e, "typed_legacy_session_create_400", False)
+                    ),
                 )
 
         # Run async method in sync context

--- a/traigent/config/backend_config.py
+++ b/traigent/config/backend_config.py
@@ -118,11 +118,13 @@ class BackendConfig:
 
         origin = cls._normalize_origin(backend_env)
         if origin:
+            cls._log_env_backend_override_if_different("TRAIGENT_BACKEND_URL", origin)
             logger.debug("Using TRAIGENT_BACKEND_URL: %s", origin)
             return origin
 
         api_origin, _ = cls._extract_origin_and_path(api_env)
         if api_origin:
+            cls._log_env_backend_override_if_different("TRAIGENT_API_URL", api_origin)
             logger.debug("Using TRAIGENT_API_URL origin: %s", api_origin)
             return api_origin
 
@@ -142,6 +144,28 @@ class BackendConfig:
             pass
 
         return None
+
+    @classmethod
+    def _log_env_backend_override_if_different(
+        cls, env_name: str, env_origin: str
+    ) -> None:
+        """Log when an env backend URL intentionally overrides stored CLI state."""
+
+        try:
+            from traigent.cloud.credential_manager import CredentialManager
+
+            raw_url = CredentialManager.get_stored_backend_url()
+        except (ImportError, AttributeError):
+            return
+
+        stored_url = cls._normalize_origin(raw_url) if raw_url else None
+        if stored_url and stored_url != env_origin:
+            logger.info(
+                "%s overrides stored CLI backend_url: stored=%s env=%s",
+                env_name,
+                stored_url,
+                env_origin,
+            )
 
     @classmethod
     def get_configured_backend_url(cls) -> str | None:

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -280,10 +280,10 @@ def resolve_execution_mode(
             _warn_deprecated_execution_mode_alias(
                 mode,
                 "Use resolve_execution_policy() for the new cloud-first policy. "
-                "This deprecated compatibility helper still maps it to "
-                "edge_analytics.",
+                "This deprecated compatibility helper maps it to the cloud-first "
+                "hybrid runtime.",
             )
-            return ExecutionMode.EDGE_ANALYTICS
+            return ExecutionMode.HYBRID
         if normalized == "local":
             _warn_deprecated_execution_mode_alias(
                 mode,

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -37,6 +37,7 @@ from traigent.core.execution_policy_runtime import (
     policy_is_cloud_brain,
     policy_requires_cloud,
     session_failure_is_connectivity,
+    session_failure_is_session_create_400,
 )
 from traigent.core.metadata_helpers import build_backend_metadata
 from traigent.core.objectives import ObjectiveSchema
@@ -366,7 +367,9 @@ class BackendSessionManager:
         self._backend_tracking_enabled = False
         self._backend_disabled_reason = reason
 
-    def handle_session_creation_result(self, result: SessionCreationResult) -> str:
+    def handle_session_creation_result(
+        self, result: SessionCreationResult, *, governed_session: bool = False
+    ) -> str:
         """Consume a SessionCreationResult: flip breaker, emit warning, return session_id.
 
         Single place that interprets the structured result — ensures warning text
@@ -392,10 +395,17 @@ class BackendSessionManager:
                     "Cloud execution is required, but backend session creation "
                     f"failed: {fallback_reason}"
                 )
+            if governed_session:
+                raise ConfigurationError(
+                    "Governed backend session creation failed; local fallback is "
+                    f"not allowed: {fallback_reason}"
+                )
             if policy_is_cloud_brain(policy):
-                if policy_allows_cloud_fallback(
-                    policy
-                ) and session_failure_is_connectivity(result):
+                cloud_fallback_allowed = policy_allows_cloud_fallback(policy)
+                if cloud_fallback_allowed and (
+                    session_failure_is_connectivity(result)
+                    or session_failure_is_session_create_400(result)
+                ):
                     self._fallback_reason = fallback_reason
                     mark_local_fallback(self._traigent_config, fallback_reason)
                     logger.warning(
@@ -719,7 +729,10 @@ class BackendSessionManager:
                 tvl_governance=tvl_governance,
             )
             result = self.normalize_session_creation_result(raw_result)
-            session_id = self.handle_session_creation_result(result)
+            session_id = self.handle_session_creation_result(
+                result,
+                governed_session=bool(promotion_policy or tvl_governance),
+            )
             if result.backend_connected:
                 owning_context = {
                     key: normalized

--- a/traigent/core/execution_policy_runtime.py
+++ b/traigent/core/execution_policy_runtime.py
@@ -244,6 +244,18 @@ def session_failure_is_connectivity(result: SessionCreationResult) -> bool:
     return bool(_contains_any(text, CONNECTIVITY_PATTERNS))
 
 
+def session_failure_is_session_create_400(result: SessionCreationResult) -> bool:
+    """Return true for the auto-contract typed+legacy HTTP 400 failure."""
+
+    if not result.typed_legacy_session_create_400:
+        return False
+    detail = result.failure_response
+    if detail and detail.status_code == 400:
+        return True
+    text = _combined_session_text(result)
+    return "http 400" in text or "status 400" in text
+
+
 def exception_status(exc: BaseException) -> int | None:
     """Extract an HTTP status code from common cloud/backend exception shapes."""
 

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -497,8 +497,6 @@ class OptimizedFunction:
                 execution_mode=execution_mode,
                 source_hint="optimized_function",
             )
-        else:
-            execution_mode = self._requested_execution_mode or execution_mode
 
         try:
             effective_mode_enum = validate_execution_mode(execution_mode)

--- a/traigent/core/session_types.py
+++ b/traigent/core/session_types.py
@@ -114,6 +114,7 @@ class SessionCreationResult:
     failure_response: SessionCreationFailureDetail | None = None
     project_id: str | None = None
     tenant_id: str | None = None
+    typed_legacy_session_create_400: bool = False
 
     def __str__(self) -> str:
         """Return the session ID string for backwards compatibility.
@@ -153,6 +154,7 @@ class SessionCreationResult:
         reason: SessionCreationFailureReason,
         detail: str | None = None,
         failure_response: SessionCreationFailureDetail | None = None,
+        typed_legacy_session_create_400: bool = False,
     ) -> SessionCreationResult:
         """Factory for a local-fallback session after backend failure."""
         return cls(
@@ -161,4 +163,5 @@ class SessionCreationResult:
             failure_reason=reason,
             failure_detail=detail,
             failure_response=failure_response,
+            typed_legacy_session_create_400=typed_legacy_session_create_400,
         )


### PR DESCRIPTION
Three execution/credential SDK fixes from the 2026-06-24 dev incident. Dual-gated: codex 5.5 xhigh built; opus adversarially reviewed → MERGEABLE (fail-closed path verified; all 9 updated tests audited as strengthenings, not weakenings).

### #1483 — `algorithm="auto"` degrades to local on session-create 400 (was: total abort)
Non-governed CLOUD_BRAIN `auto` runs whose **typed AND legacy** session-create both 400 now degrade to local with a loud `logger.warning("traigent.cloud_brain_fallback ...")` instead of raising `ConfigurationError`. **Triple-guarded fail-closed:** governed sessions, strict mode, `TRAIGENT_REQUIRE_CLOUD=1`, and typed-only-400 all still RAISE. Trial/result 400 behavior unchanged.

### #1484 — `execution_mode="cloud"` consistency (was: split-brain)
`execution_mode="cloud"` now maps to the cloud-first `hybrid` runtime, so policy / runtime / logged-mode / metadata agree (previously policy said `cloud_brain` while runtime silently said `edge_analytics`, producing the misleading "Configuring for edge_analytics" log). `initialize(execution_mode="cloud")` consumed consistently by decorators. Deprecation warning still fires. 9 existing tests updated to assert corrected `mode=="hybrid"` (each still asserts `intent=="cloud_brain"` + deprecation) + a new fail-closed suite.

### #1485 — credential env-precedence visibility (LOW)
Adds a `logger` line when `TRAIGENT_BACKEND_URL`/`TRAIGENT_API_URL` overrides a *different* stored CLI backend_url (no secret leak — URLs only), + a regression test exercising the full `CredentialManager.get_credentials()` path with stale stored creds present (env wins). Original report was a local stale-`credentials.json` artifact; develop is env-first.

### Checklist
- Worst-case prod path: a cloud-REQUIRED run still hard-fails (no silent local egress/cost mismatch) — parametrized raise tests. Only best-effort non-governed `auto` degrades, loudly.
- Tests: `test_cloud_brain_session_create_400_*`, `test_get_credentials_env_url_and_key_override_stale_stored_credentials`, + 9 updated execmode tests.
- No quality gate relaxed.

Spine-Trail: st_e6eea6dc9b92