### PR TITLE
fix(sdk): warn on boolean configuration_space knobs before cloud session-create 400 (#1488)

### DIFF
--- a/tests/unit/cloud/test_configspace_bool_warning.py
+++ b/tests/unit/cloud/test_configspace_bool_warning.py
@@ -1,0 +1,126 @@
+"""Regression coverage for boolean configuration_space cloud diagnostics."""
+
+import logging
+from unittest.mock import Mock
+
+from traigent.cloud.api_operations import ApiOperations, _typed_configuration_space
+from traigent.cloud.models import SessionCreationRequest
+
+LOGGER_NAME = "traigent.cloud.api_operations"
+
+
+def _request(configuration_space):
+    return SessionCreationRequest(
+        function_name="answer_question",
+        configuration_space=configuration_space,
+        objectives=["accuracy"],
+        dataset_metadata={"size": 3},
+        max_trials=5,
+        metadata={"evaluation_set": "dev"},
+    )
+
+
+def _bool_config_warnings(caplog):
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and "configuration_space parameter(s)" in record.getMessage()
+        and "boolean values" in record.getMessage()
+    ]
+
+
+def test_boolean_choice_list_warns_once_with_field_and_workaround(caplog):
+    config_space = {
+        "include_schema": [True, False],
+        "model": ["cheap", "strong"],
+        "top_k": [1, 3],
+        "temperature": {"low": 0.0, "high": 1.0},
+    }
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        normalized = _typed_configuration_space(config_space)
+
+    warnings = _bool_config_warnings(caplog)
+    assert len(warnings) == 1
+    warning = warnings[0]
+    assert "include_schema" in warning
+    assert "#1488" in warning
+    assert "strings" in warning
+    assert "0/1" in warning
+    assert normalized["include_schema"] == {
+        "type": "categorical",
+        "choices": [True, False],
+    }
+    assert normalized["model"] == {
+        "type": "categorical",
+        "choices": ["cheap", "strong"],
+    }
+
+
+def test_non_boolean_configuration_space_does_not_warn(caplog):
+    config_space = {
+        "model": ["cheap", "strong"],
+        "top_k": [1, 3],
+        "temperature": {"low": 0.0, "high": 1.0},
+        "mode": {"type": "categorical", "choices": ["with", "without"]},
+        "ratio": (0.1, 0.5),
+    }
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        _typed_configuration_space(config_space)
+
+    assert _bool_config_warnings(caplog) == []
+
+
+def test_scalar_bool_and_typed_categorical_bool_are_detected(caplog):
+    config_space = {
+        "enabled": True,
+        "include_schema": {"type": "categorical", "choices": [True, False]},
+        "format": "json",
+    }
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        normalized = _typed_configuration_space(config_space)
+
+    warnings = _bool_config_warnings(caplog)
+    assert len(warnings) == 1
+    warning = warnings[0]
+    assert "enabled" in warning
+    assert "include_schema" in warning
+    assert normalized["enabled"] == {"type": "categorical", "choices": [True]}
+    assert normalized["include_schema"] is config_space["include_schema"]
+
+
+def test_values_key_in_typed_categorical_bool_is_detected(caplog):
+    config_space = {
+        "use_context": {"type": "categorical", "values": [True, False]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        normalized = _typed_configuration_space(config_space)
+
+    warnings = _bool_config_warnings(caplog)
+    assert len(warnings) == 1
+    assert "use_context" in warnings[0]
+    assert normalized["use_context"] is config_space["use_context"]
+
+
+def test_explicit_legacy_payload_warns_once_without_changing_search_space(
+    monkeypatch, caplog
+):
+    monkeypatch.setenv("TRAIGENT_SESSION_CONTRACT", "legacy")
+    config_space = {
+        "include_schema": [True, False],
+        "model": ["cheap", "strong"],
+    }
+
+    with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        payload = ApiOperations(Mock())._build_session_payload(
+            _request(config_space), max_trials=5
+        )
+
+    warnings = _bool_config_warnings(caplog)
+    assert len(warnings) == 1
+    assert "include_schema" in warnings[0]
+    assert payload["search_space"] is config_space

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -217,6 +217,52 @@ def map_status_to_wire(status: str, *, endpoint: str = "experiment_run") -> str:
     return mapped
 
 
+def _choice_sequence_contains_bool(values: Any) -> bool:
+    """Return True when a categorical choice container contains a bool."""
+
+    if not isinstance(values, (list, tuple)):
+        return False
+    return any(isinstance(value, bool) for value in values)
+
+
+def _configuration_space_entry_uses_bool(entry: Any) -> bool:
+    """Detect bool-valued knobs without changing their wire representation."""
+
+    # bool is a subclass of int, so detect it before any numeric handling.
+    if isinstance(entry, bool):
+        return True
+    if isinstance(entry, (list, tuple)):
+        return _choice_sequence_contains_bool(entry)
+    if isinstance(entry, dict):
+        return _choice_sequence_contains_bool(
+            entry.get("choices")
+        ) or _choice_sequence_contains_bool(entry.get("values"))
+    return False
+
+
+def _warn_boolean_config_values(space: Any) -> None:
+    """Warn when configuration_space contains bools the cloud API rejects."""
+
+    if not isinstance(space, dict):
+        return
+
+    offending_parameters = [
+        str(name)
+        for name, entry in space.items()
+        if _configuration_space_entry_uses_bool(entry)
+    ]
+    if not offending_parameters:
+        return
+
+    logger.warning(
+        "configuration_space parameter(s) %s use boolean values, which the "
+        "cloud session API does not accept and will reject with a generic "
+        "HTTP 400. Encode boolean knobs as strings (e.g. ['with','without']) "
+        "or integers (0/1) and map back at the call site. See issue #1488.",
+        offending_parameters,
+    )
+
+
 def _typed_configuration_space(space: Any) -> Any:
     """Normalize shorthand configuration space to the typed wire contract.
 
@@ -229,6 +275,7 @@ def _typed_configuration_space(space: Any) -> Any:
     """
     if not isinstance(space, dict):
         return space
+    _warn_boolean_config_values(space)
     normalized: dict[str, Any] = {}
     for name, entry in space.items():
         if isinstance(entry, (list, tuple)):
@@ -461,7 +508,9 @@ class ApiOperations:
                     "TRAIGENT_SESSION_CONTRACT=auto)"
                 )
                 legacy_payload = self._build_legacy_session_payload(
-                    session_request, max_trials_value
+                    session_request,
+                    max_trials_value,
+                    warn_boolean_config_values=False,
                 )
                 try:
                     return await self._post_session_creation(
@@ -606,12 +655,18 @@ class ApiOperations:
         return payload
 
     def _build_legacy_session_payload(
-        self, session_request: SessionCreationRequest, max_trials: int
+        self,
+        session_request: SessionCreationRequest,
+        max_trials: int,
+        *,
+        warn_boolean_config_values: bool = True,
     ) -> dict[str, Any]:
         """The pre-Phase-8 legacy shape (problem_statement/search_space) —
         non-governed compatibility only."""
         metadata = session_request.metadata or {}
         evaluation_set = metadata.get("evaluation_set", "default")
+        if warn_boolean_config_values:
+            _warn_boolean_config_values(session_request.configuration_space)
 
         return {
             "problem_statement": session_request.function_name,


### PR DESCRIPTION
## Summary
Boolean values in `configuration_space` (e.g. `include_schema=[True, False]`) are wrapped into categorical choices and sent to the cloud session API, which rejects boolean choices with a generic **HTTP 400 (VALIDATION_ERROR)** naming no field. Users had to bisect the config space to find the culprit (#1488).

This PR adds **client-side detection** of boolean config-space values and emits one clear, **field-naming warning before the network round-trip**, telling the user which knob is unsupported and how to encode it (strings or 0/1).

## Scope (deliberate)
Fixes the **SDK debuggability half** of #1488. It intentionally:
- **does NOT hard-raise** — preserves the `algorithm=auto` degrade-to-local recovery on a session-create 400 (added in #1487); non-breaking.
- **does NOT coerce** booleans on the wire — that would silently corrupt the value the user's function receives at injection.

Detection covers raw scalar bool, list/tuple choices (`[True, False]`), and `{type:categorical, choices/values:[...]}` dict shapes (bool checked before int, since `bool` subclasses `int`).

## Cross-repo follow-up (out of scope here)
The **capability** gap — the backend rejecting boolean categorical choices — and a **field-specific 400 message** are a backend/schema concern. The OpenAPI `configuration_space` schema is a permissive `{type: object}`, so the rejection is deeper backend validation. Follow-up: TraigentBackend should accept boolean categorical choices (or return a field-specific 400). No other repos edited in this PR.

## Testing
`tests/unit/cloud/test_configspace_bool_warning.py` (failing-first -> passing): warning names the field + mentions #1488/workaround; no warning for non-bool knobs (strings/ints/floats/ranges); scalar/list/dict detection; normalized wire payload unchanged (no coercion); explicit legacy-path behavior.
- `python3 -m pytest tests/unit/cloud/test_configspace_bool_warning.py -q -n 0` -> 5 passed
- `tests/unit/cloud/test_api_operations.py::TestTypedConfigurationSpace -q -n 0` -> 12 passed

Reviewed GO by codex gpt-5.5-xhigh (impl) and opus-4.8 (independent review).

## PR checklist
1. **Worst-case prod path** - pure `logger.warning`; no behavior/branch change, no policy surface. Worst case is an extra log line.
2. **Production-branch test** - N/A (no production-gated branch); behavior is environment-independent. Tests assert the warning fires/does-not-fire and payload is unchanged.
3. **Contract regeneration** - none in this PR; the boolean **capability** is a noted backend/schema follow-up.
4. **Public surface delta** - none; no `__all__`/route/OpenAPI change.
5. **Review threads resolved** - will resolve all bot/human threads before merge.
6. **Quality gates not relaxed** - no gate changes.

Refs #1488 (debuggability half only; capability gap is a backend follow-up — issue stays open)

Spine-Trail: st_691b1fd5bbfb