### PR TITLE
fix(sdk-evaluators): exclude unknown evaluation_type from accuracy denominator + typed/bool exact-match hardening (#1452 #1463)

### DIFF
--- a/tests/unit/adapters/test_execution_adapter.py
+++ b/tests/unit/adapters/test_execution_adapter.py
@@ -108,6 +108,11 @@ async def test_local_adapter_unknown_evaluation_type_fails_closed():
     dataset = {
         "examples": [
             {
+                "input": {"text": "valid"},
+                "expected_output": "OK",
+                "metadata": {"evaluation_type": "exact_match"},
+            },
+            {
                 "input": {"text": "a"},
                 "expected_output": "OK",
                 "metadata": {"evaluation_type": "bogus"},
@@ -119,9 +124,11 @@ async def test_local_adapter_unknown_evaluation_type_fails_closed():
         agent_spec={}, dataset=dataset, trial_id="unknown-eval"
     )
 
-    assert result["metrics"]["accuracy"] == 0.0
-    assert result["metrics"]["success_rate"] == 0.0
-    assert result["metrics"]["accuracy_bogus"] == 0.0
+    assert result["metrics"]["accuracy"] == 1.0
+    assert result["metrics"]["success_rate"] == 0.5
+    assert result["metrics"]["examples_with_ground_truth"] == 1.0
+    assert result["metrics"]["accuracy_exact_match"] == 1.0
+    assert "accuracy_bogus" not in result["metrics"]
     assert result["metadata"]["failures"] == 1
 
 

--- a/tests/unit/evaluators/test_accuracy_comparison_regressions.py
+++ b/tests/unit/evaluators/test_accuracy_comparison_regressions.py
@@ -64,3 +64,58 @@ def test_numeric_accuracy_uses_float_tolerance_across_paths() -> None:
         [expected],
     )
     assert metrics_result.metrics["accuracy"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_issue_1464_numeric_accuracy_tolerance_keeps_real_mismatches() -> None:
+    """Numeric exact-match accuracy tolerates float noise but not real mismatches."""
+    evaluator = LocalEvaluator(metrics=["accuracy"], detailed=True)
+    dataset = Dataset(
+        [
+            EvaluationExample({"case": "float_noise"}, 0.3),
+            EvaluationExample({"case": "different"}, 2.0),
+        ],
+        name="numeric_tolerance_regression",
+    )
+
+    def numeric_outputs(input_data: dict[str, str]) -> float:
+        if input_data["case"] == "float_noise":
+            return 0.1 + 0.2
+        return 1.0
+
+    result = await evaluator.evaluate(numeric_outputs, {}, dataset)
+
+    assert result.metrics["accuracy"] == pytest.approx(0.5)
+    assert result.example_results[0].metrics["accuracy"] == pytest.approx(1.0)
+    assert result.example_results[1].metrics["accuracy"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_issue_1463_string_outputs_match_typed_expected_values(caplog) -> None:
+    """Exact-match accuracy compares string model outputs to typed expected values."""
+    caplog.set_level("WARNING", logger="traigent.evaluators.base")
+    evaluator = LocalEvaluator(metrics=["accuracy"], detailed=True)
+    dataset = Dataset(
+        [
+            EvaluationExample({"case": "int"}, 42),
+            EvaluationExample({"case": "float"}, 3.0),
+            EvaluationExample({"case": "mismatch"}, 42),
+        ],
+        name="typed_expected_regression",
+    )
+
+    def string_outputs(input_data: dict[str, str]) -> str:
+        outputs = {
+            "int": "42",
+            "float": "3.0",
+            "mismatch": "43",
+        }
+        return outputs[input_data["case"]]
+
+    result = await evaluator.evaluate(string_outputs, {}, dataset)
+
+    assert result.metrics["accuracy"] == pytest.approx(2 / 3)
+    assert result.example_results[0].metrics["accuracy"] == pytest.approx(1.0)
+    assert result.example_results[1].metrics["accuracy"] == pytest.approx(1.0)
+    assert result.example_results[2].metrics["accuracy"] == pytest.approx(0.0)
+    assert "Coercing string output" in caplog.text

--- a/tests/unit/test_coverage_improvements.py
+++ b/tests/unit/test_coverage_improvements.py
@@ -382,8 +382,12 @@ async def test_local_adapter_unknown_evaluation_type():
         agent_spec={}, dataset=dataset, trial_id="unknown-type-1"
     )
 
-    # Unknown evaluation type should still complete
+    # Unknown evaluation type should still complete, but it is an errored
+    # example and must not contribute a bogus 0% accuracy bucket.
     assert result["metrics"]["total_examples"] == 1.0
+    assert result["metrics"]["success_rate"] == 0.0
+    assert result["metrics"]["examples_with_ground_truth"] == 0.0
+    assert "accuracy_unknown_custom_type" not in result["metrics"]
 
 
 @pytest.mark.asyncio

--- a/traigent/adapters/execution_adapter.py
+++ b/traigent/adapters/execution_adapter.py
@@ -246,7 +246,6 @@ class LocalExecutionAdapter(ExecutionAdapter):
 
         else:
             # Unknown evaluation type
-            result["correct"] = False
             result["success"] = False
             result["unknown_eval_type"] = eval_type
             result["error"] = (
@@ -256,7 +255,8 @@ class LocalExecutionAdapter(ExecutionAdapter):
             )
             logger.error(
                 "Unsupported evaluation_type %r for LocalExecutionAdapter; marking "
-                "example as failed. trial_id=%s example_index=%s",
+                "example as failed and excluding it from accuracy. "
+                "trial_id=%s example_index=%s",
                 eval_type,
                 trial_id or "<unknown>",
                 example_index if example_index is not None else "<unknown>",

--- a/traigent/evaluators/base.py
+++ b/traigent/evaluators/base.py
@@ -113,7 +113,16 @@ def _coerce_string_to_expected_type(actual: str, expected: Any) -> tuple[Any, bo
 
 
 def _typed_accuracy_equality(actual: Any, expected: Any) -> bool:
-    """Return direct equality for accuracy comparisons with an explicit bool type."""
+    """Return direct equality, treating bool as distinct from plain numerics.
+
+    Python's ``bool`` is an ``int`` subclass, so ``True == 1`` and ``False == 0``.
+    For typed exact-match accuracy that conflation silently scores a numeric
+    output as a boolean match (and vice versa). When exactly one side is a bool
+    and the other is a non-bool number, the values do not match.
+    """
+    if isinstance(actual, bool) != isinstance(expected, bool):
+        if isinstance(actual, (int, float)) and isinstance(expected, (int, float)):
+            return False
     return cast(bool, actual == expected)
 
 
@@ -2219,7 +2228,11 @@ class BaseEvaluator(ABC):
         if error is None and example.expected_output is not None:
             try:
                 metrics_payload["accuracy"] = (
-                    1.0 if result.actual_output == example.expected_output else 0.0
+                    1.0
+                    if _accuracy_values_match(
+                        result.actual_output, example.expected_output
+                    )
+                    else 0.0
                 )
             except Exception as exc:
                 logger.warning(


### PR DESCRIPTION
Closes #1452
Closes #1463

## What
- **#1452**: an unknown/unsupported `evaluation_type` no longer sets `result["correct"]=False`, which polluted the accuracy denominator and silently dragged accuracy down. Verified failing-first on develop (accuracy scored 0.5 instead of 1.0 with a bogus type); the example is now marked failed and excluded from the denominator.
- **#1463**: the per-example accuracy path now routes through the typed `_accuracy_values_match` comparator (string output is coerced/compared against a typed expected, with a warning) and `bool` is treated as distinct from plain numerics (`True != 1`, `False != 0`).

## Notes
- **#1464** (float-tolerance accuracy) is **already addressed on develop** via the `math.isclose` `rel_tol` path; no `abs_tol` change is made here.
- Tests: `tests/unit/evaluators` + `tests/unit/adapters/test_execution_adapter.py` → 433 passed, 2 skipped.

## PR checklist
- Worst-case prod path: accuracy mis-scoring only; no auth/billing/data-leak surface.
- Production-branch test: n/a (no production gating).
- Contract regeneration: none.
- Public surface delta: none.
- Quality gates: not relaxed.

Spine-Trail: st_b94fffa9e8c1