### PR TITLE
fix(sdk-result): cost-limit stop_reason precedence + PRUNED/FAILED token accounting (#1461 #1462)

### DIFF
--- a/tests/unit/core/test_metrics_aggregator.py
+++ b/tests/unit/core/test_metrics_aggregator.py
@@ -122,6 +122,29 @@ def test_mandatory_metrics_prefer_trial_values() -> None:
     assert aggregated.processed_metrics["total_tokens"] == 20
 
 
+def test_pruned_spend_counts_but_objective_metrics_stay_completed_only() -> None:
+    registry = MetricRegistry.default()
+
+    completed = make_trial(
+        trial_id="completed",
+        metrics={"accuracy": 0.8, "total_cost": 0.11, "total_tokens": 100},
+        status=TrialStatus.COMPLETED,
+    )
+    pruned = make_trial(
+        trial_id="pruned",
+        metrics={"accuracy": 0.1, "total_cost": 0.07, "total_tokens": 40},
+        status=TrialStatus.PRUNED,
+    )
+
+    aggregated = aggregate_metrics([completed, pruned], registry)
+
+    assert aggregated.total_cost == pytest.approx(0.18)
+    assert aggregated.total_tokens == 140
+    assert aggregated.processed_metrics["total_cost"] == pytest.approx(0.18)
+    assert aggregated.processed_metrics["total_tokens"] == 140
+    assert aggregated.processed_metrics["accuracy"] == pytest.approx(0.8)
+
+
 def test_build_safeguards_telemetry_defaults_to_allow_repeats() -> None:
     telemetry = build_safeguards_telemetry(
         trials_prevented=2,

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -2309,6 +2309,35 @@ class TestStopReasonInResult:
         assert 1 <= len(result.trials) <= 3
         assert orchestrator.cost_enforcer.get_status().limit_reached is True
 
+    @pytest.mark.asyncio
+    async def test_stop_reason_cost_limit_precedes_max_trials(
+        self, sample_dataset, monkeypatch
+    ):
+        """If cost and trial limits are both true, report the binding cost guard."""
+        monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
+        config_space = {"param1": (0, 1)}
+        optimizer = MockOptimizer(config_space, ["accuracy"])
+        optimizer.set_max_suggestions(10)
+
+        evaluator = MockEvaluator(metrics=["accuracy"])
+        evaluator.set_metrics({"accuracy": 0.5, "cost": 0.06})
+
+        orchestrator = OptimizationOrchestrator(
+            optimizer=optimizer,
+            evaluator=evaluator,
+            max_trials=2,
+            config=TraigentConfig.edge_analytics_mode(),
+            cost_limit=0.12,
+            cost_approved=True,
+        )
+
+        result = await orchestrator.optimize(lambda _: "ok", sample_dataset)
+
+        assert len(result.trials) == 2
+        assert orchestrator.cost_enforcer.get_status().limit_reached is True
+        assert result.stop_reason == "cost_limit"
+        assert result.stop_reason != "max_trials_reached"
+
 
 class TestUsageAnalyticsSubmission:
     """Tests for optimization-completion analytics submission."""

--- a/tests/unit/core/test_trial_result_factory.py
+++ b/tests/unit/core/test_trial_result_factory.py
@@ -65,6 +65,7 @@ def progress_state():
         "total_examples": 20,
         "correct_sum": 8.5,
         "total_cost": 0.15,
+        "total_tokens": 321,
     }
 
 
@@ -518,6 +519,7 @@ class TestBuildPrunedResult:
         assert "cost" in result.metrics
         assert result.metrics["cost"] == 0.15
         assert result.metadata["total_example_cost"] == 0.15
+        assert result.metrics["total_tokens"] == 321
 
     def test_pruned_with_optuna_id(self, eval_config, prune_error):
         """Test pruned result includes optuna trial ID."""
@@ -699,6 +701,7 @@ class TestBuildFailedResult:
         assert "total_cost" in result.metrics
         assert result.metrics["total_cost"] == 0.15
         assert result.metadata["total_example_cost"] == 0.15
+        assert result.metrics["total_tokens"] == 321
 
     def test_failed_with_optuna_id(self, eval_config):
         """Test failed result includes optuna trial ID."""

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2423,6 +2423,11 @@ class OptimizationOrchestrator:
         """Check cost approval before optimization. Delegates to CostEstimator."""
         self._cost_estimator.check_cost_approval(dataset)
 
+    def _is_cost_limit_reached(self) -> bool:
+        """Return whether the shared cost enforcer has hit its run limit."""
+        cost_enforcer = getattr(self, "cost_enforcer", None)
+        return bool(cost_enforcer is not None and cost_enforcer.is_limit_reached)
+
     def _check_budget_limits(
         self, trial_count: int
     ) -> tuple[float, float, StopReason | None]:
@@ -2434,6 +2439,10 @@ class OptimizationOrchestrator:
         remaining = (
             float("inf") if self.max_trials is None else self.max_trials - trial_count
         )
+
+        if self._is_cost_limit_reached():
+            logger.info("Cost limit reached")
+            return remaining, 0, "cost_limit"
 
         if remaining <= 0:
             logger.info(f"Trial limit reached: {self.max_trials}")
@@ -2452,7 +2461,7 @@ class OptimizationOrchestrator:
         """Record a budget stop reason and return True if the loop should break."""
         if not budget_stop:
             return False
-        if not self._stop_reason:
+        if budget_stop == "cost_limit" or not self._stop_reason:
             self._stop_reason = budget_stop
         return True
 
@@ -3050,18 +3059,19 @@ class OptimizationOrchestrator:
         # Evaluate reusable stop conditions first
         stop_triggered, reason = self._stop_condition_manager.should_stop(self._trials)
         if stop_triggered:
-            if not self._stop_reason:
-                # Map stop condition reasons to StopReason literals
-                reason_mapping: dict[str | None, StopReason] = {
-                    "max_samples": "max_samples_reached",
-                    "max_trials": "max_trials_reached",
-                    "plateau": "plateau",
-                    "cost_limit": "cost_limit",
-                    "timeout": "timeout",
-                    "metric_limit": "metric_limit",
-                    "convergence": "convergence",
-                }
-                self._stop_reason = reason_mapping.get(reason, "condition")
+            # Map stop condition reasons to StopReason literals
+            reason_mapping: dict[str | None, StopReason] = {
+                "max_samples": "max_samples_reached",
+                "max_trials": "max_trials_reached",
+                "plateau": "plateau",
+                "cost_limit": "cost_limit",
+                "timeout": "timeout",
+                "metric_limit": "metric_limit",
+                "convergence": "convergence",
+            }
+            mapped_reason = reason_mapping.get(reason, "condition")
+            if mapped_reason == "cost_limit" or not self._stop_reason:
+                self._stop_reason = mapped_reason
             logger.info("Stopping: %s condition triggered", self._stop_reason)
             return True
 

--- a/traigent/core/stop_condition_manager.py
+++ b/traigent/core/stop_condition_manager.py
@@ -156,7 +156,7 @@ class StopConditionManager:
             The registered CostLimitStopCondition for reference.
         """
         condition = CostLimitStopCondition(cost_enforcer)
-        self._conditions.append(condition)
+        self._conditions.insert(0, condition)
         return condition
 
     def add_condition(self, condition: StopCondition) -> None:

--- a/traigent/core/trial_result_factory.py
+++ b/traigent/core/trial_result_factory.py
@@ -328,6 +328,27 @@ def _set_metric_if_convertible(
         )
 
 
+def _set_token_metric_from_progress(
+    metrics: dict[str, Any],
+    progress_state: dict[str, Any],
+    key: str,
+    trial_id: str,
+) -> None:
+    raw_value = progress_state.get(key)
+    if raw_value is None:
+        return
+    try:
+        metrics.setdefault(key, int(float(raw_value)))
+    except (TypeError, ValueError) as error:
+        logger.warning(
+            "Failed to convert %s to int for trial %s: %s (value: %s)",
+            key,
+            trial_id,
+            error,
+            raw_value,
+        )
+
+
 def _reconcile_cost_with_total_cost(metrics: dict[str, Any], trial_id: str) -> None:
     """Wire the per-config ``cost`` metric to ``total_cost`` when decoupled (#1423).
 
@@ -614,6 +635,10 @@ def build_pruned_result(
                     total_cost_value,
                 )
 
+        _set_token_metric_from_progress(
+            metrics, progress_state, "total_tokens", trial_id
+        )
+
     return TrialResult(
         trial_id=trial_id,
         config=copy.deepcopy(evaluation_config),
@@ -673,6 +698,10 @@ def build_failed_result(
                     e,
                     total_cost_value,
                 )
+
+        _set_token_metric_from_progress(
+            metrics, progress_state, "total_tokens", trial_id
+        )
 
     return TrialResult(
         trial_id=trial_id,


### PR DESCRIPTION
Closes #1461
Refs #1462 (run-total under-count already recovered on develop via _from_aggregated_tokens; this PR adds forward-looking factory parity. Live-lifecycle progress_state token population is dormant post Optuna-eviction — leaving open for a follow-up that wires it or confirms the aggregated path fully closes it)

## What
- **#1461**: `stop_reason` now reports `cost_limit` when the cost budget is the binding constraint instead of mislabeling it `max_trials_reached`. The cost-limit stop condition is evaluated before registration-order trial/sample limits and can override an already-set reason. Verified failing-first on develop.
- **#1462**: PRUNED/FAILED trials that already spent budget now carry their `total_tokens` into trial metrics (cost was already accumulated via `_SPEND_ACCUMULATING_STATUSES`), so `OptimizationResult.total_tokens` reflects real mid-execution spend. Objective/accuracy aggregation stays COMPLETED-only (no pollution). Verified failing-first on develop (KeyError total_tokens).

## Tests
- `tests/unit/core` (orchestrator stop-reason precedence, trial_result_factory PRUNED/FAILED token, metrics_aggregator spend-vs-objective separation).

## PR checklist
- Worst-case prod path: reporting only (under-counted spend / mislabeled stop reason); hard cost limit still enforced separately by CostEnforcer — no overspend.
- Production-branch test: n/a.
- Contract regeneration: none.
- Public surface delta: `OptimizationResult.total_tokens` / `stop_reason` values corrected; shapes unchanged.
- Quality gates: not relaxed.

Spine-Trail: st_c973d3a23363