### PR TITLE
fix(integrations): resolve cached_property resource accessors so OpenAI/Anthropic method overrides apply (#1456)

### DIFF
--- a/tests/unit/test_enhanced_framework_override.py
+++ b/tests/unit/test_enhanced_framework_override.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Tests for enhanced framework override system with streaming and tool support."""
 
+import functools
+import sys
+from types import ModuleType
+
 import pytest
 
 from traigent.config.context import set_config
@@ -198,6 +202,76 @@ class TestMethodOverrides:
         assert "temperature" in chat_params
         assert "stream" in chat_params
         assert "tools" in chat_params
+
+    def test_cached_property_resource_method_override_reaches_resource_class(
+        self, monkeypatch
+    ):
+        """Method override reaches resource classes behind cached_property accessors."""
+        disable_framework_overrides()
+        target, resource_class = self._cached_property_target(monkeypatch)
+        original_create = resource_class.create
+
+        if target not in self.manager._method_mappings:
+            self.manager._parameter_mappings[target] = {"model": "model"}
+            self.manager._method_mappings[target] = {
+                "chat.completions.create": ["model"]
+            }
+
+        try:
+            self.manager.activate_overrides([target])
+
+            assert resource_class.create is not original_create
+            wrapped_create = getattr(resource_class.create, "__wrapped__", None)
+            assert wrapped_create is original_create
+        finally:
+            self.manager.deactivate_overrides()
+            assert resource_class.create is original_create
+
+    def _cached_property_target(self, monkeypatch):
+        try:
+            from openai.resources.chat.completions import Completions
+
+            return "openai.OpenAI", Completions
+        except ImportError:
+            return self._cached_property_sdk_stand_in(monkeypatch)
+
+    def _cached_property_sdk_stand_in(self, monkeypatch):
+        sdk_module = ModuleType("cached_property_sdk")
+        sdk_module.__path__ = []
+        resources_module = ModuleType("cached_property_sdk.resources")
+
+        resources_module.__dict__["functools"] = functools
+        exec(
+            """
+class ChatCompletions:
+    def create(self, **kwargs):
+        return kwargs
+
+class Chat:
+    @functools.cached_property
+    def completions(self) -> "ChatCompletions":
+        return ChatCompletions()
+""",
+            resources_module.__dict__,
+        )
+
+        sdk_module.__dict__["functools"] = functools
+        exec(
+            """
+class Client:
+    @functools.cached_property
+    def chat(self) -> "Chat":
+        return resources.Chat()
+""",
+            sdk_module.__dict__,
+        )
+        sdk_module.resources = resources_module
+
+        monkeypatch.setitem(sys.modules, "cached_property_sdk", sdk_module)
+        monkeypatch.setitem(
+            sys.modules, "cached_property_sdk.resources", resources_module
+        )
+        return "cached_property_sdk.Client", resources_module.ChatCompletions
 
     def test_anthropic_method_override(self):
         """Test Anthropic method parameter override (simplified test)."""

--- a/traigent/integrations/framework_override.py
+++ b/traigent/integrations/framework_override.py
@@ -414,7 +414,38 @@ class FrameworkOverrideManager(BaseOverrideManager):
         resolved = self._resolve_annotation_name(annotation_name, globalns)
         if isinstance(resolved, type):
             return cast(type, resolved)
+        for module_name in self._annotation_candidate_modules(func):
+            try:
+                module = importlib.import_module(module_name)
+            except (ImportError, ValueError):
+                continue
+            module_globals = vars(module)
+            if module_globals is globalns:
+                continue
+            resolved = self._resolve_annotation_name(annotation_name, module_globals)
+            if isinstance(resolved, type):
+                return cast(type, resolved)
         return None
+
+    def _annotation_candidate_modules(self, func: Callable[..., Any]) -> list[str]:
+        """Return modules that commonly expose SDK resource annotation names."""
+
+        module_name = getattr(func, "__module__", "")
+        if not module_name:
+            return []
+
+        candidate_names = [module_name]
+        package_name = module_name.split(".", 1)[0]
+        if package_name:
+            candidate_names.append(f"{package_name}.resources")
+
+        seen: set[str] = set()
+        unique_candidate_names = []
+        for candidate_name in candidate_names:
+            if candidate_name and candidate_name not in seen:
+                seen.add(candidate_name)
+                unique_candidate_names.append(candidate_name)
+        return unique_candidate_names
 
     def _normalize_annotation_string(self, annotation: str) -> str:
         """Normalize quoted forward-reference annotation strings."""


### PR DESCRIPTION
Refs #1456 (cached_property navigation no-op fixed; loud-warning for still-unpatchable targets + end-to-end param-injection test left as follow-up — issue stays open)

## What
`_apply_method_override` navigated resource accessors via class-level `getattr`, which returns the raw `functools.cached_property` on modern OpenAI/Anthropic SDKs and silently no-oped the zero-code-change override. The cached_property return class is now resolved via the SDK package `*.resources` module (e.g. `openai.resources`) when the accessor annotation is not present in the defining module globalns, so the override actually patches the resource method.

## Verification
- Reviewed GO and confirmed load-bearing against real openai 2.x: without the `.resources` fallback, `openai.OpenAI.chat`'s return class is unresolvable and the override is skipped; with it, the real `Completions.create` identity changes on activate and restores on deactivate.
- `anthropic` is not installed in the local venv; its path is structurally fixed the same way but unverified locally.
- Tests: `tests/unit/test_enhanced_framework_override.py` + `tests/unit/api/test_decorator_framework_override.py` -> 29 passed.

## PR checklist
- Worst-case prod path: integration override silently not applied (telemetry/optimization gap); no auth/data surface.
- Production-branch test: n/a.
- Contract regeneration: none.
- Public surface delta: none (behavior of the documented auto_override entry point is fixed).
- Quality gates: not relaxed.

Spine-Trail: st_b61e0ecfac9d