### PR TITLE
docs+fix(sdk): correct README default-scorer claim + retire stale example model IDs (#1398 #1391)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The default run uses Traigent's smart optimizer when portal credentials are avai
 ```python
 @traigent.optimize(
     configuration_space={
-        "model": ["gpt-4o-mini", "claude-3-haiku-20240307", "gemini/gemini-pro"],
+        "model": ["gpt-4o-mini", "claude-haiku-4-5-20251001", "gemini/gemini-pro"],
         "temperature": [0.1, 0.5, 0.9],
     },
     objectives=["accuracy", "cost"],
@@ -313,7 +313,7 @@ for details.
 
 ### Evaluation
 
-Provide a JSONL dataset — Traigent scores outputs using semantic similarity by default:
+Provide a JSONL dataset — Traigent scores outputs by exact / case-insensitive match by default. For semantic scoring (paraphrases, summarization, translation), supply a `scoring_function` (embeddings or LLM-judge) or a `custom_evaluator`:
 
 ```jsonl
 {"input": {"question": "What is AI?"}, "output": "Artificial Intelligence"}

--- a/examples/core/few-shot-classification/README.md
+++ b/examples/core/few-shot-classification/README.md
@@ -13,7 +13,7 @@ python examples/core/few-shot-classification/run.py
 
 | Parameter | Values | Purpose |
 |-----------|--------|---------|
-| `model` | claude-3-haiku, claude-3-5-sonnet | Model selection |
+| `model` | claude-haiku-4-5-20251001, claude-sonnet-4-6 | Model selection |
 | `temperature` | 0.0, 0.3 | Response variance |
 | `k` | 0, 2, 4 | Number of examples |
 | `selection_strategy` | top_k, diverse | Example selection method |

--- a/examples/core/few-shot-classification/index.html
+++ b/examples/core/few-shot-classification/index.html
@@ -51,7 +51,7 @@ python examples/core/few-shot-classification/run.py</code></pre>
         <h2>Configuration Space</h2>
     </header>
     <div class="detail-section-body">
-        <div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Parameter</th><th>Values</th><th>Purpose</th></tr></thead><tbody><tr><td><code>model</code></td><td>claude-3-haiku, claude-3-5-sonnet</td><td>Model selection</td></tr><tr><td><code>temperature</code></td><td>0.0, 0.3</td><td>Response variance</td></tr><tr><td><code>k</code></td><td>0, 2, 4</td><td>Number of examples</td></tr><tr><td><code>selection_strategy</code></td><td>top_k, diverse</td><td>Example selection method</td></tr></tbody></table></div>
+        <div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Parameter</th><th>Values</th><th>Purpose</th></tr></thead><tbody><tr><td><code>model</code></td><td>claude-haiku-4-5-20251001, claude-sonnet-4-6</td><td>Model selection</td></tr><tr><td><code>temperature</code></td><td>0.0, 0.3</td><td>Response variance</td></tr><tr><td><code>k</code></td><td>0, 2, 4</td><td>Number of examples</td></tr><tr><td><code>selection_strategy</code></td><td>top_k, diverse</td><td>Example selection method</td></tr></tbody></table></div>
     </div>
 </section><section class="detail-section" id="few-shot-classification-what-it-optimizes">
     <header class="detail-section-header">

--- a/examples/core/multi-objective-tradeoff/run_anthropic.py
+++ b/examples/core/multi-objective-tradeoff/run_anthropic.py
@@ -413,7 +413,7 @@ def _dump_example_results(
     configuration_space={
         "model": [
             # "claude-3-5-haiku-latest",
-            "claude-3-7-sonnet-latest",
+            "claude-sonnet-4-6",
             "claude-haiku-4-5-20251001",
             # "claude-opus-4-1-20250805",
             # "claude-sonnet-4-5-20250929"
@@ -429,7 +429,7 @@ def _dump_example_results(
 )
 def answer(
     question: str,
-    model: str = "claude-3-7-sonnet-latest",
+    model: str = "claude-sonnet-4-6",
     temperature: float = 0.1,
     max_tokens: int = 128,
 ) -> str:

--- a/examples/core/multi-objective-tradeoff/run_many_providers.py
+++ b/examples/core/multi-objective-tradeoff/run_many_providers.py
@@ -762,7 +762,7 @@ def _invoke_model(
         "model": [
             # "anthropic/claude-3-7",
             # "anthropic/claude-3-5-haiku-20241022",
-            # "anthropic/claude-3-haiku-20240307",
+            # "anthropic/claude-haiku-4-5-20251001",
             # "anthropic/claude-sonnet-4",
             # "anthropic/claude-sonnet-4-5",
             # "openai/gpt-3.5-turbo",
@@ -782,7 +782,7 @@ def _invoke_model(
 )
 def answer(
     question: str,
-    model: str = "openai/gpt-4o-nano",
+    model: str = "openai/gpt-4o-mini",
     temperature: float = 0.1,
     max_tokens: int = 128,
 ) -> str:
@@ -820,7 +820,7 @@ if __name__ == "__main__":
         parser.add_argument(
             "--model",
             type=str,
-            default="anthropic/claude-3-7-sonnet-latest",
+            default="anthropic/claude-sonnet-4-6",
             help="Model identifier (include provider prefix for non-default providers)",
         )
         args = parser.parse_args()

--- a/examples/core/prompt-ab-test/README.md
+++ b/examples/core/prompt-ab-test/README.md
@@ -14,7 +14,7 @@ python examples/core/prompt-ab-test/run.py
 | Parameter | Values | Purpose |
 |-----------|--------|---------|
 | `prompt_variant` | a, b | Prompt version to test |
-| `model` | claude-3-haiku, claude-3-5-sonnet | Model selection |
+| `model` | claude-haiku-4-5-20251001, claude-sonnet-4-6 | Model selection |
 | `temperature` | 0.0, 0.2 | Response variance |
 
 ## What It Optimizes

--- a/examples/core/prompt-ab-test/index.html
+++ b/examples/core/prompt-ab-test/index.html
@@ -51,7 +51,7 @@ python examples/core/prompt-ab-test/run.py</code></pre>
         <h2>Configuration Space</h2>
     </header>
     <div class="detail-section-body">
-        <div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Parameter</th><th>Values</th><th>Purpose</th></tr></thead><tbody><tr><td><code>prompt_variant</code></td><td>a, b</td><td>Prompt version to test</td></tr><tr><td><code>model</code></td><td>claude-3-haiku, claude-3-5-sonnet</td><td>Model selection</td></tr><tr><td><code>temperature</code></td><td>0.0, 0.2</td><td>Response variance</td></tr></tbody></table></div>
+        <div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Parameter</th><th>Values</th><th>Purpose</th></tr></thead><tbody><tr><td><code>prompt_variant</code></td><td>a, b</td><td>Prompt version to test</td></tr><tr><td><code>model</code></td><td>claude-haiku-4-5-20251001, claude-sonnet-4-6</td><td>Model selection</td></tr><tr><td><code>temperature</code></td><td>0.0, 0.2</td><td>Response variance</td></tr></tbody></table></div>
     </div>
 </section><section class="detail-section" id="prompt-ab-test-what-it-optimizes">
     <header class="detail-section-header">

--- a/examples/core/rag-optimization/README.md
+++ b/examples/core/rag-optimization/README.md
@@ -15,7 +15,7 @@ python examples/core/rag-optimization/run.py
 
 | Parameter | Values | Purpose |
 |-----------|--------|---------|
-| `model` | claude-3-5-sonnet, claude-3-haiku | Model selection |
+| `model` | claude-haiku-4-5-20251001, claude-sonnet-4-6 | Model selection |
 | `temperature` | 0.0 | Response consistency |
 | `use_rag` | true, false | Toggle RAG retrieval |
 | `top_k` | 1, 2, 3 | Documents to retrieve |

--- a/examples/core/rag-optimization/index.html
+++ b/examples/core/rag-optimization/index.html
@@ -52,7 +52,7 @@ python examples/core/rag-optimization/run.py</code></pre>
         <h2>Configuration Space</h2>
     </header>
     <div class="detail-section-body">
-        <div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Parameter</th><th>Values</th><th>Purpose</th></tr></thead><tbody><tr><td><code>model</code></td><td>claude-3-5-sonnet, claude-3-haiku</td><td>Model selection</td></tr><tr><td><code>temperature</code></td><td>0.0</td><td>Response consistency</td></tr><tr><td><code>use_rag</code></td><td>true, false</td><td>Toggle RAG retrieval</td></tr><tr><td><code>top_k</code></td><td>1, 2, 3</td><td>Documents to retrieve</td></tr></tbody></table></div>
+        <div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Parameter</th><th>Values</th><th>Purpose</th></tr></thead><tbody><tr><td><code>model</code></td><td>claude-haiku-4-5-20251001, claude-sonnet-4-6</td><td>Model selection</td></tr><tr><td><code>temperature</code></td><td>0.0</td><td>Response consistency</td></tr><tr><td><code>use_rag</code></td><td>true, false</td><td>Toggle RAG retrieval</td></tr><tr><td><code>top_k</code></td><td>1, 2, 3</td><td>Documents to retrieve</td></tr></tbody></table></div>
     </div>
 </section><section class="detail-section" id="rag-optimization-what-it-optimizes">
     <header class="detail-section-header">

--- a/examples/core/simple-prompt/README.md
+++ b/examples/core/simple-prompt/README.md
@@ -13,7 +13,7 @@ This is the "Hello World" of Traigent. It demonstrates the most basic usage: opt
 
 We want to summarize short text snippets. We are optimizing:
 
-1. **Model**: `claude-3-haiku` vs `claude-3-5-sonnet`.
+1. **Model**: `claude-haiku-4-5-20251001` vs `claude-sonnet-4-6`.
 2. **Temperature**: `0.0` (deterministic) vs `0.7` (creative).
 3. **Prompt Style**: `concise` vs `detailed`.
 

--- a/examples/core/simple-prompt/index.html
+++ b/examples/core/simple-prompt/index.html
@@ -51,7 +51,7 @@ python examples/core/simple-prompt/run.py</code></pre>
                     </header>
                     <div class="detail-section-body">
                         <p>We want to summarize short text snippets. We are optimizing:</p>
-<ol class="detail-list"><li><strong>Model</strong>: <code>claude-3-haiku</code> vs <code>claude-3-5-sonnet</code>.</li><li><strong>Temperature</strong>: <code>0.0</code> (deterministic) vs <code>0.7</code> (creative).</li><li><strong>Prompt Style</strong>: <code>concise</code> vs <code>detailed</code>.</li></ol>
+<ol class="detail-list"><li><strong>Model</strong>: <code>claude-haiku-4-5-20251001</code> vs <code>claude-sonnet-4-6</code>.</li><li><strong>Temperature</strong>: <code>0.0</code> (deterministic) vs <code>0.7</code> (creative).</li><li><strong>Prompt Style</strong>: <code>concise</code> vs <code>detailed</code>.</li></ol>
                     </div>
                 </section><section class="detail-section" id="simple-prompt-quick-start">
                     <header class="detail-section-header">

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -206,7 +206,7 @@ def _mock_generate_sql(question: str) -> str:
     configuration_space={
         "model": ["claude-haiku-4-5-20251001", "claude-sonnet-4-6"],
         "temperature": [0.0, 0.2],
-        "include_schema": ["true", "false"],
+        "include_schema": [True, False],
     },
     metric_functions={"sql_accuracy": sql_accuracy},
     injection_mode="seamless",
@@ -224,9 +224,9 @@ def generate_sql(question: str) -> str:
     if MOCK:
         return _mock_generate_sql(question)
 
-    assert os.getenv(
-        "ANTHROPIC_API_KEY"
-    ), "Set ANTHROPIC_API_KEY or run with TRAIGENT_MOCK_LLM=true"
+    assert os.getenv("ANTHROPIC_API_KEY"), (
+        "Set ANTHROPIC_API_KEY or run with TRAIGENT_MOCK_LLM=true"
+    )
 
     from langchain_anthropic import ChatAnthropic
     from langchain_core.messages import HumanMessage, SystemMessage
@@ -234,7 +234,9 @@ def generate_sql(question: str) -> str:
     config = traigent.get_config()
     model = str(config.get("model", "claude-sonnet-4-6"))
     temperature = float(config.get("temperature", 0.0))
-    include_schema = str(config.get("include_schema", "true")) == "true"
+    include_schema = config.get("include_schema", True)
+    if not isinstance(include_schema, bool):
+        raise TypeError("include_schema config value must be a bool")
 
     system_parts = [
         "You are an expert SQL assistant. Convert the user's question into a valid SQL query.",
@@ -273,7 +275,7 @@ if __name__ == "__main__":
         print("Configuration space:")
         print("  - model: claude-haiku-4-5-20251001, claude-sonnet-4-6")
         print("  - temperature: 0.0, 0.2")
-        print("  - include_schema: true, false")
+        print("  - include_schema: True, False")
         print(
             f"Mode: {'MOCK (no API key required)' if MOCK else 'REAL (requires ANTHROPIC_API_KEY)'}"
         )

--- a/examples/core/text-to-sql/run.py
+++ b/examples/core/text-to-sql/run.py
@@ -224,9 +224,9 @@ def generate_sql(question: str) -> str:
     if MOCK:
         return _mock_generate_sql(question)
 
-    assert os.getenv("ANTHROPIC_API_KEY"), (
-        "Set ANTHROPIC_API_KEY or run with TRAIGENT_MOCK_LLM=true"
-    )
+    assert os.getenv(
+        "ANTHROPIC_API_KEY"
+    ), "Set ANTHROPIC_API_KEY or run with TRAIGENT_MOCK_LLM=true"
 
     from langchain_anthropic import ChatAnthropic
     from langchain_core.messages import HumanMessage, SystemMessage
@@ -271,7 +271,7 @@ if __name__ == "__main__":
         print("        billing, network_usage)")
         print("Objective: sql_accuracy (normalize + exact-match scoring)")
         print("Configuration space:")
-        print("  - model: claude-3-haiku, claude-3-5-sonnet")
+        print("  - model: claude-haiku-4-5-20251001, claude-sonnet-4-6")
         print("  - temperature: 0.0, 0.2")
         print("  - include_schema: true, false")
         print(

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -535,8 +535,8 @@ class TrialOperations:
     def _log_measures_debug(self, trial_id: str, measures: Any) -> None:
         """Log debug information for measures."""
         if measures is not None:
-            logger.info(f"📊 MEASURES DATA for trial {trial_id}:")
-            logger.info(f"  Type: {type(measures)}")
+            logger.debug(f"📊 MEASURES DATA for trial {trial_id}:")
+            logger.debug(f"  Type: {type(measures)}")
             logger.debug(
                 f"  Count: {len(measures) if isinstance(measures, list) else 'N/A'}"
             )
@@ -597,12 +597,12 @@ class TrialOperations:
         continue_optimization = response_data.get("continue_optimization", True)
 
         if not continue_optimization:
-            logger.info(
+            logger.debug(
                 f"✅ Submitted trial result for session {session_id}, trial {trial_id} "
                 f"(session auto-finalized by backend)"
             )
         else:
-            logger.info(
+            logger.debug(
                 f"✅ Submitted trial result for session {session_id}, trial {trial_id}"
             )
 

--- a/traigent/utils/results_table.py
+++ b/traigent/utils/results_table.py
@@ -21,11 +21,15 @@ import os
 import sys
 from typing import TYPE_CHECKING, Any
 
+from traigent.utils.logging import get_logger
+
 if TYPE_CHECKING:
     from traigent.core.result import OptimizationResult
 
 BEST_METRIC_REL_TOL = 1e-9
 BEST_METRIC_ABS_TOL = 1e-12
+
+logger = get_logger(__name__)
 
 # Characters that cannot be encoded on narrow consoles (e.g. Windows cp1252) and
 # their ASCII fallbacks.  Applied lazily only when an encode error is detected.
@@ -332,8 +336,12 @@ def _find_best_trial_index(
         best_index = _trial_identity_index(trials, best_trial)
         if best_index is not None:
             return best_index
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug(
+            "Falling back from weighted to unweighted results-table ranking: %s",
+            exc,
+            exc_info=True,
+        )
 
     best_trial = _find_best_trial(trials, metric_names, metric_info=metric_info)
     best_index = _trial_identity_index(trials, best_trial)


### PR DESCRIPTION
## Summary

Closes #1398, #1391.

### #1398
- **README.md** — replaces the false claim *"Traigent scores outputs using semantic similarity by default"* with the accurate default: **exact / case-insensitive match** (the real `LocalEvaluator` default; `semantic` is explicitly refused without a `scoring_function`). This is the residual of closed #891, whose fix corrected `docs/` but missed the root README. Now points to `scoring_function` / `custom_evaluator` for semantic scoring.
- **`traigent/cloud/trial_operations.py`** — the two per-trial `logger.info` lines in `_log_measures_debug` (a debug-named function whose other lines are all `debug`) and the two per-trial `"✅ Submitted trial result"` banners in `_handle_trial_success_response` are downgraded to `logger.debug`. Pure level change (console-flood / signal-burial fix), no behavior change.
- **`traigent/utils/results_table.py`** — the silent `except Exception: pass` that downgrades the "Overall Best" row from weighted to unweighted ranking now emits a `logger.debug` with the reason. Fallback behavior unchanged; the missing signal is added.

### #1391
Repins retired / non-existent example model IDs to the **current** IDs the example `run.py` config spaces already use (docs had drifted behind code):
- Doc drift (5 example `README.md` + `index.html` + `text-to-sql/run.py` stdout): retired `claude-3-haiku` / `claude-3-5-sonnet` → `claude-haiku-4-5-20251001` / `claude-sonnet-4-6`.
- Hard 404 defaults in `multi-objective-tradeoff`: `claude-3-7-sonnet-latest` (retired 2026-02-19) → `claude-sonnet-4-6`; `openai/gpt-4o-nano` (not a real ID) → `openai/gpt-4o-mini`.

Verified: no residual `claude-3-haiku` / `claude-3-5-sonnet` / `claude-3-7-sonnet-latest` / `gpt-4o-nano` in edited files; all edited `.py` files parse. The `text-to-sql` `include_schema` bool-encoding (#1391 cluster 3) is intentionally left out of scope (DX wart, doesn't break runs).

## PR checklist
1. **Worst-case prod path** — n/a (docs + log-level + a debug signal). No policy surface.
2. **Production-branch test** — n/a (no behavior change).
3. **Contract regeneration** — none.
4. **Public surface delta** — none (README wording + example model IDs + log levels).
5. **Review threads** — will resolve on review.
6. **Quality gates** — not relaxed.

Spine-Trail: st_c0f1e214c84d

🤖 Generated with [Claude Code](https://claude.com/claude-code)