### PR TITLE
fix(sdk): warn when CONTEXT-mode tuned knobs shadow wrapped fn params (#1372)

### DIFF
--- a/tests/unit/api/test_context_mode_shadow_warning.py
+++ b/tests/unit/api/test_context_mode_shadow_warning.py
@@ -1,0 +1,82 @@
+"""Tests for the CONTEXT-mode parameter-shadowing warning (issue #1372).
+
+When a function already declares the tuned knobs as parameters and is wrapped
+with the default ``injection_mode=InjectionMode.CONTEXT`` (which does NOT
+override function parameters), every trial silently runs with the signature
+defaults. The decorator must emit a loud warning instead of failing silently.
+"""
+
+import warnings
+
+import pytest
+
+from traigent.api.decorators import optimize
+
+
+def test_context_mode_param_shadowing_warns():
+    """A knob declared as a function param under CONTEXT mode warns loudly."""
+    with pytest.warns(UserWarning, match="injection_mode is CONTEXT"):
+
+        @optimize(
+            configuration_space={"model": ["a", "b"], "temperature": [0.1, 0.9]},
+            algorithm="grid",
+        )
+        def generate(question, *, model="default", temperature=0.0):
+            return f"{model}:{temperature}"
+
+    # The warning names the actually-shadowed knobs.
+    with pytest.warns(UserWarning) as record:
+
+        @optimize(
+            configuration_space={"model": ["a", "b"], "temperature": [0.1, 0.9]},
+            algorithm="grid",
+        )
+        def generate2(question, *, model="default", temperature=0.0):
+            return f"{model}:{temperature}"
+
+    msg = str(record[0].message)
+    assert "model" in msg and "temperature" in msg
+
+
+def test_no_warn_when_body_reads_get_config():
+    """A body that reads traigent.get_config() honors the knobs — no warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any matching warning would raise
+
+        @optimize(
+            configuration_space={"model": ["a", "b"]},
+            algorithm="grid",
+        )
+        def generate(question, *, model="default"):
+            import traigent
+
+            cfg = traigent.get_config()
+            return cfg.get("model", model)
+
+
+def test_no_warn_when_no_param_overlap():
+    """Knobs that are NOT function params (pure CONTEXT pattern) do not warn."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        @optimize(
+            configuration_space={"model": ["a", "b"]},
+            algorithm="grid",
+        )
+        def generate(question):
+            return question
+
+
+def test_no_warn_in_parameter_mode():
+    """PARAMETER mode injects explicitly, so an overlap is expected and silent."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        @optimize(
+            configuration_space={"model": ["a", "b"]},
+            injection_mode="parameter",
+            config_param="config",
+            algorithm="grid",
+        )
+        def generate(question, model="default", config=None):
+            return model

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -437,6 +437,80 @@ def _validate_custom_evaluator_signature(evaluator: Callable[..., Any]) -> None:
         )
 
 
+def _warn_context_mode_param_shadowing(
+    func: Callable[..., Any],
+    configuration_space: Any,
+    injection_mode: Any,
+    config_param: str | None,
+) -> None:
+    """Warn when CONTEXT-mode tuned knobs shadow the wrapped function's params.
+
+    In the default ``injection_mode=InjectionMode.CONTEXT`` the optimizer does
+    **not** override function parameters — the per-trial config lives in
+    contextvars and must be read via ``traigent.get_config()``. If a function
+    already declares the tuned knobs as parameters (the common "wrap a pre-existing
+    agent function" shape) and never reads ``get_config()``, every trial silently
+    receives the signature defaults, so the optimizer reports a "best config" for a
+    sweep that never actually varied those parameters (see issue #1372). This emits
+    a loud warning so the no-op is not silent. It is advisory (never raises): a
+    function that intentionally reads ``get_config()`` is detected and skipped.
+    """
+    # Only CONTEXT mode shadows parameters; PARAMETER/SEAMLESS inject explicitly.
+    if injection_mode not in (InjectionMode.CONTEXT, "context"):
+        return
+    if not configuration_space:
+        return
+    try:
+        config_keys = set(configuration_space.keys())
+    except AttributeError:
+        return
+    if not config_keys:
+        return
+
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):  # pragma: no cover - unintrospectable callable
+        return
+
+    param_names = {
+        name
+        for name, p in sig.parameters.items()
+        if p.kind
+        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    }
+    if config_param:
+        param_names.discard(config_param)
+
+    shadowed = sorted(config_keys & param_names)
+    if not shadowed:
+        return
+
+    # Best-effort: if the body already reads the per-trial config, the knobs are
+    # honored and the overlap is intentional — do not warn.
+    try:
+        source = inspect.getsource(func)
+        if "get_config" in source or "current_config" in source:
+            return
+    except (OSError, TypeError):  # pragma: no cover - source unavailable
+        pass
+
+    import warnings
+
+    func_name = getattr(func, "__name__", repr(func))
+    message = (
+        f"@traigent.optimize: the tuned variable(s) {shadowed} are declared as "
+        f"parameters of '{func_name}', but injection_mode is CONTEXT (the default), "
+        f"which does NOT override function parameters. Unless the body reads "
+        f"traigent.get_config(), every trial will run with the signature defaults "
+        f"and the optimization will silently sweep nothing (a false-positive 'best "
+        f"config'). To actually vary {shadowed}: read them via traigent.get_config() "
+        f'inside the function, or use injection_mode="seamless" (zero code change) / '
+        f'injection_mode="parameter".'
+    )
+    warnings.warn(message, UserWarning, stacklevel=3)
+    logger.warning("%s", message)
+
+
 _DEFAULT_SENTINEL = object()
 _AUTO_DETECT_TVARS_MODES = frozenset({"off", "suggest", "apply"})
 
@@ -2649,6 +2723,15 @@ def optimize(  # NOSONAR(S107)
                         **detected_defaults,
                         **(resolved_default_config or {}),
                     }
+
+        # #1372: loudly warn if CONTEXT-mode tuned knobs shadow the wrapped
+        # function's own parameters (silent no-op sweep otherwise).
+        _warn_context_mode_param_shadowing(
+            func,
+            resolved_configuration_space,
+            actual_injection_mode,
+            config_param,
+        )
 
         optimized_func = OptimizedFunction(
             func=func,


### PR DESCRIPTION
## Summary
Refs #1372 (delivers the advisory CONTEXT-mode shadow warning for the headline case; substring get_config detection can false-negative and #1372 also asks for AST-based detection + a separately-tracked skills recipe — issue stays open).

A naive \`@traigent.optimize\` wrap of a function that already declares the tuned knobs as **parameters** (the "wrap a pre-existing agent function" shape, e.g. \`generate_sql(question, *, model, temperature, ...)\`) **silently sweeps the signature defaults on every trial** under the default \`injection_mode=InjectionMode.CONTEXT\`, which does **not** override function parameters. The optimizer then prints a confident "best config" table for a sweep that never actually varied those params — a fail-silent false-positive.

This adds a loud, advisory guard at decoration time: when CONTEXT mode is in effect and one or more configuration-space keys collide with the wrapped function's parameter names, emit a \`UserWarning\` + \`logger.warning\` naming the shadowed knobs and pointing the user at \`traigent.get_config()\` / \`injection_mode="seamless"\` / \`injection_mode="parameter"\`.

It is **advisory only (never raises)** and is **skipped** when the body already references \`get_config()\`/\`current_config\` (intentional CONTEXT usage) or when overlap is empty / mode is parameter/seamless.

## Test
\`tests/unit/api/test_context_mode_shadow_warning.py\` (4 cases): warns on shadowing + names knobs; no-warn when body reads get_config; no-warn without overlap; no-warn in parameter mode. Run: \`pytest tests/unit/api/test_context_mode_shadow_warning.py -n0\`. Full \`test_decorators.py\` (64) green.

## PR checklist
1. **Worst-case prod path** — N/A policy surface; pure additive warning at decoration time, no behavior change to optimization execution.
2. **Production-branch test** — N/A (no production-gated branch).
3. **Contract regeneration** — none (no schema/DTO change).
4. **Public surface delta** — none (\`__all__\` unchanged; new helper is module-private \`_warn_context_mode_param_shadowing\`).
5. **Review threads** — will resolve all.
6. **Quality gates** — unchanged.

Spine-Trail: st_a6e7a9c83d6d

🤖 Generated with [Claude Code](https://claude.com/claude-code)