### PR TITLE
feat(sdk): bounded auto-retry/backoff for transient vendor errors (#1404)

### DIFF
--- a/tests/unit/core/test_pause_on_error.py
+++ b/tests/unit/core/test_pause_on_error.py
@@ -47,7 +47,14 @@ class TestHandleVendorPause:
 
         # We test the methods directly by calling them on a mock
         orch = MagicMock()
-        # Bind the real method
+        # Bind the real handler methods. #1404 added a bounded auto-retry layer
+        # in front of the prompt path; it is opt-in (default off), so the prompt
+        # contract asserted here is unchanged.
+        orch._vendor_retry_counts = {}
+        orch._vendor_retry_settings = OptimizationOrchestrator._vendor_retry_settings
+        orch._maybe_auto_retry_vendor_error = (
+            OptimizationOrchestrator._maybe_auto_retry_vendor_error.__get__(orch)
+        )
         orch._handle_vendor_pause = (
             OptimizationOrchestrator._handle_vendor_pause.__get__(orch)
         )

--- a/tests/unit/core/test_vendor_auto_retry.py
+++ b/tests/unit/core/test_vendor_auto_retry.py
@@ -1,0 +1,116 @@
+"""Tests for bounded auto-retry/backoff on transient vendor errors (issue #1404).
+
+A single transient ``429``/``503`` from the LLM provider must not auto-stop an
+entire unattended/CI optimization run. The orchestrator should auto-retry
+recoverable categories with bounded backoff before falling back to the
+resume/stop prompt path (which auto-stops in non-interactive mode).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from traigent.core.exception_handler import VendorErrorCategory
+from traigent.core.orchestrator import OptimizationOrchestrator
+from traigent.utils.exceptions import VendorPauseError
+
+
+class _StopAdapter:
+    def __init__(self):
+        self.calls = 0
+
+    def prompt_vendor_pause(self, error, category):
+        self.calls += 1
+        return "stop"
+
+
+@pytest.fixture
+def orch(monkeypatch):
+    """Mock orchestrator with the real retry/pause handlers bound."""
+    monkeypatch.setenv("TRAIGENT_VENDOR_RETRY_BACKOFF", "0")  # no real sleeping
+    o = MagicMock()
+    o._vendor_retry_counts = {}
+    o._vendor_retry_settings = OptimizationOrchestrator._vendor_retry_settings
+    o._maybe_auto_retry_vendor_error = (
+        OptimizationOrchestrator._maybe_auto_retry_vendor_error.__get__(o)
+    )
+    o._handle_vendor_pause = OptimizationOrchestrator._handle_vendor_pause.__get__(o)
+    return o
+
+
+def _rate_limit_exc():
+    return VendorPauseError("rate limit", category=VendorErrorCategory.RATE_LIMIT)
+
+
+@pytest.mark.asyncio
+async def test_transient_rate_limit_auto_retries_before_prompt(orch, monkeypatch):
+    """First 429 auto-retries ("continue") instead of consulting the stop prompt."""
+    monkeypatch.setenv("TRAIGENT_VENDOR_MAX_RETRIES", "2")
+    adapter = _StopAdapter()
+    orch._prompt_adapter = adapter
+
+    result = await orch._handle_vendor_pause(_rate_limit_exc())
+
+    assert result == "continue"
+    assert adapter.calls == 0  # the stop prompt was NOT consulted
+
+
+@pytest.mark.asyncio
+async def test_retry_budget_is_bounded_then_stops(orch, monkeypatch):
+    """After the retry budget is exhausted, it falls back to the stop prompt."""
+    monkeypatch.setenv("TRAIGENT_VENDOR_MAX_RETRIES", "2")
+    adapter = _StopAdapter()
+    orch._prompt_adapter = adapter
+
+    r1 = await orch._handle_vendor_pause(_rate_limit_exc())
+    r2 = await orch._handle_vendor_pause(_rate_limit_exc())
+    r3 = await orch._handle_vendor_pause(_rate_limit_exc())
+
+    assert [r1, r2] == ["continue", "continue"]  # 2 bounded retries
+    assert r3 == "break"  # budget exhausted -> prompt -> stop
+    assert adapter.calls == 1  # prompt only consulted after budget exhausted
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_max_retries_zero(orch, monkeypatch):
+    """TRAIGENT_VENDOR_MAX_RETRIES=0 restores immediate stop (no auto-retry)."""
+    monkeypatch.setenv("TRAIGENT_VENDOR_MAX_RETRIES", "0")
+    adapter = _StopAdapter()
+    orch._prompt_adapter = adapter
+
+    result = await orch._handle_vendor_pause(_rate_limit_exc())
+
+    assert result == "break"
+    assert adapter.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_recoverable_categories_not_retried(orch, monkeypatch):
+    """Insufficient funds / quota exhausted are not transient -> no auto-retry."""
+    monkeypatch.setenv("TRAIGENT_VENDOR_MAX_RETRIES", "2")
+    adapter = _StopAdapter()
+    orch._prompt_adapter = adapter
+
+    for cat in (
+        VendorErrorCategory.INSUFFICIENT_FUNDS,
+        VendorErrorCategory.QUOTA_EXHAUSTED,
+    ):
+        orch._vendor_retry_counts.clear()
+        exc = VendorPauseError("x", category=cat)
+        result = await orch._handle_vendor_pause(exc)
+        assert result == "break"
+
+
+@pytest.mark.asyncio
+async def test_service_unavailable_is_recoverable(orch, monkeypatch):
+    """503 service-unavailable is a recoverable transient category."""
+    monkeypatch.setenv("TRAIGENT_VENDOR_MAX_RETRIES", "1")
+    adapter = _StopAdapter()
+    orch._prompt_adapter = adapter
+
+    exc = VendorPauseError("503", category=VendorErrorCategory.SERVICE_UNAVAILABLE)
+    result = await orch._handle_vendor_pause(exc)
+
+    assert result == "continue"

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -8,6 +8,7 @@ import asyncio
 import copy
 import inspect
 import math
+import os
 import sys
 import time
 import uuid
@@ -700,6 +701,10 @@ class OptimizationOrchestrator:
         self._status = OptimizationStatus.PENDING
         self._optimization_id = str(uuid.uuid4())
         self._stop_reason: StopReason | None = None
+        # #1404: bounded auto-retry budget for transient vendor errors (429/503)
+        # before the run loop gives up. Cumulative per category so the run always
+        # terminates. Configured via TRAIGENT_VENDOR_MAX_RETRIES (default 2).
+        self._vendor_retry_counts: dict[VendorErrorCategory, int] = {}
         self._logger: OptimizationLogger | None = None
         self._logger_v2: Any | None = None
         self._logger_facade = LoggerFacade()
@@ -2553,12 +2558,96 @@ class OptimizationOrchestrator:
                 return trial_count, "break"
             return trial_count, "continue"  # User chose to resume
 
+    @staticmethod
+    def _vendor_retry_settings() -> tuple[int, float]:
+        """Resolve bounded vendor-retry budget and base backoff from env (#1404).
+
+        Returns ``(max_retries, base_backoff_seconds)``. Defaults to ``0``
+        (opt-in) so the documented graceful fail-stop contract is unchanged
+        unless the operator sets ``TRAIGENT_VENDOR_MAX_RETRIES``. A malformed
+        value also yields the default.
+        """
+
+        def _read(name: str, default: float, *, minimum: float) -> float:
+            raw = os.environ.get(name)
+            if raw is None or not raw.strip():
+                return default
+            try:
+                value = float(raw)
+            except (TypeError, ValueError):
+                return default
+            return value if value >= minimum else default
+
+        max_retries = int(_read("TRAIGENT_VENDOR_MAX_RETRIES", 0.0, minimum=0.0))
+        base_backoff = _read("TRAIGENT_VENDOR_RETRY_BACKOFF", 1.0, minimum=0.0)
+        return max_retries, base_backoff
+
+    async def _maybe_auto_retry_vendor_error(self, exc: VendorPauseError) -> str | None:
+        """Bounded auto-retry/backoff for transient vendor errors (#1404).
+
+        For *recoverable* categories (rate limit / service unavailable) a single
+        transient ``429``/``503`` should not auto-stop an entire unattended run.
+        Sleeps with bounded backoff (honoring ``Retry-After`` when the vendor
+        exposes it) and returns ``"continue"`` up to ``TRAIGENT_VENDOR_MAX_RETRIES``
+        times per category. Returns ``None`` when no auto-retry applies, so the
+        caller falls back to the existing resume/stop prompt path. The budget is
+        cumulative per category, guaranteeing the loop always terminates.
+        """
+        category = exc.category
+        recoverable = {
+            VendorErrorCategory.RATE_LIMIT,
+            VendorErrorCategory.SERVICE_UNAVAILABLE,
+        }
+        if category not in recoverable:
+            return None
+
+        max_retries, base_backoff = self._vendor_retry_settings()
+        if max_retries <= 0:
+            return None
+
+        used = self._vendor_retry_counts.get(category, 0)
+        if used >= max_retries:
+            logger.warning(
+                "traigent.vendor_auto_retry exhausted category=%s attempts=%s/%s",
+                category.value,
+                used,
+                max_retries,
+            )
+            return None
+
+        self._vendor_retry_counts[category] = used + 1
+
+        # Honor a vendor-provided Retry-After when available, else exponential.
+        retry_after = getattr(exc.original_error, "retry_after", None)
+        try:
+            delay = float(retry_after) if retry_after is not None else None
+        except (TypeError, ValueError):
+            delay = None
+        if delay is None or delay < 0:
+            delay = base_backoff * (2**used)
+
+        logger.warning(
+            "traigent.vendor_auto_retry category=%s attempt=%s/%s backoff=%.2fs "
+            "(set TRAIGENT_VENDOR_MAX_RETRIES=0 to disable)",
+            category.value,
+            used + 1,
+            max_retries,
+            delay,
+        )
+        if delay > 0:
+            await asyncio.sleep(delay)
+        return "continue"
+
     async def _handle_vendor_pause(self, exc: VendorPauseError) -> str:
         """Prompt user to resume or stop after a vendor error.
 
         Returns:
             ``"continue"`` to retry the trial, ``"break"`` to stop.
         """
+        if exc.category is not None:
+            auto = await self._maybe_auto_retry_vendor_error(exc)
+            if auto is not None:
+                return auto
         if self._prompt_adapter is None or exc.category is None:
             return "break"
         decision = self._prompt_adapter.prompt_vendor_pause(

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -703,7 +703,7 @@ class OptimizationOrchestrator:
         self._stop_reason: StopReason | None = None
         # #1404: bounded auto-retry budget for transient vendor errors (429/503)
         # before the run loop gives up. Cumulative per category so the run always
-        # terminates. Configured via TRAIGENT_VENDOR_MAX_RETRIES (default 2).
+        # terminates. Opt-in via TRAIGENT_VENDOR_MAX_RETRIES (default 0 = off).
         self._vendor_retry_counts: dict[VendorErrorCategory, int] = {}
         self._logger: OptimizationLogger | None = None
         self._logger_v2: Any | None = None

--- a/traigent/skills/traigent-quickstart/references/environment-variables.md
+++ b/traigent/skills/traigent-quickstart/references/environment-variables.md
@@ -10,6 +10,8 @@ Complete reference of environment variables recognized by the Traigent SDK.
 | `TRAIGENT_OFFLINE_MODE`            | `false`         | When `true`, skips all backend communication. Use for local-only development.                       |
 | `TRAIGENT_RUN_COST_LIMIT`         | `2.0`           | Maximum cost budget (in USD) per optimization run. Optimization stops when this limit is reached.    |
 | `TRAIGENT_COST_APPROVED`          | `false`         | Exact value `true` pre-approves both the cost-limit prompt and unpriced-model preflight. `1`, `yes`, and `on` do not approve. |
+| `TRAIGENT_VENDOR_MAX_RETRIES`     | `0`             | Bounded auto-retries on a transient vendor error (`429` rate-limit / `503` service-unavailable) before the run stops. `0` (default) preserves the immediate graceful stop; set e.g. `2` so a single transient blip does not abort an unattended/CI run. |
+| `TRAIGENT_VENDOR_RETRY_BACKOFF`   | `1.0`           | Base backoff (seconds) between vendor auto-retries; grows exponentially and honors a vendor `Retry-After` when present. Only used when `TRAIGENT_VENDOR_MAX_RETRIES` > 0. |
 | `TRAIGENT_SKIP_PROVIDER_VALIDATION`| `false`        | When `true`, skips API key validation at decoration time. Useful in CI environments.                |
 | `TRAIGENT_VALIDATION_TIMEOUT`     | `5.0`           | Timeout in seconds for provider API key validation checks.                                          |
 | `TRAIGENT_STRICT_COST_ACCOUNTING` | `false`         | Exact value `true` fails fast before trial 1 on unpriced models and when runtime cost extraction is missing or unknown. |


### PR DESCRIPTION
## Summary
Closes #1404.

In a non-interactive run (CI / script / notebook), the **first** transient vendor error on any trial — a `429` rate-limit or `503` service-unavailable — currently auto-stops the entire optimization (the non-interactive prompt adapter returns `"stop"`). A single transient blip ends an otherwise-healthy multi-trial run.

This adds a **bounded auto-retry layer** in front of the existing resume/stop prompt path in `_handle_vendor_pause`:
- Only **recoverable** categories (`RATE_LIMIT`, `SERVICE_UNAVAILABLE`) are retried; `INSUFFICIENT_FUNDS` / `QUOTA_EXHAUSTED` are never retried.
- Retries up to `TRAIGENT_VENDOR_MAX_RETRIES` (**default `0` = unchanged** graceful stop) with exponential backoff (`TRAIGENT_VENDOR_RETRY_BACKOFF`, default `1.0s`) that **honors a vendor `Retry-After`** when present.
- The budget is **cumulative per category**, so the loop always terminates (still bounded; partials still preserved on final stop).

**Default is off by design**: flipping the documented graceful fail-stop policy to retry-by-default is an owner decision, so this ships the mechanism opt-in. Set `TRAIGENT_VENDOR_MAX_RETRIES=2` to get "a single blip won't kill the run."

> **Owner flag:** should the default be flipped to a small non-zero value (e.g. 2) so unattended runs are resilient out of the box? That changes the pinned stop-reason contract, hence left to the owner.

## Test
`tests/unit/core/test_vendor_auto_retry.py` (5 cases): auto-retry before prompt; bounded-then-stop; disabled at 0; non-recoverable not retried; 503 recoverable. Existing `test_pause_on_error.py` / `test_stop_reason_contract.py` (38) remain green (default off). Run: `pytest tests/unit/core/test_vendor_auto_retry.py tests/unit/core/test_pause_on_error.py tests/unit/core/test_stop_reason_contract.py -n0`.

## PR checklist
1. **Worst-case prod path** — opt-in; with default `0` behavior is identical to today. Bounded budget guarantees termination, so no infinite-retry/cost-runaway risk; non-recoverable categories never retry.
2. **Production-branch test** — N/A (no production-gated branch); see bounded-then-stop test.
3. **Contract regeneration** — none.
4. **Public surface delta** — none (new helpers are private; two new documented env vars).
5. **Review threads** — will resolve all.
6. **Quality gates** — unchanged.

Spine-Trail: st_b900fb3d3337

🤖 Generated with [Claude Code](https://claude.com/claude-code)