### PR TITLE
chore(api): declare __all__ on public traigent.api.* submodules (#1446)

### DIFF
--- a/tests/unit/api/test_api_submodule_exports.py
+++ b/tests/unit/api/test_api_submodule_exports.py
@@ -1,0 +1,48 @@
+"""Tests that public ``traigent.api.*`` submodules declare ``__all__`` (issue #1446).
+
+Without ``__all__`` every non-underscore top-level name — including internal
+helpers and resolution-only classes — leaks via ``import *``, IDE autocomplete,
+and autodoc. These tests pin the curated export surface.
+"""
+
+import importlib
+
+import pytest
+
+_SUBMODULES = [
+    "agent_inference",
+    "config_builder",
+    "constraint_builders",
+    "decorators",
+    "functions",
+    "parameter_validator",
+    "strategy_presets",
+    "types",
+]
+
+
+@pytest.mark.parametrize("name", _SUBMODULES)
+def test_submodule_declares_all(name):
+    mod = importlib.import_module(f"traigent.api.{name}")
+    assert hasattr(mod, "__all__"), f"{name} is missing __all__"
+    # Every declared name must actually exist on the module.
+    missing = [n for n in mod.__all__ if not hasattr(mod, n)]
+    assert not missing, f"{name}.__all__ references missing names: {missing}"
+    # No private names and no module-level logger noise leak into the surface.
+    assert "logger" not in mod.__all__
+    assert all(not n.startswith("_") for n in mod.__all__)
+
+
+def test_decorators_does_not_export_internals():
+    """The internals named in #1446 must no longer leak via import *."""
+    ns: dict = {}
+    exec("from traigent.api.decorators import *", ns)  # noqa: S102
+    for internal in (
+        "get_optimize_default",
+        "LegacyOptimizeArgs",
+        "ResolvedExecutionOptions",
+    ):
+        assert internal not in ns, f"{internal} still leaks via import *"
+    # Public API is still exported.
+    assert "optimize" in ns
+    assert "EvaluationOptions" in ns

--- a/traigent/api/agent_inference.py
+++ b/traigent/api/agent_inference.py
@@ -36,6 +36,12 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+__all__ = [
+    "build_agent_configuration",
+    "extract_parameter_agents",
+]
+
+
 def build_agent_configuration(
     configuration_space: dict[str, Any],
     explicit_agents: dict[str, AgentDefinition] | None = None,

--- a/traigent/api/config_builder.py
+++ b/traigent/api/config_builder.py
@@ -21,6 +21,15 @@ logger = logging.getLogger(__name__)
 _GLOBAL_CONFIG: dict[str, Any] = {}
 
 
+__all__ = [
+    "ConfigurationBuilder",
+    "build_optimize_configuration",
+    "update_global_config",
+    "get_global_config",
+    "clear_global_config",
+]
+
+
 class ConfigurationBuilder:
     """Builds configuration for OptimizedFunction from validated parameters."""
 

--- a/traigent/api/constraint_builders.py
+++ b/traigent/api/constraint_builders.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+__all__ = [
+    "NumericConstraintBuilderMixin",
+    "CategoricalConstraintBuilderMixin",
+]
+
+
 def _parameter_label(tvar: Any) -> str:
     return str(getattr(tvar, "name", None) or "parameter")
 

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -102,6 +102,17 @@ from traigent.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+__all__ = [
+    "EvaluationOptions",
+    "InjectionOptions",
+    "HybridAPIOptions",
+    "ExternalServiceEvaluator",
+    "ExecutionOptions",
+    "MockModeOptions",
+    "optimize",
+]
+
+
 class EvaluationOptions(BaseModel):
     """Grouped evaluation settings used by the optimize decorator."""
 

--- a/traigent/api/functions.py
+++ b/traigent/api/functions.py
@@ -50,6 +50,27 @@ if TYPE_CHECKING:
     from traigent.core.objectives import ObjectiveSchema
 
 
+__all__ = [
+    "configure",
+    "initialize",
+    "get_global_config",
+    "get_api_key",
+    "get_config",
+    "get_trial_config",
+    "get_current_config",
+    "override_config",
+    "configure_for_budget",
+    "set_strategy",
+    "get_available_strategies",
+    "list_recommendation_agent_types",
+    "recommend_configuration_space",
+    "get_version_info",
+    "get_optimization_insights",
+    "get_global_parallel_config",
+    "with_usage",
+]
+
+
 def configure(
     default_storage_backend: str | None = None,
     parallel_workers: int | None = None,

--- a/traigent/api/parameter_validator.py
+++ b/traigent/api/parameter_validator.py
@@ -25,6 +25,14 @@ from traigent.utils.exceptions import ValidationError
 logger = logging.getLogger(__name__)
 
 
+__all__ = [
+    "OptimizeParameters",
+    "ParameterValidator",
+    "validate_optimize_parameters",
+    "validate_safety_constraints",
+]
+
+
 @dataclass
 class OptimizeParameters:
     """Structured representation of optimize decorator parameters."""

--- a/traigent/api/strategy_presets.py
+++ b/traigent/api/strategy_presets.py
@@ -49,6 +49,24 @@ _FAILED_PARETO_RATIONALE = (
 _FLOAT_BOUNDARY_TOLERANCE = 1e-9
 
 
+__all__ = [
+    "PresetName",
+    "ADVISORY_SELECTION_NOTICE",
+    "MAX_ACCURACY_THEN_CHEAPEST",
+    "QUALITY_FLOOR_MIN_COST",
+    "PARETO_FRONTIER",
+    "StrategyPresetError",
+    "UnknownStrategyPresetError",
+    "StrategyPresetValidationError",
+    "NormalizedStrategyPreset",
+    "is_strategy_preset_name",
+    "normalize_strategy_preset",
+    "normalize",
+    "select_strategy_preset",
+    "calculate_weighted_trial_score",
+]
+
+
 class StrategyPresetError(ValueError):
     """Base class for strategy preset validation errors."""
 

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -32,6 +32,38 @@ if TYPE_CHECKING:
     from traigent.core.objectives import ObjectiveSchema
 
 
+__all__ = [
+    "SelectionGrade",
+    "OptimizationStatus",
+    "TrialStatus",
+    "MetricCoverage",
+    "ComparabilityInfo",
+    "StopReason",
+    "TrialDatetimeFormat",
+    "Trial",
+    "TrialError",
+    "TrialResult",
+    "PresetSelection",
+    "serialize_trials",
+    "ExampleResult",
+    "ExperimentStats",
+    "OptimizationResult",
+    "SensitivityAnalysis",
+    "ConfigurationComparison",
+    "ParetoFront",
+    "StrategyConfig",
+    "OptimizationJob",
+    "AgentType",
+    "AgentMeta",
+    "AgentDefinition",
+    "GlobalConfiguration",
+    "AgentConfiguration",
+    "ConfigSpace",
+    "Metrics",
+    "Objectives",
+]
+
+
 class OptimizationStatus(StrEnum):
     """Status of an optimization run."""
 


### PR DESCRIPTION
## Summary
Closes #1446.

The public `traigent.api.*` submodules declared **no `__all__`**. In a `py.typed` library that means every non-underscore top-level name — including internal helpers and resolution-only classes (`get_optimize_default`, `LegacyOptimizeArgs`, `ResolvedExecutionOptions`, module `logger`s) — leaks via `from traigent.api.decorators import *`, IDE autocomplete, and autodoc. The package surface (`api/__init__.py`) is curated; the submodules were not.

Adds a curated `__all__` to `agent_inference`, `config_builder`, `constraint_builders`, `decorators`, `functions`, `parameter_validator`, `strategy_presets`, and `types`, excluding `logger`, typevars, and the named decorator internals. **Explicit imports are unaffected** (`__all__` only governs `import *` / autodoc), and no module does `import *` from these submodules.

## Test
`tests/unit/api/test_api_submodule_exports.py` (9 cases): each submodule declares `__all__`, names exist, `logger`/private excluded; decorators internals no longer leak via `import *` while `optimize`/`EvaluationOptions` still do. Full `test_decorators.py` + `test_functions.py` (117) green. Run: `pytest tests/unit/api/test_api_submodule_exports.py -n0`.

## PR checklist
1. **Worst-case prod path** — N/A; export-surface metadata only, no runtime behavior change.
2. **Production-branch test** — N/A.
3. **Contract regeneration** — none.
4. **Public surface delta** — `__all__` added (tightens the implicit `import *` surface to the intended public API; explicit imports unchanged).
5. **Review threads** — will resolve all.
6. **Quality gates** — unchanged (RUF022 not enabled; lists in definition order).

Spine-Trail: st_ab8731ee2b0c

🤖 Generated with [Claude Code](https://claude.com/claude-code)