### PR TITLE
ci: fail-fast gate (unit behind preflight) + queue-aware spine-trail check

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -108,10 +108,10 @@ jobs:
 
   unit:
     name: unit
-    if: ${{ !cancelled() && needs.changes.outputs.code_changed == 'true' && (github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !cancelled() && needs.changes.outputs.code_changed == 'true' && needs.preflight.result == 'success' && (github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: changes
+    needs: [changes, preflight]
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6.2.0

--- a/.github/workflows/spine-trail-gate.yml
+++ b/.github/workflows/spine-trail-gate.yml
@@ -15,12 +15,13 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  merge_group: {}
 
 permissions:
   contents: read
 
 concurrency:
-  group: spine-trail-gate-${{ github.event.pull_request.number }}
+  group: spine-trail-gate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,6 +34,11 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "✅ merge_group candidate — spine mark already validated at PR time."
+            exit 0
+          fi
+
           # Valid markers (anchored to line start, tolerant of leading spaces).
           trail='^[[:space:]]*Spine-Trail:[[:space:]]*st_[0-9a-f]{12}[[:space:]]*$'
           session='^[[:space:]]*Spine:[[:space:]]*cs_[0-9a-z]{6,}[[:space:]]*$'


### PR DESCRIPTION
## CI throughput: fail-fast gate + queue-aware required check (replicates TraigentBackend)

Replicates the TraigentBackend two-tier CI throughput pattern onto the SDK
required PR gate. Two surgical workflow edits only.

### (a) FAIL-FAST — `.github/workflows/pr-gate.yml`
The expensive `unit` job previously ran in **parallel** with the cheap
`preflight` (changed-file ruff) job, so a lint/format failure still spent a
45-minute runner on the full unit suite. Now `unit` `needs: [changes, preflight]`
and only runs when `needs.preflight.result == 'success'` — a ruff/format failure
**skips** the unit suite.

**Fail-closed preserved:** the `required-pr-gate` aggregator is unchanged. It
`needs: [changes, preflight, unit]` and treats only `success|skipped` as pass.
When `preflight` fails, `unit` is skipped **but `preflight=failure` independently
fails the aggregator** — a skipped `unit` never produces a fake-green merge.

### (c) QUEUE-AWARE — `.github/workflows/spine-trail-gate.yml`
The PR-body `spine-trail present` check cannot read a PR body on `merge_group`
(queue) events. It now triggers on `merge_group` and short-circuits to SUCCESS
(the mark was already validated at PR time). The check **name is unchanged**, so
branch protection still matches, and the concurrency group gains a `github.ref`
fallback (PR number is null on merge_group). This future-proofs the gate for a
merge queue. `pr-gate.yml` (the only currently-required check, `required-pr-gate`)
was already `merge_group`-aware.

### (b) REMOVE FAKE-GREEN — no change required (honest finding)
The required gate (`pr-gate.yml`) has **zero** `|| true` / `continue-on-error`,
and coverage is not generated on the gate path. All `|| true` masks in the repo
live in `workflow_dispatch`/`schedule`-only, **non-required** workflows
(`tests.yml`, `quality.yml`, etc.) and are advisory scans — out of scope for the
merge gate. Nothing to remove.

### Validation
- `python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → all 23 workflows parse.
- Opus 4.8 review confirmed: fail-fast is fail-closed, no fake-green in the gate, queue-aware check posts a status on `merge_group` with the name unchanged.

### PR checklist
1. **Worst-case prod path** — N/A: CI-config only, no runtime/policy/product code. Worst case is a CI gate mis-skip; the aggregator stays fail-closed via `preflight`.
2. **Production-branch test** — N/A (no production code path).
3. **Contract regeneration** — none (no TraigentSchema / OpenAPI / cross-SDK change).
4. **Public surface delta** — none. Required check name (`required-pr-gate`) and `spine-trail present` are unchanged.
5. **Review threads resolved** — will resolve any bot threads before merge.
6. **Quality gates not relaxed** — no threshold widened; this *adds* a fail-fast gate and a queue-safe trigger.

Spine-Trail: st_22f4d018e2c7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
