### PR TITLE
fix(sdk): #1410 unify PaginationInfo.per_page default (projects 0->20)

### DIFF
--- a/tests/unit/projects/test_pagination_info_default.py
+++ b/tests/unit/projects/test_pagination_info_default.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from traigent.observability.dtos import PaginationInfo as ObservabilityPaginationInfo
+from traigent.projects.dtos import PaginationInfo as ProjectsPaginationInfo
+from traigent.prompts.dtos import PaginationInfo as PromptsPaginationInfo
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "pagination_info_cls",
+    [
+        ProjectsPaginationInfo,
+        PromptsPaginationInfo,
+        ObservabilityPaginationInfo,
+    ],
+)
+def test_pagination_info_missing_per_page_defaults_to_twenty(
+    pagination_info_cls: type[
+        ProjectsPaginationInfo | PromptsPaginationInfo | ObservabilityPaginationInfo
+    ],
+) -> None:
+    assert pagination_info_cls.from_dict({}).per_page == 20

--- a/traigent/projects/dtos.py
+++ b/traigent/projects/dtos.py
@@ -50,7 +50,7 @@ class PaginationInfo:
     def from_dict(cls, payload: dict[str, Any]) -> PaginationInfo:
         return cls(
             page=int(payload.get("page", 1)),
-            per_page=int(payload.get("per_page", 0)),
+            per_page=int(payload.get("per_page", 20)),
             total=int(payload.get("total", 0)),
             total_pages=int(payload.get("total_pages", 1)),
             has_next=bool(payload.get("has_next", False)),


### PR DESCRIPTION
## Summary

`PaginationInfo` is defined three times in the SDK with identical fields and a near-identical `from_dict`, but the `per_page` default when the server omits the key **diverged**: `traigent/projects/dtos.py` defaulted to `0` while `traigent/prompts/dtos.py` and `traigent/observability/dtos.py` default to `20`. A page size of `0` is nonsensical, and the same missing-`per_page` payload yielded a different `per_page` depending on which package parsed it (silent client divergence). This unifies the `projects` copy to `20`.

Scope is deliberately minimal: only the divergent default value is changed. The deeper 3->1 consolidation of the duplicate `PaginationInfo` definitions is noted in #1410 as a separate follow-up and is **not** done here; the parametrized regression test guards against future cross-copy divergence in the meantime.

## Test

`tests/unit/projects/test_pagination_info_default.py` — parametrized over all three `PaginationInfo` definitions, asserts `from_dict({}).per_page == 20`. Verified: **fails** on the pre-fix value `0`, **passes** on `20`. `tests/unit/projects/` (12 tests) pass; ruff clean.

Closes #1410

## PR checklist
1. **Worst-case prod path** — n/a. Client-side defensive default for a missing key in a paginated response envelope; in real responses `per_page` is always present. No policy surface.
2. **Production-branch test** — n/a (no production-gated branch). Behavioral regression cited above.
3. **Contract regeneration** — none. This is a client-side parse default, not a wire-shape change; no TraigentSchema bump required.
4. **Public surface delta** — none (`PaginationInfo` fields unchanged; only a defaulted parse value).
5. **Review threads** — will resolve on review.
6. **Quality gates** — not relaxed.

Spine-Trail: st_920b8b4582d8

🤖 Generated with [Claude Code](https://claude.com/claude-code)