### PR TITLE
fix(sdk): loosen litellm exact pin + reassess install-blocking dep floors (#1418)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "cryptography>=46.0.7",  # CVE-2026-26007 + 3 more fixed in 46.0.7 (see #709)
     "PyJWT[crypto]>=2.13.0,<3.0.0",  # >=2.13.0: Dependabot alerts — DoS, SSRF via JWKClient, HS256 forgery, alg bypass, kid DoS
     "backoff>=2.2.0",
-    "litellm==1.87.1",  # Stable pin: 1.83.x python-dotenv==1.0.1 and 1.83.14 openai==2.24.0 sub-pins are gone from stable 1.84+ (1.87.1 ships openai>=2.20,<3 and python-dotenv>=1.0,<2, compatible with langchain-openai>=1.1.14). Keep pinned + verified on bumps; no need for RC/dev builds anymore.
+    "litellm>=1.87.1,<2",  # Floor: 1.84+ escaped the 1.83.x python-dotenv==1.0.1 and openai==2.24.0 exact sub-pins; 1.87.1 is the first stable release verified against this SDK. Upper bound <2 guards against a future breaking major. The demo (TraigentDemo) requires 1.88.0; this range admits it. Only the public API surface (completion, acompletion, cost_per_token, token_counter, model_cost, ModelResponse) is used — stable across the 1.x line.
     "rank-bm25",
     "psutil>=5.8.0",
     # Required by API decorators and config validation

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,6 @@ typing-extensions>=4.0.0; python_version<"3.11"
 claude-code-sdk>=0.0.14
 mcp>=1.27.0
 backoff>=2.2.0
-litellm==1.87.1
+litellm>=1.87.1,<2
 rank-bm25
 psutil>=5.8.0

--- a/tests/unit/test_dependency_pins.py
+++ b/tests/unit/test_dependency_pins.py
@@ -32,10 +32,18 @@ def _get_litellm_specifier_from_pyproject() -> str:
     data = tomllib.loads(PYPROJECT_PATH.read_text())
     deps: list[str] = data["project"]["dependencies"]
     for dep in deps:
-        normalized = dep.strip().lower().split("[")[0].split(">=")[0].split("==")[0].split(",")[0].strip()
+        normalized = (
+            dep.strip()
+            .lower()
+            .split("[")[0]
+            .split(">=")[0]
+            .split("==")[0]
+            .split(",")[0]
+            .strip()
+        )
         if normalized.rstrip() == "litellm":
             # Extract the specifier part: everything after "litellm"
-            specifier = dep.strip()[len("litellm"):]
+            specifier = dep.strip()[len("litellm") :]
             # Strip trailing comments
             specifier = specifier.split("#")[0].strip()
             return specifier
@@ -87,7 +95,7 @@ def test_litellm_specifier_is_not_exact_pin():
 def test_quickstart_install_hint_uses_range():
     """The quickstart error hint should NOT hardcode a specific exact version."""
     source = QUICKSTART_MAIN_PATH.read_text()
-    assert 'litellm==1.87.1' not in source, (
+    assert "litellm==1.87.1" not in source, (
         "traigent/examples/quickstart/__main__.py still hardcodes 'litellm==1.87.1' "
         "in the install hint. Update it to match the pyproject.toml range "
         "(e.g. 'litellm>=1.87.1,<2'). See GitHub issue #1418."

--- a/tests/unit/test_dependency_pins.py
+++ b/tests/unit/test_dependency_pins.py
@@ -1,0 +1,105 @@
+"""Regression test for dependency specifier ranges.
+
+Guards that the litellm specifier in pyproject.toml admits the demo-required
+version 1.88.0 (and beyond), not just the baseline 1.87.1. Before the fix
+for GitHub issue #1418, the spec was ``litellm==1.87.1``, which caused:
+  - customer installs to conflict with the demo (which needs 1.88.0)
+  - the pyproject to be unduly rigid for any minor litellm release
+
+This test FAILS on the pre-fix ``==1.87.1`` pin and PASSES on the loosened
+``>=1.87.1,<2`` range.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.specifiers import SpecifierSet
+
+# File is at tests/unit/test_dependency_pins.py
+# parents[0] = tests/unit/, parents[1] = tests/, parents[2] = repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT_PATH = _REPO_ROOT / "pyproject.toml"
+QUICKSTART_MAIN_PATH = (
+    _REPO_ROOT / "traigent" / "examples" / "quickstart" / "__main__.py"
+)
+REQUIREMENTS_CORE_PATH = _REPO_ROOT / "requirements" / "requirements.txt"
+
+
+def _get_litellm_specifier_from_pyproject() -> str:
+    """Extract the raw litellm specifier string from pyproject.toml."""
+    data = tomllib.loads(PYPROJECT_PATH.read_text())
+    deps: list[str] = data["project"]["dependencies"]
+    for dep in deps:
+        normalized = dep.strip().lower().split("[")[0].split(">=")[0].split("==")[0].split(",")[0].strip()
+        if normalized.rstrip() == "litellm":
+            # Extract the specifier part: everything after "litellm"
+            specifier = dep.strip()[len("litellm"):]
+            # Strip trailing comments
+            specifier = specifier.split("#")[0].strip()
+            return specifier
+    raise AssertionError("litellm not found in pyproject.toml [project.dependencies]")
+
+
+def test_litellm_specifier_admits_1_88():
+    """litellm specifier must admit version 1.88.0 (the demo requirement)."""
+    raw_spec = _get_litellm_specifier_from_pyproject()
+    spec_set = SpecifierSet(raw_spec)
+    assert spec_set.contains("1.88.0"), (
+        f"litellm specifier '{raw_spec}' does NOT admit 1.88.0. "
+        "The demo (TraigentDemo) requires litellm 1.88.0. "
+        "Loosen the pin from '==1.87.1' to '>=1.87.1,<2' (see GitHub issue #1418)."
+    )
+
+
+def test_litellm_specifier_admits_baseline_1_87_1():
+    """litellm specifier must still admit the baseline 1.87.1."""
+    raw_spec = _get_litellm_specifier_from_pyproject()
+    spec_set = SpecifierSet(raw_spec)
+    assert spec_set.contains("1.87.1"), (
+        f"litellm specifier '{raw_spec}' does NOT admit 1.87.1, the previously-verified baseline."
+    )
+
+
+def test_litellm_specifier_rejects_major_2():
+    """litellm specifier should exclude major version 2 (unverified breaking changes)."""
+    raw_spec = _get_litellm_specifier_from_pyproject()
+    spec_set = SpecifierSet(raw_spec)
+    assert not spec_set.contains("2.0.0"), (
+        f"litellm specifier '{raw_spec}' admits 2.0.0 (a future major version). "
+        "Add an upper bound '<2' to guard against unverified breaking changes."
+    )
+
+
+def test_litellm_specifier_is_not_exact_pin():
+    """litellm specifier must not be an exact == pin, which breaks co-installation."""
+    raw_spec = _get_litellm_specifier_from_pyproject()
+    assert raw_spec.strip().startswith(">="), (
+        f"litellm specifier '{raw_spec}' appears to be an exact pin (==). "
+        "Library packages should use version ranges, not exact pins, "
+        "so customers can co-install the SDK with other packages that need "
+        "a different litellm minor (e.g. the demo needs 1.88.0). "
+        "See GitHub issue #1418."
+    )
+
+
+def test_quickstart_install_hint_uses_range():
+    """The quickstart error hint should NOT hardcode a specific exact version."""
+    source = QUICKSTART_MAIN_PATH.read_text()
+    assert 'litellm==1.87.1' not in source, (
+        "traigent/examples/quickstart/__main__.py still hardcodes 'litellm==1.87.1' "
+        "in the install hint. Update it to match the pyproject.toml range "
+        "(e.g. 'litellm>=1.87.1,<2'). See GitHub issue #1418."
+    )
+
+
+def test_requirements_txt_not_exact_litellm_pin():
+    """requirements/requirements.txt must not exact-pin litellm."""
+    requirements_text = REQUIREMENTS_CORE_PATH.read_text()
+    assert "litellm==1.87.1" not in requirements_text, (
+        "requirements/requirements.txt still has 'litellm==1.87.1'. "
+        "Update it to match the pyproject.toml range (e.g. 'litellm>=1.87.1,<2'). "
+        "See GitHub issue #1418."
+    )

--- a/tests/unit/test_dependency_pins.py
+++ b/tests/unit/test_dependency_pins.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-import pytest
 from packaging.specifiers import SpecifierSet
 
 # File is at tests/unit/test_dependency_pins.py

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -45,7 +45,7 @@ except ModuleNotFoundError as exc:
     missing = exc.name or "litellm"
     print(
         f"[traigent] Missing required quickstart dependency '{missing}'. "
-        f'Run: {sys.executable} -m pip install "litellm==1.87.1"',
+        f'Run: {sys.executable} -m pip install "litellm>=1.87.1,<2"',
         file=sys.stderr,
     )
     raise SystemExit(1) from None


### PR DESCRIPTION
## Summary

Fixes #1418. The SDK's `pyproject.toml` exact-pinned `litellm==1.87.1`, which prevented customers from co-installing the SDK with the demo (which requires 1.88.0) and blocked any litellm upgrade.

### What changed

| File | Before | After |
|------|--------|-------|
| `pyproject.toml` | `litellm==1.87.1` | `litellm>=1.87.1,<2` |
| `requirements/requirements.txt` | `litellm==1.87.1` | `litellm>=1.87.1,<2` |
| `traigent/examples/quickstart/__main__.py` | install hint `litellm==1.87.1` | `litellm>=1.87.1,<2` |

### Security floors — ALL KEPT (CVE-driven)

All four "aggressive" floors have explicit CVE justifications in the comments and were not changed:

- `aiohttp>=3.14.0,<4.0` — CVE-2026-34993/CVE-2026-47265
- `requests>=2.33.0` — CVE-2026-25645 / GHSA-9hjg-9r4m-mvj7
- `cryptography>=46.0.7` — CVE-2026-26007 + 3 more (see #709)
- `PyJWT[crypto]>=2.13.0,<3.0.0` — DoS, SSRF via JWKClient, HS256 forgery, alg bypass, kid DoS

### litellm API compatibility

The SDK uses only stable litellm 1.x public APIs: `completion`, `acompletion`, `cost_per_token`, `token_counter`, `model_cost`, `model_alias_map`, and `ModelResponse`. These have been stable across the entire 1.x line. The git history shows a Dependabot bump to 1.88.0rc1 was attempted (commit `3432d66`) and the suite passed — confirming API compatibility at 1.88.x.

### Resolution check

`uv pip compile pyproject.toml` resolves cleanly to `litellm==1.89.4` (latest stable). The dep-floor drift CI guard (`scripts/ci/check_dep_floor_drift.py`) passes — floor in both files remains `1.87.1`.

### Regression test

Added `tests/unit/test_dependency_pins.py` (6 tests). Confirmed:
- **FAILS pre-fix** (`==1.87.1`): `test_litellm_specifier_admits_1_88` and `test_litellm_specifier_is_not_exact_pin` both fail.
- **Passes post-fix** (`>=1.87.1,<2`): all 6 pass.

## PR checklist

1. **Worst-case prod path**: dependency specifier loosening — no runtime security surface changed.
2. **Production-branch test**: N/A — this is a packaging-only change.
3. **Contract regeneration**: N/A — no API shape changes.
4. **Public surface delta**: No `__all__` or route changes.
5. **Review threads resolved**: N/A (new PR).
6. **Quality gates not relaxed**: no threshold changes. New test adds coverage.

Spine-Trail: st_503b569e5697