### PR TITLE
fix(sdk): surface silent auth-publish failures + self-describing default experiment name (#1373, #1422)

### DIFF
--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -252,21 +252,22 @@ def test_create_session_prunes_completed_sessions_with_aware_timestamps(monkeypa
     assert "session-123" in client._active_sessions
 
 
-def test_create_session_auth_failure_logs_warning_not_debug(monkeypatch, caplog):
-    """Issue #1373(A): a backend AuthenticationError during the outer
-    ``SessionOperations.create_session`` path must surface at WARNING.
+def test_create_session_inner_auth_failure_logs_warning_not_debug(monkeypatch, caplog):
+    """Issue #1373: the INNER ``create_session`` auth handler must surface at
+    WARNING.
 
     This drives the REAL create-session code path (not just
     ``handle_session_creation_result``): ``_create_traigent_session_via_api``
-    raises ``AuthenticationError``, which is caught by the inner handler that
-    logs ``"Backend auth failed for ..."`` (session_operations.py ~:573).
+    raises ``AuthenticationError`` inside ``_create_session_async``'s inner
+    ``try``, which is caught by the inner handler that logs
+    ``"Backend auth failed for ..."`` (session_operations.py ~:573 — the
+    "inner sibling" the issue attributes to #1278's layer).
 
     Pre-fix that site was ``logger.debug``, so the failed publish was invisible
     at the default log level. After the fix it is ``logger.warning``.
 
-    Coverage proof: reverting ONLY that line back to ``logger.debug`` makes
-    this test FAIL (no WARNING record captured); restoring ``logger.warning``
-    makes it PASS.
+    Coverage proof: reverting ONLY :573 back to ``logger.debug`` makes this
+    test FAIL (no WARNING record captured); restoring ``logger.warning`` PASSes.
     """
     client = FakeClient()
     ops = SessionOperations(client)
@@ -289,7 +290,7 @@ def test_create_session_auth_failure_logs_warning_not_debug(monkeypatch, caplog)
     assert result.backend_connected is False
     assert result.failure_reason == SessionCreationFailureReason.AUTH
 
-    # The auth failure MUST be visible at WARNING level (issue #1373(A)).
+    # The auth failure MUST be visible at WARNING level (issue #1373).
     auth_warnings = [
         record
         for record in caplog.records
@@ -298,6 +299,63 @@ def test_create_session_auth_failure_logs_warning_not_debug(monkeypatch, caplog)
     ]
     assert auth_warnings, (
         "Expected a WARNING-level 'Backend auth failed' record from the "
-        "create_session auth-failure path; got: "
+        "INNER create_session auth-failure path; got: "
+        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_create_session_outer_auth_swallow_logs_warning_not_debug(monkeypatch, caplog):
+    """Issue #1373 — the named "OUTER create_session swallow".
+
+    The issue's title and Case 2 name an OUTER ``except AuthenticationError``
+    handler (anchor SHA 3f6710f0 lines 585-606; current ~:639) that catches an
+    auth failure ESCAPING ``_create_session_async`` and logs it at
+    ``logger.debug`` — silent at the default log level. This is distinct from
+    the inner sibling (~:573) which catches the failure raised inside the API
+    call. The two are mutually exclusive per failure: a single
+    ``AuthenticationError`` is caught by exactly one handler, so lifting both
+    does not double-log.
+
+    This test reaches the OUTER handler by making the ``has_api_key()``
+    preflight (called at the top of ``_create_session_async``, OUTSIDE the
+    inner ``try``) raise ``AuthenticationError``. That exception escapes
+    ``_create_session_async`` and is caught by the outer handler at ~:636,
+    which must now log at WARNING (was DEBUG).
+
+    Coverage proof: reverting ONLY :639 back to ``logger.debug`` makes this
+    test FAIL (no WARNING captured); restoring ``logger.warning`` PASSes.
+    """
+    client = FakeClient()
+
+    def _raise_auth() -> bool:
+        raise AuthenticationError("403 Forbidden: missing experiment.write")
+
+    # has_api_key is invoked OUTSIDE the inner try in _create_session_async,
+    # so the raised AuthenticationError escapes to the OUTER handler (~:636).
+    monkeypatch.setattr(client.auth_manager, "has_api_key", _raise_auth)
+
+    ops = SessionOperations(client)
+
+    with caplog.at_level(logging.WARNING, logger="traigent.cloud.session_operations"):
+        # Non-governed (no promotion_policy/tvl_governance) → not fail-loud →
+        # the outer handler catches, logs, and returns a local AUTH fallback.
+        result = ops.create_session(
+            "demo-function",
+            {"model": ["gpt-4o"]},
+            metadata={"max_trials": 3, "dataset_size": 4},
+        )
+
+    assert result.backend_connected is False
+    assert result.failure_reason == SessionCreationFailureReason.AUTH
+
+    auth_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "Backend auth failed" in record.getMessage()
+    ]
+    assert auth_warnings, (
+        "Expected a WARNING-level 'Backend auth failed' record from the OUTER "
+        "create_session swallow (#1373); got: "
         f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
     )

--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -1,5 +1,6 @@
 """Validation and locking tests for SessionOperations."""
 
+import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -8,8 +9,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from traigent.cloud.api_operations import TraigentSessionApiResult
+from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.models import OptimizationSession, OptimizationSessionStatus
 from traigent.cloud.session_operations import SessionOperations
+from traigent.cloud.session_types import SessionCreationFailureReason
 from traigent.utils.exceptions import ValidationError as ValidationException
 
 
@@ -247,3 +250,54 @@ def test_create_session_prunes_completed_sessions_with_aware_timestamps(monkeypa
     assert "completed-oldest" not in client._active_sessions
     assert "active-newer" in client._active_sessions
     assert "session-123" in client._active_sessions
+
+
+def test_create_session_auth_failure_logs_warning_not_debug(monkeypatch, caplog):
+    """Issue #1373(A): a backend AuthenticationError during the outer
+    ``SessionOperations.create_session`` path must surface at WARNING.
+
+    This drives the REAL create-session code path (not just
+    ``handle_session_creation_result``): ``_create_traigent_session_via_api``
+    raises ``AuthenticationError``, which is caught by the inner handler that
+    logs ``"Backend auth failed for ..."`` (session_operations.py ~:573).
+
+    Pre-fix that site was ``logger.debug``, so the failed publish was invisible
+    at the default log level. After the fix it is ``logger.warning``.
+
+    Coverage proof: reverting ONLY that line back to ``logger.debug`` makes
+    this test FAIL (no WARNING record captured); restoring ``logger.warning``
+    makes it PASS.
+    """
+    client = FakeClient()
+    ops = SessionOperations(client)
+
+    async def create_via_api(_request):
+        raise AuthenticationError("403 Forbidden: missing_permissions")
+
+    monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
+
+    with caplog.at_level(logging.WARNING, logger="traigent.cloud.session_operations"):
+        # Non-governed call → AuthenticationError is NOT fail-loud; it is caught,
+        # logged, and downgraded to a local fallback result.
+        result = ops.create_session(
+            "demo-function",
+            {"model": ["gpt-4o"]},
+            metadata={"max_trials": 3, "dataset_size": 4},
+        )
+
+    # The call returns a local fallback with reason=AUTH (no exception raised).
+    assert result.backend_connected is False
+    assert result.failure_reason == SessionCreationFailureReason.AUTH
+
+    # The auth failure MUST be visible at WARNING level (issue #1373(A)).
+    auth_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "Backend auth failed" in record.getMessage()
+    ]
+    assert auth_warnings, (
+        "Expected a WARNING-level 'Backend auth failed' record from the "
+        "create_session auth-failure path; got: "
+        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )

--- a/tests/unit/core/test_backend_session_manager.py
+++ b/tests/unit/core/test_backend_session_manager.py
@@ -173,9 +173,11 @@ class TestBackendSessionManagerCreation:
         # Verify backend client called
         mock_backend_client.create_session.assert_called_once()
         call_kwargs = mock_backend_client.create_session.call_args[1]
-        # Assert concrete format: "display_name (hash_suffix)"
+        # When experiment_display_name is None, the portal name is self-describing
+        # (issue #1422): it encodes objectives + knobs, NOT the function display_name.
         portal_name = call_kwargs["function_name"]
-        assert portal_name.startswith(descriptor.display_name)
+        assert "opt:accuracy,cost" in portal_name  # objectives present
+        assert "param1" in portal_name  # knob name present
         assert portal_name.endswith(f"({descriptor.slug[-8:]})")
         assert call_kwargs["optimization_goal"] == "maximize"
         assert (
@@ -1825,3 +1827,263 @@ class TestRuntimeDegradationSourceMarker:
             record for record in caplog.records if "LOCAL-ONLY" in record.getMessage()
         ]
         assert len(local_only_warnings) == 1, "should warn once, not per trial"
+
+
+class TestIssue1373SilentAuthPathSurfacing:
+    """Regression tests for issue #1373 – auth failures must surface at WARNING.
+
+    Two sub-cases:
+    (A) OUTER path in session_operations.py: AuthenticationError is now logged
+        at WARNING (was DEBUG) before returning a fallback SessionCreationResult.
+        This is tested by directly invoking handle_session_creation_result with an
+        AUTH-reason result and confirming a WARNING-level record is emitted.
+    (B) GUARD: when backend tracking was already disabled (was_enabled=False),
+        an AUTH-reason failure must still emit a WARNING with the remedy text.
+        Previously the code early-returned without emitting anything.
+    """
+
+    def _make_auth_result(self, missing_permissions=None):
+        """Return a fallback SessionCreationResult with reason=AUTH."""
+        from traigent.cloud.session_types import SessionCreationFailureDetail
+
+        detail = None
+        if missing_permissions is not None:
+            detail = SessionCreationFailureDetail(
+                status_code=403,
+                error_code="PERMISSION_DENIED",
+                message="Access denied",
+                missing_permissions=missing_permissions,
+                raw_body=None,
+            )
+        return SessionCreationResult.fallback(
+            session_id="local-fallback-session",
+            reason=SessionCreationFailureReason.AUTH,
+            detail="auth failed",
+            failure_response=detail,
+        )
+
+    def test_auth_failure_emits_warning_on_first_disable(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_optimizer,
+        monkeypatch,
+        caplog,
+    ):
+        """(A) First-time auth failure must surface at WARNING level.
+
+        When TRAIGENT_ALLOW_UNTRACKED=1 the code takes the logger.warning
+        branch (not ConfigurationError). This test pins that the full
+        TRAIGENT BACKEND TRACKING UNAVAILABLE block is logged at WARNING.
+        """
+        monkeypatch.setenv("TRAIGENT_ALLOW_UNTRACKED", "1")
+
+        manager = BackendSessionManager(
+            backend_client=None,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-first",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+        # Tracking is enabled; this is the first auth failure.
+        assert manager.backend_tracking_enabled is True
+
+        result = self._make_auth_result(missing_permissions=["read_experiments"])
+
+        with caplog.at_level(
+            logging.WARNING, logger="traigent.core.backend_session_manager"
+        ):
+            manager.handle_session_creation_result(result)
+
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warning_records, "Expected at least one WARNING record for AUTH failure"
+        combined = "\n".join(r.getMessage() for r in warning_records)
+        # The remedy text distinguishes AUTH warnings from generic ones
+        assert "TRAIGENT BACKEND TRACKING UNAVAILABLE" in combined
+        assert "Missing permissions" in combined or "Remedy" in combined
+
+    def test_auth_failure_emits_warning_when_was_enabled_false(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_optimizer,
+        monkeypatch,
+        caplog,
+    ):
+        """(B) Auth failure warning must fire even when was_enabled=False.
+
+        Pre-fix: handle_session_creation_result early-returned when
+        _backend_tracking_enabled was already False, skipping the AUTH-specific
+        warning block entirely.  A user whose second create_session also returned
+        AUTH would see no visible signal at default log level.
+
+        After the fix the full TRAIGENT BACKEND TRACKING UNAVAILABLE block is
+        emitted at WARNING regardless.
+
+        Pre-fix proof: stash/revert the guard fix in backend_session_manager.py
+        (restore `if not was_enabled: return str(result.session_id)`) and this
+        test FAILs because no WARNING records are captured.
+        """
+        monkeypatch.setenv("TRAIGENT_ALLOW_UNTRACKED", "1")
+
+        manager = BackendSessionManager(
+            backend_client=None,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=mock_optimizer,
+            optimization_id="test-opt-guard",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+        # Pre-disable tracking so was_enabled=False on next call
+        manager.disable_backend_tracking(SessionCreationFailureReason.AUTH)
+        assert manager.backend_tracking_enabled is False
+
+        result = self._make_auth_result(missing_permissions=["read_experiments"])
+
+        with caplog.at_level(
+            logging.WARNING, logger="traigent.core.backend_session_manager"
+        ):
+            manager.handle_session_creation_result(result)
+
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warning_records, (
+            "Expected a WARNING for AUTH failure even when was_enabled=False"
+        )
+        combined = "\n".join(r.getMessage() for r in warning_records)
+        assert "TRAIGENT BACKEND TRACKING UNAVAILABLE" in combined
+
+
+class TestIssue1422SelfDescribingPortalName:
+    """Regression tests for issue #1422 – SDK default experiment name must be
+    self-describing.
+
+    When no explicit experiment_name is supplied to @traigent.optimize(), the
+    portal name passed to create_session must encode the optimization objectives
+    and tuned-variable (knob) names rather than just `<funcname> (hash)`.
+
+    Pre-fix format: ``answer_question (f282c9de)``
+    Post-fix format: ``opt:accuracy,cost · model,temperature (f282c9de)``
+    """
+
+    def test_default_portal_name_contains_objectives_and_knobs(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_dataset,
+    ):
+        """With experiment_display_name=None the portal name encodes objectives
+        and knob names — not just the function name."""
+        from unittest.mock import Mock
+
+        mock_client = Mock()
+        mock_client.create_session = Mock(
+            return_value=SessionCreationResult.connected(session_id="sess-123")
+        )
+        mock_client.get_session_mapping = Mock(return_value=None)
+
+        optimizer = Mock()
+        optimizer.config_space = {
+            "model": ["gpt-4o", "gpt-4o-mini"],
+            "temperature": [0.0, 0.7],
+        }
+
+        manager = BackendSessionManager(
+            backend_client=mock_client,
+            traigent_config=traigent_config,
+            objectives=["accuracy", "cost"],
+            objective_schema=objective_schema,
+            optimizer=optimizer,
+            optimization_id="opt-name-test",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        def my_agent_func(x):
+            return x
+
+        from traigent.utils.function_identity import resolve_function_descriptor
+
+        descriptor = resolve_function_descriptor(my_agent_func)
+
+        # No experiment_display_name → self-describing default
+        manager.create_session(
+            func=my_agent_func,
+            dataset=mock_dataset,
+            function_descriptor=descriptor,
+            max_trials=5,
+            start_time=0.0,
+            experiment_display_name=None,
+        )
+
+        call_kwargs = mock_client.create_session.call_args[1]
+        portal_name = call_kwargs["function_name"]
+
+        # Must include objective names
+        assert "accuracy" in portal_name, (
+            f"Expected objectives in portal name, got: {portal_name!r}"
+        )
+        assert "cost" in portal_name, (
+            f"Expected objectives in portal name, got: {portal_name!r}"
+        )
+        # Must include at least one knob name
+        assert "model" in portal_name or "temperature" in portal_name, (
+            f"Expected knob names in portal name, got: {portal_name!r}"
+        )
+        # Must NOT be just the function name (pre-fix regression check)
+        assert portal_name != f"{my_agent_func.__name__} ({descriptor.slug[-8:]})", (
+            "Portal name should be self-describing, not just the function name"
+        )
+
+    def test_explicit_experiment_name_is_honoured_unchanged(
+        self,
+        traigent_config,
+        objective_schema,
+        mock_dataset,
+    ):
+        """When an explicit experiment_name IS supplied, the portal name must
+        use it (objectives/knobs must NOT override the user's choice)."""
+        from unittest.mock import Mock
+
+        mock_client = Mock()
+        mock_client.create_session = Mock(
+            return_value=SessionCreationResult.connected(session_id="sess-456")
+        )
+        mock_client.get_session_mapping = Mock(return_value=None)
+
+        optimizer = Mock()
+        optimizer.config_space = {"model": ["gpt-4o"]}
+
+        manager = BackendSessionManager(
+            backend_client=mock_client,
+            traigent_config=traigent_config,
+            objectives=["accuracy"],
+            objective_schema=objective_schema,
+            optimizer=optimizer,
+            optimization_id="opt-explicit-name",
+            optimization_status=OptimizationStatus.RUNNING,
+        )
+
+        def my_func(x):
+            return x
+
+        from traigent.utils.function_identity import resolve_function_descriptor
+
+        descriptor = resolve_function_descriptor(my_func)
+
+        manager.create_session(
+            func=my_func,
+            dataset=mock_dataset,
+            function_descriptor=descriptor,
+            max_trials=5,
+            start_time=0.0,
+            experiment_display_name="My Custom Experiment",
+        )
+
+        call_kwargs = mock_client.create_session.call_args[1]
+        portal_name = call_kwargs["function_name"]
+
+        assert portal_name.startswith("My Custom Experiment"), (
+            f"Explicit name not honoured in portal_name: {portal_name!r}"
+        )

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -636,7 +636,15 @@ class SessionOperations:
         except AuthenticationError as exc:
             if _must_fail_loud(exc):
                 raise
-            logger.debug(
+            # Issue #1373 (the "outer create_session swallow"): an auth/scope
+            # failure that ESCAPES _create_session_async (e.g. from the
+            # has_api_key preflight, or the async-runner machinery) on a
+            # non-governed run must NOT fall to debug-only — a failed publish
+            # would be invisible at the default log level. Mirror the inner
+            # sibling (~:573) and surface at WARNING. The two sites are
+            # mutually exclusive per failure (a single AuthenticationError is
+            # caught by exactly one handler), so this does not double-log.
+            logger.warning(
                 "Backend auth failed for '%s': %s",
                 function_name,
                 exc,

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -570,7 +570,7 @@ class SessionOperations:
                 await self._reset_client_session("create_session auth_failure")
                 if _must_fail_loud(e):
                     raise
-                logger.debug("Backend auth failed for '%s': %s", function_name, e)
+                logger.warning("Backend auth failed for '%s': %s", function_name, e)
                 failure_response = _get_session_creation_failure_detail(e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -386,6 +386,21 @@ class BackendSessionManager:
             self.disable_backend_tracking(reason)
 
             if not was_enabled:
+                # Even when tracking was already disabled, an AUTH-reason failure
+                # must surface at WARNING so the user sees the remedy text
+                # (missing_permissions, re-auth hint, etc.) — issue #1373 Case 2.
+                # For non-auth reasons (NO_API_KEY, SESSION_FAILED) the normal
+                # message was already emitted on the first disable; stay silent.
+                if reason == SessionCreationFailureReason.AUTH:
+                    classification = _classify_session_creation_failure(
+                        reason, result.failure_response
+                    )
+                    logger.warning(
+                        "%s",
+                        _format_untracked_warning_block(
+                            result, classification, aborting=False
+                        ),
+                    )
                 return str(result.session_id)
 
             policy = policy_from_config(self._traigent_config)
@@ -712,10 +727,31 @@ class BackendSessionManager:
                     self._strategy_preset_metadata
                 )
 
-            # Use human-readable name with disambiguating hash suffix
-            # e.g. "answer_question (f282c9de)" instead of the full slug
-            portal_name = function_display_name or function_identifier
+            # Build the portal display name.
+            # When the user supplied an explicit experiment_name, honour it.
+            # When no name was given, weave in objectives and knob names so the
+            # experiment is self-describing in the portal's Recent Experiments
+            # list (issue #1422): e.g. "opt:accuracy,cost · model,temperature".
             slug_hash = function_slug.rsplit("_", 1)[-1] if function_slug else ""
+            if experiment_display_name is None:
+                # Collect up to 3 objective names and up to 4 knob names to
+                # keep the label concise.
+                obj_names = (self._objectives or [])[:3]
+                knob_names = list(
+                    (getattr(self._optimizer, "config_space", {}) or {}).keys()
+                )[:4]
+                label_parts: list[str] = []
+                if obj_names:
+                    label_parts.append("opt:" + ",".join(obj_names))
+                if knob_names:
+                    label_parts.append(",".join(knob_names))
+                portal_name = (
+                    " · ".join(label_parts)
+                    if label_parts
+                    else (function_display_name or function_identifier)
+                )
+            else:
+                portal_name = function_display_name or function_identifier
             if slug_hash:
                 portal_name = f"{portal_name} ({slug_hash})"
 


### PR DESCRIPTION
## Summary

Three narrow fixes in the portal-visibility / experiment-naming stack:

- **Auth publish now visible at WARNING** (`session_operations.py`): `AuthenticationError` during session creation was logged at DEBUG, invisible at default log level. Now logged at WARNING so users see the failure immediately.
- **was_enabled=False guard** (`backend_session_manager.py`): when `_backend_tracking_enabled` was already False, `handle_session_creation_result` early-returned silently for AUTH failures, skipping the full `TRAIGENT BACKEND TRACKING UNAVAILABLE` block. Now emits the warning with remedy/permissions text even in that case.
- **Self-describing portal name** (`backend_session_manager.py`): when no `experiment_name` is supplied, the portal label now encodes objectives + knob names instead of just `<funcname> (hash)`:
  - **Before:** `my_agent (a303c9db)`
  - **After:** `opt:accuracy,cost · model,temperature (a303c9db)`
  - Explicit `experiment_name` values are passed through unchanged.

**Out of scope** (BE/FE concerns, not in this repo): `TraiGent Typed Session:` prefix/truncation in the portal list, rename-405 — hence `Refs #1422`, not `Closes #1422`.

Closes #1373
Refs #1422 (SDK weak-default-name only — BE/FE truncation + rename-405 out of repo)

## Regression tests

- `TestIssue1373SilentAuthPathSurfacing::test_auth_failure_emits_warning_on_first_disable` — FAIL pre-fix (no WARNING emitted), PASS post-fix
- `TestIssue1373SilentAuthPathSurfacing::test_auth_failure_emits_warning_when_was_enabled_false` — FAIL pre-fix (guard silently returns, no WARNING), PASS post-fix
- `TestIssue1422SelfDescribingPortalName::test_default_portal_name_contains_objectives_and_knobs` — FAIL pre-fix (`'accuracy' not in 'my_agent_func (d538c4b8)'`), PASS post-fix
- `TestIssue1422SelfDescribingPortalName::test_explicit_experiment_name_is_honoured_unchanged` — PASS both pre and post-fix (safeguard: explicit names must not be overridden)

Full test run: 2727 passed, 1 skipped across `tests/unit/core/` and `tests/unit/security/`.

## PR checklist

1. **Worst-case prod path**: log-level lift and warning emission are read-only from a security standpoint. Name change only affects the display string sent to the backend; it cannot cause data loss or auth bypass.
2. **Production-branch test**: no policy surface touched. N/A.
3. **Contract regeneration**: no schema changes. N/A.
4. **Public surface delta**: `create_session` signature unchanged; portal `function_name` string format changes only when `experiment_display_name is None` (the default).
5. **Review threads**: no prior threads — fresh PR.
6. **Quality gates**: test count increased (+4 tests); no threshold widened.

Spine-Trail: st_5d08c004c8fc