### PR TITLE
fix(sdk): fail-closed promotion-gate adjust method + Holm/Bonferroni (#1416 Axis B)

### DIFF
--- a/tests/unit/tvl/test_models.py
+++ b/tests/unit/tvl/test_models.py
@@ -226,6 +226,17 @@ class TestPromotionPolicy:
         assert policy.adjust == "BH"
         assert len(policy.chance_constraints) == 1
 
+    def test_supported_adjust_methods(self) -> None:
+        """Supported multiple-comparison adjustment methods are accepted."""
+        for adjust in ("none", "BH", "holm", "bonferroni"):
+            policy = PromotionPolicy.from_dict({"adjust": adjust})
+            assert policy.adjust == adjust
+
+    def test_unsupported_adjust_method_rejected(self) -> None:
+        """Unsupported adjustment methods fail at policy construction."""
+        with pytest.raises(ValueError, match="Unsupported promotion_policy.adjust"):
+            PromotionPolicy(adjust="sidak")  # type: ignore[arg-type]
+
 
 class TestStructuralConstraint:
     """Tests for StructuralConstraint data class."""

--- a/tests/unit/tvl/test_promotion_gate.py
+++ b/tests/unit/tvl/test_promotion_gate.py
@@ -1,5 +1,7 @@
 """Unit tests for TVL promotion gate."""
 
+import pytest
+
 from traigent.tvl.models import BandTarget, ChanceConstraint, PromotionPolicy
 from traigent.tvl.promotion_gate import (
     ObjectiveSpec,
@@ -174,6 +176,54 @@ class TestPromotionGate:
 
         # Should have adjusted p-values
         assert len(decision.adjusted_p_values) > 0
+
+    def test_holm_adjustment_blocks_raw_p_value_promotion(self) -> None:
+        """Holm adjustment prevents promotion that raw p-values would allow."""
+        incumbent_metrics = {
+            "a": [0.0] * 10,
+            "b": [0.0] * 10,
+        }
+        candidate_metrics = {
+            "a": [-0.9, -0.4, 0.1, 0.6, 1.1, 1.6, 2.1, -0.15, 0.85, 1.1],
+            "b": [0.0] * 10,
+        }
+        objectives = [
+            ObjectiveSpec("a", "maximize"),
+            ObjectiveSpec("b", "maximize"),
+        ]
+
+        raw_gate = PromotionGate(
+            PromotionPolicy(alpha=0.05, min_effect={"a": 0.0, "b": 0.0}),
+            objectives,
+        )
+        raw_decision = raw_gate.evaluate(incumbent_metrics, candidate_metrics)
+        assert raw_decision.decision == "promote"
+        assert raw_decision.adjusted_p_values["a"] < raw_gate.policy.alpha
+
+        holm_gate = PromotionGate(
+            PromotionPolicy(
+                alpha=0.05,
+                min_effect={"a": 0.0, "b": 0.0},
+                adjust="holm",
+            ),
+            objectives,
+        )
+        holm_decision = holm_gate.evaluate(incumbent_metrics, candidate_metrics)
+        assert holm_decision.adjusted_p_values["a"] > holm_gate.policy.alpha
+        assert holm_decision.decision == "no_decision"
+        assert holm_decision.dominance_satisfied is False
+
+    def test_unsupported_adjust_value_reaching_gate_raises(self) -> None:
+        """The gate fails closed if an unsupported adjust value reaches it."""
+        policy = PromotionPolicy(alpha=0.05, adjust="none")
+        policy.adjust = "sidak"  # type: ignore[assignment]
+        gate = PromotionGate(policy, [ObjectiveSpec("accuracy", "maximize")])
+
+        with pytest.raises(ValueError, match="Unsupported promotion_policy.adjust"):
+            gate.evaluate(
+                incumbent_metrics={"accuracy": [0.0] * 5},
+                candidate_metrics={"accuracy": [1.0] * 5},
+            )
 
     def test_missing_objectives_no_decision(self) -> None:
         """No decision when objective data is missing."""

--- a/tests/unit/tvl/test_statistics.py
+++ b/tests/unit/tvl/test_statistics.py
@@ -5,7 +5,9 @@ import pytest
 from traigent.tvl.statistics import (
     PairedComparisonResult,
     benjamini_hochberg_adjust,
+    bonferroni_adjust,
     clopper_pearson_lower_bound,
+    holm_bonferroni_adjust,
     hypervolume_improvement,
     paired_comparison_test,
 )
@@ -60,6 +62,38 @@ class TestBenjaminiHochbergAdjust:
         # For rank 3: 0.03 * 4 / 3 = 0.04
         # For rank 4: 0.04 * 4 / 4 = 0.04
         assert all(abs(p - 0.04) < 1e-10 for p in adjusted)
+
+
+class TestBonferroniAdjust:
+    """Tests for Bonferroni adjustment."""
+
+    def test_empty_list(self) -> None:
+        """Empty list returns empty list."""
+        assert bonferroni_adjust([]) == []
+
+    def test_known_example_and_clipping(self) -> None:
+        """Bonferroni multiplies by the number of tests and caps at one."""
+        assert bonferroni_adjust([0.01, 0.20, 0.60]) == pytest.approx([0.03, 0.60, 1.0])
+
+
+class TestHolmBonferroniAdjust:
+    """Tests for Holm-Bonferroni adjustment."""
+
+    def test_empty_list(self) -> None:
+        """Empty list returns empty list."""
+        assert holm_bonferroni_adjust([]) == []
+
+    def test_single_value_is_capped(self) -> None:
+        """Single p-value is returned as-is, capped at one."""
+        assert holm_bonferroni_adjust([0.05]) == [0.05]
+        assert holm_bonferroni_adjust([1.5]) == [1.0]
+
+    def test_known_step_down_example_preserves_input_order(self) -> None:
+        """Holm adjustment applies step-down monotonic adjusted p-values."""
+        p_vals = [0.01, 0.04, 0.03, 0.20]
+        adjusted = holm_bonferroni_adjust(p_vals)
+
+        assert adjusted == pytest.approx([0.04, 0.09, 0.09, 0.20])
 
 
 class TestClopperPearsonLowerBound:

--- a/traigent/tvl/__init__.py
+++ b/traigent/tvl/__init__.py
@@ -54,7 +54,9 @@ from .spec_validator import (
 from .statistics import (
     PairedComparisonResult,
     benjamini_hochberg_adjust,
+    bonferroni_adjust,
     clopper_pearson_lower_bound,
+    holm_bonferroni_adjust,
     hypervolume_improvement,
     paired_comparison_test,
 )
@@ -89,7 +91,9 @@ __all__ = [
     # Statistics
     "PairedComparisonResult",
     "benjamini_hochberg_adjust",
+    "bonferroni_adjust",
     "clopper_pearson_lower_bound",
+    "holm_bonferroni_adjust",
     "hypervolume_improvement",
     "paired_comparison_test",
     # Promotion gate

--- a/traigent/tvl/models.py
+++ b/traigent/tvl/models.py
@@ -12,13 +12,30 @@ Sync: SYNC-OptimizationFlow
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 # Type aliases for TVL type system
 TVarType = Literal["bool", "int", "float", "enum", "tuple", "callable"]
 DomainKind = Literal["enum", "range", "set", "registry"]
-AdjustMethod = Literal["none", "BH"]
+AdjustMethod = Literal["none", "BH", "holm", "bonferroni"]
+SUPPORTED_ADJUST_METHODS: tuple[AdjustMethod, ...] = (
+    "none",
+    "BH",
+    "holm",
+    "bonferroni",
+)
 TieBreaker = Literal["min_abs_deviation", "custom"]
+
+
+def validate_adjust_method(adjust: Any) -> AdjustMethod:
+    """Validate and normalize a promotion-policy adjustment method."""
+    if not isinstance(adjust, str) or adjust not in SUPPORTED_ADJUST_METHODS:
+        allowed = ", ".join(SUPPORTED_ADJUST_METHODS)
+        raise ValueError(
+            f"Unsupported promotion_policy.adjust {adjust!r}; "
+            f"expected one of: {allowed}"
+        )
+    return cast(AdjustMethod, adjust)
 
 
 @dataclass(slots=True)
@@ -294,7 +311,8 @@ class PromotionPolicy:
         dominance: Dominance relation (TVL 0.9 mandates "epsilon_pareto").
         alpha: Family-wise error rate budget (0 < alpha < 1, default 0.05).
         min_effect: Per-objective epsilon tolerances for dominance comparison.
-        adjust: Multiple testing adjustment ("none" or "BH" for Benjamini-Hochberg).
+        adjust: Multiple testing adjustment ("none", "BH", "holm", or
+            "bonferroni").
         chance_constraints: Hard constraints with confidence thresholds.
         tie_breakers: Secondary ordering rules for ties.
     """
@@ -311,6 +329,8 @@ class PromotionPolicy:
         """Validate promotion policy."""
         if not 0 < self.alpha < 1:
             raise ValueError(f"Alpha must be in (0, 1), got {self.alpha}")
+
+        self.adjust = validate_adjust_method(self.adjust)
 
         for name, epsilon in self.min_effect.items():
             if epsilon < 0:

--- a/traigent/tvl/promotion_gate.py
+++ b/traigent/tvl/promotion_gate.py
@@ -15,11 +15,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from .models import BandTarget, PromotionPolicy
+from .models import BandTarget, PromotionPolicy, validate_adjust_method
 from .objectives import tost_equivalence_test
 from .statistics import (
     benjamini_hochberg_adjust,
+    bonferroni_adjust,
     clopper_pearson_lower_bound,
+    holm_bonferroni_adjust,
     paired_comparison_test,
 )
 
@@ -79,7 +81,7 @@ class PromotionDecision:
         reason: Human-readable explanation of the decision.
         objective_results: Per-objective comparison results.
         chance_results: Per-constraint evaluation results.
-        adjusted_p_values: P-values after BH adjustment (if applied).
+        adjusted_p_values: P-values after multiple-testing adjustment (if applied).
         dominance_satisfied: Whether epsilon-Pareto dominance holds.
     """
 
@@ -176,11 +178,23 @@ class PromotionGate:
         self, raw_p_values: dict[str, float]
     ) -> dict[str, float]:
         """Apply multiple testing adjustment if configured."""
-        if self.policy.adjust == "BH" and len(raw_p_values) > 1:
-            p_list = list(raw_p_values.values())
+        adjust = validate_adjust_method(self.policy.adjust)
+        if adjust == "none" or len(raw_p_values) <= 1:
+            return raw_p_values.copy()
+
+        p_list = list(raw_p_values.values())
+        if adjust == "BH":
             adjusted_list = benjamini_hochberg_adjust(p_list)
-            return dict(zip(raw_p_values.keys(), adjusted_list, strict=True))
-        return raw_p_values.copy()
+        elif adjust == "holm":
+            adjusted_list = holm_bonferroni_adjust(p_list)
+        elif adjust == "bonferroni":
+            adjusted_list = bonferroni_adjust(p_list)
+        else:
+            # validate_adjust_method is the primary fail-closed path; keep this
+            # branch as a defensive guard against future enum drift.
+            raise ValueError(f"Unsupported promotion_policy.adjust {adjust!r}")
+
+        return dict(zip(raw_p_values.keys(), adjusted_list, strict=True))
 
     def _check_dominance(
         self,

--- a/traigent/tvl/statistics.py
+++ b/traigent/tvl/statistics.py
@@ -90,6 +90,49 @@ def benjamini_hochberg_adjust(p_values: Sequence[float]) -> list[float]:
     return adjusted
 
 
+def bonferroni_adjust(p_values: Sequence[float]) -> list[float]:
+    """Apply Bonferroni multiple-testing correction.
+
+    Args:
+        p_values: Sequence of raw p-values.
+
+    Returns:
+        List of adjusted p-values (same order as input).
+    """
+    n = len(p_values)
+    if n == 0:
+        return []
+
+    return [min(p * n, 1.0) for p in p_values]
+
+
+def holm_bonferroni_adjust(p_values: Sequence[float]) -> list[float]:
+    """Apply step-down Holm-Bonferroni multiple-testing correction.
+
+    Args:
+        p_values: Sequence of raw p-values.
+
+    Returns:
+        List of adjusted p-values (same order as input).
+    """
+    n = len(p_values)
+    if n == 0:
+        return []
+
+    indexed = [(p, i) for i, p in enumerate(p_values)]
+    indexed.sort(key=lambda x: x[0])
+
+    adjusted = [0.0] * n
+    previous_adjusted = 0.0
+    for rank, (p, original_idx) in enumerate(indexed):
+        current_adjusted = min(p * (n - rank), 1.0)
+        current_adjusted = max(current_adjusted, previous_adjusted)
+        adjusted[original_idx] = current_adjusted
+        previous_adjusted = current_adjusted
+
+    return adjusted
+
+
 def clopper_pearson_lower_bound(
     successes: int,
     trials: int,


### PR DESCRIPTION
Refs #1416 (Axis B only — multiple-comparison adjustment method).

## Problem (fail-open)
`PromotionGate._apply_multiple_testing_adjustment` only handled `adjust == "BH"`; any other value (`holm`, or any unsupported method) silently fell through to RAW p-values — a fail-open over-promotion path. `AdjustMethod` only allowed `none`/`BH`.

## Fix (fail-closed)
- `AdjustMethod` extended to `none | BH | holm | bonferroni`.
- Added tested `holm_bonferroni_adjust` (step-down, monotone) + `bonferroni_adjust` helpers in `statistics.py`.
- `PromotionPolicy` validates `adjust` at construction (`__post_init__`) — unsupported values raise `ValueError`. The gate re-validates before adjustment, so a mutated/stale policy cannot fall through to raw p-values.
- `none`/`BH` behavior preserved exactly.

## Regression tests (fail on pre-fix code)
- `test_holm_adjustment_blocks_raw_p_value_promotion` — pre-fix Holm stayed raw (over-promoted); post-fix corrected.
- `test_unsupported_adjust_value_reaching_gate_raises` — pre-fix `sidak` silently used raw p-values; post-fix fail-closed.
- Suite: 135 passed.

## Scope / HOLD
Axis A (non-inferiority/IUT) and Axis C (chance-constraint) parity with the canonical epsilon-pareto-gate remain HOLD-OWNER (need canonical source) — tracked on #1416.

Spine-Trail: st_b3760c76fec6