### PR TITLE
security(sdk): DNS-rebind parity for utils validate_outbound_url (#1409)

### DIFF
--- a/tests/unit/cloud/test_url_security.py
+++ b/tests/unit/cloud/test_url_security.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import socket
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -13,18 +13,22 @@ from traigent.cloud.url_security import (
 )
 
 
+def _addr_info(ip_address: str) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            (ip_address, 443),
+        )
+    ]
+
+
 def test_validate_cloud_base_url_normalizes_safe_public_url() -> None:
     with patch(
         "socket.getaddrinfo",
-        return_value=[
-            (
-                socket.AF_INET,
-                socket.SOCK_STREAM,
-                6,
-                "",
-                ("93.184.216.34", 443),
-            )
-        ],
+        return_value=_addr_info("93.184.216.34"),
     ):
         assert (
             validate_cloud_base_url("https://auth.example.com/base/")
@@ -79,6 +83,34 @@ def test_validate_cloud_base_url_rejects_metadata_and_nonstandard_ip_hosts(
     with patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=True):
         with pytest.raises(ValueError, match=message):
             validate_cloud_base_url(url)
+
+
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        ("https://metadata", "metadata service"),
+        ("https://metadata.", "metadata service"),
+        ("https://metadata.google.internal", "metadata service"),
+        ("https://metadata.google.internal.", "metadata service"),
+        ("https://0x7f.0.0.1", "non-standard IP address notation"),
+        ("https://2130706433", "non-standard IP address notation"),
+        ("https://0177.0.0.1", "non-standard IP address notation"),
+    ],
+)
+def test_validate_cloud_base_url_rejects_metadata_and_numeric_hosts_before_dns(
+    url: str,
+    message: str,
+) -> None:
+    mock_getaddrinfo = Mock(return_value=_addr_info("93.184.216.34"))
+
+    with (
+        patch.dict("os.environ", {"ENVIRONMENT": "production"}, clear=True),
+        patch("traigent.cloud.url_security.socket.getaddrinfo", mock_getaddrinfo),
+    ):
+        with pytest.raises(ValueError, match=message):
+            validate_cloud_base_url(url)
+
+    mock_getaddrinfo.assert_not_called()
 
 
 def test_validate_cloud_base_url_fails_closed_on_dns_failure() -> None:

--- a/tests/unit/utils/test_url_security.py
+++ b/tests/unit/utils/test_url_security.py
@@ -1,12 +1,36 @@
 """Tests for outbound URL safety validation."""
 
+import socket
+
 import pytest
 
 from traigent.utils.url_security import UnsafeUrlError, validate_outbound_url
 
 
-def test_validate_outbound_url_normalizes_trailing_slash() -> None:
-    assert validate_outbound_url("https://api.example.com/") == "https://api.example.com"
+def _addr_info(ip_address: str) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    return [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            (ip_address, 443),
+        )
+    ]
+
+
+def test_validate_outbound_url_normalizes_trailing_slash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda _host, _port: _addr_info("93.184.216.34"),
+    )
+
+    assert (
+        validate_outbound_url("https://api.example.com/") == "https://api.example.com"
+    )
 
 
 @pytest.mark.parametrize(
@@ -15,7 +39,10 @@ def test_validate_outbound_url_normalizes_trailing_slash() -> None:
         ("", "must not be empty"),
         ("file:///tmp/socket", "http or https"),
         ("https://example.com?token=abc", "query or fragment"),
-        ("https://user:pass@example.com", "embedded credentials"),  # pragma: allowlist secret
+        (
+            "https://user:pass@example.com",
+            "embedded credentials",
+        ),  # pragma: allowlist secret
         ("https://example.com:99999", "invalid port"),
         ("https://api.example.com/v1/..", "dot-segment"),
         ("https://api.example.com/v1/%2e%2e", "dot-segment"),
@@ -40,6 +67,51 @@ def test_validate_outbound_url_allows_private_hosts_when_requested() -> None:
     )
 
 
-def test_validate_outbound_url_still_blocks_metadata_when_private_hosts_allowed() -> None:
+def test_validate_outbound_url_rejects_hostname_resolving_to_private_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda _host, _port: _addr_info("169.254.169.254"),
+    )
+
+    with pytest.raises(UnsafeUrlError, match="must not resolve"):
+        validate_outbound_url("https://rebind.example")
+
+
+def test_validate_outbound_url_accepts_hostname_resolving_to_global_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda _host, _port: _addr_info("93.184.216.34"),
+    )
+
+    assert (
+        validate_outbound_url("https://api.example.com/") == "https://api.example.com"
+    )
+
+
+def test_validate_outbound_url_allows_localhost_when_private_hosts_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_resolved(_host: str, _port: int | None) -> list[object]:
+        raise AssertionError("allow_private_hosts should skip DNS resolution")
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        fail_if_resolved,
+    )
+
+    assert (
+        validate_outbound_url("http://localhost:8080/", allow_private_hosts=True)
+        == "http://localhost:8080"
+    )
+
+
+def test_validate_outbound_url_blocks_metadata_when_private_hosts_allowed() -> None:
     with pytest.raises(UnsafeUrlError, match="non-routable"):
         validate_outbound_url("http://169.254.169.254", allow_private_hosts=True)

--- a/tests/unit/utils/test_url_security.py
+++ b/tests/unit/utils/test_url_security.py
@@ -1,6 +1,7 @@
 """Tests for outbound URL safety validation."""
 
 import socket
+from unittest.mock import Mock
 
 import pytest
 
@@ -58,6 +59,32 @@ def test_validate_outbound_url_normalizes_trailing_slash(
 def test_validate_outbound_url_rejects_unsafe_urls(url: str, message: str) -> None:
     with pytest.raises(UnsafeUrlError, match=message):
         validate_outbound_url(url)
+
+
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        ("https://metadata", "metadata service"),
+        ("https://metadata.", "metadata service"),
+        ("https://metadata.google.internal", "metadata service"),
+        ("https://metadata.google.internal.", "metadata service"),
+        ("https://0x7f.0.0.1", "non-standard IP"),
+        ("https://2130706433", "non-standard IP"),
+        ("https://0177.0.0.1", "non-standard IP"),
+    ],
+)
+def test_validate_outbound_url_rejects_metadata_and_numeric_hosts_before_dns(
+    url: str,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_getaddrinfo = Mock(return_value=_addr_info("93.184.216.34"))
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    with pytest.raises(UnsafeUrlError, match=message):
+        validate_outbound_url(url)
+
+    mock_getaddrinfo.assert_not_called()
 
 
 def test_validate_outbound_url_allows_private_hosts_when_requested() -> None:

--- a/traigent/utils/url_security.py
+++ b/traigent/utils/url_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import socket
 from urllib.parse import ParseResult, unquote, urlparse, urlunparse
 
 
@@ -78,6 +79,35 @@ def _validate_hostname(
         raise UnsafeUrlError(f"{purpose} points at localhost")
 
 
+def _validate_hostname_resolution(
+    hostname: str,
+    *,
+    purpose: str,
+    allow_private_hosts: bool,
+) -> None:
+    if allow_private_hosts:
+        return
+
+    normalized_hostname = hostname.rstrip(".").lower()
+    if _parse_ip_literal(normalized_hostname) is not None:
+        return
+
+    try:
+        addr_infos = socket.getaddrinfo(normalized_hostname, None)
+    except socket.gaierror:
+        raise UnsafeUrlError(f"{purpose} host could not be resolved") from None
+
+    for _family, _socktype, _proto, _canonname, sockaddr in addr_infos:
+        try:
+            resolved_ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if not resolved_ip.is_global:
+            raise UnsafeUrlError(
+                f"{purpose} must not resolve to private or loopback IPs"
+            ) from None
+
+
 def _normalize_path(path: str, purpose: str) -> str:
     decoded_path = unquote(path)
     if any(segment in {".", ".."} for segment in decoded_path.split("/")):
@@ -122,4 +152,9 @@ def validate_outbound_url(
     )
 
     normalized_path = _normalize_path(parsed.path, purpose)
+    _validate_hostname_resolution(
+        parsed.hostname or "",
+        purpose=purpose,
+        allow_private_hosts=allow_private_hosts,
+    )
     return urlunparse((parsed.scheme, parsed.netloc, normalized_path, "", "", ""))


### PR DESCRIPTION
Closes #1409.

## Problem
The utils-side SSRF validator `traigent/utils/url_security.py` `validate_outbound_url` had metadata-by-name + 0x/hex IP + link-local/reserved checks but LACKED the DNS-rebind defense that the cloud-side validator (`traigent/cloud/url_security.py`, hardened in #1499) has — a hostname resolving to a private/metadata IP passed. Asymmetric SSRF coverage (#1409).

## Fix
Added `_validate_hostname_resolution` (socket.getaddrinfo) to `validate_outbound_url`: rejects when any resolved IP is non-global (private/loopback/link-local/reserved/metadata), mirroring the cloud-side logic + error style. Skipped when `allow_private_hosts=True` so local-agent/dev endpoints still work. `cloud/url_security.py` unchanged.

## Test
`tests/unit/utils/test_url_security.py`: private/metadata-resolution rejected, global accepted, localhost-when-allowed accepted. Revert-proof (fails pre-fix). 20 passed; ruff clean.

Spine-Trail: st_1e5c938e36fd