### PR TITLE
harden(sdk): drop bug-masking fallbacks on contract-guaranteed fields (#1491 #1492 #1493 #1494)

### DIFF
--- a/tests/unit/cloud/test_traigent_cloud_client.py
+++ b/tests/unit/cloud/test_traigent_cloud_client.py
@@ -498,3 +498,80 @@ class TestCloudServiceError:
         """Test CloudServiceError inheritance from Exception."""
         error = CloudServiceError("Test error")
         assert isinstance(error, Exception)
+
+
+class TestFallbackOptimizationTrialsCount:
+    """_fallback_optimization reports len(optimization_result.trials) directly.
+
+    Regression (#1493): the former guard
+    ``len(trials) if isinstance(trials, list) else 0`` would mask a
+    producer-contract violation; the fix uses ``len(trials)`` directly so a
+    non-list trials value raises instead of silently reporting 0.
+    """
+
+    def test_trials_count_equals_number_of_returned_trials(self) -> None:
+        """trials_count == len(optimization_result.trials) for a valid result."""
+        from datetime import UTC, datetime
+
+        from traigent.api.types import (
+            OptimizationResult,
+            OptimizationStatus,
+            TrialResult,
+            TrialStatus,
+        )
+
+        def _trial(tid: str) -> TrialResult:
+            return TrialResult(
+                trial_id=tid,
+                config={"k": "v"},
+                metrics={"accuracy": 0.5},
+                status=TrialStatus.COMPLETED,
+                duration=1.0,
+                timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+            )
+
+        # 4-trial result — OptimizationResult.trials is always list[TrialResult]
+        mock_result = OptimizationResult(
+            trials=[_trial("t1"), _trial("t2"), _trial("t3"), _trial("t4")],
+            best_config={"k": "v"},
+            best_score=0.5,
+            optimization_id="oid",
+            duration=4.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+
+        client = TraigentCloudClient(
+            api_key="tg_test_" + "x" * 56,  # pragma: allowlist secret
+            base_url="http://localhost",
+        )
+        dataset = Dataset([EvaluationExample({"text": "x"}, "x")], name="d")
+
+        async def run_test() -> CloudOptimizationResult:
+            # Patch at the source modules — local imports in _fallback_optimization
+            # pick up the patched versions from sys.modules.
+            with (
+                patch(
+                    "traigent.core.orchestrator.OptimizationOrchestrator"
+                ) as mock_orch_cls,
+                patch("traigent.evaluators.local.LocalEvaluator"),
+                patch("traigent.optimizers.registry.get_optimizer"),
+            ):
+                mock_orch = mock_orch_cls.return_value
+                mock_orch.optimize = AsyncMock(return_value=mock_result)
+                return await client._fallback_optimization(
+                    function_name="dummy",
+                    dataset=dataset,
+                    configuration_space={"k": ["v"]},
+                    objectives=["accuracy"],
+                    max_trials=4,
+                    local_function=lambda text: text,
+                )
+
+        result = asyncio.run(run_test())
+
+        # Must be 4 (len(trials)), not 0 (former isinstance-guard fallback value)
+        assert result.trials_count == 4

--- a/tests/unit/cloud/test_traigent_cloud_client.py
+++ b/tests/unit/cloud/test_traigent_cloud_client.py
@@ -575,3 +575,52 @@ class TestFallbackOptimizationTrialsCount:
 
         # Must be 4 (len(trials)), not 0 (former isinstance-guard fallback value)
         assert result.trials_count == 4
+
+    def test_non_list_trials_raises_not_zero_count(self) -> None:
+        """A non-list ``trials`` (contract violation) must raise, not report 0.
+
+        Pre-fix: ``len(trials) if isinstance(trials, list) else 0`` returned 0
+        for a non-list value, masking the producer-contract breach.
+        Post-fix: ``len(trials)`` raises TypeError, surfacing it.
+
+        FAILS on pre-fix code (which would return trials_count=0); PASSES on
+        the fixed code (which raises).
+        """
+        # optimization_result whose `trials` is None — a producer-contract
+        # violation that the removed `isinstance ... else 0` guard would mask.
+        from types import SimpleNamespace
+
+        bad_result = SimpleNamespace(
+            trials=None,
+            best_config={"k": "v"},
+            best_metrics={"accuracy": 0.5},
+            best_score=0.5,
+        )
+
+        client = TraigentCloudClient(
+            api_key="tg_test_" + "x" * 56,  # pragma: allowlist secret
+            base_url="http://localhost",
+        )
+        dataset = Dataset([EvaluationExample({"text": "x"}, "x")], name="d")
+
+        async def run_test() -> CloudOptimizationResult:
+            with (
+                patch(
+                    "traigent.core.orchestrator.OptimizationOrchestrator"
+                ) as mock_orch_cls,
+                patch("traigent.evaluators.local.LocalEvaluator"),
+                patch("traigent.optimizers.registry.get_optimizer"),
+            ):
+                mock_orch = mock_orch_cls.return_value
+                mock_orch.optimize = AsyncMock(return_value=bad_result)
+                return await client._fallback_optimization(
+                    function_name="dummy",
+                    dataset=dataset,
+                    configuration_space={"k": ["v"]},
+                    objectives=["accuracy"],
+                    max_trials=4,
+                    local_function=lambda text: text,
+                )
+
+        with pytest.raises(TypeError):
+            asyncio.run(run_test())

--- a/tests/unit/core/test_config_state_manager_export.py
+++ b/tests/unit/core/test_config_state_manager_export.py
@@ -1,0 +1,130 @@
+"""Tests for ConfigStateManager._create_full_export — contract field direct access.
+
+Regression (#1492): _create_full_export must use t.status directly (a
+TrialStatus StrEnum — no hasattr/"completed" fallback) and iterate
+self._optimization_results.trials directly (no dead `or []` guard).
+"""
+# Traceability: CONC-Layer-Core FUNC-ORCH-LIFECYCLE REQ-ORCH-003
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from traigent.api.types import (
+    OptimizationResult,
+    OptimizationStatus,
+    TrialResult,
+    TrialStatus,
+)
+from traigent.core.config_state_manager import ConfigStateManager
+
+
+def _minimal_manager(opt_result: OptimizationResult) -> ConfigStateManager:
+    """Construct a bare ConfigStateManager without calling __init__.
+
+    Only the attributes required by _create_full_export are set.
+    """
+    mgr: ConfigStateManager = ConfigStateManager.__new__(ConfigStateManager)
+    mgr._optimization_results = opt_result
+    mgr._best_config = opt_result.best_config
+    mgr.func = lambda x: x
+    mgr.func.__name__ = "test_fn"  # type: ignore[method-assign]
+    mgr.configuration_space = None
+    return mgr
+
+
+def _make_trial(
+    tid: str,
+    status: TrialStatus,
+    score: float,
+) -> TrialResult:
+    return TrialResult(
+        trial_id=tid,
+        config={"model": "gpt-4o"},
+        metrics={"accuracy": score},
+        status=status,
+        duration=1.5,
+        timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+
+
+def _make_opt_result(*trials: TrialResult) -> OptimizationResult:
+    return OptimizationResult(
+        trials=list(trials),
+        best_config={"model": "gpt-4o"},
+        best_score=0.9,
+        optimization_id="opt-test",
+        duration=5.0,
+        convergence_info={},
+        status=OptimizationStatus.COMPLETED,
+        objectives=["accuracy"],
+        algorithm="random",
+        timestamp=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+
+
+class TestCreateFullExportContractFields:
+    """_create_full_export reads contract-guaranteed TrialResult fields directly."""
+
+    def test_export_uses_real_status_not_completed_fallback(self) -> None:
+        """t.status is used directly — a FAILED trial must export TrialStatus.FAILED,
+        not the removed hasattr/"completed" fallback value."""
+        trials = [
+            _make_trial("t1", TrialStatus.COMPLETED, 0.9),
+            _make_trial("t2", TrialStatus.FAILED, 0.0),
+            _make_trial("t3", TrialStatus.CANCELLED, 0.5),
+        ]
+        mgr = _minimal_manager(_make_opt_result(*trials))
+
+        export = mgr._create_full_export(include_metadata=False)
+
+        statuses = [t["status"] for t in export["trials"]]
+        # Direct t.status access: TrialStatus is a StrEnum so it compares equal
+        # to its string value, but must NOT be the hard-coded "completed" string.
+        assert statuses[0] == TrialStatus.COMPLETED  # "completed"
+        assert statuses[1] == TrialStatus.FAILED  # "failed" — key regression
+        assert statuses[2] == TrialStatus.CANCELLED  # "cancelled"
+        # The former bug: without direct access, any status that failed hasattr
+        # would have been silently emitted as "completed".
+        assert statuses[1] != "completed", (
+            "FAILED trial must not be exported as 'completed' (bug-masking fallback removed)"
+        )
+
+    def test_export_includes_all_trials_from_contract_list(self) -> None:
+        """Every trial in OptimizationResult.trials is exported; the removed
+        `or []` guard cannot silently truncate the list."""
+        trials = [
+            _make_trial(f"t{i}", TrialStatus.COMPLETED, float(i) * 0.1)
+            for i in range(5)
+        ]
+        mgr = _minimal_manager(_make_opt_result(*trials))
+
+        export = mgr._create_full_export(include_metadata=False)
+
+        assert len(export["trials"]) == 5
+        exported_ids = [t["trial_id"] for t in export["trials"]]
+        assert exported_ids == [f"t{i}" for i in range(5)]
+
+    def test_export_total_trials_consistent_with_trial_list_length(self) -> None:
+        """optimization.total_trials must equal len(export["trials"]).
+
+        The former `or []` guard at :1002 was inconsistent with the sibling
+        unguarded len() at :1006; both must see the same list.
+        """
+        trials = [_make_trial(f"t{i}", TrialStatus.COMPLETED, 0.8) for i in range(3)]
+        mgr = _minimal_manager(_make_opt_result(*trials))
+
+        export = mgr._create_full_export(include_metadata=False)
+
+        assert export["optimization"]["total_trials"] == 3
+        assert export["optimization"]["total_trials"] == len(export["trials"])
+
+    def test_export_with_empty_trials_list_produces_empty_trials_key(self) -> None:
+        """An OptimizationResult with zero trials produces an empty list — not a
+        crash (the `or []` removal is safe since trials is always a list)."""
+        mgr = _minimal_manager(_make_opt_result())  # empty trials
+
+        export = mgr._create_full_export(include_metadata=False)
+
+        assert export["trials"] == []
+        assert export["optimization"]["total_trials"] == 0

--- a/tests/unit/core/test_config_state_manager_export.py
+++ b/tests/unit/core/test_config_state_manager_export.py
@@ -9,6 +9,9 @@ self._optimization_results.trials directly (no dead `or []` guard).
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
 
 from traigent.api.types import (
     OptimizationResult,
@@ -128,3 +131,42 @@ class TestCreateFullExportContractFields:
 
         assert export["trials"] == []
         assert export["optimization"]["total_trials"] == 0
+
+
+class TestCreateFullExportFailLoud:
+    """A genuinely-missing contract field surfaces as an error, not fake-success.
+
+    These tests FAIL on the pre-fix code (where the hasattr/"completed"
+    fallback masked a missing status) and PASS on the fixed code (direct
+    t.status access raises).
+    """
+
+    def test_trial_missing_status_raises_not_completed_default(self) -> None:
+        """A trial object without a ``status`` attribute must raise AttributeError.
+
+        Pre-fix: ``t.status if hasattr(t, "status") else "completed"`` silently
+        emitted ``"completed"`` (the #1302 success-masking pattern).
+        Post-fix: ``t.status`` raises, surfacing the contract break.
+        """
+        # A trial-shaped object that is MISSING the contract-guaranteed `status`.
+        bad_trial = SimpleNamespace(
+            trial_id="t1",
+            config={"model": "gpt-4o"},
+            metrics={"accuracy": 0.9},
+            # status deliberately absent
+        )
+        opt_result = SimpleNamespace(
+            trials=[bad_trial],
+            best_config={"model": "gpt-4o"},
+            best_metrics={},
+            stop_reason=None,
+        )
+        mgr: ConfigStateManager = ConfigStateManager.__new__(ConfigStateManager)
+        mgr._optimization_results = opt_result  # type: ignore[assignment]
+        mgr._best_config = {"model": "gpt-4o"}
+        mgr.func = lambda x: x
+        mgr.func.__name__ = "test_fn"  # type: ignore[method-assign]
+        mgr.configuration_space = None
+
+        with pytest.raises(AttributeError):
+            mgr._create_full_export(include_metadata=False)

--- a/tests/unit/integrations/observability/test_wandb.py
+++ b/tests/unit/integrations/observability/test_wandb.py
@@ -368,52 +368,57 @@ class TestTraigentWandBTrackerLogTrial:
         # Should not log anything
         assert len(mock_wandb_available.logged_data) == 0
 
-    def test_log_trial_missing_trial_id(self, mock_wandb_available: MockWandB) -> None:
-        """Test logging trial without trial_id."""
+    def test_log_trial_contract_fields_read_directly(
+        self, mock_wandb_available: MockWandB
+    ) -> None:
+        """trial_id, status, and duration are read directly from TrialResult —
+        no getattr defaults, no fallback values.
+
+        Pins the direct-access contract: the values logged must be exactly
+        what the TrialResult carries, not a substituted default.
+        """
+        trial = TrialResult(
+            trial_id="direct_id",
+            config={"k": "v"},
+            metrics={"accuracy": 0.9},
+            status=TrialStatus.FAILED,
+            duration=3.14,
+            timestamp=datetime(2025, 6, 1, tzinfo=UTC),
+        )
         tracker = wandb_module.TraigentWandBTracker()
         tracker.current_run = MockWandBRun()
 
-        # Create trial without trial_id
-        trial = Mock(spec=[])
-        trial.trial_id = None
+        tracker.log_trial(trial, trial_number=2)
 
-        tracker.log_trial(trial, trial_number=1)
+        assert len(mock_wandb_available.logged_data) == 1
+        logged_data, _ = mock_wandb_available.logged_data[0]
+        # status is read from trial.status.value — must be "failed", not a
+        # fallback like "completed"
+        assert logged_data["trial_2/status"] == "failed"
+        # duration is read directly as float — must be 3.14, not 0.0
+        assert logged_data["trial_2/duration"] == 3.14
 
-        # Should not log
-        assert len(mock_wandb_available.logged_data) == 0
+    def test_log_trial_none_duration_raises_not_defaults_to_zero(
+        self, mock_wandb_available: MockWandB
+    ) -> None:
+        """When duration is None (contract violation), float() raises TypeError.
 
-    def test_log_trial_missing_status(self, mock_wandb_available: MockWandB) -> None:
-        """Test logging trial without status."""
-        tracker = wandb_module.TraigentWandBTracker()
-        tracker.current_run = MockWandBRun()
-
-        trial = Mock()
-        trial.trial_id = "test_001"
-        trial.status = None
-
-        tracker.log_trial(trial, trial_number=1)
-
-        # Should not log
-        assert len(mock_wandb_available.logged_data) == 0
-
-    def test_log_trial_missing_duration(self, mock_wandb_available: MockWandB) -> None:
-        """Test logging trial with missing duration defaults to 0."""
+        The old code silently logged 0.0; the new code fails loud so a real
+        upstream defect surfaces instead of being masked as a plausible value.
+        """
         tracker = wandb_module.TraigentWandBTracker()
         tracker.current_run = MockWandBRun()
 
         trial = Mock()
         trial.trial_id = "test_001"
         trial.status = TrialStatus.COMPLETED
-        trial.duration = None
-        trial.config = {}
-        trial.metrics = {}
-        trial.timestamp = None
+        trial.duration = None  # contract violation — should never happen in prod
 
-        tracker.log_trial(trial, trial_number=1)
+        with pytest.raises(TypeError):
+            tracker.log_trial(trial, trial_number=1)
 
-        assert len(mock_wandb_available.logged_data) == 1
-        logged_data, _ = mock_wandb_available.logged_data[0]
-        assert logged_data["trial_1/duration"] == 0.0
+        # Nothing was logged (fail loud, not fake-success)
+        assert len(mock_wandb_available.logged_data) == 0
 
     def test_log_trial_non_mapping_config(
         self, mock_wandb_available: MockWandB

--- a/tests/unit/integrations/test_wandb_tracker.py
+++ b/tests/unit/integrations/test_wandb_tracker.py
@@ -45,14 +45,26 @@ def stubbed_wandb(monkeypatch, tmp_path) -> DummyWandB:
     return dummy
 
 
-def test_log_trial_skips_payload_missing_status(stubbed_wandb: DummyWandB) -> None:
+def test_log_trial_missing_status_raises_not_skipped(
+    stubbed_wandb: DummyWandB,
+) -> None:
+    """A trial missing the contract-guaranteed ``status`` field must fail loud.
+
+    Regression (#1491): the old guard silently skipped logging (asserted
+    ``logged == []``) when ``status`` was absent. ``TrialResult.status`` is a
+    required field (``traigent/api/types.py:364``), so ``log_trial`` now reads
+    ``trial.status.value`` directly — a genuinely missing status is a contract
+    break that must raise (AttributeError), not be masked as a silent no-op.
+    """
     tracker = wandb_module.TraigentWandBTracker()
     tracker.current_run = DummyRun()
 
     invalid_trial = types.SimpleNamespace(trial_id="trial-1", duration=2.5)
 
-    tracker.log_trial(invalid_trial, trial_number=1)
+    with pytest.raises(AttributeError):
+        tracker.log_trial(invalid_trial, trial_number=1)
 
+    # Nothing was logged or saved (fail loud, not fake-success).
     assert stubbed_wandb.logged == []
     assert stubbed_wandb.saved == []
 

--- a/tests/unit/utils/test_results_table.py
+++ b/tests/unit/utils/test_results_table.py
@@ -14,7 +14,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from traigent.api.types import TrialResult, TrialStatus
+from traigent.api.types import (
+    OptimizationResult,
+    OptimizationStatus,
+    TrialResult,
+    TrialStatus,
+)
 from traigent.utils.results_table import (
     _find_best_per_objective,
     _trials_all_failed,
@@ -375,3 +380,79 @@ class TestOverallBestIdentity:
         assert "examples" in out
         assert "0/20" in out
         assert "20/20" in out
+
+
+class TestPrintResultsTableDirectFieldAccess:
+    """print_results_table accesses results.trials and t.metrics directly.
+
+    Regression (#1494): the former getattr defaults (results.trials → []) and
+    (t.metrics → {}) masked contract violations. Direct access raises on a
+    contract break rather than silently rendering an empty table.
+    """
+
+    def test_real_optimization_result_renders_correct_metrics(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A real OptimizationResult is rendered via direct attribute access.
+
+        Verifies that results.trials (not getattr default []) and
+        trials[0].metrics (not getattr default {}) are used — if the getattr
+        defaults were in effect for a valid result, the table would render
+        identically; but this test proves the direct path executes without error
+        and propagates the real metric values.
+        """
+        trials = [
+            _trial({"model": "m1"}, {"accuracy": 0.7}),
+            _trial({"model": "m2"}, {"accuracy": 0.9}),
+        ]
+        results = OptimizationResult(
+            trials=trials,
+            best_config={"model": "m2"},
+            best_score=0.9,
+            optimization_id="oid-direct",
+            duration=2.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        print_results_table(
+            results,
+            config_space={"model": ["m1", "m2"]},
+            objectives=["accuracy"],
+        )
+
+        out = capsys.readouterr().out
+        # Table was rendered (not "No trials to display" — direct trials access)
+        assert "No trials to display" not in out
+        # sample_metrics = trials[0].metrics → {"accuracy": 0.7}
+        # If the former getattr({}) were in effect on a bad trial, "accuracy"
+        # would be absent from metric_info and not rendered.
+        assert "accuracy" in out.lower()
+
+    def test_sample_metrics_direct_access_populates_metric_column(self) -> None:
+        """trials[0].metrics is the real dict, not a getattr {} default.
+
+        _find_best_per_objective is called with metric_info populated from
+        sample_metrics = trials[0].metrics. This verifies the value is the
+        actual metrics dict (non-empty), so the correct best-trial index is found.
+        """
+        trials_with_metrics = [
+            _trial({"model": "a"}, {"score": 0.3}),
+            _trial({"model": "b"}, {"score": 0.8}),
+        ]
+        # Directly call _find_best_per_objective using the real TrialResult.metrics
+        # (simulating what print_results_table does after sample_metrics = trials[0].metrics)
+        sample_metrics = trials_with_metrics[0].metrics  # direct access, not getattr
+        assert "score" in sample_metrics  # proves real dict, not {} default
+
+        best = _find_best_per_objective(
+            trials_with_metrics,
+            metric_info=[("score", None)],
+            metric_overrides=None,
+        )
+        # Trial index 1 (score=0.8) is best — only works if metric_info was
+        # populated from the real metrics dict
+        assert 1 in best.get("score", set())

--- a/tests/unit/utils/test_results_table.py
+++ b/tests/unit/utils/test_results_table.py
@@ -9,6 +9,7 @@ should emit a clear "all trials failed" banner.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -456,3 +457,63 @@ class TestPrintResultsTableDirectFieldAccess:
         # Trial index 1 (score=0.8) is best — only works if metric_info was
         # populated from the real metrics dict
         assert 1 in best.get("score", set())
+
+
+class TestPrintResultsTableFailLoud:
+    """Missing contract fields surface as errors, not silent empty rendering.
+
+    These tests FAIL on the pre-fix code (where the getattr defaults masked
+    the missing attribute and rendered an empty/degraded table) and PASS on
+    the fixed code (direct access raises).
+    """
+
+    def test_results_missing_trials_raises_not_no_trials_banner(self) -> None:
+        """A results object without ``.trials`` must raise AttributeError.
+
+        Pre-fix: ``getattr(results, "trials", [])`` returned ``[]`` and the
+        function printed "No trials to display" and returned cleanly — masking
+        a contract break as a benign empty run.
+        Post-fix: ``results.trials`` raises, surfacing the breach.
+        """
+        # An OptimizationResult-shaped object MISSING the required `trials`.
+        bad_results = SimpleNamespace(
+            best_config={"model": "m1"},
+            best_score=0.5,
+            metadata={},
+        )
+
+        with pytest.raises(AttributeError):
+            print_results_table(
+                bad_results,  # type: ignore[arg-type]
+                config_space={"model": ["m1"]},
+                objectives=["accuracy"],
+            )
+
+    def test_trial_missing_metrics_raises_not_empty_metric_set(self) -> None:
+        """A first trial without ``.metrics`` must raise AttributeError.
+
+        Pre-fix: ``getattr(trials[0], "metrics", {})`` returned ``{}`` so the
+        metric columns silently vanished from the table.
+        Post-fix: ``trials[0].metrics`` raises, surfacing the breach.
+        """
+        # Non-empty trials so the `if not trials` guard is passed, but the
+        # first trial is MISSING the required `metrics` attribute.
+        trial_without_metrics = SimpleNamespace(
+            trial_id="t1",
+            config={"model": "m1"},
+            status=TrialStatus.COMPLETED,
+            duration=0.1,
+        )
+        bad_results = SimpleNamespace(
+            trials=[trial_without_metrics],
+            best_config={"model": "m1"},
+            best_score=0.5,
+            metadata={},
+        )
+
+        with pytest.raises(AttributeError):
+            print_results_table(
+                bad_results,  # type: ignore[arg-type]
+                config_space={"model": ["m1"]},
+                objectives=["accuracy"],
+            )

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -950,8 +950,8 @@ class TraigentCloudClient(BaseTraigentClient):
                     best_metrics = {objectives[0]: float(best_score_raw)}
                 except (TypeError, ValueError):
                     best_metrics = {}
-        trials = getattr(optimization_result, "trials", [])
-        trials_count = len(trials) if isinstance(trials, list) else 0
+        trials = optimization_result.trials
+        trials_count = len(trials)
 
         return CloudOptimizationResult(
             best_config=best_config,

--- a/traigent/core/config_state_manager.py
+++ b/traigent/core/config_state_manager.py
@@ -997,9 +997,9 @@ class ConfigStateManager:
                     "trial_id": t.trial_id,
                     "config": t.config,
                     "metrics": t.metrics,
-                    "status": t.status if hasattr(t, "status") else "completed",
+                    "status": t.status,
                 }
-                for t in (self._optimization_results.trials or [])
+                for t in self._optimization_results.trials
             ]
 
             export["optimization"] = {

--- a/traigent/integrations/observability/wandb.py
+++ b/traigent/integrations/observability/wandb.py
@@ -166,33 +166,9 @@ class TraigentWandBTracker:
         if step is None:
             step = trial_number
 
-        trial_id_raw = getattr(trial, "trial_id", None)
-        if trial_id_raw is None:
-            logger.warning(
-                "Skipping W&B logging for trial %s: missing 'trial_id'", trial_number
-            )
-            return
-        trial_id = trial_id_raw if isinstance(trial_id_raw, str) else str(trial_id_raw)
-
-        status_obj = getattr(trial, "status", None)
-        if status_obj is None:
-            logger.warning(
-                "Skipping W&B logging for trial %s: missing 'status'", trial_id
-            )
-            return
-        status_value = (
-            status_obj.value if hasattr(status_obj, "value") else str(status_obj)
-        )
-
-        duration_raw = getattr(trial, "duration", None)
-        if isinstance(duration_raw, Number):
-            duration_value = float(duration_raw)
-        else:
-            logger.warning(
-                "Trial %s duration missing or non-numeric; defaulting to 0.0",
-                trial_id,
-            )
-            duration_value = 0.0
+        trial_id = trial.trial_id
+        status_value = trial.status.value
+        duration_value = float(trial.duration)
 
         config_values: dict[str, Any] = {}
         raw_config = getattr(trial, "config", None)

--- a/traigent/utils/results_table.py
+++ b/traigent/utils/results_table.py
@@ -424,7 +424,7 @@ def print_results_table(
         mode_label: Optional label rendered in the table title, e.g. ``"MOCK"``.
         metric_overrides: Optional per-metric display values by trial index.
     """
-    trials = getattr(results, "trials", [])
+    trials = results.trials
     if not trials:
         _safe_table_print("\nNo trials to display.")
         return
@@ -434,7 +434,7 @@ def print_results_table(
 
     # Resolve objectives & metrics present in trial data
     objective_info = _get_objective_info(objectives)
-    sample_metrics = getattr(trials[0], "metrics", {})
+    sample_metrics = trials[0].metrics
     metric_info = [(n, o) for n, o in objective_info if n in sample_metrics]
     metric_names = [n for n, _ in metric_info]
     param_names = list(config_space.keys())


### PR DESCRIPTION
## Summary

Removes four dead/bug-masking fallbacks on fields that `TrialResult` / `OptimizationResult` contract-guarantee are always present. Each fallback was reachable in the control-flow graph but unreachable in practice; keeping them silently converts a real upstream defect into a plausible-looking fake-success value instead of surfacing it (fail-fast violation, "Class 17" fallback).

All four issues confirmed: the field types are `@dataclass` with no default — the contract guarantees presence.

---

### #1491 — `wandb.py log_trial`: drop `getattr`+`0.0` duration guard + sibling trial_id/status guards

**Fallback removed:**
```python
# Old: guard → silent early-return or 0.0 substitute
trial_id_raw = getattr(trial, "trial_id", None)
if trial_id_raw is None: return  # silent skip
status_obj = getattr(trial, "status", None)
if status_obj is None: return     # silent skip
duration_raw = getattr(trial, "duration", None)
if isinstance(duration_raw, Number): duration_value = float(duration_raw)
else: duration_value = 0.0        # silent fake-success
```
**New:**
```python
trial_id = trial.trial_id
status_value = trial.status.value
duration_value = float(trial.duration)
```
**Contract evidence:** `traigent/api/types.py:361` (`trial_id: str`), `:364` (`status: TrialStatus`), `:365` (`duration: float`) — all required positional fields with no default. Correct sibling pattern: `mlflow.py:221` (unguarded direct read, unchanged).

---

### #1492 — `config_state_manager.py _create_full_export`: drop `hasattr/"completed"` status fallback + `or []` trials guard

**Fallback removed:**
```python
# Old
"status": t.status if hasattr(t, "status") else "completed",  # asserts success!
for t in (self._optimization_results.trials or [])            # dead guard
```
**New:**
```python
"status": t.status,
for t in self._optimization_results.trials
```
**Contract evidence:** `traigent/api/types.py:364` (`status: TrialStatus`, required) and `:704` (`trials: list[TrialResult]`, required). The `hasattr/"completed"` branch was the #1302 silent-success pattern; `or []` was inconsistent with the sibling unguarded `len()` at `:1006`.

---

### #1493 — `cloud/client.py _fallback_optimization`: drop `isinstance(trials, list) else 0` trial-count guard

**Fallback removed:**
```python
# Old
trials = getattr(optimization_result, "trials", [])
trials_count = len(trials) if isinstance(trials, list) else 0
```
**New:**
```python
trials = optimization_result.trials
trials_count = len(trials)
```
**Contract evidence:** `traigent/api/types.py:704` (`trials: list[TrialResult]`, required non-Optional). `isinstance(trials, list)` was always `True`; `else 0` would have masked a producer-contract violation by reporting 0 trials.

---

### #1494 — `results_table.py print_results_table`: drop `getattr` defaults on `results.trials` and `t.metrics`

**Fallback removed:**
```python
# Old
trials = getattr(results, "trials", [])
sample_metrics = getattr(trials[0], "metrics", {})
```
**New:**
```python
trials = results.trials
sample_metrics = trials[0].metrics
```
**Contract evidence:** `traigent/api/types.py:704` (`trials: list[TrialResult]`, required) and `:363` (`metrics: dict[str, float]`, required).

---

## Tests

| Issue | Stale tests removed | New tests added |
|-------|---------------------|-----------------|
| #1491 | `test_log_trial_missing_trial_id`, `test_log_trial_missing_status`, `test_log_trial_missing_duration` (tested removed fallback behavior) | `test_log_trial_contract_fields_read_directly` (pins real FAILED status/3.14 duration, not defaults), `test_log_trial_none_duration_raises_not_defaults_to_zero` (fail-loud: `float(None)` raises TypeError) |
| #1492 | — | `test_config_state_manager_export.py` (new file): 4 tests — FAILED status exported as `"failed"` not `"completed"`; all 5 trials exported; total_trials consistent; empty-trials list safe |
| #1493 | — | `TestFallbackOptimizationTrialsCount.test_trials_count_equals_number_of_returned_trials` — 4-trial mock result produces `trials_count=4`, not 0 |
| #1494 | — | `TestPrintResultsTableDirectFieldAccess` — 2 tests: real `OptimizationResult` renders correctly; `trials[0].metrics` populates metric column |

**pytest result (all 102 affected tests):** 102 passed, 0 failed  
**ruff format --check:** 8 files already formatted  
**ruff check:** All checks passed

## PR Checklist

1. **Worst-case prod path:** dead-code removal — no new production code path added. The fallback branches being removed were unreachable in practice; their removal makes a real contract break surface as an exception rather than fake success.
2. **Production-branch test:** n/a — this is hardening/dead-code removal, not a policy-surface change.
3. **Contract regeneration:** no schema changes; no cross-SDK parity impact.
4. **Public surface delta:** no change to `__all__`, documented routes, or OpenAPI paths.
5. **Review threads:** n/a (new PR).
6. **Quality gates not relaxed:** no thresholds widened.

Closes #1491
Closes #1492
Closes #1493
Closes #1494

Spine-Trail: st_6b5e8f50dc21