### PR TITLE
fix(sdk): standardize cost_limit surfacing — raise exported CostLimitExceeded (#1490)

### DIFF
--- a/tests/unit/core/test_cost_enforcement.py
+++ b/tests/unit/core/test_cost_enforcement.py
@@ -31,6 +31,7 @@ from traigent.core.cost_enforcement import (
     normalize_cost_approved,
 )
 from traigent.core.stop_conditions import CostLimitStopCondition
+from traigent.utils.exceptions import OptimizationError
 
 
 def _create_mock_permit(amount: float = 0.0) -> Permit:
@@ -852,7 +853,12 @@ class TestCostEnforcerExceptions:
         assert "5.00" in str(exc)
         assert "2.00" in str(exc)
         assert exc.accumulated == 5.0
+        assert exc.spent == 5.0
         assert exc.limit == 2.0
+
+    def test_cost_limit_exceeded_is_optimization_error(self) -> None:
+        """CostLimitExceeded remains catchable by OptimizationError handlers."""
+        assert issubclass(CostLimitExceeded, OptimizationError)
 
     def test_optimization_aborted(self) -> None:
         """OptimizationAborted can be raised."""

--- a/tests/unit/core/test_cost_enforcement_no_bypass.py
+++ b/tests/unit/core/test_cost_enforcement_no_bypass.py
@@ -149,12 +149,12 @@ class TestCostEnforcerNoMockBypass:
             # Now budget is exhausted; the bypass would have granted id=0,
             # but the real path must deny.
             second = enforcer.acquire_permit()
-            assert (
-                not second.is_granted
-            ), "Mock-mode must not override real cost limits after exhaustion"
-            assert (
-                second.id == -1
-            ), "Denied permit must use sentinel id=-1, not bypass id=0"
+            assert not second.is_granted, (
+                "Mock-mode must not override real cost limits after exhaustion"
+            )
+            assert second.id == -1, (
+                "Denied permit must use sentinel id=-1, not bypass id=0"
+            )
 
     def test_release_permit_uses_real_locked_path_under_mock_env(
         self, mock_env: dict[str, str]
@@ -206,8 +206,8 @@ class TestCostEstimatorMockPreflight:
     def test_raw_mock_env_does_not_bypass_when_mock_sot_false(
         self, mock_env: dict[str, str]
     ) -> None:
-        from traigent.core.cost_enforcement import OptimizationAborted
         from traigent.core.cost_estimator import CostEstimator
+        from traigent.utils.exceptions import CostLimitExceeded
 
         with patch.dict(os.environ, mock_env, clear=False):
             enforcer = CostEnforcer(CostEnforcerConfig(limit=0.01, approved=False))
@@ -226,5 +226,5 @@ class TestCostEstimatorMockPreflight:
                     return_value=False,
                 ),
             ):
-                with pytest.raises(OptimizationAborted):
+                with pytest.raises(CostLimitExceeded):
                     estimator.check_cost_approval(dataset=None)

--- a/tests/unit/core/test_cost_estimator.py
+++ b/tests/unit/core/test_cost_estimator.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from traigent.core.cost_estimator import CostEstimator
+from traigent.utils.exceptions import CostLimitExceeded, OptimizationError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -342,21 +343,23 @@ class TestCheckCostApproval:
             estimator.check_cost_approval(_FakeDataset())
         enforcer.check_and_approve.assert_called_once()
 
-    def test_raises_when_declined(self) -> None:
+    def test_raises_cost_limit_exceeded_when_declined(self) -> None:
         enforcer = MagicMock(is_mock_mode=False)
         enforcer.check_and_approve.return_value = False
         enforcer.config.limit = 1.0
         estimator = CostEstimator(enforcer, max_trials=5, max_total_examples=None)
 
-        from traigent.core.cost_enforcement import OptimizationAborted
-
         with (
             patch("traigent.core.cost_estimator.is_mock_llm", return_value=False),
-            pytest.raises(OptimizationAborted) as exc_info,
+            pytest.raises(CostLimitExceeded) as exc_info,
         ):
             estimator.check_cost_approval(_FakeDataset())
 
         message = str(exc_info.value)
+        assert exc_info.value.accumulated == 0.0
+        assert exc_info.value.spent == 0.0
+        assert exc_info.value.limit == 1.0
+        assert exc_info.value.estimated == pytest.approx(20.25)
         assert "Cost approval declined" in message
         assert "Rough conservative upper-bound estimate" in message
         assert "TRAIGENT_RUN_COST_LIMIT" in message
@@ -364,6 +367,20 @@ class TestCheckCostApproval:
         assert "cost_approved=True" in message
         assert "TRAIGENT_CUSTOM_MODEL_PRICING_FILE" in message
         assert "TRAIGENT_CUSTOM_MODEL_PRICING_JSON" in message
+
+    def test_declined_cost_limit_is_catchable_as_optimization_error(self) -> None:
+        enforcer = MagicMock(is_mock_mode=False)
+        enforcer.check_and_approve.return_value = False
+        enforcer.config.limit = 1.0
+        estimator = CostEstimator(enforcer, max_trials=5, max_total_examples=None)
+
+        with (
+            patch("traigent.core.cost_estimator.is_mock_llm", return_value=False),
+            pytest.raises(OptimizationError) as exc_info,
+        ):
+            estimator.check_cost_approval(_FakeDataset())
+
+        assert isinstance(exc_info.value, CostLimitExceeded)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -2351,8 +2351,10 @@ class TestStopReasonInResult:
         assert len(result.trials) == 0
 
     @pytest.mark.asyncio
-    async def test_stop_reason_cost_limit(self, sample_dataset, monkeypatch):
-        """stop_reason is 'cost_limit' when the spend guard stops the run."""
+    async def test_mid_run_cost_limit_gracefully_returns_result(
+        self, sample_dataset, monkeypatch
+    ):
+        """Mid-run cost stops return a partial result with stop_reason='cost_limit'."""
         # Disable mock-LLM bypass so CostEnforcer tracks real permits.
         monkeypatch.setenv("TRAIGENT_MOCK_LLM", "false")
         config_space = {"param1": (0, 1)}
@@ -2373,6 +2375,7 @@ class TestStopReasonInResult:
 
         result = await orchestrator.optimize(lambda _: "ok", sample_dataset)
 
+        assert isinstance(result, OptimizationResult)
         assert result.stop_reason == "cost_limit"
         assert orchestrator._stop_reason == "cost_limit"
         assert len(result.trials) >= 1

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -685,7 +685,8 @@ class OptimizationResult:
             - "max_trials_reached": Hit the configured max_trials limit
             - "max_samples_reached": Hit the max samples/examples limit
             - "timeout": Exceeded the timeout duration
-            - "cost_limit": Hit the cost budget limit
+            - "cost_limit": Hit the cost budget limit mid-run; pre-run cost
+              approval declines raise CostLimitExceeded instead.
             - "metric_limit": Hit a soft cumulative metric limit
             - "optimizer": Optimizer decided to stop (exhausted search space)
             - "plateau": Detected optimization plateau (no improvement)

--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -252,19 +252,31 @@ class CostEnforcer:
     - Fallback to trial count limit when cost is unknown
     - XDG-compliant approval token support for CI/CD
 
+    Cost-limit surfacing contract:
+        - Pre-run approval-declined cost limits raise ``CostLimitExceeded``,
+          which is an ``OptimizationError`` subclass.
+        - Mid-run cost limits do not raise; orchestration stops gracefully and
+          returns a partial result with ``stop_reason == "cost_limit"``.
+
     Usage:
         enforcer = CostEnforcer()
 
         # Pre-optimization check
-        if not enforcer.check_and_approve(estimated_cost=5.0):
-            raise OptimizationAborted("User declined")
+        estimated_cost = 5.0
+        if not enforcer.check_and_approve(estimated_cost=estimated_cost):
+            raise CostLimitExceeded(
+                accumulated=0.0,
+                limit=enforcer.config.limit,
+                estimated=estimated_cost,
+            )
 
         # During optimization - acquire permit before each LLM call
         if enforcer.acquire_permit():
             result = await make_llm_call()
             enforcer.track_cost(result.cost)
         else:
-            # Cancel this request - limit reached
+            # Cancel this request - mid-run limit reached; return partial result
+            # with stop_reason="cost_limit".
             pass
 
     Attributes:

--- a/traigent/core/cost_estimator.py
+++ b/traigent/core/cost_estimator.py
@@ -11,6 +11,7 @@ from traigent.core.cost_enforcement import CostEnforcer
 from traigent.evaluators.base import Dataset
 from traigent.utils.cost_calculator import UnknownModelError, get_model_token_pricing
 from traigent.utils.env_config import is_mock_llm
+from traigent.utils.exceptions import CostLimitExceeded
 from traigent.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -192,13 +193,16 @@ class CostEstimator:
         """Check cost approval before optimization.
 
         Estimates the total optimization cost and checks against the cost
-        enforcer's configured limit. Raises OptimizationAborted if declined.
+        enforcer's configured limit. If the pre-run approval is declined,
+        raises ``CostLimitExceeded`` (an ``OptimizationError`` subclass) with
+        the limit, spent amount, and estimate. Mid-run cost limits remain a
+        graceful stop: inspect ``OptimizationResult.stop_reason == "cost_limit"``.
 
         Args:
             dataset: The evaluation dataset for cost estimation
 
         Raises:
-            OptimizationAborted: If cost approval is declined
+            CostLimitExceeded: If pre-run cost approval is declined.
         """
         if is_mock_llm():
             logger.info(
@@ -209,19 +213,23 @@ class CostEstimator:
 
         estimated_cost = self.estimate_optimization_cost(dataset)
         if not self._cost_enforcer.check_and_approve(estimated_cost):
-            from traigent.core.cost_enforcement import OptimizationAborted
-
-            raise OptimizationAborted(
-                "Cost approval declined. Rough conservative upper-bound "
-                f"estimate: ${estimated_cost:.2f}, limit: "
-                f"${self._cost_enforcer.config.limit:.2f}. "
-                "Pre-run estimates use fixed token assumptions and conservative "
-                "fallback pricing when model pricing is unavailable. To proceed, "
-                "raise TRAIGENT_RUN_COST_LIMIT, approve after review with "
-                "TRAIGENT_COST_APPROVED=true or cost_approved=True, or calibrate "
-                "private/unpriced model rates with "
-                "TRAIGENT_CUSTOM_MODEL_PRICING_FILE or "
-                "TRAIGENT_CUSTOM_MODEL_PRICING_JSON."
+            limit = self._cost_enforcer.config.limit
+            raise CostLimitExceeded(
+                accumulated=0.0,
+                limit=limit,
+                estimated=estimated_cost,
+                message=(
+                    "Cost approval declined. Rough conservative upper-bound "
+                    f"estimate: ${estimated_cost:.2f}, limit: "
+                    f"${limit:.2f}. "
+                    "Pre-run estimates use fixed token assumptions and conservative "
+                    "fallback pricing when model pricing is unavailable. To proceed, "
+                    "raise TRAIGENT_RUN_COST_LIMIT, approve after review with "
+                    "TRAIGENT_COST_APPROVED=true or cost_approved=True, or calibrate "
+                    "private/unpriced model rates with "
+                    "TRAIGENT_CUSTOM_MODEL_PRICING_FILE or "
+                    "TRAIGENT_CUSTOM_MODEL_PRICING_JSON."
+                ),
             )
 
     def estimate_optimization_cost(self, dataset: Dataset) -> float:

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -2425,7 +2425,13 @@ class OptimizationOrchestrator:
             )
 
     def _check_cost_approval(self, dataset: Dataset) -> None:
-        """Check cost approval before optimization. Delegates to CostEstimator."""
+        """Check pre-run cost approval before optimization.
+
+        Delegates to CostEstimator, which raises CostLimitExceeded (an
+        OptimizationError subclass) when cost approval is declined. Mid-run
+        cost limits are handled separately as graceful ``stop_reason="cost_limit"``
+        results.
+        """
         self._cost_estimator.check_cost_approval(dataset)
 
     def _is_cost_limit_reached(self) -> bool:

--- a/traigent/core/trial_lifecycle.py
+++ b/traigent/core/trial_lifecycle.py
@@ -212,6 +212,8 @@ class TrialLifecycle:
                     "Sequential trial cancelled due to cost limit reached (config=%s)",
                     config_for_run,
                 )
+                # Mid-run cost limits are graceful by contract: return a partial
+                # result and surface result.stop_reason == "cost_limit".
                 orchestrator._stop_reason = "cost_limit"
                 return trial_count, "break"
 

--- a/traigent/skills/traigent-debugging/SKILL.md
+++ b/traigent/skills/traigent-debugging/SKILL.md
@@ -79,7 +79,9 @@ Set `TRAIGENT_DEBUG=1` to see the full traceback instead of the clean error mess
 
 ### CostLimitExceeded
 
-**When raised**: Accumulated API cost exceeds the configured budget. Has `accumulated` and `limit` attributes.
+**When raised**: Cost approval is declined before the first trial (pre-run only). Has `accumulated` and `limit` attributes. `CostLimitExceeded` is a subclass of `OptimizationError`.
+
+> **Mid-run budget overruns do not raise this exception.** When accumulated spend hits the limit during a run, the run stops gracefully and returns a partial `OptimizationResult` — check `result.stop_reason == "cost_limit"`.
 
 ```
 traigent.utils.exceptions.CostLimitExceeded: Cost limit exceeded: $0.52 >= $0.50 USD
@@ -104,9 +106,12 @@ traigent.utils.exceptions.CostLimitExceeded: Cost limit exceeded: $0.52 >= $0.50
     configuration_space={"model": ["gpt-4o-mini", "gpt-4o"]},
     max_trials=5,  # Fewer trials = lower cost
 )
+
+# Option 4: Pre-approve costs (suppresses the pre-run prompt)
+# export TRAIGENT_COST_APPROVED=true  or  cost_approved=True in code
 ```
 
-**Handling programmatically**:
+**Handling the pre-run exception**:
 
 ```python
 from traigent.utils.exceptions import CostLimitExceeded
@@ -114,8 +119,17 @@ from traigent.utils.exceptions import CostLimitExceeded
 try:
     results = await func.optimize()
 except CostLimitExceeded as e:
-    print(f"Budget exceeded: spent ${e.accumulated:.2f} of ${e.limit:.2f} limit")
-    # Check if partial results are available
+    # Raised only when approval is declined before the run starts
+    print(f"Cost approval declined: ${e.accumulated:.2f} of ${e.limit:.2f} limit")
+```
+
+**Handling a mid-run budget stop** (no exception — check `stop_reason`):
+
+```python
+results = await func.optimize()
+if results.stop_reason == "cost_limit":
+    print(f"Run stopped at cost limit: ${results.total_cost:.2f} spent")
+    # results.best_config and results.trials hold what was collected
 ```
 
 ### OptimizationStateError

--- a/traigent/skills/traigent-debugging/references/error-reference.md
+++ b/traigent/skills/traigent-debugging/references/error-reference.md
@@ -18,8 +18,8 @@ Exception
   |     +-- InvocationError
   |     +-- EvaluationError
   |     +-- OptimizationError
+  |     |     +-- CostLimitExceeded
   |     +-- OptimizationStateError
-  |     +-- CostLimitExceeded
   |     +-- FeatureNotAvailableError
   |     +-- DataIntegrityError
   |     |     +-- MetricExtractionError
@@ -110,7 +110,9 @@ Raised before optimization starts when provider API keys are invalid or missing.
 
 ### CostLimitExceeded
 
-**Budget exceeded during optimization.**
+**Pre-run cost approval declined before the first trial.** `CostLimitExceeded` is a subclass of `OptimizationError`.
+
+> **Note:** A mid-run budget overrun does **not** raise this exception. When accumulated spend reaches the limit during a run, the run stops gracefully and returns a partial `OptimizationResult` with `result.stop_reason == "cost_limit"`. See [Mid-run cost stop](#mid-run-cost-stop) below.
 
 | Attribute | Type | Description |
 |---|---|---|
@@ -123,10 +125,22 @@ from traigent.utils.exceptions import CostLimitExceeded
 try:
     results = func.optimize()
 except CostLimitExceeded as e:
-    print(f"Spent ${e.accumulated:.2f} of ${e.limit:.2f} budget")
+    # Raised only for pre-run approval failures, not mid-run budget overruns
+    print(f"Cost approval declined: ${e.accumulated:.2f} of ${e.limit:.2f} limit")
 ```
 
-**Resolution**: Increase `cost_limit`, use cheaper models, or reduce `max_trials`.
+**Resolution**: Pre-approve costs with `TRAIGENT_COST_APPROVED=true` or `cost_approved=True`, increase `cost_limit`, use cheaper models, or reduce `max_trials`.
+
+#### Mid-run cost stop
+
+When accumulated spend reaches the budget limit *during* a run, Traigent stops gracefully after the current trial and **returns** a partial result — no exception is raised:
+
+```python
+results = func.optimize()
+if results.stop_reason == "cost_limit":
+    print(f"Run stopped at cost limit: ${results.total_cost:.2f} spent")
+    # results.best_config and results.trials hold what was collected
+```
 
 ### OptimizationStateError
 
@@ -251,7 +265,8 @@ from traigent.utils.exceptions import (
 try:
     results = func.optimize()
 except CostLimitExceeded as e:
-    print(f"Over budget: ${e.accumulated:.2f}")
+    # Raised for pre-run cost approval failures; mid-run budget overruns stop gracefully (check result.stop_reason)
+    print(f"Cost approval declined: ${e.accumulated:.2f}")
 except ProviderValidationError as e:
     print(f"Bad API keys: {e.failed_providers}")
 except ConfigurationError as e:

--- a/traigent/skills/traigent-run-optimization/SKILL.md
+++ b/traigent/skills/traigent-run-optimization/SKILL.md
@@ -186,7 +186,9 @@ export TRAIGENT_STRICT_COST_ACCOUNTING=true
 ```
 
 `TRAIGENT_STRICT_COST_ACCOUNTING=true` must be the exact value `true`. Budget
-overruns are separate: they are controlled by `TRAIGENT_RUN_COST_LIMIT` and raise
+limits are separate: they are controlled by `TRAIGENT_RUN_COST_LIMIT`. A mid-run
+overrun stops the run gracefully and returns a partial result
+(`result.stop_reason == "cost_limit"`); only a pre-run approval failure raises
 `CostLimitExceeded`.
 
 ## Stop Conditions

--- a/traigent/skills/traigent-run-optimization/SKILL.md
+++ b/traigent/skills/traigent-run-optimization/SKILL.md
@@ -127,9 +127,11 @@ export TRAIGENT_RUN_COST_LIMIT=5.00  # $5 max per optimization run
 
 The default limit is $2.00 per run.
 
-### Handling CostLimitExceeded
+### Cost Limit Behavior
 
-When the cost limit is reached, Traigent raises `CostLimitExceeded`:
+Traigent enforces cost limits through **two distinct surfaces**:
+
+**Pre-run (raises `CostLimitExceeded`)**: If cost approval is declined before the first trial — e.g. a non-interactive shell without `TRAIGENT_COST_APPROVED=true`, or the interactive prompt is rejected — Traigent raises `CostLimitExceeded`. `CostLimitExceeded` is a subclass of `OptimizationError`, so `except OptimizationError` also catches it.
 
 ```python
 from traigent.utils.exceptions import CostLimitExceeded
@@ -137,13 +139,21 @@ from traigent.utils.exceptions import CostLimitExceeded
 try:
     results = await func.optimize(max_trials=100, algorithm="random")
 except CostLimitExceeded as e:
-    print(f"Cost limit hit: ${e.accumulated:.2f} / ${e.limit:.2f}")
-    # Optimization stopped but partial results may be available
+    print(f"Cost approval declined: ${e.accumulated:.2f} / ${e.limit:.2f}")
 ```
 
 The exception has two attributes:
-- `e.accumulated` (float) - Total cost accumulated before the limit was hit.
+- `e.accumulated` (float) - Total cost accumulated when approval was declined.
 - `e.limit` (float) - The configured cost limit.
+
+**Mid-run (graceful stop, no exception)**: If accumulated spend reaches the budget *during* a run, Traigent stops gracefully after the current trial and returns a partial `OptimizationResult`. No exception is raised. Check `result.stop_reason`:
+
+```python
+results = await func.optimize(max_trials=100, algorithm="random")
+if results.stop_reason == "cost_limit":
+    print(f"Run stopped at cost limit: ${results.total_cost:.2f} spent")
+    # results.best_config and results.trials hold what was collected
+```
 
 ### Pre-Approving Costs
 

--- a/traigent/skills/traigent-run-optimization/references/cost-management.md
+++ b/traigent/skills/traigent-run-optimization/references/cost-management.md
@@ -27,42 +27,39 @@ os.environ["TRAIGENT_RUN_COST_LIMIT"] = "5.00"
 
 The default limit is $2.00 per optimization run. This applies per call to `optimize()` or `optimize_sync()`.
 
-## CostLimitExceeded Exception
+## Cost Limit Behavior
 
-When accumulated costs reach or exceed the limit, Traigent raises `CostLimitExceeded`.
+Traigent enforces cost limits through two distinct surfaces:
 
-```python
-from traigent.utils.exceptions import CostLimitExceeded
-```
+### Pre-Run: CostLimitExceeded (raised)
 
-### Attributes
-
-| Attribute | Type | Description |
-|---|---|---|
-| `accumulated` | `float` | Total cost in USD accumulated before the limit was hit. |
-| `limit` | `float` | The configured cost limit in USD. |
-
-### Handling
+`CostLimitExceeded` is raised when cost approval is **declined before the first trial** — for example when a non-interactive shell has no `TRAIGENT_COST_APPROVED=true`, or when the interactive cost-approval prompt is rejected. `CostLimitExceeded` is a subclass of `OptimizationError`, so `except OptimizationError` also catches it.
 
 ```python
-from traigent.utils.exceptions import CostLimitExceeded
+from traigent.utils.exceptions import CostLimitExceeded, OptimizationError
 
 try:
     results = await func.optimize(max_trials=100, algorithm="random")
 except CostLimitExceeded as e:
-    print(f"Cost limit exceeded: ${e.accumulated:.2f} of ${e.limit:.2f} budget")
-    # The optimization stopped gracefully.
-    # Partial results may be available via the orchestrator.
+    print(f"Cost approval declined: ${e.accumulated:.2f} of ${e.limit:.2f} limit")
 ```
 
-### Stop Reason
+#### CostLimitExceeded Attributes
 
-When optimization stops due to cost (without raising an exception), the result will have:
+| Attribute | Type | Description |
+|---|---|---|
+| `accumulated` | `float` | Total cost in USD accumulated when approval was declined. |
+| `limit` | `float` | The configured cost limit in USD. |
+
+### Mid-Run: Graceful stop (check stop_reason)
+
+When accumulated spend reaches the budget limit *during* a run, Traigent stops gracefully after the current trial and **returns** a partial `OptimizationResult`. No exception is raised. Inspect `result.stop_reason` to detect this:
 
 ```python
 results = await func.optimize(max_trials=50, algorithm="random")
 if results.stop_reason == "cost_limit":
-    print(f"Stopped at cost limit. Total cost: ${results.total_cost:.2f}")
+    print(f"Run stopped at cost limit. Total cost: ${results.total_cost:.2f}")
+    # results.best_config and results.trials hold what was collected so far
 ```
 
 ## Cost Tracking via LiteLLM
@@ -119,8 +116,9 @@ The environment value must be exactly `true`. In strict mode, unpriced models
 fail fast before trial 1, and missing or unknown runtime cost extraction raises
 `CostTrackingRequiredError` instead of logging a warning and continuing.
 
-Budget overruns are separate: `TRAIGENT_RUN_COST_LIMIT` controls the run budget
-and raises `CostLimitExceeded` when exceeded.
+Budget limits are separate: `TRAIGENT_RUN_COST_LIMIT` controls the run budget.
+Mid-run overruns stop the run gracefully (check `result.stop_reason == "cost_limit"`);
+pre-run approval failures raise `CostLimitExceeded`.
 
 ## Cost Warning Threshold
 

--- a/traigent/utils/exceptions.py
+++ b/traigent/utils/exceptions.py
@@ -308,13 +308,42 @@ class RateLimitError(RetryableError):
         super().__init__(message, retry_after=retry_after)
 
 
-class CostLimitExceeded(TraigentError):
-    """Raised when accumulated cost exceeds the configured limit."""
+class CostLimitExceeded(OptimizationError):
+    """Raised when a pre-run cost approval decline prevents optimization.
 
-    def __init__(self, accumulated: float, limit: float) -> None:
-        super().__init__(f"Cost limit exceeded: ${accumulated:.2f} >= ${limit:.2f} USD")
+    The mid-run cost-limit contract is intentionally graceful: optimization
+    returns a partial result and callers should inspect
+    ``result.stop_reason == "cost_limit"``.
+    """
+
+    def __init__(
+        self,
+        accumulated: float,
+        limit: float,
+        *,
+        estimated: float | None = None,
+        message: str | None = None,
+    ) -> None:
+        spent = accumulated
+        if message is None:
+            message = f"Cost limit exceeded: ${spent:.2f} >= ${limit:.2f} USD"
+            if estimated is not None:
+                message = (
+                    f"Cost limit exceeded: estimated ${estimated:.2f} >= "
+                    f"${limit:.2f} USD; spent ${spent:.2f}"
+                )
+        details: dict[str, Any] = {
+            "accumulated": accumulated,
+            "spent": spent,
+            "limit": limit,
+        }
+        if estimated is not None:
+            details["estimated"] = estimated
+        super().__init__(message, details=details)
         self.accumulated = accumulated
+        self.spent = spent
         self.limit = limit
+        self.estimated = estimated
 
 
 class VendorPauseError(TraigentError):


### PR DESCRIPTION
Closes #1490.

## Problem
`CostLimitExceeded` is exported + documented but NEVER raised in production — `except CostLimitExceeded` caught nothing (a fake public surface). Pre-run cost-decline raised a generic `OptimizationAborted`; mid-run set `stop_reason='cost_limit'` gracefully — three inconsistent surfaces.

## Fix (non-breaking)
- `CostLimitExceeded` now subclasses `OptimizationError` and carries accumulated/spent/limit/estimated.
- Pre-run cost-decline now raises `CostLimitExceeded` (was `OptimizationAborted`). Backward compatible: existing `except OptimizationError` callers still catch it.
- Mid-run UNCHANGED: graceful stop with `result.stop_reason=='cost_limit'` + partial result returned (intended UX, not converted to an exception).
- Documented the contract (pre-run/approval-declined → raises CostLimitExceeded; mid-run → graceful stop, inspect stop_reason) in CostEnforcer/CostEstimator/OptimizationOrchestrator/OptimizationResult.

## Tests
raises CostLimitExceeded when declined; catchable as OptimizationError (backward compat); is-OptimizationError; mid-run graceful returns result. Pre-fix failed (raised OptimizationAborted + not OptimizationError subclass). 246 passed.

Spine-Trail: st_9f6a03b076c3