### PR TITLE
fix(sdk): docstring model-id + mock-mode score warning (#1447 #1419)

### DIFF
--- a/tests/unit/core/test_mock_mode_warning.py
+++ b/tests/unit/core/test_mock_mode_warning.py
@@ -1,0 +1,206 @@
+"""Tests for #1419 mock-mode output-score warning and #1447 docstring model-ID fix.
+
+#1447 — public @optimize / Choices docstrings must not cite decommissioned model IDs.
+#1419 — create_effective_evaluator must emit a one-time WARNING when mock mode is
+        active and an output-based scorer (custom_evaluator / metric_functions /
+        scoring_function) is supplied, because mock LLM returns a canned constant
+        string so every trial scores identically.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from traigent.core.optimization_pipeline import create_effective_evaluator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DUMMY_EVALUATOR = MagicMock(return_value=(MagicMock(), None))
+_DUMMY_LOCAL = MagicMock(return_value=(MagicMock(), None))
+_DUMMY_CUSTOM = MagicMock()  # callable used as custom_evaluator
+
+
+def _call_create_evaluator(**overrides: Any) -> Any:
+    """Call create_effective_evaluator with safe defaults, merging overrides."""
+    defaults: dict[str, Any] = {
+        "timeout": None,
+        "custom_evaluator": None,
+        "effective_batch_size": None,
+        "effective_thread_workers": None,
+        "effective_privacy_enabled": False,
+        "objectives": ["accuracy"],
+        "execution_mode": "local",
+        "mock_mode_config": None,
+        "metric_functions": None,
+        "scoring_function": None,
+        "decorator_custom_evaluator": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# #1419 — warning fires in mock mode + output-based scorer
+# ---------------------------------------------------------------------------
+
+
+class TestMockModeOutputScoreWarning:
+    """create_effective_evaluator emits a WARNING when mock mode + output scorer."""
+
+    def _run(self, mock_llm: bool, caplog: pytest.LogCaptureFixture, **kw: Any) -> None:
+        """Invoke create_effective_evaluator with both underlying builders patched out."""
+        kwargs = _call_create_evaluator(**kw)
+        with (
+            patch(
+                "traigent.core.optimization_pipeline.is_mock_llm",
+                return_value=mock_llm,
+            ),
+            patch(
+                "traigent.core.optimization_pipeline._create_wrapped_custom_evaluator",
+                return_value=(MagicMock(), None),
+            ),
+            patch(
+                "traigent.core.optimization_pipeline._create_local_evaluator",
+                return_value=(MagicMock(), None),
+            ),
+        ):
+            with caplog.at_level(
+                logging.WARNING, logger="traigent.core.optimization_pipeline"
+            ):
+                create_effective_evaluator(**kwargs)
+
+    # --- fires ---
+
+    def test_warns_when_mock_and_custom_evaluator(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning fires: mock mode ON + custom_evaluator supplied."""
+        self._run(
+            mock_llm=True,
+            caplog=caplog,
+            custom_evaluator=_DUMMY_CUSTOM,
+        )
+        assert any("Mock mode active" in r.message for r in caplog.records), (
+            "Expected 'Mock mode active' warning in log records"
+        )
+        assert any(
+            "output-based metrics are not meaningful" in r.message
+            for r in caplog.records
+        )
+
+    def test_warns_when_mock_and_metric_functions(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning fires: mock mode ON + metric_functions supplied."""
+        self._run(
+            mock_llm=True,
+            caplog=caplog,
+            metric_functions={"accuracy": lambda pred, ref: float(pred == ref)},
+        )
+        assert any("Mock mode active" in r.message for r in caplog.records)
+
+    def test_warns_when_mock_and_scoring_function(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning fires: mock mode ON + scoring_function supplied."""
+        self._run(
+            mock_llm=True,
+            caplog=caplog,
+            scoring_function=lambda pred, ref: float(pred == ref),
+        )
+        assert any("Mock mode active" in r.message for r in caplog.records)
+
+    def test_warns_when_mock_and_decorator_custom_evaluator(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning fires: mock mode ON + decorator-level custom_evaluator."""
+        self._run(
+            mock_llm=True,
+            caplog=caplog,
+            decorator_custom_evaluator=_DUMMY_CUSTOM,
+        )
+        assert any("Mock mode active" in r.message for r in caplog.records)
+
+    # --- does NOT fire ---
+
+    def test_no_warn_when_not_mock_mode(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No warning when mock mode is OFF, even with output-based scorer."""
+        self._run(
+            mock_llm=False,
+            caplog=caplog,
+            custom_evaluator=_DUMMY_CUSTOM,
+        )
+        assert not any("Mock mode active" in r.message for r in caplog.records)
+
+    def test_no_warn_when_mock_but_no_output_scorer(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No warning when mock mode is ON but no output-based scorer is supplied."""
+        self._run(
+            mock_llm=True,
+            caplog=caplog,
+            # No custom_evaluator / metric_functions / scoring_function
+        )
+        assert not any("Mock mode active" in r.message for r in caplog.records)
+
+    def test_warning_is_at_warning_level(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The mock-score notice must be at WARNING level (not DEBUG/INFO)."""
+        self._run(
+            mock_llm=True,
+            caplog=caplog,
+            custom_evaluator=_DUMMY_CUSTOM,
+        )
+        warning_records = [r for r in caplog.records if "Mock mode active" in r.message]
+        assert warning_records, "Expected at least one matching log record"
+        assert all(r.levelno == logging.WARNING for r in warning_records)
+
+
+# ---------------------------------------------------------------------------
+# #1447 — decommissioned model IDs removed from public docstrings
+# ---------------------------------------------------------------------------
+
+
+class TestDocstringModelIds:
+    """Public-API docstrings must not reference the retired claude-2 model ID."""
+
+    def test_decorators_module_no_claude2(self) -> None:
+        """traigent/api/decorators.py docstrings must not cite claude-2."""
+        import inspect
+
+        import traigent.api.decorators as mod
+
+        source = inspect.getsource(mod)
+        assert "claude-2" not in source, (
+            "Found retired model ID 'claude-2' in traigent/api/decorators.py. "
+            "Replace with a current model ID (e.g. claude-haiku-4-5-20251001)."
+        )
+
+    def test_parameter_ranges_module_no_claude2(self) -> None:
+        """traigent/api/parameter_ranges.py Choices docstring must not cite claude-2."""
+        import traigent.api.parameter_ranges as mod
+        import inspect
+
+        source = inspect.getsource(mod)
+        assert "claude-2" not in source, (
+            "Found retired model ID 'claude-2' in traigent/api/parameter_ranges.py. "
+            "Replace with a current model ID (e.g. claude-haiku-4-5-20251001)."
+        )
+
+    def test_choices_docstring_uses_current_model_id(self) -> None:
+        """The Choices class docstring example uses a current model ID."""
+        from traigent.api.parameter_ranges import Choices
+
+        doc = Choices.__doc__ or ""
+        assert "claude-haiku-4-5-20251001" in doc, (
+            "Expected Choices docstring to use claude-haiku-4-5-20251001 "
+            f"as the example Anthropic model ID. Got docstring:\n{doc}"
+        )

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -26,7 +26,7 @@ Examples:
     ...     eval_dataset="customer_support.jsonl",
     ...     objectives=["accuracy", "cost", "latency"],
     ...     configuration_space={
-    ...         "model": ["gpt-3.5-turbo", "gpt-4", "claude-2"],
+    ...         "model": ["gpt-3.5-turbo", "gpt-4", "claude-haiku-4-5-20251001"],
     ...         "temperature": [0.1, 0.3, 0.5, 0.7, 0.9],
     ...         "max_tokens": [100, 500, 1000]
     ...     },
@@ -2285,7 +2285,7 @@ def optimize(  # NOSONAR(S107)
         ...         "minimal_logging": True,
         ...     },
         ...     configuration_space={
-        ...         "model": ["gpt-4", "claude-2"],
+        ...         "model": ["gpt-4", "claude-haiku-4-5-20251001"],
         ...         "temperature": [0.1, 0.3, 0.5],
         ...         "safety_filter": ["strict", "moderate"]
         ...     }

--- a/traigent/api/parameter_ranges.py
+++ b/traigent/api/parameter_ranges.py
@@ -650,7 +650,7 @@ class Choices(CategoricalConstraintBuilderMixin, ParameterRange, Generic[T]):
             Set to False to allow mixed types (e.g., [None, "default", 1]).
 
     Example:
-        >>> model = Choices(["gpt-4", "gpt-3.5-turbo", "claude-2"])
+        >>> model = Choices(["gpt-4", "gpt-3.5-turbo", "claude-haiku-4-5-20251001"])
         >>> use_cache = Choices([True, False], default=True)
         >>> temperature = Choices([0.0, 0.3, 0.7, 1.0])
         >>> # Multi-agent: assign to specific agent

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -31,6 +31,7 @@ from traigent.core.evaluator_wrapper import CustomEvaluatorWrapper
 from traigent.core.trace_env import is_trace_enabled
 from traigent.evaluators.base import BaseEvaluator, Dataset
 from traigent.evaluators.local import LocalEvaluator
+from traigent.utils.env_config import is_mock_llm
 from traigent.utils.logging import get_logger
 from traigent.utils.validation import validate_config_space
 
@@ -514,6 +515,18 @@ def create_effective_evaluator(
         mock_mode_config=mock_mode_config,
         decorator_custom_evaluator=decorator_custom_evaluator,
     )
+
+    # Warn once when mock LLM mode is active and an output-based scorer is supplied.
+    # Mock mode returns a canned constant string for every LLM call, so any evaluator
+    # that scores the LLM output (custom_evaluator / metric_functions / scoring_function)
+    # will produce identical scores for all trials — the best_config is meaningless.
+    if is_mock_llm() and (effective_evaluator or metric_functions or scoring_function):
+        logger.warning(
+            "Mock mode active — LLM outputs are canned, so output-based metrics are not "
+            "meaningful. Run with TRAIGENT_MOCK_LLM=false and a provider key for real "
+            "scores. See traigent/examples/providers/_demo.py for a synthetic scorer "
+            "pattern that produces a ranked mock board."
+        )
 
     if effective_evaluator:
         if not callable(effective_evaluator):


### PR DESCRIPTION
## Summary

Closes #1447, Closes #1419

### #1447 — decommissioned model ID in docstrings

Replaced retired `claude-2` model ID with `claude-haiku-4-5-20251001` in three docstring examples:
- `traigent/api/decorators.py`: module-level docstring (multi-objective example) and `optimize()` method docstring (offline/local example)
- `traigent/api/parameter_ranges.py`: `Choices` class docstring example

Standardized on `claude-haiku-4-5-20251001` — the same current Anthropic ID that PR #1500 (commit `6d810c88`) pinned in the examples when retiring `claude-3-haiku` and `claude-3-5-sonnet`. Docs/docstrings only; no runtime change.

### #1419 — warn on meaningless output scores in mock mode

Added a one-time `logger.warning` in `create_effective_evaluator` (`traigent/core/optimization_pipeline.py`) that fires when:
- `is_mock_llm()` is True (TRAIGENT_MOCK_LLM or `enable_mock_mode_for_quickstart()`), AND
- an output-based scorer is supplied (`custom_evaluator` / `metric_functions` / `scoring_function`)

Mock mode returns a canned constant string for every LLM call, so output-based evaluators produce identical scores for all trials — the `best_config` and `best_score` are meaningless. The warning fires once per `.optimize()` call (not per trial) and directs users to run with a real key or use the synthetic-scorer pattern in `examples/providers/_demo.py`.

## Test plan

- `tests/unit/core/test_mock_mode_warning.py` (10 tests):
  - `TestMockModeOutputScoreWarning` (7 tests): warns for custom_evaluator / metric_functions / scoring_function / decorator_custom_evaluator; no warn without mock mode; no warn in mock mode without output scorer; warning is at WARNING level
  - `TestDocstringModelIds` (3 tests): decorators.py source has no `claude-2`; parameter_ranges.py source has no `claude-2`; Choices docstring uses `claude-haiku-4-5-20251001`
- All 10 pass; ruff format + ruff check clean

Spine-Trail: st_4e3030e9dc38