### PR TITLE
feat(sdk-dx): auto-pagination iterator over list_* endpoints (#1442)

### DIFF
--- a/tests/unit/test_auto_pagination.py
+++ b/tests/unit/test_auto_pagination.py
@@ -1,0 +1,656 @@
+"""Unit tests for the auto-pagination ``iter_*`` helpers (#1442).
+
+Coverage goals
+--------------
+* 3-page fixture: all items are yielded exactly once and in order.
+* Single-page fixture: terminates after one request.
+* Empty first-page fixture: yields nothing, makes exactly one request.
+* Infinite-loop guard: a backend that always returns has_next=True but
+  never advances the page number terminates cleanly (no duplicates).
+* Existing single-page ``list_*`` signatures are unchanged (smoke).
+* The generic ``iter_pages`` helper is also exercised directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs
+
+import pytest
+
+from traigent.utils.pagination import iter_pages
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal fake DTOs and path-parsing utilities
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakePagination:
+    page: int
+    per_page: int
+    total: int
+    total_pages: int
+    has_next: bool
+    has_prev: bool
+
+
+@dataclass(frozen=True)
+class _FakeItem:
+    id: str
+
+
+@dataclass(frozen=True)
+class _FakeListResponse:
+    items: list[_FakeItem]
+    pagination: _FakePagination
+
+
+def _make_response(
+    page: int,
+    per_page: int,
+    items: list[str],
+    total: int,
+    total_pages: int,
+    has_next: bool,
+) -> _FakeListResponse:
+    return _FakeListResponse(
+        items=[_FakeItem(id=i) for i in items],
+        pagination=_FakePagination(
+            page=page,
+            per_page=per_page,
+            total=total,
+            total_pages=total_pages,
+            has_next=has_next,
+            has_prev=page > 1,
+        ),
+    )
+
+
+def _page_from_path(path: str) -> int:
+    """Extract the ``page`` query parameter from a URL path string.
+
+    Handles both ``/api/v1beta/resource?page=2&per_page=2`` and bare
+    ``?page=2&per_page=2`` forms.  Returns 1 if the parameter is absent.
+    """
+    # Strip a leading scheme+host so urlparse doesn't confuse bare paths.
+    qs = path.split("?", 1)[1] if "?" in path else ""
+    params = parse_qs(qs)
+    return int(params.get("page", ["1"])[0])
+
+
+# ---------------------------------------------------------------------------
+# iter_pages — core helper
+# ---------------------------------------------------------------------------
+
+
+class TestIterPages:
+    """Tests for the generic :func:`traigent.utils.pagination.iter_pages`."""
+
+    def test_three_pages_all_items_yielded(self):
+        """All items across 3 pages are returned in order."""
+        responses = {
+            1: _make_response(1, 2, ["a", "b"], 6, 3, has_next=True),
+            2: _make_response(2, 2, ["c", "d"], 6, 3, has_next=True),
+            3: _make_response(3, 2, ["e", "f"], 6, 3, has_next=False),
+        }
+        call_log: list[int] = []
+
+        def list_fn(*, page: int, per_page: int, **_filters: Any):
+            call_log.append(page)
+            return responses[page]
+
+        result = list(iter_pages(list_fn, per_page=2))
+        assert [item.id for item in result] == ["a", "b", "c", "d", "e", "f"]
+        assert call_log == [1, 2, 3], "exactly 3 requests — one per page"
+
+    def test_single_page_terminates_after_one_request(self):
+        """A single-page result stops immediately."""
+        call_log: list[int] = []
+
+        def list_fn(*, page: int, per_page: int, **_filters: Any):
+            call_log.append(page)
+            return _make_response(1, 20, ["x", "y"], 2, 1, has_next=False)
+
+        result = list(iter_pages(list_fn, per_page=20))
+        assert [item.id for item in result] == ["x", "y"]
+        assert call_log == [1]
+
+    def test_empty_first_page_yields_nothing(self):
+        """An empty first page produces an empty iterator with one request."""
+        call_log: list[int] = []
+
+        def list_fn(*, page: int, per_page: int, **_filters: Any):
+            call_log.append(page)
+            return _make_response(1, 100, [], 0, 0, has_next=False)
+
+        result = list(iter_pages(list_fn, per_page=100))
+        assert result == []
+        assert call_log == [1]
+
+    def test_infinite_loop_guard_aborts_on_stale_page(self):
+        """If the server always returns has_next=True with the same page number,
+        the guard detects the stall and stops without emitting duplicates."""
+        call_count = 0
+
+        def list_fn(*, page: int, per_page: int, **_filters: Any):
+            nonlocal call_count
+            call_count += 1
+            # Always returns page=1, has_next=True regardless of the requested page.
+            return _make_response(1, 10, ["z"], 0, 99, has_next=True)
+
+        result = list(iter_pages(list_fn, per_page=10))
+
+        # First call yields the item; the second call sees pagination.page=1
+        # (already seen) and the guard fires before yielding — so exactly 1
+        # item is emitted and exactly 2 requests are made.
+        assert call_count == 2, (
+            f"guard should fire on the second call; got {call_count} calls"
+        )
+        assert [item.id for item in result] == ["z"], (
+            "no duplicate items should be emitted"
+        )
+
+    def test_filters_forwarded_on_every_page(self):
+        """Keyword filters are passed through verbatim on every page request."""
+        received_args: list[dict[str, Any]] = []
+
+        def list_fn(*, page: int, per_page: int, **filters: Any):
+            received_args.append({"page": page, "per_page": per_page, **filters})
+            has_next = page < 2
+            return _make_response(page, per_page, ["i"], 2, 2, has_next=has_next)
+
+        list(iter_pages(list_fn, per_page=50, search="hello", status="active"))
+
+        assert len(received_args) == 2
+        for args in received_args:
+            assert args["search"] == "hello"
+            assert args["status"] == "active"
+            assert args["per_page"] == 50
+
+    def test_positional_args_forwarded_on_every_page(self):
+        """Positional arguments (e.g. queue_id) are forwarded on every call."""
+        received_positional: list[tuple] = []
+
+        def list_fn(queue_id, *, page: int, per_page: int, **_filters: Any):
+            received_positional.append((queue_id,))
+            has_next = page < 2
+            return _make_response(page, per_page, ["j"], 2, 2, has_next=has_next)
+
+        list(iter_pages(list_fn, "queue-42", per_page=10))
+
+        assert len(received_positional) == 2
+        for pos in received_positional:
+            assert pos == ("queue-42",)
+
+
+# ---------------------------------------------------------------------------
+# EvaluationClient — iter_* smoke tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _online(monkeypatch):
+    """These tests use a mock request sender; opt out of offline mode."""
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+
+
+def _eval_list_item(idx: int) -> dict[str, Any]:
+    return {
+        "id": f"ev_{idx}",
+        "name": f"Evaluator {idx}",
+        "description": "",
+        "measure_id": "m1",
+        "primary_measure_id": "m1",
+        "target_type": "observability_trace",
+        "judge_config": {
+            "instructions": "Judge",
+            "model_id": "gpt-4.1-mini",
+            "context_type": "none",
+            "parameters": {},
+        },
+        "sampling_rate": 1.0,
+        "target_filters": {},
+        "is_active": True,
+        "measure": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _eval_page_response(page: int, total_pages: int) -> dict[str, Any]:
+    idx = (page - 1) * 2 + 1
+    return {
+        "data": {
+            "items": [_eval_list_item(idx), _eval_list_item(idx + 1)],
+            "pagination": {
+                "page": page,
+                "per_page": 2,
+                "total": total_pages * 2,
+                "total_pages": total_pages,
+                "has_next": page < total_pages,
+                "has_prev": page > 1,
+            },
+        }
+    }
+
+
+class TestEvaluationClientIter:
+    @pytest.fixture(autouse=True)
+    def _use_online(self, _online):
+        pass
+
+    def test_iter_evaluators_three_pages(self):
+        """iter_evaluators yields all items across 3 pages."""
+        from traigent.evaluation import EvaluationClient
+
+        pages_requested: list[int] = []
+
+        def sender(method: str, path: str, payload: Any):
+            p = _page_from_path(path)
+            pages_requested.append(p)
+            return _eval_page_response(p, 3)
+
+        client = EvaluationClient(request_sender=sender)
+        result = list(client.iter_evaluators(per_page=2))
+        assert len(result) == 6
+        assert result[0].id == "ev_1"
+        assert result[5].id == "ev_6"
+        assert pages_requested == [1, 2, 3]
+
+    def test_list_evaluators_still_returns_single_page(self):
+        """Existing list_evaluators is unchanged — returns a single page."""
+        from traigent.evaluation import EvaluationClient
+
+        def sender(method: str, path: str, payload: Any):
+            return _eval_page_response(1, 3)
+
+        client = EvaluationClient(request_sender=sender)
+        resp = client.list_evaluators()
+        # Returns a single page object, not an iterator
+        assert hasattr(resp, "pagination")
+        assert hasattr(resp, "items")
+        assert len(resp.items) == 2  # only first page
+
+    def test_iter_evaluators_empty_result(self):
+        """iter_evaluators on an empty collection yields nothing."""
+        from traigent.evaluation import EvaluationClient
+
+        def sender(method: str, path: str, payload: Any):
+            return {
+                "data": {
+                    "items": [],
+                    "pagination": {
+                        "page": 1,
+                        "per_page": 100,
+                        "total": 0,
+                        "total_pages": 0,
+                        "has_next": False,
+                        "has_prev": False,
+                    },
+                }
+            }
+
+        client = EvaluationClient(request_sender=sender)
+        result = list(client.iter_evaluators())
+        assert result == []
+
+    def test_iter_evaluator_runs_two_pages(self):
+        """iter_evaluator_runs yields all items across 2 pages."""
+        from traigent.evaluation import EvaluationClient
+
+        def _run_item(idx: int) -> dict[str, Any]:
+            return {
+                "id": f"run_{idx}",
+                "evaluator_id": "ev_1",
+                "target_type": "observability_trace",
+                "target_id": f"trace_{idx}",
+                "status": "completed",
+                "score": None,
+                "raw_output": None,
+                "error": None,
+                "started_at": None,
+                "completed_at": None,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+
+        pages_seen: list[int] = []
+
+        def sender(method: str, path: str, payload: Any):
+            p = _page_from_path(path)
+            pages_seen.append(p)
+            idx = (p - 1) * 2 + 1
+            return {
+                "data": {
+                    "items": [_run_item(idx), _run_item(idx + 1)],
+                    "pagination": {
+                        "page": p,
+                        "per_page": 2,
+                        "total": 4,
+                        "total_pages": 2,
+                        "has_next": p < 2,
+                        "has_prev": p > 1,
+                    },
+                }
+            }
+
+        client = EvaluationClient(request_sender=sender)
+        result = list(client.iter_evaluator_runs(per_page=2))
+        assert len(result) == 4
+        assert pages_seen == [1, 2]
+
+    def test_iter_annotation_queue_items_positional_queue_id(self):
+        """iter_annotation_queue_items forwards queue_id on every request."""
+        from traigent.evaluation import EvaluationClient
+
+        seen_paths: list[str] = []
+
+        def _item(idx: int) -> dict[str, Any]:
+            return {
+                "id": f"item_{idx}",
+                "queue_id": "q1",
+                "target_type": "observability_trace",
+                "target_id": f"trace_{idx}",
+                "status": "pending",
+                "assigned_user_id": None,
+                "scores": [],
+                "note": None,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+
+        def sender(method: str, path: str, payload: Any):
+            seen_paths.append(path)
+            p = _page_from_path(path)
+            idx = (p - 1) * 2 + 1
+            return {
+                "data": {
+                    "items": [_item(idx), _item(idx + 1)],
+                    "pagination": {
+                        "page": p,
+                        "per_page": 2,
+                        "total": 4,
+                        "total_pages": 2,
+                        "has_next": p < 2,
+                        "has_prev": p > 1,
+                    },
+                }
+            }
+
+        client = EvaluationClient(request_sender=sender)
+        result = list(client.iter_annotation_queue_items("q1", per_page=2))
+        assert len(result) == 4
+        # Both paths should reference the queue ID
+        for p in seen_paths:
+            assert "annotation-queues/q1/items" in p
+
+
+# ---------------------------------------------------------------------------
+# ObservabilityClient — iter_traces and iter_sessions smoke
+# ---------------------------------------------------------------------------
+
+
+def _trace_item(idx: int) -> dict[str, Any]:
+    return {
+        "id": f"trace_{idx}",
+        "name": f"Trace {idx}",
+        "start_time": "2026-01-01T00:00:00+00:00",
+        "end_time": "2026-01-01T00:01:00+00:00",
+        "status": "ok",
+        "environment": "production",
+        "tags": [],
+        "bookmarked": False,
+        "user_id": None,
+        "session_id": None,
+        "release": None,
+        "model": None,
+        "input": {},
+        "output": {},
+        "metadata": {},
+        "latency_ms": 1000,
+        "total_tokens": 100,
+        "prompt_tokens": 80,
+        "completion_tokens": 20,
+        "cost_usd": None,
+    }
+
+
+def _trace_page_response(page: int, total_pages: int) -> dict[str, Any]:
+    idx = (page - 1) * 2 + 1
+    return {
+        "data": {
+            "items": [_trace_item(idx), _trace_item(idx + 1)],
+            "pagination": {
+                "page": page,
+                "per_page": 2,
+                "total": total_pages * 2,
+                "total_pages": total_pages,
+                "has_next": page < total_pages,
+                "has_prev": page > 1,
+            },
+        }
+    }
+
+
+class TestObservabilityClientIter:
+    def test_iter_traces_two_pages(self, monkeypatch):
+        """iter_traces yields all items across 2 pages."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.observability.client import ObservabilityClient
+
+        def sender(traces: list) -> dict | None:
+            return None  # ingest path — unused
+
+        client = ObservabilityClient(sender=sender, request_sender=None)
+
+        pages_seen: list[int] = []
+
+        def _request_json_mock(method: str, path: str, payload=None):
+            p = _page_from_path(path)
+            pages_seen.append(p)
+            return _trace_page_response(p, 2)
+
+        client._request_json = _request_json_mock  # type: ignore[method-assign]
+
+        result = list(client.iter_traces(per_page=2))
+        assert len(result) == 4
+        assert pages_seen == [1, 2]
+
+    def test_list_traces_unchanged(self, monkeypatch):
+        """list_traces still returns a single-page response object."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.observability.client import ObservabilityClient
+
+        client = ObservabilityClient()
+
+        def _request_json_mock(method: str, path: str, payload=None):
+            return _trace_page_response(1, 5)
+
+        client._request_json = _request_json_mock  # type: ignore[method-assign]
+
+        resp = client.list_traces()
+        assert hasattr(resp, "pagination")
+        assert resp.pagination.has_next is True
+        assert len(resp.items) == 2  # only first page returned
+
+    def test_iter_sessions_two_pages(self, monkeypatch):
+        """iter_sessions yields all items across 2 pages."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.observability.client import ObservabilityClient
+
+        def _session_item(idx: int) -> dict[str, Any]:
+            return {
+                "id": f"session_{idx}",
+                "environment": "production",
+                "user_id": None,
+                "tags": [],
+                "release": None,
+                "trace_count": 1,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            }
+
+        def _session_page(page: int, total_pages: int) -> dict[str, Any]:
+            idx = (page - 1) * 2 + 1
+            return {
+                "data": {
+                    "items": [_session_item(idx), _session_item(idx + 1)],
+                    "pagination": {
+                        "page": page,
+                        "per_page": 2,
+                        "total": total_pages * 2,
+                        "total_pages": total_pages,
+                        "has_next": page < total_pages,
+                        "has_prev": page > 1,
+                    },
+                }
+            }
+
+        client = ObservabilityClient()
+        pages_seen: list[int] = []
+
+        def _request_json_mock(method: str, path: str, payload=None):
+            p = _page_from_path(path)
+            pages_seen.append(p)
+            return _session_page(p, 2)
+
+        client._request_json = _request_json_mock  # type: ignore[method-assign]
+
+        result = list(client.iter_sessions(per_page=2))
+        assert len(result) == 4
+        assert pages_seen == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# PromptManagementClient — iter_prompts smoke
+# ---------------------------------------------------------------------------
+
+
+def _prompt_item(idx: int) -> dict[str, Any]:
+    return {
+        "name": f"prompt_{idx}",
+        "description": None,
+        "prompt_type": "text",
+        "labels": [],
+        "version_count": 1,
+        "latest_version": 1,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _prompt_page_response(page: int, total_pages: int) -> dict[str, Any]:
+    idx = (page - 1) * 2 + 1
+    return {
+        "data": {
+            "items": [_prompt_item(idx), _prompt_item(idx + 1)],
+            "pagination": {
+                "page": page,
+                "per_page": 2,
+                "total": total_pages * 2,
+                "total_pages": total_pages,
+                "has_next": page < total_pages,
+                "has_prev": page > 1,
+            },
+        }
+    }
+
+
+class TestPromptClientIter:
+    def test_iter_prompts_two_pages(self, monkeypatch):
+        """iter_prompts yields all items across 2 pages."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.prompts.client import PromptManagementClient
+
+        pages_seen: list[int] = []
+
+        def sender(method: str, path: str, payload=None):
+            p = _page_from_path(path)
+            pages_seen.append(p)
+            return _prompt_page_response(p, 2)
+
+        client = PromptManagementClient(request_sender=sender)
+        result = list(client.iter_prompts(per_page=2))
+        assert len(result) == 4
+        assert pages_seen == [1, 2]
+
+    def test_list_prompts_unchanged(self, monkeypatch):
+        """list_prompts still returns a single-page response object."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.prompts.client import PromptManagementClient
+
+        def sender(method: str, path: str, payload=None):
+            return _prompt_page_response(1, 3)
+
+        client = PromptManagementClient(request_sender=sender)
+        resp = client.list_prompts()
+        assert hasattr(resp, "pagination")
+        assert resp.pagination.has_next is True
+
+
+# ---------------------------------------------------------------------------
+# ProjectManagementClient — iter_projects smoke
+# ---------------------------------------------------------------------------
+
+
+def _project_item(idx: int) -> dict[str, Any]:
+    return {
+        "id": f"proj_{idx}",
+        "name": f"Project {idx}",
+        "slug": f"project-{idx}",
+        "description": None,
+        "status": "active",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _project_page_response(page: int, total_pages: int) -> dict[str, Any]:
+    idx = (page - 1) * 2 + 1
+    return {
+        "data": {
+            "items": [_project_item(idx), _project_item(idx + 1)],
+            "pagination": {
+                "page": page,
+                "per_page": 2,
+                "total": total_pages * 2,
+                "total_pages": total_pages,
+                "has_next": page < total_pages,
+                "has_prev": page > 1,
+            },
+        }
+    }
+
+
+class TestProjectClientIter:
+    def test_iter_projects_two_pages(self, monkeypatch):
+        """iter_projects yields all items across 2 pages."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.projects.client import ProjectManagementClient
+
+        pages_seen: list[int] = []
+
+        def sender(method: str, path: str, payload=None):
+            p = _page_from_path(path)
+            pages_seen.append(p)
+            return _project_page_response(p, 2)
+
+        client = ProjectManagementClient(request_sender=sender)
+        result = list(client.iter_projects(per_page=2))
+        assert len(result) == 4
+        assert pages_seen == [1, 2]
+
+    def test_list_projects_unchanged(self, monkeypatch):
+        """list_projects still returns a single-page response object."""
+        monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+        from traigent.projects.client import ProjectManagementClient
+
+        def sender(method: str, path: str, payload=None):
+            return _project_page_response(1, 5)
+
+        client = ProjectManagementClient(request_sender=sender)
+        resp = client.list_projects()
+        assert hasattr(resp, "pagination")
+        assert resp.pagination.has_next is True

--- a/traigent/evaluation/client.py
+++ b/traigent/evaluation/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 from typing import Any, Literal, cast, overload
+from collections.abc import Iterator
 from urllib import error, request
 from urllib.parse import quote, urlencode
 
@@ -36,6 +37,7 @@ from traigent.utils.exceptions import (
     ClientError,
     TraigentConnectionError,
 )
+from traigent.utils.pagination import iter_pages
 
 
 class EvaluationClient:
@@ -79,6 +81,37 @@ class EvaluationClient:
         payload = self._request_json("GET", path)
         return EvaluatorListResponse.from_dict(
             self._unwrap_data(payload, "evaluator list")
+        )
+
+    def iter_evaluators(
+        self,
+        *,
+        per_page: int = 100,
+        search: str | None = None,
+        measure_id: str | None = None,
+        target_type: EvaluationTargetType | str | None = None,
+        is_active: bool | None = None,
+    ) -> Iterator[EvaluatorDefinitionDTO]:
+        """Iterate over *all* evaluators across pages, fetching lazily.
+
+        Equivalent to calling :meth:`list_evaluators` in a ``while has_next``
+        loop, but without the boilerplate.  Filter arguments are forwarded
+        unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        search, measure_id, target_type, is_active:
+            Same filter semantics as :meth:`list_evaluators`.
+        """
+        yield from iter_pages(
+            self.list_evaluators,
+            per_page=per_page,
+            search=search,
+            measure_id=measure_id,
+            target_type=target_type,
+            is_active=is_active,
         )
 
     def get_evaluator(self, evaluator_id: str) -> EvaluatorDefinitionDTO:
@@ -216,6 +249,35 @@ class EvaluationClient:
         payload = self._request_json("GET", path)
         return EvaluatorRunListResponse.from_dict(
             self._unwrap_data(payload, "evaluator run list")
+        )
+
+    def iter_evaluator_runs(
+        self,
+        *,
+        per_page: int = 100,
+        evaluator_id: str | None = None,
+        target_type: EvaluationTargetType | str | None = None,
+        target_id: str | None = None,
+        status: EvaluatorRunStatus | str | None = None,
+    ) -> Iterator[EvaluatorRunDTO]:
+        """Iterate over *all* evaluator runs across pages, fetching lazily.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        evaluator_id, target_type, target_id, status:
+            Same filter semantics as :meth:`list_evaluator_runs`.
+        """
+        yield from iter_pages(
+            self.list_evaluator_runs,
+            per_page=per_page,
+            evaluator_id=evaluator_id,
+            target_type=target_type,
+            target_id=target_id,
+            status=status,
         )
 
     def get_evaluator_run(self, run_id: str) -> EvaluatorRunDTO:
@@ -367,6 +429,33 @@ class EvaluationClient:
             self._unwrap_data(payload, "score list")
         )
 
+    def iter_scores(
+        self,
+        *,
+        target: EvaluationTargetRefDTO | dict[str, Any],
+        measure_id: str | None = None,
+        per_page: int = 100,
+    ) -> Iterator[ScoreRecordDTO]:
+        """Iterate over *all* score records for *target* across pages.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        target:
+            The evaluation target to fetch scores for (required).
+        measure_id:
+            Optional measure filter.
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        """
+        yield from iter_pages(
+            self.list_scores,
+            per_page=per_page,
+            target=target,
+            measure_id=measure_id,
+        )
+
     def list_annotation_queues(
         self,
         *,
@@ -391,6 +480,33 @@ class EvaluationClient:
         payload = self._request_json("GET", path)
         return AnnotationQueueListResponse.from_dict(
             self._unwrap_data(payload, "annotation queue list")
+        )
+
+    def iter_annotation_queues(
+        self,
+        *,
+        per_page: int = 100,
+        search: str | None = None,
+        target_type: EvaluationTargetType | str | None = None,
+        status: AnnotationQueueStatus | str | None = None,
+    ) -> Iterator[AnnotationQueueDTO]:
+        """Iterate over *all* annotation queues across pages, fetching lazily.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        search, target_type, status:
+            Same filter semantics as :meth:`list_annotation_queues`.
+        """
+        yield from iter_pages(
+            self.list_annotation_queues,
+            per_page=per_page,
+            search=search,
+            target_type=target_type,
+            status=status,
         )
 
     def get_annotation_queue(self, queue_id: str) -> AnnotationQueueDTO:
@@ -490,6 +606,37 @@ class EvaluationClient:
         payload = self._request_json("GET", path)
         return AnnotationQueueItemListResponse.from_dict(
             self._unwrap_data(payload, "annotation queue item list")
+        )
+
+    def iter_annotation_queue_items(
+        self,
+        queue_id: str,
+        *,
+        per_page: int = 100,
+        status: AnnotationQueueItemStatus | str | None = None,
+        assigned_user_id: str | None = None,
+        target_id: str | None = None,
+    ) -> Iterator[AnnotationQueueItemDTO]:
+        """Iterate over *all* items in an annotation queue across pages.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        queue_id:
+            The annotation queue to iterate over.
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        status, assigned_user_id, target_id:
+            Same filter semantics as :meth:`list_annotation_queue_items`.
+        """
+        yield from iter_pages(
+            self.list_annotation_queue_items,
+            queue_id,
+            per_page=per_page,
+            status=status,
+            assigned_user_id=assigned_user_id,
+            target_id=target_id,
         )
 
     def get_next_annotation_queue_item(

--- a/traigent/observability/client.py
+++ b/traigent/observability/client.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import Any, cast
+from collections.abc import Iterator
 from urllib import error, request
 from urllib.parse import urlencode
 
@@ -45,6 +46,7 @@ from traigent.utils.exceptions import (
     TraigentConnectionError,
 )
 from traigent.utils.logging import get_logger
+from traigent.utils.pagination import iter_pages
 from traigent.utils.retry import CLOUD_API_RETRY_CONFIG, RetryHandler
 
 logger = get_logger(__name__)
@@ -733,6 +735,48 @@ class ObservabilityClient:
         payload = self._request_json("GET", f"/traces{query}")
         return TraceListResponse.from_dict(self._unwrap_data(payload, "trace list"))
 
+    def iter_traces(
+        self,
+        *,
+        per_page: int = 100,
+        search: str | None = None,
+        environment: str | None = None,
+        status: str | None = None,
+        user_id: str | None = None,
+        session_id: str | None = None,
+        tags: list[str] | str | None = None,
+        release: str | None = None,
+        model: str | None = None,
+        start_time_from: datetime | None = None,
+        start_time_to: datetime | None = None,
+    ) -> Iterator[TraceRecord]:
+        """Iterate over *all* traces across pages, fetching lazily.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        search, environment, status, user_id, session_id, tags, release,
+        model, start_time_from, start_time_to:
+            Same filter semantics as :meth:`list_traces`.
+        """
+        yield from iter_pages(
+            self.list_traces,
+            per_page=per_page,
+            search=search,
+            environment=environment,
+            status=status,
+            user_id=user_id,
+            session_id=session_id,
+            tags=tags,
+            release=release,
+            model=model,
+            start_time_from=start_time_from,
+            start_time_to=start_time_to,
+        )
+
     def get_trace(self, trace_id: str) -> TraceRecord:
         payload = self._request_json("GET", f"/traces/{trace_id}")
         return TraceRecord.from_dict(self._unwrap_data(payload, "trace detail"))
@@ -769,6 +813,42 @@ class ObservabilityClient:
         )
         payload = self._request_json("GET", f"/sessions{query}")
         return SessionListResponse.from_dict(self._unwrap_data(payload, "session list"))
+
+    def iter_sessions(
+        self,
+        *,
+        per_page: int = 100,
+        search: str | None = None,
+        environment: str | None = None,
+        user_id: str | None = None,
+        tags: list[str] | str | None = None,
+        release: str | None = None,
+        start_time_from: datetime | None = None,
+        start_time_to: datetime | None = None,
+    ) -> Iterator[SessionRecord]:
+        """Iterate over *all* sessions across pages, fetching lazily.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        search, environment, user_id, tags, release, start_time_from,
+        start_time_to:
+            Same filter semantics as :meth:`list_sessions`.
+        """
+        yield from iter_pages(
+            self.list_sessions,
+            per_page=per_page,
+            search=search,
+            environment=environment,
+            user_id=user_id,
+            tags=tags,
+            release=release,
+            start_time_from=start_time_from,
+            start_time_to=start_time_to,
+        )
 
     def get_session(self, session_id: str) -> SessionRecord:
         payload = self._request_json("GET", f"/sessions/{session_id}")

--- a/traigent/projects/client.py
+++ b/traigent/projects/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from collections.abc import Iterator
 from urllib import error, request
 from urllib.parse import quote, urlencode
 
@@ -21,6 +22,7 @@ from traigent.utils.exceptions import (
     ClientError,
     TraigentConnectionError,
 )
+from traigent.utils.pagination import iter_pages
 
 
 class ProjectManagementClient:
@@ -53,6 +55,31 @@ class ProjectManagementClient:
         path = f"?{query}" if query else ""
         payload = self._request_json("GET", path)
         return ProjectListResponse.from_dict(self._unwrap_data(payload, "project list"))
+
+    def iter_projects(
+        self,
+        *,
+        per_page: int = 100,
+        search: str | None = None,
+        status: str | None = None,
+    ) -> Iterator[ProjectDTO]:
+        """Iterate over *all* projects across pages, fetching lazily.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        search, status:
+            Same filter semantics as :meth:`list_projects`.
+        """
+        yield from iter_pages(
+            self.list_projects,
+            per_page=per_page,
+            search=search,
+            status=status,
+        )
 
     def get_project(self, project_id: str) -> ProjectDTO:
         payload = self._request_json("GET", f"/{quote(project_id, safe='')}")

--- a/traigent/prompts/client.py
+++ b/traigent/prompts/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any, cast
+from collections.abc import Iterator
 from urllib import error, request
 from urllib.parse import quote, urlencode
 
@@ -14,6 +15,7 @@ from traigent.prompts.dtos import (
     PromptDetail,
     PromptListResponse,
     PromptPlaygroundResult,
+    PromptSummary,
     PromptType,
     ResolvedPrompt,
 )
@@ -23,6 +25,7 @@ from traigent.utils.exceptions import (
     ClientError,
     TraigentConnectionError,
 )
+from traigent.utils.pagination import iter_pages
 
 
 class PromptManagementClient:
@@ -62,6 +65,33 @@ class PromptManagementClient:
         )
         payload = self._request_json("GET", query or "")
         return PromptListResponse.from_dict(self._unwrap_data(payload, "prompt list"))
+
+    def iter_prompts(
+        self,
+        *,
+        per_page: int = 100,
+        search: str | None = None,
+        prompt_type: PromptType | str | None = None,
+        label: str | None = None,
+    ) -> Iterator[PromptSummary]:
+        """Iterate over *all* prompts across pages, fetching lazily.
+
+        Filter arguments are forwarded unchanged on every page request.
+
+        Parameters
+        ----------
+        per_page:
+            Items per page.  Defaults to 100 to minimise round-trips.
+        search, prompt_type, label:
+            Same filter semantics as :meth:`list_prompts`.
+        """
+        yield from iter_pages(
+            self.list_prompts,
+            per_page=per_page,
+            search=search,
+            prompt_type=prompt_type,
+            label=label,
+        )
 
     def get_prompt(self, name: str) -> PromptDetail:
         payload = self._request_json("GET", f"/{self._quote_name(name)}")

--- a/traigent/utils/pagination.py
+++ b/traigent/utils/pagination.py
@@ -1,0 +1,89 @@
+"""Generic auto-pagination helper for Traigent list endpoints.
+
+Every paginated ``list_*`` response in the SDK carries a ``pagination``
+field (a :class:`~traigent.prompts.dtos.PaginationInfo`) with ``has_next``
+and ``page`` attributes.  This module provides a single private helper that
+any client module can use to implement transparent ``iter_*`` companions
+without duplicating the while-loop boilerplate across every caller.
+
+Usage (within a client)::
+
+    from traigent.utils.pagination import iter_pages
+
+    def iter_evaluators(self, *, per_page: int = 100, **filters):
+        yield from iter_pages(self.list_evaluators, per_page=per_page, **filters)
+
+The helper is intentionally *not* exported from the public ``traigent``
+top-level namespace — it is a client-implementation detail.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+from collections.abc import Callable, Generator
+
+# The concrete item type yielded by the iterator (covariant).
+_T = TypeVar("_T")
+
+
+def iter_pages(
+    list_fn: Callable[..., Any],
+    *positional: Any,
+    per_page: int = 100,
+    **filters: Any,
+) -> Generator[Any, None, None]:
+    """Iterate transparently over all pages of a paginated list endpoint.
+
+    Parameters
+    ----------
+    list_fn:
+        A bound ``list_*`` method whose first keyword arguments are ``page``
+        and ``per_page`` and whose return value has ``.items`` (list) and
+        ``.pagination.has_next`` (bool).
+    *positional:
+        Positional arguments forwarded verbatim to *list_fn* on every call
+        (e.g. the ``queue_id`` required by
+        :meth:`~traigent.evaluation.client.EvaluationClient.list_annotation_queue_items`).
+    per_page:
+        Number of items to request per page.  Defaults to 100 to minimise
+        round-trips while staying within typical server limits.
+    **filters:
+        Keyword filter arguments forwarded verbatim to *list_fn* on every
+        call (e.g. ``search=``, ``measure_id=``, ``status=`` …).
+
+    Yields
+    ------
+    object
+        Every item across all pages, in order.
+
+    Notes
+    -----
+    * The loop exits as soon as ``response.pagination.has_next`` is
+      ``False`` — the same signal the caller would use when hand-rolling.
+    * An infinite-loop guard: if the page number returned by the server does
+      *not* advance between two consecutive fetches the loop aborts.  This
+      handles pathological backends that always return ``has_next=True``.
+    * An empty first page (zero items) terminates immediately.
+    """
+    page = 1
+    seen_pages: set[int] = set()
+
+    while True:
+        response = list_fn(*positional, page=page, per_page=per_page, **filters)
+
+        pagination = response.pagination
+
+        # Infinite-loop guard: abort if the server returns a page we have
+        # already processed.  This handles pathological backends that always
+        # return ``has_next=True`` but never advance the page number.  We
+        # check *before* yielding so duplicate items are never emitted.
+        if pagination.page in seen_pages:
+            return
+
+        seen_pages.add(pagination.page)
+        yield from response.items
+
+        if not pagination.has_next:
+            return
+
+        page = pagination.page + 1


### PR DESCRIPTION
## Summary

Closes #1442 (Python SDK only). JS-SDK parity (`iterate*` companions in `traigent-js`) is a **cross-repo follow-up** — the Python and JS halves are independent; this PR delivers the Python capability.

### What changed

Added a shared `iter_pages()` driver (`traigent/utils/pagination.py`) and 9 new `iter_*` companion methods — one per paginated `list_*` endpoint. Existing `list_*` methods are **unchanged** (additive only).

| Client | New method |
|---|---|
| `EvaluationClient` | `iter_evaluators` |
| `EvaluationClient` | `iter_evaluator_runs` |
| `EvaluationClient` | `iter_scores` |
| `EvaluationClient` | `iter_annotation_queues` |
| `EvaluationClient` | `iter_annotation_queue_items` |
| `ObservabilityClient` | `iter_traces` |
| `ObservabilityClient` | `iter_sessions` |
| `PromptManagementClient` | `iter_prompts` |
| `ProjectManagementClient` | `iter_projects` |

### Iterator API

```python
# Before — callers hand-roll the loop
page = 1
while True:
    resp = client.list_evaluators(page=page, per_page=100, search="gpt")
    for ev in resp.items:
        process(ev)
    if not resp.pagination.has_next:
        break
    page += 1

# After — transparent iterator
for ev in client.iter_evaluators(search="gpt"):
    process(ev)
```

The iterator defaults to `per_page=100` to minimise round-trips. Every filter argument accepted by the corresponding `list_*` method is forwarded unchanged on every page fetch.

### Infinite-loop guard

Uses a `seen_pages: set[int]` checked **before** yielding items from each page. If a pathological backend returns `has_next=True` with the same page number twice, the second fetch is made, the guard fires, and the loop terminates cleanly — no duplicate items emitted.

### Tests (`tests/unit/test_auto_pagination.py`)

18 new tests covering:
- `iter_pages` helper (6 tests): 3-page fixture all items; single-page terminates; empty page yields nothing; infinite-loop guard; filters forwarded; positional args forwarded
- `EvaluationClient` (5 tests): `iter_evaluators` 3-page + empty; `list_evaluators` unchanged; `iter_evaluator_runs` 2-page; `iter_annotation_queue_items` with positional `queue_id`
- `ObservabilityClient` (3 tests): `iter_traces` 2-page; `list_traces` unchanged; `iter_sessions` 2-page
- `PromptManagementClient` (2 tests): `iter_prompts` 2-page; `list_prompts` unchanged
- `ProjectManagementClient` (2 tests): `iter_projects` 2-page; `list_projects` unchanged

All 18 pass. `ruff check` and `ruff format --check` clean.

### JS-SDK cross-repo follow-up

The issue requests matching `iterate*` async-generator companions in `traigent-js` for `listEvaluators`, `listEvaluatorRuns`, `listScores`, `listAnnotationQueues`, `listAnnotationQueueItems`, `listTraces`, `listSessions`, `listProjects`. That is tracked separately in the `traigent-js` repo. This PR intentionally scopes to Python only.

## Test plan

- [x] `python3 -m pytest tests/unit/test_auto_pagination.py -n0 -q` → 18 passed
- [x] `ruff format --check` → no changes needed
- [x] `ruff check` → all checks passed
- [x] Existing `list_*` methods verified unchanged (dedicated smoke tests per client)

Spine-Trail: st_68b21f15c78d

🤖 Generated with [Claude Code](https://claude.com/claude-code)