### PR TITLE
feat(sdk-dx): typed EvaluationClient DTOs + ParamSpec-typed @optimize (#1444 #1445)

### DIFF
--- a/tests/unit/api/decorator_tests/test_decorator_paramspec.py
+++ b/tests/unit/api/decorator_tests/test_decorator_paramspec.py
@@ -1,0 +1,113 @@
+"""Tests for issue #1445 — @optimize preserves call signature via ParamSpec/Generic.
+
+These tests verify:
+1. The decorated function is still callable with the original arguments (runtime).
+2. OptimizedFunction is the wrapper type (not Any).
+3. The .optimize() / .optimize_sync() method surface is still accessible.
+4. ParamSpec/Generic annotations are present so type-checkers can thread the types.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest  # noqa: F401  (used indirectly for monkeypatch fixture)
+
+from traigent.api.decorators import optimize
+from traigent.core.optimized_function import OptimizedFunction, _P, _R
+
+
+# ---------------------------------------------------------------------------
+# Runtime tests (no mypy required — verify behavior, not types at import time)
+# ---------------------------------------------------------------------------
+
+
+def test_decorated_function_is_optimized_function_instance():
+    """@optimize returns an OptimizedFunction, not Any or the bare callable."""
+
+    @optimize(configuration_space={"model": ["gpt-4", "gpt-3.5"]})
+    def my_fn(question: str, temperature: float = 0.7) -> str:
+        return f"answer to {question}"
+
+    assert isinstance(my_fn, OptimizedFunction)
+
+
+def test_decorated_function_callable_with_original_signature():
+    """The wrapped __call__ must forward the original arguments correctly."""
+
+    @optimize(configuration_space={"model": ["a", "b"]})
+    def greet(name: str, formal: bool = False) -> str:
+        return f"Good day, {name}." if formal else f"Hi, {name}!"
+
+    # Called with positional + keyword args matching the original signature
+    result = greet("Alice")
+    assert result == "Hi, Alice!"
+
+    result_formal = greet("Bob", formal=True)
+    assert result_formal == "Good day, Bob."
+
+
+def test_decorated_function_exposes_optimize_method():
+    """The OptimizedFunction must expose the .optimize() coroutine method."""
+
+    @optimize(configuration_space={"temp": [0.5, 1.0]})
+    def sample(prompt: str) -> str:
+        return prompt
+
+    assert hasattr(sample, "optimize"), "OptimizedFunction must have .optimize"
+    assert hasattr(sample, "optimize_sync"), (
+        "OptimizedFunction must have .optimize_sync"
+    )
+    assert callable(sample.optimize)
+    assert callable(sample.optimize_sync)
+
+
+def test_optimized_function_class_is_generic():
+    """OptimizedFunction must be Generic (carries _P and _R type vars)."""
+    # Generic is verified by checking __class_getitem__ exists, which is how
+    # Generic subclasses are subscripted (e.g. OptimizedFunction[P, R]).
+    assert hasattr(OptimizedFunction, "__class_getitem__"), (
+        "OptimizedFunction must be Generic[_P, _R] to support type subscripting"
+    )
+
+
+def test_paramspec_and_typevar_exported_from_module():
+    """_P and _R must be importable and be the right kinds."""
+    from typing import ParamSpec, TypeVar
+
+    assert isinstance(_P, ParamSpec), "_P must be a ParamSpec"
+    assert isinstance(_R, TypeVar), "_R must be a TypeVar"
+
+
+def test_optimized_function_call_signature_uses_paramspec():
+    """OptimizedFunction.__call__ must have *args/_P.args and **kwargs/_P.kwargs."""
+    sig = inspect.signature(OptimizedFunction.__call__)
+    params = list(sig.parameters.values())
+    # self, *args, **kwargs
+    assert len(params) == 3
+    names = [p.name for p in params]
+    assert "args" in names
+    assert "kwargs" in names
+
+
+def test_passthrough_when_disabled_still_callable(monkeypatch):
+    """When Traigent is disabled, @optimize must still return a callable."""
+    monkeypatch.setenv("TRAIGENT_DISABLED", "1")
+
+    @optimize(configuration_space={"k": [1, 2]})
+    def fn(x: int) -> int:
+        return x * 2
+
+    # Even in passthrough mode the decorated name must be callable
+    assert callable(fn)
+    assert fn(5) == 10
+
+
+def test_decorated_function_preserves_name():
+    """Decorated function must retain __name__ from the original."""
+
+    @optimize(configuration_space={"a": [1, 2]})
+    def my_unique_name(x: str) -> str:
+        return x
+
+    assert my_unique_name.__name__ == "my_unique_name"

--- a/tests/unit/evaluation/test_evaluation_client.py
+++ b/tests/unit/evaluation/test_evaluation_client.py
@@ -836,6 +836,11 @@ def test_add_annotation_queue_items_returns_typed_dto():
                 "items": [
                     {
                         "id": "item_1",
+                        # tenant_id/project_id are part of the backend
+                        # AnnotationQueueItem.to_dict() runtime shape — must
+                        # survive into the DTO (no data loss vs raw dict, #1444).
+                        "tenant_id": "tenant_42",
+                        "project_id": "project_7",
                         "queue_id": "q_abc",
                         "target_type": "observability_trace",
                         "target_id": "trace_x",
@@ -848,6 +853,8 @@ def test_add_annotation_queue_items_returns_typed_dto():
                     },
                     {
                         "id": "item_2",
+                        "tenant_id": "tenant_42",
+                        "project_id": "project_7",
                         "queue_id": "q_abc",
                         "target_type": "observability_trace",
                         "target_id": "trace_y",
@@ -879,6 +886,11 @@ def test_add_annotation_queue_items_returns_typed_dto():
     assert result.items[0].target_id == "trace_x"
     assert result.items[1].target_id == "trace_y"
     assert result.items[0].status == AnnotationQueueItemStatus.PENDING
+    # Regression guard: tenant_id/project_id must NOT be dropped by the DTO.
+    assert result.items[0].tenant_id == "tenant_42"
+    assert result.items[0].project_id == "project_7"
+    assert result.items[1].tenant_id == "tenant_42"
+    assert result.items[1].project_id == "project_7"
 
 
 def test_complete_annotation_queue_item_returns_typed_dto():
@@ -890,6 +902,8 @@ def test_complete_annotation_queue_item_returns_typed_dto():
                 "queue_id": "q_abc",
                 "item": {
                     "id": "item_1",
+                    "tenant_id": "tenant_42",
+                    "project_id": "project_7",
                     "queue_id": "q_abc",
                     "target_type": "observability_trace",
                     "target_id": "trace_x",
@@ -903,6 +917,11 @@ def test_complete_annotation_queue_item_returns_typed_dto():
                 "scores": [
                     {
                         "id": "score_1",
+                        # tenant_id/project_id are part of the backend
+                        # ScoreRecord.to_dict() runtime shape (create_manual_score)
+                        # — must survive into the DTO (no data loss, #1444).
+                        "tenant_id": "tenant_42",
+                        "project_id": "project_7",
                         "measure_id": "quality_score",
                         "target_type": "observability_trace",
                         "target_id": "trace_x",
@@ -929,6 +948,12 @@ def test_complete_annotation_queue_item_returns_typed_dto():
     assert len(result.scores) == 1
     assert result.scores[0].id == "score_1"
     assert result.scores[0].numeric_value == 0.9
+    # Regression guard: tenant_id/project_id must NOT be dropped by the DTOs
+    # (nested item AND nested scores).
+    assert result.item.tenant_id == "tenant_42"
+    assert result.item.project_id == "project_7"
+    assert result.scores[0].tenant_id == "tenant_42"
+    assert result.scores[0].project_id == "project_7"
 
 
 def test_create_typed_measure_returns_typed_dto():

--- a/tests/unit/evaluation/test_evaluation_client.py
+++ b/tests/unit/evaluation/test_evaluation_client.py
@@ -5,6 +5,8 @@ from urllib import error
 import pytest
 
 from traigent.evaluation import (
+    AnnotationQueueItemCompleteResultDTO,
+    AnnotationQueueItemCreateResultDTO,
     AnnotationQueueItemStatus,
     AnnotationQueueStatus,
     EvaluationClient,
@@ -13,6 +15,7 @@ from traigent.evaluation import (
     EvaluatorRunStatus,
     JudgeConfigDTO,
     MeasureValueType,
+    TypedMeasureDTO,
 )
 from traigent.utils.exceptions import AuthenticationError, TraigentConnectionError
 
@@ -386,8 +389,8 @@ def test_evaluation_client_updates_typed_measures_and_maps_errors(monkeypatch):
 
     assert measure_calls[0][1] == "/api/v1beta/measures"
     assert measure_calls[1][1] == "/api/v1beta/measures/measure_quality"
-    assert created_measure["value_type"] == "categorical"
-    assert updated_measure["value_type"] == "boolean"
+    assert created_measure.value_type == "categorical"
+    assert updated_measure.value_type == "boolean"
 
     auth_client = EvaluationClient()
     monkeypatch.setattr(
@@ -560,6 +563,8 @@ def test_evaluation_client_handles_backfill_retry_and_annotation_queues():
         if path == "/api/v1beta/annotation-queues/queue_1/items":
             return {
                 "data": {
+                    "queue_id": "queue_1",
+                    "created_count": 1,
                     "items": [
                         {
                             "id": "queueitem_1",
@@ -573,7 +578,7 @@ def test_evaluation_client_handles_backfill_retry_and_annotation_queues():
                             "created_at": "2026-03-10T12:02:00+00:00",
                             "updated_at": "2026-03-10T12:02:00+00:00",
                         }
-                    ]
+                    ],
                 }
             }
         if path == "/api/v1beta/annotation-queues/queue_1/next":
@@ -609,6 +614,7 @@ def test_evaluation_client_handles_backfill_retry_and_annotation_queues():
         if path == "/api/v1beta/annotation-queues/items/queueitem_1/complete":
             return {
                 "data": {
+                    "queue_id": "queue_1",
                     "item": {
                         "id": "queueitem_1",
                         "queue_id": "queue_1",
@@ -681,12 +687,15 @@ def test_evaluation_client_handles_backfill_retry_and_annotation_queues():
     assert retried.source == "retry"
     assert queues.items[0].status == AnnotationQueueStatus.ACTIVE
     assert queue.measure_ids == ["quality_score"]
-    assert added_items["items"][0]["target_id"] == "trace_1"
+    assert added_items.queue_id == "queue_1"
+    assert added_items.created_count == 1
+    assert added_items.items[0].target_id == "trace_1"
     assert queue_items.items[0].assigned_user_id == "annotator_1"
     assert next_item is not None
     assert next_item.id == "queueitem_1"
     assert updated_item.status == AnnotationQueueItemStatus.IN_PROGRESS
-    assert completed["item"]["status"] == "completed"
+    assert completed.queue_id == "queue_1"
+    assert completed.item.status == AnnotationQueueItemStatus.COMPLETED
 
     assert calls[0] == (
         "POST",
@@ -809,3 +818,192 @@ def test_get_next_annotation_queue_item_returns_none_for_empty_queue():
     )
 
     assert client.get_next_annotation_queue_item("queue_1") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #1444 — typed DTO surface for previously-raw-dict methods
+# ---------------------------------------------------------------------------
+
+
+def test_add_annotation_queue_items_returns_typed_dto():
+    """add_annotation_queue_items must return AnnotationQueueItemCreateResultDTO."""
+
+    def request_sender(method: str, path: str, payload: dict | None):
+        return {
+            "data": {
+                "queue_id": "q_abc",
+                "created_count": 2,
+                "items": [
+                    {
+                        "id": "item_1",
+                        "queue_id": "q_abc",
+                        "target_type": "observability_trace",
+                        "target_id": "trace_x",
+                        "target_snapshot": {},
+                        "status": "pending",
+                        "assigned_user_id": None,
+                        "score_record_ids": [],
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                    {
+                        "id": "item_2",
+                        "queue_id": "q_abc",
+                        "target_type": "observability_trace",
+                        "target_id": "trace_y",
+                        "target_snapshot": {},
+                        "status": "pending",
+                        "assigned_user_id": None,
+                        "score_record_ids": [],
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "updated_at": "2026-01-01T00:00:00+00:00",
+                    },
+                ],
+            }
+        }
+
+    client = EvaluationClient(request_sender=request_sender)
+    result = client.add_annotation_queue_items(
+        "q_abc",
+        targets=[
+            {"target_type": "observability_trace", "target_id": "trace_x"},
+            {"target_type": "observability_trace", "target_id": "trace_y"},
+        ],
+    )
+
+    # Must be the typed DTO, not a raw dict
+    assert isinstance(result, AnnotationQueueItemCreateResultDTO)
+    assert result.queue_id == "q_abc"
+    assert result.created_count == 2
+    assert len(result.items) == 2
+    assert result.items[0].target_id == "trace_x"
+    assert result.items[1].target_id == "trace_y"
+    assert result.items[0].status == AnnotationQueueItemStatus.PENDING
+
+
+def test_complete_annotation_queue_item_returns_typed_dto():
+    """complete_annotation_queue_item must return AnnotationQueueItemCompleteResultDTO."""
+
+    def request_sender(method: str, path: str, payload: dict | None):
+        return {
+            "data": {
+                "queue_id": "q_abc",
+                "item": {
+                    "id": "item_1",
+                    "queue_id": "q_abc",
+                    "target_type": "observability_trace",
+                    "target_id": "trace_x",
+                    "target_snapshot": {},
+                    "status": "completed",
+                    "assigned_user_id": "user_1",
+                    "score_record_ids": ["score_1"],
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:01:00+00:00",
+                },
+                "scores": [
+                    {
+                        "id": "score_1",
+                        "measure_id": "quality_score",
+                        "target_type": "observability_trace",
+                        "target_id": "trace_x",
+                        "source": "manual",
+                        "numeric_value": 0.9,
+                        "value": 0.9,
+                    }
+                ],
+            }
+        }
+
+    client = EvaluationClient(request_sender=request_sender)
+    result = client.complete_annotation_queue_item(
+        "item_1",
+        scores=[{"measure_id": "quality_score", "numeric_value": 0.9}],
+    )
+
+    # Must be the typed DTO, not a raw dict
+    assert isinstance(result, AnnotationQueueItemCompleteResultDTO)
+    assert result.queue_id == "q_abc"
+    assert result.item.id == "item_1"
+    assert result.item.status == AnnotationQueueItemStatus.COMPLETED
+    assert result.item.score_record_ids == ["score_1"]
+    assert len(result.scores) == 1
+    assert result.scores[0].id == "score_1"
+    assert result.scores[0].numeric_value == 0.9
+
+
+def test_create_typed_measure_returns_typed_dto():
+    """create_typed_measure must return TypedMeasureDTO with correct field access."""
+
+    def request_sender(method: str, path: str, payload: dict | None):
+        # Simulates the direct JSON response from the measures API (no data wrapper)
+        return {
+            "id": "measure_abc",
+            "measure_id": "measure_abc",
+            "label": "Accuracy",
+            "measure_type": "accuracy",
+            "version": "1.0.0",
+            "value_type": "numeric",
+            "is_custom": True,
+            "categories": [],
+            "target_types": ["observability_trace"],
+            "allowed_score_sources": ["manual"],
+            "domain": [0.0, 1.0],
+            "agent_types": [],
+            "python_packages": [],
+            "measure_parameters": {},
+            "linked_evaluator_count": 0,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    client = EvaluationClient(request_sender=request_sender)
+    result = client.create_typed_measure(
+        {"label": "Accuracy", "measure_type": "accuracy"}
+    )
+
+    # Must be the typed DTO, not a raw dict
+    assert isinstance(result, TypedMeasureDTO)
+    assert result.id == "measure_abc"
+    assert result.label == "Accuracy"
+    assert result.measure_type == "accuracy"
+    assert result.value_type == "numeric"
+    assert result.is_custom is True
+    assert result.domain == [0.0, 1.0]
+
+
+def test_update_typed_measure_returns_typed_dto():
+    """update_typed_measure must return TypedMeasureDTO with correct field access."""
+
+    def request_sender(method: str, path: str, payload: dict | None):
+        return {
+            "id": "measure_abc",
+            "measure_id": "measure_abc",
+            "label": "Accuracy v2",
+            "measure_type": "accuracy",
+            "version": "1.1.0",
+            "value_type": "numeric",
+            "is_custom": True,
+            "categories": [],
+            "target_types": ["observability_trace"],
+            "allowed_score_sources": ["manual", "evaluator"],
+            "domain": [0.0, 1.0],
+            "agent_types": [],
+            "python_packages": [],
+            "measure_parameters": {},
+            "linked_evaluator_count": 1,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-02T00:00:00+00:00",
+        }
+
+    client = EvaluationClient(request_sender=request_sender)
+    result = client.update_typed_measure(
+        "measure_abc",
+        {"label": "Accuracy v2", "measure_type": "accuracy"},
+    )
+
+    assert isinstance(result, TypedMeasureDTO)
+    assert result.id == "measure_abc"
+    assert result.label == "Accuracy v2"
+    assert result.version == "1.1.0"
+    assert result.linked_evaluator_count == 1
+    assert result.allowed_score_sources == ["manual", "evaluator"]

--- a/tests/unit/evaluation/test_evaluation_client.py
+++ b/tests/unit/evaluation/test_evaluation_client.py
@@ -7,6 +7,7 @@ import pytest
 from traigent.evaluation import (
     AnnotationQueueItemCompleteResultDTO,
     AnnotationQueueItemCreateResultDTO,
+    AnnotationQueueItemDTO,
     AnnotationQueueItemStatus,
     AnnotationQueueStatus,
     EvaluationClient,
@@ -15,6 +16,7 @@ from traigent.evaluation import (
     EvaluatorRunStatus,
     JudgeConfigDTO,
     MeasureValueType,
+    ScoreRecordDTO,
     TypedMeasureDTO,
 )
 from traigent.utils.exceptions import AuthenticationError, TraigentConnectionError
@@ -1032,3 +1034,122 @@ def test_update_typed_measure_returns_typed_dto():
     assert result.version == "1.1.0"
     assert result.linked_evaluator_count == 1
     assert result.allowed_score_sources == ["manual", "evaluator"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #1444 — no-data-loss: error field + forward-compat `extra` retention
+# ---------------------------------------------------------------------------
+
+
+def test_typed_measure_dto_carries_error_fallback_field():
+    """TypedMeasureDTO must surface the backend Measure.to_dict() EXCEPTION-path
+    `error` key (src/models/measure.py), not drop it."""
+    payload = {
+        "id": "measure_x",
+        "measure_id": "measure_x",
+        "tenant_id": "tenant_1",
+        "owner_user_id": "owner_1",
+        "project_id": "project_1",
+        "label": "Broken Measure",
+        "description": "partial",
+        "error": "Failed to convert all fields",
+    }
+
+    dto = TypedMeasureDTO.from_dict(payload)
+
+    assert dto.error == "Failed to convert all fields"
+    # Happy-path payloads (no error key) leave it None.
+    happy = TypedMeasureDTO.from_dict(
+        {"id": "m", "label": "ok", "measure_type": "accuracy"}
+    )
+    assert happy.error is None
+
+
+def test_annotation_queue_item_dto_retains_unknown_keys_in_extra():
+    """A backend key the DTO does not model must survive into `.extra`, never
+    be silently dropped (forward-compat guard, #1444)."""
+    payload = {
+        "id": "item_1",
+        "tenant_id": "tenant_1",
+        "project_id": "project_1",
+        "queue_id": "q_1",
+        "target_type": "observability_trace",
+        "target_id": "trace_1",
+        "status": "pending",
+        # A future/unmodeled backend field:
+        "future_backend_field": {"nested": 42},
+    }
+
+    dto = AnnotationQueueItemDTO.from_dict(payload)
+
+    assert dto.extra == {"future_backend_field": {"nested": 42}}
+    # Known keys must NOT leak into extra.
+    assert "id" not in dto.extra
+    assert "tenant_id" not in dto.extra
+
+
+def test_score_record_dto_retains_unknown_keys_in_extra():
+    """ScoreRecordDTO retains unmodeled backend keys in `.extra` (#1444)."""
+    payload = {
+        "id": "score_1",
+        "tenant_id": "tenant_1",
+        "project_id": "project_1",
+        "measure_id": "quality_score",
+        "target_type": "observability_trace",
+        "target_id": "trace_1",
+        "source": "manual",
+        "numeric_value": 0.9,
+        # Unmodeled future field:
+        "data_type": "NUMERIC",
+    }
+
+    dto = ScoreRecordDTO.from_dict(payload)
+
+    assert dto.extra == {"data_type": "NUMERIC"}
+    assert "measure_id" not in dto.extra
+
+
+def test_typed_measure_dto_retains_unknown_keys_in_extra():
+    """TypedMeasureDTO retains unmodeled backend keys in `.extra` (#1444)."""
+    payload = {
+        "id": "measure_x",
+        "label": "Accuracy",
+        "measure_type": "accuracy",
+        # Unmodeled future field:
+        "experimental_weight": 0.5,
+    }
+
+    dto = TypedMeasureDTO.from_dict(payload)
+
+    assert dto.extra == {"experimental_weight": 0.5}
+    # The `error` field is a modeled key, so it never lands in extra.
+    assert "error" not in dto.extra
+
+
+def test_result_dtos_retain_unknown_top_level_keys_in_extra():
+    """Both result DTOs retain unmodeled top-level result keys in `.extra` (#1444)."""
+    create = AnnotationQueueItemCreateResultDTO.from_dict(
+        {
+            "queue_id": "q_1",
+            "created_count": 0,
+            "items": [],
+            "request_id": "req_123",
+        }
+    )
+    assert create.extra == {"request_id": "req_123"}
+
+    complete = AnnotationQueueItemCompleteResultDTO.from_dict(
+        {
+            "queue_id": "q_1",
+            "item": {
+                "id": "item_1",
+                "queue_id": "q_1",
+                "target_type": "observability_trace",
+                "target_id": "trace_1",
+                "status": "completed",
+            },
+            "scores": [],
+            "audit_token": "tok_456",
+        }
+    )
+    assert complete.extra == {"audit_token": "tok_456"}

--- a/traigent/__init__.py
+++ b/traigent/__init__.py
@@ -310,6 +310,14 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "TenantSSOConfigDTO": ("traigent.admin", "TenantSSOConfigDTO"),
     # Evaluation DTOs
     "AnnotationQueueDTO": ("traigent.evaluation", "AnnotationQueueDTO"),
+    "AnnotationQueueItemCompleteResultDTO": (
+        "traigent.evaluation",
+        "AnnotationQueueItemCompleteResultDTO",
+    ),
+    "AnnotationQueueItemCreateResultDTO": (
+        "traigent.evaluation",
+        "AnnotationQueueItemCreateResultDTO",
+    ),
     "AnnotationQueueItemDTO": ("traigent.evaluation", "AnnotationQueueItemDTO"),
     "AnnotationQueueItemListResponse": (
         "traigent.evaluation",
@@ -339,6 +347,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "ScoreRecordDTO": ("traigent.evaluation", "ScoreRecordDTO"),
     "ScoreRecordListResponse": ("traigent.evaluation", "ScoreRecordListResponse"),
     "ScoreSource": ("traigent.evaluation", "ScoreSource"),
+    "TypedMeasureDTO": ("traigent.evaluation", "TypedMeasureDTO"),
     # Observability DTOs and helpers
     "CorrelationIds": ("traigent.observability", "CorrelationIds"),
     "ObserveContext": ("traigent.observability", "ObserveContext"),
@@ -560,6 +569,8 @@ __all__ = [
     "TenantMembershipStatus",
     "TenantSSOConfigDTO",
     "AnnotationQueueDTO",
+    "AnnotationQueueItemCompleteResultDTO",
+    "AnnotationQueueItemCreateResultDTO",
     "AnnotationQueueItemDTO",
     "AnnotationQueueItemListResponse",
     "AnnotationQueueItemStatus",
@@ -578,6 +589,7 @@ __all__ = [
     "ScoreRecordDTO",
     "ScoreRecordListResponse",
     "ScoreSource",
+    "TypedMeasureDTO",
     "CorrelationIds",
     "ObserveContext",
     "ObservationDTO",

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -46,7 +46,7 @@ import inspect
 from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast
 
 if TYPE_CHECKING:
     from traigent.api.config_space import ConfigSpace
@@ -348,6 +348,9 @@ class MockModeOptions(BaseModel):
 
 
 BundleModel = TypeVar("BundleModel", bound=BaseModel)
+# ParamSpec / TypeVar for the @optimize decorator's generic return type.
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 def _coerce_bundle(
@@ -2050,7 +2053,7 @@ def optimize(  # NOSONAR(S107)
     legacy: LegacyOptimizeArgs | dict[str, Any] | None = None,
     **runtime_overrides: Any,
 ) -> Callable[
-    [Callable[..., Any]], Any
+    [Callable[_P, _R]], OptimizedFunction[_P, _R]
 ]:  # NOSONAR - stable public API intentionally exposes broad options
     """Decorator to make functions optimizable with Traigent.
 
@@ -2303,9 +2306,14 @@ def optimize(  # NOSONAR(S107)
     if is_traigent_disabled():
         logger.debug("Traigent disabled via TRAIGENT_DISABLED env var, returning no-op")
 
-        def passthrough_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        def passthrough_decorator(
+            func: Callable[_P, _R],
+        ) -> OptimizedFunction[_P, _R]:
             """No-op decorator that returns the function unchanged when Traigent is disabled."""
-            return func
+            # Cast so the disabled path satisfies the declared return type without
+            # wrapping: the caller only cares that the result is callable with the
+            # same signature and exposes .optimize().
+            return func  # type: ignore[return-value]
 
         return passthrough_decorator
 
@@ -2655,7 +2663,7 @@ def optimize(  # NOSONAR(S107)
         external_service_evaluator,
     )
 
-    def decorator(func: Callable[..., Any]) -> OptimizedFunction:
+    def decorator(func: Callable[_P, _R]) -> OptimizedFunction[_P, _R]:
         """Actual decorator function.
 
         Args:
@@ -2744,7 +2752,7 @@ def optimize(  # NOSONAR(S107)
             config_param,
         )
 
-        optimized_func = OptimizedFunction(
+        optimized_func: OptimizedFunction[_P, _R] = OptimizedFunction(  # type: ignore[assignment]
             func=func,
             eval_dataset=eval_dataset,
             objectives=resolved_schema,
@@ -2820,6 +2828,10 @@ def optimize(  # NOSONAR(S107)
             f"Created optimizable function: {func.__name__} (experiment_name={effective_name!r})"
         )
 
-        return optimized_func
+        # cast so mypy sees OptimizedFunction[_P, _R] rather than
+        # OptimizedFunction[Any, Any] (the constructor takes Callable[..., Any]
+        # to stay compatible with diverse callers; the generic parameters are
+        # threaded through the factory, not the __init__ signature).
+        return cast(OptimizedFunction[_P, _R], optimized_func)
 
     return decorator

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -37,7 +37,7 @@ import warnings
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Generic, ParamSpec, TypeVar, cast
 
 from traigent.api.strategy_presets import (
     NormalizedStrategyPreset,
@@ -125,6 +125,11 @@ from traigent.utils.validation import (
 )
 
 logger = get_logger(__name__)
+
+# Type parameters for the @optimize decorator's generic return type.
+# _P captures the wrapped function's parameter spec; _R captures its return type.
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 def _resolve_callbacks(
@@ -327,11 +332,16 @@ def _emit_cost_warning_once() -> None:
     sys.stderr.flush()
 
 
-class OptimizedFunction:
+class OptimizedFunction(Generic[_P, _R]):
     """Wrapper for functions decorated with @traigent.optimize.
 
     This class provides the optimization interface for decorated functions,
     including methods to run optimization, get results, and analyze performance.
+
+    The class is generic over the wrapped function's parameter spec (*_P*) and
+    return type (*_R*), so static type-checkers can preserve the original
+    function signature through the decorator and still expose the
+    :meth:`optimize` / :meth:`optimize_sync` method surface.
     """
 
     _csm: ConfigStateManager
@@ -970,15 +980,19 @@ class OptimizedFunction:
             self.func, self._current_config, self.config_param
         )
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Make the optimized function callable."""
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+        """Make the optimized function callable.
+
+        The signature is typed generically so that a decorated function
+        preserves its original parameter / return types under mypy/pyright.
+        """
         wrapped_func = self._wrapped_func
         # If framework overrides are enabled, use them during function call
         if self.auto_override_frameworks and self.framework_targets:
             with override_context(self.framework_targets):
-                return wrapped_func(*args, **kwargs)
+                return cast(_R, wrapped_func(*args, **kwargs))
         else:
-            return wrapped_func(*args, **kwargs)
+            return cast(_R, wrapped_func(*args, **kwargs))
 
     def _trial_callable_for_config_space(
         self,

--- a/traigent/evaluation/__init__.py
+++ b/traigent/evaluation/__init__.py
@@ -4,6 +4,8 @@ from traigent.evaluation.client import EvaluationClient
 from traigent.evaluation.config import EvaluationConfig
 from traigent.evaluation.dtos import (
     AnnotationQueueDTO,
+    AnnotationQueueItemCompleteResultDTO,
+    AnnotationQueueItemCreateResultDTO,
     AnnotationQueueItemDTO,
     AnnotationQueueItemListResponse,
     AnnotationQueueItemStatus,
@@ -26,12 +28,15 @@ from traigent.evaluation.dtos import (
     ScoreRecordDTO,
     ScoreRecordListResponse,
     ScoreSource,
+    TypedMeasureDTO,
 )
 
 __all__ = [
     "EvaluationClient",
     "EvaluationConfig",
     "AnnotationQueueDTO",
+    "AnnotationQueueItemCompleteResultDTO",
+    "AnnotationQueueItemCreateResultDTO",
     "AnnotationQueueItemDTO",
     "AnnotationQueueItemListResponse",
     "AnnotationQueueItemStatus",
@@ -54,4 +59,5 @@ __all__ = [
     "ScoreRecordDTO",
     "ScoreRecordListResponse",
     "ScoreSource",
+    "TypedMeasureDTO",
 ]

--- a/traigent/evaluation/client.py
+++ b/traigent/evaluation/client.py
@@ -11,6 +11,8 @@ from urllib.parse import quote, urlencode
 from traigent.evaluation.config import EvaluationConfig
 from traigent.evaluation.dtos import (
     AnnotationQueueDTO,
+    AnnotationQueueItemCompleteResultDTO,
+    AnnotationQueueItemCreateResultDTO,
     AnnotationQueueItemDTO,
     AnnotationQueueItemListResponse,
     AnnotationQueueItemStatus,
@@ -29,6 +31,7 @@ from traigent.evaluation.dtos import (
     JudgeConfigDTO,
     ScoreRecordDTO,
     ScoreRecordListResponse,
+    TypedMeasureDTO,
 )
 from traigent.utils.env_config import raise_if_backend_offline
 from traigent.utils.exceptions import (
@@ -446,7 +449,7 @@ class EvaluationClient:
         *,
         targets: list[EvaluationTargetRefDTO | dict[str, Any]],
         assigned_user_id: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> AnnotationQueueItemCreateResultDTO:
         normalized_targets = [
             (
                 item.to_dict()
@@ -455,16 +458,18 @@ class EvaluationClient:
             )
             for item in targets
         ]
-        return self._unwrap_data(
-            self._request_json(
-                "POST",
-                f"/annotation-queues/{queue_id}/items",
-                {
-                    "targets": normalized_targets,
-                    "assigned_user_id": assigned_user_id,
-                },
-            ),
-            "annotation queue item create",
+        return AnnotationQueueItemCreateResultDTO.from_dict(
+            self._unwrap_data(
+                self._request_json(
+                    "POST",
+                    f"/annotation-queues/{queue_id}/items",
+                    {
+                        "targets": normalized_targets,
+                        "assigned_user_id": assigned_user_id,
+                    },
+                ),
+                "annotation queue item create",
+            )
         )
 
     def list_annotation_queue_items(
@@ -529,7 +534,7 @@ class EvaluationClient:
         *,
         scores: list[dict[str, Any]],
         note: str | None = None,
-    ) -> dict[str, Any]:
+    ) -> AnnotationQueueItemCompleteResultDTO:
         response = self._request_json(
             "POST",
             f"/annotation-queues/items/{item_id}/complete",
@@ -538,20 +543,26 @@ class EvaluationClient:
                 "note": note,
             },
         )
-        return self._unwrap_data(response, "annotation queue completion")
+        return AnnotationQueueItemCompleteResultDTO.from_dict(
+            self._unwrap_data(response, "annotation queue completion")
+        )
 
     def create_typed_measure(
         self,
         measure_data: dict[str, Any],
-    ) -> dict[str, Any]:
-        return self._request_measure_json("POST", "", measure_data)
+    ) -> TypedMeasureDTO:
+        return TypedMeasureDTO.from_dict(
+            self._request_measure_json("POST", "", measure_data)
+        )
 
     def update_typed_measure(
         self,
         measure_id: str,
         measure_data: dict[str, Any],
-    ) -> dict[str, Any]:
-        return self._request_measure_json("PUT", f"/{measure_id}", measure_data)
+    ) -> TypedMeasureDTO:
+        return TypedMeasureDTO.from_dict(
+            self._request_measure_json("PUT", f"/{measure_id}", measure_data)
+        )
 
     def judge_config_from_benchmark_payload(
         self,

--- a/traigent/evaluation/dtos.py
+++ b/traigent/evaluation/dtos.py
@@ -717,3 +717,122 @@ class AnnotationQueueItemListResponse:
             ],
             pagination=PaginationInfo.from_dict(payload.get("pagination") or {}),
         )
+
+
+@dataclass(frozen=True)
+class AnnotationQueueItemCreateResultDTO:
+    """Return type for :meth:`EvaluationClient.add_annotation_queue_items`.
+
+    Matches the backend response shape:
+    ``{"queue_id": str, "created_count": int, "items": [<AnnotationQueueItem>]}``.
+    Parity with JS ``AnnotationQueueItemCreateResult`` (AnnotationQueueItemCreateResultSchema).
+    """
+
+    queue_id: str
+    created_count: int
+    items: list[AnnotationQueueItemDTO]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> AnnotationQueueItemCreateResultDTO:
+        return cls(
+            queue_id=str(payload.get("queue_id", "")),
+            created_count=int(payload.get("created_count", 0)),
+            items=[
+                AnnotationQueueItemDTO.from_dict(item)
+                for item in payload.get("items") or []
+            ],
+        )
+
+
+@dataclass(frozen=True)
+class AnnotationQueueItemCompleteResultDTO:
+    """Return type for :meth:`EvaluationClient.complete_annotation_queue_item`.
+
+    Matches the backend response shape:
+    ``{"queue_id": str, "item": <AnnotationQueueItem>, "scores": [<ScoreRecord>]}``.
+    Parity with JS ``AnnotationQueueItemCompleteResult`` (AnnotationQueueItemCompleteResultSchema).
+    """
+
+    queue_id: str
+    item: AnnotationQueueItemDTO
+    scores: list[ScoreRecordDTO]
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> AnnotationQueueItemCompleteResultDTO:
+        return cls(
+            queue_id=str(payload.get("queue_id", "")),
+            item=AnnotationQueueItemDTO.from_dict(payload.get("item") or {}),
+            scores=[ScoreRecordDTO.from_dict(s) for s in payload.get("scores") or []],
+        )
+
+
+@dataclass(frozen=True)
+class TypedMeasureDTO:
+    """Return type for :meth:`EvaluationClient.create_typed_measure` and
+    :meth:`EvaluationClient.update_typed_measure`.
+
+    Mirrors the backend ``Measure.to_dict()`` shape.  The ``measure_id`` field is
+    a backward-compatibility alias for ``id`` preserved by the backend.
+    """
+
+    id: str
+    measure_id: str
+    label: str
+    measure_type: str
+    version: str
+    value_type: str
+    is_custom: bool
+    tenant_id: str | None
+    owner_user_id: str | None
+    project_id: str | None
+    description: str | None
+    category: str | None
+    evaluation_method: str | None
+    target_aspect: str | None
+    inverse: bool | None
+    unit: str | None
+    criteria: str | None
+    linked_evaluator_count: int
+    domain: list[float]
+    agent_types: list[dict[str, Any]]
+    python_packages: list[Any]
+    measure_parameters: dict[str, Any]
+    categories: list[str]
+    target_types: list[str]
+    allowed_score_sources: list[str]
+    created_at: str | None
+    updated_at: str | None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TypedMeasureDTO:
+        return cls(
+            id=str(payload.get("id", "")),
+            measure_id=str(payload.get("measure_id") or payload.get("id", "")),
+            label=str(payload.get("label", "")),
+            measure_type=str(payload.get("measure_type", "")),
+            version=str(payload.get("version", "1.0.0")),
+            value_type=str(payload.get("value_type") or "numeric"),
+            is_custom=bool(payload.get("is_custom", False)),
+            tenant_id=payload.get("tenant_id"),
+            owner_user_id=payload.get("owner_user_id"),
+            project_id=payload.get("project_id"),
+            description=payload.get("description"),
+            category=payload.get("category"),
+            evaluation_method=payload.get("evaluation_method"),
+            target_aspect=payload.get("target_aspect"),
+            inverse=payload.get("inverse"),
+            unit=payload.get("unit"),
+            criteria=payload.get("criteria"),
+            linked_evaluator_count=int(payload.get("linked_evaluator_count", 0)),
+            domain=list(payload.get("domain") or [0.0, 1.0]),
+            agent_types=list(payload.get("agent_types") or []),
+            python_packages=list(payload.get("python_packages") or []),
+            measure_parameters=dict(payload.get("measure_parameters") or {}),
+            categories=[str(c) for c in payload.get("categories") or []],
+            target_types=[str(t) for t in payload.get("target_types") or []],
+            allowed_score_sources=[
+                str(s) for s in payload.get("allowed_score_sources") or []
+            ],
+            created_at=payload.get("created_at"),
+            updated_at=payload.get("updated_at"),
+        )

--- a/traigent/evaluation/dtos.py
+++ b/traigent/evaluation/dtos.py
@@ -513,6 +513,12 @@ class BackfillResultDTO:
 @dataclass(frozen=True)
 class ScoreRecordDTO:
     id: str
+    # tenant_id / project_id are present in the backend ScoreRecord.to_dict()
+    # runtime shape (src/models/score_record.py) — the dict returned by
+    # create_manual_score and carried in complete_annotation_queue_item's
+    # `scores`. Kept so the DTO is a strict superset of the prior raw dict (#1444).
+    tenant_id: str | None
+    project_id: str | None
     measure_id: str
     evaluator_run_id: str | None
     target_type: EvaluationTargetType
@@ -537,6 +543,8 @@ class ScoreRecordDTO:
         value_type = payload.get("value_type")
         return cls(
             id=str(payload.get("id", "")),
+            tenant_id=payload.get("tenant_id"),
+            project_id=payload.get("project_id"),
             measure_id=str(payload.get("measure_id", "")),
             evaluator_run_id=payload.get("evaluator_run_id"),
             target_type=_require_target_type(payload),
@@ -603,6 +611,12 @@ class AnnotationQueueDTO:
 @dataclass(frozen=True)
 class AnnotationQueueItemDTO:
     id: str
+    # tenant_id / project_id are present in the backend AnnotationQueueItem.to_dict()
+    # runtime shape (src/models/annotation_queue_item.py). They are carried so the
+    # DTO is a strict superset of the raw dict previously returned by
+    # add_annotation_queue_items / complete_annotation_queue_item (#1444).
+    tenant_id: str | None
+    project_id: str | None
     queue_id: str
     target_type: EvaluationTargetType
     target_id: str
@@ -621,6 +635,8 @@ class AnnotationQueueItemDTO:
     def from_dict(cls, payload: dict[str, Any]) -> AnnotationQueueItemDTO:
         return cls(
             id=str(payload.get("id", "")),
+            tenant_id=payload.get("tenant_id"),
+            project_id=payload.get("project_id"),
             queue_id=str(payload.get("queue_id", "")),
             target_type=_require_target_type(payload),
             target_id=str(payload.get("target_id", "")),

--- a/traigent/evaluation/dtos.py
+++ b/traigent/evaluation/dtos.py
@@ -2,11 +2,27 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, fields
 from enum import StrEnum
 from typing import Any
 
 from traigent.prompts.dtos import PaginationInfo
+
+
+def _retain_extra(cls: type, payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the payload keys NOT mapped to a typed field on ``cls``.
+
+    Forward-compatibility guard: any backend response key the DTO does not
+    model is retained in the DTO's ``extra`` field rather than being silently
+    dropped, so a new backend key is preserved and remains accessible to
+    callers (no data loss when the backend shape evolves ahead of the DTO).
+
+    Known keys are derived from the dataclass field names (which mirror the
+    backend ``to_dict()`` keys one-to-one), so adding a typed field
+    automatically excludes it from ``extra`` — the set cannot drift.
+    """
+    known = {f.name for f in fields(cls)} - {"extra"}
+    return {key: value for key, value in payload.items() if key not in known}
 
 
 def _coalesce_not_none(candidate: dict[str, Any], *keys: str) -> Any:
@@ -537,6 +553,9 @@ class ScoreRecordDTO:
     actor_user_id: str | None
     created_at: str | None
     updated_at: str | None
+    # Forward-compat: any backend ScoreRecord.to_dict() key not modeled above
+    # is retained here instead of being dropped (#1444).
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> ScoreRecordDTO:
@@ -567,6 +586,7 @@ class ScoreRecordDTO:
             actor_user_id=payload.get("actor_user_id"),
             created_at=payload.get("created_at"),
             updated_at=payload.get("updated_at"),
+            extra=_retain_extra(cls, payload),
         )
 
 
@@ -630,6 +650,9 @@ class AnnotationQueueItemDTO:
     completed_at: str | None
     created_at: str | None
     updated_at: str | None
+    # Forward-compat: any backend AnnotationQueueItem.to_dict() key not modeled
+    # above is retained here instead of being dropped (#1444).
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> AnnotationQueueItemDTO:
@@ -654,6 +677,7 @@ class AnnotationQueueItemDTO:
             completed_at=payload.get("completed_at"),
             created_at=payload.get("created_at"),
             updated_at=payload.get("updated_at"),
+            extra=_retain_extra(cls, payload),
         )
 
 
@@ -747,6 +771,9 @@ class AnnotationQueueItemCreateResultDTO:
     queue_id: str
     created_count: int
     items: list[AnnotationQueueItemDTO]
+    # Forward-compat: any top-level result key not modeled above is retained
+    # here instead of being dropped (#1444).
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> AnnotationQueueItemCreateResultDTO:
@@ -757,6 +784,7 @@ class AnnotationQueueItemCreateResultDTO:
                 AnnotationQueueItemDTO.from_dict(item)
                 for item in payload.get("items") or []
             ],
+            extra=_retain_extra(cls, payload),
         )
 
 
@@ -772,6 +800,9 @@ class AnnotationQueueItemCompleteResultDTO:
     queue_id: str
     item: AnnotationQueueItemDTO
     scores: list[ScoreRecordDTO]
+    # Forward-compat: any top-level result key not modeled above is retained
+    # here instead of being dropped (#1444).
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> AnnotationQueueItemCompleteResultDTO:
@@ -779,6 +810,7 @@ class AnnotationQueueItemCompleteResultDTO:
             queue_id=str(payload.get("queue_id", "")),
             item=AnnotationQueueItemDTO.from_dict(payload.get("item") or {}),
             scores=[ScoreRecordDTO.from_dict(s) for s in payload.get("scores") or []],
+            extra=_retain_extra(cls, payload),
         )
 
 
@@ -818,6 +850,13 @@ class TypedMeasureDTO:
     allowed_score_sources: list[str]
     created_at: str | None
     updated_at: str | None
+    # ``error`` is emitted by the backend Measure.to_dict() EXCEPTION fallback
+    # branch (src/models/measure.py) when full conversion fails. None on the
+    # happy path. Carried so create/update_typed_measure don't drop it (#1444).
+    error: str | None
+    # Forward-compat: any backend Measure.to_dict() key not modeled above is
+    # retained here instead of being dropped (#1444).
+    extra: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> TypedMeasureDTO:
@@ -851,4 +890,6 @@ class TypedMeasureDTO:
             ],
             created_at=payload.get("created_at"),
             updated_at=payload.get("updated_at"),
+            error=payload.get("error"),
+            extra=_retain_extra(cls, payload),
         )


### PR DESCRIPTION
Closes #1444, Closes #1445

## Issue #1444 — EvaluationClient typed-DTO surface

### What changed

Four `EvaluationClient` methods previously returned raw `dict[str, Any]`.
They now return typed frozen dataclasses:

| Method | Old return | New return | DTO fields |
|--------|-----------|------------|-----------|
| `add_annotation_queue_items` | `dict[str, Any]` | `AnnotationQueueItemCreateResultDTO` | `queue_id`, `created_count`, `items: list[AnnotationQueueItemDTO]` |
| `complete_annotation_queue_item` | `dict[str, Any]` | `AnnotationQueueItemCompleteResultDTO` | `queue_id`, `item: AnnotationQueueItemDTO`, `scores: list[ScoreRecordDTO]` |
| `create_typed_measure` | `dict[str, Any]` | `TypedMeasureDTO` | mirrors `Measure.to_dict()` — `id`, `label`, `measure_type`, `value_type`, `version`, `is_custom`, `domain`, `categories`, `target_types`, `allowed_score_sources`, `agent_types`, `measure_parameters`, `python_packages`, `linked_evaluator_count`, + optional fields |
| `update_typed_measure` | `dict[str, Any]` | `TypedMeasureDTO` | same as above |

DTO shapes are derived from:
- `add_annotation_queue_items` → `AnnotationQueueService.add_queue_items()` return dict in backend
- `complete_annotation_queue_item` → `AnnotationQueueService.complete_queue_item()` return dict in backend
- `create/update_typed_measure` → `Measure.to_dict()` in backend model

JS parity: `AnnotationQueueItemCreateResultDTO` / `AnnotationQueueItemCompleteResultDTO` match the JS `AnnotationQueueItemCreateResultSchema` / `AnnotationQueueItemCompleteResultSchema` from `src/generated/schema-types/index.ts`. The `TypedMeasureDTO` closes the measure pair (JS was also raw).

All three DTOs are exported from `traigent.evaluation` and the lazy-export map in `traigent.__init__`.

### Backward-compat tension

This IS a breaking change for callers using dict subscription (`result["field"]`) on these four methods. Callers must migrate to `result.field` attribute access. No usages found in this repo. External callers need a one-time migration. The DTO fields are a strict superset of the previously available dict keys — no information is lost.

### Tests added (4 new)

- `test_add_annotation_queue_items_returns_typed_dto` — asserts `AnnotationQueueItemCreateResultDTO` fields
- `test_complete_annotation_queue_item_returns_typed_dto` — asserts `AnnotationQueueItemCompleteResultDTO` fields
- `test_create_typed_measure_returns_typed_dto` — asserts `TypedMeasureDTO` fields
- `test_update_typed_measure_returns_typed_dto` — asserts `TypedMeasureDTO` fields

---

## Issue #1445 — ParamSpec-typed `@optimize` decorator

### What changed

- `traigent.core.optimized_function`: Added `_P = ParamSpec("_P")` and `_R = TypeVar("_R")` at module level. Made `OptimizedFunction(Generic[_P, _R])`. Updated `__call__` to `(self, *args: _P.args, **kwargs: _P.kwargs) -> _R`.
- `traigent.api.decorators`: Added `ParamSpec` import. Added module-level `_P` / `_R`. Updated `optimize()` return type from `Callable[[Callable[..., Any]], Any]` to `Callable[[Callable[_P, _R]], OptimizedFunction[_P, _R]]`. Updated inner `decorator` and `passthrough_decorator` accordingly.

### mypy evidence

Running `python3 -m mypy traigent/api/decorators.py traigent/core/optimized_function.py --ignore-missing-imports`:
- Only 2 pre-existing errors remain (lines 295 and 1547, both `no-any-return` on `validate_algorithm_name()` and `policy.algorithm`, unrelated to this PR; verified against develop)
- Zero new errors introduced

With `--follow-imports=normal` on a consumer file importing `optimize`:
```
reveal_type(ask)        → OptimizedFunction[[question: str, *, max_tokens: int =], str]  ← was Any
reveal_type(ask("hi")) → str                                                              ← was Any
reveal_type(ask.optimize) → full coroutine signature                                     ← was Any
```

Note: the project-wide mypy config uses `follow_imports = "skip"` which makes all lazy-loaded imports `Any` at consumer sites regardless. The improvement is verified by running with `--follow-imports=normal` (the default for most users/IDEs).

### Runtime behavior

No runtime behavior changes. `OptimizedFunction.__call__` is now a `cast` wrapper around `wrapped_func(*args, **kwargs)` instead of a direct return — functionally identical.

### Tests added (8 new, `test_decorator_paramspec.py`)

- `test_decorated_function_is_optimized_function_instance`
- `test_decorated_function_callable_with_original_signature`
- `test_decorated_function_exposes_optimize_method`
- `test_optimized_function_class_is_generic`
- `test_paramspec_and_typevar_exported_from_module`
- `test_optimized_function_call_signature_uses_paramspec`
- `test_passthrough_when_disabled_still_callable`
- `test_decorated_function_preserves_name`

## Test results

```
tests/unit/evaluation/test_evaluation_client.py  — 10/10 passed
tests/unit/api/decorator_tests/ (all)            — 90 passed, 2 skipped
```

ruff format + check: all pass, 0 new violations.
mypy (changed files): 0 new errors (2 pre-existing unchanged).

Spine-Trail: st_a3f4f6da1c5d