### PR TITLE
docs(sdk/cost): estimate-honesty for retry_factor + divergence-guard + cap-granularity (#1388)

### DIFF
--- a/traigent/core/cost_enforcement.py
+++ b/traigent/core/cost_enforcement.py
@@ -9,7 +9,8 @@ Adaptive Cost Estimation:
     - Initial estimates use configured estimated_cost_per_trial
     - After trials complete, estimates update via exponential moving average (EMA)
     - Confidence levels indicate reliability of estimates (0.0-1.0)
-    - Warnings log when estimates diverge significantly from reality
+    - Divergence warnings are estimate-accuracy signals only; they do not
+      override permit admission or enforce the run budget
 
 Environment Variables:
     TRAIGENT_RUN_COST_LIMIT: Maximum USD spending per optimization run (default: 2.0)
@@ -19,7 +20,8 @@ Environment Variables:
     TRAIGENT_STRICT_COST_ACCOUNTING: Fail fast for unknown/missing runtime costs
         (default: false)
     TRAIGENT_COST_DIVERGENCE_THRESHOLD: Log warning if actual/estimated ratio exceeds
-        this value (default: 2.0, meaning 2x divergence triggers warning)
+        this value (default: 2.0, meaning 2x divergence triggers warning).
+        This is a per-trial actual-vs-EMA estimate check, not a budget guardrail.
 
 Note:
     ``TRAIGENT_MOCK_LLM`` is intentionally NOT consulted here. Sprint 2-B
@@ -27,6 +29,11 @@ Note:
     and billing accounting if the variable ever leaked into a production
     environment. Cost approval, permit acquisition, and cost tracking
     always run regardless of any mock-mode flag.
+    Runtime budget enforcement is permit-based and trial-granular: each trial
+    reserves an estimated amount before it starts, then records actual cost
+    after completion. A single large trial can therefore overshoot the approved
+    limit by roughly one trial's actual-minus-reserved delta, plus any parallel
+    in-flight reservation slack, before the next admission check halts new work.
 """
 
 from __future__ import annotations
@@ -129,7 +136,8 @@ class CostEnforcerConfig:
         warning_threshold: Fraction of limit at which to emit warnings.
         fallback_trial_limit: If cost cannot be determined, limit by trial count.
         estimated_cost_per_trial: Initial estimate for per-trial cost reservation.
-            Used for in-flight budget reservation in parallel execution.
+            Used for in-flight budget reservation in parallel execution; actual
+            trial cost may exceed the reservation before later admissions stop.
     """
 
     limit: float = DEFAULT_COST_LIMIT_USD
@@ -580,6 +588,10 @@ Options:
         When a permit is acquired, budget is reserved for the in-flight trial
         to prevent multiple parallel trials from all starting when there's only
         budget for one. The reservation is released when track_cost is called.
+        This is a per-trial admission check against an estimated reservation,
+        not a mid-trial or per-token hard stop. If an admitted trial costs more
+        than reserved, actual spend can overshoot the approved limit by about
+        one trial plus parallel reservation slack before the next denial.
 
         Returns:
             Permit object with is_granted=True if permitted, or is_granted=False
@@ -639,6 +651,8 @@ Options:
         When a permit is acquired, budget is reserved for the in-flight trial
         to prevent multiple parallel trials from all starting when there's only
         budget for one. The reservation is released when track_cost_async is called.
+        Like the sync path, this is a per-trial estimated reservation rather
+        than a mid-trial billing cap.
 
         Returns:
             Permit object with is_granted=True if permitted, or is_granted=False
@@ -730,8 +744,11 @@ Options:
     def _check_cost_divergence(self, actual_cost: float) -> None:
         """Check if actual cost diverges significantly from estimate.
 
-        Called with lock held. Logs warning if ratio exceeds threshold.
+        Called with lock held. Logs warning or info based on the ratio between
+        the latest trial's actual cost and the current per-trial EMA estimate.
         Configured via TRAIGENT_COST_DIVERGENCE_THRESHOLD (default 2.0).
+        This is an estimate-accuracy signal only: it does not abort execution,
+        revoke permits, or enforce the approved run budget.
 
         Args:
             actual_cost: The actual cost observed for a trial.
@@ -935,7 +952,8 @@ Options:
             self._active_permits[permit.id] = permit
             return permit
 
-        # Check if there's budget available considering reserved in-flight cost
+        # Admission is checked at trial granularity using the current estimated
+        # reservation plus any already-reserved in-flight cost.
         reserved_amount = self._estimated_cost
         total_committed = self._accumulated_cost + self._reserved_cost
         if total_committed + reserved_amount > self.config.limit:
@@ -1208,7 +1226,8 @@ Options:
 
         I4 is an admission-time budget guard enforced by _acquire_permit_locked(),
         not a runtime state invariant. Post-execution actuals may exceed reserved
-        estimates, even while other permits remain in flight.
+        estimates, even while other permits remain in flight, so overshoot is
+        bounded at admitted-trial granularity rather than prevented mid-trial.
         """
         violations: list[str] = []
 

--- a/traigent/core/cost_estimator.py
+++ b/traigent/core/cost_estimator.py
@@ -239,7 +239,7 @@ class CostEstimator:
         - Estimates total samples based on configuration and dataset size
         - Uses max_total_examples if configured (shared budget across trials)
         - Otherwise estimates samples_per_trial x max_trials
-        - Includes retry factor (1.2x) for potential failures
+        - Applies a flat 1.2x conservative buffer to the estimate
         - Uses conservative estimates for unknown models
 
         Note: This is an ESTIMATE. Actual costs may vary significantly.
@@ -274,13 +274,15 @@ class CostEstimator:
             total_samples = max_trials * samples_per_trial
             estimation_mode = "per_trial_full_dataset"
 
-        # Total cost with retry factor for failures and potential re-evaluations
+        # Apply a flat conservative buffer. The optimizer eval path invokes
+        # invoker.invoke() directly today, so this does not model automatic
+        # per-example retries in the default evaluation loop.
         retry_factor = 1.2
         estimated_total = total_samples * base_cost_per_example * retry_factor
 
         logger.debug(
             f"Cost estimate ({estimation_mode}): {total_samples} total samples "
-            f"× ${base_cost_per_example}/sample × {retry_factor} retry = ${estimated_total:.2f} "
+            f"× ${base_cost_per_example}/sample × {retry_factor} buffer = ${estimated_total:.2f} "
             f"(pricing_source={pricing_source})"
         )
 

--- a/traigent/invokers/base.py
+++ b/traigent/invokers/base.py
@@ -398,7 +398,12 @@ class BaseInvoker(ABC):
         config: dict[str, Any],
         input_data: dict[str, Any],
     ) -> InvocationResult:
-        """Invoke function with retry logic.
+        """Invoke function with retry logic for callers that opt into it.
+
+        This helper is part of the BaseInvoker surface, but the optimizer's
+        default evaluation path calls ``invoke()`` directly today. As a result,
+        ``max_retries`` here is not automatically wired into per-example eval
+        retries unless a caller explicitly routes execution through this helper.
 
         Args:
             func: Function to invoke


### PR DESCRIPTION
Closes #1388 (docs/honesty scope).

Comment/docstring changes PLUS one intentional runtime debug-log wording fix (no functional behavior change): the `logger.debug` message in `cost_estimator.py` said "retry" — that wording was itself part of the mislabel #1388 asks to correct, so it is changed to "buffer". The `1.2` VALUE is unchanged, the warn-only divergence behavior is unchanged, and `CostLimitExceeded` is untouched.

## Changes
- `cost_estimator.py`: `retry_factor = 1.2` comment corrected — flat conservative buffer, NOT per-example retry amplification; the misleading `logger.debug` wording `retry`→`buffer` (the only runtime-observable change, and it is a log STRING only — same level, same call site).
- `cost_enforcement.py`: docstrings clarify `TRAIGENT_COST_DIVERGENCE_THRESHOLD` is an estimate-ACCURACY warning (per-trial actual vs per-trial EMA), NOT a budget guardrail — the real cap is permit admission against the approved `cost_limit`, with per-trial-granular overshoot disclosed. Warn-only behavior UNCHANGED.
- `invokers/base.py`: `invoke_with_retry` KEPT (BaseInvoker surface + documented in docs/feature_matrices/invokers.yml) with a docstring noting it is not wired into the default optimizer eval path.

## Notes
- Section D / "CostLimitExceeded never raised" was already resolved by #1490/#1513 — not re-touched.
- The issue’s OPTIONAL behavior-tightening directions (budget-proximity signal; cold-start reservation / per-example permit check) are deliberate behavior changes left as an owner-optional follow-up.

Spine-Trail: st_f6b7385d3857