### PR TITLE
fix(sdk-cloud): retry parity for sync backend_client (#1441)

### DIFF
--- a/tests/unit/cloud/test_best_config_cloud_client.py
+++ b/tests/unit/cloud/test_best_config_cloud_client.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from traigent.cloud.backend_client import BackendIntegratedClient
+from traigent.cloud.client import CloudServiceError
 
 FAKE_TRAIGENT_API_KEY = "tg_" + "x" * 61  # pragma: allowlist secret
 
@@ -17,6 +20,20 @@ def _spec() -> dict:
         "environment": "staging",
         "config": {"temperature": 0.2},
     }
+
+
+def _response(
+    status_code: int,
+    payload: dict | None = None,
+    *,
+    text: str = "ok",
+) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    response.headers = {}
+    response.json.return_value = payload or {"success": True, "data": {"ok": True}}
+    return response
 
 
 @patch("requests.post")
@@ -51,6 +68,52 @@ def test_publish_best_config_sync_posts_to_backend(mock_post, monkeypatch):
     assert call_args.kwargs["headers"]["If-Match"] == 'W/"1-old"'
     assert call_args.kwargs["headers"]["Authorization"] == "Bearer test-token"
     assert call_args.kwargs["headers"]["X-Project-Id"] == "project_cloud_123"
+
+
+@patch("traigent.utils.retry.time.sleep", return_value=None)
+@patch("requests.post")
+def test_publish_best_config_sync_retries_transient_503_then_succeeds(
+    mock_post,
+    mock_sleep,
+):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_post.side_effect = [
+        _response(503, text="temporarily unavailable"),
+        _response(201, {"success": True, "data": {"config_id": "answerer"}}),
+    ]
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        result = client.publish_best_config_sync(_spec(), environment="staging")
+
+    assert result == {"config_id": "answerer"}
+    assert mock_post.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("traigent.utils.retry.time.sleep", return_value=None)
+@patch("requests.post")
+def test_publish_best_config_sync_does_not_retry_401(mock_post, mock_sleep):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_post.return_value = _response(401, text="unauthorized")
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        with pytest.raises(CloudServiceError):
+            client.publish_best_config_sync(_spec(), environment="staging")
+
+    mock_post.assert_called_once()
+    mock_sleep.assert_not_called()
 
 
 @patch("requests.get")
@@ -92,6 +155,59 @@ def test_fetch_best_config_sync_gets_current_config(mock_get):
     assert call_args.kwargs["headers"]["If-None-Match"] == 'W/"1-old"'
 
 
+@patch("traigent.utils.retry.time.sleep", return_value=None)
+@patch("requests.get")
+def test_fetch_best_config_sync_retries_transient_503_then_succeeds(
+    mock_get,
+    mock_sleep,
+):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_get.side_effect = [
+        _response(503, text="temporarily unavailable"),
+        _response(
+            200,
+            {
+                "success": True,
+                "data": {"config_id": "answerer", "spec": _spec()},
+            },
+        ),
+    ]
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        result = client.fetch_best_config_sync("answerer", environment="staging")
+
+    assert result is not None
+    assert result["config_id"] == "answerer"
+    assert mock_get.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("traigent.utils.retry.time.sleep", return_value=None)
+@patch("requests.get")
+def test_fetch_best_config_sync_does_not_retry_422(mock_get, mock_sleep):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_get.return_value = _response(422, text="invalid query")
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        with pytest.raises(CloudServiceError):
+            client.fetch_best_config_sync("answerer", environment="staging")
+
+    mock_get.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
 @patch("requests.get")
 def test_fetch_best_config_sync_returns_none_for_not_found(mock_get):
     client = BackendIntegratedClient(
@@ -105,3 +221,57 @@ def test_fetch_best_config_sync_returns_none_for_not_found(mock_get):
         AsyncMock(return_value={"Authorization": "Bearer test-token"}),
     ):
         assert client.fetch_best_config_sync("missing") is None
+
+
+@patch("traigent.utils.retry.time.sleep", return_value=None)
+@patch("requests.post")
+def test_upload_example_features_retries_transient_503_then_succeeds(
+    mock_post,
+    mock_sleep,
+):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_post.side_effect = [
+        _response(503, text="temporarily unavailable"),
+        _response(200),
+    ]
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        result = client.upload_example_features(
+            "run_123",
+            "simhash_v1",
+            [{"example_id": "ex_1", "feature": "0f0f"}],
+        )
+
+    assert result is True
+    assert mock_post.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("traigent.utils.retry.time.sleep", return_value=None)
+@patch("requests.post")
+def test_upload_example_features_does_not_retry_422(mock_post, mock_sleep):
+    client = BackendIntegratedClient(
+        api_key=FAKE_TRAIGENT_API_KEY, base_url="https://api.test"
+    )
+    mock_post.return_value = _response(422, text="invalid features")
+
+    with patch.object(
+        client.auth_manager.auth,
+        "get_headers",
+        AsyncMock(return_value={"Authorization": "Bearer test-token"}),
+    ):
+        result = client.upload_example_features(
+            "run_123",
+            "simhash_v1",
+            [{"example_id": "ex_1", "feature": "0f0f"}],
+        )
+
+    assert result is False
+    mock_post.assert_called_once()
+    mock_sleep.assert_not_called()

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -12,8 +12,9 @@ import os
 import secrets
 import sys
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, Any, cast
@@ -65,7 +66,9 @@ from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env
 from traigent.evaluators.base import Dataset
 from traigent.security.session_manager import SessionManager as SecuritySessionManager
+from traigent.utils.exceptions import RetryableError
 from traigent.utils.logging import get_logger
+from traigent.utils.retry import RetryConfig, RetryHandler
 
 # Type alias for aiohttp session, falling back to Any at runtime if unavailable
 if TYPE_CHECKING:
@@ -109,6 +112,84 @@ logger = get_logger(__name__)
 _ALLOWED_EXAMPLE_FEATURE_KINDS = frozenset({"simhash_v1"})
 _JSON_CONTENT_TYPE = "application/json"
 _SDK_USER_AGENT = get_sdk_user_agent()
+_SYNC_BACKEND_TRANSIENT_STATUSES = frozenset({408, 429, *range(500, 600)})
+
+
+class _SyncBackendTransientError(RetryableError):
+    """Retryable wrapper for transient sync backend transport failures."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message, retry_after=retry_after)
+        self.status_code = status_code
+
+
+_SYNC_BACKEND_RETRY_CONFIG = RetryConfig(
+    max_attempts=3,
+    initial_delay=0.25,
+    max_delay=2.0,
+    jitter=False,
+    retry_on_exception={_SyncBackendTransientError},
+    retry_on_status=set(_SYNC_BACKEND_TRANSIENT_STATUSES),
+    respect_retry_after=True,
+)
+
+
+def _parse_retry_after(headers: Any) -> float | None:
+    if not headers:
+        return None
+    try:
+        value = headers.get("Retry-After")
+    except AttributeError:
+        return None
+    if value is None:
+        return None
+
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        pass
+
+    try:
+        retry_at = parsedate_to_datetime(str(value))
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=UTC)
+    return max(0.0, (retry_at - datetime.now(UTC)).total_seconds())
+
+
+def _raise_for_transient_backend_response(response: Any, operation: str) -> None:
+    status_code = getattr(response, "status_code", None)
+    if status_code not in _SYNC_BACKEND_TRANSIENT_STATUSES:
+        return
+
+    response_text = getattr(response, "text", "")
+    raise _SyncBackendTransientError(
+        f"{operation} returned transient HTTP {status_code}: {str(response_text)[:200]}",
+        status_code=status_code,
+        retry_after=_parse_retry_after(getattr(response, "headers", None)),
+    )
+
+
+def _run_sync_backend_request_with_retry(
+    operation: str,
+    request_call: Callable[[], Any],
+) -> Any:
+    retry = RetryHandler(_SYNC_BACKEND_RETRY_CONFIG)
+    result = retry.execute_with_result(request_call)
+    if result.success:
+        return result.result
+
+    error = result.error
+    if isinstance(error, AuthenticationError):
+        raise error
+    raise CloudServiceError(f"{operation} failed: {error}") from error
 
 
 def _session_is_closed(session: Any) -> bool:
@@ -1136,17 +1217,30 @@ class BackendIntegratedClient:
         if environment:
             payload["environment"] = environment
 
-        try:
-            response = requests.post(  # nosec B113 - timeout is provided
-                url,
-                json=payload,
-                headers=headers,
-                timeout=min(self.timeout, 30.0),
-            )
-        except AuthenticationError:
-            raise
-        except Exception as exc:
-            raise CloudServiceError(f"Best-config publish failed: {exc}") from exc
+        def _post_best_config() -> Any:
+            try:
+                response = requests.post(  # nosec B113 - timeout is provided
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=min(self.timeout, 30.0),
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                ConnectionError,
+                TimeoutError,
+            ) as exc:
+                raise _SyncBackendTransientError(
+                    f"Best-config publish transport failed: {exc}"
+                ) from exc
+            _raise_for_transient_backend_response(response, "Best-config publish")
+            return response
+
+        response = _run_sync_backend_request_with_retry(
+            "Best-config publish",
+            _post_best_config,
+        )
 
         if response.status_code >= 400:
             raise CloudServiceError(
@@ -1186,17 +1280,30 @@ class BackendIntegratedClient:
             if value
         }
 
-        try:
-            response = requests.get(  # nosec B113 - timeout is provided
-                url,
-                params=params or None,
-                headers=headers,
-                timeout=min(self.timeout, 30.0),
-            )
-        except AuthenticationError:
-            raise
-        except Exception as exc:
-            raise CloudServiceError(f"Best-config fetch failed: {exc}") from exc
+        def _get_best_config() -> Any:
+            try:
+                response = requests.get(  # nosec B113 - timeout is provided
+                    url,
+                    params=params or None,
+                    headers=headers,
+                    timeout=min(self.timeout, 30.0),
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                ConnectionError,
+                TimeoutError,
+            ) as exc:
+                raise _SyncBackendTransientError(
+                    f"Best-config fetch transport failed: {exc}"
+                ) from exc
+            _raise_for_transient_backend_response(response, "Best-config fetch")
+            return response
+
+        response = _run_sync_backend_request_with_retry(
+            "Best-config fetch",
+            _get_best_config,
+        )
 
         if response.status_code in {304, 404}:
             return None
@@ -1259,12 +1366,30 @@ class BackendIntegratedClient:
             return False
         payload = {"feature_kind": feature_kind, "features": features}
 
+        def _post_example_features() -> Any:
+            try:
+                response = requests.post(  # nosec B113 - timeout is provided
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=min(self.timeout, 30.0),
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                ConnectionError,
+                TimeoutError,
+            ) as exc:
+                raise _SyncBackendTransientError(
+                    f"Example feature upload transport failed: {exc}"
+                ) from exc
+            _raise_for_transient_backend_response(response, "Example feature upload")
+            return response
+
         try:
-            response = requests.post(  # nosec B113 — timeout is provided
-                url,
-                json=payload,
-                headers=headers,
-                timeout=min(self.timeout, 30.0),
+            response = _run_sync_backend_request_with_retry(
+                "Example feature upload",
+                _post_example_features,
             )
         except Exception as exc:
             logger.debug(


### PR DESCRIPTION
Closes #1441.

## Problem
3 sync outbound calls in cloud/backend_client.py (publish_best_config_sync, fetch_best_config_sync, upload_example_features) issued a single `requests` call with NO retry — asymmetric with the hybrid (#1242) and observability paths which already wrap outbound calls in RetryHandler. A transient 429/503/ECONNRESET fails on the first attempt.

## Fix
Route all 3 through the EXISTING retry stack (utils/retry.py RetryHandler) with a 3-attempt RetryConfig + exponential backoff + Retry-After. Retries ONLY transient classes (connection/timeout + HTTP 408/429/5xx); does NOT retry 4xx auth/validation (AuthenticationError still short-circuits) and preserves the 304/404 fast-paths. Public contracts after exhausting retries unchanged: publish/fetch raise CloudServiceError; upload_example_features returns False.

## Tests
test_best_config_cloud_client.py: each of the 3 methods recovers from a single transient 503→200, and 401/422 is not retried (called once). Captain re-ran: 9 passed. `grep -cE 'RetryHandler|RetryConfig' backend_client.py` now 3 (was 0). ruff clean.

Note: JS-side parallel asymmetry (traigent-js internal/http.ts) is a tracked cross-repo follow-up.

Spine-Trail: st_60da50233206