### PR TITLE
fix(cloud): finalizer net + await cancelled sync tasks (#1408)

### DIFF
--- a/tests/unit/cloud/test_authentication_stress.py
+++ b/tests/unit/cloud/test_authentication_stress.py
@@ -10,10 +10,39 @@ import threading
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
+import aiohttp
 import psutil
 import pytest
 
+# Genuine aiohttp classes captured from their defining submodules (never the
+# target of the ``patch("...aiohttp.ClientSession")`` calls below), used to
+# restore the real ``aiohttp`` module attributes after each stress test.
+from aiohttp.client import ClientSession as _REAL_CLIENT_SESSION
+from aiohttp.client import ClientTimeout as _REAL_CLIENT_TIMEOUT
+from aiohttp.connector import TCPConnector as _REAL_TCP_CONNECTOR
+
 from traigent.cloud.client import TraigentCloudClient
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_aiohttp_after_stress():
+    """Prevent cross-file aiohttp pollution from concurrent ``patch`` enters.
+
+    Several stress tests enter ``with patch("...aiohttp.ClientSession")`` from
+    coroutines run concurrently via ``asyncio.gather``. ``unittest.mock.patch``
+    saves/restores the *current* attribute value, so two concurrent enters of
+    the same target can interleave such that the restore leaves a MagicMock on
+    the real ``aiohttp`` module instead of the genuine class. That mock then
+    bleeds into later test files (e.g. the finalizer tests in
+    test_session_cleanup.py) which need a real session/connector. Restore the
+    genuine classes after every test here so the global module is left clean.
+    """
+    try:
+        yield
+    finally:
+        aiohttp.ClientSession = _REAL_CLIENT_SESSION
+        aiohttp.ClientTimeout = _REAL_CLIENT_TIMEOUT
+        aiohttp.TCPConnector = _REAL_TCP_CONNECTOR
 
 
 class TestHighVolumeRequests:
@@ -122,18 +151,18 @@ class TestHighVolumeRequests:
                                     incorrect_auth_count += 1
 
                         # All requests should have correct authentication
-                        assert (
-                            missing_auth_count == 0
-                        ), f"{missing_auth_count} requests missing Authorization header"
-                        assert (
-                            incorrect_auth_count == 0
-                        ), f"{incorrect_auth_count} requests with incorrect auth"
+                        assert missing_auth_count == 0, (
+                            f"{missing_auth_count} requests missing Authorization header"
+                        )
+                        assert incorrect_auth_count == 0, (
+                            f"{incorrect_auth_count} requests with incorrect auth"
+                        )
 
                         # Performance check - should complete reasonably quickly
                         execution_time = end_time - start_time
-                        assert (
-                            execution_time < 10.0
-                        ), f"Stress test took too long: {execution_time:.2f}s"
+                        assert execution_time < 10.0, (
+                            f"Stress test took too long: {execution_time:.2f}s"
+                        )
 
                         print(
                             f"✅ {num_requests} concurrent requests completed in {execution_time:.2f}s"
@@ -226,12 +255,12 @@ class TestHighVolumeRequests:
                         end_time = time.time()
 
                     # Verify authentication consistency
-                    assert (
-                        len(auth_headers_seen) <= 2
-                    ), f"Too many different auth headers: {len(auth_headers_seen)}"
-                    assert (
-                        len(inconsistent_headers) == 0
-                    ), f"Found inconsistent headers: {inconsistent_headers}"
+                    assert len(auth_headers_seen) <= 2, (
+                        f"Too many different auth headers: {len(auth_headers_seen)}"
+                    )
+                    assert len(inconsistent_headers) == 0, (
+                        f"Found inconsistent headers: {inconsistent_headers}"
+                    )
 
                     # Verify all requests were processed
                     assert len(request_times) == num_requests
@@ -243,12 +272,12 @@ class TestHighVolumeRequests:
                     print(
                         f"✅ {num_requests} extreme concurrent requests in {execution_time:.2f}s"
                     )
-                    print(f"   Average: {avg_request_time*1000:.2f}ms per request")
+                    print(f"   Average: {avg_request_time * 1000:.2f}ms per request")
 
                     # Should maintain reasonable performance
-                    assert (
-                        avg_request_time < 0.1
-                    ), f"Average request time too high: {avg_request_time:.3f}s"
+                    assert avg_request_time < 0.1, (
+                        f"Average request time too high: {avg_request_time:.3f}s"
+                    )
 
 
 class TestSessionSharingUnderLoad:
@@ -368,19 +397,19 @@ class TestSessionSharingUnderLoad:
                         print(f"Corruptions detected: {len(corruption_detected)}")
 
                         # Should create minimal sessions (ideally 1, at most a few)
-                        assert (
-                            len(session_creations) <= 5
-                        ), f"Too many sessions created: {len(session_creations)}"
+                        assert len(session_creations) <= 5, (
+                            f"Too many sessions created: {len(session_creations)}"
+                        )
 
                         # Should have many more usages than creations (session reuse)
-                        assert (
-                            len(session_usages) > len(session_creations) * 100
-                        ), "Insufficient session reuse"
+                        assert len(session_usages) > len(session_creations) * 100, (
+                            "Insufficient session reuse"
+                        )
 
                         # No corruption should occur
-                        assert (
-                            len(corruption_detected) == 0
-                        ), f"Header corruption detected: {corruption_detected[:5]}"
+                        assert len(corruption_detected) == 0, (
+                            f"Header corruption detected: {corruption_detected[:5]}"
+                        )
 
     @pytest.mark.asyncio
     async def test_session_cleanup_under_load(self):
@@ -487,14 +516,14 @@ class TestSessionSharingUnderLoad:
                             else 0
                         )
                         # Relax this requirement for mock environment
-                        assert (
-                            cleanup_ratio >= 0.0
-                        ), f"Negative cleanup ratio: {cleanup_ratio:.2f}"
+                        assert cleanup_ratio >= 0.0, (
+                            f"Negative cleanup ratio: {cleanup_ratio:.2f}"
+                        )
 
                         # Memory usage should be reasonable
-                        assert (
-                            memory_increase_mb < 50
-                        ), f"Excessive memory usage: {memory_increase_mb:.2f} MB"
+                        assert memory_increase_mb < 50, (
+                            f"Excessive memory usage: {memory_increase_mb:.2f} MB"
+                        )
 
 
 class TestAuthenticationPerformanceUnderLoad:
@@ -589,27 +618,27 @@ class TestAuthenticationPerformanceUnderLoad:
 
                         print(f"Total requests: {num_requests}")
                         print(f"Total time: {total_time:.3f}s")
-                        print(f"Avg request time: {avg_request_time*1000:.2f}ms")
-                        print(f"Avg auth time: {avg_auth_time*1000:.2f}ms")
+                        print(f"Avg request time: {avg_request_time * 1000:.2f}ms")
+                        print(f"Avg auth time: {avg_auth_time * 1000:.2f}ms")
                         print(f"Auth overhead: {auth_overhead_ratio:.1%}")
 
                         # Performance requirements
-                        assert (
-                            avg_request_time < 0.05
-                        ), f"Requests too slow: {avg_request_time:.3f}s"
+                        assert avg_request_time < 0.05, (
+                            f"Requests too slow: {avg_request_time:.3f}s"
+                        )
                         # Auth overhead may be high in mock environment, so relax this requirement
                         # In real usage, session caching would reduce this significantly
-                        assert (
-                            auth_overhead_ratio < 150
-                        ), f"Auth overhead too high: {auth_overhead_ratio:.1%}"
+                        assert auth_overhead_ratio < 150, (
+                            f"Auth overhead too high: {auth_overhead_ratio:.1%}"
+                        )
 
                         # Auth should be called reasonable number of times (session reuse)
                         # In mock environment, this may be called more than expected
                         # Allow up to 2 auth calls per request for mock test environment
                         expected_max_auth_calls = num_requests * 2
-                        assert (
-                            len(auth_times) <= expected_max_auth_calls + 10
-                        ), f"Too many auth calls: {len(auth_times)}"
+                        assert len(auth_times) <= expected_max_auth_calls + 10, (
+                            f"Too many auth calls: {len(auth_times)}"
+                        )
 
     @pytest.mark.asyncio
     async def test_concurrent_auth_operations_performance(self):
@@ -725,7 +754,7 @@ class TestAuthenticationPerformanceUnderLoad:
         print(f"  Avg client time: {avg_client_duration:.3f}s")
         print(f"  Slowest client: {slowest_client['duration']:.3f}s")
         print(f"  Fastest client: {fastest_client['duration']:.3f}s")
-        print(f"  Effective RPS: {total_requests/overall_duration:.1f}")
+        print(f"  Effective RPS: {total_requests / overall_duration:.1f}")
 
         # Performance requirements
         assert overall_duration < 5.0, f"Overall test too slow: {overall_duration:.3f}s"
@@ -747,9 +776,9 @@ class TestAuthenticationPerformanceUnderLoad:
         )
         p25_duration = sorted_durations[p25_idx]
         p75_duration = sorted_durations[p75_idx]
-        assert (
-            p75_duration / max(p25_duration, 1e-6) < 8.0
-        ), "Too much variance between clients"
+        assert p75_duration / max(p25_duration, 1e-6) < 8.0, (
+            "Too much variance between clients"
+        )
 
 
 class TestErrorRecoveryUnderLoad:
@@ -865,17 +894,17 @@ class TestErrorRecoveryUnderLoad:
                         # Verify authentication consistency during errors and recovery
                         if auth_headers_during_errors:
                             unique_error_headers = set(auth_headers_during_errors)
-                            assert (
-                                len(unique_error_headers) <= 1
-                            ), f"Inconsistent auth during errors: {len(unique_error_headers)}"
+                            assert len(unique_error_headers) <= 1, (
+                                f"Inconsistent auth during errors: {len(unique_error_headers)}"
+                            )
 
                             # Error requests should have same auth as success requests
                             if auth_headers_during_success:
                                 success_header = auth_headers_during_success[0]
                                 error_header = auth_headers_during_errors[0]
-                                assert (
-                                    success_header == error_header
-                                ), "Auth headers differ between success and error"
+                                assert success_header == error_header, (
+                                    "Auth headers differ between success and error"
+                                )
 
                         # All requests should have included proper authentication
                         missing_auth = [
@@ -883,15 +912,15 @@ class TestErrorRecoveryUnderLoad:
                             for a in request_attempts
                             if not a["headers"].get("Authorization")
                         ]
-                        assert (
-                            len(missing_auth) == 0
-                        ), f"Requests missing auth during errors: {len(missing_auth)}"
+                        assert len(missing_auth) == 0, (
+                            f"Requests missing auth during errors: {len(missing_auth)}"
+                        )
 
                         # Should have reasonable success rate despite errors
                         success_rate = len(recovered_requests) / len(request_attempts)
-                        assert (
-                            success_rate > 0.7
-                        ), f"Success rate too low: {success_rate:.1%}"
+                        assert success_rate > 0.7, (
+                            f"Success rate too low: {success_rate:.1%}"
+                        )
 
 
 class TestClientIsolationUnderStress:
@@ -1090,9 +1119,9 @@ class TestClientIsolationUnderStress:
         print(f"  Cross-contaminations detected: {len(cross_contamination_detected)}")
 
         # Verify isolation was maintained
-        assert (
-            len(cross_contamination_detected) == 0
-        ), f"Cross-contamination detected: {cross_contamination_detected[:3]}"
+        assert len(cross_contamination_detected) == 0, (
+            f"Cross-contamination detected: {cross_contamination_detected[:3]}"
+        )
 
         # Verify each client used consistent authentication
         for client_id in range(num_clients):
@@ -1100,33 +1129,33 @@ class TestClientIsolationUnderStress:
                 client_auth_headers = client_auth_usage[client_id]
                 unique_headers = set(client_auth_headers)
 
-                assert (
-                    len(unique_headers) <= 1
-                ), f"Client {client_id} used inconsistent auth headers: {len(unique_headers)}"
+                assert len(unique_headers) <= 1, (
+                    f"Client {client_id} used inconsistent auth headers: {len(unique_headers)}"
+                )
 
                 if unique_headers:
                     auth_header = list(unique_headers)[0]
                     expected_key = client_api_keys[client_id]
-                    assert (
-                        expected_key in auth_header
-                    ), f"Client {client_id} auth header missing expected key"
+                    assert expected_key in auth_header, (
+                        f"Client {client_id} auth header missing expected key"
+                    )
 
         # Performance should be reasonable even under stress
         requests_per_second = (
             total_successful_requests / execution_time if execution_time > 0 else 0
         )
-        assert (
-            requests_per_second > 50
-        ), f"Too slow under stress: {requests_per_second:.1f} RPS"
+        assert requests_per_second > 50, (
+            f"Too slow under stress: {requests_per_second:.1f} RPS"
+        )
 
         # Some requests should succeed (relaxed for mock environment)
         # The main test is for isolation, not success rate
         success_rate = (
             total_successful_requests / total_requests if total_requests > 0 else 0
         )
-        assert (
-            success_rate > 0.3
-        ), f"Success rate too low under stress: {success_rate:.1%}"
+        assert success_rate > 0.3, (
+            f"Success rate too low under stress: {success_rate:.1%}"
+        )
 
 
 class TestMemoryAndResourceManagement:
@@ -1232,16 +1261,18 @@ class TestMemoryAndResourceManagement:
         print(f"  Net increase: {memory_increase:.1f} MB")
         print(f"  Peak increase: {peak_increase:.1f} MB")
         print(f"  Total operations: {total_operations}")
-        print(f"  Memory per operation: {peak_increase*1024/total_operations:.2f} KB")
+        print(
+            f"  Memory per operation: {peak_increase * 1024 / total_operations:.2f} KB"
+        )
 
         # Memory usage should be reasonable
         assert peak_increase < 100, f"Memory increase too high: {peak_increase:.1f} MB"
-        assert (
-            memory_increase < 50
-        ), f"Final memory increase too high: {memory_increase:.1f} MB"
+        assert memory_increase < 50, (
+            f"Final memory increase too high: {memory_increase:.1f} MB"
+        )
 
         # Memory per operation should be minimal
         memory_per_op_kb = peak_increase * 1024 / total_operations
-        assert (
-            memory_per_op_kb < 50
-        ), f"Memory per operation too high: {memory_per_op_kb:.2f} KB"
+        assert memory_per_op_kb < 50, (
+            f"Memory per operation too high: {memory_per_op_kb:.2f} KB"
+        )

--- a/tests/unit/cloud/test_backend_synchronizer.py
+++ b/tests/unit/cloud/test_backend_synchronizer.py
@@ -157,5 +157,67 @@ async def test_background_sync_loop_reraises_cancellation(monkeypatch):
 
     monkeypatch.setattr(asyncio, "sleep", raise_cancelled)
 
-    with pytest.raises(asyncio.CancelledError):
-        await sync._background_sync_loop()
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await sync._background_sync_loop()
+    finally:
+        await sync.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_stop_background_sync_awaits_cancelled_background_task():
+    sync = BackendSynchronizer(enable_auto_sync=False, sync_interval=0.1)
+    cancelled = asyncio.Event()
+
+    async def pending_background_loop():
+        try:
+            await asyncio.Future()
+        finally:
+            cancelled.set()
+
+    task = asyncio.create_task(pending_background_loop(), name="background_sync")
+    sync._background_sync_task = task
+    await asyncio.sleep(0)
+
+    await sync.stop_background_sync()
+
+    assert cancelled.is_set()
+    assert task.done()
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_awaits_cancelled_sync_tasks_before_clearing():
+    sync = BackendSynchronizer(enable_auto_sync=False, sync_interval=0.1)
+    cancelled = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    exception_contexts = []
+    previous_handler = loop.get_exception_handler()
+
+    def capture_exception_context(_loop, context):
+        exception_contexts.append(context)
+
+    async def pending_sync():
+        try:
+            await asyncio.Future()
+        finally:
+            cancelled.set()
+
+    task = asyncio.create_task(pending_sync(), name="queued_sync_session-1")
+    sync._sync_tasks["session-1"] = task
+    await asyncio.sleep(0)
+
+    loop.set_exception_handler(capture_exception_context)
+    try:
+        await sync.cleanup()
+        del task
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert cancelled.is_set()
+    assert sync._sync_tasks == {}
+    assert not any(
+        context.get("message") == "Task was destroyed but it is pending!"
+        for context in exception_contexts
+    )

--- a/tests/unit/cloud/test_session_cleanup.py
+++ b/tests/unit/cloud/test_session_cleanup.py
@@ -18,6 +18,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# Import the genuine aiohttp classes directly from their defining submodules.
+# Other cloud tests patch the top-level re-exports
+# (``aiohttp.ClientSession`` / ``traigent.cloud.client.aiohttp.ClientSession``);
+# concurrent ``with patch(...)`` enters from gathered coroutines can interleave
+# their save/restore and leak a MagicMock onto the real ``aiohttp`` module. The
+# submodule attributes (``aiohttp.client.ClientSession`` etc.) are never the
+# patch target, so these references stay genuine regardless of pollution.
+from aiohttp.client import ClientSession as _REAL_CLIENT_SESSION
+from aiohttp.client import ClientTimeout as _REAL_CLIENT_TIMEOUT
+
 _TEST_API_KEY = "tg_test_" + "x" * 56
 
 
@@ -125,8 +135,33 @@ def _build_client_on_private_loop(client_kind: str) -> tuple[Any, Any, Any]:
 
     session = client._session
     assert session is not None
+
+    # Pollution resistance: if an earlier cloud test left
+    # ``aiohttp.ClientSession`` patched to a Mock, the lazily-built session (and
+    # therefore its connector) would be a Mock — its ``_conns`` is not
+    # subscriptable and the finalizer guard would skip a Mock session entirely.
+    # Deterministically exercise the REAL finalizer transport-close path by
+    # rebuilding a genuine session from the unpatched class and re-registering
+    # the finalizer on it. With a clean global this branch is a no-op.
+    if not isinstance(session, _REAL_CLIENT_SESSION):
+
+        async def _make_real_session() -> Any:
+            return _REAL_CLIENT_SESSION(
+                timeout=_REAL_CLIENT_TIMEOUT(total=30),
+            )
+
+        session = loop.run_until_complete(_make_real_session())
+        client._session = session
+        client._register_session_finalizer(session)
+
     connector = session._connector
     assert connector is not None
+    # The finalizer walks/clears exactly these internals; ensure they are the
+    # real owning containers the test injects into (a genuine session provides
+    # a ``defaultdict(list)`` / ``set`` / ``list`` here already).
+    assert isinstance(connector._conns, dict)
+    assert isinstance(connector._acquired, set)
+    assert isinstance(connector._cleanup_closed_transports, list)
     return loop, client, connector
 
 
@@ -388,3 +423,97 @@ class TestCloudClientSessionCleanup:
 
         mock_session.close.assert_awaited_once()
         mock_sleep.assert_not_awaited()
+
+
+class TestMockSessionNoFinalizer:
+    """GC of a client holding a Mock session must never raise TypeError."""
+
+    def test_mock_session_gc_raises_nothing_backend(self):
+        """BackendIntegratedClient with a Mock session: no finalizer, no TypeError on GC."""
+        import gc
+        from unittest.mock import MagicMock
+
+        from traigent.cloud.backend_client import BackendIntegratedClient
+
+        client = object.__new__(BackendIntegratedClient)
+        client._session_finalizer = None
+        client._session = MagicMock()
+
+        # _register_session_finalizer must NOT register a finalizer for a Mock
+        client._register_session_finalizer(client._session)
+        assert client._session_finalizer is None
+
+        # Drop the reference and force GC — must not raise
+        del client
+        gc.collect()
+        gc.collect()
+
+    def test_mock_session_gc_raises_nothing_cloud(self):
+        """TraigentCloudClient with a Mock session: no finalizer, no TypeError on GC."""
+        import gc
+        from unittest.mock import MagicMock
+
+        from traigent.cloud.client import TraigentCloudClient
+
+        client = object.__new__(TraigentCloudClient)
+        client._session_finalizer = None
+        client._aio_session = MagicMock()
+
+        # _register_session_finalizer must NOT register a finalizer for a Mock
+        client._register_session_finalizer(client._aio_session)
+        assert client._session_finalizer is None
+
+        # Drop the reference and force GC — must not raise
+        del client
+        gc.collect()
+        gc.collect()
+
+    def test_finalize_aiohttp_session_is_noop_for_mock(self):
+        """_finalize_aiohttp_session called directly with a Mock must be a no-op."""
+        from unittest.mock import MagicMock
+
+        from traigent.cloud.client import _finalize_aiohttp_session
+
+        mock_session = MagicMock()
+        # Must return immediately without accessing mock attributes that raise TypeError
+        _finalize_aiohttp_session(mock_session, "TestOwner")
+
+    def test_guard_recognizes_real_session_even_when_module_attr_is_mocked(self):
+        """The guard must identify a genuine session even under global pollution.
+
+        Regression for a guard that checked ``isinstance(session,
+        aiohttp.ClientSession)`` against the *mutable module attribute*. When an
+        earlier test leaves ``aiohttp.ClientSession`` replaced with a MagicMock,
+        that check raises ``TypeError`` (non-type) and is swallowed to ``False``,
+        wrongly rejecting a real session and skipping finalizer registration.
+        Checking against the class captured from ``aiohttp.client`` at import
+        time stays correct regardless of the module-attribute pollution.
+        """
+        from traigent.cloud.client import _is_real_aiohttp_session
+
+        async def _make_real_session() -> Any:
+            return _REAL_CLIENT_SESSION(timeout=_REAL_CLIENT_TIMEOUT(total=30))
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            real_session = loop.run_until_complete(_make_real_session())
+            try:
+                # Sanity: recognized when the global is clean.
+                assert _is_real_aiohttp_session(real_session) is True
+
+                # Pollute the mutable module attribute, exactly as a concurrent
+                # ``with patch("...aiohttp.ClientSession")`` leak would. The old
+                # module-attribute guard returns False here (and would raise
+                # TypeError internally); the import-time-class guard stays True.
+                with patch(
+                    "traigent.cloud.client.aiohttp.ClientSession",
+                    new=MagicMock(name="ClientSession"),
+                ):
+                    assert _is_real_aiohttp_session(real_session) is True
+                    assert _is_real_aiohttp_session(MagicMock()) is False
+            finally:
+                loop.run_until_complete(real_session.close())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)

--- a/tests/unit/cloud/test_session_cleanup.py
+++ b/tests/unit/cloud/test_session_cleanup.py
@@ -9,12 +9,16 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import socket
 import subprocess
 import sys
 import warnings
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+_TEST_API_KEY = "tg_test_" + "x" * 56
 
 
 def _resource_warning_messages(caught: list[warnings.WarningMessage]) -> list[str]:
@@ -23,6 +27,155 @@ def _resource_warning_messages(caught: list[warnings.WarningMessage]) -> list[st
         for warning in caught
         if issubclass(warning.category, ResourceWarning)
     ]
+
+
+def _unclosed_resource_warning_messages(
+    caught: list[warnings.WarningMessage],
+) -> list[str]:
+    return [
+        message
+        for message in _resource_warning_messages(caught)
+        if "Unclosed" in message
+    ]
+
+
+class _LoopClosedTransport:
+    """Socket-backed transport that exposes whether close/abort was attempted."""
+
+    def __init__(self) -> None:
+        self._sock, self._peer = socket.socketpair()
+        self._closing = False
+
+    def close(self) -> None:
+        self._closing = True
+        raise RuntimeError("Event loop is closed")
+
+    def abort(self) -> None:
+        self._closing = True
+        raise RuntimeError("Event loop is closed")
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        if name == "socket":
+            return self._sock
+        return default
+
+    def fileno(self) -> int:
+        return self._sock.fileno()
+
+    def cleanup(self) -> None:
+        self._peer.close()
+        if self._sock.fileno() != -1:
+            self._sock.close()
+
+
+class _TrackedProtocol:
+    def __init__(self, transport: _LoopClosedTransport) -> None:
+        self.transport = transport
+
+    def abort(self) -> None:
+        self.transport.abort()
+
+    def close(self) -> None:
+        self.transport.close()
+
+
+async def _build_backend_client_with_lazy_session() -> Any:
+    from traigent.cloud.backend_client import (
+        BackendClientConfig,
+        BackendIntegratedClient,
+    )
+
+    client = BackendIntegratedClient(
+        api_key=_TEST_API_KEY,
+        base_url="http://localhost:8000",
+        backend_config=BackendClientConfig(backend_base_url="http://localhost:8000"),
+        enable_fallback=False,
+    )
+    client.auth_manager.auth.get_headers = AsyncMock(
+        return_value={"X-API-Key": _TEST_API_KEY}
+    )
+    await client._ensure_session()
+    return client
+
+
+async def _build_cloud_client_with_lazy_session() -> Any:
+    from traigent.cloud.client import TraigentCloudClient
+
+    client = TraigentCloudClient(
+        api_key=_TEST_API_KEY,
+        base_url="http://localhost:8000",
+    )
+    client.auth.get_headers = AsyncMock(return_value={"X-API-Key": _TEST_API_KEY})
+    await client._ensure_session()
+    return client
+
+
+def _build_client_on_private_loop(client_kind: str) -> tuple[Any, Any, Any]:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    if client_kind == "backend":
+        client = loop.run_until_complete(_build_backend_client_with_lazy_session())
+    elif client_kind == "cloud":
+        client = loop.run_until_complete(_build_cloud_client_with_lazy_session())
+    else:  # pragma: no cover - test authoring guard
+        raise AssertionError(f"unknown client kind: {client_kind}")
+
+    session = client._session
+    assert session is not None
+    connector = session._connector
+    assert connector is not None
+    return loop, client, connector
+
+
+@pytest.mark.parametrize("client_kind", ["backend", "cloud"])
+def test_finalizer_closes_transports_when_session_loop_is_already_closed(
+    client_kind: str,
+) -> None:
+    """Finalizer must close connector transports after the aiohttp loop is closed."""
+
+    loop, client, connector = _build_client_on_private_loop(client_kind)
+    pooled_transport = _LoopClosedTransport()
+    acquired_transport = _LoopClosedTransport()
+    cleanup_transport = _LoopClosedTransport()
+
+    try:
+        connector._conns[object()].append((_TrackedProtocol(pooled_transport), 0.0))
+        connector._acquired.add(_TrackedProtocol(acquired_transport))
+        connector._cleanup_closed_transports.append(cleanup_transport)
+
+        loop.close()
+        asyncio.set_event_loop(None)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            doomed_client = client
+            client = None
+            del doomed_client
+            gc.collect()
+            gc.collect()
+
+        assert pooled_transport.is_closing()
+        assert pooled_transport.fileno() == -1
+        assert acquired_transport.is_closing()
+        assert acquired_transport.fileno() == -1
+        assert cleanup_transport.is_closing()
+        assert cleanup_transport.fileno() == -1
+        assert connector.closed
+        assert not connector._conns
+        assert not connector._acquired
+        assert not _unclosed_resource_warning_messages(caught)
+    finally:
+        if client is not None and not loop.is_closed():
+            loop.run_until_complete(client.close())
+        if not loop.is_closed():
+            loop.close()
+        asyncio.set_event_loop(None)
+        pooled_transport.cleanup()
+        acquired_transport.cleanup()
+        cleanup_transport.cleanup()
 
 
 class TestBackendClientSessionCleanup:
@@ -94,9 +247,7 @@ asyncio.run(main())
             await asyncio.sleep(0)
             gc.collect()
 
-        assert "Unclosed client session" not in "\n".join(
-            _resource_warning_messages(caught)
-        )
+        assert not _unclosed_resource_warning_messages(caught)
 
     @pytest.mark.asyncio
     async def test_aexit_delegates_to_close(self):
@@ -188,9 +339,7 @@ class TestCloudClientSessionCleanup:
             await asyncio.sleep(0)
             gc.collect()
 
-        assert "Unclosed client session" not in "\n".join(
-            _resource_warning_messages(caught)
-        )
+        assert not _unclosed_resource_warning_messages(caught)
 
     @pytest.mark.asyncio
     async def test_aexit_delegates_to_close(self):

--- a/tests/unit/cloud/test_session_cleanup.py
+++ b/tests/unit/cloud/test_session_cleanup.py
@@ -8,11 +8,21 @@ drain the event loop after session.close(), preventing the
 from __future__ import annotations
 
 import asyncio
+import gc
 import subprocess
 import sys
+import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+def _resource_warning_messages(caught: list[warnings.WarningMessage]) -> list[str]:
+    return [
+        str(warning.message)
+        for warning in caught
+        if issubclass(warning.category, ResourceWarning)
+    ]
 
 
 class TestBackendClientSessionCleanup:
@@ -48,12 +58,45 @@ asyncio.run(main())
             text=True,
             timeout=60,
         )
-        assert (
-            result.returncode == 0
-        ), f"Subprocess crashed (rc={result.returncode}):\n{result.stderr}"
-        assert (
-            "Unclosed client session" not in result.stderr
-        ), f"Got unclosed session warning:\n{result.stderr}"
+        assert result.returncode == 0, (
+            f"Subprocess crashed (rc={result.returncode}):\n{result.stderr}"
+        )
+        assert "Unclosed client session" not in result.stderr, (
+            f"Got unclosed session warning:\n{result.stderr}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_finalizer_closes_lazy_session_without_explicit_close(self):
+        """GC finalizer should close a lazily-created session if close() is skipped."""
+        from traigent.cloud.backend_client import (
+            BackendClientConfig,
+            BackendIntegratedClient,
+        )
+
+        client = BackendIntegratedClient(
+            api_key="tg_test_" + "x" * 56,
+            base_url="http://localhost:8000",
+            backend_config=BackendClientConfig(
+                backend_base_url="http://localhost:8000"
+            ),
+            enable_fallback=False,
+        )
+        client.auth_manager.auth.get_headers = AsyncMock(
+            return_value={"X-API-Key": "tg_test_" + "x" * 56}
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            await client._ensure_session()
+            assert client._session is not None
+            del client
+            gc.collect()
+            await asyncio.sleep(0)
+            gc.collect()
+
+        assert "Unclosed client session" not in "\n".join(
+            _resource_warning_messages(caught)
+        )
 
     @pytest.mark.asyncio
     async def test_aexit_delegates_to_close(self):
@@ -122,6 +165,32 @@ class TestCloudClientSessionCleanup:
             await client.close()
 
         mock_close.assert_awaited_once_with(reason="shutdown")
+
+    @pytest.mark.asyncio
+    async def test_finalizer_closes_lazy_session_without_explicit_close(self):
+        """GC finalizer should close a lazily-created session if close() is skipped."""
+        from traigent.cloud.client import TraigentCloudClient
+
+        client = TraigentCloudClient(
+            api_key="tg_test_" + "x" * 56,
+            base_url="http://localhost:8000",
+        )
+        client.auth.get_headers = AsyncMock(
+            return_value={"X-API-Key": "tg_test_" + "x" * 56}
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", ResourceWarning)
+            await client._ensure_session()
+            assert client._session is not None
+            del client
+            gc.collect()
+            await asyncio.sleep(0)
+            gc.collect()
+
+        assert "Unclosed client session" not in "\n".join(
+            _resource_warning_messages(caught)
+        )
 
     @pytest.mark.asyncio
     async def test_aexit_delegates_to_close(self):

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -36,6 +36,7 @@ from traigent.cloud.backend_components import (
 from traigent.cloud.client import (
     CloudServiceError,
     _finalize_aiohttp_session,
+    _is_real_aiohttp_session,
     cloud_backend_egress_disabled,
     raise_if_cloud_egress_disabled,
 )
@@ -827,12 +828,13 @@ class BackendIntegratedClient:
 
     def _register_session_finalizer(self, session: AioClientSession) -> None:
         self._detach_session_finalizer()
-        self._session_finalizer = weakref.finalize(
-            self,
-            _finalize_aiohttp_session,
-            session,
-            self.__class__.__name__,
-        )
+        if _is_real_aiohttp_session(session):
+            self._session_finalizer = weakref.finalize(
+                self,
+                _finalize_aiohttp_session,
+                session,
+                self.__class__.__name__,
+            )
 
     def _detach_session_finalizer(self) -> None:
         finalizer = getattr(self, "_session_finalizer", None)

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -12,6 +12,7 @@ import os
 import secrets
 import sys
 import time
+import weakref
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
@@ -33,6 +34,7 @@ from traigent.cloud.backend_components import (
 )
 from traigent.cloud.client import (
     CloudServiceError,
+    _finalize_aiohttp_session,
     cloud_backend_egress_disabled,
     raise_if_cloud_egress_disabled,
 )
@@ -427,6 +429,7 @@ class BackendIntegratedClient:
         # Initialize session
         self._session: AioClientSession | None = None
         self._session_lock: asyncio.Lock = asyncio.Lock()
+        self._session_finalizer: weakref.finalize | None = None
 
         # Initialize remaining components
         self.subset_selector = SmartSubsetSelector()
@@ -641,6 +644,7 @@ class BackendIntegratedClient:
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
                 headers=headers,
             )
+            self._register_session_finalizer(self._session)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -697,6 +701,7 @@ class BackendIntegratedClient:
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
                 headers=headers,
             )
+            self._register_session_finalizer(self._session)
 
             return cast(AioClientSession, self._session)
 
@@ -713,6 +718,7 @@ class BackendIntegratedClient:
 
         session = self._session
         self._session = None
+        self._detach_session_finalizer()
         try:
             if _session_is_closed(session):
                 return
@@ -737,6 +743,21 @@ class BackendIntegratedClient:
         """Close any active HTTP session to avoid resource leaks."""
 
         await self._reset_http_session(_reason)
+
+    def _register_session_finalizer(self, session: AioClientSession) -> None:
+        self._detach_session_finalizer()
+        self._session_finalizer = weakref.finalize(
+            self,
+            _finalize_aiohttp_session,
+            session,
+            self.__class__.__name__,
+        )
+
+    def _detach_session_finalizer(self) -> None:
+        finalizer = getattr(self, "_session_finalizer", None)
+        if finalizer is not None:
+            finalizer.detach()
+            self._session_finalizer = None
 
     # === Delegated Operations ===
     # The following methods delegate to the refactored sub-modules

--- a/traigent/cloud/backend_synchronizer.py
+++ b/traigent/cloud/backend_synchronizer.py
@@ -638,12 +638,13 @@ class BackendSynchronizer:
         except asyncio.QueueFull:
             logger.warning(f"Sync queue full, dropping session {session_id}")
 
-    def stop_background_sync(self) -> None:
+    async def stop_background_sync(self) -> None:
         """Stop background synchronization."""
         self.enable_auto_sync = False
 
         if self._background_sync_task and not self._background_sync_task.done():
             self._background_sync_task.cancel()
+            await asyncio.gather(self._background_sync_task, return_exceptions=True)
             logger.info("Stopped background synchronization")
 
     async def wait_for_pending_syncs(self, timeout: float = 30.0) -> bool:
@@ -701,14 +702,18 @@ class BackendSynchronizer:
             },
         }
 
-    def cleanup(self) -> None:
+    async def cleanup(self) -> None:
         """Clean up synchronizer resources."""
-        self.stop_background_sync()
+        await self.stop_background_sync()
 
         # Cancel all pending sync tasks
-        for task in self._sync_tasks.values():
+        tasks = list(self._sync_tasks.values())
+        for task in tasks:
             if not task.done():
                 task.cancel()
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         self._sync_tasks.clear()
         self._pending_syncs.clear()

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -17,6 +17,20 @@ from typing import Any, NoReturn, cast
 from urllib.parse import urlparse
 
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
+
+# Capture the genuine, unpatched ClientSession class at module-load time — before
+# any test can monkeypatch the mutable ``aiohttp.ClientSession`` module attribute.
+# The submodule attribute (``aiohttp.client.ClientSession``) is never the patch
+# target, so ``isinstance`` checks against this reference stay correct even when
+# ``aiohttp.ClientSession`` has been replaced with a MagicMock by another test.
+if AIOHTTP_AVAILABLE:
+    try:
+        from aiohttp.client import ClientSession as _REAL_AIOHTTP_CLIENT_SESSION
+    except ImportError:  # pragma: no cover - unexpected aiohttp layout
+        _REAL_AIOHTTP_CLIENT_SESSION = aiohttp.ClientSession
+else:  # pragma: no cover - minimal environments without aiohttp
+    _REAL_AIOHTTP_CLIENT_SESSION = None
+
 from traigent.config.backend_config import BackendConfig
 from traigent.evaluators.base import Dataset
 from traigent.utils.env_config import is_backend_offline
@@ -376,8 +390,30 @@ def _close_aiohttp_session_transports_sync(session: Any) -> None:
             pass
 
 
+def _is_real_aiohttp_session(session: Any) -> bool:
+    """Return True only when *session* is a genuine aiohttp ClientSession.
+
+    The ``isinstance`` check uses ``_REAL_AIOHTTP_CLIENT_SESSION`` — the real
+    class captured from ``aiohttp.client`` at module-load time — rather than the
+    mutable ``aiohttp.ClientSession`` module attribute. Tests routinely
+    monkeypatch that attribute to a MagicMock; checking against it would both
+    raise ``TypeError`` (a non-type as the second isinstance arg) AND wrongly
+    reject a *genuine* session whenever the global is polluted, which would skip
+    finalizer registration on a real session. The captured class is always a
+    real type, so the check stays correct under such pollution.
+    """
+    return (
+        AIOHTTP_AVAILABLE
+        and _REAL_AIOHTTP_CLIENT_SESSION is not None
+        and isinstance(session, _REAL_AIOHTTP_CLIENT_SESSION)
+    )
+
+
 def _finalize_aiohttp_session(session: Any, owner: str) -> None:
     """Synchronously close an aiohttp session from a weakref finalizer."""
+
+    if not _is_real_aiohttp_session(session):
+        return
 
     try:
         if session is None or _session_is_closed(session):
@@ -861,12 +897,13 @@ class TraigentCloudClient(BaseTraigentClient):
 
     def _register_session_finalizer(self, session: aiohttp.ClientSession) -> None:
         self._detach_session_finalizer()
-        self._session_finalizer = weakref.finalize(
-            self,
-            _finalize_aiohttp_session,
-            session,
-            self.__class__.__name__,
-        )
+        if _is_real_aiohttp_session(session):
+            self._session_finalizer = weakref.finalize(
+                self,
+                _finalize_aiohttp_session,
+                session,
+                self.__class__.__name__,
+            )
 
     def _detach_session_finalizer(self) -> None:
         finalizer = getattr(self, "_session_finalizer", None)

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -8,6 +8,7 @@ import asyncio
 import inspect
 import os
 import time
+import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -109,6 +110,29 @@ def _session_is_closed(session: Any) -> bool:
     if isinstance(closed_flag, bool):
         return closed_flag
     return False
+
+
+def _finalize_aiohttp_session(session: Any, owner: str) -> None:
+    """Synchronously close an aiohttp session from a weakref finalizer."""
+
+    try:
+        if session is None or _session_is_closed(session):
+            return
+
+        connector = getattr(session, "_connector", None)
+        owns_connector = bool(getattr(session, "_connector_owner", True))
+        if connector is not None and owns_connector:
+            close_now = getattr(connector, "_close", None)
+            if callable(close_now):
+                try:
+                    close_now(abort_ssl=True)
+                except TypeError:
+                    close_now()
+
+        if hasattr(session, "_connector"):
+            session._connector = None
+    except Exception as exc:  # pragma: no cover - defensive finalizer
+        logger.debug("Error finalizing %s aiohttp session: %s", owner, exc)
 
 
 def _coerce_enum(enum_cls: Any, raw: Any, *, fallback: Any) -> Any:
@@ -480,6 +504,7 @@ class TraigentCloudClient(BaseTraigentClient):
         # Session management
         self._aio_session: aiohttp.ClientSession | None = None
         self._session_lock: asyncio.Lock = asyncio.Lock()
+        self._session_finalizer: weakref.finalize | None = None
         # Track session ownership fingerprints for clearer error reporting
         self._session_owners: dict[str, dict[str, Any]] = {}
 
@@ -505,6 +530,7 @@ class TraigentCloudClient(BaseTraigentClient):
             timeout=aiohttp.ClientTimeout(total=self.timeout),
             headers=await self.auth.get_headers(),
         )
+        self._register_session_finalizer(self._aio_session)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
@@ -553,6 +579,7 @@ class TraigentCloudClient(BaseTraigentClient):
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
                 headers=headers,
             )
+            self._register_session_finalizer(self._aio_session)
             return self._aio_session
 
     async def _get_headers(self) -> dict[str, str]:
@@ -571,6 +598,21 @@ class TraigentCloudClient(BaseTraigentClient):
         """Close and discard the shared aiohttp session after failures."""
         await self._close_http_session(reason=reason)
 
+    def _register_session_finalizer(self, session: aiohttp.ClientSession) -> None:
+        self._detach_session_finalizer()
+        self._session_finalizer = weakref.finalize(
+            self,
+            _finalize_aiohttp_session,
+            session,
+            self.__class__.__name__,
+        )
+
+    def _detach_session_finalizer(self) -> None:
+        finalizer = getattr(self, "_session_finalizer", None)
+        if finalizer is not None:
+            finalizer.detach()
+            self._session_finalizer = None
+
     async def _close_http_session(self, reason: str | None = None) -> None:
         """Best-effort close for the shared HTTP session."""
         if not self._aio_session:
@@ -580,6 +622,7 @@ class TraigentCloudClient(BaseTraigentClient):
         if session is None:
             return
         self._aio_session = None
+        self._detach_session_finalizer()
 
         close_method = getattr(session, "close", None)
         if not callable(close_method):

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -112,6 +112,270 @@ def _session_is_closed(session: Any) -> bool:
     return False
 
 
+def _log_finalizer_close_task_result(task: asyncio.Task[Any], owner: str) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        logger.debug("%s aiohttp session close task was cancelled", owner)
+    except Exception as exc:  # pragma: no cover - defensive finalizer callback
+        logger.debug("Error closing %s aiohttp session: %s", owner, exc)
+
+
+def _close_awaitable(thing: Any) -> None:
+    close_method = getattr(thing, "close", None)
+    if callable(close_method):
+        try:
+            close_method()
+        except Exception:
+            pass
+
+
+def _schedule_aiohttp_session_close(
+    session: Any,
+    loop: asyncio.AbstractEventLoop,
+    owner: str,
+) -> bool:
+    close_method = getattr(session, "close", None)
+    if not callable(close_method):
+        return False
+
+    def create_task() -> None:
+        close_result: Any = None
+        try:
+            close_result = close_method()
+            if inspect.isawaitable(close_result):
+                task = loop.create_task(close_result)
+                task.add_done_callback(
+                    lambda done_task: _log_finalizer_close_task_result(done_task, owner)
+                )
+        except Exception as exc:  # pragma: no cover - defensive finalizer path
+            _close_awaitable(close_result)
+            logger.debug("Error scheduling %s aiohttp session close: %s", owner, exc)
+
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+
+    try:
+        if current_loop is loop:
+            create_task()
+        else:
+            loop.call_soon_threadsafe(create_task)
+    except Exception as exc:  # pragma: no cover - defensive finalizer path
+        logger.debug("Error scheduling %s aiohttp session close: %s", owner, exc)
+        return False
+    return True
+
+
+def _run_aiohttp_session_close(
+    session: Any,
+    loop: asyncio.AbstractEventLoop,
+    owner: str,
+) -> bool:
+    close_method = getattr(session, "close", None)
+    if not callable(close_method):
+        return False
+
+    close_result: Any = None
+    try:
+        close_result = close_method()
+        if inspect.isawaitable(close_result):
+            loop.run_until_complete(close_result)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive finalizer path
+        _close_awaitable(close_result)
+        logger.debug("Error closing %s aiohttp session on its loop: %s", owner, exc)
+        return False
+
+
+def _iter_connector_protocols(connector: Any) -> list[Any]:
+    protocols: list[Any] = []
+    seen: set[int] = set()
+
+    def add(protocol: Any) -> None:
+        if protocol is None:
+            return
+        identifier = id(protocol)
+        if identifier in seen:
+            return
+        seen.add(identifier)
+        protocols.append(protocol)
+
+    conns = getattr(connector, "_conns", None)
+    values = getattr(conns, "values", None)
+    if callable(values):
+        for pooled_connections in list(values()):
+            for connection_entry in list(pooled_connections):
+                protocol = connection_entry
+                if isinstance(connection_entry, (tuple, list)) and connection_entry:
+                    protocol = connection_entry[0]
+                add(getattr(protocol, "protocol", protocol))
+
+    for protocol in list(getattr(connector, "_acquired", ()) or ()):
+        add(getattr(protocol, "protocol", protocol))
+
+    return protocols
+
+
+def _raw_socket_from_transport(transport: Any) -> Any:
+    get_extra_info = getattr(transport, "get_extra_info", None)
+    if callable(get_extra_info):
+        try:
+            socket_info = get_extra_info("socket")
+        except Exception:
+            socket_info = None
+        if socket_info is not None:
+            return getattr(socket_info, "_sock", socket_info)
+    return getattr(transport, "_sock", None)
+
+
+def _close_transport_sync(transport: Any, seen: set[int] | None = None) -> None:
+    if transport is None:
+        return
+
+    if seen is None:
+        seen = set()
+    identifier = id(transport)
+    if identifier in seen:
+        return
+    seen.add(identifier)
+
+    for method_name in ("abort", "close"):
+        method = getattr(transport, method_name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+
+    call_connection_lost = getattr(transport, "_call_connection_lost", None)
+    if callable(call_connection_lost):
+        try:
+            call_connection_lost(None)
+        except Exception:
+            pass
+
+    raw_socket = _raw_socket_from_transport(transport)
+    if raw_socket is not None:
+        close_socket = getattr(raw_socket, "close", None)
+        if callable(close_socket):
+            try:
+                close_socket()
+            except Exception:
+                pass
+
+    for nested_attr in ("_transport",):
+        nested_transport = getattr(transport, nested_attr, None)
+        if nested_transport is not None:
+            _close_transport_sync(nested_transport, seen)
+
+    ssl_protocol = getattr(transport, "_ssl_protocol", None)
+    nested_transport = getattr(ssl_protocol, "_transport", None)
+    if nested_transport is not None:
+        _close_transport_sync(nested_transport, seen)
+
+
+def _close_protocol_sync(protocol: Any) -> None:
+    transport = getattr(protocol, "transport", None)
+
+    for method_name in ("abort", "close"):
+        method = getattr(protocol, method_name, None)
+        if callable(method):
+            try:
+                method()
+                break
+            except Exception:
+                pass
+
+    _close_transport_sync(transport)
+
+
+def _cancel_connector_handle(connector: Any, name: str) -> None:
+    handle = getattr(connector, name, None)
+    cancel = getattr(handle, "cancel", None)
+    if callable(cancel):
+        try:
+            cancel()
+        except Exception:
+            pass
+    if hasattr(connector, name):
+        try:
+            setattr(connector, name, None)
+        except Exception:
+            pass
+
+
+def _clear_connector_waiters(connector: Any) -> None:
+    waiters = getattr(connector, "_waiters", None)
+    values = getattr(waiters, "values", None)
+    if callable(values):
+        for keyed_waiters in list(values()):
+            for waiter in list(keyed_waiters):
+                cancel = getattr(waiter, "cancel", None)
+                if callable(cancel):
+                    try:
+                        cancel()
+                    except Exception:
+                        pass
+    clear = getattr(waiters, "clear", None)
+    if callable(clear):
+        try:
+            clear()
+        except Exception:
+            pass
+
+
+def _clear_connector_collection(connector: Any, name: str) -> None:
+    collection = getattr(connector, name, None)
+    clear = getattr(collection, "clear", None)
+    if callable(clear):
+        try:
+            clear()
+        except Exception:
+            pass
+
+
+def _close_connector_transports_sync(connector: Any) -> None:
+    for protocol in _iter_connector_protocols(connector):
+        _close_protocol_sync(protocol)
+
+    for transport in list(getattr(connector, "_cleanup_closed_transports", ()) or ()):
+        _close_transport_sync(transport)
+
+    for handle_name in ("_cleanup_handle", "_cleanup_closed_handle"):
+        _cancel_connector_handle(connector, handle_name)
+
+    _clear_connector_waiters(connector)
+    for collection_name in (
+        "_conns",
+        "_acquired",
+        "_acquired_per_host",
+        "_cleanup_closed_transports",
+    ):
+        _clear_connector_collection(connector, collection_name)
+
+    if hasattr(connector, "_closed"):
+        try:
+            connector._closed = True
+        except Exception:
+            pass
+
+
+def _close_aiohttp_session_transports_sync(session: Any) -> None:
+    connector = getattr(session, "_connector", None)
+    owns_connector = bool(getattr(session, "_connector_owner", True))
+
+    if connector is not None and owns_connector:
+        _close_connector_transports_sync(connector)
+
+    if hasattr(session, "_connector"):
+        try:
+            session._connector = None
+        except Exception:
+            pass
+
+
 def _finalize_aiohttp_session(session: Any, owner: str) -> None:
     """Synchronously close an aiohttp session from a weakref finalizer."""
 
@@ -119,18 +383,15 @@ def _finalize_aiohttp_session(session: Any, owner: str) -> None:
         if session is None or _session_is_closed(session):
             return
 
-        connector = getattr(session, "_connector", None)
-        owns_connector = bool(getattr(session, "_connector_owner", True))
-        if connector is not None and owns_connector:
-            close_now = getattr(connector, "_close", None)
-            if callable(close_now):
-                try:
-                    close_now(abort_ssl=True)
-                except TypeError:
-                    close_now()
+        session_loop = getattr(session, "_loop", None)
+        if session_loop is not None and not session_loop.is_closed():
+            if session_loop.is_running():
+                if _schedule_aiohttp_session_close(session, session_loop, owner):
+                    return
+            elif _run_aiohttp_session_close(session, session_loop, owner):
+                return
 
-        if hasattr(session, "_connector"):
-            session._connector = None
+        _close_aiohttp_session_transports_sync(session)
     except Exception as exc:  # pragma: no cover - defensive finalizer
         logger.debug("Error finalizing %s aiohttp session: %s", owner, exc)
 


### PR DESCRIPTION
Closes #1408.

## Problem (defensive hardening — no live first-party leak)
1. TraigentCloudClient + BackendIntegratedClient hold a LAZILY-created aiohttp ClientSession closed only by explicit close()/__aexit__. A caller that bare-constructs (no `async with`), triggers a request, then drops the ref without close() leaks the connection (aiohttp 'Unclosed client session' ResourceWarning). No __del__/finalizer net existed.
2. BackendSynchronizer.stop_background_sync/cleanup cancel background tasks then clear refs WITHOUT awaiting → 'Task was destroyed but it is pending' under teardown.

## Fix
1. Register a `weakref.finalize` (shared helper) when the aiohttp session is created; on GC-without-close it closes the session/connector synchronously (handles the async-close-in-sync-finalizer case + no-running-loop guard). Detached on explicit close() so there's no double-close.
2. stop_background_sync + cleanup now `await asyncio.gather(*tasks, return_exceptions=True)` (suppressing CancelledError) BEFORE clearing `_sync_tasks`.

## Tests
test_session_cleanup.py: bare-construct → lazy session → drop + gc.collect() asserts NO 'Unclosed client session' ResourceWarning for both clients. test_backend_synchronizer.py: cancelled tasks are awaited (no pending-task warning). Captain re-ran the cloud suite: 276 passed (1 pre-existing unrelated warning). ruff clean.

Spine-Trail: st_3ec4cdbd8f9f