### PR TITLE
fix(sdk-dx): actionable strategy=/algorithm= errors + quickstart docs reconcile (#1401)

### DIFF
--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -47,6 +47,7 @@ import asyncio
 from langchain_openai import ChatOpenAI
 import traigent
 
+
 @traigent.optimize(
     configuration_space={
         "model": ["gpt-4o-mini", "gpt-4o"],
@@ -59,6 +60,7 @@ def answer(question: str) -> str:
     cfg = traigent.get_config()
     llm = ChatOpenAI(model=cfg["model"], temperature=cfg["temperature"])
     return llm.invoke(question).content
+
 
 # Run optimization
 result = asyncio.run(answer.optimize(max_trials=6))
@@ -78,6 +80,10 @@ print(f"Best score:  {result.best_score:.2%}")
 ## 🧪 Datasets
 
 - Format: JSONL with `input` and optional `output`/`expected_output`
+- Beginner examples use the flat `eval_dataset=` keyword. The bundled
+  `evaluation=EvaluationOptions(...)` form is also supported when you want to
+  group evaluation settings, but `eval_dataset=` is the recommended minimal-call
+  shape in this guide.
 - Minimal example:
 
 ```jsonl
@@ -88,15 +94,12 @@ print(f"Best score:  {result.best_score:.2%}")
 ## 🎛️ Multiple Objectives
 
 ```python
-from traigent.api.decorators import EvaluationOptions
-
 @traigent.optimize(
     objectives=["accuracy", "cost", "latency"],
-    evaluation=EvaluationOptions(eval_dataset="data.jsonl"),
+    eval_dataset="data.jsonl",
     configuration_space={"temperature": (0.0, 1.0), "model": ["gpt-4o-mini", "gpt-4o"]},
 )
-def classify(text: str) -> str:
-    ...
+def classify(text: str) -> str: ...
 ```
 
 ## 🧪 Examples
@@ -129,6 +132,7 @@ pip install litellm
 ```python
 from litellm import completion
 
+
 @traigent.optimize(
     configuration_space={
         "model": ["gpt-4o-mini", "claude-3-haiku-20240307", "gemini/gemini-pro"],
@@ -138,7 +142,9 @@ from litellm import completion
 )
 def my_agent(query: str) -> str:
     config = traigent.get_config()
-    response = completion(model=config.get("model"), messages=[{"role": "user", "content": query}])
+    response = completion(
+        model=config.get("model"), messages=[{"role": "user", "content": query}]
+    )
     return str(response.choices[0].message.content)
 ```
 

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -12,6 +12,8 @@ from traigent.api.strategy_presets import (
     MAX_ACCURACY_THEN_CHEAPEST,
     PARETO_FRONTIER,
     QUALITY_FLOOR_MIN_COST,
+    VALID_PRESET_NAMES,
+    UnknownStrategyPresetError,
 )
 from traigent.api.types import ExampleResult
 from traigent.core.optimized_function import OptimizedFunction
@@ -219,8 +221,8 @@ class TestOptimizeDecorator:
         assert sample_function.algorithm == "grid"
 
     def test_decorator_rejects_unknown_strategy_name(self):
-        """Non-preset strategy values should raise ValueError."""
-        with pytest.raises(ValueError, match="Unknown strategy preset"):
+        """Non-preset strategy values should list valid presets."""
+        with pytest.raises(ValueError) as exc_info:
 
             @optimize(
                 configuration_space={"x": [1, 2]},
@@ -228,6 +230,15 @@ class TestOptimizeDecorator:
             )
             def sample_function(x: int) -> int:
                 return x
+
+        assert isinstance(exc_info.value, UnknownStrategyPresetError)
+        message = str(exc_info.value)
+        assert message == (
+            f"Unknown strategy preset 'grid'. Valid presets: "
+            f"{', '.join(VALID_PRESET_NAMES)}."
+        )
+        for preset_name in VALID_PRESET_NAMES:
+            assert preset_name in message
 
     def test_decorator_accepts_strategy_preset(self):
         """Registered strategy names should configure advisory preset metadata."""

--- a/tests/unit/api/test_execution_policy_resolution.py
+++ b/tests/unit/api/test_execution_policy_resolution.py
@@ -8,7 +8,11 @@ import warnings
 import pytest
 
 from traigent.api.decorators import ExecutionOptions, HybridAPIOptions, optimize
-from traigent.config.types import ExecutionIntent, resolve_execution_policy
+from traigent.config.types import (
+    ExecutionIntent,
+    accepted_algorithm_values,
+    resolve_execution_policy,
+)
 from traigent.core.optimized_function import OptimizedFunction
 from traigent.utils.exceptions import ConfigurationError
 
@@ -298,11 +302,19 @@ def test_offline_smart_algorithm_hard_errors() -> None:
 def test_unknown_algorithm_name_rejected() -> None:
     # Defect #3 regression: unknown ``optuna_*`` (and any unknown) name must be
     # rejected at the public boundary, not accepted-then-failed later.
-    with pytest.raises(ValueError, match="known smart optimizer name"):
+    with pytest.raises(ValueError) as exc_info:
 
         @optimize(configuration_space={"x": [1, 2]}, algorithm="optuna_foo")
         def sample(x: int) -> int:
             return x
+
+    message = str(exc_info.value)
+    assert message.startswith("algorithm must be one of: ")
+    for algorithm_name in accepted_algorithm_values():
+        assert algorithm_name in message
+    assert "optuna_tpe" in message
+    assert "bayesian" in message
+    assert "got 'optuna_foo'" in message
 
 
 def test_known_smart_algorithm_names_accepted() -> None:

--- a/tests/unit/config/test_types.py
+++ b/tests/unit/config/test_types.py
@@ -7,8 +7,10 @@ import pytest
 from traigent.config.types import (
     ExecutionMode,
     TraigentConfig,
+    accepted_algorithm_values,
     accepted_execution_mode_values,
     resolve_execution_mode,
+    validate_algorithm_name,
     validate_execution_mode,
 )
 from traigent.utils.exceptions import ConfigurationError, ValidationError
@@ -249,6 +251,20 @@ class TestTraigentConfig:
         assert result["custom_setting"] is True
         assert result["api_version"] == "2023-07-01"
         assert result["model"] == "GPT-4o"
+
+
+class TestValidateAlgorithmName:
+    """Tests for validate_algorithm_name function."""
+
+    def test_unknown_algorithm_message_lists_canonical_names(self) -> None:
+        """Unknown algorithm errors should enumerate the accepted public names."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_algorithm_name("optuna_foo")
+
+        message = str(exc_info.value)
+        for algorithm_name in accepted_algorithm_values():
+            assert algorithm_name in message
+        assert "optuna_foo" in message
 
 
 class TestValidateExecutionMode:

--- a/tests/unit/optimizers/test_public_contract_characterization.py
+++ b/tests/unit/optimizers/test_public_contract_characterization.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pytest
 
 import traigent.optimizers as optimizer_exports
-from traigent.config.types import resolve_execution_policy, validate_algorithm_name
+from traigent.config.types import (
+    accepted_algorithm_values,
+    resolve_execution_policy,
+    validate_algorithm_name,
+)
 from traigent.core.stop_conditions import (
     CostLimitStopCondition,
     HypervolumeConvergenceStopCondition,
@@ -82,8 +86,13 @@ def test_validate_algorithm_name_accepts_public_names(name: str) -> None:
 
 
 def test_validate_algorithm_name_rejects_unknown_optuna_variant() -> None:
-    with pytest.raises(ValueError, match="known smart optimizer"):
+    with pytest.raises(ValueError) as exc_info:
         validate_algorithm_name("optuna_foo")
+
+    message = str(exc_info.value)
+    for algorithm_name in accepted_algorithm_values():
+        assert algorithm_name in message
+    assert "optuna_foo" in message
 
 
 @pytest.mark.parametrize("name", SMART_OPTIMIZER_NAMES)

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -64,6 +64,7 @@ from traigent.api.parameter_ranges import (
 )
 from traigent.api.strategy_presets import (
     NormalizedStrategyPreset,
+    UnknownStrategyPresetError,
     is_strategy_preset_name,
     normalize_strategy_preset,
 )
@@ -1057,11 +1058,7 @@ def _resolve_strategy_argument(
     if is_strategy_preset_name(strategy) or strategy_params is not None:
         return strategy, runtime_overrides
 
-    raise ValueError(
-        f"Unknown strategy preset: {strategy!r}. "
-        "Use 'algorithm' to select an optimizer by name, or provide a valid "
-        "strategy preset name."
-    )
+    raise UnknownStrategyPresetError(strategy)
 
 
 def _apply_strategy_preset_to_options(

--- a/traigent/config/types.py
+++ b/traigent/config/types.py
@@ -166,10 +166,8 @@ def validate_algorithm_name(algorithm: str | None) -> str:
         or normalized in _SMART_ALGORITHMS
     ):
         return normalized
-    raise ValueError(
-        "algorithm must be 'auto', 'grid', 'random', or a known smart optimizer "
-        f"name, got {algorithm!r}"
-    )
+    valid = ", ".join(accepted_algorithm_values())
+    raise ValueError(f"algorithm must be one of: {valid}; got {algorithm!r}")
 
 
 def accepted_execution_mode_values() -> tuple[str, ...]:


### PR DESCRIPTION
Closes #1401 (Friction B + docs part of A; the optional typed-signature/@overload redesign is noted as a follow-up).

## Friction B — non-actionable entry-surface errors (the real bug)
- Unknown `strategy=` preset now raises the EXISTING actionable `UnknownStrategyPresetError(strategy)` (enumerates `VALID_PRESET_NAMES`) instead of a bare ValueError that said 'you're wrong' without the valid names. (Still catchable as ValueError.)
- Unknown `algorithm=` now ENUMERATES the real smart-optimizer names via `accepted_algorithm_values()` (single source of truth) instead of hiding them behind 'a known smart optimizer name'.

## Friction A — docs only
- Reconciled `GETTING_STARTED.md` flat (`eval_dataset=`) vs bundle (`EvaluationOptions`): recommend the flat minimal-call shape for beginners, note the bundle still exists. (Did NOT redesign the signature — that optional typed-@overload work is a follow-up.)

## Tests
Assert unknown strategy=/algorithm= now raise messages CONTAINING the valid names (non-tautological); updated the stale existing tests that asserted the old messages. Captain re-ran: 1130 passed, 0 failed. ruff clean.

Spine-Trail: st_337c2a1f9e3d