### PR TITLE
docs(cleanup): drop dead optuna link; evaluation-dataset noun

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Works with any LLM provider — [OpenAI](https://platform.openai.com/docs), [Ant
 | **Get started** | [Installation](docs/getting-started/installation.md) · [5-minute tutorial](docs/getting-started/GETTING_STARTED.md) |
 | **User guides** | [Injection Modes](docs/user-guide/injection_modes.md) · [Configuration Spaces](docs/user-guide/configuration-spaces.md) · [Evaluation](docs/user-guide/evaluation_guide.md) |
 | **Tunable Variable Language** | [TVL Guide](docs/user-guide/tuned_variables.md) |
-| **Advanced** | [Agent Optimization](docs/user-guide/agent_optimization.md) · [Optuna Integration](docs/user-guide/optuna_integration.md) |
+| **Advanced** | [Agent Optimization](docs/user-guide/agent_optimization.md) |
 | **API reference** | [Decorator Reference](docs/api-reference/decorator-reference.md) · [Constraint DSL](docs/features/constraint-dsl.md) |
 
 </details>

--- a/examples/core/guided-generation/README.md
+++ b/examples/core/guided-generation/README.md
@@ -1,6 +1,6 @@
 # Guided Generation
 
-**Privacy-preserving prompt rewrite + benchmark growth, guided by backend tuning
+**Privacy-preserving prompt rewrite + evaluation dataset growth, guided by backend tuning
 signals — without ever revealing those signals.**
 
 Traigent can generate *new* tuning material for you:
@@ -8,7 +8,7 @@ Traigent can generate *new* tuning material for you:
 - **Prompt rewrite** — LLM-generated prompt candidates aimed at your prompt's
   measured weak spots, folded into the configuration space as new `Choices` the
   optimizer searches (no optimizer changes).
-- **Benchmark guide generation** — new evaluation examples synthesized near the
+- **Evaluation dataset guide generation** — new evaluation examples synthesized near the
   informative/difficult frontier, growing your dataset.
 
 Both run **on your own LLM** in privacy mode, so prompt text and example content


### PR DESCRIPTION
## What
Audit-driven doc cleanup (wave 2):
- `README.md`: drop the dead `docs/user-guide/optuna_integration.md` link (Optuna was removed from the SDK; target file doesn't exist).
- `examples/core/guided-generation/README.md`: use the public noun "evaluation dataset" instead of "benchmark" in prose.

## Why
Found by a read-only stale-docs audit on latest `develop`. Docs prose only — no code, API, or schema change. `rg` confirms no remaining reference to the removed link.
Independently reviewed (codex 5.5 xhigh): GO.

Spine-Trail: st_5c962ce89f9f
