### PR TITLE
fix(sdk): all-fail best_config {}->None canonical shape (#1406)

### DIFF
--- a/tests/integration/test_full_optimization.py
+++ b/tests/integration/test_full_optimization.py
@@ -85,7 +85,10 @@ class TestFullOptimizationWorkflow:
 
         # Verify results - should have some trials
         assert len(result.trials) > 0
-        assert result.best_config is not None
+        if result.best_score is None:
+            assert result.best_config is None
+        else:
+            assert result.best_config is not None
 
     @pytest.mark.asyncio
     async def test_optimization_with_jsonl_file(self, jsonl_dataset_file):
@@ -170,7 +173,7 @@ class TestFullOptimizationWorkflow:
                 assert (
                     session_summary.get("reason_code") == "NO_RANKING_ELIGIBLE_TRIALS"
                 )
-                assert result.best_config == {}
+                assert result.best_config is None
             else:
                 assert result.best_score >= 0
             assert result.algorithm == "RandomSearchOptimizer"

--- a/tests/unit/agents/test_specification_generator.py
+++ b/tests/unit/agents/test_specification_generator.py
@@ -616,6 +616,35 @@ import requests.auth
         assert updated_spec.metadata["optimized"] is True
         assert "last_optimization" in updated_spec.metadata
 
+    def test_update_agent_specification_skips_none_best_config(self, spec_generator):
+        """All-fail optimization results should not be treated as a dict config."""
+        spec = AgentSpecification(
+            id="test-agent",
+            name="Test Agent",
+            agent_type="conversational",
+            agent_platform="openai",
+            prompt_template="Test",
+            model_parameters={"model": "gpt-4o-mini", "temperature": 0.7},
+            metadata={},
+        )
+
+        optimization_results = {
+            "best_config": None,
+            "best_score": None,
+            "iterations": 3,
+        }
+
+        updated_spec = spec_generator.update_agent_specification(
+            spec, optimization_results
+        )
+
+        assert updated_spec.model_parameters == {
+            "model": "gpt-4o-mini",
+            "temperature": 0.7,
+        }
+        assert updated_spec.metadata["optimization_results"] == optimization_results
+        assert updated_spec.metadata["optimized"] is True
+
     def test_extract_optimization_config_from_traigent_config(
         self, spec_generator, sample_traigent_config
     ):

--- a/tests/unit/api/test_types.py
+++ b/tests/unit/api/test_types.py
@@ -516,6 +516,24 @@ class TestOptimizationResult:
 
         assert result.best_metrics == {}
 
+    def test_best_metrics_none_best_config_no_winner(self):
+        """All-fail results use None best_config and make no best-metrics claim."""
+        result = OptimizationResult(
+            trials=self.trials,
+            best_config=None,
+            best_score=None,
+            optimization_id="opt_001",
+            duration=10.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=["accuracy"],
+            algorithm="random",
+            timestamp=datetime.now(),
+        )
+
+        assert result.best_config is None
+        assert result.best_metrics == {}
+
     def test_to_dataframe(self):
         """Test to_dataframe method."""
         result = OptimizationResult(

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -1962,6 +1962,32 @@ class TestConfigPersistence:
             assert loaded is not None
             assert loaded["temperature"] == pytest.approx(0.3)
 
+    def test_load_config_from_path_null_best_config(
+        self, mock_function, sample_config_space, sample_objectives, sample_dataset
+    ):
+        """All-fail best_config artifacts should load as no config, not crash."""
+        opt_func = OptimizedFunction(
+            func=mock_function,
+            configuration_space=sample_config_space,
+            objectives=sample_objectives,
+            eval_dataset=sample_dataset,
+        )
+
+        import json
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "best_config.json"
+            config_data = {
+                "best_config": None,
+                "best_score": None,
+            }
+            with open(config_path, "w") as f:
+                json.dump(config_data, f)
+
+            loaded = opt_func._load_config_from_path(str(config_path))
+
+            assert loaded is None
+
     def test_load_config_from_path_direct_dict(
         self, mock_function, sample_config_space, sample_objectives, sample_dataset
     ):

--- a/tests/unit/core/test_orchestrator.py
+++ b/tests/unit/core/test_orchestrator.py
@@ -759,7 +759,7 @@ class TestOptimizationOrchestrator:
 
         assert result.status == OptimizationStatus.COMPLETED
         assert len(result.trials) == 0
-        assert result.best_config == {}
+        assert result.best_config is None
         assert result.best_metrics == {}
         assert result.best_score is None
 
@@ -796,7 +796,8 @@ class TestOptimizationOrchestrator:
             result.status == OptimizationStatus.COMPLETED
         )  # Optimization completes even if all fail
         assert len(result.trials) == 3  # All trials are recorded, even if failed
-        assert result.best_config == {}  # No successful config
+        assert result.best_config is None  # No successful config
+        assert result.best_score is None
 
         # Check that failed trials are recorded
         failed_trials = [t for t in result.trials if t.status == TrialStatus.FAILED]

--- a/tests/unit/core/test_result_selection.py
+++ b/tests/unit/core/test_result_selection.py
@@ -61,7 +61,7 @@ def test_returns_default_when_no_successful_trials():
         aggregate_configs=False,
     )
     assert result == SelectionResult(
-        best_config={},
+        best_config=None,
         best_score=None,
         session_summary={
             "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
@@ -82,7 +82,7 @@ def test_returns_default_when_no_successful_trials():
 def test_trial_completed_with_zero_successful_examples_yields_no_winner():
     """Regression: a trial that completes but had 0 successful examples
     (e.g. every provider call inside it 404'd on a deprecated model) is not
-    a valid winner. best_score must be None, best_config must be {}."""
+    a valid winner. best_score must be None, best_config must be None."""
     trials = [
         FakeTrial(metrics={"accuracy": 0.0}, config={"model": "deprecated-a"}),
         FakeTrial(metrics={"accuracy": 0.0}, config={"model": "deprecated-b"}),
@@ -100,7 +100,7 @@ def test_trial_completed_with_zero_successful_examples_yields_no_winner():
     )
 
     assert result.best_score is None
-    assert result.best_config == {}
+    assert result.best_config is None
     assert result.reason_code == NO_RANKING_ELIGIBLE_TRIALS
 
 
@@ -311,7 +311,7 @@ def test_aggregated_selection_all_nan_returns_no_eligible_reason():
         comparability_mode="legacy",
     )
 
-    assert result.best_config == {}
+    assert result.best_config is None
     assert result.best_score is None
     assert result.reason_code == NO_RANKING_ELIGIBLE_TRIALS
 
@@ -770,7 +770,7 @@ def test_execute_only_quality_objective_is_ineligible():
         aggregate_configs=False,
     )
 
-    assert result.best_config == {}
+    assert result.best_config is None
     assert result.best_score is None
     assert result.reason_code == NO_RANKING_ELIGIBLE_TRIALS
 
@@ -786,7 +786,7 @@ def test_unknown_comparability_is_excluded_by_default():
         aggregate_configs=False,
     )
 
-    assert result.best_config == {}
+    assert result.best_config is None
     assert result.best_score is None
     assert result.reason_code == NO_RANKING_ELIGIBLE_TRIALS
     assert result.session_summary is not None

--- a/tests/unit/visualization/test_plots.py
+++ b/tests/unit/visualization/test_plots.py
@@ -1079,6 +1079,21 @@ class TestGenerateOptimizationReport:
         assert "learning_rate: 0.01" in report
         assert "batch_size: 32" in report
 
+    def test_report_handles_none_best_configuration(
+        self, plotter: PlotGenerator
+    ) -> None:
+        """All-fail optimization reports should not iterate a missing config."""
+        trials = [_make_trial("t1", 0.9, 0.5)]
+        result = _make_result(trials, {}, objectives=["accuracy"])
+        result.best_config = None
+
+        with patch.object(plotter, "plot_optimization_progress") as mock_progress:
+            mock_progress.return_value = "PROGRESS_PLOT_HERE"
+            report = plotter.generate_optimization_report(result)
+
+        assert "Best Configuration" in report
+        assert "No best configuration available" in report
+
 
 class TestCreateQuickPlot:
     """Tests for create_quick_plot function."""

--- a/traigent/agents/specification_generator.py
+++ b/traigent/agents/specification_generator.py
@@ -443,8 +443,8 @@ class SpecificationGenerator:
         )
 
         # Update model parameters with best configuration
-        if "best_config" in optimization_results:
-            best_config = optimization_results["best_config"]
+        best_config = optimization_results.get("best_config")
+        if isinstance(best_config, dict):
             updated_params = (agent_spec.model_parameters or {}).copy()
 
             # Update with optimized parameters

--- a/traigent/api/types.py
+++ b/traigent/api/types.py
@@ -667,7 +667,8 @@ class OptimizationResult:
 
     Attributes:
         trials: List of all trial results from the optimization.
-        best_config: The configuration that achieved the best score.
+        best_config: The configuration that achieved the best score, or None
+            when no eligible trial produced a winner.
         best_score: The best objective score achieved (None when no eligible trial).
         optimization_id: Unique identifier for this optimization run.
         duration: Total wall-clock time in seconds.
@@ -703,7 +704,7 @@ class OptimizationResult:
     """
 
     trials: list[TrialResult]
-    best_config: dict[str, Any]
+    best_config: dict[str, Any] | None
     best_score: float | None
     optimization_id: str
     duration: float
@@ -777,10 +778,10 @@ class OptimizationResult:
     def best_metrics(self) -> dict[str, float]:
         """Get best metrics from the best trial.
 
-        A result with NO WINNER — empty ``best_config`` AND ``best_score``
-        of ``None``, the NO_CERTIFIED_SELECTION shape from strict evidence
-        runs — makes no winner-metric claims. A valid winner whose config
-        happens to be empty still carries a score and keeps its metrics.
+        A result with NO WINNER — ``best_config`` missing/empty AND
+        ``best_score`` of ``None`` — makes no winner-metric claims. A valid
+        winner whose config happens to be empty still carries a score and
+        keeps its metrics.
         """
         if not self.best_config and self.best_score is None:
             return {}
@@ -1372,7 +1373,7 @@ class OptimizationResult:
 
     def _select_best_weighted_result(
         self, weighted_scores: list[tuple[TrialResult, float]]
-    ) -> tuple[dict[str, Any], float]:
+    ) -> tuple[dict[str, Any] | None, float]:
         """Select the best configuration from computed weighted scores."""
 
         if not weighted_scores:
@@ -1459,7 +1460,7 @@ class OptimizationResult:
         Winner-claim note (FR-SDK-FAIL-CLOSED-PROMOTION-V1): the per-trial
         weighted scores are DESCRIPTIVE statistics and always computed; the
         ``best_weighted_config`` key is a winner claim and is omitted when the
-        result carries no certified winner (empty ``best_config``).
+        result carries no certified winner (missing/empty ``best_config``).
 
         Args:
             objective_weights: Dictionary of objective weights (defaults to equal weights)

--- a/traigent/core/config_state_manager.py
+++ b/traigent/core/config_state_manager.py
@@ -809,9 +809,11 @@ class ConfigStateManager:
                 data = json.load(f)
 
             if "config" in data:
-                return dict(data["config"])
+                config = data["config"]
+                return dict(config) if config is not None else None
             elif "best_config" in data:
-                return dict(data["best_config"])
+                best_config = data["best_config"]
+                return dict(best_config) if best_config is not None else None
             elif isinstance(data, dict) and not any(
                 k in data for k in ["trials", "metrics", "metadata"]
             ):

--- a/traigent/core/result_selection.py
+++ b/traigent/core/result_selection.py
@@ -35,7 +35,7 @@ PRIMARY_SCORE_TIE_ABS_TOL = 1e-12
 class SelectionResult:
     """Best-configuration selection output for orchestrator result building."""
 
-    best_config: dict[str, Any]
+    best_config: dict[str, Any] | None
     best_score: float | None
     session_summary: dict[str, Any] | None
     reason_code: str | None = None
@@ -411,7 +411,7 @@ def _select_best_single_trial(
             scored_trials.append((trial, score))
     if not scored_trials:
         return SelectionResult(
-            best_config={},
+            best_config=None,
             best_score=None,
             session_summary={
                 "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
@@ -568,7 +568,7 @@ def _select_best_aggregated(
     """Select best configuration from aggregated results with tie-breaking."""
     if not aggregated:
         return SelectionResult(
-            best_config={},
+            best_config=None,
             best_score=None,
             session_summary={
                 "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
@@ -595,7 +595,7 @@ def _select_best_aggregated(
     all_scores = [s for s in all_scores if math.isfinite(s)]
     if not all_scores:
         return SelectionResult(
-            best_config={},
+            best_config=None,
             best_score=None,
             session_summary={
                 "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
@@ -786,7 +786,7 @@ def select_best_configuration(
         )
     if not successful_trials:
         return SelectionResult(
-            best_config={},
+            best_config=None,
             best_score=None,
             session_summary={
                 "reason_code": NO_RANKING_ELIGIBLE_TRIALS,
@@ -829,7 +829,7 @@ def select_best_configuration(
 
     if not eligible_trials:
         return SelectionResult(
-            best_config={},
+            best_config=None,
             best_score=None,
             session_summary={
                 "reason_code": NO_RANKING_ELIGIBLE_TRIALS,

--- a/traigent/examples/quickstart/__main__.py
+++ b/traigent/examples/quickstart/__main__.py
@@ -159,7 +159,7 @@ def main() -> None:
 
     # Fail closed on an all-failed run. If every trial errors (or the run is
     # otherwise misconfigured), optimize() returns NORMALLY with best_score=None
-    # / best_config={} — it does not raise — so without this guard the quickstart
+    # / best_config=None — it does not raise — so without this guard the quickstart
     # would exit 0 on a run that produced no winner, i.e. a silent all-failed run
     # that looks like success (CLAUDE.md Rule 2: no fake completion). The import
     # guard above only covers the missing-litellm case.

--- a/traigent/visualization/plots.py
+++ b/traigent/visualization/plots.py
@@ -608,8 +608,11 @@ class PlotGenerator:
         # Best configuration
         lines.append("🏆 Best Configuration")
         lines.append("-" * 30)
-        for param, value in result.best_config.items():
-            lines.append(f"{param}: {value}")
+        if result.best_config:
+            for param, value in result.best_config.items():
+                lines.append(f"{param}: {value}")
+        else:
+            lines.append("No best configuration available")
         lines.append("")
 
         return "\n".join(lines)


### PR DESCRIPTION
Closes #1406 (Python SDK side). **Owner-decided** canonical all-fail shape = null/None.

## Problem
On an all-fail run Python returned `best_config={}` / `best_score=None` while JS returns `bestConfig=null` — cross-SDK readers broke.

## Fix (owner decision: null/None canonical)
- All-fail / no-rankable path (`core/result_selection.py`) now returns `best_config=None` (was `{}`); `best_score` stays None.
- `OptimizationResult.best_config` type → `dict[str, Any] | None`.
- Audited + guarded every `best_config` dict-reader so None can't crash them (spec generation, visualization report, config-state export, quickstart). The widely-used `if result.best_config:` truthiness guards already handle both `{}` and None.
- Success path unchanged (returns the winning dict).
- JS already returns null → no JS change. **TraigentSchema doc-update is a merge-blocking-free follow-up** to record the canonical shape.

## Tests
All-fail returns `best_config is None`; success returns the winning dict; readers handle None. Captain re-ran a broad consumer slice (core + visualization + agents + api): **2098 passed, 0 failed**; ruff clean.

## PR checklist
- Worst-case prod path: a None `best_config` reaching an unguarded `.items()`/`[key]` → crash. Audited all readers; guarded. Tests cover the all-fail None path.
- Contract: this is a public-shape change (`{}`→None) decided by the owner; aligns Python to JS's existing null. Schema doc follow-up noted.

Spine-Trail: st_8da9a917b24a