### PR TITLE
fix(sdk): @optimize default max_trials 50->10 + implicit-default notice (#1405)

### DIFF
--- a/docs/api-reference/complete-function-specification.md
+++ b/docs/api-reference/complete-function-specification.md
@@ -255,7 +255,7 @@ Unknown keys are forwarded to the optimizer and may raise errors when unsupporte
 **Example:**
 ```python
 # Run optimization with the default smart optimizer
-result = await my_agent.optimize(max_trials=50)
+result = await my_agent.optimize()
 
 # Save results
 await my_agent.save_optimization_results("results.json")

--- a/docs/api-reference/decorator-reference.md
+++ b/docs/api-reference/decorator-reference.md
@@ -570,7 +570,7 @@ Legacy `execution_mode=` inputs are deprecated compatibility shims. Use
 Run controls such as `max_trials` and `timeout` are passed to `.optimize()`:
 
 ```python
-result = await my_agent.optimize(max_trials=50, timeout=3600)
+result = await my_agent.optimize(max_trials=10, timeout=3600)
 ```
 
 **Cost Controls**:

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -15,7 +15,6 @@ from traigent.api.strategy_presets import (
 )
 from traigent.api.types import ExampleResult
 from traigent.core.optimized_function import OptimizedFunction
-from traigent.defaults import DEFAULT_MAX_TRIALS
 from traigent.evaluators.base import Dataset
 from traigent.utils.exceptions import ConfigurationError
 
@@ -216,7 +215,7 @@ class TestOptimizeDecorator:
             return x
 
         assert isinstance(sample_function, OptimizedFunction)
-        assert sample_function.max_trials == DEFAULT_MAX_TRIALS
+        assert sample_function.max_trials == 10
 
     def test_decorator_accepts_algorithm_runtime_default(self):
         """Decorator-level algorithm should become the optimize() default."""

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -15,6 +15,7 @@ from traigent.api.strategy_presets import (
 )
 from traigent.api.types import ExampleResult
 from traigent.core.optimized_function import OptimizedFunction
+from traigent.defaults import DEFAULT_MAX_TRIALS
 from traigent.evaluators.base import Dataset
 from traigent.utils.exceptions import ConfigurationError
 
@@ -190,7 +191,7 @@ class TestOptimizeDecorator:
         """Regression: max_trials from decorator must reach OptimizedFunction.
 
         Bug: max_trials went into combined_settings via record_option but was
-        never extracted, so OptimizedFunction always got the default of 50.
+        never extracted, so OptimizedFunction always got the SDK default.
         """
 
         @optimize(
@@ -204,6 +205,18 @@ class TestOptimizeDecorator:
         assert sample_function.max_trials == 10, (
             f"max_trials should be 10 (from decorator), got {sample_function.max_trials}"
         )
+
+    def test_decorator_omitted_max_trials_uses_sdk_default(self):
+        """Omitting max_trials on the decorator should use the shared default."""
+
+        @optimize(
+            configuration_space={"x": [1, 2, 3]},
+        )
+        def sample_function(x: int) -> int:
+            return x
+
+        assert isinstance(sample_function, OptimizedFunction)
+        assert sample_function.max_trials == DEFAULT_MAX_TRIALS
 
     def test_decorator_accepts_algorithm_runtime_default(self):
         """Decorator-level algorithm should become the optimize() default."""

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -20,6 +20,7 @@ import pytest
 import traigent
 from traigent.api.types import ExampleResult, OptimizationResult, OptimizationStatus
 from traigent.core.optimized_function import OptimizationState, OptimizedFunction
+from traigent.defaults import DEFAULT_MAX_TRIALS
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.utils.exceptions import (
     ConfigurationError,
@@ -139,7 +140,7 @@ class TestOptimizedFunction:
         assert opt_func.configuration_space == sample_config_space
         assert opt_func.objectives == sample_objectives
         assert opt_func.algorithm == "random"  # default
-        assert opt_func.max_trials == 50  # default
+        assert opt_func.max_trials == DEFAULT_MAX_TRIALS  # default
         assert opt_func.custom_evaluator is None
 
     def test_optimized_function_creation_with_all_params(
@@ -585,6 +586,158 @@ class TestOptimizedFunction:
 
         with pytest.raises(ValueError, match="max_trials must be a positive integer"):
             await opt_func.optimize(max_trials=0)
+
+    @pytest.mark.asyncio
+    async def test_optimize_logs_implicit_default_max_trials_once(
+        self,
+        caplog,
+        mock_function,
+        sample_config_space,
+        sample_objectives,
+        sample_dataset,
+    ):
+        """Omitted max_trials should resolve to 10 and emit one informational notice."""
+        opt_func = OptimizedFunction(
+            func=mock_function,
+            configuration_space=sample_config_space,
+            objectives=sample_objectives,
+            eval_dataset=sample_dataset,
+        )
+
+        from datetime import datetime
+
+        from traigent.api.types import TrialResult, TrialStatus
+
+        mock_result = OptimizationResult(
+            trials=[
+                TrialResult(
+                    trial_id="trial_default_notice",
+                    config={"temperature": 0.5},
+                    metrics={"accuracy": 0.8},
+                    status=TrialStatus.COMPLETED,
+                    duration=1.0,
+                    timestamp=datetime.now(),
+                    metadata={},
+                )
+            ],
+            best_config={"temperature": 0.5},
+            best_score=0.8,
+            optimization_id="opt_default_notice",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=sample_objectives,
+            algorithm="random",
+            timestamp=datetime.now(),
+            metadata={},
+        )
+
+        with (
+            patch(
+                "traigent.core.optimized_function.get_optimizer"
+            ) as mock_get_optimizer,
+            patch(
+                "traigent.core.optimized_function.OptimizationOrchestrator"
+            ) as mock_orchestrator_class,
+            caplog.at_level("INFO", logger="traigent.core.optimized_function"),
+        ):
+            mock_get_optimizer.return_value = Mock()
+            mock_orchestrator = Mock()
+            mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            result = await opt_func.optimize(algorithm="random")
+            second_result = await opt_func.optimize(algorithm="random")
+
+        assert result is mock_result
+        assert second_result is mock_result
+        assert mock_get_optimizer.call_count == 2
+        mock_get_optimizer.assert_any_call(
+            "random",
+            sample_config_space,
+            sample_objectives,
+            max_trials=DEFAULT_MAX_TRIALS,
+        )
+        notices = [
+            record.message
+            for record in caplog.records
+            if "Using default max_trials=" in record.message
+        ]
+        assert notices == [
+            f"Using default max_trials={DEFAULT_MAX_TRIALS}; pass max_trials=... to change."
+        ]
+
+    @pytest.mark.asyncio
+    async def test_optimize_skips_default_notice_for_explicit_max_trials(
+        self,
+        caplog,
+        mock_function,
+        sample_config_space,
+        sample_objectives,
+        sample_dataset,
+    ):
+        """Explicit max_trials should be honored unchanged without the default notice."""
+        opt_func = OptimizedFunction(
+            func=mock_function,
+            configuration_space=sample_config_space,
+            objectives=sample_objectives,
+            eval_dataset=sample_dataset,
+        )
+
+        from datetime import datetime
+
+        from traigent.api.types import TrialResult, TrialStatus
+
+        mock_result = OptimizationResult(
+            trials=[
+                TrialResult(
+                    trial_id="trial_explicit_notice",
+                    config={"temperature": 0.6},
+                    metrics={"accuracy": 0.9},
+                    status=TrialStatus.COMPLETED,
+                    duration=1.0,
+                    timestamp=datetime.now(),
+                    metadata={},
+                )
+            ],
+            best_config={"temperature": 0.6},
+            best_score=0.9,
+            optimization_id="opt_explicit_notice",
+            duration=1.0,
+            convergence_info={},
+            status=OptimizationStatus.COMPLETED,
+            objectives=sample_objectives,
+            algorithm="random",
+            timestamp=datetime.now(),
+            metadata={},
+        )
+
+        with (
+            patch(
+                "traigent.core.optimized_function.get_optimizer"
+            ) as mock_get_optimizer,
+            patch(
+                "traigent.core.optimized_function.OptimizationOrchestrator"
+            ) as mock_orchestrator_class,
+            caplog.at_level("INFO", logger="traigent.core.optimized_function"),
+        ):
+            mock_get_optimizer.return_value = Mock()
+            mock_orchestrator = Mock()
+            mock_orchestrator.optimize = AsyncMock(return_value=mock_result)
+            mock_orchestrator_class.return_value = mock_orchestrator
+
+            result = await opt_func.optimize(algorithm="random", max_trials=17)
+
+        assert result is mock_result
+        mock_get_optimizer.assert_called_with(
+            "random",
+            sample_config_space,
+            sample_objectives,
+            max_trials=17,
+        )
+        assert not any(
+            "Using default max_trials=" in record.message for record in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_optimize_with_custom_evaluator(

--- a/tests/unit/core/test_optimized_function.py
+++ b/tests/unit/core/test_optimized_function.py
@@ -140,7 +140,7 @@ class TestOptimizedFunction:
         assert opt_func.configuration_space == sample_config_space
         assert opt_func.objectives == sample_objectives
         assert opt_func.algorithm == "random"  # default
-        assert opt_func.max_trials == DEFAULT_MAX_TRIALS  # default
+        assert opt_func.max_trials == 10  # owner-decided default
         assert opt_func.custom_evaluator is None
 
     def test_optimized_function_creation_with_all_params(

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -88,6 +88,7 @@ from traigent.core.objectives import (
     normalize_objectives,
 )
 from traigent.core.optimized_function import OptimizedFunction
+from traigent.defaults import DEFAULT_MAX_TRIALS
 from traigent.evaluators.base import Dataset, EvaluationExample
 from traigent.tvl.options import TVLOptions
 from traigent.tvl.promotion_gate import PromotionGate
@@ -560,7 +561,7 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "injection": None,
     "execution": None,
     "mock": None,
-    "max_trials": 50,
+    "max_trials": DEFAULT_MAX_TRIALS,
     # Early stopping parameters
     "plateau_window": None,  # Stop if no improvement for N trials
     "plateau_epsilon": None,  # Improvement threshold for plateau detection
@@ -2318,6 +2319,9 @@ def optimize(  # NOSONAR(S107)
         return passthrough_decorator
 
     legacy_args = _parse_legacy_args(legacy)
+    max_trials_explicit = runtime_overrides.get("max_trials") is not None
+    if legacy_args is not None and legacy_args.max_trials is not None:
+        max_trials_explicit = True
 
     combined_settings = dict(_OPTIMIZE_DEFAULTS)
     if "execution_mode" in _GLOBAL_CONFIG:
@@ -2810,6 +2814,7 @@ def optimize(  # NOSONAR(S107)
             strategy_preset=strategy_preset,
             # Optimizer limits (extracted from combined_settings)
             max_trials=max_trials_value,
+            _max_trials_explicit=max_trials_explicit,
             # Experiment display name (overrides func.__name__ in portal/storage)
             experiment_name=experiment_name_value,
             # Guided-generation defaults (consumed by optimize_with_guidance)

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -94,6 +94,7 @@ from traigent.core.optimization_pipeline import (
     resolve_execution_parameters,
 )
 from traigent.core.orchestrator import OptimizationOrchestrator
+from traigent.defaults import DEFAULT_MAX_TRIALS
 from traigent.evaluators.base import (
     BaseEvaluator,
     Dataset,
@@ -392,6 +393,13 @@ class OptimizedFunction(Generic[_P, _R]):
             **kwargs: Additional configuration
         """
         # Extract decorator-provided metadata before core storage
+        max_trials_explicit = kwargs.pop("_max_trials_explicit", None)
+        self._max_trials_uses_sdk_default = (
+            "max_trials" not in kwargs
+            if max_trials_explicit is None
+            else not bool(max_trials_explicit)
+        )
+        self._max_trials_default_notice_logged = False
         self._requested_execution_mode = kwargs.pop("requested_execution_mode", None)
         provided_execution_policy = kwargs.pop("execution_policy", None)
         self.execution_policy = (
@@ -603,7 +611,7 @@ class OptimizedFunction(Generic[_P, _R]):
         self.algorithm = kwargs.pop("algorithm", "random")
         kwargs["algorithm"] = self.algorithm
 
-        self.max_trials = kwargs.pop("max_trials", 50)
+        self.max_trials = kwargs.pop("max_trials", DEFAULT_MAX_TRIALS)
         kwargs["max_trials"] = self.max_trials
 
         # Experiment display name: decorator param > TRAIGENT_EXPERIMENT_NAME > func.__name__
@@ -2327,6 +2335,7 @@ Remediation:
             configuration_space = discovered_config_space
 
         # Phase 1: Resolve and validate parameters
+        requested_max_trials = max_trials
         algorithm, max_trials, effective_config_space = resolve_execution_parameters(
             algorithm,
             max_trials,
@@ -2335,6 +2344,20 @@ Remediation:
             fallback_algorithm=cast(str, getattr(self, "algorithm", "grid")),
             fallback_max_trials=getattr(self, "max_trials", None),
         )
+        used_implicit_default_max_trials = (
+            requested_max_trials is None
+            and getattr(self, "_max_trials_uses_sdk_default", False)
+            and max_trials == DEFAULT_MAX_TRIALS
+        )
+        if (
+            used_implicit_default_max_trials
+            and not self._max_trials_default_notice_logged
+        ):
+            logger.info(
+                "Using default max_trials=%d; pass max_trials=... to change.",
+                max_trials,
+            )
+            self._max_trials_default_notice_logged = True
 
         stored_policy = getattr(self, "execution_policy", None)
         if not isinstance(stored_policy, ResolvedExecutionPolicy):
@@ -2584,7 +2607,7 @@ Remediation:
                 dataset=dataset,
                 configuration_space=effective_config_space,
                 objectives=self.objectives,
-                max_trials=max_trials if max_trials is not None else 50,
+                max_trials=max_trials if max_trials is not None else DEFAULT_MAX_TRIALS,
                 local_function=self.func,
             )
             return await self._resolve_awaitable_value(cloud_candidate)

--- a/traigent/defaults.py
+++ b/traigent/defaults.py
@@ -1,0 +1,3 @@
+"""Shared SDK defaults for optimization behavior."""
+
+DEFAULT_MAX_TRIALS = 10


### PR DESCRIPTION
Closes #1405. **Owner decision: standardize the default trial budget to 10** (JS already defaults to 10, so this aligns the SDKs).

## Change (narrow — user-facing @traigent.optimize default only)
- The user-facing `@traigent.optimize` implicit `max_trials` default is now **10** (was 50), via a shared `traigent/defaults.py::DEFAULT_MAX_TRIALS` used by `decorators.py` (_OPTIMIZE_DEFAULTS) + `optimized_function.py` (the optimize() default + effective fallback). An explicit user-supplied `max_trials` is honored unchanged.
- A **one-time** informational notice fires (per run, not per trial) ONLY when the implicit default is used: 'Using default max_trials=10; pass max_trials= to change.' Does not fire when the user set it explicitly.

## Scope discipline
A first pass over-reached — it swept ~12 DISTINCT `max_trials=50` defaults (analytics prediction horizon, backend/session contract defaults, cloud-agent defaults, MCP experiment default, service/billing default) to the constant. Those were **reverted** (independent codex scope review flagged them as distinct, owner-unauthorized changes); this PR changes ONLY the user-facing optimize default. Cloud/analytics defaults are untouched (0 diff vs develop).

## Tests
Omitted max_trials → 10; explicit honored; the notice fires once when omitted and not when explicit (caplog). Captain re-ran: 1131 passed, 0 failed. ruff clean.

Spine-Trail: st_95cd7a00135d