### PR TITLE
ci(sdk): pin aws-actions/configure-aws-credentials@v6 to commit SHA

### DIFF
--- a/.github/workflows/example-auto-tune-secure.yml
+++ b/.github/workflows/example-auto-tune-secure.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Configure AWS credentials via OIDC
         if: inputs.environment != 'development' && vars.AWS_ROLE_TO_ASSUME != ''
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions-auto-tune-secure

--- a/.github/workflows/example-auto-tune.yml
+++ b/.github/workflows/example-auto-tune.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Configure AWS credentials via OIDC (for DVC storage)
         if: inputs.environment != 'development' && vars.AWS_ROLE_TO_ASSUME != ''
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions-auto-tune


### PR DESCRIPTION
## What

Pin `aws-actions/configure-aws-credentials@v6` (mutable tag) to commit SHA `254c19bd…` in both `example-auto-tune.yml:86` and `example-auto-tune-secure.yml:215`.

## Why

Surfaced by a repo-forensics CI-hygiene triage (2026-06-27). These steps configure AWS credentials via OIDC, so an upstream tag compromise of `aws-actions` would run attacker code with cloud credentials in CI. SHA-pinning makes the action immutable.

No behavior change — same action version, now content-addressed.

Spine-Trail: st_2ed5ca39af5b
