### PR TITLE
fix(sdk): remove dead LOCAL_ADVANCED_OPTIMIZERS feature flag (#1275 Finding 1 follow-up)

### DIFF
--- a/tests/unit/config/test_feature_flags.py
+++ b/tests/unit/config/test_feature_flags.py
@@ -5,68 +5,80 @@ from __future__ import annotations
 import pytest
 
 from traigent.api.functions import configure
-from traigent.config.feature_flags import (
-    Flag,
-    FlagNames,
-    flag_registry,
-    is_local_advanced_optimizers_enabled,
+from traigent.config.feature_flags import Flag, flag_registry
+
+# Register a test-only flag once at module level (FlagRegistry has no
+# deregister API, so registration must be permanent for the test session).
+# The flag name and env var are namespaced under "test.*" to avoid any
+# future conflict with production flags.
+_TEST_FLAG_NAME = "test.infrastructure.flag"
+_TEST_ENV_VAR = "TRAIGENT_TEST_INFRA_FLAG_ENABLED"
+
+flag_registry.register(
+    Flag(
+        name=_TEST_FLAG_NAME,
+        default=True,
+        env_var=_TEST_ENV_VAR,
+        description="Test-only flag for registry infrastructure tests.",
+        config_path="test.infrastructure.flag",
+    )
 )
 
 
 @pytest.fixture(autouse=True)
 def reset_flags(monkeypatch):
-    """Reset registry overrides/config before each test."""
+    """Reset registry overrides/config and env before each test."""
     flag_registry.reset()
-    monkeypatch.delenv("TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED", raising=False)
+    monkeypatch.delenv(_TEST_ENV_VAR, raising=False)
     yield
     flag_registry.reset()
 
 
-def test_local_advanced_optimizer_flag_defaults_to_true():
-    assert is_local_advanced_optimizers_enabled() is True
+def test_flag_defaults_to_registered_default():
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is True
 
 
 def test_environment_override(monkeypatch):
-    monkeypatch.setenv("TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED", "1")
-    assert is_local_advanced_optimizers_enabled() is True
+    monkeypatch.setenv(_TEST_ENV_VAR, "1")
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is True
 
-    monkeypatch.setenv("TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED", "off")
-    assert is_local_advanced_optimizers_enabled() is False
+    monkeypatch.setenv(_TEST_ENV_VAR, "off")
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is False
 
 
 def test_config_override(monkeypatch):
-    monkeypatch.delenv("TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED", raising=False)
-    flag_registry.apply_config({"optimizers": {"local_advanced": {"enabled": True}}})
-    assert is_local_advanced_optimizers_enabled() is True
+    monkeypatch.delenv(_TEST_ENV_VAR, raising=False)
+    flag_registry.apply_config({"test": {"infrastructure": {"flag": True}}})
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is True
 
-    flag_registry.apply_config({"optimizers": {"local_advanced": {"enabled": "no"}}})
-    assert is_local_advanced_optimizers_enabled() is False
+    flag_registry.apply_config({"test": {"infrastructure": {"flag": "no"}}})
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is False
 
 
 def test_manual_override_context():
-    assert is_local_advanced_optimizers_enabled() is True
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is True
 
-    with flag_registry.override(FlagNames.LOCAL_ADVANCED_OPTIMIZERS, False):
-        assert is_local_advanced_optimizers_enabled() is False
+    with flag_registry.override(_TEST_FLAG_NAME, False):
+        assert flag_registry.is_enabled(_TEST_FLAG_NAME) is False
 
-    assert is_local_advanced_optimizers_enabled() is True
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is True
 
 
 def test_registering_duplicate_flag_raises():
-    duplicate = Flag(name=FlagNames.LOCAL_ADVANCED_OPTIMIZERS)
+    duplicate = Flag(name=_TEST_FLAG_NAME)
     with pytest.raises(ValueError):
         flag_registry.register(duplicate)
 
 
 def test_snapshot_includes_registered_flags():
     snapshot = flag_registry.snapshot()
-    assert FlagNames.LOCAL_ADVANCED_OPTIMIZERS in snapshot
-    assert snapshot[FlagNames.LOCAL_ADVANCED_OPTIMIZERS] is True
+    assert _TEST_FLAG_NAME in snapshot
+    assert snapshot[_TEST_FLAG_NAME] is True
 
 
 def test_configure_applies_feature_flags(monkeypatch):
-    monkeypatch.delenv("TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED", raising=False)
+    monkeypatch.delenv(_TEST_ENV_VAR, raising=False)
     flag_registry.reset()
 
-    configure(feature_flags={"optimizers": {"local_advanced": {"enabled": True}}})
-    assert is_local_advanced_optimizers_enabled() is True
+    configure(feature_flags={"test": {"infrastructure": {"flag": True}}})
+    assert flag_registry.is_enabled(_TEST_FLAG_NAME) is True

--- a/tests/unit/optimizers/test_optimizer_registry.py
+++ b/tests/unit/optimizers/test_optimizer_registry.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pytest
 
 from traigent.api.types import TrialResult
-from traigent.config.feature_flags import flag_registry
 from traigent.optimizers.base import BaseOptimizer
 from traigent.optimizers.registry import (
     _OPTIMIZER_REGISTRY,
@@ -50,18 +49,6 @@ class NotAnOptimizer:
     """Class that doesn't inherit from BaseOptimizer."""
 
     pass
-
-
-@pytest.fixture(autouse=True)
-def reset_local_advanced_optimizer_flag(monkeypatch):
-    """Reset local advanced optimizer flag state for registry tests.
-
-    The flag is enabled by default, so we just ensure consistent state.
-    """
-    monkeypatch.delenv("TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED", raising=False)
-    flag_registry.reset()
-    yield
-    flag_registry.reset()
 
 
 class TestOptimizerRegistry:

--- a/traigent/config/feature_flags.py
+++ b/traigent/config/feature_flags.py
@@ -170,28 +170,9 @@ class FlagRegistry:
 class FlagNames:
     """Canonical flag identifiers used across the codebase."""
 
-    LOCAL_ADVANCED_OPTIMIZERS = "optimizers.local_advanced.enabled"
-
 
 # Global registry instance
 flag_registry = FlagRegistry()
-
-# Register built-in flags
-flag_registry.register(
-    Flag(
-        name=FlagNames.LOCAL_ADVANCED_OPTIMIZERS,
-        default=True,
-        env_var="TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED",
-        description="Toggle local advanced optimizer hooks globally.",
-        config_path="optimizers.local_advanced.enabled",
-    )
-)
-
-
-def is_local_advanced_optimizers_enabled() -> bool:
-    """Convenience accessor for the local advanced optimizer flag."""
-
-    return flag_registry.is_enabled(FlagNames.LOCAL_ADVANCED_OPTIMIZERS)
 
 
 __all__ = [
@@ -199,5 +180,4 @@ __all__ = [
     "FlagNames",
     "FlagRegistry",
     "flag_registry",
-    "is_local_advanced_optimizers_enabled",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -6030,7 +6030,7 @@ wheels = [
 
 [[package]]
 name = "traigent"
-version = "0.17.0.dev0"
+version = "0.18.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -6341,7 +6341,7 @@ requires-dist = [
     { name = "langchain-google-genai", marker = "extra == 'integrations'", specifier = ">=2.1.4" },
     { name = "langchain-openai", marker = "extra == 'integrations'", specifier = ">=1.1.14" },
     { name = "langchain-text-splitters", marker = "extra == 'integrations'", specifier = ">=0.3.8" },
-    { name = "litellm", specifier = "==1.87.1" },
+    { name = "litellm", specifier = ">=1.87.1,<2" },
     { name = "matplotlib", marker = "extra == 'analytics'", specifier = ">=3.5.0" },
     { name = "matplotlib", marker = "extra == 'visualization'", specifier = ">=3.5.0" },
     { name = "mcp", marker = "extra == 'hybrid'", specifier = ">=1.27.0" },


### PR DESCRIPTION
Closes the last SDK-actionable item on #1275 Finding 1 (local advanced-optimizer IP-defense).

## What

Removes the **dead** `LOCAL_ADVANCED_OPTIMIZERS` feature flag from `traigent/config/feature_flags.py`:
- the `FlagNames.LOCAL_ADVANCED_OPTIMIZERS` constant,
- its `Flag(...)` registration (`env_var="TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED"`),
- the `is_local_advanced_optimizers_enabled()` getter,
- the `__all__` export.

## Why

The local advanced-optimizer IP-defense already shipped in #1411: `get_optimizer()` (`traigent/optimizers/registry.py`) **unconditionally** raises `OptimizationError` for any smart algorithm via `_is_smart_algorithm()`, and `_register_builtin_optimizers()` registers only grid/random/batch/remote. The flag was registered and exported but **read by no production code** — the env var `TRAIGENT_LOCAL_ADVANCED_OPTIMIZERS_ENABLED` did nothing. It was a misleading "you can re-enable advanced optimizers locally" surface that contradicts the hard gate — a latent IP re-enable vector. This is the dead-registration cleanup called out in the #1275 triage comment.

Behavior-preserving: the flag was read by nothing, so removing it changes no runtime behavior; it only eliminates the misleading dead env-var contract.

## Tests

- `test_feature_flags.py` rewritten to exercise `FlagRegistry` (default / env override / config override / override-context / duplicate-raise / snapshot / `configure()` integration) via a **test-only** flag (`test.infrastructure.flag`), so registry infrastructure coverage is preserved.
- `test_optimizer_registry.py`: dropped the now-dead `reset_local_advanced_optimizer_flag` fixture + unused import. The cloud-only **hard-gate assertions** (`get_optimizer("bayesian", ...)` raises regardless of env) are untouched (`test_smart_optimizers_cloud_only.py`).
- Local run: `87 passed`. isort/ruff/ruff-format clean on changed files. Independently reviewed by codex gpt-5.5 xhigh → **GO** (verified zero production readers, hard gate intact, no documented public contract hit).

## PR checklist

1. **Worst-case prod path** — n/a behavioral. The dead flag, if it had ever been wired, would have been a *re-enable* vector for locally-exposing the gated smart optimizers (the IP leak #1411 closed). Removing it makes the hard gate the single source of truth — strictly safer.
2. **Production-branch test** — the hard gate is the production behavior; its denial is asserted in `tests/unit/optimizers/test_smart_optimizers_cloud_only.py` (`get_optimizer` raises for smart algorithms regardless of env), untouched by this PR.
3. **Contract regeneration** — none. No schema / OpenAPI / cross-SDK change.
4. **Public surface delta** — `__all__` drops `is_local_advanced_optimizers_enabled` (a getter for a flag read by nothing; not referenced in any docs/README/examples — verified by grep). No documented public contract relied on it.
5. **Review threads resolved** — none yet (new PR).
6. **Quality gates not relaxed** — no threshold widened. (Pre-existing whole-tree mypy debt in unrelated files — `config/types.py`, `orchestrator.py`, `cloud/client.py`, etc. — is untouched; CI runs changed-file mypy which is clean for this diff.)

Spine-Trail: st_4323eea3c7b2