### PR TITLE
feat(sdk): warm_start_from param — seed a new optimization from a prior run (Traigent#1529)

### DIFF
--- a/tests/unit/cloud/test_session_creation_warm_start.py
+++ b/tests/unit/cloud/test_session_creation_warm_start.py
@@ -1,0 +1,356 @@
+"""Unit tests for warm_start_from threading through session creation."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from traigent.cloud.api_operations import ApiOperations
+from traigent.cloud.models import OptimizationSession, SessionCreationRequest
+from traigent.cloud.session_operations import SessionOperations
+
+
+# ---------------------------------------------------------------------------
+# Shared FakeClient infrastructure (mirrors test_session_operations_validation.py)
+# ---------------------------------------------------------------------------
+
+
+class TrackingLock:
+    def __init__(self) -> None:
+        self.enter_count = 0
+
+    def __enter__(self):
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class FakeSessionBridge:
+    def create_session_mapping(self, **kwargs) -> None:
+        return None
+
+    def get_session_mapping(self, session_id: str):
+        return SimpleNamespace(experiment_run_id="run-1")
+
+    _session_mappings: dict[str, Any] = {}
+
+
+class FakeAuth:
+    async def get_headers(self) -> dict[str, str]:
+        return {}
+
+
+class FakeAuthManager:
+    def __init__(self) -> None:
+        self.auth = FakeAuth()
+
+    def has_api_key(self) -> bool:
+        return True
+
+
+class CapturingFakeClient:
+    """FakeClient that records the SessionCreationRequest passed to the API."""
+
+    def __init__(self) -> None:
+        self._active_sessions_lock = TrackingLock()
+        self._active_sessions: dict[str, OptimizationSession] = {}
+        self._max_active_sessions = 5
+        self.session_bridge = FakeSessionBridge()
+        self.backend_config = SimpleNamespace(api_base_url=None, backend_base_url=None)
+        self.auth_manager = FakeAuthManager()
+        self._register_security_session = MagicMock()
+        self.local_storage = None
+        self.captured_session_request: SessionCreationRequest | None = None
+
+    async def _ensure_session(self):
+        return SimpleNamespace(post=AsyncMock(), get=AsyncMock())
+
+    async def _create_traigent_session_via_api(
+        self, session_request: SessionCreationRequest
+    ):
+        self.captured_session_request = session_request
+        return ("session-001", "exp-001", "run-001")
+
+    def _revoke_security_session(self, *args, **kwargs) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _offline_disabled(monkeypatch):
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+    monkeypatch.setenv("TRAIGENT_OFFLINE", "false")
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_typed_session_payload includes / omits warm_start_from
+# ---------------------------------------------------------------------------
+
+
+def _make_api_ops() -> ApiOperations:
+    return ApiOperations(MagicMock())
+
+
+def _typed_request(**kwargs: Any) -> SessionCreationRequest:
+    """Minimal valid SessionCreationRequest for payload-builder tests."""
+    defaults: dict[str, Any] = {
+        "function_name": "test_func",
+        "configuration_space": {"param": [1, 2, 3]},
+        "objectives": ["accuracy"],
+        "dataset_metadata": {"size": 1},
+        "promotion_policy": None,
+        "tvl_governance": None,
+    }
+    defaults.update(kwargs)
+    return SessionCreationRequest(**defaults)
+
+
+class TestBuildTypedSessionPayloadWarmStart:
+    """_build_typed_session_payload warm_start_from contract."""
+
+    def test_warm_start_from_included_when_set(self):
+        ops = _make_api_ops()
+        request = _typed_request(warm_start_from="exp_abc123")
+        payload = ops._build_typed_session_payload(request, max_trials=5)
+        assert payload["warm_start_from"] == "exp_abc123"
+
+    def test_warm_start_from_omitted_when_none(self):
+        ops = _make_api_ops()
+        request = _typed_request(warm_start_from=None)
+        payload = ops._build_typed_session_payload(request, max_trials=5)
+        assert "warm_start_from" not in payload
+
+    def test_warm_start_from_omitted_when_empty_string(self):
+        """Empty string must not emit the key (falsy guard in payload builder)."""
+        ops = _make_api_ops()
+        request = _typed_request()
+        request.warm_start_from = ""
+        payload = ops._build_typed_session_payload(request, max_trials=5)
+        assert "warm_start_from" not in payload
+
+    def test_no_regression_baseline_payload_omits_warm_start_key(self):
+        """Normal session without warm_start_from must not include the key."""
+        ops = _make_api_ops()
+        request = _typed_request()
+        payload = ops._build_typed_session_payload(request, max_trials=10)
+        assert "warm_start_from" not in payload
+        # Confirm required typed-contract keys are still present
+        assert "function_name" in payload
+        assert "configuration_space" in payload
+        assert "objectives" in payload
+        assert "max_trials" in payload
+
+
+# ---------------------------------------------------------------------------
+# Tests: SessionCreationRequest.warm_start_from field
+# ---------------------------------------------------------------------------
+
+
+class TestSessionCreationRequestField:
+    def test_default_is_none(self):
+        req = SessionCreationRequest(function_name="f")
+        assert req.warm_start_from is None
+
+    def test_field_round_trips(self):
+        req = SessionCreationRequest(function_name="f", warm_start_from="exp_xyz")
+        assert req.warm_start_from == "exp_xyz"
+
+
+# ---------------------------------------------------------------------------
+# Tests: SessionOperations.create_session threads warm_start_from
+# ---------------------------------------------------------------------------
+
+
+class TestSessionOperationsWarmStartThreading:
+    """create_session passes warm_start_from into the SessionCreationRequest."""
+
+    def _make_ops(self) -> tuple[SessionOperations, CapturingFakeClient]:
+        client = CapturingFakeClient()
+        return SessionOperations(client), client
+
+    def test_warm_start_from_threads_to_session_request(self):
+        ops, client = self._make_ops()
+        ops.create_session(
+            "my_func",
+            {"model": ["a", "b"]},
+            metadata={"max_trials": 5, "dataset_size": 10, "evaluation_set": "test"},
+            warm_start_from="exp_prior_123",
+        )
+        assert client.captured_session_request is not None
+        assert client.captured_session_request.warm_start_from == "exp_prior_123"
+
+    def test_no_warm_start_leaves_field_none(self):
+        ops, client = self._make_ops()
+        ops.create_session(
+            "my_func",
+            {"model": ["a", "b"]},
+            metadata={"max_trials": 5, "dataset_size": 10, "evaluation_set": "test"},
+        )
+        assert client.captured_session_request is not None
+        assert client.captured_session_request.warm_start_from is None
+
+    def test_empty_string_warm_start_treated_as_none(self):
+        """Empty string must normalise to None before reaching SessionCreationRequest."""
+        ops, client = self._make_ops()
+        ops.create_session(
+            "my_func",
+            {"model": ["a", "b"]},
+            metadata={"max_trials": 3, "dataset_size": 5, "evaluation_set": "test"},
+            warm_start_from="",
+        )
+        assert client.captured_session_request is not None
+        assert client.captured_session_request.warm_start_from is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: LegacyOptimizeArgs recognises warm_start_from (no TypeError)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyOptimizeArgsWarmStart:
+    """warm_start_from is a known direct option, so the legacy bundle accepts it."""
+
+    def test_from_mapping_round_trips_warm_start(self):
+        from traigent.api.decorators import LegacyOptimizeArgs
+
+        # Must not raise TypeError: warm_start_from is in _DIRECT_OPTION_KEYS
+        # (via _OPTIMIZE_DEFAULTS) so from_mapping routes it to a real field,
+        # not to ``extra``.
+        args = LegacyOptimizeArgs.from_mapping({"warm_start_from": "exp_1"})
+        assert args.warm_start_from == "exp_1"
+        assert "warm_start_from" not in args.extra
+
+    def test_default_is_none(self):
+        from traigent.api.decorators import LegacyOptimizeArgs
+
+        assert LegacyOptimizeArgs().warm_start_from is None
+
+    def test_iter_known_values_includes_warm_start(self):
+        from traigent.api.decorators import LegacyOptimizeArgs
+
+        args = LegacyOptimizeArgs(warm_start_from="exp_2")
+        known = dict(args.iter_known_values())
+        assert "warm_start_from" in known
+        assert known["warm_start_from"] == "exp_2"
+
+
+# ---------------------------------------------------------------------------
+# Tests: orchestrator result-metadata assembly surfaces warm_start_from
+# ---------------------------------------------------------------------------
+
+
+class TestResultMetadataWarmStartProvenance:
+    """_build_result_metadata records warm_start_from on the returned result."""
+
+    def _call_build(self, monkeypatch, warm_start_from):
+        import traigent.core.orchestrator as orch_mod
+        from traigent.core.orchestrator import OptimizationOrchestrator
+
+        # Neutralise offline detection so traigent_config value is irrelevant.
+        monkeypatch.setattr(orch_mod, "policy_from_config", lambda _cfg: None)
+        monkeypatch.setattr(orch_mod, "is_offline_requested", lambda _policy: False)
+
+        fake_self = SimpleNamespace(
+            _warm_start_from=warm_start_from,
+            _function_descriptor=None,
+            traigent_config=None,
+        )
+        return OptimizationOrchestrator._build_result_metadata(
+            fake_self,
+            session_summary=None,
+            safeguards_telemetry={},
+        )
+
+    def test_metadata_includes_warm_start_when_set(self, monkeypatch):
+        metadata = self._call_build(monkeypatch, "exp_prior_99")
+        assert metadata["warm_start_from"] == "exp_prior_99"
+
+    def test_metadata_omits_warm_start_when_unset(self, monkeypatch):
+        metadata = self._call_build(monkeypatch, None)
+        assert "warm_start_from" not in metadata
+
+    def test_metadata_omits_warm_start_when_empty(self, monkeypatch):
+        metadata = self._call_build(monkeypatch, "")
+        assert "warm_start_from" not in metadata
+
+
+# ---------------------------------------------------------------------------
+# Tests: EVERY SessionCreationRequest -> /sessions payload serializer must
+# emit warm_start_from. There are THREE live serializers (all asserted here):
+#   1. ApiOperations._build_typed_session_payload   (typed contract, default)
+#   2. ApiOperations._build_legacy_session_payload  (TRAIGENT_SESSION_CONTRACT=
+#      legacy + auto-contract retry for non-governed sessions)
+#   3. TraigentCloudClient._serialize_session_request (cloud-client path)
+# A field set by the user must not silently die on whichever path a run takes.
+# ---------------------------------------------------------------------------
+
+
+def _serialize_typed(warm_start_from):
+    ops = ApiOperations(MagicMock())
+    request = SessionCreationRequest(
+        function_name="f",
+        configuration_space={"p": [1, 2]},
+        objectives=["accuracy"],
+        dataset_metadata={"size": 1},
+        warm_start_from=warm_start_from,
+    )
+    return ops._build_typed_session_payload(request, max_trials=5)
+
+
+def _serialize_legacy(warm_start_from):
+    ops = ApiOperations(MagicMock())
+    request = SessionCreationRequest(
+        function_name="f",
+        configuration_space={"p": [1, 2]},
+        objectives=["accuracy"],
+        dataset_metadata={"size": 1},
+        warm_start_from=warm_start_from,
+    )
+    return ops._build_legacy_session_payload(request, max_trials=5)
+
+
+def _serialize_cloud_client(warm_start_from):
+    from traigent.cloud.client import TraigentCloudClient
+
+    # Lightweight fake self: stub the two helpers the serializer calls so we
+    # exercise only the payload-assembly logic (no live client construction).
+    fake_self = SimpleNamespace(
+        _ensure_owner_metadata=lambda metadata: metadata or {},
+        _serialize_session_objective=lambda objective: objective,
+    )
+    request = SessionCreationRequest(
+        function_name="f",
+        configuration_space={"p": [1, 2]},
+        objectives=["accuracy"],
+        dataset_metadata={"size": 1},
+        warm_start_from=warm_start_from,
+    )
+    return TraigentCloudClient._serialize_session_request(fake_self, request)
+
+
+_ALL_SERIALIZERS = [
+    pytest.param(_serialize_typed, id="typed"),
+    pytest.param(_serialize_legacy, id="legacy"),
+    pytest.param(_serialize_cloud_client, id="cloud_client"),
+]
+
+
+class TestAllSerializerPathsWarmStart:
+    """Every live /sessions serializer emits/omits warm_start_from consistently."""
+
+    @pytest.mark.parametrize("serialize", _ALL_SERIALIZERS)
+    def test_includes_warm_start_when_set(self, serialize):
+        payload = serialize("exp_drop")
+        assert payload["warm_start_from"] == "exp_drop"
+
+    @pytest.mark.parametrize("serialize", _ALL_SERIALIZERS)
+    def test_omits_warm_start_when_none(self, serialize):
+        payload = serialize(None)
+        assert "warm_start_from" not in payload
+
+    @pytest.mark.parametrize("serialize", _ALL_SERIALIZERS)
+    def test_omits_warm_start_when_empty_string(self, serialize):
+        payload = serialize("")
+        assert "warm_start_from" not in payload

--- a/tests/unit/test_privacy_mode.py
+++ b/tests/unit/test_privacy_mode.py
@@ -106,6 +106,7 @@ class TestPrivacyCompliance:
             "budget",
             "constraints",
             "default_config",
+            "warm_start_from",  # Prior run/session id only; no raw examples leave the client
             "promotion_policy",
             "tvl_governance",
             "optimization_strategy",
@@ -325,16 +326,16 @@ class TestSubsetSelection:
             subset_sizes[i] for i in range(len(subset_sizes)) if i >= 10
         ]
 
-        assert all(
-            s <= 10 for s in early_sizes
-        ), "Early trials should use small subsets"
+        assert all(s <= 10 for s in early_sizes), (
+            "Early trials should use small subsets"
+        )
         if actual_late_trials:  # Only check if we have late trials
-            assert all(
-                s >= 15 for s in actual_late_trials
-            ), "Late trials should use larger subsets"
-        assert max(early_sizes) <= min(
-            subset_sizes[3:]
-        ), "Subset size should increase over time"
+            assert all(s >= 15 for s in actual_late_trials), (
+                "Late trials should use larger subsets"
+            )
+        assert max(early_sizes) <= min(subset_sizes[3:]), (
+            "Subset size should increase over time"
+        )
 
         # Verify different strategies are used
         assert "diverse_sampling" in strategies

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -536,6 +536,7 @@ _OPTIMIZE_DEFAULTS: dict[str, Any] = {
     "configuration_space": None,
     "experiment_name": None,
     "default_config": None,
+    "warm_start_from": None,
     "constraints": None,
     "safety_constraints": None,
     "tvl_spec": None,
@@ -725,6 +726,7 @@ class LegacyOptimizeArgs:
     experiment_name: str | None = None
     configuration_space: dict[str, Any] | None = None
     default_config: dict[str, Any] | None = None
+    warm_start_from: str | None = None
     constraints: list[Callable[..., Any]] | None = None
     safety_constraints: list[Any] | None = (
         None  # SafetyConstraint | CompoundSafetyConstraint
@@ -819,6 +821,7 @@ class LegacyOptimizeArgs:
             ("experiment_name", self.experiment_name),
             ("configuration_space", self.configuration_space),
             ("default_config", self.default_config),
+            ("warm_start_from", self.warm_start_from),
             ("constraints", self.constraints),
             ("safety_constraints", self.safety_constraints),
             ("tvl_spec", self.tvl_spec),
@@ -2014,6 +2017,7 @@ def optimize(  # NOSONAR(S107)
     configuration_space: dict[str, Any] | ConfigSpace | None = None,
     experiment_name: str | None = None,
     default_config: dict[str, Any] | None = None,
+    warm_start_from: str | None = None,
     constraints: list[Constraint | BoolExpr | Callable[..., Any]] | None = None,
     safety_constraints: list[SafetyConstraint | CompoundSafetyConstraint] | None = None,
     tvl_spec: str | Path | None = None,
@@ -2346,6 +2350,7 @@ def optimize(  # NOSONAR(S107)
         "configuration_space": configuration_space,
         "experiment_name": experiment_name,
         "default_config": default_config,
+        "warm_start_from": warm_start_from,
         "constraints": constraints,
         "safety_constraints": safety_constraints,
         "tvl_spec": tvl_spec,
@@ -2481,6 +2486,8 @@ def optimize(  # NOSONAR(S107)
         raise ValueError("max_trials must be a positive integer")
     # Experiment display name (decorator > env var > func.__name__ at decoration time)
     experiment_name_value = combined_settings["experiment_name"]
+    # Warm-start: prior experiment id to seed this run (empty string -> None).
+    warm_start_from_value: str | None = combined_settings.get("warm_start_from") or None
     # Tuned variable auto-detection
     auto_detect_tvars_value = combined_settings["auto_detect_tvars"]
     auto_detect_tvars_mode_value = combined_settings["auto_detect_tvars_mode"]
@@ -2814,6 +2821,8 @@ def optimize(  # NOSONAR(S107)
             _max_trials_explicit=max_trials_explicit,
             # Experiment display name (overrides func.__name__ in portal/storage)
             experiment_name=experiment_name_value,
+            # Warm-start: seed this run from a prior experiment's learned configs.
+            warm_start_from=warm_start_from_value,
             # Guided-generation defaults (consumed by optimize_with_guidance)
             prompt_rewrite=prompt_rewrite,
             grow_dataset=grow_dataset,

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -652,6 +652,8 @@ class ApiOperations:
         wire_governance = tvl_governance_to_wire(session_request.tvl_governance)
         if wire_governance:
             payload["tvl_governance"] = wire_governance
+        if getattr(session_request, "warm_start_from", None):
+            payload["warm_start_from"] = session_request.warm_start_from
         return payload
 
     def _build_legacy_session_payload(
@@ -668,7 +670,7 @@ class ApiOperations:
         if warn_boolean_config_values:
             _warn_boolean_config_values(session_request.configuration_space)
 
-        return {
+        payload: dict[str, Any] = {
             "problem_statement": session_request.function_name,
             "dataset": {
                 "examples": [],  # Privacy mode - no actual data sent
@@ -690,6 +692,12 @@ class ApiOperations:
                 **metadata,
             },
         }
+        # Warm-start: never silently drop a user-set prior experiment id, even
+        # on the legacy contract (empty string treated as absent). The legacy
+        # BE may not consume it yet; the SDK must still forward it.
+        if getattr(session_request, "warm_start_from", None):
+            payload["warm_start_from"] = session_request.warm_start_from
+        return payload
 
     def _build_connector(self) -> Any | None:
         """Create an aiohttp connector when custom transport settings are required."""

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -959,6 +959,7 @@ class BackendIntegratedClient:
         objectives: list[Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
+        warm_start_from: str | None = None,
     ) -> SessionCreationResult:
         """Synchronous wrapper for creating a session.
         Delegates to session_operations module. Phase 8: objectives are
@@ -972,6 +973,7 @@ class BackendIntegratedClient:
             objectives=objectives,
             promotion_policy=promotion_policy,
             tvl_governance=tvl_governance,
+            warm_start_from=warm_start_from,
         )
 
     async def create_hybrid_session(

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -1854,6 +1854,9 @@ class TraigentCloudClient(BaseTraigentClient):
             payload["default_config"] = request.default_config
         if request.promotion_policy is not None:
             payload["promotion_policy"] = request.promotion_policy
+        # Warm-start: prior experiment id (empty string treated as absent).
+        if request.warm_start_from:
+            payload["warm_start_from"] = request.warm_start_from
         return payload
 
     @staticmethod

--- a/traigent/cloud/models.py
+++ b/traigent/cloud/models.py
@@ -193,6 +193,7 @@ class SessionCreationRequest:
     budget: dict[str, Any] | None = None
     constraints: dict[str, Any] | None = None
     default_config: dict[str, Any] | None = None
+    warm_start_from: str | None = None
     promotion_policy: dict[str, Any] | None = None
     # Content-free TVL governance summary (RFC 0001 P8): cvar names/types/
     # governed flags only — built by traigent.cloud.governance, never ad hoc.

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -328,6 +328,7 @@ class SessionOperations:
         objectives: list[Any] | None = None,
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
+        warm_start_from: str | None = None,
     ) -> SessionCreationResult:
         """Create a session with backend metadata submission.
 
@@ -430,6 +431,7 @@ class SessionOperations:
                 # fallback when the caller supplied none (legacy shape keeps
                 # reading objectives[0] as its optimization_goal).
                 objectives=list(objectives) if objectives else [optimization_goal],
+                warm_start_from=warm_start_from or None,
                 dataset_metadata={
                     "size": metadata.get("dataset_size", 0) if metadata else 0,
                     # Carry the dataset label (content is not submitted) so the

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -660,6 +660,7 @@ class BackendSessionManager:
         promotion_policy: dict[str, Any] | None = None,
         tvl_governance: dict[str, Any] | None = None,
         experiment_display_name: str | None = None,
+        warm_start_from: str | None = None,
     ) -> SessionContext:
         """Create backend session and return context.
 
@@ -726,6 +727,8 @@ class BackendSessionManager:
                 session_metadata["strategy_preset"] = dict(
                     self._strategy_preset_metadata
                 )
+            if warm_start_from:
+                session_metadata["warm_start_from"] = warm_start_from
 
             # Build the portal display name.
             # When the user supplied an explicit experiment_name, honour it.
@@ -763,6 +766,7 @@ class BackendSessionManager:
                 objectives=objectives,
                 promotion_policy=promotion_policy,
                 tvl_governance=tvl_governance,
+                warm_start_from=warm_start_from,
             )
             result = self.normalize_session_creation_result(raw_result)
             session_id = self.handle_session_creation_result(

--- a/traigent/core/optimization_pipeline.py
+++ b/traigent/core/optimization_pipeline.py
@@ -624,6 +624,7 @@ def collect_orchestrator_kwargs(
     promotion_gate: Any | None,
     safety_constraints: list[Any] | None = None,
     invocations_per_example: int = 1,
+    warm_start_from: str | None = None,
 ) -> dict[str, Any]:
     """Collect optional kwargs for orchestrator from algorithm_kwargs and attrs.
 
@@ -684,6 +685,7 @@ def collect_orchestrator_kwargs(
         ("global_measures", global_measures, None),
         ("promotion_gate", promotion_gate, None),
         ("safety_constraints", safety_constraints, None),
+        ("warm_start_from", warm_start_from, None),
     ]
     for attr_name, value, transform in optional_attrs:
         if value is not None:

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -739,6 +739,11 @@ class OptimizedFunction(Generic[_P, _R]):
             kwargs, sentinel, "strategy_preset", None
         )
 
+        # Warm-start: seed a new run from a prior experiment's learned configs.
+        self.warm_start_from = self._store_optional_param(
+            kwargs, sentinel, "warm_start_from", None
+        )
+
         self.kwargs = kwargs
         excluded_runtime_keys = {
             "algorithm",
@@ -763,6 +768,7 @@ class OptimizedFunction(Generic[_P, _R]):
             # Safety constraints
             "safety_constraints",
             "strategy_preset",
+            "warm_start_from",
         }
         self._decorator_runtime_overrides = {
             key: value
@@ -1804,6 +1810,7 @@ class OptimizedFunction(Generic[_P, _R]):
             global_measures=getattr(self, "global_measures", None),
             promotion_gate=getattr(self, "promotion_gate", None),
             safety_constraints=getattr(self, "safety_constraints", None),
+            warm_start_from=getattr(self, "warm_start_from", None),
         )
 
         # Auto-initialize workflow traces tracker if backend is configured

--- a/traigent/core/orchestrator.py
+++ b/traigent/core/orchestrator.py
@@ -209,6 +209,7 @@ class OptimizationOrchestrator:
         self.strategy_preset: NormalizedStrategyPreset | None = kwargs.pop(
             "strategy_preset", None
         )
+        self._warm_start_from: str | None = kwargs.pop("warm_start_from", None)
         self._config_metrics_history: dict[str, dict[str, list[float]]] = {}
         self._incumbent_config_hash: str | None = None
 
@@ -2196,6 +2197,7 @@ class OptimizationOrchestrator:
             promotion_policy=wire_policy,
             tvl_governance=wire_governance,
             experiment_display_name=experiment_display_name,
+            warm_start_from=self._warm_start_from,
         )
         session_id: str | None = session_context.session_id
         self._active_session_id = session_id
@@ -3321,6 +3323,12 @@ class OptimizationOrchestrator:
         # Flag offline mode so callbacks can show appropriate hints
         if is_offline_requested(policy_from_config(self.traigent_config)):
             metadata["offline_mode"] = True
+
+        # Warm-start provenance: surface the prior experiment id that seeded
+        # this run so users can query result.metadata["warm_start_from"].
+        # Only present for warm-started runs; absent otherwise.
+        if self._warm_start_from:
+            metadata["warm_start_from"] = self._warm_start_from
 
         return metadata
 


### PR DESCRIPTION
SDK layer of multi-seed warm-start (#1529). Pairs with the BE keystone **TraigentBackend#1760** (which consumes `warm_start_from` and seeds the session optimizer).

## What
Adds an optional `warm_start_from` (a prior experiment id) to `@traigent.optimize` / `optimize()`. When set, the SDK sends it in the typed cloud session-create payload; the Backend seeds the new session optimizer with the prior run good configs so it starts warm instead of cold.

- Threaded end-to-end: `optimize()` → `OptimizedFunction` → `collect_orchestrator_kwargs` → `Orchestrator` → `BackendSessionManager` → `BackendIntegratedClient` → `SessionOperations` → `SessionCreationRequest` → wire payload. Registered in `_OPTIMIZE_DEFAULTS`, direct-option keys, `LegacyOptimizeArgs` (field + `iter_known_values`), `excluded_runtime_keys` — mirrors `default_config`. Empty string → None (no empty key on the wire).
- Emitted by **all three** `SessionCreationRequest` serializers (`_build_typed_session_payload`, `_build_legacy_session_payload`, cloud-client `_serialize_session_request`); an exhaustive audit confirmed no other reachable serializer drops it (deprecated/dead + fail-closed paths documented).
- **Provenance**: when set, lands on `OptimizationResult.metadata["warm_start_from"]`.

## Tests
24 (`tests/unit/cloud/test_session_creation_warm_start.py`): parametrized over all three serializers × {set / None / empty}; `LegacyOptimizeArgs` round-trip; result-metadata provenance; `SessionOperations` threading. ruff clean. **codex gpt-5.5-xhigh → GO** (4 rounds — caught a dead-write provenance, a `LegacyOptimizeArgs` TypeError, and two additional silent-drop serializer paths; all fixed).

## PR checklist
1. **Worst-case prod path** — `warm_start_from` is an optional opaque prior-experiment id forwarded to the backend (which tenant-scopes the seed retrieval, BE#1760). If it runs in prod by accident with no value, behavior is unchanged (cold start). No auth/charge/data-leak path in the SDK layer.
2. **Production-branch test** — N/A (no fail-open branch); the serializer omit-when-None behavior is asserted across all three paths.
3. **Contract regeneration** — typed `/sessions` create is inline-validated server-side (no formal request schema); `warm_start_from` is additive. JS parity is a follow-up.
4. **Public surface delta** — `optimize()` gains an optional `warm_start_from: str | None = None`; docs/skills update is a follow-up. No removed/renamed surface.
5. **Review threads** — none yet (new PR).
6. **Quality gates not relaxed** — none changed.

Spine-Trail: st_4eed6750274f