### PR TITLE
chore(release): prepare SDK 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-27
+
 ### Added
 - Added a no-content-egress cloud-brain canary test that captures serialized
   session, next-trial, metrics, and finalize payloads and asserts dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.0.dev0"
+version = "0.18.0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -6030,7 +6030,7 @@ wheels = [
 
 [[package]]
 name = "traigent"
-version = "0.18.0.dev0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Spine-Trail: st_5653b4ba5dff

## Summary
- Promote SDK package metadata from 0.18.0.dev0 to 0.18.0 for a develop-line PyPI release.
- Add a dated 0.18.0 changelog section for the current Unreleased entries.
- Keep uv.lock project metadata in sync with pyproject.toml.

## Verification
- python3 -m build
- /tmp/traigent-release-check-0.18.0/bin/python -m twine check dist/*
- /tmp/traigent-release-check-0.18.0/bin/python -m pip install dist/traigent-0.18.0-py3-none-any.whl
- /tmp/traigent-release-check-0.18.0/bin/python -c "import traigent; print(traigent.__version__)"  # 0.18.0