### PR TITLE
chore(release): prepare SDK 0.18.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.0"
+version = "0.18.1.dev0"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -6030,7 +6030,7 @@ wheels = [
 
 [[package]]
 name = "traigent"
-version = "0.18.0"
+version = "0.18.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Spine-Trail: st_1b466a7afdd2

## Summary
- Bump the develop SDK package metadata to 0.18.1.dev0 for a dev/prerelease PyPI build.
- Keep uv.lock project metadata in sync with pyproject.toml.

## Verification
- python3 -m build
- /tmp/traigent-release-check-0.18.1-dev0/bin/python -m twine check dist/*
- /tmp/traigent-release-check-0.18.1-dev0/bin/python -m pip install dist/traigent-0.18.1.dev0-py3-none-any.whl
- /tmp/traigent-release-check-0.18.1-dev0/bin/python -c "import traigent; print(traigent.__version__)"  # 0.18.1.dev0