### PR TITLE
feat(cloud): persona interaction-policy client with offline-safe fallback

### DIFF
--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -1,0 +1,307 @@
+"""Unit tests for BackendIntegratedClient.get_interaction_policy."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from traigent.cloud.backend_client import STATIC_POLICY_TEXT, BackendIntegratedClient
+from traigent.testing import _reset_for_tests, enable_mock_mode_for_quickstart
+
+FAKE_API_KEY = "tg_" + "x" * 61  # pragma: allowlist secret
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        payload: object | None = None,
+        json_exc: Exception | None = None,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status = status
+        self.headers = headers or {}
+        self._payload = payload
+        self._json_exc = json_exc
+        self._text = text
+
+    async def json(self) -> object | None:
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._payload
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _FakeRequestContext:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        *,
+        response: _FakeResponse | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        self._response = response
+        self._exc = exc
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def get(self, url: str, **kwargs):
+        self.calls.append((url, kwargs))
+        if self._exc is not None:
+            raise self._exc
+        assert self._response is not None
+        return _FakeRequestContext(self._response)
+
+
+class _FakeClientSessionContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _FakeSession:
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_interaction_policy_env(monkeypatch):
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "false")
+    monkeypatch.delenv("TRAIGENT_API_KEY", raising=False)
+    monkeypatch.delenv("TRAIGENT_MOCK_LLM", raising=False)
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _make_client(api_key: str | None = None) -> BackendIntegratedClient:
+    return BackendIntegratedClient(
+        api_key=api_key,
+        base_url="https://api.example.test",
+        timeout=12.0,
+    )
+
+
+def _assert_static_policy(result: dict[str, object]) -> None:
+    assert result == {
+        "schema_version": "traigent.agent_interaction.response.v1",
+        "profile": {
+            "control": "guided",
+            "expertise": "se",
+            "pace": "balanced",
+            "source": "default",
+            "confidence": 0.0,
+            "schema_version": "traigent.interaction_policy.v1",
+        },
+        "policy_text": STATIC_POLICY_TEXT,
+        "question_budget": 2,
+        "options_max": 3,
+        "jargon_level": "plain",
+        "next_skill_hint": None,
+        "fallback_policy": "static_v1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_policy_returns_backend_payload(monkeypatch) -> None:
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+    client = _make_client(api_key=FAKE_API_KEY)
+    payload = {
+        "schema_version": "traigent.agent_interaction.response.v1",
+        "profile": {
+            "control": "inspect",
+            "expertise": "ds",
+            "pace": "explore",
+            "source": "backend",
+            "confidence": 0.92,
+            "schema_version": "traigent.interaction_policy.v1",
+        },
+        "policy_text": "backend policy text",
+        "question_budget": 1,
+        "options_max": 3,
+        "jargon_level": "compact",
+        "next_skill_hint": "spine:feature",
+        "fallback_policy": "backend_v1",
+    }
+    response = _FakeResponse(
+        status=200,
+        payload=payload,
+        headers={"ETag": '"policy-v1"'},
+    )
+    fake_session = _FakeSession(response=response)
+    fake_aiohttp = SimpleNamespace(
+        ClientSession=Mock(return_value=_FakeClientSessionContext(fake_session)),
+        ClientTimeout=Mock(side_effect=lambda total=None: {"total": total}),
+        ClientError=type("FakeClientError", (Exception,), {}),
+    )
+
+    with (
+        patch("traigent.cloud.backend_client.AIOHTTP_AVAILABLE", True),
+        patch("traigent.cloud.backend_client.aiohttp", fake_aiohttp),
+    ):
+        result = await client.get_interaction_policy(
+            harness="codex",
+            skill="python",
+            signals={
+                "pace": "execute",
+                "control": "delegate",
+                "private_note": "raw-secret-signal",
+            },
+        )
+
+    assert result == payload
+    assert len(fake_session.calls) == 1
+    url, kwargs = fake_session.calls[0]
+    assert url == "https://api.example.test/api/v1/auth/me/interaction-policy"
+    assert kwargs["headers"]["X-API-Key"] == FAKE_API_KEY
+    assert kwargs["headers"]["User-Agent"]
+    assert "Authorization" not in kwargs["headers"]
+    assert kwargs["params"] == {
+        "harness": "codex",
+        "skill": "python",
+        "signals": (
+            '{"control":"delegate","pace":"execute","private_note":"raw-secret-signal"}'
+        ),
+    }
+    assert kwargs["timeout"] == {"total": 12.0}
+    cache_entry = client._interaction_policy_cache[("codex", "python")]
+    assert set(cache_entry) == {"etag", "policy_text", "profile"}
+    assert cache_entry["policy_text"] == "backend policy text"
+    assert cache_entry["etag"] == '"policy-v1"'
+    assert cache_entry["profile"] == payload["profile"]
+    assert "raw-secret-signal" not in repr(cache_entry)
+    assert "signals" not in repr(cache_entry)
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_policy_offline_returns_static_without_network(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
+    client = _make_client(api_key=FAKE_API_KEY)
+
+    with patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session:
+        result = await client.get_interaction_policy()
+
+    _assert_static_policy(result)
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_policy_without_api_key_returns_static_without_network() -> (
+    None
+):
+    client = _make_client()
+
+    with patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session:
+        result = await client.get_interaction_policy()
+
+    _assert_static_policy(result)
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_policy_mock_mode_returns_static_without_network(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+    enable_mock_mode_for_quickstart()
+    client = _make_client(api_key=FAKE_API_KEY)
+
+    with patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session:
+        result = await client.get_interaction_policy()
+
+    _assert_static_policy(result)
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_interaction_policy_legacy_mock_llm_returns_static_without_network(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+    monkeypatch.setenv("TRAIGENT_MOCK_LLM", "true")
+    client = _make_client(api_key=FAKE_API_KEY)
+
+    with (
+        patch("traigent.cloud.backend_client.AIOHTTP_AVAILABLE", True),
+        patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session,
+    ):
+        result = await client.get_interaction_policy(
+            signals={"private_note": "raw-secret-signal"}
+        )
+
+    _assert_static_policy(result)
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "transport_error"),
+    [
+        (_FakeResponse(status=503, text="backend unavailable"), None),
+        (None, TimeoutError("timed out")),
+        (_FakeResponse(status=200, json_exc=ValueError("not json")), None),
+        (
+            _FakeResponse(
+                status=200,
+                payload={
+                    "schema_version": "traigent.agent_interaction.response.v1",
+                    "profile": {
+                        "control": "inspect",
+                        "expertise": "ds",
+                        "pace": "explore",
+                        "source": "backend",
+                        "confidence": 0.92,
+                        "schema_version": "traigent.interaction_policy.v1",
+                    },
+                    "question_budget": 1,
+                    "options_max": 3,
+                    "jargon_level": "compact",
+                    "next_skill_hint": "spine:feature",
+                    "fallback_policy": "backend_v1",
+                },
+            ),
+            None,
+        ),
+    ],
+)
+async def test_get_interaction_policy_backend_failures_return_static(
+    monkeypatch,
+    response: _FakeResponse | None,
+    transport_error: Exception | None,
+) -> None:
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+    client = _make_client(api_key=FAKE_API_KEY)
+    fake_session = _FakeSession(response=response, exc=transport_error)
+    fake_aiohttp = SimpleNamespace(
+        ClientSession=Mock(return_value=_FakeClientSessionContext(fake_session)),
+        ClientTimeout=Mock(side_effect=lambda total=None: {"total": total}),
+        ClientError=type("FakeClientError", (Exception,), {}),
+    )
+
+    with (
+        patch("traigent.cloud.backend_client.AIOHTTP_AVAILABLE", True),
+        patch("traigent.cloud.backend_client.aiohttp", fake_aiohttp),
+    ):
+        result = await client.get_interaction_policy(harness="codex")
+
+    _assert_static_policy(result)
+    assert len(fake_session.calls) == 1

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -8,6 +8,7 @@ for better maintainability and adherence to software engineering principles.
 
 import asyncio
 import concurrent.futures
+import json
 import os
 import secrets
 import sys
@@ -24,7 +25,7 @@ from urllib.parse import quote, urlparse, urlunparse
 # Import and re-export BackendClientConfig for backward compatibility
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
 from traigent.cloud.api_operations import ApiOperations
-from traigent.cloud.auth import AuthenticationError
+from traigent.cloud.auth import AuthenticationError, _build_api_key_auth_headers
 from traigent.cloud.backend_bridges import SDKBackendBridge, SessionExperimentMapping
 from traigent.cloud.backend_bridges import bridge as _bridge
 from traigent.cloud.backend_components import (
@@ -116,6 +117,48 @@ _ALLOWED_EXAMPLE_FEATURE_KINDS = frozenset({"simhash_v1"})
 _JSON_CONTENT_TYPE = "application/json"
 _SDK_USER_AGENT = get_sdk_user_agent()
 _SYNC_BACKEND_TRANSIENT_STATUSES = frozenset({408, 429, *range(500, 600)})
+_INTERACTION_POLICY_REQUIRED_KEYS = frozenset(
+    {
+        "schema_version",
+        "profile",
+        "policy_text",
+        "question_budget",
+        "options_max",
+        "jargon_level",
+        "next_skill_hint",
+        "fallback_policy",
+    }
+)
+_INTERACTION_POLICY_PROFILE_REQUIRED_KEYS = frozenset(
+    {
+        "schema_version",
+        "control",
+        "expertise",
+        "pace",
+        "source",
+        "confidence",
+    }
+)
+_INTERACTION_POLICY_RESPONSE_SCHEMA_VERSION = "traigent.agent_interaction.response.v1"
+_INTERACTION_POLICY_PROFILE_SCHEMA_VERSION = "traigent.interaction_policy.v1"
+
+STATIC_POLICY_TEXT = (
+    "Adapt to the user's interaction profile — persona "
+    "(control=delegate|guided|inspect, expertise=se|ds|unknown) and session "
+    "mood (pace=execute|balanced|explore); default guided,se,balanced; infer "
+    "from explicit statements first then behavior, corrections win. Always be "
+    "concise. Match terminology to expertise: plain words and define each term "
+    "once for se; compact statistics/optimization terms for ds. When asking, "
+    "show at most 3 options, mark one Recommended, give one short trade-off "
+    "each. For delegate/execute, proceed with the recommended reversible "
+    "action and ask only at hard gates (paid/provider calls, data egress, "
+    "destructive edits, service-owned decisions, missing required facts); for "
+    "inspect/explore, give brief rationale before asking. Always recommend "
+    "the next skill or action. Never weaken safety (dry-run before paid runs; "
+    "approval before cost or egress; service-returned plans are authoritative) "
+    "and never put persona or private content into telemetry, metadata, names, "
+    "logs, or provenance."
+)
 
 
 class _SyncBackendTransientError(RetryableError):
@@ -563,6 +606,10 @@ class BackendIntegratedClient:
         # Read-only analytics accessor (lazily exposed via the ``analytics``
         # property). Kept separate from the write paths above.
         self._analytics_ns: AnalyticsNamespace | None = None
+        self._interaction_policy_cache: dict[
+            tuple[str | None, str | None], dict[str, Any]
+        ] = {}
+        self._interaction_policy_fallback_logged = False
 
     @property
     def analytics(self) -> "AnalyticsNamespace":
@@ -577,11 +624,285 @@ class BackendIntegratedClient:
             self._analytics_ns = AnalyticsNamespace(self)
         return self._analytics_ns
 
+    def _log_local_interaction_policy_once(self) -> None:
+        if self._interaction_policy_fallback_logged:
+            return
+        logger.info("using local interaction policy")
+        self._interaction_policy_fallback_logged = True
+
+    def _static_interaction_policy(self) -> dict[str, Any]:
+        self._log_local_interaction_policy_once()
+        return {
+            "schema_version": _INTERACTION_POLICY_RESPONSE_SCHEMA_VERSION,
+            "profile": {
+                "control": "guided",
+                "expertise": "se",
+                "pace": "balanced",
+                "source": "default",
+                "confidence": 0.0,
+                "schema_version": _INTERACTION_POLICY_PROFILE_SCHEMA_VERSION,
+            },
+            "policy_text": STATIC_POLICY_TEXT,
+            "question_budget": 2,
+            "options_max": 3,
+            "jargon_level": "plain",
+            "next_skill_hint": None,
+            "fallback_policy": "static_v1",
+        }
+
+    @staticmethod
+    def _interaction_policy_cache_key(
+        *,
+        harness: str | None,
+        skill: str | None,
+    ) -> tuple[str | None, str | None]:
+        def _normalize(value: str | None) -> str | None:
+            if not isinstance(value, str):
+                return value
+            cleaned = value.strip()
+            return cleaned or None
+
+        return (_normalize(harness), _normalize(skill))
+
+    @staticmethod
+    def _build_interaction_policy_params(
+        *,
+        harness: str | None,
+        skill: str | None,
+        signals: Any,
+    ) -> dict[str, str] | None:
+        params: dict[str, str] = {}
+        if isinstance(harness, str) and harness.strip():
+            params["harness"] = harness.strip()
+        if isinstance(skill, str) and skill.strip():
+            params["skill"] = skill.strip()
+        if signals is not None:
+            params["signals"] = json.dumps(
+                signals, separators=(",", ":"), sort_keys=True
+            )
+        return params or None
+
+    @staticmethod
+    def _normalize_interaction_policy_payload(payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise CloudServiceError(
+                "Interaction policy endpoint returned a non-JSON object response"
+            )
+
+        data = payload.get("data", payload)
+        if not isinstance(data, dict):
+            raise CloudServiceError(
+                "Interaction policy endpoint returned invalid response data"
+            )
+
+        missing = sorted(_INTERACTION_POLICY_REQUIRED_KEYS - data.keys())
+        if missing:
+            raise CloudServiceError(
+                "Interaction policy endpoint returned malformed response: "
+                f"missing {', '.join(missing)}"
+            )
+
+        if data.get("schema_version") != _INTERACTION_POLICY_RESPONSE_SCHEMA_VERSION:
+            raise CloudServiceError(
+                "Interaction policy endpoint returned unsupported response schema"
+            )
+
+        profile = data.get("profile")
+        if not isinstance(profile, dict):
+            raise CloudServiceError(
+                "Interaction policy endpoint returned malformed profile"
+            )
+
+        missing_profile = sorted(
+            _INTERACTION_POLICY_PROFILE_REQUIRED_KEYS - profile.keys()
+        )
+        if missing_profile:
+            raise CloudServiceError(
+                "Interaction policy endpoint returned malformed profile: "
+                f"missing {', '.join(missing_profile)}"
+            )
+
+        if profile.get("schema_version") != _INTERACTION_POLICY_PROFILE_SCHEMA_VERSION:
+            raise CloudServiceError(
+                "Interaction policy endpoint returned unsupported profile schema"
+            )
+
+        return {
+            "schema_version": data["schema_version"],
+            "profile": {
+                "control": profile["control"],
+                "expertise": profile["expertise"],
+                "pace": profile["pace"],
+                "source": profile["source"],
+                "confidence": profile["confidence"],
+                "schema_version": profile["schema_version"],
+            },
+            "policy_text": data["policy_text"],
+            "question_budget": data["question_budget"],
+            "options_max": data["options_max"],
+            "jargon_level": data["jargon_level"],
+            "next_skill_hint": data["next_skill_hint"],
+            "fallback_policy": data["fallback_policy"],
+        }
+
+    def _cache_interaction_policy(
+        self,
+        *,
+        cache_key: tuple[str | None, str | None],
+        policy: Mapping[str, Any],
+        etag: str | None,
+    ) -> None:
+        profile = policy.get("profile")
+        cached_profile: dict[str, Any] | None = None
+        if isinstance(profile, Mapping):
+            cached_profile = {
+                "control": profile.get("control"),
+                "expertise": profile.get("expertise"),
+                "pace": profile.get("pace"),
+                "source": profile.get("source"),
+                "confidence": profile.get("confidence"),
+                "schema_version": profile.get("schema_version"),
+            }
+        self._interaction_policy_cache[cache_key] = {
+            "etag": etag,
+            "policy_text": policy["policy_text"],
+            "profile": cached_profile,
+        }
+
+    def _cached_interaction_policy(
+        self, cache_key: tuple[str | None, str | None]
+    ) -> dict[str, Any] | None:
+        cached = self._interaction_policy_cache.get(cache_key)
+        if not isinstance(cached, dict):
+            return None
+
+        policy_text = cached.get("policy_text")
+        if not isinstance(policy_text, str):
+            return None
+
+        profile = cached.get("profile")
+        if not isinstance(profile, dict):
+            return None
+
+        restored = {
+            "schema_version": _INTERACTION_POLICY_RESPONSE_SCHEMA_VERSION,
+            "profile": {
+                "control": profile.get("control"),
+                "expertise": profile.get("expertise"),
+                "pace": profile.get("pace"),
+                "source": profile.get("source"),
+                "confidence": profile.get("confidence"),
+                "schema_version": profile.get("schema_version"),
+            },
+            "policy_text": policy_text,
+            "question_budget": 2,
+            "options_max": 3,
+            "jargon_level": "plain",
+            "next_skill_hint": None,
+            "fallback_policy": "static_v1",
+        }
+        return restored
+
     @property
     def session_bridge(self) -> "SDKBackendBridge":
         """Return the shared session bridge (exposed for test patching)."""
 
         return bridge
+
+    async def get_interaction_policy(
+        self,
+        *,
+        harness: str | None = None,
+        skill: str | None = None,
+        signals: Any = None,
+    ) -> dict[str, Any]:
+        """Return the backend persona-interaction policy seed for this session.
+
+        The backend response is a seed for the agent's starting interaction
+        profile only. Explicit user corrections made in-conversation remain
+        authoritative and must override this seed.
+        """
+        from traigent.utils.env_config import is_mock_llm
+
+        if cloud_backend_egress_disabled(self.no_egress):
+            return self._static_interaction_policy()
+
+        api_key = os.getenv("TRAIGENT_API_KEY") or self._api_key_fallback
+        if not api_key or is_mock_llm() or not AIOHTTP_AVAILABLE:
+            return self._static_interaction_policy()
+
+        cache_key = self._interaction_policy_cache_key(
+            harness=harness,
+            skill=skill,
+        )
+        cached = self._interaction_policy_cache.get(cache_key)
+
+        headers = _build_api_key_auth_headers(api_key)
+        headers.setdefault("User-Agent", _SDK_USER_AGENT)
+        cached_etag = cached.get("etag") if isinstance(cached, dict) else None
+        if isinstance(cached_etag, str) and cached_etag:
+            headers["If-None-Match"] = cached_etag
+
+        try:
+            params = self._build_interaction_policy_params(
+                harness=harness,
+                skill=skill,
+                signals=signals,
+            )
+            backend_origin = (
+                self.backend_config.backend_base_url or BackendConfig.get_backend_url()
+            ).rstrip("/")
+            url = f"{backend_origin}/api/v1/auth/me/interaction-policy"
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url,
+                    headers=headers,
+                    params=params,
+                    timeout=aiohttp.ClientTimeout(total=self.timeout),
+                ) as response:
+                    if response.status == 304:
+                        cached_policy = self._cached_interaction_policy(cache_key)
+                        if cached_policy is not None:
+                            return cached_policy
+                        raise CloudServiceError(
+                            "Interaction policy cache miss for backend 304 response"
+                        )
+
+                    if response.status >= 400:
+                        error_text = await response.text()
+                        raise CloudServiceError(
+                            "Interaction policy request failed with HTTP "
+                            f"{response.status}: {error_text[:200]}"
+                        )
+
+                    try:
+                        payload = await response.json()
+                    except Exception as exc:
+                        raise CloudServiceError(
+                            "Interaction policy endpoint returned non-JSON response"
+                        ) from exc
+
+                    policy = self._normalize_interaction_policy_payload(payload)
+                    self._cache_interaction_policy(
+                        cache_key=cache_key,
+                        policy=policy,
+                        etag=response.headers.get("ETag"),
+                    )
+                    return policy
+        except (
+            aiohttp.ClientError,
+            TimeoutError,
+            CloudServiceError,
+            AuthenticationError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            logger.debug(
+                "Interaction policy request failed; using local fallback: %s",
+                exc,
+            )
+            return self._static_interaction_policy()
 
     def _resolve_local_storage_path(self, override: str | None) -> Path:
         """Determine the root path for local fallback storage."""


### PR DESCRIPTION
## What
Python SDK leg (**Phase 4**) of the persona-adaptive interaction layer. Consumes **TraigentSchema#249**; pairs with **TraigentBackend#1785**.

`BackendIntegratedClient.get_interaction_policy()` fetches the resolved persona policy from `GET /api/v1/auth/me/interaction-policy` (X-API-Key) and **falls back to a bundled static default** whenever the network must not be used.

## No-egress / fail-safe (independent Codex gpt-5.5 review fixes)
- Returns the static default with **no network call** when: offline, no API key, mock mode (**both** `is_mock_mode_enabled()` **and** legacy `TRAIGENT_MOCK_LLM` via `is_mock_llm()`), and on backend error / timeout / non-JSON / missing-key responses. Tests assert `aiohttp.ClientSession` is **never** invoked in those states.
- Static fallback matches the backend response envelope exactly (top-level `schema_version="traigent.agent_interaction.response.v1"`, nested `profile.schema_version="traigent.interaction_policy.v1"`).
- Cache stores only `{etag, policy_text, allowlisted profile}`; raw request signals are sent for resolution but **never cached**.

`STATIC_POLICY_TEXT` matches the backend `POLICY_TEXT` verbatim. Backend persona is a **seed**, never an override of in-conversation corrections. **14 cloud tests pass** (incl. no-egress + non-JSON/missing-key fallback).

## Notes
- Pre-commit mypy flags 16 **pre-existing** errors in unrelated files (`config/types.py`, `core/orchestrator.py`, `cloud/client.py`, …) — none in the touched `backend_client.py`, which is mypy-clean. CI mypy checks changed files only.
- JS parity (`traigent-js`) is a tracked fast-follow.

## Companion PRs
Skills (Phase 1): Traigent/traigent-skills#106 · Schema (Phase 2): Traigent/TraigentSchema#249 (merged) · Backend (Phase 3): Traigent/TraigentBackend#1785.

Spine-Trail: st_72bc058e3747