### PR TITLE
feat(sdk): pass opaque warm_start_transfer block to result.metadata

### DIFF
--- a/tests/unit/cloud/test_session_creation_warm_start.py
+++ b/tests/unit/cloud/test_session_creation_warm_start.py
@@ -1,5 +1,6 @@
 """Unit tests for warm_start_from threading through session creation."""
 
+import json
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -9,7 +10,7 @@ import pytest
 from traigent.cloud.api_operations import ApiOperations
 from traigent.cloud.models import OptimizationSession, SessionCreationRequest
 from traigent.cloud.session_operations import SessionOperations
-
+from traigent.core.backend_session_manager import BackendSessionManager
 
 # ---------------------------------------------------------------------------
 # Shared FakeClient infrastructure (mirrors test_session_operations_validation.py)
@@ -274,6 +275,62 @@ class TestResultMetadataWarmStartProvenance:
     def test_metadata_omits_warm_start_when_empty(self, monkeypatch):
         metadata = self._call_build(monkeypatch, "")
         assert "warm_start_from" not in metadata
+
+
+class TestWarmStartTransferMetadataPassthrough:
+    def _manager(self):
+        manager = BackendSessionManager.__new__(BackendSessionManager)
+        manager._backend_client = None
+        manager._egress_disabled = lambda: False
+        manager._session_owning_context = {}
+        return manager
+
+    def test_backend_warm_start_transfer_metadata_copied_verbatim(self):
+        transfer_metadata = {
+            "transfer_mode": "accepted",
+            "final_warm_start_weight": "medium",
+            "search_space_overlap": "partial",
+            "n_seed_configs_applied": 2,
+            "refused_reason": None,
+        }
+        result = SimpleNamespace(metadata={"warm_start_from": "exp_prior_99"})
+
+        self._manager().attach_session_metadata(
+            result=result,
+            session_id="session-123",
+            session_summary={"metadata": {"warm_start_transfer": transfer_metadata}},
+        )
+
+        assert result.metadata["warm_start_transfer"] == transfer_metadata
+        assert result.metadata["warm_start_transfer"] is not transfer_metadata
+        assert result.metadata["warm_start_from"] == "exp_prior_99"
+        field_names = json.dumps(
+            sorted(result.metadata["warm_start_transfer"].keys())
+        ).lower()
+        assert "score" not in field_names
+        assert "signal" not in field_names
+
+    @pytest.mark.parametrize(
+        "session_summary",
+        [
+            {},
+            {"metadata": {}},
+            {"metadata": {"warm_start_transfer": None}},
+            {"metadata": {"warm_start_transfer": "opaque"}},
+        ],
+    )
+    def test_warm_start_transfer_absent_or_non_dict_adds_no_key(
+        self, session_summary
+    ):
+        result = SimpleNamespace(metadata={})
+
+        self._manager().attach_session_metadata(
+            result=result,
+            session_id="session-123",
+            session_summary=session_summary,
+        )
+
+        assert "warm_start_transfer" not in result.metadata
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cloud/test_session_creation_warm_start.py
+++ b/tests/unit/cloud/test_session_creation_warm_start.py
@@ -319,9 +319,7 @@ class TestWarmStartTransferMetadataPassthrough:
             {"metadata": {"warm_start_transfer": "opaque"}},
         ],
     )
-    def test_warm_start_transfer_absent_or_non_dict_adds_no_key(
-        self, session_summary
-    ):
+    def test_warm_start_transfer_absent_or_non_dict_adds_no_key(self, session_summary):
         result = SimpleNamespace(metadata={})
 
         self._manager().attach_session_metadata(

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -1443,9 +1443,9 @@ class BackendSessionManager:
             result.metadata.get("statistical_significance") if result.metadata else None
         )
         if stat_sig:
-            summary_stats_with_aggregation["metadata"]["statistical_significance"] = (
-                stat_sig
-            )
+            summary_stats_with_aggregation["metadata"][
+                "statistical_significance"
+            ] = stat_sig
 
         try:
             successful_trials = len([t for t in result.trials if t.is_successful])
@@ -1563,6 +1563,11 @@ class BackendSessionManager:
         update_payload: dict[str, Any] = {"local_session_id": session_id}
         if session_summary is not None:
             update_payload["local_session_summary"] = session_summary
+            summary_metadata = session_summary.get("metadata")
+            if isinstance(summary_metadata, dict):
+                warm_start_transfer = summary_metadata.get("warm_start_transfer")
+                if isinstance(warm_start_transfer, dict):
+                    update_payload["warm_start_transfer"] = dict(warm_start_transfer)
         if owning_context := self._session_owning_context.get(session_id):
             update_payload.update(owning_context)
 

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -1443,9 +1443,9 @@ class BackendSessionManager:
             result.metadata.get("statistical_significance") if result.metadata else None
         )
         if stat_sig:
-            summary_stats_with_aggregation["metadata"][
-                "statistical_significance"
-            ] = stat_sig
+            summary_stats_with_aggregation["metadata"]["statistical_significance"] = (
+                stat_sig
+            )
 
         try:
             successful_trials = len([t for t in result.trials if t.is_successful])


### PR DESCRIPTION
Part of cross-run warm-start meta-learning — **PR-A ("honest v1")** of feature `FR-CROSS-WARM-START-TRANSFER-V1`. Surfaces the backend's opaque, IP-safe `warm_start_transfer` block to the user.

## Changes
- `BackendSessionManager.attach_session_metadata` copies `session_summary.metadata.warm_start_transfer` (a dict) verbatim into `result.metadata["warm_start_transfer"]`; adds no key when absent/non-dict.
- No `smartopt` import; no signal taxonomy in docstrings/types; preserves existing `result.metadata["warm_start_from"]` provenance.
- Test: verbatim passthrough + omitted-when-absent + no signal field names.

## PR checklist
1. **Worst-case prod path** — harmless metadata passthrough of a closed-enum opaque dict; no policy/charge/leak path.
2. **Production-branch test** — `tests/unit/cloud/test_session_creation_warm_start.py` asserts verbatim copy, omission when absent, and no signal names.
3. **Contract regeneration** — consumes the companion `TraigentSchema` contract; no DTO codegen needed.
4. **Public surface delta** — adds opaque `warm_start_transfer` key to `result.metadata`; no signal taxonomy exposed.
5. **Review threads** — will resolve all before merge.
6. **Quality gates not relaxed.**

Spine-Trail: st_d7e648797955
Spine-Session: cs_05a3d10d066f21d4