### PR TITLE
fix(bedrock): model= alias on invoke() + bump 0.18.1.dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev0"
+version = "0.18.1.dev1"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]

--- a/tests/unit/integrations/test_bedrock_client.py
+++ b/tests/unit/integrations/test_bedrock_client.py
@@ -275,6 +275,32 @@ class TestBedrockChatClientInvoke:
         body = json.loads(mock_client.invoke_model.call_args.kwargs["body"])
         assert body["messages"] == messages
 
+    @pytest.mark.parametrize(
+        ("model_kwargs", "expected_model_id"),
+        [
+            ({"model": "model-alias"}, "model-alias"),
+            ({"model_id": "model-id"}, "model-id"),
+            (
+                {"model": "model-alias", "model_id": "explicit-model-id"},
+                "explicit-model-id",
+            ),
+        ],
+    )
+    def test_invoke_accepts_model_alias_and_model_id(
+        self, model_kwargs: dict[str, str], expected_model_id: str
+    ) -> None:
+        """Test invoke accepts model= as an alias while preserving model_id=."""
+        mock_client = _mock_invoke_client(
+            {"content": [{"type": "text", "text": "Alias response"}]}
+        )
+        client = BedrockChatClient(client=mock_client)
+
+        response = client.invoke(messages="test", **model_kwargs)
+
+        assert response.text == "Alias response"
+        assert response.model == expected_model_id
+        assert mock_client.invoke_model.call_args.kwargs["modelId"] == expected_model_id
+
     def test_invoke_with_temperature_and_top_p(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/traigent/integrations/bedrock_client.py
+++ b/traigent/integrations/bedrock_client.py
@@ -164,7 +164,8 @@ class BedrockChatClient:
     def invoke(
         self,
         *,
-        model_id: str,
+        model_id: str | None = None,
+        model: str | None = None,
         messages: list[Mapping[str, Any]] | str | Iterable[str],
         max_tokens: int = 512,
         temperature: float = 0.5,
@@ -174,8 +175,17 @@ class BedrockChatClient:
     ) -> BedrockChatResponse:
         """Perform a non-streaming chat invocation.
 
+        `model` is accepted as an alias for `model_id`; when both are supplied,
+        `model_id` is used.
         Returns normalized `BedrockChatResponse` with text and raw payload.
         """
+        resolved_model_id = model_id if model_id is not None else model
+        if resolved_model_id is None:
+            raise TypeError(
+                "BedrockChatClient.invoke() missing required model_id/model"
+            )
+        model_id = resolved_model_id
+
         if self._is_mock_enabled():
             return self._mock_response(model_id)
 


### PR DESCRIPTION
P1 from the hidden-state-machines E2E gate. `BedrockChatClient.invoke()` accepted only `model_id=`; passing the canonical `model=` raised. Now `model=` is an alias for `model_id=` (explicit `model_id` wins if both); BedrockPlugin normalizer unchanged. Version bumped 0.18.1.dev0->0.18.1.dev1 for republish.

Tests: model=/model_id=/both covered; 66 bedrock tests pass; ruff clean. codex GO.

Spine-Trail: st_68d3d3e79522
