### PR TITLE
fix(warm-start): surface warm_start_transfer via cloud finalize + fix persistence crash

### DIFF
--- a/tests/unit/cloud/test_session_creation_warm_start.py
+++ b/tests/unit/cloud/test_session_creation_warm_start.py
@@ -330,6 +330,46 @@ class TestWarmStartTransferMetadataPassthrough:
 
         assert "warm_start_transfer" not in result.metadata
 
+    def test_warm_start_transfer_extracted_from_finalization_response_object(self):
+        # Real cloud path: finalize_session returns an OptimizationFinalizationResponse
+        # dataclass that exposes ``.metadata`` as an ATTRIBUTE and has no ``.get()``.
+        # Regression: calling ``.get()`` on it raised AttributeError, which the
+        # persistence try/except swallowed as "persistence failed" on every cloud run
+        # (also nulling experiment_id). Must read ``.metadata`` via attribute instead.
+        transfer_metadata = {
+            "transfer_mode": "replay_only",
+            "final_warm_start_weight": "low",
+            "search_space_overlap": "high",
+            "n_seed_configs_applied": 3,
+            "refused_reason": None,
+        }
+        finalization_response = SimpleNamespace(
+            metadata={"warm_start_transfer": transfer_metadata}
+        )
+        assert not hasattr(finalization_response, "get")  # like the real dataclass
+        result = SimpleNamespace(metadata={})
+
+        self._manager().attach_session_metadata(
+            result=result,
+            session_id="session-123",
+            session_summary=finalization_response,
+        )
+
+        assert result.metadata["warm_start_transfer"] == transfer_metadata
+        assert result.metadata["warm_start_transfer"] is not transfer_metadata
+
+    def test_session_summary_object_without_metadata_attr_does_not_crash(self):
+        no_meta = SimpleNamespace()  # neither .get nor .metadata
+        result = SimpleNamespace(metadata={})
+
+        self._manager().attach_session_metadata(
+            result=result,
+            session_id="session-123",
+            session_summary=no_meta,
+        )
+
+        assert "warm_start_transfer" not in result.metadata
+
 
 # ---------------------------------------------------------------------------
 # Tests: EVERY SessionCreationRequest -> /sessions payload serializer must

--- a/tests/unit/cloud/test_session_finalization.py
+++ b/tests/unit/cloud/test_session_finalization.py
@@ -152,6 +152,81 @@ class TestSessionFinalization:
         ]
 
     @pytest.mark.asyncio
+    async def test_finalize_session_surfaces_backend_warm_start_transfer(self, client):
+        """The opaque, IP-safe metadata.warm_start_transfer block from the backend
+        finalize response must be carried onto the SDK response metadata (it was
+        previously dropped, so result.metadata.warm_start_transfer stayed None)."""
+        session_id = "test-session-warmstart"
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-ws",
+            experiment_run_id="run-ws",
+            function_name="ws_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+        transfer = {
+            "transfer_mode": "cold",
+            "final_warm_start_weight": "none",
+            "search_space_overlap": "unknown",
+            "n_seed_configs_applied": 0,
+            "refused_reason": "no_seed_configs",
+        }
+        backend_payload = {
+            "best_config": {"model": "gpt-4o"},
+            "best_metrics": {"accuracy": 0.9},
+            "metadata": {
+                "stop_reason": "max_trials_reached",
+                "warm_start_transfer": transfer,
+            },
+        }
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=backend_payload)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        assert response.metadata["warm_start_transfer"] == transfer
+
+    @pytest.mark.asyncio
+    async def test_finalize_session_omits_warm_start_transfer_when_absent(self, client):
+        """No warm_start_transfer in backend metadata -> key absent (no synthetic)."""
+        session_id = "test-session-no-ws"
+        client.session_bridge.create_session_mapping(
+            session_id=session_id,
+            experiment_id="exp-nows",
+            experiment_run_id="run-nows",
+            function_name="nows_func",
+            configuration_space={},
+            objectives=["accuracy"],
+        )
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"stop_reason": "timeout", "metadata": {}}
+        )
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = AsyncMock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = await client._session_ops.finalize_session(session_id)
+
+        assert "warm_start_transfer" not in response.metadata
+
+    @pytest.mark.asyncio
     async def test_finalize_session_partial_summary_lists_preserved_fields(
         self, client
     ):

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -1033,6 +1033,12 @@ class SessionOperations:
         backend_stop_reason = backend_summary.get("stop_reason")
         backend_convergence_history = backend_summary.get("convergence_history")
         backend_full_history = backend_summary.get("full_history")
+        backend_metadata = backend_summary.get("metadata")
+        backend_warm_start_transfer = (
+            backend_metadata.get("warm_start_transfer")
+            if isinstance(backend_metadata, dict)
+            else None
+        )
 
         summary_fields: list[str] = []
 
@@ -1133,6 +1139,14 @@ class SessionOperations:
                 # before treating best_config/best_metrics as authoritative.
                 "summary_available": summary_available,
                 "summary_fields": summary_fields,
+                # Pass the backend's opaque, IP-safe warm-start transfer block
+                # (transfer_mode / refused_reason / search_space_overlap / ...)
+                # through so the SDK can surface result.metadata.warm_start_transfer.
+                **(
+                    {"warm_start_transfer": backend_warm_start_transfer}
+                    if isinstance(backend_warm_start_transfer, dict)
+                    else {}
+                ),
             },
         )
 

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -1567,7 +1567,15 @@ class BackendSessionManager:
         update_payload: dict[str, Any] = {"local_session_id": session_id}
         if session_summary is not None:
             update_payload["local_session_summary"] = session_summary
-            summary_metadata = session_summary.get("metadata")
+            # session_summary may be a plain dict OR an OptimizationFinalizationResponse
+            # dataclass (the real cloud finalize path), which exposes ``.metadata`` as an
+            # attribute and has no ``.get()``. Calling ``.get()`` on the dataclass raised
+            # AttributeError, which the persistence try/except swallowed as
+            # "persistence failed" on every cloud run. Guard the type before extracting.
+            if isinstance(session_summary, dict):
+                summary_metadata = session_summary.get("metadata")
+            else:
+                summary_metadata = getattr(session_summary, "metadata", None)
             if isinstance(summary_metadata, dict):
                 warm_start_transfer = summary_metadata.get("warm_start_transfer")
                 if isinstance(warm_start_transfer, dict):


### PR DESCRIPTION
Bug fix found by the real Bedrock E2E of the warm-start feature (`FR-CROSS-WARM-START-TRANSFER-V1`).

## Root cause (two layers)
1. **Persistence crash on every cloud run.** `BackendSessionManager.attach_session_metadata` called `session_summary.get("metadata")`, but `finalize_session` returns an `OptimizationFinalizationResponse` **dataclass** (a `.metadata` attribute, no `.get()`). The `AttributeError` was swallowed by the persistence `try/except` as `persistence_status=failed` — which also left `result.experiment_id` `None`. → Read `.metadata` via attribute when not a dict.
2. **`warm_start_transfer` dropped in finalize deserialization.** `session_operations.finalize_session` built a *curated* `OptimizationFinalizationResponse.metadata` (`finalized_at`, `summary_fields`, …) and never copied the backend response's `metadata.warm_start_transfer`. → Pass it through.

## Verification (E2E against dev, real Bedrock + cloud)
- Before: `experiment_id=None`, `persistence failed: 'OptimizationFinalizationResponse' object has no attribute 'get'`, `warm_start_transfer=None`.
- After: `experiment_id` populates; `result.metadata.warm_start_transfer` surfaces — `{transfer_mode: cold, refused_reason: not_requested}` for a plain run and `{transfer_mode: cold, refused_reason: no_seed_configs}` for a warm run (honest fail-closed).
- Unit: 46 tests pass incl. new regressions (dataclass `.metadata` extraction; finalize passthrough; absent-key safety). ruff clean.

## PR checklist
1. **Worst-case prod path** — this *fixes* a worst-case: persistence silently failed on all cloud runs. No new policy/charge path; opaque block stays IP-safe (closed enums only).
2. **Production-branch test** — `tests/unit/cloud/test_session_finalization.py` (passthrough + absent), `tests/unit/cloud/test_session_creation_warm_start.py` (dataclass extraction, no-crash).
3. **Contract regeneration** — none (consumes existing TraigentSchema `warm_start_transfer`).
4. **Public surface delta** — `result.metadata.warm_start_transfer` now actually populates (was silently dropped); no new keys/signals.
5. **Review threads** — will resolve all before merge.
6. **Quality gates not relaxed.**

Spine-Trail: st_b7350d178fd6
Spine-Session: cs_05a3d10d066f21d4