### PR TITLE
chore(sdk): bump 0.18.1.dev2 (publish #1555 finalization-crash fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev1"
+version = "0.18.1.dev2"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
Bump 0.18.1.dev1 → 0.18.1.dev2 to publish #1555 to PyPI.

#1555 (merged to develop, ad08579a) fixed the finalization `.get()`-on-dataclass crash so `result.experiment_run_id`/`experiment_id` populate for real clients (verified the bug on 0.18.1.dev1 via live diagnostic). This bump just gets that fix onto PyPI; closes the publish step for #1554.

No code change beyond the version string.

Spine-Trail: st_5a7e829bf165
Spine: none (reason: version-bump chore to publish an already-merged fix)
