### PR TITLE
fix(cloud): get_interaction_policy() falls back to static on unreachable backend (fail-safe read, fail-closed ops)

### DIFF
--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -486,3 +486,62 @@ async def test_invalid_url_cloud_ops_fail_closed_with_zero_transport(
             await client.request_trial_slot("sess-invalid-url")
 
     mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_url_context_manager_does_no_egress(monkeypatch) -> None:
+    """Entering the async context manager on an unusable URL must not dial out.
+
+    __aenter__ would otherwise call auth.get_headers() (which can POST
+    /keys/validate) and build an aiohttp session against the inert placeholder
+    origin. On _url_invalid it must return an inert client with no transport and
+    no auth round-trip.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    client = BackendIntegratedClient(
+        api_key=FAKE_API_KEY,
+        base_url="https://does-not-exist.traigent.invalid",
+    )
+    assert client._url_invalid is True
+
+    with patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session:
+        with patch.object(client.auth_manager.auth, "get_headers") as mock_get_headers:
+            async with client as entered:
+                assert entered is client
+                assert client._session is None
+
+    mock_session.assert_not_called()
+    mock_get_headers.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "traversal_path",
+    [
+        "/%2e%2e/secret",
+        # Multiply-encoded traversal on the FULL base_url path must not survive
+        # the fixed-point decode in validate_cloud_base_url (regression: it was a
+        # fixed two-pass decode, so triple-encoded %25252e slipped through).
+        "/%252e%252e/secret",
+        "/%25252e%25252e/secret",
+    ],
+)
+@pytest.mark.asyncio
+async def test_full_url_multiply_encoded_traversal_is_rejected(
+    monkeypatch,
+    traversal_path: str,
+) -> None:
+    """A traversal path on the primary base_url must fail loud, not be swallowed.
+
+    This exercises validate_cloud_base_url directly (the full-URL path), not the
+    explicit api_base_url guard — they must be consistent.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    with pytest.raises(ValueError, match="traversal"):
+        BackendIntegratedClient(
+            api_key=FAKE_API_KEY,
+            base_url=f"https://api.example.test{traversal_path}",
+        )

--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -352,9 +352,7 @@ async def test_unreachable_url_init_does_not_raise_and_returns_static_policy(
 
     # get_interaction_policy() must return the static fallback without any
     # network call
-    with patch(
-        "traigent.cloud.backend_client.aiohttp.ClientSession"
-    ) as mock_session:
+    with patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session:
         result = await client.get_interaction_policy()
 
     _assert_static_policy(result)
@@ -439,9 +437,7 @@ async def test_valid_url_does_not_set_url_invalid(monkeypatch) -> None:
         base_url="https://api.example.test",
     )
 
-    assert client._url_invalid is False, (
-        "Expected _url_invalid=False for a valid URL"
-    )
+    assert client._url_invalid is False, "Expected _url_invalid=False for a valid URL"
 
 
 # ---------------------------------------------------------------------------
@@ -479,9 +475,7 @@ async def test_invalid_url_cloud_ops_fail_closed_with_zero_transport(
 
     # Representative high-level cloud ops must fail closed end-to-end with no
     # network session ever constructed.
-    with patch(
-        "traigent.cloud.backend_client.aiohttp.ClientSession"
-    ) as mock_session:
+    with patch("traigent.cloud.backend_client.aiohttp.ClientSession") as mock_session:
         with pytest.raises(CloudEgressBlockedError):
             await client.create_hybrid_session(
                 "guarded_problem",

--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -305,3 +305,72 @@ async def test_get_interaction_policy_backend_failures_return_static(
 
     _assert_static_policy(result)
     assert len(fake_session.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: unreachable/invalid backend URL must not raise from __init__,
+# and get_interaction_policy() must return the static default without a
+# network call.  (Bug: ValueError from validate_cloud_base_url was raised
+# in __init__ before get_interaction_policy()'s try/except could catch it.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        # Unresolvable hostname (DNS lookup raises socket.gaierror → ValueError)
+        "https://does-not-exist.traigent.invalid",
+        # Private-network IP blocked in production
+        "https://192.168.1.1",
+        # Non-http scheme
+        "ftp://bad-scheme.example.com",
+        # URL with credentials (explicitly forbidden)
+        "https://user:pass@api.example.com",  # pragma: allowlist secret
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_url_init_does_not_raise_and_returns_static_policy(
+    monkeypatch,
+    bad_url: str,
+) -> None:
+    """BackendIntegratedClient must not raise on an unusable URL.
+
+    get_interaction_policy() must return the static default (guided/se/balanced)
+    when the backend URL was rejected during __init__ — it must never propagate
+    the ValueError to the caller.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    # __init__ must succeed even with a bad URL
+    client = BackendIntegratedClient(api_key=FAKE_API_KEY, base_url=bad_url)
+
+    assert client._url_invalid is True, (
+        "Expected _url_invalid=True for an unusable URL"
+    )
+
+    # get_interaction_policy() must return the static fallback without any
+    # network call
+    with patch(
+        "traigent.cloud.backend_client.aiohttp.ClientSession"
+    ) as mock_session:
+        result = await client.get_interaction_policy()
+
+    _assert_static_policy(result)
+    mock_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_url_does_not_set_url_invalid(monkeypatch) -> None:
+    """A well-formed, routable URL must leave _url_invalid=False."""
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    client = BackendIntegratedClient(
+        api_key=FAKE_API_KEY,
+        base_url="https://api.example.test",
+    )
+
+    assert client._url_invalid is False, (
+        "Expected _url_invalid=False for a valid URL"
+    )

--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -374,3 +374,53 @@ async def test_valid_url_does_not_set_url_invalid(monkeypatch) -> None:
     assert client._url_invalid is False, (
         "Expected _url_invalid=False for a valid URL"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression (fail-CLOSED counterpart): an unusable backend URL must NOT make
+# real cloud operations silently target the inert placeholder. Every cloud op
+# must fail closed with CloudEgressBlockedError and emit ZERO transport calls.
+# (Policy reads fall back to static; everything else is denied.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_url_cloud_ops_fail_closed_with_zero_transport(
+    monkeypatch,
+) -> None:
+    from traigent.cloud.client import CloudEgressBlockedError
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    client = BackendIntegratedClient(
+        api_key=FAKE_API_KEY,
+        base_url="https://does-not-exist.traigent.invalid",
+    )
+    assert client._url_invalid is True
+
+    # Each component's fail-closed chokepoint must deny when the URL is invalid.
+    for guard_owner in (
+        client,
+        client._api_ops,
+        client._session_ops,
+        client._trial_ops,
+    ):
+        with pytest.raises(CloudEgressBlockedError):
+            guard_owner._raise_if_backend_egress_disabled("probe")
+
+    # Representative high-level cloud ops must fail closed end-to-end with no
+    # network session ever constructed.
+    with patch(
+        "traigent.cloud.backend_client.aiohttp.ClientSession"
+    ) as mock_session:
+        with pytest.raises(CloudEgressBlockedError):
+            await client.create_hybrid_session(
+                "guarded_problem",
+                {"temperature": [0.1]},
+                {"objectives": ["accuracy"], "max_trials": 1},
+            )
+        with pytest.raises(CloudEgressBlockedError):
+            await client.request_trial_slot("sess-invalid-url")
+
+    mock_session.assert_not_called()

--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -316,37 +316,34 @@ async def test_get_interaction_policy_backend_failures_return_static(
 
 
 @pytest.mark.parametrize(
-    "bad_url",
+    "unreachable_url",
     [
-        # Unresolvable hostname (DNS lookup raises socket.gaierror → ValueError)
+        # Unresolvable hostname (DNS lookup raises socket.gaierror →
+        # CloudUrlUnreachableError). This is the ONLY fallback-eligible case:
+        # a backend that is simply not reachable, not an unsafe origin.
         "https://does-not-exist.traigent.invalid",
-        # Private-network IP blocked in production
-        "https://192.168.1.1",
-        # Non-http scheme
-        "ftp://bad-scheme.example.com",
-        # URL with credentials (explicitly forbidden)
-        "https://user:pass@api.example.com",  # pragma: allowlist secret
+        "https://api.unreachable.traigent.invalid",
     ],
 )
 @pytest.mark.asyncio
-async def test_invalid_url_init_does_not_raise_and_returns_static_policy(
+async def test_unreachable_url_init_does_not_raise_and_returns_static_policy(
     monkeypatch,
-    bad_url: str,
+    unreachable_url: str,
 ) -> None:
-    """BackendIntegratedClient must not raise on an unusable URL.
+    """An UNREACHABLE backend must degrade to the static policy, not raise.
 
     get_interaction_policy() must return the static default (guided/se/balanced)
-    when the backend URL was rejected during __init__ — it must never propagate
-    the ValueError to the caller.
+    when the backend host could not be resolved during __init__ — it must never
+    propagate the error to the caller.
     """
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
 
-    # __init__ must succeed even with a bad URL
-    client = BackendIntegratedClient(api_key=FAKE_API_KEY, base_url=bad_url)
+    # __init__ must succeed when the host is merely unreachable
+    client = BackendIntegratedClient(api_key=FAKE_API_KEY, base_url=unreachable_url)
 
     assert client._url_invalid is True, (
-        "Expected _url_invalid=True for an unusable URL"
+        "Expected _url_invalid=True for an unreachable URL"
     )
 
     # get_interaction_policy() must return the static fallback without any
@@ -358,6 +355,38 @@ async def test_invalid_url_init_does_not_raise_and_returns_static_policy(
 
     _assert_static_policy(result)
     mock_session.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "unsafe_url",
+    [
+        # Cloud metadata endpoint (SSRF target) — must NEVER be swallowed
+        "https://169.254.169.254",
+        # Loopback / private-network targets blocked in production
+        "https://127.0.0.1:5000",
+        "https://192.168.1.1",
+        # Non-http scheme
+        "ftp://bad-scheme.example.com",
+        # URL with embedded credentials (explicitly forbidden)
+        "https://user:pass@api.example.com",  # pragma: allowlist secret
+    ],
+)
+@pytest.mark.asyncio
+async def test_unsafe_url_still_fails_loud_and_is_not_swallowed(
+    monkeypatch,
+    unsafe_url: str,
+) -> None:
+    """UNSAFE origins must keep failing loud — the fallback must not relax SSRF.
+
+    The interaction-policy fallback is scoped strictly to unreachable hosts; an
+    unsafe origin (metadata/loopback/private IP, bad scheme, credentialed URL)
+    must still raise from __init__ exactly as before the fallback was added.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    with pytest.raises(ValueError):
+        BackendIntegratedClient(api_key=FAKE_API_KEY, base_url=unsafe_url)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -7,7 +7,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from traigent.cloud.backend_client import STATIC_POLICY_TEXT, BackendIntegratedClient
+from traigent.cloud.backend_client import (
+    STATIC_POLICY_TEXT,
+    BackendClientConfig,
+    BackendIntegratedClient,
+)
 from traigent.testing import _reset_for_tests, enable_mock_mode_for_quickstart
 
 FAKE_API_KEY = "tg_" + "x" * 61  # pragma: allowlist secret
@@ -387,6 +391,38 @@ async def test_unsafe_url_still_fails_loud_and_is_not_swallowed(
 
     with pytest.raises(ValueError):
         BackendIntegratedClient(api_key=FAKE_API_KEY, base_url=unsafe_url)
+
+
+@pytest.mark.parametrize(
+    "traversal_path",
+    [
+        "/api/../../admin",
+        "/%2e%2e/secret",
+        "/v1/./../..",
+    ],
+)
+@pytest.mark.asyncio
+async def test_explicit_api_base_path_traversal_is_rejected(
+    monkeypatch,
+    traversal_path: str,
+) -> None:
+    """An explicitly configured api_base_url with path traversal must fail loud.
+
+    __init__ validates only the api ORIGIN and re-attaches the configured path,
+    so the decoded path is independently traversal-checked — otherwise a crafted
+    api_base_url could reach an unintended path past the origin guard (the path
+    on this config field is NOT run through validate_cloud_base_url's full check).
+    """
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("TRAIGENT_API_KEY", FAKE_API_KEY)
+
+    config = BackendClientConfig(
+        backend_base_url="https://api.example.test",
+        api_base_url=f"https://api.example.test{traversal_path}",
+    )
+
+    with pytest.raises(ValueError, match="traversal"):
+        BackendIntegratedClient(api_key=FAKE_API_KEY, backend_config=config)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cloud/test_backend_client_interaction_policy.py
+++ b/tests/unit/cloud/test_backend_client_interaction_policy.py
@@ -399,6 +399,9 @@ async def test_unsafe_url_still_fails_loud_and_is_not_swallowed(
         "/api/../../admin",
         "/%2e%2e/secret",
         "/v1/./../..",
+        # Multiply-encoded traversal must not survive fixed-point decoding
+        "/%252e%252e/secret",
+        "/%25252e%25252e/secret",
     ],
 )
 @pytest.mark.asyncio

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 
 from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.client import (
+    CloudEgressBlockedError,
     CloudRemoteExecutionUnavailableError,
     CloudServiceError,
     SessionContractError,
@@ -34,12 +35,12 @@ from traigent.core.session_types import (
     SessionCreationFailureDetail,
     SessionCreationHTTPError,
 )
-from traigent.utils.env_config import is_backend_offline
-from traigent.utils.exceptions import MetricExtractionError
 from traigent.utils.artifact_fingerprints import (
     artifact_fingerprints_to_wire,
     fingerprint_meta_to_wire,
 )
+from traigent.utils.env_config import is_backend_offline
+from traigent.utils.exceptions import MetricExtractionError
 from traigent.utils.logging import get_logger
 from traigent.utils.validation import validate_numeric_metric
 
@@ -321,6 +322,8 @@ class ApiOperations:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
+        if getattr(self.client, "_url_invalid", False):
+            raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(
             operation,
             no_egress=getattr(self.client, "no_egress", False),

--- a/traigent/cloud/api_operations.py
+++ b/traigent/cloud/api_operations.py
@@ -322,7 +322,7 @@ class ApiOperations:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
-        if getattr(self.client, "_url_invalid", False):
+        if getattr(self.client, "_url_invalid", False) is True:
             raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(
             operation,

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -1078,6 +1078,11 @@ class BackendIntegratedClient:
         """Async context manager entry."""
         if cloud_backend_egress_disabled(self.no_egress):
             return self
+        # Fail closed on an unusable backend URL: the placeholder origin set in
+        # __init__ must never be dialed, and auth.get_headers() below may POST
+        # to /keys/validate. Return an inert client with no transport.
+        if getattr(self, "_url_invalid", False):
+            return self
         if AIOHTTP_AVAILABLE:
             # Try to get headers, but don't fail if authentication is not available
             # B4 ROUND 4: ``AuthenticationError`` must propagate -- a

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -540,12 +540,19 @@ class BackendIntegratedClient:
             # here — otherwise an explicit api_base_url like ".../../admin" would
             # bypass the traversal guard that validate_cloud_base_url applies to
             # full URLs.
+            # Decode to a fixed point (bounded) so multiply-encoded traversal
+            # (e.g. %25252e) cannot survive a fixed two-pass decode.
             _decoded_api_path = api_path or ""
-            for _ in range(2):
+            for _ in range(8):
                 _next = unquote(_decoded_api_path)
                 if _next == _decoded_api_path:
                     break
                 _decoded_api_path = _next
+            else:
+                # Still changing after 8 decodes — pathologically encoded; reject.
+                raise ValueError(
+                    "backend client API base URL must not contain path traversal"
+                )
             if any(
                 seg in {".", ".."} for seg in _decoded_api_path.split("/") if seg
             ):

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -35,6 +35,7 @@ from traigent.cloud.backend_components import (
     BackendTrialManager,
 )
 from traigent.cloud.client import (
+    CloudEgressBlockedError,
     CloudServiceError,
     _finalize_aiohttp_session,
     _is_real_aiohttp_session,
@@ -492,40 +493,65 @@ class BackendIntegratedClient:
         if effective_base_url is None:
             effective_base_url = BackendConfig.get_backend_url()
 
-        # Validate and sanitize URLs
-        effective_base_url = validate_cloud_base_url(
-            effective_base_url, purpose="backend client"
-        )
-        self.base_url = self._api_ops.validate_and_sanitize_url(effective_base_url)
-
-        backend_base_url = self.base_url
-        if not explicit_base_origin:
-            backend_base_url = self.backend_config.backend_base_url or self.base_url
-        backend_base_url = validate_cloud_base_url(
-            backend_base_url, purpose="backend client"
-        )
-        self.backend_config.backend_base_url = self._api_ops.validate_and_sanitize_url(
-            backend_base_url
-        )
-
-        if explicit_api_base and not getattr(
-            self.backend_config, "api_explicitly_set", False
-        ):
-            api_base_candidate = explicit_api_base
-        else:
-            api_base_candidate = (
-                self.backend_config.api_base_url
-                or BackendConfig.build_api_base(self.backend_config.backend_base_url)
+        # Validate and sanitize URLs.  If the supplied URL is unreachable or
+        # structurally invalid (e.g. unresolvable hostname, private-IP target),
+        # mark _url_invalid so get_interaction_policy() can fall back to the
+        # static policy without raising.  The live validation path is entirely
+        # unchanged — only the fallback branch activates when the URL is
+        # genuinely unusable.
+        self._url_invalid = False
+        try:
+            effective_base_url = validate_cloud_base_url(
+                effective_base_url, purpose="backend client"
             )
-        api_origin, api_path = BackendConfig.split_api_url(api_base_candidate)
-        if api_origin is None:
-            raise ValueError("backend client API base URL must include an origin")
-        api_origin = validate_cloud_base_url(api_origin, purpose="backend client")
-        api_base_candidate = (
-            f"{api_origin}{api_path or BackendConfig.get_default_api_path()}"
-        )
-        self.api_base_url = self._api_ops.validate_and_sanitize_url(api_base_candidate)
-        self.backend_config.api_base_url = self.api_base_url
+            self.base_url = self._api_ops.validate_and_sanitize_url(effective_base_url)
+
+            backend_base_url = self.base_url
+            if not explicit_base_origin:
+                backend_base_url = self.backend_config.backend_base_url or self.base_url
+            backend_base_url = validate_cloud_base_url(
+                backend_base_url, purpose="backend client"
+            )
+            self.backend_config.backend_base_url = (
+                self._api_ops.validate_and_sanitize_url(backend_base_url)
+            )
+
+            if explicit_api_base and not getattr(
+                self.backend_config, "api_explicitly_set", False
+            ):
+                api_base_candidate = explicit_api_base
+            else:
+                api_base_candidate = (
+                    self.backend_config.api_base_url
+                    or BackendConfig.build_api_base(
+                        self.backend_config.backend_base_url
+                    )
+                )
+            api_origin, api_path = BackendConfig.split_api_url(api_base_candidate)
+            if api_origin is None:
+                raise ValueError("backend client API base URL must include an origin")
+            api_origin = validate_cloud_base_url(api_origin, purpose="backend client")
+            api_base_candidate = (
+                f"{api_origin}{api_path or BackendConfig.get_default_api_path()}"
+            )
+            self.api_base_url = self._api_ops.validate_and_sanitize_url(
+                api_base_candidate
+            )
+            self.backend_config.api_base_url = self.api_base_url
+        except ValueError:
+            # URL is structurally invalid or the hostname could not be resolved.
+            # Store a safe inert placeholder so the rest of __init__ completes;
+            # get_interaction_policy() will short-circuit to _static_interaction_policy.
+            self._url_invalid = True
+            _placeholder = "https://backend.invalid"
+            self.base_url = _placeholder
+            self.backend_config.backend_base_url = _placeholder
+            self.api_base_url = _placeholder
+            self.backend_config.api_base_url = _placeholder
+            logger.debug(
+                "BackendIntegratedClient: URL validation failed; "
+                "falling back to static interaction policy"
+            )
 
         self.enable_fallback = enable_fallback
         self.no_egress = bool(no_egress)
@@ -827,6 +853,9 @@ class BackendIntegratedClient:
         if cloud_backend_egress_disabled(self.no_egress):
             return self._static_interaction_policy()
 
+        if getattr(self, "_url_invalid", False):
+            return self._static_interaction_policy()
+
         api_key = os.getenv("TRAIGENT_API_KEY") or self._api_key_fallback
         if not api_key or is_mock_llm() or not AIOHTTP_AVAILABLE:
             return self._static_interaction_policy()
@@ -1111,6 +1140,8 @@ class BackendIntegratedClient:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
+        if getattr(self, "_url_invalid", False):
+            raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(operation, no_egress=self.no_egress)
 
     async def _reset_http_session(self, reason: str | None = None) -> None:

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -553,9 +553,7 @@ class BackendIntegratedClient:
                 raise ValueError(
                     "backend client API base URL must not contain path traversal"
                 )
-            if any(
-                seg in {".", ".."} for seg in _decoded_api_path.split("/") if seg
-            ):
+            if any(seg in {".", ".."} for seg in _decoded_api_path.split("/") if seg):
                 raise ValueError(
                     "backend client API base URL must not contain path traversal"
                 )

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -20,7 +20,7 @@ from email.utils import parsedate_to_datetime
 from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import quote, urlparse, urlunparse
+from urllib.parse import quote, unquote, urlparse, urlunparse
 
 # Import and re-export BackendClientConfig for backward compatibility
 from traigent.cloud._aiohttp_compat import AIOHTTP_AVAILABLE, aiohttp
@@ -535,6 +535,23 @@ class BackendIntegratedClient:
             if api_origin is None:
                 raise ValueError("backend client API base URL must include an origin")
             api_origin = validate_cloud_base_url(api_origin, purpose="backend client")
+            # validate_cloud_base_url only saw the origin; the API path is
+            # reattached below, so re-check the (decoded) path for traversal
+            # here — otherwise an explicit api_base_url like ".../../admin" would
+            # bypass the traversal guard that validate_cloud_base_url applies to
+            # full URLs.
+            _decoded_api_path = api_path or ""
+            for _ in range(2):
+                _next = unquote(_decoded_api_path)
+                if _next == _decoded_api_path:
+                    break
+                _decoded_api_path = _next
+            if any(
+                seg in {".", ".."} for seg in _decoded_api_path.split("/") if seg
+            ):
+                raise ValueError(
+                    "backend client API base URL must not contain path traversal"
+                )
             api_base_candidate = (
                 f"{api_origin}{api_path or BackendConfig.get_default_api_path()}"
             )

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -65,7 +65,10 @@ from traigent.cloud.session_operations import SessionOperations
 from traigent.cloud.session_types import SessionCreationResult
 from traigent.cloud.subset_selection import SmartSubsetSelector
 from traigent.cloud.trial_operations import TrialOperations
-from traigent.cloud.url_security import validate_cloud_base_url
+from traigent.cloud.url_security import (
+    CloudUrlUnreachableError,
+    validate_cloud_base_url,
+)
 from traigent.cloud.user_agent import get_sdk_user_agent
 from traigent.config.backend_config import BackendConfig
 from traigent.config.project import read_optional_project_env
@@ -493,12 +496,13 @@ class BackendIntegratedClient:
         if effective_base_url is None:
             effective_base_url = BackendConfig.get_backend_url()
 
-        # Validate and sanitize URLs.  If the supplied URL is unreachable or
-        # structurally invalid (e.g. unresolvable hostname, private-IP target),
-        # mark _url_invalid so get_interaction_policy() can fall back to the
-        # static policy without raising.  The live validation path is entirely
-        # unchanged — only the fallback branch activates when the URL is
-        # genuinely unusable.
+        # Validate and sanitize URLs.  If the supplied URL is simply
+        # *unreachable* (host cannot be resolved), mark _url_invalid so
+        # get_interaction_policy() can fall back to the static policy without
+        # raising.  UNSAFE-origin rejections (private/loopback/metadata IPs,
+        # bad scheme, embedded credentials, path traversal) are NOT caught here
+        # — they keep failing loud to preserve SSRF protection.  The live
+        # validation path is otherwise entirely unchanged.
         self._url_invalid = False
         try:
             effective_base_url = validate_cloud_base_url(
@@ -538,10 +542,13 @@ class BackendIntegratedClient:
                 api_base_candidate
             )
             self.backend_config.api_base_url = self.api_base_url
-        except ValueError:
-            # URL is structurally invalid or the hostname could not be resolved.
+        except CloudUrlUnreachableError:
+            # The backend host could not be resolved (genuinely unreachable).
             # Store a safe inert placeholder so the rest of __init__ completes;
-            # get_interaction_policy() will short-circuit to _static_interaction_policy.
+            # get_interaction_policy() will short-circuit to _static_interaction_policy,
+            # while every cloud op fails closed via _raise_if_backend_egress_disabled.
+            # NOTE: unsafe-origin ValueErrors are intentionally NOT caught here —
+            # they propagate so SSRF/credentialed-URL rejections still fail loud.
             self._url_invalid = True
             _placeholder = "https://backend.invalid"
             self.base_url = _placeholder

--- a/traigent/cloud/backend_client.py
+++ b/traigent/cloud/backend_client.py
@@ -882,7 +882,7 @@ class BackendIntegratedClient:
         if cloud_backend_egress_disabled(self.no_egress):
             return self._static_interaction_policy()
 
-        if getattr(self, "_url_invalid", False):
+        if getattr(self, "_url_invalid", False) is True:
             return self._static_interaction_policy()
 
         api_key = os.getenv("TRAIGENT_API_KEY") or self._api_key_fallback
@@ -1081,7 +1081,7 @@ class BackendIntegratedClient:
         # Fail closed on an unusable backend URL: the placeholder origin set in
         # __init__ must never be dialed, and auth.get_headers() below may POST
         # to /keys/validate. Return an inert client with no transport.
-        if getattr(self, "_url_invalid", False):
+        if getattr(self, "_url_invalid", False) is True:
             return self
         if AIOHTTP_AVAILABLE:
             # Try to get headers, but don't fail if authentication is not available
@@ -1174,7 +1174,7 @@ class BackendIntegratedClient:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
-        if getattr(self, "_url_invalid", False):
+        if getattr(self, "_url_invalid", False) is True:
             raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(operation, no_egress=self.no_egress)
 

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -100,7 +100,7 @@ class SessionOperations:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
-        if getattr(self.client, "_url_invalid", False):
+        if getattr(self.client, "_url_invalid", False) is True:
             raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(
             operation,

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -100,6 +100,8 @@ class SessionOperations:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
+        if getattr(self.client, "_url_invalid", False):
+            raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(
             operation,
             no_egress=getattr(self.client, "no_egress", False),

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -67,7 +67,7 @@ class TrialOperations:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
-        if getattr(self.client, "_url_invalid", False):
+        if getattr(self.client, "_url_invalid", False) is True:
             raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(
             operation,

--- a/traigent/cloud/trial_operations.py
+++ b/traigent/cloud/trial_operations.py
@@ -15,7 +15,10 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from traigent._version import get_version
-from traigent.cloud.client import raise_if_cloud_egress_disabled
+from traigent.cloud.client import (
+    CloudEgressBlockedError,
+    raise_if_cloud_egress_disabled,
+)
 from traigent.cloud.dtos import MeasuresDict
 from traigent.cloud.validators import validate_configuration_run_submission
 from traigent.config.backend_config import BackendConfig
@@ -64,6 +67,8 @@ class TrialOperations:
     def _raise_if_backend_egress_disabled(self, operation: str) -> None:
         """Fail closed before any backend HTTP request."""
 
+        if getattr(self.client, "_url_invalid", False):
+            raise CloudEgressBlockedError(operation)
         raise_if_cloud_egress_disabled(
             operation,
             no_egress=getattr(self.client, "no_egress", False),

--- a/traigent/cloud/url_security.py
+++ b/traigent/cloud/url_security.py
@@ -170,12 +170,20 @@ def validate_cloud_base_url(base_url: str, *, purpose: str = "cloud request") ->
     if not allow_local and parsed.scheme != "https":
         raise ValueError(f"{purpose} base URL must use https in production") from None
 
+    # Decode to a fixed point (bounded) so multiply-encoded traversal
+    # (e.g. %25252e) cannot survive a fixed two-pass decode. Mirrors the
+    # explicit-api_base_url guard in backend_client.py.
     decoded_path = parsed.path
-    for _ in range(2):
+    for _ in range(8):
         next_path = unquote(decoded_path)
         if next_path == decoded_path:
             break
         decoded_path = next_path
+    else:
+        # Still changing after 8 decodes — pathologically encoded; reject.
+        raise ValueError(
+            f"{purpose} base URL must not contain path traversal"
+        ) from None
 
     path_segments = [part for part in decoded_path.split("/") if part]
     if any(part in {".", ".."} for part in path_segments):

--- a/traigent/cloud/url_security.py
+++ b/traigent/cloud/url_security.py
@@ -23,6 +23,19 @@ _METADATA_HOSTNAMES = {
 }
 
 
+class CloudUrlUnreachableError(ValueError):
+    """A cloud base URL was structurally valid but its host could not be resolved.
+
+    Distinct from the other ``ValueError``s raised by :func:`validate_cloud_base_url`,
+    which signal an *unsafe* URL (private/loopback/metadata IP, bad scheme, embedded
+    credentials, path traversal) and MUST always fail loud. This subclass marks the
+    narrow "backend is simply unreachable" case, so best-effort callers (e.g. the
+    interaction-policy read) may fall back to a static default instead of crashing,
+    WITHOUT relaxing any SSRF/unsafe-origin protection. Subclasses ``ValueError`` so
+    existing ``except ValueError`` callers keep catching it.
+    """
+
+
 def _is_development_environment() -> bool:
     """Return True only for explicit/local SDK development environments.
 
@@ -110,7 +123,9 @@ def _reject_unsafe_hostname(hostname: str, *, allow_local: bool) -> None:
     try:
         addr_infos = socket.getaddrinfo(normalized, None)
     except socket.gaierror:
-        raise ValueError("Cloud base URL host could not be resolved") from None
+        raise CloudUrlUnreachableError(
+            "Cloud base URL host could not be resolved"
+        ) from None
 
     for _family, _socktype, _proto, _canonname, sockaddr in addr_infos:
         try:


### PR DESCRIPTION
## What

`get_interaction_policy()` must degrade gracefully when the Traigent backend is unreachable. Before this PR, an unresolvable/unusable backend URL raised `ValueError` inside `BackendIntegratedClient.__init__` (via `validate_cloud_base_url`), **before** `get_interaction_policy()`'s own try/except could catch it — so the persona-policy read threw instead of returning the static default. This is the recommended-enhancement #2 from the persona-layer E2E validation.

## How

- **`__init__` now catches only the unreachable case.** A new `CloudUrlUnreachableError(ValueError)` is raised **only** at the DNS `getaddrinfo` failure site in `url_security.py`. `__init__` catches that narrow subclass → sets `_url_invalid=True` + an inert `https://backend.invalid` placeholder. **Every other rejection** (private/loopback/metadata IP, non-https, bad scheme, embedded credentials, path traversal) still raises bare `ValueError` and **propagates** — SSRF/unsafe-origin protection is unchanged.
- **`get_interaction_policy()`** short-circuits to `_static_interaction_policy()` when `_url_invalid` (returns `guided,se,balanced`, zero transport).
- **All cloud ops fail closed.** Each of the four `_raise_if_backend_egress_disabled` chokepoints (`backend_client`, `api_operations`, `session_operations`, `trial_operations`) raises `CloudEgressBlockedError` when `_url_invalid`, so session/trial/sync ops never reach the placeholder.
- **Adjacent hardening:** closed a pre-existing path-traversal gap where an explicitly-configured `backend_config.api_base_url` had only its origin validated and its path re-attached unchecked. The api path is now decoded to a bounded fixed point and dot-segment-rejected (catches `%2e`, `%252e`, `%25252e`).

## Tests

`tests/unit/cloud/test_backend_client_interaction_policy.py` (+ full cloud sweep, **131 passed**):
- unreachable URL → static fallback, no network call
- unsafe origins (incl. `169.254.169.254` metadata, `127.0.0.1`, private IP, ftp, credentialed) **still raise** from `__init__`
- invalid URL + cloud op → `CloudEgressBlockedError` across all four guards, **zero transport**
- explicit `api_base_url` traversal (raw + multiply-encoded) rejected

## Dual-gate

Codex gpt-5.5 xhigh: **GO** (pass 4) — "No remaining in-scope blocker; safe to merge to develop." Earlier passes caught a self-introduced SSRF regression and the pre-existing traversal gap, both fixed.

---

### Production-safety PR checklist

1. **Worst-case prod path** — an unreachable backend now yields the static interaction policy (a safe, non-privileged default) instead of an exception; an *unsafe* URL still fails loud. Fails safe for the policy read, fails closed for every cloud op.
2. **Production-branch test** — `test_unsafe_url_still_fails_loud_and_is_not_swallowed` (ENVIRONMENT=production) proves unsafe origins raise; `test_invalid_url_cloud_ops_fail_closed_with_zero_transport` proves cloud ops deny with zero transport.
3. **Contract regeneration** — none. No schema/OpenAPI/DTO shape change; `STATIC_POLICY_TEXT` default unchanged.
4. **Public surface delta** — none. `get_interaction_policy()` signature unchanged; new `CloudUrlUnreachableError` is an internal `ValueError` subclass (existing `except ValueError` callers unaffected).
5. **Review threads resolved** — N/A at open; will resolve all bot/human threads before merge.
6. **Quality gates not relaxed** — no thresholds touched.

Spine-Trail: st_660678333ed3
