### PR TITLE
chore(release): bump dev version 0.18.1.dev2 -> 0.18.1.dev3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev2"
+version = "0.18.1.dev3"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## Bump dev version `0.18.1.dev2` → `0.18.1.dev3`

Cuts a new `.dev` so the per-example measures fix (**#1563**, merged) can be published to PyPI — together
with the backend route fix (**TraigentBackend#1826**), this makes Compute Scores produce per-example scores
for SDK-managed runs.

`dev2` is already the published latest, so a new version is required to publish the fix. Version is
single-sourced in `pyproject.toml`; `traigent/_version.py` reads it dynamically (no other file to touch).

### Publish path (owner-gated — not done here)
`publish.yml` publishes on a `v*` tag (guarded to `main`) **or** manual `workflow_dispatch`. Since this `.dev`
lives on develop (main is at `0.17.0`, 65 commits behind), the `.dev` is published via **manual
`workflow_dispatch`** (environment `pypi`, `confirm_publish=true`) on this branch/develop after merge. I have
**not** triggered any publish — that's your call.

### PR checklist
1. **Worst-case prod path** — version-string bump only; no code/behavior change.
2. **Production-branch test** — n/a (version metadata).
3. **Contract regeneration** — none.
4. **Public surface delta** — version number only.
5. **Review threads resolved** — n/a.
6. **Quality gates not relaxed** — none.

Spine-Trail: st_650b61798aab
