### PR TITLE
fix(config): accept HF_TOKEN/HUGGING_FACE_HUB_TOKEN for HuggingFace (#1569)

### DIFF
--- a/tests/unit/config/test_hf_env_aliases.py
+++ b/tests/unit/config/test_hf_env_aliases.py
@@ -1,0 +1,98 @@
+"""Tests for HuggingFace environment-variable alias resolution (#1569).
+
+Covers both resolution paths so they cannot drift:
+  - APIKeyManager.get_api_key  (traigent/config/api_keys.py)
+  - env_config.get_api_key     (traigent/utils/env_config.py)
+
+Alias order: HF_TOKEN (native) -> HUGGING_FACE_HUB_TOKEN -> HF_API_KEY (back-compat).
+All three vars are cleared before each test to ensure full isolation.
+"""
+
+import pytest
+
+from traigent.config.api_keys import APIKeyManager
+from traigent.utils.env_config import get_api_key as env_get_api_key
+
+_HF_VARS = ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HF_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _clear_hf_env(monkeypatch):
+    """Remove all three HF vars before every test in this module."""
+    for var in _HF_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# APIKeyManager tests
+# ---------------------------------------------------------------------------
+
+
+class TestAPIKeyManagerHF:
+    def setup_method(self, method):
+        self.manager = APIKeyManager()
+
+    def test_hf_token_only(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "tok-native")
+        assert self.manager.get_api_key("huggingface") == "tok-native"
+
+    def test_hugging_face_hub_token_only(self, monkeypatch):
+        monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "tok-hub")
+        assert self.manager.get_api_key("huggingface") == "tok-hub"
+
+    def test_hf_api_key_only(self, monkeypatch):
+        monkeypatch.setenv("HF_API_KEY", "tok-legacy")
+        assert self.manager.get_api_key("huggingface") == "tok-legacy"
+
+    def test_hf_token_wins_over_hub_and_legacy(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "tok-wins")
+        monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "tok-hub")
+        monkeypatch.setenv("HF_API_KEY", "tok-legacy")
+        assert self.manager.get_api_key("huggingface") == "tok-wins"
+
+    def test_hub_token_wins_over_legacy_when_no_hf_token(self, monkeypatch):
+        monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "tok-hub")
+        monkeypatch.setenv("HF_API_KEY", "tok-legacy")
+        assert self.manager.get_api_key("huggingface") == "tok-hub"
+
+    def test_none_when_no_hf_vars(self):
+        result = self.manager.get_api_key("huggingface")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# env_config.get_api_key tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnvConfigGetApiKeyHF:
+    def test_hf_token_only(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "tok-native")
+        assert env_get_api_key("huggingface") == "tok-native"
+
+    def test_hugging_face_hub_token_only(self, monkeypatch):
+        monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "tok-hub")
+        assert env_get_api_key("huggingface") == "tok-hub"
+
+    def test_hf_api_key_only(self, monkeypatch):
+        monkeypatch.setenv("HF_API_KEY", "tok-legacy")
+        assert env_get_api_key("huggingface") == "tok-legacy"
+
+    def test_hf_token_wins_over_hub_and_legacy(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "tok-wins")
+        monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "tok-hub")
+        monkeypatch.setenv("HF_API_KEY", "tok-legacy")
+        assert env_get_api_key("huggingface") == "tok-wins"
+
+    def test_hub_token_wins_over_legacy_when_no_hf_token(self, monkeypatch):
+        monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "tok-hub")
+        monkeypatch.setenv("HF_API_KEY", "tok-legacy")
+        assert env_get_api_key("huggingface") == "tok-hub"
+
+    def test_none_when_no_hf_vars(self):
+        result = env_get_api_key("huggingface")
+        assert result is None
+
+    def test_case_insensitive_provider(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "tok-case")
+        assert env_get_api_key("HuggingFace") == "tok-case"

--- a/traigent/config/api_keys.py
+++ b/traigent/config/api_keys.py
@@ -62,12 +62,21 @@ class APIKeyManager:
             "openai": "OPENAI_API_KEY",
             "anthropic": "ANTHROPIC_API_KEY",
             "cohere": "COHERE_API_KEY",
-            "huggingface": "HF_API_KEY",
+            # HuggingFace: native HF_TOKEN first; HF_API_KEY kept for back-compat
+            "huggingface": "HF_TOKEN",
         }
 
         # Check environment first (most secure)
         if provider in env_names:
-            env_key = os.getenv(env_names[provider])
+            if provider == "huggingface":
+                # Native-first alias chain: HF_TOKEN -> HUGGING_FACE_HUB_TOKEN -> HF_API_KEY
+                env_key = (
+                    os.getenv("HF_TOKEN")
+                    or os.getenv("HUGGING_FACE_HUB_TOKEN")
+                    or os.getenv("HF_API_KEY")
+                )
+            else:
+                env_key = os.getenv(env_names[provider])
             if env_key:
                 return env_key
 

--- a/traigent/utils/env_config.py
+++ b/traigent/utils/env_config.py
@@ -304,15 +304,24 @@ def get_api_key(provider: str) -> str | None:
         "openai": "OPENAI_API_KEY",
         "anthropic": "ANTHROPIC_API_KEY",
         "cohere": "COHERE_API_KEY",
-        "huggingface": "HF_API_KEY",
+        # HuggingFace: native HF_TOKEN first; HF_API_KEY kept for back-compat
+        "huggingface": "HF_TOKEN",
         "traigent": "TRAIGENT_API_KEY",
     }
 
-    env_var = env_map.get(provider.lower())
-    if not env_var:
+    normalized = provider.lower()
+    if normalized not in env_map:
         return None
 
-    return get_env_var(env_var, mask_in_logs=True)
+    if normalized == "huggingface":
+        # Native-first alias chain: HF_TOKEN -> HUGGING_FACE_HUB_TOKEN -> HF_API_KEY
+        return (
+            get_env_var("HF_TOKEN", mask_in_logs=True)
+            or get_env_var("HUGGING_FACE_HUB_TOKEN", mask_in_logs=True)
+            or get_env_var("HF_API_KEY", mask_in_logs=True)
+        )
+
+    return get_env_var(env_map[normalized], mask_in_logs=True)
 
 
 def get_database_url() -> str:


### PR DESCRIPTION
Fixes #1569.

HuggingFace token now resolves native-first: `HF_TOKEN` → `HUGGING_FACE_HUB_TOKEN` → `HF_API_KEY` (back-compat retained), in BOTH `traigent/config/api_keys.py` and `traigent/utils/env_config.py` so the two maps can't drift.

Spine-Trail: st_a0562cfb8a1b

## Validation
- Captain re-ran `tests/unit/config` → **234 passed** (13 new alias tests).
- ruff clean on changed files.
- Independent review: Codex gpt-5.5 xhigh → **VERDICT: GO** (ran a live provider-regression probe; openai/anthropic/cohere/traigent + code-set path unaffected).

## Notes
Local pre-commit mypy hook fails on PRE-EXISTING debt in out-of-scope files (`core/orchestrator.py`, `config/types.py`, …), verified identical on base `fbe22e54` — not introduced here; committed `--no-verify` per the evidence-backed CI-exception rule. No quality gate widened.
