### PR TITLE
fix(cloud): fail closed on rejected/unreachable managed session (no silent local masquerade)

### DIFF
--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -1,5 +1,6 @@
 """Validation and locking tests for SessionOperations."""
 
+import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -9,8 +10,10 @@ import pytest
 
 from traigent.cloud.api_operations import TraigentSessionApiResult
 from traigent.cloud.auth import AuthenticationError
+from traigent.cloud.client import CloudServiceError
 from traigent.cloud.models import OptimizationSession, OptimizationSessionStatus
 from traigent.cloud.session_operations import SessionOperations
+from traigent.cloud.session_types import SessionCreationFailureReason
 from traigent.utils.exceptions import ValidationError as ValidationException
 
 
@@ -318,3 +321,85 @@ def test_create_session_outer_auth_failure_fails_loud(monkeypatch):
             {"model": ["gpt-4o"]},
             metadata={"max_trials": 3, "dataset_size": 4},
         )
+
+
+def test_create_session_offline_mode_runs_local_without_raising(monkeypatch):
+    """The benign offline path MUST still run locally without raising.
+
+    Fail-closed applies ONLY to a managed/cloud intent whose configured key is
+    rejected (or whose backend is unreachable). Explicit local execution
+    (offline mode) is a deliberate configuration, so it returns a local result
+    with degraded=False — it is not a downgrade.
+    """
+    monkeypatch.setenv("TRAIGENT_OFFLINE_MODE", "true")
+    monkeypatch.setenv("TRAIGENT_OFFLINE", "true")
+
+    client = FakeClient()
+    ops = SessionOperations(client)
+
+    result = ops.create_session(
+        "demo-function",
+        {"model": ["gpt-4o"]},
+        metadata={"max_trials": 3},
+    )
+
+    assert result.backend_connected is False
+    assert result.degraded is False  # intentional local, NOT a downgrade
+    assert result.backend_fallback is True
+    assert result.execution_path == "local_fallback"
+
+
+def test_create_session_no_api_key_runs_local_without_raising(monkeypatch):
+    """No API key configured → run locally without raising (not a downgrade)."""
+    client = FakeClient()
+    monkeypatch.setattr(client.auth_manager, "has_api_key", lambda: False)
+    ops = SessionOperations(client)
+
+    result = ops.create_session(
+        "demo-function",
+        {"model": ["gpt-4o"]},
+        metadata={"max_trials": 3},
+    )
+
+    assert result.backend_connected is False
+    assert result.failure_reason == SessionCreationFailureReason.NO_API_KEY
+    assert result.degraded is False  # no key = intentional local, not degraded
+
+
+def test_create_session_backend_unreachable_flags_degraded_and_warns(monkeypatch, caplog):
+    """Backend UNREACHABLE with a configured key → degrade to local, but the
+    result MUST be flagged (degraded + local_fallback) and a WARNING emitted so
+    the local run is never mistaken for a managed one.
+    """
+    client = FakeClient()
+    ops = SessionOperations(client)
+
+    async def create_via_api(_request):
+        raise CloudServiceError("503 Service Unavailable: backend down")
+
+    monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
+
+    with caplog.at_level(logging.WARNING, logger="traigent.cloud.session_operations"):
+        result = ops.create_session(
+            "demo-function",
+            {"model": ["gpt-4o"]},
+            metadata={"max_trials": 3, "dataset_size": 4},
+        )
+
+    # Degraded local result — explicitly flagged, not silent.
+    assert result.backend_connected is False
+    assert result.failure_reason == SessionCreationFailureReason.SESSION_FAILED
+    assert result.degraded is True
+    assert result.backend_fallback is True
+    assert result.execution_path == "local_fallback"
+
+    degraded_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "degrading to LOCAL" in record.getMessage()
+    ]
+    assert degraded_warnings, (
+        "Expected a WARNING that the managed run degraded to local; got: "
+        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )

--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -369,7 +369,9 @@ def test_create_session_no_api_key_runs_local_without_raising(monkeypatch):
     assert result.degraded is False  # no key = intentional local, not degraded
 
 
-def test_create_session_backend_unreachable_flags_degraded_and_warns(monkeypatch, caplog):
+def test_create_session_backend_unreachable_flags_degraded_and_warns(
+    monkeypatch, caplog
+):
     """Backend UNREACHABLE with a configured key → degrade to local, but the
     result MUST be flagged (degraded + local_fallback) and a WARNING emitted so
     the local run is never mistaken for a managed one.
@@ -434,7 +436,9 @@ def test_create_session_structured_401_fails_loud(monkeypatch):
         )
 
 
-def test_create_session_auth_validation_timeout_degrades_not_silent(monkeypatch, caplog):
+def test_create_session_auth_validation_timeout_degrades_not_silent(
+    monkeypatch, caplog
+):
     """A NON-definitive AuthenticationError — the auth layer maps a key-validation
     TIMEOUT/transport failure to AuthenticationError — must take the UNREACHABLE
     contract: degrade to LOCAL but FLAGGED (degraded=True, SESSION_FAILED,
@@ -445,7 +449,9 @@ def test_create_session_auth_validation_timeout_degrades_not_silent(monkeypatch,
     ops = SessionOperations(client)
 
     async def create_via_api(_request):
-        raise AuthenticationError("API key validation failed: backend validation timed out")
+        raise AuthenticationError(
+            "API key validation failed: backend validation timed out"
+        )
 
     monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
 

--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -478,3 +478,33 @@ def test_create_session_auth_validation_timeout_degrades_not_silent(
         "Expected a WARNING that the validation-timeout run degraded to local; got: "
         f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
     )
+
+
+def test_create_session_local_routed_rejected_key_does_not_raise(monkeypatch):
+    """#1421 regression: a LOCAL-routed run (cloud_egress_intent=False — e.g.
+    algorithm grid/random) must NOT fail closed on a configured-but-invalid/
+    rejected key. The backend session is only OPTIONAL tracking there, so the
+    bad key is irrelevant: the run continues untracked locally (degraded=False),
+    NOT a downgrade. (Fail-closed applies only to cloud-intended runs.)
+    """
+    client = FakeClient()
+    client.cloud_egress_intent = False  # local-routed (grid/random)
+    ops = SessionOperations(client)
+
+    async def create_via_api(_request):
+        # Even a definitive rejection must not hard-fail a local run.
+        exc = AuthenticationError("Authentication failed (401): HTTP 401")
+        exc.session_creation_failure = SessionCreationFailureDetail(status_code=401)
+        raise exc
+
+    monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
+
+    result = ops.create_session(
+        "demo-function",
+        {"model": ["gpt-4o"]},
+        metadata={"max_trials": 3, "dataset_size": 4},
+    )
+
+    assert result.backend_connected is False
+    assert result.degraded is False  # local run, key irrelevant — not a downgrade
+    assert result.failure_reason == SessionCreationFailureReason.AUTH

--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -13,7 +13,10 @@ from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.client import CloudServiceError
 from traigent.cloud.models import OptimizationSession, OptimizationSessionStatus
 from traigent.cloud.session_operations import SessionOperations
-from traigent.cloud.session_types import SessionCreationFailureReason
+from traigent.cloud.session_types import (
+    SessionCreationFailureDetail,
+    SessionCreationFailureReason,
+)
 from traigent.utils.exceptions import ValidationError as ValidationException
 
 
@@ -401,5 +404,71 @@ def test_create_session_backend_unreachable_flags_degraded_and_warns(monkeypatch
     ]
     assert degraded_warnings, (
         "Expected a WARNING that the managed run degraded to local; got: "
+        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_create_session_structured_401_fails_loud(monkeypatch):
+    """REAL session-API shape: a 401/403 is an AuthenticationError whose HTTP
+    status lives on ``exc.session_creation_failure.status_code`` (set by
+    api_operations._handle_session_error), NOT on ``exc.status_code`` and NOT in
+    the message text. The rejection MUST fail closed via the structured status —
+    a marker-string-only check would miss it and silently fall back.
+    """
+    client = FakeClient()
+    ops = SessionOperations(client)
+
+    async def create_via_api(_request):
+        # Mirrors api_operations._handle_session_error for a 401.
+        exc = AuthenticationError("Authentication failed (401): HTTP 401")
+        exc.session_creation_failure = SessionCreationFailureDetail(status_code=401)
+        raise exc
+
+    monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
+
+    with pytest.raises(AuthenticationError):
+        ops.create_session(
+            "demo-function",
+            {"model": ["gpt-4o"]},
+            metadata={"max_trials": 3, "dataset_size": 4},
+        )
+
+
+def test_create_session_auth_validation_timeout_degrades_not_silent(monkeypatch, caplog):
+    """A NON-definitive AuthenticationError — the auth layer maps a key-validation
+    TIMEOUT/transport failure to AuthenticationError — must take the UNREACHABLE
+    contract: degrade to LOCAL but FLAGGED (degraded=True, SESSION_FAILED,
+    local_fallback) + WARN. It must NOT raise and must NOT be a silent AUTH
+    fallback with degraded=False.
+    """
+    client = FakeClient()
+    ops = SessionOperations(client)
+
+    async def create_via_api(_request):
+        raise AuthenticationError("API key validation failed: backend validation timed out")
+
+    monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
+
+    with caplog.at_level(logging.WARNING, logger="traigent.cloud.session_operations"):
+        result = ops.create_session(
+            "demo-function",
+            {"model": ["gpt-4o"]},
+            metadata={"max_trials": 3, "dataset_size": 4},
+        )
+
+    assert result.backend_connected is False
+    assert result.degraded is True  # reachability failure, NOT silent
+    assert result.backend_fallback is True
+    assert result.execution_path == "local_fallback"
+    assert result.failure_reason == SessionCreationFailureReason.SESSION_FAILED
+
+    degraded_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "degrading to LOCAL" in record.getMessage()
+    ]
+    assert degraded_warnings, (
+        "Expected a WARNING that the validation-timeout run degraded to local; got: "
         f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
     )

--- a/tests/unit/cloud/test_session_operations_validation.py
+++ b/tests/unit/cloud/test_session_operations_validation.py
@@ -1,6 +1,5 @@
 """Validation and locking tests for SessionOperations."""
 
-import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -12,7 +11,6 @@ from traigent.cloud.api_operations import TraigentSessionApiResult
 from traigent.cloud.auth import AuthenticationError
 from traigent.cloud.models import OptimizationSession, OptimizationSessionStatus
 from traigent.cloud.session_operations import SessionOperations
-from traigent.cloud.session_types import SessionCreationFailureReason
 from traigent.utils.exceptions import ValidationError as ValidationException
 
 
@@ -252,110 +250,71 @@ def test_create_session_prunes_completed_sessions_with_aware_timestamps(monkeypa
     assert "session-123" in client._active_sessions
 
 
-def test_create_session_inner_auth_failure_logs_warning_not_debug(monkeypatch, caplog):
-    """Issue #1373: the INNER ``create_session`` auth handler must surface at
-    WARNING.
+def test_create_session_inner_auth_failure_fails_loud(monkeypatch):
+    """A configured-but-rejected API key fails LOUD from the INNER create_session
+    path — it must NOT silently degrade to a local/anonymous run.
 
-    This drives the REAL create-session code path (not just
-    ``handle_session_creation_result``): ``_create_traigent_session_via_api``
-    raises ``AuthenticationError`` inside ``_create_session_async``'s inner
-    ``try``, which is caught by the inner handler that logs
-    ``"Backend auth failed for ..."`` (session_operations.py ~:573 — the
-    "inner sibling" the issue attributes to #1278's layer).
+    Policy evolution: issue #1373 made this site at least *visible* (WARNING not
+    DEBUG). The validation-package finding (silent cloud->local masquerade when a
+    key is revoked mid-run) shows visibility is not enough — a managed/Bayesian
+    run that quietly becomes a local search, with no backend/billing/governance
+    record, is presented as success. Reaching this handler means a key WAS
+    configured (the no-key path returns NO_API_KEY before any HTTP) and the
+    backend REJECTED it, so it is a user-actionable credential error. It now
+    fails closed; users who want local execution opt in explicitly via
+    ``offline=True`` / ``TRAIGENT_OFFLINE_MODE``.
 
-    Pre-fix that site was ``logger.debug``, so the failed publish was invisible
-    at the default log level. After the fix it is ``logger.warning``.
-
-    Coverage proof: reverting ONLY :573 back to ``logger.debug`` makes this
-    test FAIL (no WARNING record captured); restoring ``logger.warning`` PASSes.
+    ``_create_traigent_session_via_api`` raises ``AuthenticationError`` inside
+    ``_create_session_async``'s inner ``try`` (session_operations.py ~:577);
+    ``_must_fail_loud`` now returns True for it, so it re-raises rather than
+    returning an AUTH fallback.
     """
     client = FakeClient()
     ops = SessionOperations(client)
 
     async def create_via_api(_request):
-        raise AuthenticationError("403 Forbidden: missing_permissions")
+        raise AuthenticationError("401 Unauthorized: invalid API key")
 
     monkeypatch.setattr(ops.client, "_create_traigent_session_via_api", create_via_api)
 
-    with caplog.at_level(logging.WARNING, logger="traigent.cloud.session_operations"):
-        # Non-governed call → AuthenticationError is NOT fail-loud; it is caught,
-        # logged, and downgraded to a local fallback result.
-        result = ops.create_session(
+    # Non-governed call with a configured-but-rejected key → fail closed (raise),
+    # NOT a silent local AUTH fallback.
+    with pytest.raises(AuthenticationError, match="invalid API key"):
+        ops.create_session(
             "demo-function",
             {"model": ["gpt-4o"]},
             metadata={"max_trials": 3, "dataset_size": 4},
         )
 
-    # The call returns a local fallback with reason=AUTH (no exception raised).
-    assert result.backend_connected is False
-    assert result.failure_reason == SessionCreationFailureReason.AUTH
 
-    # The auth failure MUST be visible at WARNING level (issue #1373).
-    auth_warnings = [
-        record
-        for record in caplog.records
-        if record.levelno >= logging.WARNING
-        and "Backend auth failed" in record.getMessage()
-    ]
-    assert auth_warnings, (
-        "Expected a WARNING-level 'Backend auth failed' record from the "
-        "INNER create_session auth-failure path; got: "
-        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
-    )
+def test_create_session_outer_auth_failure_fails_loud(monkeypatch):
+    """A configured-but-rejected key fails LOUD from the OUTER create_session
+    handler too (the auth error that ESCAPES ``_create_session_async``).
 
-
-def test_create_session_outer_auth_swallow_logs_warning_not_debug(monkeypatch, caplog):
-    """Issue #1373 — the named "OUTER create_session swallow".
-
-    The issue's title and Case 2 name an OUTER ``except AuthenticationError``
-    handler (anchor SHA 3f6710f0 lines 585-606; current ~:639) that catches an
-    auth failure ESCAPING ``_create_session_async`` and logs it at
-    ``logger.debug`` — silent at the default log level. This is distinct from
-    the inner sibling (~:573) which catches the failure raised inside the API
-    call. The two are mutually exclusive per failure: a single
-    ``AuthenticationError`` is caught by exactly one handler, so lifting both
-    does not double-log.
-
-    This test reaches the OUTER handler by making the ``has_api_key()``
-    preflight (called at the top of ``_create_session_async``, OUTSIDE the
-    inner ``try``) raise ``AuthenticationError``. That exception escapes
-    ``_create_session_async`` and is caught by the outer handler at ~:636,
-    which must now log at WARNING (was DEBUG).
-
-    Coverage proof: reverting ONLY :639 back to ``logger.debug`` makes this
-    test FAIL (no WARNING captured); restoring ``logger.warning`` PASSes.
+    Companion to the inner test: issue #1373 named an OUTER
+    ``except AuthenticationError`` handler (~:644) that previously swallowed an
+    auth failure escaping ``_create_session_async`` (e.g. from the
+    ``has_api_key()`` preflight). Under the fail-closed policy both the inner
+    and outer handlers now re-raise on a rejected credential, so neither can
+    masquerade a cloud run as local. The two are mutually exclusive per
+    failure, so exactly one handler raises.
     """
     client = FakeClient()
 
     def _raise_auth() -> bool:
-        raise AuthenticationError("403 Forbidden: missing experiment.write")
+        raise AuthenticationError("401 Unauthorized: revoked API key")
 
     # has_api_key is invoked OUTSIDE the inner try in _create_session_async,
-    # so the raised AuthenticationError escapes to the OUTER handler (~:636).
+    # so the raised AuthenticationError escapes to the OUTER handler (~:644).
     monkeypatch.setattr(client.auth_manager, "has_api_key", _raise_auth)
 
     ops = SessionOperations(client)
 
-    with caplog.at_level(logging.WARNING, logger="traigent.cloud.session_operations"):
-        # Non-governed (no promotion_policy/tvl_governance) → not fail-loud →
-        # the outer handler catches, logs, and returns a local AUTH fallback.
-        result = ops.create_session(
+    # Non-governed (no promotion_policy/tvl_governance) → still fail-loud on a
+    # rejected credential; no local AUTH fallback.
+    with pytest.raises(AuthenticationError, match="revoked API key"):
+        ops.create_session(
             "demo-function",
             {"model": ["gpt-4o"]},
             metadata={"max_trials": 3, "dataset_size": 4},
         )
-
-    assert result.backend_connected is False
-    assert result.failure_reason == SessionCreationFailureReason.AUTH
-
-    auth_warnings = [
-        record
-        for record in caplog.records
-        if record.levelno >= logging.WARNING
-        and "Backend auth failed" in record.getMessage()
-    ]
-    assert auth_warnings, (
-        "Expected a WARNING-level 'Backend auth failed' record from the OUTER "
-        "create_session swallow (#1373); got: "
-        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
-    )

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -109,6 +109,18 @@ def _is_definitive_auth_rejection(exc: Exception) -> bool:
     degrade gracefully (as before), not hard-fail. Ambiguous errors default to
     NOT a rejection, preserving the prior resilient fallback.
     """
+    # Primary source: the real session API attaches the HTTP status on the
+    # structured failure detail (api_operations._handle_session_error maps a
+    # 401/403 to AuthenticationError with exc.session_creation_failure). A bare
+    # exc.status_code is a secondary source.
+    detail = getattr(exc, "session_creation_failure", None)
+    detail_status = getattr(detail, "status_code", None)
+    if isinstance(detail_status, int) and detail_status in (401, 403):
+        return True
+    if isinstance(detail_status, int) and (
+        detail_status == 429 or detail_status >= 500
+    ):
+        return False
     status = getattr(exc, "status_code", None)
     if isinstance(status, int):
         if status in (401, 403):
@@ -641,20 +653,36 @@ class SessionOperations:
                 await self._reset_client_session("create_session auth_failure")
                 if _must_fail_loud(e):
                     raise
-                logger.warning("Backend auth failed for '%s': %s", function_name, e)
+                # Non-definitive AuthenticationError = the backend did NOT clearly
+                # reject the credential; the auth layer maps a key-validation
+                # TIMEOUT / transport failure (could-not-reach /keys/validate) to
+                # AuthenticationError. That is a reachability failure, not a
+                # rejection, so it takes the same UNREACHABLE contract as a
+                # backend outage: degrade to LOCAL but FLAG it (degraded=True +
+                # SESSION_FAILED + WARN) so the local run is never mistaken for a
+                # managed one. Definitive rejections fail loud above.
+                logger.warning(
+                    "Managed session creation failed (could not validate "
+                    "credentials — backend unreachable) for '%s'; degrading to "
+                    "LOCAL execution — results are NOT tracked on the backend "
+                    "(set offline=True to make this explicit): %s",
+                    function_name,
+                    e,
+                )
                 failure_response = _get_session_creation_failure_detail(e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
                 )
                 return SessionCreationResult.fallback(
                     session_id=fallback_id,
-                    reason=SessionCreationFailureReason.AUTH,
+                    reason=SessionCreationFailureReason.SESSION_FAILED,
                     detail=(
                         failure_response.one_line_summary()
                         if failure_response
                         else str(e)[:200]
                     ),
                     failure_response=failure_response,
+                    degraded=True,
                 )
 
             except (TimeoutError, CloudServiceError, OSError) as e:
@@ -719,16 +747,21 @@ class SessionOperations:
         except AuthenticationError as exc:
             if _must_fail_loud(exc):
                 raise
-            # Issue #1373 (the "outer create_session swallow"): an auth/scope
-            # failure that ESCAPES _create_session_async (e.g. from the
-            # has_api_key preflight, or the async-runner machinery) on a
-            # non-governed run must NOT fall to debug-only — a failed publish
-            # would be invisible at the default log level. Mirror the inner
-            # sibling (~:573) and surface at WARNING. The two sites are
-            # mutually exclusive per failure (a single AuthenticationError is
-            # caught by exactly one handler), so this does not double-log.
+            # Issue #1373 "outer create_session swallow": an auth failure that
+            # ESCAPES _create_session_async (e.g. the has_api_key preflight or
+            # the async-runner machinery). A DEFINITIVE rejection fails loud
+            # above; reaching here means a non-definitive auth failure (could not
+            # validate the credential — typically a /keys/validate timeout the
+            # auth layer maps to AuthenticationError). Mirror the inner sibling:
+            # take the UNREACHABLE contract — degrade to LOCAL but FLAG it
+            # (degraded=True + SESSION_FAILED + WARN) so it is never silent. The
+            # two sites are mutually exclusive per failure, so this never
+            # double-logs.
             logger.warning(
-                "Backend auth failed for '%s': %s",
+                "Managed session creation failed (could not validate "
+                "credentials — backend unreachable) for '%s'; degrading to "
+                "LOCAL execution — results are NOT tracked on the backend "
+                "(set offline=True to make this explicit): %s",
                 function_name,
                 exc,
             )
@@ -738,13 +771,14 @@ class SessionOperations:
             )
             return SessionCreationResult.fallback(
                 session_id=fallback_id,
-                reason=SessionCreationFailureReason.AUTH,
+                reason=SessionCreationFailureReason.SESSION_FAILED,
                 detail=(
                     failure_response.one_line_summary()
                     if failure_response
                     else str(exc)[:200]
                 ),
                 failure_response=failure_response,
+                degraded=True,
             )
 
         except (TimeoutError, CloudServiceError, OSError) as exc:

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -362,8 +362,20 @@ class SessionOperations:
         governed = bool(promotion_policy or tvl_governance)
 
         def _must_fail_loud(exc: Exception) -> bool:
+            # An AuthenticationError reaching a handler means a key WAS
+            # configured (the no-key path returns NO_API_KEY before any HTTP)
+            # and the backend REJECTED it (invalid / revoked / unauthorized).
+            # That is a user-actionable credential error, not a transient
+            # backend outage: silently degrading a cloud/managed run to a
+            # local/anonymous one would change execution semantics (managed
+            # Bayesian -> local search), drop the backend/billing/governance
+            # record, and present the degraded run as success. Fail closed;
+            # users who genuinely want local execution opt in explicitly via
+            # offline=True / TRAIGENT_OFFLINE_MODE (handled by
+            # is_backend_offline() above, before any auth attempt).
             return governed or isinstance(
-                exc, (CloudEgressBlockedError, SessionContractError)
+                exc,
+                (AuthenticationError, CloudEgressBlockedError, SessionContractError),
             )
 
         if is_backend_offline():

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -71,6 +71,56 @@ def _get_session_creation_failure_detail(
     return None
 
 
+# Transient signals: the SDK could not REACH/validate the backend (the auth
+# layer fails closed on these for safety, but the run should still degrade
+# gracefully as it did before, not hard-fail).
+_AUTH_TRANSIENT_MARKERS = (
+    "timed out",
+    "timeout",
+    "transport error",
+    "rate limited",
+    "temporarily unavailable",
+    "service unavailable",
+    "connection",
+)
+# Definitive signals: the backend REJECTED the credential (user-actionable;
+# fix the key). Only these fail closed.
+_AUTH_REJECTION_MARKERS = (
+    "unauthorized",
+    "invalid api key",
+    "invalid_api_key",
+    "api_key_validation_failed",
+    "reported key invalid",
+    "revoked",
+    "forbidden",
+    "expired",
+    "permission",
+)
+
+
+def _is_definitive_auth_rejection(exc: Exception) -> bool:
+    """True only when an auth failure is a DEFINITIVE credential rejection.
+
+    A configured key that the backend rejected (invalid / revoked / expired /
+    unauthorized / forbidden — typically 401/403) is user-actionable and must
+    fail closed. A transient inability to validate the key (timeout / transport
+    error / 5xx / 429 during ``/keys/validate``) is NOT a rejection: the auth
+    layer fails closed on it for safety, but the optimization run should still
+    degrade gracefully (as before), not hard-fail. Ambiguous errors default to
+    NOT a rejection, preserving the prior resilient fallback.
+    """
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        if status in (401, 403):
+            return True
+        if status == 429 or status >= 500:
+            return False
+    msg = str(exc).lower()
+    if any(marker in msg for marker in _AUTH_TRANSIENT_MARKERS):
+        return False
+    return any(marker in msg for marker in _AUTH_REJECTION_MARKERS)
+
+
 class SessionOperations:
     """Handles session management operations."""
 
@@ -362,20 +412,21 @@ class SessionOperations:
         governed = bool(promotion_policy or tvl_governance)
 
         def _must_fail_loud(exc: Exception) -> bool:
-            # An AuthenticationError reaching a handler means a key WAS
-            # configured (the no-key path returns NO_API_KEY before any HTTP)
-            # and the backend REJECTED it (invalid / revoked / unauthorized).
-            # That is a user-actionable credential error, not a transient
-            # backend outage: silently degrading a cloud/managed run to a
-            # local/anonymous one would change execution semantics (managed
-            # Bayesian -> local search), drop the backend/billing/governance
-            # record, and present the degraded run as success. Fail closed;
-            # users who genuinely want local execution opt in explicitly via
-            # offline=True / TRAIGENT_OFFLINE_MODE (handled by
-            # is_backend_offline() above, before any auth attempt).
+            # A DEFINITIVELY rejected credential (invalid / revoked / expired /
+            # unauthorized — a key WAS configured; the no-key path returns
+            # NO_API_KEY before any HTTP) is a user-actionable error. Silently
+            # degrading a cloud/managed run to a local/anonymous one would
+            # change execution semantics (managed Bayesian -> local search),
+            # drop the backend/billing/governance record, and present the
+            # degraded run as success — so fail closed. A *transient* failure
+            # to reach/validate the backend is NOT a rejection and still
+            # degrades gracefully (see _is_definitive_auth_rejection). Users
+            # who want local execution opt in explicitly via offline=True /
+            # TRAIGENT_OFFLINE_MODE (handled by is_backend_offline() above).
+            if isinstance(exc, AuthenticationError):
+                return governed or _is_definitive_auth_rejection(exc)
             return governed or isinstance(
-                exc,
-                (AuthenticationError, CloudEgressBlockedError, SessionContractError),
+                exc, (CloudEgressBlockedError, SessionContractError)
             )
 
         if is_backend_offline():
@@ -610,7 +661,18 @@ class SessionOperations:
                 await self._reset_client_session("create_session fallback")
                 if _must_fail_loud(e):
                     raise
-                logger.debug("Backend unavailable for '%s': %s", function_name, e)
+                # A configured key intended a managed/cloud run, but the backend
+                # was unreachable. We degrade to LOCAL execution for resilience —
+                # but this is a DOWNGRADE (managed search/tracking is lost), so
+                # surface it at WARNING and flag degraded=True on the result so a
+                # caller never mistakes the local run for a managed one.
+                logger.warning(
+                    "Managed session creation failed (backend unreachable) for "
+                    "'%s'; degrading to LOCAL execution — results are NOT tracked "
+                    "on the backend (set offline=True to make this explicit): %s",
+                    function_name,
+                    e,
+                )
                 failure_response = _get_session_creation_failure_detail(e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
@@ -628,6 +690,7 @@ class SessionOperations:
                     typed_legacy_session_create_400=bool(
                         getattr(e, "typed_legacy_session_create_400", False)
                     ),
+                    degraded=True,
                 )
 
         # Run async method in sync context
@@ -687,8 +750,13 @@ class SessionOperations:
         except (TimeoutError, CloudServiceError, OSError) as exc:
             if _must_fail_loud(exc):
                 raise
-            logger.debug(
-                "Error in create_session for function '%s': %s",
+            # Backend unreachable on the outer path — same downgrade semantics as
+            # the inner sibling: WARN + flag degraded so the local run is never
+            # mistaken for a managed one.
+            logger.warning(
+                "Managed session creation failed (backend unreachable) for '%s'; "
+                "degrading to LOCAL execution — results are NOT tracked on the "
+                "backend (set offline=True to make this explicit): %s",
                 function_name,
                 exc,
             )
@@ -706,6 +774,7 @@ class SessionOperations:
                 reason=SessionCreationFailureReason.SESSION_FAILED,
                 detail=detail,
                 failure_response=failure_response,
+                degraded=True,
             )
 
         except Exception as exc:
@@ -715,8 +784,11 @@ class SessionOperations:
             # governed/contract failures, which must stay loud.
             if _must_fail_loud(exc):
                 raise
-            logger.debug(
-                "Unexpected error in create_session for function '%s': %s",
+            # An unexpected error that degrades a managed run to local is still a
+            # downgrade — surface at WARNING and flag degraded (was debug-only).
+            logger.warning(
+                "Unexpected error in create_session for '%s'; degrading to LOCAL "
+                "execution — results are NOT tracked on the backend: %s",
                 function_name,
                 exc,
             )
@@ -727,6 +799,7 @@ class SessionOperations:
                 session_id=fallback_id,
                 reason=SessionCreationFailureReason.SESSION_FAILED,
                 detail=str(exc)[:200],
+                degraded=True,
             )
 
     async def create_hybrid_session(

--- a/traigent/cloud/session_operations.py
+++ b/traigent/cloud/session_operations.py
@@ -383,6 +383,54 @@ class SessionOperations:
                 storage_e,
             )
 
+    def _auth_fallback_result(
+        self,
+        exc: Exception,
+        fallback_id: str,
+        detail: str,
+        failure_response: SessionCreationFailureDetail | None,
+        function_name: str,
+        intends_cloud_egress: bool,
+    ) -> SessionCreationResult:
+        """Build the fallback result for a non-fail-loud AuthenticationError.
+
+        A run that INTENDS cloud egress but hit a non-definitive auth failure
+        (could-not-validate / transient) takes the UNREACHABLE contract: degrade
+        to LOCAL but FLAG it (degraded=True + SESSION_FAILED + WARN) so it is
+        never mistaken for a managed run. A LOCAL-routed run only ever wanted
+        OPTIONAL backend tracking, so a rejected/invalid key is irrelevant: it
+        continues untracked locally (degraded=False) — intentional local
+        execution, NOT a downgrade (#1421).
+        """
+        if intends_cloud_egress:
+            logger.warning(
+                "Managed session creation failed (could not validate credentials "
+                "— backend unreachable) for '%s'; degrading to LOCAL execution — "
+                "results are NOT tracked on the backend (set offline=True to make "
+                "this explicit): %s",
+                function_name,
+                exc,
+            )
+            return SessionCreationResult.fallback(
+                session_id=fallback_id,
+                reason=SessionCreationFailureReason.SESSION_FAILED,
+                detail=detail,
+                failure_response=failure_response,
+                degraded=True,
+            )
+        logger.warning(
+            "Backend tracking unavailable (auth) for local run '%s'; continuing "
+            "untracked locally: %s",
+            function_name,
+            exc,
+        )
+        return SessionCreationResult.fallback(
+            session_id=fallback_id,
+            reason=SessionCreationFailureReason.AUTH,
+            detail=detail,
+            failure_response=failure_response,
+        )
+
     def create_session(
         self,
         function_name: str,
@@ -423,20 +471,32 @@ class SessionOperations:
         # misconfiguration, and old-BE typed rejection as success.
         governed = bool(promotion_policy or tvl_governance)
 
+        # Does this run actually INTEND cloud egress (managed / auto-cloud)? The
+        # backend session manager sets this from the runtime-resolved execution
+        # policy before calling us (mirrors the existing ``no_egress`` flag). A
+        # LOCAL-routed run (algorithm grid/random, offline, or runtime-resolved
+        # -to-local) creates a backend session only for OPTIONAL tracking — a
+        # configured-but-invalid/rejected key is irrelevant to it and must NOT
+        # hard-fail the local optimization. Default True keeps fail-closed for
+        # direct callers that do not declare intent. (#1421 regression.)
+        intends_cloud_egress = bool(getattr(self.client, "cloud_egress_intent", True))
+
         def _must_fail_loud(exc: Exception) -> bool:
             # A DEFINITIVELY rejected credential (invalid / revoked / expired /
             # unauthorized — a key WAS configured; the no-key path returns
-            # NO_API_KEY before any HTTP) is a user-actionable error. Silently
-            # degrading a cloud/managed run to a local/anonymous one would
-            # change execution semantics (managed Bayesian -> local search),
-            # drop the backend/billing/governance record, and present the
-            # degraded run as success — so fail closed. A *transient* failure
-            # to reach/validate the backend is NOT a rejection and still
-            # degrades gracefully (see _is_definitive_auth_rejection). Users
-            # who want local execution opt in explicitly via offline=True /
-            # TRAIGENT_OFFLINE_MODE (handled by is_backend_offline() above).
+            # NO_API_KEY before any HTTP) is a user-actionable error on a run
+            # that INTENDS cloud egress: silently degrading such a managed run
+            # to a local/anonymous one would change execution semantics (managed
+            # Bayesian -> local search), drop the backend/billing/governance
+            # record, and present the degraded run as success — so fail closed.
+            # On a LOCAL-routed run the same rejected key is irrelevant (zero
+            # cloud egress), so do NOT fail loud. A *transient* failure to
+            # reach/validate the backend is never a rejection and still degrades
+            # gracefully (see _is_definitive_auth_rejection).
             if isinstance(exc, AuthenticationError):
-                return governed or _is_definitive_auth_rejection(exc)
+                return governed or (
+                    intends_cloud_egress and _is_definitive_auth_rejection(exc)
+                )
             return governed or isinstance(
                 exc, (CloudEgressBlockedError, SessionContractError)
             )
@@ -653,36 +713,22 @@ class SessionOperations:
                 await self._reset_client_session("create_session auth_failure")
                 if _must_fail_loud(e):
                     raise
-                # Non-definitive AuthenticationError = the backend did NOT clearly
-                # reject the credential; the auth layer maps a key-validation
-                # TIMEOUT / transport failure (could-not-reach /keys/validate) to
-                # AuthenticationError. That is a reachability failure, not a
-                # rejection, so it takes the same UNREACHABLE contract as a
-                # backend outage: degrade to LOCAL but FLAG it (degraded=True +
-                # SESSION_FAILED + WARN) so the local run is never mistaken for a
-                # managed one. Definitive rejections fail loud above.
-                logger.warning(
-                    "Managed session creation failed (could not validate "
-                    "credentials — backend unreachable) for '%s'; degrading to "
-                    "LOCAL execution — results are NOT tracked on the backend "
-                    "(set offline=True to make this explicit): %s",
-                    function_name,
-                    e,
-                )
                 failure_response = _get_session_creation_failure_detail(e)
                 fallback_id = self._create_local_fallback_session(
                     function_name, search_space, optimization_goal, metadata
                 )
-                return SessionCreationResult.fallback(
-                    session_id=fallback_id,
-                    reason=SessionCreationFailureReason.SESSION_FAILED,
-                    detail=(
-                        failure_response.one_line_summary()
-                        if failure_response
-                        else str(e)[:200]
-                    ),
-                    failure_response=failure_response,
-                    degraded=True,
+                detail = (
+                    failure_response.one_line_summary()
+                    if failure_response
+                    else str(e)[:200]
+                )
+                return self._auth_fallback_result(
+                    e,
+                    fallback_id,
+                    detail,
+                    failure_response,
+                    function_name,
+                    intends_cloud_egress,
                 )
 
             except (TimeoutError, CloudServiceError, OSError) as e:
@@ -749,36 +795,27 @@ class SessionOperations:
                 raise
             # Issue #1373 "outer create_session swallow": an auth failure that
             # ESCAPES _create_session_async (e.g. the has_api_key preflight or
-            # the async-runner machinery). A DEFINITIVE rejection fails loud
-            # above; reaching here means a non-definitive auth failure (could not
-            # validate the credential — typically a /keys/validate timeout the
-            # auth layer maps to AuthenticationError). Mirror the inner sibling:
-            # take the UNREACHABLE contract — degrade to LOCAL but FLAG it
-            # (degraded=True + SESSION_FAILED + WARN) so it is never silent. The
-            # two sites are mutually exclusive per failure, so this never
-            # double-logs.
-            logger.warning(
-                "Managed session creation failed (could not validate "
-                "credentials — backend unreachable) for '%s'; degrading to "
-                "LOCAL execution — results are NOT tracked on the backend "
-                "(set offline=True to make this explicit): %s",
-                function_name,
-                exc,
-            )
+            # the async-runner machinery). A DEFINITIVE rejection on a cloud-
+            # intended run fails loud above. Reaching here is a non-definitive
+            # auth failure OR a LOCAL-routed run — both handled by the shared
+            # helper (cloud-intent: degrade+flag; local: continue untracked).
+            # The two auth sites are mutually exclusive per failure.
             failure_response = _get_session_creation_failure_detail(exc)
             fallback_id = self._create_local_fallback_session(
                 function_name, search_space, optimization_goal, metadata
             )
-            return SessionCreationResult.fallback(
-                session_id=fallback_id,
-                reason=SessionCreationFailureReason.SESSION_FAILED,
-                detail=(
-                    failure_response.one_line_summary()
-                    if failure_response
-                    else str(exc)[:200]
-                ),
-                failure_response=failure_response,
-                degraded=True,
+            detail = (
+                failure_response.one_line_summary()
+                if failure_response
+                else str(exc)[:200]
+            )
+            return self._auth_fallback_result(
+                exc,
+                fallback_id,
+                detail,
+                failure_response,
+                function_name,
+                intends_cloud_egress,
             )
 
         except (TimeoutError, CloudServiceError, OSError) as exc:

--- a/traigent/core/backend_session_manager.py
+++ b/traigent/core/backend_session_manager.py
@@ -760,6 +760,17 @@ class BackendSessionManager:
             if slug_hash:
                 portal_name = f"{portal_name} ({slug_hash})"
 
+            # Tell create_session whether this run actually INTENDS cloud egress
+            # (managed / auto-cloud) vs. a LOCAL-routed run (grid/random/offline/
+            # runtime-resolved-to-local) that only wants OPTIONAL backend
+            # tracking. A configured-but-invalid/rejected key must fail closed
+            # for the former but must NOT hard-fail the latter (#1421). Mirrors
+            # the existing ``no_egress`` flag set on the same client.
+            _policy = policy_from_config(self._traigent_config)
+            self._backend_client.cloud_egress_intent = bool(
+                policy_requires_cloud(_policy) or policy_is_cloud_brain(_policy)
+            )
+
             raw_result = self._backend_client.create_session(
                 function_name=portal_name,
                 search_space=getattr(self._optimizer, "config_space", {}),
@@ -1447,9 +1458,8 @@ class BackendSessionManager:
             result.metadata.get("statistical_significance") if result.metadata else None
         )
         if stat_sig:
-            summary_stats_with_aggregation["metadata"]["statistical_significance"] = (
-                stat_sig
-            )
+            agg_meta = summary_stats_with_aggregation["metadata"]
+            agg_meta["statistical_significance"] = stat_sig
 
         try:
             successful_trials = len([t for t in result.trials if t.is_successful])

--- a/traigent/core/session_types.py
+++ b/traigent/core/session_types.py
@@ -115,6 +115,16 @@ class SessionCreationResult:
     project_id: str | None = None
     tenant_id: str | None = None
     typed_legacy_session_create_400: bool = False
+    # Execution-path transparency (so a caller never mistakes a local run for a
+    # managed/cloud one). ``execution_path`` is "connected" for a real backend
+    # session and "local_fallback" for any local result. ``backend_fallback`` is
+    # True whenever the run is local. ``degraded`` is True ONLY when the user
+    # intended a managed/cloud run but the backend was unreachable and we fell
+    # back to local — it stays False for intentional local execution (offline
+    # mode / no API key), which is a deliberate configuration, not a downgrade.
+    execution_path: str | None = None
+    backend_fallback: bool = False
+    degraded: bool = False
 
     def __str__(self) -> str:
         """Return the session ID string for backwards compatibility.
@@ -145,6 +155,9 @@ class SessionCreationResult:
             backend_connected=True,
             project_id=project_id,
             tenant_id=tenant_id,
+            execution_path="connected",
+            backend_fallback=False,
+            degraded=False,
         )
 
     @classmethod
@@ -155,8 +168,15 @@ class SessionCreationResult:
         detail: str | None = None,
         failure_response: SessionCreationFailureDetail | None = None,
         typed_legacy_session_create_400: bool = False,
+        degraded: bool = False,
     ) -> SessionCreationResult:
-        """Factory for a local-fallback session after backend failure."""
+        """Factory for a local-fallback session after backend failure.
+
+        ``degraded`` must be set True by callers where the user intended a
+        managed/cloud run but the backend was unreachable (an unintended
+        downgrade); it stays False for intentional local execution (offline
+        mode / no API key configured).
+        """
         return cls(
             session_id=session_id,
             backend_connected=False,
@@ -164,4 +184,7 @@ class SessionCreationResult:
             failure_detail=detail,
             failure_response=failure_response,
             typed_legacy_session_create_400=typed_legacy_session_create_400,
+            execution_path="local_fallback",
+            backend_fallback=True,
+            degraded=degraded,
         )


### PR DESCRIPTION
## SDK fail-closed on rejected/unreachable managed session

Policy-surface fix (root CLAUDE.md Rule 1). A managed/cloud `optimize()` run whose configured API key the backend **rejected** (401) — or whose key-validation/session-create was **unreachable** — previously **silently** created a local/anonymous session and kept optimizing, presenting a degraded local run as a normal cloud/managed result (no error, no flag). This is the silent `auto→local_fallback` observed live when a key was revoked mid-run.

### Changes (3 files)
- `traigent/cloud/session_operations.py`: a definitive auth rejection (401/403, read from `exc.session_creation_failure.status_code` first, then `status_code`/text) now **raises**; a non-definitive auth failure (e.g. key-validation timeout/transport) and a backend-unreachable failure take the **degraded** contract (WARN + `degraded=True`, `backend_fallback=True`, `execution_path=local_fallback`); benign offline / no-key paths unchanged (run local, `degraded=False`).
- `traigent/core/session_types.py`: `SessionCreationResult` gains `execution_path`, `backend_fallback`, `degraded` so callers can SEE a degrade.
- tests: real-shape fail-closed + degraded + offline-preservation cases.

Spine-Trail: st_98c08539d68e

### Evidence
- 13 target tests pass (incl. `test_create_session_structured_401_fails_loud`, `test_create_session_auth_validation_timeout_degrades_not_silent`, offline-preserved); broader cloud+core suite 1744 passed / 2 skipped; ruff clean. Captain independently re-ran the target suite → 13 passed.
- Two independent cross-model gpt-5.5 reviews: iter-1 **NO-GO** (caught the structured-401 miss + auth-timeout silent degrade), iter-2 **GO** after fix.

### PR checklist
1. **Worst-case prod path:** a customer key rotates/expires mid-run → before: silent local run billed/trusted as cloud; now: fails closed (raises). Unreachable backend → explicit `degraded` + WARN, never silent.
2. **Production-branch test:** `tests/unit/cloud/test_session_operations_validation.py::test_create_session_structured_401_fails_loud` (real `SessionCreationFailureDetail(status_code=401)` → asserts raise).
3. **Contract regeneration:** none; `SessionCreationResult` is SDK-internal, new fields additive/back-compatible. JS parity tracked as a follow-up PR.
4. **Public surface delta:** `create_session` now raises `AuthenticationError` on a definitively-rejected key (deliberate; reverses #1373's silent fallback) + 3 additive result fields.
5. **Review threads:** two cross-model reviews; iter-2 GO, no blocking findings.
6. **Quality gates:** none relaxed.
