### PR TITLE
fix(integrations): wire HuggingFace overrides to huggingface_hub.* with per-method params (#1570)

### DIFF
--- a/reports/hf-override-result.md
+++ b/reports/hf-override-result.md
@@ -1,0 +1,131 @@
+# HF Override Fix — Worker Result (Issue #1570)
+
+**Branch:** fix/hf-override-1570  
+**Base:** origin/develop @ fbe22e54  
+**Date:** 2026-06-29
+
+---
+
+## Round 2 — Codex NO-GO Review Fixes (commit 64c5ee1d)
+
+Two blocking findings from the independent Codex gpt-5.5 review were addressed:
+
+### Finding 1: Generation params injected into `InferenceClient.__init__` → TypeError
+
+**Root cause:** The class-level `PARAMETER_MAPPINGS` for `huggingface_hub.InferenceClient`
+and `AsyncInferenceClient` included generation kwargs (`temperature`, `max_tokens`→`max_new_tokens`,
+`top_p`, `top_k`, `stop`, `stream`). `FrameworkOverrideManager._create_override_constructor`
+iterates over `PARAMETER_MAPPINGS` and injects ALL mapped params into `__init__`. Since
+`InferenceClient.__init__` only accepts constructor kwargs (`model`, `token`, `timeout`,
+`base_url`, `headers`, `cookies`, `api_key`), injecting generation params caused:
+
+```
+TypeError: InferenceClient.__init__() got an unexpected keyword argument 'temperature'
+```
+
+**Fix applied:**
+
+`mappings.py` — PARAMETER_MAPPINGS for both InferenceClient classes:
+- **Before:** `{model, temperature, max_tokens→max_new_tokens, top_p, top_k, stop, stream}`
+- **After:** `{model}` — constructor-valid params only
+
+`mappings.py` — new `METHOD_PARAMETER_TRANSLATIONS` dict:
+- Stores method-level param name translations for generation params absent from class-level PARAMETER_MAPPINGS
+- `huggingface_hub.InferenceClient.text_generation: {max_tokens: max_new_tokens}`
+- `huggingface_hub.AsyncInferenceClient.text_generation: {max_tokens: max_new_tokens}`
+- `chat_completion: {}` (max_tokens excluded from METHOD_MAPPINGS for this method; no translation needed)
+
+`framework_override.py` — `_create_override_method` refactored:
+- Builds an **effective per-method translation** by merging (priority order):
+  1. `METHOD_PARAMETER_TRANSLATIONS` for this class+method (method-specific, e.g. max_tokens→max_new_tokens)
+  2. Class-level `PARAMETER_MAPPINGS` (constructor params, e.g. model)
+  3. Identity fallback for all remaining `supported_params` (e.g. temperature→temperature)
+- Loop now iterates over `supported_params` (not `parameter_mapping.items()`) so all
+  method-accepted generation params are injected with correct translation even when absent
+  from the class-level PARAMETER_MAPPINGS
+
+`framework_override.py` — new `_init_method_parameter_translations()` method and
+`_method_parameter_translations` instance attribute (deep-copied from `METHOD_PARAMETER_TRANSLATIONS`).
+
+### Finding 2: False "fallback/plugin-precedence" documentation at two remaining sites
+
+**Before (mappings.py module docstring):**
+> "This module contains the static mappings used as FALLBACK when no plugin is registered.
+> Plugin mappings (via LLMPlugin._get_default_mappings) take precedence over these static mappings."
+
+**Before (framework_override.py `_init_method_mappings` docstring ~line 100):**
+> "These serve as fallback when no plugin is registered for a framework."
+
+Both were false — the static maps are the single active source; there is no plugin-precedence
+layer on top of them in `FrameworkOverrideManager`.
+
+**Fix:** Both docstrings updated to accurately describe the role of the static maps.
+
+---
+
+## Changed Files (Round 2)
+
+| File | Change |
+|------|--------|
+| `traigent/integrations/mappings.py` | Module docstring fixed; PARAMETER_MAPPINGS for InferenceClient/AsyncInferenceClient stripped to `{model}`; new `METHOD_PARAMETER_TRANSLATIONS` dict + `get_method_parameter_translation()` helper |
+| `traigent/integrations/framework_override.py` | `_init_method_mappings` docstring fixed; import `METHOD_PARAMETER_TRANSLATIONS`; new `_init_method_parameter_translations()`; `_create_override_method` refactored (both sync + async inner functions) to use effective per-method mapping |
+| `tests/unit/integrations/test_hf_override_consistency.py` | `test_hf_parameter_mappings_have_core_params` updated (now asserts generation params ABSENT from class-level, asserts METHOD_PARAMETER_TRANSLATIONS has max_tokens→max_new_tokens); new `test_hf_constructor_no_generation_param_injection` (Codex repro); new `test_hf_manager_uses_all_target_classes` (strengthened coverage assertion) |
+
+---
+
+## Validation Output (Round 2)
+
+### Codex repro directly confirmed:
+
+```
+SUCCESS: InferenceClient created without TypeError
+Client model: gpt2
+Override restored.
+```
+
+### HF consistency tests (10 tests, up from 8):
+
+```
+tests/unit/integrations/test_hf_override_consistency.py ..........
+10 passed in 1.63s
+```
+
+### Full integrations suite:
+
+```
+1597 passed in 5.73s
+```
+
+### Ruff:
+
+```
+All checks passed!
+```
+
+---
+
+## Round 1 Summary (original fix, commit on branch)
+
+See git log for prior commit. Root cause was that `override_huggingface()` and
+`override_all_platforms()` targeted `transformers.*` instead of `huggingface_hub.*`,
+and PARAMETER_MAPPINGS/METHOD_MAPPINGS had no `huggingface_hub.*` entries at all.
+
+---
+
+## Residual Risks (post Round 2)
+
+1. **`transformers.*` entries remain in PARAMETER_MAPPINGS.** They are no longer enabled
+   by `override_huggingface()` / `override_all_platforms()`. Users explicitly calling
+   `enable_framework_overrides(["transformers.pipeline"])` still get constructor-level
+   override. This is an acceptable legacy artifact; removal is a separate cleanup PR.
+
+2. **mypy pre-existing debt.** The `--no-verify` flag is authorized by the captain for
+   the pre-existing mypy failures in files outside the write scope (verified identical
+   on base fbe22e54).
+
+---
+
+## PR-Ready
+
+**Code changes:** Yes — all tests pass (1597), ruff clean, Codex repro confirmed no TypeError.  
+**Commit:** 64c5ee1d — `fix(integrations): scope HF generation params to methods, not InferenceClient.__init__ (#1570 review fixes)`

--- a/tests/unit/integrations/test_hf_override_consistency.py
+++ b/tests/unit/integrations/test_hf_override_consistency.py
@@ -116,19 +116,30 @@ def test_hf_method_mappings_text_generation_includes_max_tokens():
 
 
 @pytest.mark.unit
-def test_hf_method_mappings_chat_completion_excludes_max_tokens():
-    """chat_completion must NOT list max_tokens: PARAMETER_MAPPINGS maps it to max_new_tokens
-    which is not a valid chat_completion kwarg."""
-    assert (
-        "max_tokens"
-        not in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["chat_completion"]
-    )
-    assert (
-        "max_tokens"
-        not in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"][
-            "chat_completion"
-        ]
-    )
+def test_hf_method_mappings_chat_completion_includes_max_tokens():
+    """chat_completion MUST list max_tokens (issue #1570 round-3).
+
+    The installed huggingface_hub InferenceClient.chat_completion accepts max_tokens
+    NATIVELY (OpenAI-style). Omitting it from METHOD_MAPPINGS silently drops a configured
+    max_tokens for chat calls. It must be present, and it must NOT have a
+    max_tokens -> max_new_tokens translation (chat_completion has no max_new_tokens kwarg),
+    so the canonical/native name is passed through unchanged.
+    """
+    for cls in (
+        "huggingface_hub.InferenceClient",
+        "huggingface_hub.AsyncInferenceClient",
+    ):
+        assert "max_tokens" in METHOD_MAPPINGS[cls]["chat_completion"], (
+            f"{cls}.chat_completion must list max_tokens — it is a native chat_completion "
+            f"kwarg and is otherwise silently dropped (issue #1570)."
+        )
+        chat_translations = METHOD_PARAMETER_TRANSLATIONS.get(cls, {}).get(
+            "chat_completion", {}
+        )
+        assert "max_tokens" not in chat_translations, (
+            f"{cls}.chat_completion must NOT translate max_tokens (it is native); a "
+            f"max_tokens -> max_new_tokens entry here would drop the configured value."
+        )
 
 
 @pytest.mark.unit
@@ -246,3 +257,98 @@ def test_hf_manager_uses_all_target_classes():
             f"declared by HuggingFacePlugin.get_target_classes(). "
             f"Add it to METHOD_MAPPINGS in mappings.py."
         )
+
+
+@pytest.mark.unit
+def test_hf_method_injection_per_method_param_names(monkeypatch):
+    """Wrapper-probe (issue #1570 round-3): with the HF override active and a config of
+    {max_tokens, temperature, top_p}, assert the kwargs ACTUALLY delivered to each method
+    use the name THAT method accepts.
+
+      * chat_completion receives max_tokens NATIVELY (and no max_new_tokens).
+      * text_generation receives max_new_tokens (translated; and no leftover max_tokens).
+      * both receive temperature/top_p under their canonical names.
+
+    Neither call may raise or drop a configured generation param. This is the behavior the
+    earlier round regressed by dropping max_tokens from chat_completion entirely.
+    """
+    import huggingface_hub
+
+    from traigent.config.context import (
+        config_context,
+        config_space_context,
+        set_config,
+        set_config_space,
+    )
+    from traigent.config.types import TraigentConfig
+    from traigent.integrations.framework_override import FrameworkOverrideManager
+
+    captured: dict[str, dict] = {}
+
+    def capture_text_generation(self, *args, **kwargs):
+        captured["text_generation"] = dict(kwargs)
+        return "text-generation-ok"
+
+    def capture_chat_completion(self, *args, **kwargs):
+        captured["chat_completion"] = dict(kwargs)
+        return "chat-completion-ok"
+
+    # Replace the real network-bound methods with capturing stubs BEFORE activation so
+    # the override wraps the stub (no real inference endpoint is contacted).
+    monkeypatch.setattr(
+        huggingface_hub.InferenceClient,
+        "text_generation",
+        capture_text_generation,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        huggingface_hub.InferenceClient,
+        "chat_completion",
+        capture_chat_completion,
+        raising=False,
+    )
+
+    manager = FrameworkOverrideManager()
+    manager.activate_overrides(["huggingface_hub.InferenceClient"])
+
+    config = TraigentConfig(max_tokens=42, temperature=0.5, top_p=0.9)
+    cfg_token = set_config(config)
+    space_token = set_config_space(
+        {"max_tokens": [42], "temperature": [0.5], "top_p": [0.9]}
+    )
+    try:
+        client = huggingface_hub.InferenceClient(model="gpt2")
+
+        # These must not raise and must carry the per-method-correct param names.
+        assert client.text_generation("hello") == "text-generation-ok"
+        assert (
+            client.chat_completion(messages=[{"role": "user", "content": "hi"}])
+            == "chat-completion-ok"
+        )
+    finally:
+        config_space_context.reset(space_token)
+        config_context.reset(cfg_token)
+        manager.deactivate_overrides()
+
+    tg = captured["text_generation"]
+    cc = captured["chat_completion"]
+
+    # text_generation: HF-native name max_new_tokens; canonical max_tokens must be gone.
+    assert tg.get("max_new_tokens") == 42, (
+        f"text_generation must receive the configured max_tokens as max_new_tokens; got {tg!r}"
+    )
+    assert "max_tokens" not in tg, (
+        f"text_generation must NOT receive the OpenAI-style max_tokens name; got {tg!r}"
+    )
+    assert tg.get("temperature") == 0.5, f"text_generation lost temperature; got {tg!r}"
+    assert tg.get("top_p") == 0.9, f"text_generation lost top_p; got {tg!r}"
+
+    # chat_completion: native max_tokens passthrough; max_new_tokens must NOT appear.
+    assert cc.get("max_tokens") == 42, (
+        f"chat_completion must receive the configured max_tokens NATIVELY (not dropped); got {cc!r}"
+    )
+    assert "max_new_tokens" not in cc, (
+        f"chat_completion must NOT receive max_new_tokens (not a valid kwarg); got {cc!r}"
+    )
+    assert cc.get("temperature") == 0.5, f"chat_completion lost temperature; got {cc!r}"
+    assert cc.get("top_p") == 0.9, f"chat_completion lost top_p; got {cc!r}"

--- a/tests/unit/integrations/test_hf_override_consistency.py
+++ b/tests/unit/integrations/test_hf_override_consistency.py
@@ -1,0 +1,133 @@
+"""Regression guard for issue #1570: HuggingFace override consistency.
+
+Ensures that every class declared by HuggingFacePlugin.get_target_classes() has
+corresponding entries in the static PARAMETER_MAPPINGS and METHOD_MAPPINGS used by
+FrameworkOverrideManager, and that the convenience override functions target the
+correct huggingface_hub.* classes.
+"""
+
+import pytest
+
+from traigent.integrations.llms.huggingface_plugin import HuggingFacePlugin
+from traigent.integrations.mappings import METHOD_MAPPINGS, PARAMETER_MAPPINGS
+
+
+@pytest.mark.unit
+def test_hf_plugin_classes_in_parameter_mappings():
+    """Every class declared by the HF plugin must have a PARAMETER_MAPPINGS entry."""
+    plugin = HuggingFacePlugin()
+    for cls in plugin.get_target_classes():
+        assert cls in PARAMETER_MAPPINGS, (
+            f"HuggingFacePlugin declares target class {cls!r} but PARAMETER_MAPPINGS "
+            f"has no entry for it — override_huggingface() would inject no params."
+        )
+
+
+@pytest.mark.unit
+def test_hf_plugin_classes_in_method_mappings():
+    """Every class declared by the HF plugin must have a METHOD_MAPPINGS entry."""
+    plugin = HuggingFacePlugin()
+    for cls in plugin.get_target_classes():
+        assert cls in METHOD_MAPPINGS, (
+            f"HuggingFacePlugin declares target class {cls!r} but METHOD_MAPPINGS "
+            f"has no entry for it — method-level param injection is fully disabled."
+        )
+
+
+@pytest.mark.unit
+def test_hf_plugin_methods_in_method_mappings():
+    """Every method declared by the HF plugin must appear in METHOD_MAPPINGS."""
+    plugin = HuggingFacePlugin()
+    for cls, methods in plugin.get_target_methods().items():
+        assert cls in METHOD_MAPPINGS, (
+            f"HuggingFacePlugin declares methods for {cls!r} but METHOD_MAPPINGS "
+            f"has no entry for it."
+        )
+        for method in methods:
+            assert method in METHOD_MAPPINGS[cls], (
+                f"HuggingFacePlugin declares method {method!r} on {cls!r} but "
+                f"METHOD_MAPPINGS[{cls!r}] has no entry for it."
+            )
+
+
+@pytest.mark.unit
+def test_hf_parameter_mappings_have_core_params():
+    """PARAMETER_MAPPINGS for huggingface_hub.InferenceClient covers key tunable params."""
+    mapping = PARAMETER_MAPPINGS["huggingface_hub.InferenceClient"]
+    assert mapping["model"] == "model"
+    assert mapping["temperature"] == "temperature"
+    assert mapping["max_tokens"] == "max_new_tokens"
+    assert mapping["top_p"] == "top_p"
+    assert mapping["stream"] == "stream"
+
+    async_mapping = PARAMETER_MAPPINGS["huggingface_hub.AsyncInferenceClient"]
+    assert async_mapping == mapping, (
+        "Sync and async InferenceClient parameter mappings should be identical."
+    )
+
+
+@pytest.mark.unit
+def test_hf_method_mappings_text_generation_includes_max_tokens():
+    """text_generation METHOD_MAPPINGS must include max_tokens so max_new_tokens is injected."""
+    assert "max_tokens" in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["text_generation"]
+    assert "max_tokens" in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"]["text_generation"]
+
+
+@pytest.mark.unit
+def test_hf_method_mappings_chat_completion_excludes_max_tokens():
+    """chat_completion must NOT list max_tokens: PARAMETER_MAPPINGS maps it to max_new_tokens
+    which is not a valid chat_completion kwarg."""
+    assert "max_tokens" not in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["chat_completion"]
+    assert "max_tokens" not in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"]["chat_completion"]
+
+
+@pytest.mark.unit
+def test_override_huggingface_targets_huggingface_hub_classes(monkeypatch):
+    """override_huggingface() must enable huggingface_hub.* classes, not transformers.*."""
+    from traigent.integrations import framework_override as fo
+
+    captured: list[list[str]] = []
+
+    def fake_enable(targets):
+        captured.append(list(targets))
+
+    monkeypatch.setattr(fo, "enable_framework_overrides", fake_enable)
+    fo.override_huggingface()
+
+    assert captured, "override_huggingface() did not call enable_framework_overrides()"
+    enabled = captured[0]
+
+    assert "huggingface_hub.InferenceClient" in enabled, (
+        f"override_huggingface() should enable huggingface_hub.InferenceClient, got {enabled}"
+    )
+    assert "huggingface_hub.AsyncInferenceClient" in enabled, (
+        f"override_huggingface() should enable huggingface_hub.AsyncInferenceClient, got {enabled}"
+    )
+    assert "transformers.pipeline" not in enabled, (
+        "override_huggingface() must NOT enable transformers.pipeline (wrong surface)"
+    )
+    assert "transformers.AutoModelForCausalLM" not in enabled, (
+        "override_huggingface() must NOT enable transformers.AutoModelForCausalLM (wrong surface)"
+    )
+
+
+@pytest.mark.unit
+def test_override_all_platforms_includes_huggingface_hub_classes(monkeypatch):
+    """override_all_platforms() must include huggingface_hub.* classes, not transformers.*."""
+    from traigent.integrations import framework_override as fo
+
+    captured: list[list[str]] = []
+
+    def fake_enable(targets):
+        captured.append(list(targets))
+
+    monkeypatch.setattr(fo, "enable_framework_overrides", fake_enable)
+    fo.override_all_platforms()
+
+    assert captured, "override_all_platforms() did not call enable_framework_overrides()"
+    enabled = captured[0]
+
+    assert "huggingface_hub.InferenceClient" in enabled
+    assert "huggingface_hub.AsyncInferenceClient" in enabled
+    assert "transformers.pipeline" not in enabled
+    assert "transformers.AutoModelForCausalLM" not in enabled

--- a/tests/unit/integrations/test_hf_override_consistency.py
+++ b/tests/unit/integrations/test_hf_override_consistency.py
@@ -105,16 +105,30 @@ def test_hf_parameter_mappings_have_core_params():
 @pytest.mark.unit
 def test_hf_method_mappings_text_generation_includes_max_tokens():
     """text_generation METHOD_MAPPINGS must include max_tokens so max_new_tokens is injected."""
-    assert "max_tokens" in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["text_generation"]
-    assert "max_tokens" in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"]["text_generation"]
+    assert (
+        "max_tokens"
+        in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["text_generation"]
+    )
+    assert (
+        "max_tokens"
+        in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"]["text_generation"]
+    )
 
 
 @pytest.mark.unit
 def test_hf_method_mappings_chat_completion_excludes_max_tokens():
     """chat_completion must NOT list max_tokens: PARAMETER_MAPPINGS maps it to max_new_tokens
     which is not a valid chat_completion kwarg."""
-    assert "max_tokens" not in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["chat_completion"]
-    assert "max_tokens" not in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"]["chat_completion"]
+    assert (
+        "max_tokens"
+        not in METHOD_MAPPINGS["huggingface_hub.InferenceClient"]["chat_completion"]
+    )
+    assert (
+        "max_tokens"
+        not in METHOD_MAPPINGS["huggingface_hub.AsyncInferenceClient"][
+            "chat_completion"
+        ]
+    )
 
 
 @pytest.mark.unit
@@ -160,7 +174,9 @@ def test_override_all_platforms_includes_huggingface_hub_classes(monkeypatch):
     monkeypatch.setattr(fo, "enable_framework_overrides", fake_enable)
     fo.override_all_platforms()
 
-    assert captured, "override_all_platforms() did not call enable_framework_overrides()"
+    assert captured, (
+        "override_all_platforms() did not call enable_framework_overrides()"
+    )
     enabled = captured[0]
 
     assert "huggingface_hub.InferenceClient" in enabled
@@ -198,7 +214,9 @@ def test_hf_constructor_no_generation_param_injection():
     try:
         # This must not raise TypeError.
         client = huggingface_hub.InferenceClient(model="gpt2")
-        assert client is not None, "InferenceClient instance must be created without error"
+        assert client is not None, (
+            "InferenceClient instance must be created without error"
+        )
     finally:
         config_context.reset(token)
         manager.deactivate_overrides()

--- a/tests/unit/integrations/test_hf_override_consistency.py
+++ b/tests/unit/integrations/test_hf_override_consistency.py
@@ -4,12 +4,22 @@ Ensures that every class declared by HuggingFacePlugin.get_target_classes() has
 corresponding entries in the static PARAMETER_MAPPINGS and METHOD_MAPPINGS used by
 FrameworkOverrideManager, and that the convenience override functions target the
 correct huggingface_hub.* classes.
+
+Key invariant enforced here: the class-level PARAMETER_MAPPINGS for InferenceClient /
+AsyncInferenceClient must contain ONLY constructor-valid kwargs. Generation params
+(temperature, max_tokens, etc.) must NOT appear there — they would be blindly injected
+into __init__ and raise TypeError (the bug fixed in #1570). Generation params live in
+METHOD_MAPPINGS (for filtering) and METHOD_PARAMETER_TRANSLATIONS (for name translation).
 """
 
 import pytest
 
 from traigent.integrations.llms.huggingface_plugin import HuggingFacePlugin
-from traigent.integrations.mappings import METHOD_MAPPINGS, PARAMETER_MAPPINGS
+from traigent.integrations.mappings import (
+    METHOD_MAPPINGS,
+    METHOD_PARAMETER_TRANSLATIONS,
+    PARAMETER_MAPPINGS,
+)
 
 
 @pytest.mark.unit
@@ -52,13 +62,39 @@ def test_hf_plugin_methods_in_method_mappings():
 
 @pytest.mark.unit
 def test_hf_parameter_mappings_have_core_params():
-    """PARAMETER_MAPPINGS for huggingface_hub.InferenceClient covers key tunable params."""
+    """Class-level PARAMETER_MAPPINGS for InferenceClient must contain ONLY
+    constructor-valid params. Generation params must NOT be present — they would be
+    injected into InferenceClient.__init__ and raise TypeError (issue #1570 fix).
+
+    InferenceClient.__init__ accepts: model, token, timeout, base_url, headers,
+    cookies, api_key. It does NOT accept: temperature, max_tokens/max_new_tokens,
+    top_p, top_k, stop, stream.
+    """
     mapping = PARAMETER_MAPPINGS["huggingface_hub.InferenceClient"]
+
+    # model IS a valid constructor kwarg
     assert mapping["model"] == "model"
-    assert mapping["temperature"] == "temperature"
-    assert mapping["max_tokens"] == "max_new_tokens"
-    assert mapping["top_p"] == "top_p"
-    assert mapping["stream"] == "stream"
+
+    # Generation params must NOT be in the class-level mapping (TypeError risk)
+    for gen_param in ("temperature", "max_tokens", "top_p", "top_k", "stop", "stream"):
+        assert gen_param not in mapping, (
+            f"{gen_param!r} is a generation param and must NOT appear in the class-level "
+            f"PARAMETER_MAPPINGS for huggingface_hub.InferenceClient. "
+            f"Injecting it into __init__ causes TypeError (issue #1570). "
+            f"Place it in METHOD_MAPPINGS + METHOD_PARAMETER_TRANSLATIONS instead."
+        )
+
+    # max_tokens → max_new_tokens translation lives in METHOD_PARAMETER_TRANSLATIONS
+    text_gen_translations = METHOD_PARAMETER_TRANSLATIONS.get(
+        "huggingface_hub.InferenceClient", {}
+    ).get("text_generation", {})
+    assert "max_tokens" in text_gen_translations, (
+        "max_tokens → max_new_tokens translation must be in "
+        "METHOD_PARAMETER_TRANSLATIONS['huggingface_hub.InferenceClient']['text_generation']"
+    )
+    assert text_gen_translations["max_tokens"] == "max_new_tokens", (
+        "text_generation must translate max_tokens → max_new_tokens (the HF framework name)"
+    )
 
     async_mapping = PARAMETER_MAPPINGS["huggingface_hub.AsyncInferenceClient"]
     assert async_mapping == mapping, (
@@ -131,3 +167,64 @@ def test_override_all_platforms_includes_huggingface_hub_classes(monkeypatch):
     assert "huggingface_hub.AsyncInferenceClient" in enabled
     assert "transformers.pipeline" not in enabled
     assert "transformers.AutoModelForCausalLM" not in enabled
+
+
+@pytest.mark.unit
+def test_hf_constructor_no_generation_param_injection():
+    """Codex repro #1570: enabling the HF override and constructing InferenceClient
+    with an active config context containing temperature/max_tokens must NOT raise
+    TypeError.
+
+    Before fix: TypeError: InferenceClient.__init__() got an unexpected keyword
+    argument 'temperature' (and/or 'max_new_tokens', 'top_p', etc.) because
+    generation params were present in the class-level PARAMETER_MAPPINGS and the
+    constructor override injected ALL mapped params regardless of constructor validity.
+
+    After fix: class-level PARAMETER_MAPPINGS contains only constructor-valid kwargs
+    (model), so the constructor override injects nothing that __init__ doesn't accept.
+    """
+    import huggingface_hub
+
+    from traigent.config.context import config_context, set_config
+    from traigent.config.types import TraigentConfig
+    from traigent.integrations.framework_override import FrameworkOverrideManager
+
+    manager = FrameworkOverrideManager()
+    manager.activate_overrides(["huggingface_hub.InferenceClient"])
+
+    # Config that used to cause TypeError when injected into __init__
+    config = TraigentConfig(temperature=0.5, max_tokens=42, top_p=0.9)
+    token = set_config(config)
+    try:
+        # This must not raise TypeError.
+        client = huggingface_hub.InferenceClient(model="gpt2")
+        assert client is not None, "InferenceClient instance must be created without error"
+    finally:
+        config_context.reset(token)
+        manager.deactivate_overrides()
+
+
+@pytest.mark.unit
+def test_hf_manager_uses_all_target_classes():
+    """Every class the HF plugin declares must have a mapping the FrameworkOverrideManager
+    actually loads (i.e. present in both PARAMETER_MAPPINGS and METHOD_MAPPINGS).
+
+    Regression guard: a class missing from either mapping silently disables all param
+    injection for that class even when the override is active.
+    """
+    from traigent.integrations.framework_override import FrameworkOverrideManager
+
+    manager = FrameworkOverrideManager()
+    plugin = HuggingFacePlugin()
+
+    for cls in plugin.get_target_classes():
+        assert cls in manager._parameter_mappings, (
+            f"FrameworkOverrideManager._parameter_mappings has no entry for {cls!r} "
+            f"declared by HuggingFacePlugin.get_target_classes(). "
+            f"Add it to PARAMETER_MAPPINGS in mappings.py."
+        )
+        assert cls in manager._method_mappings, (
+            f"FrameworkOverrideManager._method_mappings has no entry for {cls!r} "
+            f"declared by HuggingFacePlugin.get_target_classes(). "
+            f"Add it to METHOD_MAPPINGS in mappings.py."
+        )

--- a/traigent/integrations/framework_override.py
+++ b/traigent/integrations/framework_override.py
@@ -85,9 +85,9 @@ class FrameworkOverrideManager(BaseOverrideManager):
     def _init_parameter_mappings(self) -> dict[str, dict[str, str]]:
         """Initialize parameter mappings for different frameworks.
 
-        Uses static mappings from mappings.py as the baseline.
-        These serve as fallback when no plugin is registered for a framework.
-        Plugin mappings (via LLMPlugin._get_default_mappings) take precedence.
+        Uses static mappings from mappings.py as the single source of truth.
+        Every class registered in get_target_classes() of any plugin must have
+        a corresponding entry here for overrides to inject params at call sites.
         """
         # Deep copy to allow instance-level modifications without affecting global mappings
         return {k: dict(v) for k, v in PARAMETER_MAPPINGS.items()}
@@ -971,9 +971,12 @@ def override_cohere() -> None:
 
 
 def override_huggingface() -> None:
-    """Enable overrides for HuggingFace classes."""
+    """Enable overrides for HuggingFace Hub InferenceClient classes."""
     enable_framework_overrides(
-        ["transformers.pipeline", "transformers.AutoModelForCausalLM"]
+        [
+            "huggingface_hub.InferenceClient",
+            "huggingface_hub.AsyncInferenceClient",
+        ]
     )
 
 
@@ -995,9 +998,9 @@ def override_all_platforms() -> None:
             # Cohere
             "cohere.Client",
             "cohere.AsyncClient",
-            # HuggingFace
-            "transformers.pipeline",
-            "transformers.AutoModelForCausalLM",
+            # HuggingFace Hub
+            "huggingface_hub.InferenceClient",
+            "huggingface_hub.AsyncInferenceClient",
         ]
     )
 

--- a/traigent/integrations/framework_override.py
+++ b/traigent/integrations/framework_override.py
@@ -36,7 +36,7 @@ from ..utils.logging import get_logger
 from .base import BaseOverrideManager
 
 # Import static mappings from dedicated module
-from .mappings import METHOD_MAPPINGS, PARAMETER_MAPPINGS
+from .mappings import METHOD_MAPPINGS, METHOD_PARAMETER_TRANSLATIONS, PARAMETER_MAPPINGS
 
 logger = get_logger(__name__)
 
@@ -81,6 +81,7 @@ class FrameworkOverrideManager(BaseOverrideManager):
 
         self._parameter_mappings = self._init_parameter_mappings()
         self._method_mappings = self._init_method_mappings()
+        self._method_parameter_translations = self._init_method_parameter_translations()
 
     def _init_parameter_mappings(self) -> dict[str, dict[str, str]]:
         """Initialize parameter mappings for different frameworks.
@@ -95,15 +96,30 @@ class FrameworkOverrideManager(BaseOverrideManager):
     def _init_method_mappings(self) -> dict[str, dict[str, list[str]]]:
         """Initialize method mappings for different frameworks.
 
-        Uses static mappings from mappings.py as the baseline.
-        Maps class names to methods that should be overridden for parameter injection.
-        These serve as fallback when no plugin is registered for a framework.
+        Uses static mappings from mappings.py as the single active source of truth.
+        Maps class names to methods and the Traigent canonical param names each method
+        accepts. The method override injects only params listed here (combined with
+        METHOD_PARAMETER_TRANSLATIONS for non-identity name translations).
         """
         # Deep copy to allow instance-level modifications without affecting global mappings
         # Inner lists also need to be copied
         return {
             k: {method: list(params) for method, params in v.items()}
             for k, v in METHOD_MAPPINGS.items()
+        }
+
+    def _init_method_parameter_translations(
+        self,
+    ) -> dict[str, dict[str, dict[str, str]]]:
+        """Initialize method-level parameter name translations.
+
+        Used when a method's framework param name differs from the Traigent canonical
+        name but the param is intentionally absent from the class-level PARAMETER_MAPPINGS
+        (because it is not a valid constructor arg). Deep-copied for instance isolation.
+        """
+        return {
+            k: {method: dict(trans) for method, trans in v.items()}
+            for k, v in METHOD_PARAMETER_TRANSLATIONS.items()
         }
 
     def register_framework_target(
@@ -203,10 +219,30 @@ class FrameworkOverrideManager(BaseOverrideManager):
         Returns:
             Overridden method with parameter injection
         """
-        parameter_mapping = self._parameter_mappings.get(class_name, {})
+        # supported_params: the Traigent canonical names this method accepts.
         supported_params = self._method_mappings.get(class_name, {}).get(
             method_name, []
         )
+
+        # Build the effective parameter name translation for this method.
+        # Priority (highest to lowest):
+        #   1. Method-specific translations from METHOD_PARAMETER_TRANSLATIONS
+        #      (e.g. HF text_generation: max_tokens → max_new_tokens).
+        #      These cover generation params intentionally excluded from the class-level
+        #      PARAMETER_MAPPINGS to avoid TypeError on __init__.
+        #   2. Class-level PARAMETER_MAPPINGS (constructor-valid params, e.g. model).
+        #   3. Identity: for any supported param not covered above, the framework param
+        #      name equals the Traigent canonical name (e.g. temperature → temperature).
+        method_translations = self._method_parameter_translations.get(
+            class_name, {}
+        ).get(method_name, {})
+        class_mapping = self._parameter_mappings.get(class_name, {})
+        effective_mapping: dict[str, str] = dict(class_mapping)
+        effective_mapping.update(method_translations)  # method translations win
+        for sp in supported_params:
+            if sp not in effective_mapping:
+                effective_mapping[sp] = sp  # identity fallback
+
         override_active = self._override_active  # Capture in closure
 
         @functools.wraps(original_method)
@@ -235,15 +271,21 @@ class FrameworkOverrideManager(BaseOverrideManager):
 
             config_space = get_config_space()
 
-            # Override parameters based on mapping and supported params
+            # Override parameters based on supported_params and effective translation.
+            # Iterating supported_params (not parameter_mapping) ensures we inject all
+            # method-accepted generation params even when they are absent from the
+            # class-level PARAMETER_MAPPINGS (e.g. temperature for HF InferenceClient).
             overridden_kwargs = kwargs.copy()
             overrides_applied = []
 
-            for traigent_param, framework_param in parameter_mapping.items():
-                if traigent_param in config_dict and traigent_param in supported_params:
+            for traigent_param in supported_params:
+                if traigent_param in config_dict:
                     # Only override if parameter is in configuration space (being optimized)
                     # or if no configuration space is set (not in optimization)
                     if config_space is None or traigent_param in config_space:
+                        framework_param = effective_mapping.get(
+                            traigent_param, traigent_param
+                        )
                         override_value = config_dict[traigent_param]
                         original_value = overridden_kwargs.get(
                             framework_param, "not_set"
@@ -285,15 +327,18 @@ class FrameworkOverrideManager(BaseOverrideManager):
 
             config_space = get_config_space()
 
-            # Override parameters based on mapping and supported params
+            # Override parameters based on supported_params and effective translation.
             overridden_kwargs = kwargs.copy()
             overrides_applied = []
 
-            for traigent_param, framework_param in parameter_mapping.items():
-                if traigent_param in config_dict and traigent_param in supported_params:
+            for traigent_param in supported_params:
+                if traigent_param in config_dict:
                     # Only override if parameter is in configuration space (being optimized)
                     # or if no configuration space is set (not in optimization)
                     if config_space is None or traigent_param in config_space:
+                        framework_param = effective_mapping.get(
+                            traigent_param, traigent_param
+                        )
                         override_value = config_dict[traigent_param]
                         original_value = overridden_kwargs.get(
                             framework_param, "not_set"

--- a/traigent/integrations/llms/huggingface_plugin.py
+++ b/traigent/integrations/llms/huggingface_plugin.py
@@ -26,10 +26,13 @@ class HuggingFacePlugin(LLMPlugin):
     FRAMEWORK = Framework.HUGGINGFACE
 
     def _get_supported_canonical_params(self) -> set[str]:
-        """HuggingFace InferenceClient supports a limited set of params.
+        """Canonical params Traigent tunes for the HuggingFace client.
 
-        Params like frequency_penalty, presence_penalty, seed are not
-        supported by HuggingFace's text_generation/chat_completion.
+        This is Traigent's tuned set, not the client's full capability.
+        Some params the HuggingFace client *does* accept (e.g.
+        frequency_penalty, presence_penalty, seed) are intentionally left
+        outside Traigent's tuned set here rather than being unsupported by
+        the client.
         """
         return {
             "model",

--- a/traigent/integrations/mappings.py
+++ b/traigent/integrations/mappings.py
@@ -1,11 +1,18 @@
 """Static parameter and method mappings for framework overrides.
 
-This module contains the static mappings used as FALLBACK when no plugin is registered.
-Plugin mappings (via LLMPlugin._get_default_mappings) take precedence over these static
-mappings. These are primarily used for:
-1. Legacy override path support
-2. Frameworks without dedicated plugins
-3. Method-level parameter injection (specifying which params each method accepts)
+This module is the single active source of truth for framework parameter mappings.
+FrameworkOverrideManager loads these directly — there is no separate plugin-precedence
+layer on top of them. They are used for:
+1. Class-level (constructor) parameter injection — ONLY constructor-valid kwargs
+2. Method-level parameter injection — specifying which params each method accepts
+3. Method-specific parameter name translations (see METHOD_PARAMETER_TRANSLATIONS)
+
+IMPORTANT — constructor vs method params:
+  Class-level PARAMETER_MAPPINGS must contain ONLY parameters that are valid kwargs
+  for the class __init__. Generation params (temperature, max_tokens, top_p, etc.)
+  that are NOT accepted by __init__ must NOT appear in PARAMETER_MAPPINGS — doing so
+  causes TypeError when the constructor override injects them. Generation params for
+  such classes belong exclusively in METHOD_MAPPINGS and METHOD_PARAMETER_TRANSLATIONS.
 
 # Traceability: CONC-Layer-Integration CONC-Quality-Compatibility FUNC-INTEGRATIONS REQ-INT-008
 """
@@ -139,25 +146,19 @@ PARAMETER_MAPPINGS: dict[str, dict[str, str]] = {
         "top_k": "top_k",
     },
     # HuggingFace Hub InferenceClient mappings (primary auto-override surface)
-    # text_generation uses max_new_tokens; chat_completion uses max_tokens directly
-    # (max_tokens is excluded from chat_completion METHOD_MAPPINGS to avoid injecting max_new_tokens)
+    #
+    # CONSTRUCTOR-ONLY params: InferenceClient.__init__ accepts model, token, timeout,
+    # base_url, headers, cookies, api_key — it does NOT accept generation kwargs such as
+    # temperature, max_tokens/max_new_tokens, top_p, top_k, stop, or stream.
+    # Injecting those into __init__ raises TypeError (issue #1570).
+    #
+    # Generation params live ONLY in METHOD_MAPPINGS (to control which methods receive them)
+    # and METHOD_PARAMETER_TRANSLATIONS (for max_tokens → max_new_tokens in text_generation).
     "huggingface_hub.InferenceClient": {
         "model": "model",
-        "temperature": "temperature",
-        "max_tokens": "max_new_tokens",
-        "top_p": "top_p",
-        "top_k": "top_k",
-        "stop": "stop",
-        "stream": "stream",
     },
     "huggingface_hub.AsyncInferenceClient": {
         "model": "model",
-        "temperature": "temperature",
-        "max_tokens": "max_new_tokens",
-        "top_p": "top_p",
-        "top_k": "top_k",
-        "stop": "stop",
-        "stream": "stream",
     },
     # PydanticAI mappings — discovery/documentation only.
     # IMPORTANT: PydanticAI requires these params inside the `model_settings` dict,
@@ -349,6 +350,55 @@ METHOD_MAPPINGS: dict[str, dict[str, list[str]]] = {
         "run_stream_sync": ["temperature", "max_tokens", "top_p"],
     },
 }
+
+# Method-level parameter name translations.
+# Used when a method's framework param name differs from the Traigent canonical name
+# AND the class-level PARAMETER_MAPPINGS does not carry that translation (because the
+# param is not a constructor arg and therefore was intentionally excluded from
+# PARAMETER_MAPPINGS to prevent TypeError on __init__).
+#
+# Structure: class_name -> method_name -> {traigent_param: framework_param}
+#
+# These translations are merged by FrameworkOverrideManager._create_override_method
+# with the class-level PARAMETER_MAPPINGS and an identity fallback for remaining
+# supported_params, so only entries that differ from the canonical name are needed.
+METHOD_PARAMETER_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
+    # HuggingFace text_generation: the framework param is max_new_tokens, not max_tokens.
+    # All other generation params use the canonical Traigent name (temperature, top_p, etc.).
+    "huggingface_hub.InferenceClient": {
+        "text_generation": {
+            "max_tokens": "max_new_tokens",
+        },
+        # chat_completion: max_tokens is intentionally excluded from METHOD_MAPPINGS
+        # (it is not a valid chat_completion kwarg); no special translation needed.
+        "chat_completion": {},
+    },
+    "huggingface_hub.AsyncInferenceClient": {
+        "text_generation": {
+            "max_tokens": "max_new_tokens",
+        },
+        "chat_completion": {},
+    },
+}
+
+
+def get_method_parameter_translation(
+    class_name: str, method_name: str
+) -> dict[str, str]:
+    """Get method-level parameter translations for a specific class and method.
+
+    These supplement the class-level PARAMETER_MAPPINGS for cases where a method's
+    framework param name differs from the Traigent canonical name but the param is
+    NOT a valid constructor arg (and therefore absent from PARAMETER_MAPPINGS).
+
+    Args:
+        class_name: Fully-qualified class name (e.g., "huggingface_hub.InferenceClient")
+        method_name: Method name (e.g., "text_generation")
+
+    Returns:
+        Dict mapping traigent_param -> framework_param for this method, or empty dict
+    """
+    return METHOD_PARAMETER_TRANSLATIONS.get(class_name, {}).get(method_name, {})
 
 
 def get_parameter_mapping(class_name: str) -> dict[str, str]:

--- a/traigent/integrations/mappings.py
+++ b/traigent/integrations/mappings.py
@@ -121,7 +121,7 @@ PARAMETER_MAPPINGS: dict[str, dict[str, str]] = {
         "stream": "stream",
         "tools": "tools",
     },
-    # HuggingFace mappings
+    # HuggingFace mappings (transformers — legacy/direct-model path)
     "transformers.pipeline": {
         "model": "model",
         "temperature": "temperature",
@@ -137,6 +137,27 @@ PARAMETER_MAPPINGS: dict[str, dict[str, str]] = {
         "max_tokens": "max_new_tokens",
         "top_p": "top_p",
         "top_k": "top_k",
+    },
+    # HuggingFace Hub InferenceClient mappings (primary auto-override surface)
+    # text_generation uses max_new_tokens; chat_completion uses max_tokens directly
+    # (max_tokens is excluded from chat_completion METHOD_MAPPINGS to avoid injecting max_new_tokens)
+    "huggingface_hub.InferenceClient": {
+        "model": "model",
+        "temperature": "temperature",
+        "max_tokens": "max_new_tokens",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "stop": "stop",
+        "stream": "stream",
+    },
+    "huggingface_hub.AsyncInferenceClient": {
+        "model": "model",
+        "temperature": "temperature",
+        "max_tokens": "max_new_tokens",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "stop": "stop",
+        "stream": "stream",
     },
     # PydanticAI mappings — discovery/documentation only.
     # IMPORTANT: PydanticAI requires these params inside the `model_settings` dict,
@@ -277,6 +298,46 @@ METHOD_MAPPINGS: dict[str, dict[str, list[str]]] = {
             "k",
             "stream",
             "tools",
+        ],
+    },
+    # HuggingFace Hub InferenceClient methods (primary auto-override surface)
+    # max_tokens is listed for text_generation only: maps to max_new_tokens via PARAMETER_MAPPINGS.
+    # chat_completion omits max_tokens because its framework param name is max_tokens (not
+    # max_new_tokens), so injecting max_new_tokens there would silently be ignored/error.
+    "huggingface_hub.InferenceClient": {
+        "text_generation": [
+            "model",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "stop",
+            "stream",
+        ],
+        "chat_completion": [
+            "model",
+            "temperature",
+            "top_p",
+            "stop",
+            "stream",
+        ],
+    },
+    "huggingface_hub.AsyncInferenceClient": {
+        "text_generation": [
+            "model",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "stop",
+            "stream",
+        ],
+        "chat_completion": [
+            "model",
+            "temperature",
+            "top_p",
+            "stop",
+            "stream",
         ],
     },
     # PydanticAI methods — params are injected via model_settings dict

--- a/traigent/integrations/mappings.py
+++ b/traigent/integrations/mappings.py
@@ -302,9 +302,19 @@ METHOD_MAPPINGS: dict[str, dict[str, list[str]]] = {
         ],
     },
     # HuggingFace Hub InferenceClient methods (primary auto-override surface)
-    # max_tokens is listed for text_generation only: maps to max_new_tokens via PARAMETER_MAPPINGS.
-    # chat_completion omits max_tokens because its framework param name is max_tokens (not
-    # max_new_tokens), so injecting max_new_tokens there would silently be ignored/error.
+    #
+    # The two methods accept DIFFERENT generation-param NAMES (verified against the
+    # installed huggingface_hub signatures — issue #1570 round-3):
+    #   * InferenceClient.chat_completion(..., max_tokens, temperature, top_p, stop, stream)
+    #       — OpenAI-style names; accepts max_tokens NATIVELY; does NOT accept top_k.
+    #   * InferenceClient.text_generation(..., max_new_tokens, temperature, top_p, top_k,
+    #       stop, stream) — HF-native names; uses max_new_tokens (NOT max_tokens).
+    #
+    # Each method lists ONLY the canonical Traigent params it can actually accept.
+    # The framework-name translation (e.g. max_tokens -> max_new_tokens for text_generation)
+    # is applied per-method via METHOD_PARAMETER_TRANSLATIONS below; chat_completion needs
+    # no translation because every param it accepts uses its canonical name (max_tokens is
+    # native), so the identity fallback in _create_override_method handles it.
     "huggingface_hub.InferenceClient": {
         "text_generation": [
             "model",
@@ -317,6 +327,7 @@ METHOD_MAPPINGS: dict[str, dict[str, list[str]]] = {
         ],
         "chat_completion": [
             "model",
+            "max_tokens",
             "temperature",
             "top_p",
             "stop",
@@ -335,6 +346,7 @@ METHOD_MAPPINGS: dict[str, dict[str, list[str]]] = {
         ],
         "chat_completion": [
             "model",
+            "max_tokens",
             "temperature",
             "top_p",
             "stop",
@@ -369,8 +381,10 @@ METHOD_PARAMETER_TRANSLATIONS: dict[str, dict[str, dict[str, str]]] = {
         "text_generation": {
             "max_tokens": "max_new_tokens",
         },
-        # chat_completion: max_tokens is intentionally excluded from METHOD_MAPPINGS
-        # (it is not a valid chat_completion kwarg); no special translation needed.
+        # chat_completion accepts max_tokens NATIVELY (OpenAI-style), so no translation is
+        # needed — the identity fallback maps max_tokens -> max_tokens. Adding a
+        # max_tokens -> max_new_tokens entry here would WRONGLY drop the configured value
+        # (chat_completion has no max_new_tokens kwarg). Keep this empty.
         "chat_completion": {},
     },
     "huggingface_hub.AsyncInferenceClient": {


### PR DESCRIPTION
Fixes #1570.

The HuggingFace zero-code auto-override was wired to `transformers.*` while the HF plugin targets `huggingface_hub.InferenceClient`/`AsyncInferenceClient`, so `override_huggingface()` injected **nothing**. Now standardized on `huggingface_hub.*`:
- `override_huggingface()` / `override_all_platforms()` enable the InferenceClient classes (not transformers).
- Class-level `PARAMETER_MAPPINGS` hold only `{model}` — no generation params reach `__init__` (fixes a constructor `TypeError`).
- Per-method translations inject generation params under the names each method **actually accepts**, introspected against the installed `huggingface_hub` signatures: `chat_completion` → native `max_tokens`/`temperature`/`top_p`/`stop`; `text_generation` → `max_tokens`→`max_new_tokens`, plus `top_k` etc.
- Corrected the false "plugin mappings take precedence / fallback" docstrings.

Spine-Trail: st_ccd541de8e32

## Validation
- Captain re-ran `tests/unit/integrations` → **1598 passed** (incl. a wrapper probe proving per-method kwarg delivery + a constructor-no-generation-param regression test + every-plugin-class-has-a-mapping guard).
- ruff clean + formatted.
- Independent review: Codex gpt-5.5 xhigh — **GO** after 3 rounds (caught: constructor `TypeError`, dropped `chat_completion` `max_tokens`, false docstring — all fixed and probe-verified against the real client).

## Notes
Pre-existing mypy debt (out-of-scope files, identical on base `fbe22e54`) → committed `--no-verify`; no gate widened.
