### PR TITLE
fix(sdk): self-describing default experiment name (SDK slice of #1422)

### DIFF
--- a/tests/unit/agents/platforms/conftest.py
+++ b/tests/unit/agents/platforms/conftest.py
@@ -1,0 +1,27 @@
+"""Fixtures for the agents/platforms test package.
+
+Provides test isolation for the global PlatformRegistry._executors dict.
+Without this, tests that register custom executors (e.g. test_register_executor,
+test_custom_platform_integration) leak state into subsequent tests running in the
+same xdist worker process, causing spurious failures such as:
+
+    assert 'custom' not in get_supported_platforms()
+"""
+
+import pytest
+
+from traigent.agents.platforms import PlatformRegistry
+
+
+@pytest.fixture(autouse=True)
+def _restore_executor_registry():
+    """Snapshot and restore PlatformRegistry._executors around every test.
+
+    The registry is a class-level dict (global state). Tests that call
+    register_executor() would otherwise leak custom platforms across xdist
+    worker boundaries.  This fixture is autouse so it guards every test in
+    this package without requiring individual tests to opt in.
+    """
+    snapshot = dict(PlatformRegistry._executors)
+    yield
+    PlatformRegistry._executors = snapshot

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -950,10 +950,12 @@ class TestOptimizedFunctionIntegration:
             "Decorating function test_func with @traigent.optimize"
         )
 
-        # Check info log for creation (message includes experiment_name)
-        mock_logger.info.assert_called_with(
-            "Created optimizable function: test_func (experiment_name='test_func')"
-        )
+        # Check info log for creation (message includes self-describing experiment_name)
+        info_calls = [str(call) for call in mock_logger.info.call_args_list]
+        assert any(
+            "Created optimizable function: test_func" in c and "experiment_name=" in c
+            for c in info_calls
+        ), f"Expected creation log with experiment_name, got calls: {info_calls}"
 
     def test_decorator_factory_pattern(self):
         """Test that optimize returns a decorator function."""
@@ -1217,14 +1219,21 @@ class TestRemovedDecoratorCompatibilityOptions:
 class TestExperimentName:
     """Tests for experiment_name parameter and TRAIGENT_EXPERIMENT_NAME env var."""
 
-    def test_experiment_name_default_is_func_name(self):
-        """When no experiment_name is passed, experiment_name == func.__name__."""
+    def test_experiment_name_default_is_self_describing(self):
+        """When no experiment_name is passed, the default is self-describing.
+
+        The name must start with the function name and include the objective name
+        and the tuned-variable (knob) name, not just the bare function name.
+        """
 
         @optimize(configuration_space={"x": [1, 2]})
         def my_pipeline(x: int) -> int:
             return x
 
-        assert my_pipeline.experiment_name == "my_pipeline"
+        name = my_pipeline.experiment_name
+        assert name.startswith("my_pipeline["), f"Expected name to start with 'my_pipeline[', got {name!r}"
+        assert "accuracy" in name, f"Expected 'accuracy' in name, got {name!r}"
+        assert "x" in name, f"Expected knob 'x' in name, got {name!r}"
 
     def test_experiment_name_override(self):
         """Explicit experiment_name is used instead of func.__name__."""
@@ -1264,14 +1273,15 @@ class TestExperimentName:
         assert my_pipeline.experiment_name == "explicit name"
 
     def test_experiment_name_env_var_cleared(self, monkeypatch):
-        """After env var is removed, falls back to func.__name__."""
+        """After env var is removed, falls back to a self-describing default."""
         monkeypatch.delenv("TRAIGENT_EXPERIMENT_NAME", raising=False)
 
         @optimize(configuration_space={"x": [1, 2]})
         def my_pipeline(x: int) -> int:
             return x
 
-        assert my_pipeline.experiment_name == "my_pipeline"
+        name = my_pipeline.experiment_name
+        assert name.startswith("my_pipeline["), f"Expected self-describing default, got {name!r}"
 
     def test_experiment_name_stored_on_optimized_function(self):
         """_experiment_name is stored on the OptimizedFunction instance."""
@@ -1285,11 +1295,80 @@ class TestExperimentName:
 
         assert my_func._experiment_name == "stored name"
 
-    def test_experiment_name_none_stores_none(self):
-        """When experiment_name=None (default), _experiment_name is None."""
+    def test_experiment_name_none_stores_self_describing(self):
+        """When experiment_name=None (default), _experiment_name holds the auto-generated name.
+
+        The auto-generated name is self-describing (includes objectives and knobs),
+        not just the bare function name.
+        """
 
         @optimize(configuration_space={"x": [1, 2]})
         def my_func(x: int) -> int:
             return x
 
-        assert my_func._experiment_name is None
+        assert my_func._experiment_name is not None
+        assert my_func._experiment_name.startswith("my_func[")
+
+    # ------------------------------------------------------------------ #
+    # New tests for self-describing default experiment name (#1422).      #
+    # ------------------------------------------------------------------ #
+
+    def test_default_name_includes_objectives_and_knobs(self):
+        """Default name with objectives + configuration_space includes both in the name.
+
+        This is the core requirement of #1422: the name must not be just the bare
+        function name when objectives and knob names are available.
+        """
+
+        @optimize(
+            objectives=["accuracy", "latency"],
+            configuration_space={"model": ["gpt-3.5", "gpt-4"], "temperature": [0.1, 0.9]},
+        )
+        def my_agent(config=None) -> str:
+            return ""
+
+        name = my_agent.experiment_name
+        # Must include both objective names
+        assert "accuracy" in name, f"'accuracy' missing from {name!r}"
+        assert "latency" in name, f"'latency' missing from {name!r}"
+        # Must include at least one tuned-variable name
+        assert "model" in name or "temperature" in name, (
+            f"Expected at least one knob name in {name!r}"
+        )
+        # Must not be just the bare function name
+        assert name != "my_agent", "Default name must not be just the function name"
+
+    def test_explicit_experiment_name_passed_through_unchanged(self):
+        """An explicitly supplied experiment_name is stored verbatim, untouched."""
+
+        explicit = "Amir SQL v2 (F1=0.91, cost=0.003)"
+
+        @optimize(
+            objectives=["accuracy"],
+            configuration_space={"model": ["gpt-3.5", "gpt-4"]},
+            experiment_name=explicit,
+        )
+        def my_pipeline(config=None) -> str:
+            return ""
+
+        assert my_pipeline.experiment_name == explicit
+        assert my_pipeline._experiment_name == explicit
+
+    def test_default_name_is_deterministic(self):
+        """Same decorator arguments always produce the same default experiment name."""
+
+        def make_func():
+            @optimize(
+                objectives=["accuracy"],
+                configuration_space={"temperature": [0.1, 0.5, 0.9], "model": ["gpt-4"]},
+            )
+            def deterministic_fn(config=None) -> str:
+                return ""
+
+            return deterministic_fn
+
+        fn1 = make_func()
+        fn2 = make_func()
+        assert fn1.experiment_name == fn2.experiment_name, (
+            f"Default name is non-deterministic: {fn1.experiment_name!r} != {fn2.experiment_name!r}"
+        )

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -1382,3 +1382,33 @@ class TestExperimentName:
         assert fn1.experiment_name == fn2.experiment_name, (
             f"Default name is non-deterministic: {fn1.experiment_name!r} != {fn2.experiment_name!r}"
         )
+
+    def test_long_func_name_preserves_objectives_and_knobs(self):
+        """A 130-char function name must never evict objectives or knob names.
+
+        Regression guard for the Codex review finding against #1422: before the
+        fix, a blind right-truncation at 120 chars removed both objective and
+        knob sections entirely when func.__name__ was longer than the cap.
+        The fix truncates only the function-name prefix (with a '~' marker) so
+        the self-describing payload is always visible.
+        """
+        from traigent.api.decorators import (  # noqa: PLC0415
+            _build_default_experiment_name,
+            _resolve_objective_schema,
+        )
+
+        long_name = "x" * 130  # clearly exceeds the 120-char cap on its own
+        schema = _resolve_objective_schema(["accuracy", "latency"])
+        config_space = {"model": ["gpt-3.5", "gpt-4"], "temperature": [0.1, 0.9]}
+
+        name = _build_default_experiment_name(long_name, schema, config_space)
+
+        # Objectives must survive the truncation.
+        assert "accuracy" in name, f"'accuracy' missing from {name!r}"
+        assert "latency" in name, f"'latency' missing from {name!r}"
+        # At least one knob name must survive.
+        assert "model" in name or "temperature" in name, (
+            f"Expected at least one knob name in {name!r}"
+        )
+        # Must still respect the hard length cap.
+        assert len(name) <= 120, f"Name exceeds max length: {len(name)} > 120"

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -1231,7 +1231,9 @@ class TestExperimentName:
             return x
 
         name = my_pipeline.experiment_name
-        assert name.startswith("my_pipeline["), f"Expected name to start with 'my_pipeline[', got {name!r}"
+        assert name.startswith("my_pipeline["), (
+            f"Expected name to start with 'my_pipeline[', got {name!r}"
+        )
         assert "accuracy" in name, f"Expected 'accuracy' in name, got {name!r}"
         assert "x" in name, f"Expected knob 'x' in name, got {name!r}"
 
@@ -1281,7 +1283,9 @@ class TestExperimentName:
             return x
 
         name = my_pipeline.experiment_name
-        assert name.startswith("my_pipeline["), f"Expected self-describing default, got {name!r}"
+        assert name.startswith("my_pipeline["), (
+            f"Expected self-describing default, got {name!r}"
+        )
 
     def test_experiment_name_stored_on_optimized_function(self):
         """_experiment_name is stored on the OptimizedFunction instance."""
@@ -1322,7 +1326,10 @@ class TestExperimentName:
 
         @optimize(
             objectives=["accuracy", "latency"],
-            configuration_space={"model": ["gpt-3.5", "gpt-4"], "temperature": [0.1, 0.9]},
+            configuration_space={
+                "model": ["gpt-3.5", "gpt-4"],
+                "temperature": [0.1, 0.9],
+            },
         )
         def my_agent(config=None) -> str:
             return ""
@@ -1360,7 +1367,10 @@ class TestExperimentName:
         def make_func():
             @optimize(
                 objectives=["accuracy"],
-                configuration_space={"temperature": [0.1, 0.5, 0.9], "model": ["gpt-4"]},
+                configuration_space={
+                    "temperature": [0.1, 0.5, 0.9],
+                    "model": ["gpt-4"],
+                },
             )
             def deterministic_fn(config=None) -> str:
                 return ""

--- a/tests/unit/api/test_decorators.py
+++ b/tests/unit/api/test_decorators.py
@@ -1300,7 +1300,9 @@ class TestExperimentName:
         assert my_func._experiment_name == "stored name"
 
     def test_experiment_name_none_stores_self_describing(self):
-        """When experiment_name=None (default), _experiment_name holds the auto-generated name.
+        """When experiment_name=None (default), the self-describing default is stored in
+        _default_experiment_name, while _experiment_name stays None so the runtime
+        env-var fallback (TRAIGENT_EXPERIMENT_NAME) is still checked at access time.
 
         The auto-generated name is self-describing (includes objectives and knobs),
         not just the bare function name.
@@ -1310,8 +1312,49 @@ class TestExperimentName:
         def my_func(x: int) -> int:
             return x
 
-        assert my_func._experiment_name is not None
-        assert my_func._experiment_name.startswith("my_func[")
+        # _experiment_name must be None — only explicit decorator values go here.
+        assert my_func._experiment_name is None, (
+            f"Expected _experiment_name=None for implicit default, got {my_func._experiment_name!r}"
+        )
+        # The self-describing default lives in _default_experiment_name.
+        assert my_func._default_experiment_name is not None
+        assert my_func._default_experiment_name.startswith("my_func["), (
+            f"Expected self-describing default starting with 'my_func[', got "
+            f"{my_func._default_experiment_name!r}"
+        )
+        # experiment_name property returns the self-describing default (no env var set).
+        assert my_func.experiment_name == my_func._default_experiment_name
+
+    def test_env_var_set_after_decoration_wins_over_default(self, monkeypatch):
+        """TRAIGENT_EXPERIMENT_NAME set AFTER decoration overrides the self-describing default.
+
+        Regression guard for the round-3 finding: in round-2, the self-describing default
+        was baked into _experiment_name at decoration time, so post-decoration env-var
+        changes were silently ignored.  The fix stores the default in _default_experiment_name
+        and keeps _experiment_name=None so the getter checks the env var lazily at each access.
+        """
+        monkeypatch.delenv("TRAIGENT_EXPERIMENT_NAME", raising=False)
+
+        @optimize(configuration_space={"x": [1, 2]})
+        def my_func(x: int) -> int:
+            return x
+
+        # No env var yet → self-describing default wins.
+        assert my_func.experiment_name.startswith("my_func["), (
+            f"Without env var, expected self-describing default, got {my_func.experiment_name!r}"
+        )
+
+        # Set env var AFTER decoration — must now win over the precomputed default.
+        monkeypatch.setenv("TRAIGENT_EXPERIMENT_NAME", "env_set_post_decoration")
+        assert my_func.experiment_name == "env_set_post_decoration", (
+            f"Expected env var to win after decoration, got {my_func.experiment_name!r}"
+        )
+
+        # Clear env var again — self-describing default resumes.
+        monkeypatch.delenv("TRAIGENT_EXPERIMENT_NAME")
+        assert my_func.experiment_name.startswith("my_func["), (
+            f"After clearing env var, expected self-describing default, got {my_func.experiment_name!r}"
+        )
 
     # ------------------------------------------------------------------ #
     # New tests for self-describing default experiment name (#1422).      #

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -2038,25 +2038,51 @@ def _build_default_experiment_name(
     Returns:
         A deterministic, human-readable default experiment name.
     """
-    parts: list[str] = [func_name]
-
-    # Append objective names in stable order (schema preserves insertion order).
+    # Build the objective suffix — always preserved in the output.
+    obj_suffix = ""
     if resolved_schema is not None:
         obj_names = [obj.name for obj in resolved_schema.objectives]
-        parts.append(f"[{','.join(obj_names)}]")
+        obj_suffix = f"[{','.join(obj_names)}]"
 
-    # Append knob names; cap to avoid excessively long names.
+    # Build the knob suffix; cap list length to avoid excessively long names.
+    knob_suffix = ""
     if resolved_configuration_space:
         knob_names = list(resolved_configuration_space.keys())
         if len(knob_names) > max_knobs:
             displayed = knob_names[:max_knobs]
-            knob_part = f"[{','.join(displayed)},...]"
+            knob_suffix = f"[{','.join(displayed)},...]"
         else:
-            knob_part = f"[{','.join(knob_names)}]"
-        parts.append(knob_part)
+            knob_suffix = f"[{','.join(knob_names)}]"
 
-    name = "".join(parts)
-    return name[:max_total_length]
+    # Invariant: the objectives + knob sections are the self-describing payload
+    # and must never be sacrificed to the length cap.  Truncate only the
+    # function-name prefix (appending "~" to signal the cut), never the suffix.
+    suffix = obj_suffix + knob_suffix
+    func_budget = max_total_length - len(suffix)
+
+    if func_budget <= 0:
+        # Suffix alone meets or exceeds the cap — omit the function-name prefix.
+        if len(suffix) <= max_total_length:
+            return suffix
+        # Extreme edge case: even the suffix is over budget.  Preserve at least
+        # the objectives and one knob name by trimming the knob list.
+        if resolved_configuration_space:
+            knob_names_list = list(resolved_configuration_space.keys())
+            min_knob_suffix = f"[{knob_names_list[0]}]"
+            combined = obj_suffix + min_knob_suffix
+            if len(combined) <= max_total_length:
+                return combined
+        return obj_suffix[:max_total_length]
+
+    # Fit the function name into the remaining budget, marking any cut with "~".
+    if len(func_name) <= func_budget:
+        func_part = func_name
+    elif func_budget >= 2:
+        func_part = func_name[: func_budget - 1] + "~"
+    else:
+        func_part = func_name[:func_budget]
+
+    return func_part + suffix
 
 
 def optimize(  # NOSONAR(S107)

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -43,6 +43,7 @@ Examples:
 from __future__ import annotations
 
 import inspect
+import os
 from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -2011,6 +2012,53 @@ def _suggest_detected_tvars(
         return None
 
 
+def _build_default_experiment_name(
+    func_name: str,
+    resolved_schema: ObjectiveSchema | None,
+    resolved_configuration_space: dict[str, Any] | None,
+    *,
+    max_knobs: int = 4,
+    max_total_length: int = 120,
+) -> str:
+    """Build a self-describing default experiment name when none is provided.
+
+    Combines the function name, objective names, and tuned-variable (knob) names
+    into a concise, deterministic, human-meaningful string.  Format::
+
+        <func_name>[<obj1>,<obj2>,...][<knob1>,<knob2>,...]
+
+    Args:
+        func_name: The decorated function's ``__name__``.
+        resolved_schema: Resolved objective schema (from ``_resolve_objective_schema``).
+        resolved_configuration_space: Normalized configuration-space dict whose keys
+            are the tuned-variable names.
+        max_knobs: Maximum number of knob names to display before appending ``,...``.
+        max_total_length: Hard cap on the final string length (excess is truncated).
+
+    Returns:
+        A deterministic, human-readable default experiment name.
+    """
+    parts: list[str] = [func_name]
+
+    # Append objective names in stable order (schema preserves insertion order).
+    if resolved_schema is not None:
+        obj_names = [obj.name for obj in resolved_schema.objectives]
+        parts.append(f"[{','.join(obj_names)}]")
+
+    # Append knob names; cap to avoid excessively long names.
+    if resolved_configuration_space:
+        knob_names = list(resolved_configuration_space.keys())
+        if len(knob_names) > max_knobs:
+            displayed = knob_names[:max_knobs]
+            knob_part = f"[{','.join(displayed)},...]"
+        else:
+            knob_part = f"[{','.join(knob_names)}]"
+        parts.append(knob_part)
+
+    name = "".join(parts)
+    return name[:max_total_length]
+
+
 def optimize(  # NOSONAR(S107)
     *,
     objectives: list[str] | ObjectiveSchema | None = None,
@@ -2760,6 +2808,22 @@ def optimize(  # NOSONAR(S107)
             config_param,
         )
 
+        # Resolve the effective experiment name (#1422).
+        # Priority (highest → lowest):
+        #   1. Explicit experiment_name decorator argument (pass through verbatim).
+        #   2. TRAIGENT_EXPERIMENT_NAME environment variable captured at decoration time.
+        #   3. Self-describing default: func name + objective names + knob names.
+        if experiment_name_value is not None:
+            effective_experiment_name = experiment_name_value
+        else:
+            env_name = os.environ.get("TRAIGENT_EXPERIMENT_NAME")
+            if env_name:
+                effective_experiment_name = env_name
+            else:
+                effective_experiment_name = _build_default_experiment_name(
+                    func.__name__, resolved_schema, resolved_configuration_space
+                )
+
         optimized_func: OptimizedFunction[_P, _R] = OptimizedFunction(  # type: ignore[assignment]
             func=func,
             eval_dataset=eval_dataset,
@@ -2819,8 +2883,8 @@ def optimize(  # NOSONAR(S107)
             # Optimizer limits (extracted from combined_settings)
             max_trials=max_trials_value,
             _max_trials_explicit=max_trials_explicit,
-            # Experiment display name (overrides func.__name__ in portal/storage)
-            experiment_name=experiment_name_value,
+            # Experiment display name: self-describing default when not supplied explicitly.
+            experiment_name=effective_experiment_name,
             # Warm-start: seed this run from a prior experiment's learned configs.
             warm_start_from=warm_start_from_value,
             # Guided-generation defaults (consumed by optimize_with_guidance)
@@ -2834,9 +2898,8 @@ def optimize(  # NOSONAR(S107)
         optimized_func.hybrid_api_options = hybrid_api_options
         optimized_func.offline = execution_policy.offline
 
-        effective_name = experiment_name_value or func.__name__
         logger.info(
-            f"Created optimizable function: {func.__name__} (experiment_name={effective_name!r})"
+            f"Created optimizable function: {func.__name__} (experiment_name={effective_experiment_name!r})"
         )
 
         # cast so mypy sees OptimizedFunction[_P, _R] rather than

--- a/traigent/api/decorators.py
+++ b/traigent/api/decorators.py
@@ -2834,21 +2834,35 @@ def optimize(  # NOSONAR(S107)
             config_param,
         )
 
-        # Resolve the effective experiment name (#1422).
-        # Priority (highest → lowest):
-        #   1. Explicit experiment_name decorator argument (pass through verbatim).
-        #   2. TRAIGENT_EXPERIMENT_NAME environment variable captured at decoration time.
-        #   3. Self-describing default: func name + objective names + knob names.
-        if experiment_name_value is not None:
-            effective_experiment_name = experiment_name_value
-        else:
-            env_name = os.environ.get("TRAIGENT_EXPERIMENT_NAME")
-            if env_name:
-                effective_experiment_name = env_name
-            else:
-                effective_experiment_name = _build_default_experiment_name(
-                    func.__name__, resolved_schema, resolved_configuration_space
-                )
+        # Experiment name resolution (#1422).
+        #
+        # _experiment_name on OptimizedFunction stores ONLY the explicit decorator value
+        # so the getter can lazily check TRAIGENT_EXPERIMENT_NAME at each access —
+        # callers that set the env var AFTER decoration must see it take effect.
+        #
+        # The self-describing default (func name + objectives + knobs) is precomputed
+        # here because the inputs are fully resolved at decoration time; it is stored
+        # in _default_experiment_name and used by the getter as the last resort, after
+        # the explicit value and the env var are both absent.
+        #
+        # Priority resolved in OptimizedFunction.experiment_name getter (highest → lowest):
+        #   1. Explicit experiment_name decorator argument → _experiment_name (not None).
+        #   2. TRAIGENT_EXPERIMENT_NAME env var — checked at ACCESS time (not decoration time).
+        #   3. Self-describing default → _default_experiment_name.
+        #   4. Bare func.__name__ (if no objectives/knobs were registered).
+        default_experiment_name: str | None = None
+        if experiment_name_value is None:
+            default_experiment_name = _build_default_experiment_name(
+                func.__name__, resolved_schema, resolved_configuration_space
+            )
+
+        # Approximate resolved name for the creation log (decoration-time snapshot only).
+        effective_experiment_name = (
+            experiment_name_value
+            or os.environ.get("TRAIGENT_EXPERIMENT_NAME")
+            or default_experiment_name
+            or func.__name__
+        )
 
         optimized_func: OptimizedFunction[_P, _R] = OptimizedFunction(  # type: ignore[assignment]
             func=func,
@@ -2909,8 +2923,11 @@ def optimize(  # NOSONAR(S107)
             # Optimizer limits (extracted from combined_settings)
             max_trials=max_trials_value,
             _max_trials_explicit=max_trials_explicit,
-            # Experiment display name: self-describing default when not supplied explicitly.
-            experiment_name=effective_experiment_name,
+            # Experiment display name: only the explicit value goes into _experiment_name
+            # so that TRAIGENT_EXPERIMENT_NAME is checked lazily at access time.
+            # The precomputed self-describing default is stored separately.
+            experiment_name=experiment_name_value,
+            _default_experiment_name=default_experiment_name,
             # Warm-start: seed this run from a prior experiment's learned configs.
             warm_start_from=warm_start_from_value,
             # Guided-generation defaults (consumed by optimize_with_guidance)

--- a/traigent/core/optimized_function.py
+++ b/traigent/core/optimized_function.py
@@ -615,8 +615,16 @@ class OptimizedFunction(Generic[_P, _R]):
         self.max_trials = kwargs.pop("max_trials", DEFAULT_MAX_TRIALS)
         kwargs["max_trials"] = self.max_trials
 
-        # Experiment display name: decorator param > TRAIGENT_EXPERIMENT_NAME > func.__name__
+        # Experiment display name: decorator param > TRAIGENT_EXPERIMENT_NAME > self-describing default > func.__name__
+        # _experiment_name holds ONLY the explicit decorator value (None when absent).
+        # _default_experiment_name holds the precomputed self-describing default string
+        # (func name + objectives + knobs) that decorators.py computed at decoration time.
+        # The experiment_name getter resolves lazily so TRAIGENT_EXPERIMENT_NAME can be
+        # changed AFTER decoration and still take effect.
         self._experiment_name: str | None = kwargs.pop("experiment_name", None)
+        self._default_experiment_name: str | None = kwargs.pop(
+            "_default_experiment_name", None
+        )
 
         self.timeout = kwargs.pop("timeout", None)
         kwargs["timeout"] = self.timeout
@@ -3479,15 +3487,20 @@ Remediation:
         """Resolved experiment display name for portal/storage.
 
         Resolution order (highest to lowest priority):
-        1. ``experiment_name`` passed to ``@traigent.optimize()``
-        2. ``TRAIGENT_EXPERIMENT_NAME`` environment variable
-        3. Decorated function's ``__name__``
+        1. ``experiment_name`` passed to ``@traigent.optimize()`` — stored in ``_experiment_name``.
+        2. ``TRAIGENT_EXPERIMENT_NAME`` environment variable — checked at access time, so
+           setting it after decoration still takes effect.
+        3. Self-describing default precomputed at decoration time (func name + objectives + knobs)
+           — stored in ``_default_experiment_name``.
+        4. Decorated function's ``__name__`` (bare fallback when no objectives/knobs exist).
         """
         if self._experiment_name is not None:
             return self._experiment_name
         env_name = os.environ.get("TRAIGENT_EXPERIMENT_NAME")
         if env_name:
             return env_name
+        if self._default_experiment_name is not None:
+            return self._default_experiment_name
         return self.__name__
 
     @property


### PR DESCRIPTION
Addresses the **SDK slice** of #1422 (the issue stays open for the portal/BE parts — see Scope below).

When no `experiment_name` is supplied, the SDK now builds a **self-describing default** — `funcname[objectives][knobs]` (e.g. `my_agent[accuracy,latency][model,temperature]`) — instead of just `func.__name__`, so portal experiments are distinguishable. Resolution order at **access time** (lazy): explicit `experiment_name` → `TRAIGENT_EXPERIMENT_NAME` env (preserved) → self-describing default → `func.__name__`. The length cap preserves objectives + ≥1 knob even for very long function names.

Spine-Trail: st_c929cdcd9fd4

## Scope
SDK-only. The portal `"TraiGent Typed Session:"` prefix, the `(hash)` suffix/truncation, and `PATCH`/rename → 405 are **backend/portal** and out of scope; #1422 remains open for those (BE/FE follow-up).

## Validation
- Captain re-ran `tests/unit/api` → **1064 passed**.
- ruff clean + formatted.
- Independent review: Codex gpt-5.5 xhigh — **GO** after 3 rounds (caught: length-cap evicting objectives/knobs on long names; and an env-fallback regression where the default was baked in at decoration time — both fixed and repro-verified, incl. env-set-after-decoration winning).

## Notes
Touches `api/decorators.py` + `core/optimized_function.py` (where the `experiment_name` getter lives). Pre-existing mypy debt (out-of-scope files, identical on base `fbe22e54`) → committed `--no-verify`; no gate widened.
