### PR TITLE
chore(release): bump dev version 0.18.1.dev3 -> 0.18.1.dev4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev3"
+version = "0.18.1.dev4"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## chore: bump dev version 0.18.1.dev3 → 0.18.1.dev4

Bumps the SDK dev version so a build containing the merged **report-explainability (PR1)** and **SDK fail-closed (PR2 #1574)** fixes can be published to PyPI for the validation client to install and confirm. **Version string only** — no code/contract/policy change.

Spine: none (reason: dev-version bump; no code/contract/policy change)
