### PR TITLE
fix(cli): render 0-100 metrics as <=100% in Trial Results table (no double-scale)

### DIFF
--- a/tests/unit/utils/test_results_table.py
+++ b/tests/unit/utils/test_results_table.py
@@ -23,6 +23,7 @@ from traigent.api.types import (
 )
 from traigent.utils.results_table import (
     _find_best_per_objective,
+    _format_metric_value,
     _trials_all_failed,
     print_results_table,
 )
@@ -517,3 +518,36 @@ class TestPrintResultsTableFailLoud:
                 config_space={"model": ["m1"]},
                 objectives=["accuracy"],
             )
+
+
+class TestMetricPercentFormatting:
+    """The trial-results table must not double-scale a 0-100 metric.
+
+    Regression: ``_format_metric_value`` used ``f"{val:.1%}"`` for every quality
+    metric, so a 0-100 accuracy of 79.16 rendered as "7916.2%". Mirror the FE
+    rule: value > 1 is already a percent (render as-is); value <= 1 is a fraction
+    (scale by 100). Never produce ">100%" for a real 0-100 accuracy.
+    """
+
+    def test_zero_to_hundred_scale_accuracy_not_double_scaled(self) -> None:
+        rendered = _format_metric_value("accuracy", 79.162)
+        assert rendered == "79.2%"
+        assert "7916" not in rendered
+        numeric = float(rendered.rstrip("%"))
+        assert numeric <= 100.0  # a real accuracy can never exceed 100%
+
+    def test_fraction_scale_value_still_renders_correctly(self) -> None:
+        # 0-1 fraction inputs keep the prior behaviour (scaled to a percent).
+        assert _format_metric_value("accuracy", 0.79) == "79.0%"
+        assert _format_metric_value("accuracy", 0.0) == "0.0%"
+
+    def test_boundaries_and_other_quality_metric(self) -> None:
+        # 1.0 is treated as a fraction (100%); 100.0 as an already-percent value.
+        assert _format_metric_value("accuracy", 1.0) == "100.0%"
+        assert _format_metric_value("accuracy", 100.0) == "100.0%"
+        # The scale rule applies to any non cost/latency metric name.
+        assert _format_metric_value("score", 87.4) == "87.4%"
+
+    def test_cost_and_latency_formatting_unchanged(self) -> None:
+        assert _format_metric_value("cost", 0.00123).startswith("$")
+        assert _format_metric_value("latency", 1.234) == "1.234s"

--- a/traigent/utils/results_table.py
+++ b/traigent/utils/results_table.py
@@ -111,12 +111,28 @@ def _format_config_value(val: Any) -> str:
     return str(val)
 
 
+def _format_percent_metric(val: float) -> str:
+    """Format a quality metric (accuracy / score / ...) as a percent string.
+
+    Metrics reach the table on either a 0-1 fraction scale or an already-percent
+    0-100 scale (e.g. a 0-100 ``accuracy`` of 79.16). Mirror the frontend rule
+    (``percentFormatting``): a value ``> 1`` is already a percent and is rendered
+    as-is (79.16 -> ``"79.2%"``); a value ``<= 1`` is a fraction and scaled
+    (0.79 -> ``"79.0%"``). This never double-scales, so a 0-100 metric can no
+    longer render as ">100%" (the prior ``f"{val:.1%}"`` turned 79.16 into
+    "7916.2%").
+    """
+    if val > 1.0:
+        return f"{val:.1f}%"
+    return f"{val:.1%}"
+
+
 def _format_metric_value(metric: str, val: float) -> str:
     if metric == "cost":
         return f"${val:.5f}"
     if metric == "latency":
         return f"{val:.3f}s"
-    return f"{val:.1%}"
+    return _format_percent_metric(val)
 
 
 def _coerce_float(value: Any) -> float | None:


### PR DESCRIPTION
## Fix SDK CLI Trial-Results table rendering a 0–100 metric ×100

Client validation: a true 0–100 accuracy (`79.16`) rendered as **"7916.2%"** in the SDK CLI Trial Results table — `traigent/utils/results_table.py` used `f"{val:.1%}"`, double-scaling a metric already on a 0–100 scale.

**Fix:** `_format_percent_metric` mirroring the FE rule — `val > 1` ⇒ already a percent (render as-is), `val <= 1` ⇒ fraction (×100). A 0–100 metric can no longer exceed 100%; the 0–1 path and cost/latency formatting are unchanged.

Spine-Trail: st_92ae4dd6bed4

### Evidence
- Test `TestMetricPercentFormatting`: `79.16 → "79.2%"` (≤100), `0.79 → "79.0%"`, boundaries, cost/latency unchanged. **25** tests pass; ruff + mypy clean.
- Independent cross-model review (fresh Codex gpt-5.5) = **GO**.

### Known limitation (documented in the test, non-blocking)
`val == 1.0` is ambiguous (1.0 fraction = 100% vs 1.0 on a 0–100 scale = 1%) → renders "100.0%". Disambiguating needs scale/unit metadata, out of scope for a scalar formatter.
