### PR TITLE
chore(release): bump dev version 0.18.1.dev4 -> 0.18.1.dev5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev4"
+version = "0.18.1.dev5"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## chore: bump dev version 0.18.1.dev4 -> 0.18.1.dev5

Publishes the SDK CLI percent-render fix (#1582) to prod PyPI so the validation client can confirm the CLI display. Version string only.

Spine: none (reason: dev-version bump; no code/contract/policy change)
