### PR TITLE
feat(cloud): add list_sessions() + non-destructive delete_session default

### DIFF
--- a/tests/unit/cloud/test_client_stateful.py
+++ b/tests/unit/cloud/test_client_stateful.py
@@ -10,6 +10,7 @@ from traigent.cloud.client import CloudServiceError, TraigentCloudClient
 from traigent.cloud.models import (
     OptimizationSessionStatus,
     SessionObjectiveDefinition,
+    SessionSummary,
     TrialResultSubmission,
     TrialStatus,
 )
@@ -727,3 +728,125 @@ class TestErrorHandling:
         message = str(excinfo.value)
         assert "Forbidden" in message
         assert "Re-authenticate" in message
+
+
+class TestListSessions:
+    """GET /api/v1/sessions -> typed SessionSummary list (P3 orphan cleanup)."""
+
+    @staticmethod
+    def _mock_list_response(mock_session, payload):
+        response = Mock()
+        response.status = 200
+        response.json = AsyncMock(return_value=payload)
+        mock_session.get.return_value.__aenter__.return_value = response
+        return response
+
+    @pytest.mark.asyncio
+    async def test_parses_backend_response_into_typed_summaries(
+        self, cloud_client, mock_session
+    ):
+        cloud_client._aio_session = mock_session
+        self._mock_list_response(
+            mock_session,
+            {
+                "sessions": [
+                    {
+                        "session_id": "s-1",
+                        "status": "running",
+                        "created_at": "2026-01-01T00:00:00",
+                        "progress": {"completed": 5, "total": 10},
+                    },
+                    {"session_id": "s-2", "status": "completed"},
+                ],
+                "total": 2,
+            },
+        )
+
+        result = await cloud_client.list_sessions()
+
+        assert len(result) == 2
+        assert all(isinstance(s, SessionSummary) for s in result)
+        assert result[0].session_id == "s-1"
+        assert result[0].status == "running"
+        assert result[0].created_at == "2026-01-01T00:00:00"
+        assert result[0].progress == {"completed": 5, "total": 10}
+        assert result[1].session_id == "s-2"
+        # Real endpoint call, not a stub.
+        called_url = mock_session.get.call_args[0][0]
+        expected = f"{BackendConfig.get_backend_api_url().rstrip('/')}/sessions"
+        assert called_url == expected
+
+    @pytest.mark.asyncio
+    async def test_passes_status_and_pattern_query_params(
+        self, cloud_client, mock_session
+    ):
+        cloud_client._aio_session = mock_session
+        self._mock_list_response(mock_session, {"sessions": [], "total": 0})
+
+        await cloud_client.list_sessions(status="running", pattern="exp-*")
+
+        params = mock_session.get.call_args.kwargs["params"]
+        assert params == {"status": "running", "pattern": "exp-*"}
+
+    @pytest.mark.asyncio
+    async def test_omits_unset_query_params(self, cloud_client, mock_session):
+        cloud_client._aio_session = mock_session
+        self._mock_list_response(mock_session, {"sessions": [], "total": 0})
+
+        await cloud_client.list_sessions()
+
+        assert mock_session.get.call_args.kwargs["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_applies_client_side_limit(self, cloud_client, mock_session):
+        cloud_client._aio_session = mock_session
+        self._mock_list_response(
+            mock_session,
+            {
+                "sessions": [
+                    {"session_id": f"s-{i}", "status": "running"} for i in range(3)
+                ],
+                "total": 3,
+            },
+        )
+
+        result = await cloud_client.list_sessions(limit=2)
+
+        assert [s.session_id for s in result] == ["s-0", "s-1"]
+
+    @pytest.mark.asyncio
+    async def test_empty_list_and_forward_compatible_extra_fields(
+        self, cloud_client, mock_session
+    ):
+        cloud_client._aio_session = mock_session
+        # empty
+        self._mock_list_response(mock_session, {"sessions": [], "total": 0})
+        assert await cloud_client.list_sessions() == []
+        # extra/unknown server field preserved in .extra, not dropped
+        self._mock_list_response(
+            mock_session,
+            {
+                "sessions": [
+                    {"session_id": "s-1", "status": "running", "tenant_id": "t-1"}
+                ],
+                "total": 1,
+            },
+        )
+        result = await cloud_client.list_sessions()
+        assert result[0].extra == {"tenant_id": "t-1"}
+
+    @pytest.mark.asyncio
+    async def test_delete_session_defaults_to_non_destructive(
+        self, cloud_client, mock_session
+    ):
+        cloud_client._aio_session = mock_session
+        response = Mock()
+        response.status = 200
+        response.text = AsyncMock(return_value="")
+        mock_session.delete = Mock(return_value=AsyncMock())
+        mock_session.delete.return_value.__aenter__ = AsyncMock(return_value=response)
+        mock_session.delete.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        await cloud_client.delete_session("s-1")
+
+        assert mock_session.delete.call_args.kwargs["params"] == {"cascade": "false"}

--- a/traigent/cloud/client.py
+++ b/traigent/cloud/client.py
@@ -33,13 +33,13 @@ else:  # pragma: no cover - minimal environments without aiohttp
 
 from traigent.config.backend_config import BackendConfig
 from traigent.evaluators.base import Dataset
-from traigent.utils.env_config import is_backend_offline
-from traigent.utils.error_handler import OfflineModeError
-from traigent.utils.error_handler import TraigentError as HelpfulTraigentError
 from traigent.utils.artifact_fingerprints import (
     artifact_fingerprints_to_wire,
     fingerprint_meta_to_wire,
 )
+from traigent.utils.env_config import is_backend_offline
+from traigent.utils.error_handler import OfflineModeError
+from traigent.utils.error_handler import TraigentError as HelpfulTraigentError
 from traigent.utils.exceptions import ValidationError as ValidationException
 from traigent.utils.logging import get_logger
 from traigent.utils.retry import NetworkError, RateLimitError, retry_http_request
@@ -62,6 +62,7 @@ from .models import (
     SessionCreationRequest,
     SessionCreationResponse,
     SessionObjectiveDefinition,
+    SessionSummary,
     TrialResultSubmission,
     TrialSuggestion,
 )
@@ -1517,8 +1518,16 @@ class TraigentCloudClient(BaseTraigentClient):
                 f"Failed to finalize session: {e}", "session_finalization", e
             ) from e
 
-    async def delete_session(self, session_id: str, cascade: bool = True) -> bool:
-        """Delete a session using the backend cleanup endpoint."""
+    async def delete_session(self, session_id: str, cascade: bool = False) -> bool:
+        """Delete a session via ``DELETE /api/v1/sessions/<id>``.
+
+        Non-destructive by default (``cascade=False``), matching the backend
+        default: only the session and its run artifacts are removed. Pass
+        ``cascade=True`` to additionally hard-delete the parent experiment when
+        the deleted session was its last run. Use this with
+        :meth:`list_sessions` to enumerate and clean up orphaned / zombie
+        "running" sessions from the client.
+        """
         if not session_id:
             raise ValueError("session_id is required")
 
@@ -1555,6 +1564,68 @@ class TraigentCloudClient(BaseTraigentClient):
             raise StandardizedClientError(
                 f"Failed to delete session: {exc}", "session_delete", exc
             ) from exc
+
+    async def list_sessions(
+        self,
+        status: str | None = None,
+        pattern: str | None = None,
+        limit: int | None = None,
+    ) -> list[SessionSummary]:
+        """List sessions via ``GET /api/v1/sessions``.
+
+        Enumerates the caller's optimization sessions so orphaned / zombie
+        "running" sessions can be found and cleaned up with
+        :meth:`delete_session`. Returns typed :class:`SessionSummary` objects.
+
+        Args:
+            status: Optional lifecycle filter (server-side ``status`` query param).
+            pattern: Optional session-id match (server-side ``pattern`` query
+                param).
+            limit: Optional cap on the number of summaries returned. The backend
+                does not support a server-side limit, so this is applied
+                client-side after the response is received.
+
+        Returns:
+            A list of :class:`SessionSummary` (empty when there are none).
+        """
+        self._raise_if_backend_egress_disabled("list sessions")
+        await self._ensure_session()
+        if self._aio_session is None:
+            raise CloudServiceError(_SESSION_NOT_INITIALIZED)
+
+        params: dict[str, str] = {}
+        if status is not None:
+            params["status"] = str(status)
+        if pattern is not None:
+            params["pattern"] = str(pattern)
+
+        url = f"{self.api_base_url}/sessions"
+        try:
+            async with self._aio_session.get(url, params=params) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise CloudServiceError(
+                        f"Failed to list sessions: status={response.status} "
+                        f"body={error_text[:200]}"
+                    )
+                data = await response.json()
+        except aiohttp.ClientError as exc:
+            await self._reset_http_session("list_sessions network error")
+            raise StandardizedClientError(
+                f"Failed to list sessions: {exc}", "session_list", exc
+            ) from exc
+
+        raw_sessions = data.get("sessions") if isinstance(data, dict) else None
+        if not isinstance(raw_sessions, list):
+            raw_sessions = []
+        summaries = [
+            SessionSummary.from_dict(item)
+            for item in raw_sessions
+            if isinstance(item, dict)
+        ]
+        if limit is not None and limit >= 0:
+            summaries = summaries[:limit]
+        return summaries
 
     # Stateful optimization methods for interactive model
 

--- a/traigent/cloud/models.py
+++ b/traigent/cloud/models.py
@@ -140,6 +140,40 @@ class OptimizationSession:
 
 
 @dataclass
+class SessionSummary:
+    """Lightweight summary of a session from ``GET /api/v1/sessions``.
+
+    Returned by :meth:`traigent.cloud.client.TraigentCloudClient.list_sessions`.
+    Maps the backend session-list contract
+    (``optimization/optimization_session_list_response_schema.json``):
+    ``session_id`` and
+    ``status`` are always present; ``created_at`` / ``progress`` when the server
+    provides them. Forward-compatible — any additional server fields are kept in
+    ``extra`` rather than dropped, so the SDK can enumerate and clean up orphaned
+    sessions without a release per new field.
+    """
+
+    session_id: str
+    status: str
+    created_at: str | None = None
+    progress: dict[str, Any] | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SessionSummary:
+        """Build a summary from one backend session object, tolerating extras."""
+        known = {"session_id", "status", "created_at", "progress"}
+        progress = data.get("progress")
+        return cls(
+            session_id=str(data.get("session_id", "")),
+            status=str(data.get("status", "")),
+            created_at=data.get("created_at"),
+            progress=progress if isinstance(progress, dict) else None,
+            extra={k: v for k, v in data.items() if k not in known},
+        )
+
+
+@dataclass
 class DatasetSubsetIndices:
     """Indices for selecting a subset of the dataset."""
 


### PR DESCRIPTION
## Add SDK list_sessions() + non-destructive delete_session default

Last open item from the client report (P3 session lifecycle — zombie "Running" sessions, no client-side way to enumerate/clean orphans). The BE already serves `GET /api/v1/sessions`; the SDK exposed only `get_session_status` + delete.

- `list_sessions(status=None, pattern=None, limit=None) -> list[SessionSummary]` on `TraigentCloudClient` — real `GET {api_base}/sessions`, typed `SessionSummary` (unknown fields kept in `.extra` for forward-compat). `status`/`pattern` → BE query params (omitted when None); `limit` applied client-side (BE has no server limit — documented).
- `delete_session(..., cascade=False)` — non-destructive default, matching the BE.

Consumes TraigentSchema `session_list_response_schema` (sibling PR).

Spine-Trail: st_bc288398e5b5

### Evidence
- `TestListSessions` (6 cases: typed-parse + real-URL assert, status+pattern params, omit-unset, client-side limit, empty + forward-compat `.extra`, delete `cascade=false`). ruff clean; **new code mypy-clean**.
- Independent cross-model review (codex gpt-5.5) = **GO**: real endpoint call (no fake completion), Schema+SDK match the real BE contract, `cascade=False` flip safe (no caller relied on the old `True`; the live integration caller passes `cascade=True` explicitly).

### CI note (evidence-backed pre-existing exception, Rule 9 §6)
`mypy traigent/cloud/client.py` reports 2 errors at `client.py:166` (`task = loop.create_task(...)` — var-annotated + arg-type). **Pre-existing on develop** (same 2 errors at `client.py:165` on `origin/develop`, shifted +1 by this PR's single added import; this PR's hunks don't touch that line). Not introduced here.
