### PR TITLE
chore(release): bump dev version 0.18.1.dev5 -> 0.18.1.dev6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev5"
+version = "0.18.1.dev6"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## chore: bump dev version 0.18.1.dev5 -> 0.18.1.dev6

Publishes SDK `list_sessions()` (#1584) + the session-list Schema contract to prod PyPI for client validation. Version string only.

Spine: none (reason: dev-version bump; no code/contract/policy change)
