### PR TITLE
chore(release): bump dev version 0.18.1.dev6 -> 0.18.1.dev7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "traigent"
-version = "0.18.1.dev6"
+version = "0.18.1.dev7"
 authors = [
     {name = "Traigent Team", email = "opensource@traigent.ai"},
 ]


### PR DESCRIPTION
## chore: bump dev version 0.18.1.dev6 -> 0.18.1.dev7

Publishes the SDK smart-pruning producer (#1589) to prod PyPI so the client/QA agent can enable `smart_pruning`. Version string only.

Spine: none (reason: dev-version bump; no code/contract/policy change)
